### PR TITLE
Consolidate rerouted requests in access log

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -442,6 +442,21 @@ include::{generated-dir}/config/quarkus-vertx-http-config-group-access-log-confi
 |Vert.x MDC data (e.g. 'traceId' for OpenTelemetry)                           |          | `%{X,mdc-key}`
 |===
 
+Set `quarkus.http.access-log.consolidate-rerouted-requests=true` to enable support for the modifier `<`. This modifier can be used for requests that have been internally redirected to consult the original request.
+The following attributes support this modifier:
+
+
+[frame="topbot",options="header"]
+|===
+|Attribute                                                                    |Short Form|Long Form
+|First line of the request                                                    | `%<r`    | `%{<REQUEST_LINE}`
+|Request method                                                               | `%<m`    | `%{<METHOD}`
+|Request relative path                                                        | `%<R`    | `%{<REQUEST_PATH}`
+|Requested URL path                                                           | `%<U`    | `%{<REQUEST_URL}`
+|Query string (prepended with a '?' if it exists, otherwise an empty string)  | `%<q`    | `%{<QUERY_STRING}`
+|Query parameter                                                              |          | `%{<q,query_param_name}`
+|===
+
 [NOTE]
 ====
 Set `quarkus.http.record-request-start-time=true` to enable recording request start times when using any of the attributes related to logging request processing times.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AccessLogConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AccessLogConfig.java
@@ -77,4 +77,10 @@ public class AccessLogConfig {
     @ConfigItem(defaultValue = "true")
     public boolean rotate;
 
+    /**
+     * If rerouted requests should be consolidated into one log entry
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean consolidateReroutedRequests;
+
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -460,7 +460,8 @@ public class VertxHttpRecorder {
             } else {
                 receiver = new JBossLoggingAccessLogReceiver(accessLog.category);
             }
-            AccessLogHandler handler = new AccessLogHandler(receiver, accessLog.pattern, getClass().getClassLoader(),
+            AccessLogHandler handler = new AccessLogHandler(receiver, accessLog.pattern, accessLog.consolidateReroutedRequests,
+                    getClass().getClassLoader(),
                     accessLog.excludePattern);
             if (rootPath.equals("/") || nonRootPath.equals("/")) {
                 mainRouterRuntimeValue.orElse(httpRouterRuntimeValue).getValue().route()

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/QueryStringAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/QueryStringAttribute.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http.runtime.attribute;
 
+import io.quarkus.vertx.http.runtime.filters.OriginalRequestContext;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -11,19 +12,26 @@ public class QueryStringAttribute implements ExchangeAttribute {
     public static final String QUERY_STRING_SHORT = "%q";
     public static final String QUERY_STRING = "%{QUERY_STRING}";
     public static final String BARE_QUERY_STRING = "%{BARE_QUERY_STRING}";
+    public static final String ORIGINAL_QUERY_STRING_SHORT = "%<q";
+    public static final String ORIGINAL_QUERY_STRING = "%{<QUERY_STRING}";
+    public static final String ORIGINAL_BARE_QUERY_STRING = "%{<BARE_QUERY_STRING}";
 
-    public static final ExchangeAttribute INSTANCE = new QueryStringAttribute(true);
-    public static final ExchangeAttribute BARE_INSTANCE = new QueryStringAttribute(false);
+    public static final ExchangeAttribute INSTANCE = new QueryStringAttribute(true, false);
+    public static final ExchangeAttribute BARE_INSTANCE = new QueryStringAttribute(false, false);
+    public static final ExchangeAttribute INSTANCE_ORIGINAL_REQUEST = new QueryStringAttribute(true, true);
+    public static final ExchangeAttribute BARE_INSTANCE_ORIGINAL_REQUEST = new QueryStringAttribute(false, true);
 
     private final boolean includeQuestionMark;
+    private final boolean useOriginalRequest;
 
-    private QueryStringAttribute(boolean includeQuestionMark) {
+    private QueryStringAttribute(boolean includeQuestionMark, boolean useOriginalRequest) {
         this.includeQuestionMark = includeQuestionMark;
+        this.useOriginalRequest = useOriginalRequest;
     }
 
     @Override
     public String readAttribute(final RoutingContext exchange) {
-        String qs = exchange.request().query();
+        String qs = useOriginalRequest ? OriginalRequestContext.getQuery(exchange) : exchange.request().query();
         if (qs == null) {
             qs = "";
         }
@@ -51,6 +59,10 @@ public class QueryStringAttribute implements ExchangeAttribute {
                 return QueryStringAttribute.INSTANCE;
             } else if (token.equals(BARE_QUERY_STRING)) {
                 return QueryStringAttribute.BARE_INSTANCE;
+            } else if (token.equals(ORIGINAL_QUERY_STRING) || token.equals(ORIGINAL_QUERY_STRING_SHORT)) {
+                return QueryStringAttribute.INSTANCE_ORIGINAL_REQUEST;
+            } else if (token.equals(ORIGINAL_BARE_QUERY_STRING)) {
+                return QueryStringAttribute.BARE_INSTANCE_ORIGINAL_REQUEST;
             }
             return null;
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestLineAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestLineAttribute.java
@@ -1,5 +1,7 @@
 package io.quarkus.vertx.http.runtime.attribute;
 
+import io.quarkus.vertx.http.runtime.filters.OriginalRequestContext;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -10,19 +12,36 @@ public class RequestLineAttribute implements ExchangeAttribute {
 
     public static final String REQUEST_LINE_SHORT = "%r";
     public static final String REQUEST_LINE = "%{REQUEST_LINE}";
+    public static final String ORIGINAL_REQUEST_LINE_SHORT = "%<r";
+    public static final String ORIGINAL_REQUEST_LINE = "%{<REQUEST_LINE}";
 
-    public static final ExchangeAttribute INSTANCE = new RequestLineAttribute();
+    public static final ExchangeAttribute INSTANCE = new RequestLineAttribute(false);
+    public static final ExchangeAttribute INSTANCE_ORIGINAL_REQUEST = new RequestLineAttribute(true);
 
-    private RequestLineAttribute() {
+    private final boolean useOriginalRequest;
 
+    private RequestLineAttribute(boolean useOriginalRequest) {
+        this.useOriginalRequest = useOriginalRequest;
     }
 
     @Override
     public String readAttribute(final RoutingContext exchange) {
+        HttpMethod httpMethod;
+        String uri;
+        if (useOriginalRequest) {
+            if (!OriginalRequestContext.isPresent(exchange)) {
+                return null;
+            }
+            httpMethod = OriginalRequestContext.getMethod(exchange);
+            uri = OriginalRequestContext.getUri(exchange);
+        } else {
+            httpMethod = exchange.request().method();
+            uri = exchange.request().uri();
+        }
         StringBuilder sb = new StringBuilder()
-                .append(exchange.request().method())
+                .append(httpMethod)
                 .append(' ')
-                .append(exchange.request().uri());
+                .append(uri);
         sb.append(' ');
         String httpVersion = "-";
         switch (exchange.request().version()) {
@@ -63,6 +82,8 @@ public class RequestLineAttribute implements ExchangeAttribute {
         public ExchangeAttribute build(final String token) {
             if (token.equals(REQUEST_LINE) || token.equals(REQUEST_LINE_SHORT)) {
                 return RequestLineAttribute.INSTANCE;
+            } else if (token.equals(ORIGINAL_REQUEST_LINE) || token.equals(ORIGINAL_REQUEST_LINE_SHORT)) {
+                return RequestLineAttribute.INSTANCE_ORIGINAL_REQUEST;
             }
             return null;
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestMethodAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestMethodAttribute.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http.runtime.attribute;
 
+import io.quarkus.vertx.http.runtime.filters.OriginalRequestContext;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -10,16 +11,21 @@ public class RequestMethodAttribute implements ExchangeAttribute {
 
     public static final String REQUEST_METHOD_SHORT = "%m";
     public static final String REQUEST_METHOD = "%{METHOD}";
+    public static final String ORIGINAL_REQUEST_METHOD_SHORT = "%<m";
+    public static final String ORIGINAL_REQUEST_METHOD = "%{<METHOD}";
 
-    public static final ExchangeAttribute INSTANCE = new RequestMethodAttribute();
+    public static final ExchangeAttribute INSTANCE = new RequestMethodAttribute(false);
+    public static final ExchangeAttribute INSTANCE_ORIGINAL_REQUEST = new RequestMethodAttribute(true);
 
-    private RequestMethodAttribute() {
+    private final boolean useOriginalRequest;
 
+    private RequestMethodAttribute(boolean useOriginalRequest) {
+        this.useOriginalRequest = useOriginalRequest;
     }
 
     @Override
     public String readAttribute(final RoutingContext exchange) {
-        return exchange.request().method().name();
+        return useOriginalRequest ? OriginalRequestContext.getMethod(exchange).name() : exchange.request().method().name();
     }
 
     @Override
@@ -38,6 +44,8 @@ public class RequestMethodAttribute implements ExchangeAttribute {
         public ExchangeAttribute build(final String token) {
             if (token.equals(REQUEST_METHOD) || token.equals(REQUEST_METHOD_SHORT)) {
                 return RequestMethodAttribute.INSTANCE;
+            } else if (token.equals(ORIGINAL_REQUEST_METHOD) || token.equals(ORIGINAL_REQUEST_METHOD_SHORT)) {
+                return RequestMethodAttribute.INSTANCE_ORIGINAL_REQUEST;
             }
             return null;
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestPathAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestPathAttribute.java
@@ -1,21 +1,27 @@
 package io.quarkus.vertx.http.runtime.attribute;
 
+import io.quarkus.vertx.http.runtime.filters.OriginalRequestContext;
 import io.vertx.ext.web.RoutingContext;
 
 public class RequestPathAttribute implements ExchangeAttribute {
 
     public static final String REQUEST_PATH = "%{REQUEST_PATH}";
     public static final String REQUEST_PATH_SHORT = "%R";
+    public static final String ORIGINAL_REQUEST_PATH = "%{<REQUEST_PATH}";
+    public static final String ORIGINAL_REQUEST_PATH_SHORT = "%<R";
 
-    public static final ExchangeAttribute INSTANCE = new RequestPathAttribute();
+    public static final ExchangeAttribute INSTANCE = new RequestPathAttribute(false);
+    public static final ExchangeAttribute INSTANCE_ORIGINAL_REQUEST = new RequestPathAttribute(true);
 
-    private RequestPathAttribute() {
+    private final boolean useOriginalRequest;
 
+    private RequestPathAttribute(boolean useOriginalRequest) {
+        this.useOriginalRequest = useOriginalRequest;
     }
 
     @Override
     public String readAttribute(final RoutingContext exchange) {
-        return exchange.request().path();
+        return useOriginalRequest ? OriginalRequestContext.getPath(exchange) : exchange.request().path();
     }
 
     @Override
@@ -32,6 +38,9 @@ public class RequestPathAttribute implements ExchangeAttribute {
 
         @Override
         public ExchangeAttribute build(final String token) {
+            if (token.equals(ORIGINAL_REQUEST_PATH) || token.equals(ORIGINAL_REQUEST_PATH_SHORT)) {
+                return INSTANCE_ORIGINAL_REQUEST;
+            }
             return token.equals(REQUEST_PATH) || token.equals(REQUEST_PATH_SHORT) ? INSTANCE : null;
         }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestURLAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestURLAttribute.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http.runtime.attribute;
 
+import io.quarkus.vertx.http.runtime.filters.OriginalRequestContext;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -10,16 +11,21 @@ public class RequestURLAttribute implements ExchangeAttribute {
 
     public static final String REQUEST_URL_SHORT = "%U";
     public static final String REQUEST_URL = "%{REQUEST_URL}";
+    public static final String ORIGINAL_REQUEST_URL_SHORT = "%<U";
+    public static final String ORIGINAL_REQUEST_URL = "%{<REQUEST_URL}";
 
-    public static final ExchangeAttribute INSTANCE = new RequestURLAttribute();
+    public static final ExchangeAttribute INSTANCE = new RequestURLAttribute(false);
+    public static final ExchangeAttribute INSTANCE_ORIGINAL_REQUEST = new RequestURLAttribute(true);
 
-    private RequestURLAttribute() {
+    private final boolean useOriginalRequest;
 
+    private RequestURLAttribute(boolean useOriginalRequest) {
+        this.useOriginalRequest = useOriginalRequest;
     }
 
     @Override
     public String readAttribute(final RoutingContext exchange) {
-        return exchange.request().uri();
+        return useOriginalRequest ? OriginalRequestContext.getUri(exchange) : exchange.request().uri();
     }
 
     @Override
@@ -38,6 +44,8 @@ public class RequestURLAttribute implements ExchangeAttribute {
         public ExchangeAttribute build(final String token) {
             if (token.equals(REQUEST_URL) || token.equals(REQUEST_URL_SHORT)) {
                 return RequestURLAttribute.INSTANCE;
+            } else if (token.equals(ORIGINAL_REQUEST_URL) || token.equals(ORIGINAL_REQUEST_URL_SHORT)) {
+                return RequestURLAttribute.INSTANCE_ORIGINAL_REQUEST;
             }
             return null;
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/OriginalRequestContext.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/OriginalRequestContext.java
@@ -1,0 +1,67 @@
+package io.quarkus.vertx.http.runtime.filters;
+
+import java.util.List;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+
+public class OriginalRequestContext {
+
+    public static final String RC_DATA_KEY = "originalRequestContext";
+
+    public static boolean isPresent(RoutingContext rc) {
+        OriginalRequestContext originalRequestContext = rc.get(RC_DATA_KEY);
+        return originalRequestContext != null;
+    }
+
+    public static HttpMethod getMethod(RoutingContext rc) {
+        OriginalRequestContext originalRequestContext = rc.get(RC_DATA_KEY);
+        if (originalRequestContext == null)
+            return null;
+        return originalRequestContext.method;
+    }
+
+    public static String getUri(RoutingContext rc) {
+        OriginalRequestContext originalRequestContext = rc.get(RC_DATA_KEY);
+        if (originalRequestContext == null)
+            return null;
+        return originalRequestContext.uri;
+    }
+
+    public static String getPath(RoutingContext rc) {
+        OriginalRequestContext originalRequestContext = rc.get(RC_DATA_KEY);
+        if (originalRequestContext == null)
+            return null;
+        return originalRequestContext.path;
+    }
+
+    public static String getQuery(RoutingContext rc) {
+        OriginalRequestContext originalRequestContext = rc.get(RC_DATA_KEY);
+        if (originalRequestContext == null)
+            return null;
+        return originalRequestContext.query;
+    }
+
+    public static List<String> getAllQueryParams(RoutingContext rc, String name) {
+        OriginalRequestContext originalRequestContext = rc.get(RC_DATA_KEY);
+        if (originalRequestContext == null)
+            return null;
+        return originalRequestContext.queryParams.getAll(name);
+    }
+
+    private final HttpMethod method;
+    private final String uri;
+    private final String path;
+    private final String query;
+    private final MultiMap queryParams;
+
+    public OriginalRequestContext(RoutingContext rc) {
+        this.method = rc.request().method();
+        this.uri = rc.request().uri();
+        this.path = rc.request().path();
+        this.query = rc.request().query();
+        this.queryParams = rc.queryParams();
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import io.quarkus.vertx.http.runtime.attribute.ExchangeAttribute;
 import io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeParser;
 import io.quarkus.vertx.http.runtime.attribute.SubstituteEmptyWrapper;
+import io.quarkus.vertx.http.runtime.filters.OriginalRequestContext;
 import io.quarkus.vertx.http.runtime.filters.QuarkusRequestWrapper;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
@@ -94,13 +95,16 @@ public class AccessLogHandler implements Handler<RoutingContext> {
 
     private final AccessLogReceiver accessLogReceiver;
     private final String formatString;
+    private final boolean consolidateReroutedRequests;
     private final ExchangeAttribute tokens;
     private final Pattern excludePattern;
 
-    public AccessLogHandler(final AccessLogReceiver accessLogReceiver, final String formatString, ClassLoader classLoader,
+    public AccessLogHandler(final AccessLogReceiver accessLogReceiver, final String formatString,
+            boolean consolidateReroutedRequests, ClassLoader classLoader,
             Optional<String> excludePattern) {
         this.accessLogReceiver = accessLogReceiver;
         this.formatString = handleCommonNames(formatString);
+        this.consolidateReroutedRequests = consolidateReroutedRequests;
         this.tokens = new ExchangeAttributeParser(classLoader, Collections.singletonList(new SubstituteEmptyWrapper("-")))
                 .parse(this.formatString);
         if (excludePattern.isPresent()) {
@@ -110,9 +114,11 @@ public class AccessLogHandler implements Handler<RoutingContext> {
         }
     }
 
-    public AccessLogHandler(final AccessLogReceiver accessLogReceiver, String formatString, final ExchangeAttribute attribute) {
+    public AccessLogHandler(final AccessLogReceiver accessLogReceiver, String formatString, boolean consolidateReroutedRequests,
+            final ExchangeAttribute attribute) {
         this.accessLogReceiver = accessLogReceiver;
         this.formatString = handleCommonNames(formatString);
+        this.consolidateReroutedRequests = consolidateReroutedRequests;
         this.tokens = attribute;
         this.excludePattern = null;
     }
@@ -142,12 +148,19 @@ public class AccessLogHandler implements Handler<RoutingContext> {
                 return;
             }
         }
+        if (consolidateReroutedRequests && rc.get(OriginalRequestContext.RC_DATA_KEY, null) != null) {
+            rc.next();
+            return;
+        }
         QuarkusRequestWrapper.get(rc.request()).addRequestDoneHandler(new Handler<Void>() {
             @Override
             public void handle(Void event) {
                 accessLogReceiver.logMessage(tokens.readAttribute(rc));
             }
         });
+        if (consolidateReroutedRequests) {
+            rc.put(OriginalRequestContext.RC_DATA_KEY, new OriginalRequestContext(rc));
+        }
         rc.next();
     }
 

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/ConsolidateReroutedRequestsTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/ConsolidateReroutedRequestsTest.java
@@ -1,0 +1,317 @@
+package io.quarkus.vertx.http.runtime.attribute;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.netty.handler.codec.http.QueryStringDecoder;
+import io.quarkus.vertx.http.runtime.filters.QuarkusRequestWrapper;
+import io.quarkus.vertx.http.runtime.filters.accesslog.AccessLogHandler;
+import io.quarkus.vertx.http.runtime.filters.accesslog.AccessLogReceiver;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.impl.HostAndPortImpl;
+import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.impl.RoutingContextImpl;
+
+public class ConsolidateReroutedRequestsTest {
+
+    @Test
+    public void testDisabledNoReroutesRequestLineOnly() {
+        test(
+                false,
+                Arrays.asList("%r", "%{REQUEST_LINE}"),
+                Optional.empty(),
+                HttpMethod.GET,
+                HttpVersion.HTTP_1_1,
+                "https",
+                new HostAndPortImpl("example.org", 443),
+                "/path1",
+                "q1=v1",
+                Collections.emptyList(),
+                Arrays.asList(
+                        "GET /path1?q1=v1 HTTP/1.1"));
+    }
+
+    @Test
+    public void testDisabled2ReroutesRequestLineOnly() {
+        test(
+                false,
+                Arrays.asList("%r", "%{REQUEST_LINE}"),
+                Optional.empty(),
+                HttpMethod.GET,
+                HttpVersion.HTTP_1_1,
+                "https",
+                new HostAndPortImpl("example.org", 443),
+                "/path1",
+                "q1=v1",
+                Arrays.asList(
+                        new Reroute(null, "/path2", "q2=v2"),
+                        new Reroute(null, "/path3", "q3=v3")),
+                Arrays.asList(
+                        "GET /path3?q3=v3 HTTP/1.1",
+                        "GET /path3?q3=v3 HTTP/1.1",
+                        "GET /path3?q3=v3 HTTP/1.1"));
+    }
+
+    @Test
+    public void testDisabled1RerouteRequestPathOnly() {
+        test(
+                false,
+                Arrays.asList("%R", "%{REQUEST_PATH}"),
+                Optional.empty(),
+                HttpMethod.GET,
+                HttpVersion.HTTP_1_1,
+                "https",
+                new HostAndPortImpl("example.org", 443),
+                "/path1",
+                "q1=v1",
+                Arrays.asList(
+                        new Reroute(null, "/path2", "q2=v2")),
+                Arrays.asList(
+                        "/path2",
+                        "/path2"));
+    }
+
+    @Test
+    public void testDisabled2ReroutesOriginalRequestLineOnly() {
+        test(
+                false,
+                Arrays.asList("%<r", "%{<REQUEST_LINE}"),
+                Optional.empty(),
+                HttpMethod.GET,
+                HttpVersion.HTTP_1_1,
+                "https",
+                new HostAndPortImpl("example.org", 443),
+                "/path1",
+                "q1=v1",
+                Arrays.asList(
+                        new Reroute(null, "/path2", "q2=v2"),
+                        new Reroute(null, "/path3", "q3=v3")),
+                Arrays.asList(
+                        "-",
+                        "-",
+                        "-"));
+    }
+
+    @Test
+    public void testDisabled2ReroutesAllOriginalAndFinal() {
+        test(
+                false,
+                Arrays.asList(
+                        "%<r %r %<R %R %<q %q %{<BARE_QUERY_STRING} %{BARE_QUERY_STRING} %{<q,q} %{q,q} %<U %U",
+                        "%{<REQUEST_LINE} %{REQUEST_LINE} %{<REQUEST_PATH} %{REQUEST_PATH} %{<QUERY_STRING} %{QUERY_STRING} %{<BARE_QUERY_STRING} %{BARE_QUERY_STRING} %{<q,q} %{q,q} %{<REQUEST_URL} %{REQUEST_URL}"),
+                Optional.empty(),
+                HttpMethod.GET,
+                HttpVersion.HTTP_1_1,
+                "https",
+                new HostAndPortImpl("example.org", 443),
+                "/path1",
+                "q=v1",
+                Arrays.asList(
+                        new Reroute(null, "/path2", "q=v2"),
+                        new Reroute(null, "/path3", "q=v3")),
+                Arrays.asList(
+                        "- GET /path3?q=v3 HTTP/1.1 - /path3 - ?q=v3 - q=v3 - v3 - /path3?q=v3",
+                        "- GET /path3?q=v3 HTTP/1.1 - /path3 - ?q=v3 - q=v3 - v3 - /path3?q=v3",
+                        "- GET /path3?q=v3 HTTP/1.1 - /path3 - ?q=v3 - q=v3 - v3 - /path3?q=v3"));
+    }
+
+    @Test
+    public void testEnabledNoReroutesRequestLineOnly() {
+        test(
+                true,
+                Arrays.asList("%r", "%{REQUEST_LINE}"),
+                Optional.empty(),
+                HttpMethod.GET,
+                HttpVersion.HTTP_1_1,
+                "https",
+                new HostAndPortImpl("example.org", 443),
+                "/path1",
+                "q1=v1",
+                Collections.emptyList(),
+                Arrays.asList(
+                        "GET /path1?q1=v1 HTTP/1.1"));
+    }
+
+    @Test
+    public void testEnabled2ReroutesOriginalAndFinalRequestLine() {
+        test(
+                true,
+                Arrays.asList("%<r %r", "%{<REQUEST_LINE} %{REQUEST_LINE}"),
+                Optional.empty(),
+                HttpMethod.GET,
+                HttpVersion.HTTP_1_1,
+                "https",
+                new HostAndPortImpl("example.org", 443),
+                "/path1",
+                "q1=v1",
+                Arrays.asList(
+                        new Reroute(null, "/path2", "q2=v2"),
+                        new Reroute(null, "/path3", "q3=v3")),
+                Arrays.asList(
+                        "GET /path1?q1=v1 HTTP/1.1 GET /path3?q3=v3 HTTP/1.1"));
+    }
+
+    @Test
+    public void testEnabled2ReroutesAllOriginalAndFinal() {
+        test(
+                true,
+                Arrays.asList(
+                        "%<r %r %<R %R %<q %q %{<BARE_QUERY_STRING} %{BARE_QUERY_STRING} %{<q,q} %{q,q} %<U %U",
+                        "%{<REQUEST_LINE} %{REQUEST_LINE} %{<REQUEST_PATH} %{REQUEST_PATH} %{<QUERY_STRING} %{QUERY_STRING} %{<BARE_QUERY_STRING} %{BARE_QUERY_STRING} %{<q,q} %{q,q} %{<REQUEST_URL} %{REQUEST_URL}"),
+                Optional.empty(),
+                HttpMethod.GET,
+                HttpVersion.HTTP_1_1,
+                "https",
+                new HostAndPortImpl("example.org", 443),
+                "/path1",
+                "q=v1",
+                Arrays.asList(
+                        new Reroute(null, "/path2", "q=v2"),
+                        new Reroute(null, "/path3", "q=v3")),
+                Arrays.asList(
+                        "GET /path1?q=v1 HTTP/1.1 GET /path3?q=v3 HTTP/1.1 /path1 /path3 ?q=v1 ?q=v3 q=v1 q=v3 v1 v3 /path1?q=v1 /path3?q=v3"));
+    }
+
+    private void test(
+            boolean consolidateReroutedRequests,
+            List<String> equivalentPatterns,
+            Optional<String> excludePattern,
+            HttpMethod httpMethod,
+            HttpVersion httpVersion,
+            String scheme,
+            HostAndPort authority,
+            String path,
+            String query,
+            List<Reroute> reroutes,
+            List<String> expectedAccessLogEntries) {
+        for (String pattern : equivalentPatterns) {
+            test(consolidateReroutedRequests, pattern, excludePattern, httpMethod, httpVersion, scheme, authority, path, query,
+                    reroutes, expectedAccessLogEntries);
+        }
+    }
+
+    private void test(
+            boolean consolidateReroutedRequests,
+            String pattern,
+            Optional<String> excludePattern,
+            HttpMethod httpMethod,
+            HttpVersion httpVersion,
+            String scheme,
+            HostAndPort authority,
+            String path,
+            String query,
+            List<Reroute> reroutes,
+            List<String> expectedAccessLogEntries) {
+        List<String> accessLogEntries = new ArrayList<>();
+        AccessLogReceiver receiver = new AccessLogReceiver() {
+            @Override
+            public void logMessage(String message) {
+                accessLogEntries.add(message);
+            }
+        };
+
+        AccessLogHandler accessLogHandler = new AccessLogHandler(receiver, pattern, consolidateReroutedRequests,
+                getClass().getClassLoader(), excludePattern);
+        QuarkusRequestWrapper request = Mockito.mock(QuarkusRequestWrapper.class);
+        Mockito.when(request.getCookie(QuarkusRequestWrapper.FAKE_COOKIE_NAME)).thenReturn(request.new QuarkusCookie());
+        Mockito.when(request.version()).thenReturn(httpVersion);
+        Mockito.when(request.scheme()).thenReturn(scheme);
+        Mockito.when(request.authority()).thenReturn(authority);
+        Mockito.when(request.method()).thenReturn(httpMethod);
+        Mockito.when(request.path()).thenReturn(path);
+        Mockito.when(request.query()).thenReturn(query);
+        String uri = uriFromPathAndQuery(path, query);
+        Mockito.when(request.uri()).thenReturn(uri);
+
+        HttpServerResponse response = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(request.response()).thenReturn(response);
+
+        List<Handler<Void>> requestDoneHandlers = new ArrayList<>();
+        Mockito.doAnswer(i -> {
+            requestDoneHandlers.add(i.getArgument(0));
+            return null;
+        }).when(request).addRequestDoneHandler(any());
+
+        RoutingContextImpl rc = Mockito.mock(RoutingContextImpl.class);
+        Mockito.when(rc.queryParams()).thenReturn(decodeQueryParams(uri));
+        Mockito.when(rc.get(anyString())).thenCallRealMethod();
+        Mockito.when(rc.get(anyString(), any())).thenCallRealMethod();
+        Mockito.when(rc.put(anyString(), any())).thenCallRealMethod();
+        Mockito.when(rc.request()).thenReturn(request);
+
+        accessLogHandler.handle(rc);
+        for (Reroute reroute : reroutes) {
+            reroute.apply(rc, request);
+            accessLogHandler.handle(rc);
+        }
+        for (Handler<Void> requestDoneHandler : requestDoneHandlers) {
+            requestDoneHandler.handle(null);
+        }
+        Assertions.assertEquals(expectedAccessLogEntries, accessLogEntries);
+    }
+
+    private static MultiMap decodeQueryParams(String uri) {
+        try {
+            MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
+            Map<String, List<String>> decodedParams = new QueryStringDecoder(uri).parameters();
+            for (Map.Entry<String, List<String>> entry : decodedParams.entrySet()) {
+                queryParams.add(entry.getKey(), entry.getValue());
+            }
+            return queryParams;
+        } catch (IllegalArgumentException e) {
+            throw new HttpException(400, "Error while decoding query params", e);
+        }
+    }
+
+    private static String uriFromPathAndQuery(String path, String query) {
+        String uri = null;
+        if (path != null)
+            uri = path;
+        if (query != null)
+            uri += "?" + query;
+        return uri;
+    }
+
+    private static class Reroute {
+        private HttpMethod httpMethod;
+        private String path;
+        private String query;
+
+        public Reroute(HttpMethod httpMethod, String path, String query) {
+            this.httpMethod = httpMethod;
+            this.path = path;
+            this.query = query;
+        }
+
+        public void apply(RoutingContextImpl rc, QuarkusRequestWrapper request) {
+            if (httpMethod != null)
+                Mockito.when(request.method()).thenReturn(httpMethod);
+            if (path != null)
+                Mockito.when(request.path()).thenReturn(path);
+            if (query != null)
+                Mockito.when(request.query()).thenReturn(query);
+            String uri = uriFromPathAndQuery(path, query);
+            if (uri != null) {
+                Mockito.when(request.uri()).thenReturn(uri);
+                Mockito.when(rc.queryParams()).thenReturn(decodeQueryParams(uri));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request adds support to the access log for internally rerouted requests.
Setting the option `quarkus.http.access-log.consolidate-rerouted-requests=true`, will prevent duplicate log entries and adds support for the `<` modifier for a few relevant ExchangeAttributes.
See the updated http-reference doc in this pull request for more details.
Apache uses the same modifier, see https://httpd.apache.org/docs/2.4/mod/mod_log_config.html#modifiers
Relevant tests have been added.

There is a related issue from a while ago: https://github.com/quarkusio/quarkus/issues/30845

I understand that this issue was closed earlier without much attention, but I'm hopeful that this pull request provides an acceptable solution. I'm open to any feedback or suggestions that you may have and am willing to make any necessary adjustments to ensure the quality of the codebase.

Thank you for your time and consideration.

Best regards,
Brahim Raddahi