### PR TITLE
Enhance TLS certificate alias and SNI handling (HTTP & gRPC)

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -381,7 +381,7 @@
             <dependency>
                 <groupId>me.escoffier.certs</groupId>
                 <artifactId>certificate-generator-junit5</artifactId>
-                <version>0.4.3</version>
+                <version>0.5.0</version>
                 <scope>test</scope>
             </dependency>
 

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/tls/MtlsWithJKSTrustStoreWithHttpServerWithAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/tls/MtlsWithJKSTrustStoreWithHttpServerWithAliasTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.grpc.client.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.QuarkusUnitTest;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
+                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+})
+class MtlsWithJKSTrustStoreWithHttpServerWithAliasTest {
+
+    private static final String configuration = """
+            quarkus.grpc.clients.hello.plain-text=false
+            quarkus.grpc.clients.hello.tls.trust-certificate-jks.path=target/certs/grpc-alias-client-truststore.jks
+            quarkus.grpc.clients.hello.tls.trust-certificate-jks.password=password
+            quarkus.grpc.clients.hello.tls.key-certificate-jks.path=target/certs/grpc-alias-client-keystore.jks
+            quarkus.grpc.clients.hello.tls.key-certificate-jks.password=password
+            quarkus.grpc.clients.hello.tls.key-certificate-jks.alias=alias
+            quarkus.grpc.clients.hello.tls.key-certificate-jks.alias-password=alias-password
+            quarkus.grpc.clients.hello.tls.enabled=true
+            quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+
+            quarkus.grpc.server.use-separate-server=false
+            quarkus.grpc.server.plain-text=false # Force the client to use TLS for the tests
+
+            quarkus.http.ssl.certificate.key-store-file=target/certs/grpc-alias-keystore.jks
+            quarkus.http.ssl.certificate.key-store-password=password
+            quarkus.http.ssl.certificate.key-store-alias=alias
+            quarkus.http.ssl.certificate.key-store-alias-password=alias-password
+            quarkus.http.ssl.certificate.trust-store-file=target/certs/grpc-alias-server-truststore.jks
+            quarkus.http.ssl.certificate.trust-store-password=password
+            quarkus.http.ssl.client-auth=REQUIRED
+            quarkus.http.insecure-requests=disabled
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(HelloWorldTlsEndpoint.class.getPackage())
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .add(new StringAsset(configuration), "application.properties"));
+
+    @GrpcClient("hello")
+    GreeterGrpc.GreeterBlockingStub blockingHelloService;
+
+    @Test
+    void testClientTlsConfiguration() {
+        HelloReply reply = blockingHelloService.sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).isEqualTo("Hello neo");
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/tls/MtlsWithP12TrustStoreWithHttpServerWithAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/tls/MtlsWithP12TrustStoreWithHttpServerWithAliasTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.grpc.client.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.QuarkusUnitTest;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
+                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+})
+class MtlsWithP12TrustStoreWithHttpServerWithAliasTest {
+
+    private static final String configuration = """
+            quarkus.grpc.clients.hello.plain-text=false
+            quarkus.grpc.clients.hello.tls.trust-certificate-jks.path=target/certs/grpc-alias-client-truststore.p12
+            quarkus.grpc.clients.hello.tls.trust-certificate-jks.password=password
+            quarkus.grpc.clients.hello.tls.key-certificate-jks.path=target/certs/grpc-alias-client-keystore.p12
+            quarkus.grpc.clients.hello.tls.key-certificate-jks.password=password
+            quarkus.grpc.clients.hello.tls.key-certificate-jks.alias=alias
+            quarkus.grpc.clients.hello.tls.key-certificate-jks.alias-password=alias-password
+            quarkus.grpc.clients.hello.tls.enabled=true
+            quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+
+            quarkus.grpc.server.use-separate-server=false
+            quarkus.grpc.server.plain-text=false # Force the client to use TLS for the tests
+
+            quarkus.http.ssl.certificate.key-store-file=target/certs/grpc-alias-keystore.jks
+            quarkus.http.ssl.certificate.key-store-password=password
+            quarkus.http.ssl.certificate.key-store-alias=alias
+            quarkus.http.ssl.certificate.key-store-alias-password=alias-password
+            quarkus.http.ssl.certificate.trust-store-file=target/certs/grpc-alias-server-truststore.jks
+            quarkus.http.ssl.certificate.trust-store-password=password
+            quarkus.http.ssl.client-auth=REQUIRED
+            quarkus.http.insecure-requests=disabled
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(HelloWorldTlsEndpoint.class.getPackage())
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .add(new StringAsset(configuration), "application.properties"));
+
+    @GrpcClient("hello")
+    GreeterGrpc.GreeterBlockingStub blockingHelloService;
+
+    @Test
+    void testClientTlsConfiguration() {
+        HelloReply reply = blockingHelloService.sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).isEqualTo("Hello neo");
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithHttpServerUsingJKSWithAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithHttpServerUsingJKSWithAliasTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.grpc.server.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.ManagedChannel;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.SslContext;
+import io.quarkus.grpc.server.services.HelloService;
+import io.quarkus.test.QuarkusUnitTest;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
+                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+})
+public class TlsWithHttpServerUsingJKSWithAliasTest {
+
+    static String configuration = """
+            quarkus.grpc.server.use-separate-server=false
+
+            quarkus.http.ssl.certificate.key-store-file=target/certs/grpc-alias-keystore.jks
+            quarkus.http.ssl.certificate.key-store-password=password
+            quarkus.http.ssl.certificate.key-store-alias=alias
+            quarkus.http.ssl.certificate.key-store-alias-password=alias-password
+            quarkus.http.insecure-requests=disabled
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addClass(HelloService.class)
+                    .add(new StringAsset(configuration), "application.properties"));
+
+    protected ManagedChannel channel;
+
+    @BeforeEach
+    public void init() throws Exception {
+        File certs = new File("target/certs/alias-ca.crt");
+        SslContext sslcontext = GrpcSslContexts.forClient()
+                .trustManager(certs)
+                .build();
+        channel = NettyChannelBuilder.forAddress("localhost", 8444)
+                .sslContext(sslcontext)
+                .useTransportSecurity()
+                .build();
+    }
+
+    @AfterEach
+    public void shutdown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testInvokingGrpcServiceUsingTls() {
+        HelloReply reply = GreeterGrpc.newBlockingStub(channel)
+                .sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).isEqualTo("Hello neo");
+    }
+
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithHttpServerUsingP12WithAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithHttpServerUsingP12WithAliasTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.grpc.server.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.ManagedChannel;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.SslContext;
+import io.quarkus.grpc.server.services.HelloService;
+import io.quarkus.test.QuarkusUnitTest;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
+                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+})
+public class TlsWithHttpServerUsingP12WithAliasTest {
+
+    static String configuration = """
+            quarkus.grpc.server.use-separate-server=false
+
+            quarkus.http.ssl.certificate.key-store-file=target/certs/grpc-alias-keystore.p12
+            quarkus.http.ssl.certificate.key-store-password=password
+            quarkus.http.ssl.certificate.key-store-alias=alias
+            quarkus.http.ssl.certificate.key-store-alias-password=alias-password
+            quarkus.http.insecure-requests=disabled
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addClass(HelloService.class)
+                    .add(new StringAsset(configuration), "application.properties"));
+
+    protected ManagedChannel channel;
+
+    @BeforeEach
+    public void init() throws Exception {
+        File certs = new File("target/certs/alias-ca.crt");
+        SslContext sslcontext = GrpcSslContexts.forClient()
+                .trustManager(certs)
+                .build();
+        channel = NettyChannelBuilder.forAddress("localhost", 8444)
+                .sslContext(sslcontext)
+                .useTransportSecurity()
+                .build();
+    }
+
+    @AfterEach
+    public void shutdown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testInvokingGrpcServiceUsingTls() {
+        HelloReply reply = GreeterGrpc.newBlockingStub(channel)
+                .sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).isEqualTo("Hello neo");
+    }
+
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithJksKeyStoreAndAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithJksKeyStoreAndAliasTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.grpc.server.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.ManagedChannel;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.SslContext;
+import io.quarkus.grpc.server.services.HelloService;
+import io.quarkus.test.QuarkusUnitTest;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
+                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+})
+public class TlsWithJksKeyStoreAndAliasTest {
+
+    static String configuration = """
+            quarkus.grpc.server.ssl.key-store=target/certs/grpc-alias-keystore.jks
+            quarkus.grpc.server.ssl.key-store-password=password
+            quarkus.grpc.server.ssl.key-store-alias=alias
+            quarkus.grpc.server.ssl.key-store-alias-password=alias-password
+            quarkus.grpc.server.alpn=true
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addClass(HelloService.class)
+                    .add(new StringAsset(configuration), "application.properties"));
+
+    protected ManagedChannel channel;
+
+    @BeforeEach
+    public void init() throws Exception {
+        File certs = new File("target/certs/alias-ca.crt");
+        SslContext sslcontext = GrpcSslContexts.forClient()
+                .trustManager(certs)
+                .build();
+        channel = NettyChannelBuilder.forAddress("localhost", 9001)
+                .sslContext(sslcontext)
+                .useTransportSecurity()
+                .build();
+    }
+
+    @AfterEach
+    public void shutdown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testInvokingGrpcServiceUsingTls() {
+        HelloReply reply = GreeterGrpc.newBlockingStub(channel)
+                .sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).isEqualTo("Hello neo");
+    }
+
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithP12KeyStoreAndAliasTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/tls/TlsWithP12KeyStoreAndAliasTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.grpc.server.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.ManagedChannel;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.SslContext;
+import io.quarkus.grpc.server.services.HelloService;
+import io.quarkus.test.QuarkusUnitTest;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "grpc-alias", password = "password", formats = { Format.JKS, Format.PEM,
+                Format.PKCS12 }, client = true, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost"))
+})
+public class TlsWithP12KeyStoreAndAliasTest {
+
+    static String configuration = """
+            quarkus.grpc.server.ssl.key-store=target/certs/grpc-alias-keystore.p12
+            quarkus.grpc.server.ssl.key-store-password=password
+            quarkus.grpc.server.ssl.key-store-alias=alias
+            quarkus.grpc.server.ssl.key-store-alias-password=alias-password
+            quarkus.grpc.server.alpn=true
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addClass(HelloService.class)
+                    .add(new StringAsset(configuration), "application.properties"));
+
+    protected ManagedChannel channel;
+
+    @BeforeEach
+    public void init() throws Exception {
+        File certs = new File("target/certs/alias-ca.crt");
+        SslContext sslcontext = GrpcSslContexts.forClient()
+                .trustManager(certs)
+                .build();
+        channel = NettyChannelBuilder.forAddress("localhost", 9001)
+                .sslContext(sslcontext)
+                .useTransportSecurity()
+                .build();
+    }
+
+    @AfterEach
+    public void shutdown() {
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testInvokingGrpcServiceUsingTls() {
+        HelloReply reply = GreeterGrpc.newBlockingStub(channel)
+                .sayHello(HelloRequest.newBuilder().setName("neo").build());
+        assertThat(reply.getMessage()).isEqualTo("Hello neo");
+    }
+
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcSslUtils.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcSslUtils.java
@@ -80,6 +80,12 @@ public class GrpcSslUtils {
                     if (sslConfig.keyStorePassword.isPresent()) {
                         o.setPassword(sslConfig.keyStorePassword.get());
                     }
+                    if (sslConfig.keyStoreAlias.isPresent()) {
+                        o.setAlias(sslConfig.keyStoreAlias.get());
+                        if (sslConfig.keyStoreAliasPassword.isPresent()) {
+                            o.setAliasPassword(sslConfig.keyStoreAliasPassword.get());
+                        }
+                    }
                     options.setPfxKeyCertOptions(o);
                     break;
                 }
@@ -88,6 +94,12 @@ public class GrpcSslUtils {
                             .setValue(Buffer.buffer(data));
                     if (sslConfig.keyStorePassword.isPresent()) {
                         o.setPassword(sslConfig.keyStorePassword.get());
+                    }
+                    if (sslConfig.keyStoreAlias.isPresent()) {
+                        o.setAlias(sslConfig.keyStoreAlias.get());
+                        if (sslConfig.keyStoreAliasPassword.isPresent()) {
+                            o.setAliasPassword(sslConfig.keyStoreAliasPassword.get());
+                        }
                     }
                     options.setKeyStoreOptions(o);
                     break;

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/SslServerConfig.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/SslServerConfig.java
@@ -43,10 +43,22 @@ public class SslServerConfig {
     public Optional<String> keyStoreType;
 
     /**
-     * A parameter to specify the password of the keystore file. If not given, the default ("password") is used.
+     * A parameter to specify the password of the keystore file.
      */
     @ConfigItem
     public Optional<String> keyStorePassword;
+
+    /**
+     * A parameter to specify the alias of the keystore file.
+     */
+    @ConfigItem
+    public Optional<String> keyStoreAlias;
+
+    /**
+     * A parameter to specify the alias password of the keystore file.
+     */
+    @ConfigItem
+    public Optional<String> keyStoreAliasPassword;
 
     /**
      * An optional trust store which holds the certificate information of the certificates to trust

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksWithAliasTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithJksWithAliasTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.vertx.http.management;
+
+import java.io.File;
+import java.util.function.Consumer;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.assertj.core.api.Assertions;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.restassured.RestAssured;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12,
+        Format.PEM }, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
+public class ManagementWithJksWithAliasTest {
+    private static final String configuration = """
+            quarkus.management.enabled=true
+            quarkus.management.root-path=/management
+            quarkus.management.ssl.certificate.key-store-file=server-keystore.jks
+            quarkus.management.ssl.certificate.key-store-password=secret
+            quarkus.management.ssl.certificate.key-store-alias=alias
+            quarkus.management.ssl.certificate.key-store-alias-password=alias-password
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties")
+                    .addAsResource(new File("target/certs/ssl-management-interface-alias-test-keystore.jks"),
+                            "server-keystore.jks")
+                    .addClasses(MyObserver.class))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        NonApplicationRootPathBuildItem buildItem = context.consume(NonApplicationRootPathBuildItem.class);
+                        context.produce(buildItem.routeBuilder()
+                                .management()
+                                .route("my-route")
+                                .handler(new MyHandler())
+                                .blockingRoute()
+                                .build());
+                    }
+                }).produces(RouteBuildItem.class)
+                        .consumes(NonApplicationRootPathBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    public static class MyHandler implements Handler<RoutingContext> {
+        @Override
+        public void handle(RoutingContext rc) {
+            Assertions.assertThat(rc.request().connection().isSsl()).isTrue();
+            Assertions.assertThat(rc.request().isSSL()).isTrue();
+            Assertions.assertThat(rc.request().connection().sslSession()).isNotNull();
+            rc.response().end("ssl");
+        }
+    }
+
+    @Test
+    public void testSslWithJks() {
+        RestAssured.given()
+                .trustStore(new File("target/certs/ssl-management-interface-alias-test-truststore.jks"), "secret")
+                .get("https://0.0.0.0:9001/management/my-route")
+                .then().statusCode(200).body(Matchers.equalTo("ssl"));
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        void test(@Observes String event) {
+            //Do Nothing
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12WithAliasTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementWithP12WithAliasTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.vertx.http.management;
+
+import java.io.File;
+import java.util.function.Consumer;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.assertj.core.api.Assertions;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.restassured.RestAssured;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-management-interface-alias-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12,
+        Format.PEM }, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
+public class ManagementWithP12WithAliasTest {
+    private static final String configuration = """
+            quarkus.management.enabled=true
+            quarkus.management.root-path=/management
+            quarkus.management.ssl.certificate.key-store-file=server-keystore.p12
+            quarkus.management.ssl.certificate.key-store-password=secret
+            quarkus.management.ssl.certificate.key-store-alias=alias
+            quarkus.management.ssl.certificate.key-store-alias-password=alias-password
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties")
+                    .addAsResource(new File("target/certs/ssl-management-interface-alias-test-keystore.p12"),
+                            "server-keystore.p12")
+                    .addClasses(ManagementWithJksTest.MyObserver.class))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        NonApplicationRootPathBuildItem buildItem = context.consume(NonApplicationRootPathBuildItem.class);
+                        context.produce(buildItem.routeBuilder()
+                                .management()
+                                .route("my-route")
+                                .handler(new MyHandler())
+                                .blockingRoute()
+                                .build());
+                    }
+                }).produces(RouteBuildItem.class)
+                        .consumes(NonApplicationRootPathBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    public static class MyHandler implements Handler<RoutingContext> {
+        @Override
+        public void handle(RoutingContext rc) {
+            Assertions.assertThat(rc.request().connection().isSsl()).isTrue();
+            Assertions.assertThat(rc.request().isSSL()).isTrue();
+            Assertions.assertThat(rc.request().connection().sslSession()).isNotNull();
+            rc.response().end("ssl");
+        }
+    }
+
+    @Test
+    public void testSslWithP12() {
+        RestAssured.given()
+                .trustStore(new File("target/certs/ssl-management-interface-alias-test-truststore.jks"), "secret")
+                .get("https://0.0.0.0:9001/management/my-route")
+                .then().statusCode(200).body(Matchers.equalTo("ssl"));
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        void test(@Observes String event) {
+            //Do Nothing
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithJKSWithSniMatchingSanDNSTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithJKSWithSniMatchingSanDNSTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.vertx.http.ssl;
+
+import java.io.File;
+import java.net.URL;
+import java.security.cert.X509Certificate;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-sni", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com", aliases = {
+                @Alias(name = "alias", cn = "foo.com", subjectAlternativeNames = "DNS:acme.org", password = "secret"),
+                @Alias(name = "alias-2", cn = "bar.biz", subjectAlternativeNames = "DNS:localhost", password = "secret")
+        }))
+public class SslServerWithJKSWithSniMatchingSanDNSTest {
+
+    @TestHTTPResource(value = "/ssl", ssl = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-test-sni-keystore.jks"), "server-keystore.jks"))
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-file", "server-keystore.jks")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-password", "secret")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-alias-password", "secret")
+            .overrideConfigKey("quarkus.http.ssl.sni", "true");
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    public void testSslServerWithJKS() {
+        // Cannot use RESTAssured as it does not validate the certificate names (even when forced.)
+        WebClientOptions options = new WebClientOptions()
+                .setSsl(true)
+                .setTrustOptions(new io.vertx.core.net.JksOptions()
+                        .setPath("target/certs/ssl-test-sni-truststore.jks")
+                        .setPassword("secret"))
+                .setForceSni(true);
+        WebClient client = WebClient.create(vertx, options);
+        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm()).send().toCompletionStage().toCompletableFuture()
+                .join();
+        Assertions.assertThat(response.statusCode()).isEqualTo(200);
+        Assertions.assertThat(response.bodyAsString()).isEqualTo("ssl");
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/ssl").handler(rc -> {
+                Assertions.assertThat(rc.request().connection().isSsl()).isTrue();
+                Assertions.assertThat(rc.request().isSSL()).isTrue();
+                Assertions.assertThat(rc.request().connection().sslSession()).isNotNull();
+
+                try {
+                    X509Certificate certificate = (X509Certificate) rc.request().connection().sslSession()
+                            .getLocalCertificates()[0];
+                    Assertions.assertThat(certificate.getIssuerX500Principal().getName()).isEqualTo("CN=bar.biz");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                rc.response().end("ssl");
+            });
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithJksWithAliasTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithJksWithAliasTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.vertx.http.ssl;
+
+import static org.hamcrest.core.Is.is;
+
+import java.io.File;
+import java.net.URL;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.Router;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-alias", password = "secret", formats = {
+        Format.JKS, Format.PKCS12,
+        Format.PEM }, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
+public class SslServerWithJksWithAliasTest {
+
+    @TestHTTPResource(value = "/ssl", ssl = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-test-alias-keystore.jks"), "server-keystore.jks"))
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-file", "server-keystore.jks")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-alias", "alias")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-password", "secret")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-alias-password", "alias-password");
+
+    @Test
+    public void testSslServerWithJKS() {
+        RestAssured
+                .given()
+                .trustStore(new File("target/certs/ssl-test-alias-truststore.jks"), "secret")
+                .get(url).then().statusCode(200).body(is("ssl"));
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/ssl").handler(rc -> {
+                Assertions.assertThat(rc.request().connection().isSsl()).isTrue();
+                Assertions.assertThat(rc.request().isSSL()).isTrue();
+                Assertions.assertThat(rc.request().connection().sslSession()).isNotNull();
+                rc.response().end("ssl");
+            });
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithP12WithAliasTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithP12WithAliasTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.vertx.http.ssl;
+
+import static org.hamcrest.core.Is.is;
+
+import java.io.File;
+import java.net.URL;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.Router;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-alias", password = "secret", formats = {
+        Format.JKS, Format.PKCS12,
+        Format.PEM }, aliases = @Alias(name = "alias", password = "alias-password", subjectAlternativeNames = "DNS:localhost")))
+public class SslServerWithP12WithAliasTest {
+
+    @TestHTTPResource(value = "/ssl", ssl = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-test-alias-keystore.p12"), "server-keystore.pkcs12"))
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-file", "server-keystore.pkcs12")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-alias", "alias")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-password", "secret")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-alias-password", "alias-password");
+
+    @Test
+    public void testSslServerWithPkcs12() {
+        RestAssured
+                .given()
+                .trustStore(new File("target/certs/ssl-test-alias-truststore.jks"), "secret")
+                .get(url).then().statusCode(200).body(is("ssl"));
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/ssl").handler(rc -> {
+                Assertions.assertThat(rc.request().connection().isSsl()).isTrue();
+                Assertions.assertThat(rc.request().isSSL()).isTrue();
+                Assertions.assertThat(rc.request().connection().sslSession()).isNotNull();
+                rc.response().end("ssl");
+            });
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithP12WithSniMatchingSanDNSTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithP12WithSniMatchingSanDNSTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.vertx.http.ssl;
+
+import java.io.File;
+import java.net.URL;
+import java.security.cert.X509Certificate;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-sni", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com", aliases = {
+                @Alias(name = "alias", cn = "foo.com", subjectAlternativeNames = "DNS:acme.org", password = "secret"),
+                @Alias(name = "alias-2", cn = "bar.biz", subjectAlternativeNames = "DNS:localhost", password = "secret")
+        }))
+public class SslServerWithP12WithSniMatchingSanDNSTest {
+
+    @TestHTTPResource(value = "/ssl", ssl = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("target/certs/ssl-test-sni-keystore.p12"), "server-keystore.pkcs12"))
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-file", "server-keystore.pkcs12")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-password", "secret")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-alias-password", "secret")
+            .overrideConfigKey("quarkus.http.ssl.sni", "true");
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    public void testSslServerWithPkcs12() {
+        // Cannot use RESTAssured as it does not validate the certificate names (even when forced.)
+        WebClientOptions options = new WebClientOptions()
+                .setSsl(true)
+                .setTrustOptions(new io.vertx.core.net.JksOptions()
+                        .setPath("target/certs/ssl-test-sni-truststore.jks")
+                        .setPassword("secret"))
+                .setForceSni(true);
+        WebClient client = WebClient.create(vertx, options);
+        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm()).send().toCompletionStage().toCompletableFuture()
+                .join();
+        Assertions.assertThat(response.statusCode()).isEqualTo(200);
+        Assertions.assertThat(response.bodyAsString()).isEqualTo("ssl");
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/ssl").handler(rc -> {
+                Assertions.assertThat(rc.request().connection().isSsl()).isTrue();
+                Assertions.assertThat(rc.request().isSSL()).isTrue();
+                Assertions.assertThat(rc.request().connection().sslSession()).isNotNull();
+
+                try {
+                    X509Certificate certificate = (X509Certificate) rc.request().connection().sslSession()
+                            .getLocalCertificates()[0];
+                    Assertions.assertThat(certificate.getIssuerX500Principal().getName()).isEqualTo("CN=bar.biz");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                rc.response().end("ssl");
+            });
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithPemWithSniMatchingSanDNSTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithPemWithSniMatchingSanDNSTest.java
@@ -1,0 +1,102 @@
+package io.quarkus.vertx.http.ssl;
+
+import java.io.File;
+import java.net.URL;
+import java.security.cert.X509Certificate;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Alias;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test-sni", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }, cn = "acme.org", subjectAlternativeNames = "DNS:example.com", aliases = {
+                @Alias(name = "alias", cn = "foo.com", subjectAlternativeNames = "DNS:acme.org", password = "secret"),
+                @Alias(name = "alias-2", cn = "bar.biz", subjectAlternativeNames = "DNS:localhost", password = "secret")
+        }))
+public class SslServerWithPemWithSniMatchingSanDNSTest {
+
+    @TestHTTPResource(value = "/ssl", ssl = true)
+    URL url;
+
+    private static final String configuration = """
+            # Enable SSL, configure the key store
+            quarkus.http.ssl.certificate.files=server-cert.pem,alias.crt,alias-2.crt
+            quarkus.http.ssl.certificate.key-files=server-key.pem,alias.key,alias-2.key
+            # Test that server starts with this option
+            # See https://github.com/quarkusio/quarkus/issues/8336
+            quarkus.http.insecure-requests=disabled
+            quarkus.http.ssl.sni=true
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new StringAsset((configuration)), "application.properties")
+                    .addAsResource(new File("target/certs/ssl-test-sni.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-test-sni.crt"), "server-cert.pem")
+                    .addAsResource(new File("target/certs/alias.key"), "alias.key")
+                    .addAsResource(new File("target/certs/alias.crt"), "alias.crt")
+                    .addAsResource(new File("target/certs/alias-2.key"), "alias-2.key")
+                    .addAsResource(new File("target/certs/alias-2.crt"), "alias-2.crt"));
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    public void testSslServerWithPkcs12() {
+        // Cannot use RESTAssured as it does not validate the certificate names (even when forced.)
+        WebClientOptions options = new WebClientOptions()
+                .setSsl(true)
+                .setTrustOptions(new io.vertx.core.net.JksOptions()
+                        .setPath("target/certs/ssl-test-sni-truststore.jks")
+                        .setPassword("secret"))
+                .setForceSni(true);
+        WebClient client = WebClient.create(vertx, options);
+        HttpResponse<Buffer> response = client.getAbs(url.toExternalForm()).send().toCompletionStage().toCompletableFuture()
+                .join();
+        Assertions.assertThat(response.statusCode()).isEqualTo(200);
+        Assertions.assertThat(response.bodyAsString()).isEqualTo("ssl");
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/ssl").handler(rc -> {
+                Assertions.assertThat(rc.request().connection().isSsl()).isTrue();
+                Assertions.assertThat(rc.request().isSSL()).isTrue();
+                Assertions.assertThat(rc.request().connection().sslSession()).isNotNull();
+
+                try {
+                    X509Certificate certificate = (X509Certificate) rc.request().connection().sslSession()
+                            .getLocalCertificates()[0];
+                    Assertions.assertThat(certificate.getIssuerX500Principal().getName()).isEqualTo("CN=bar.biz");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                rc.response().end("ssl");
+            });
+        }
+
+    }
+}

--- a/integration-tests/kafka-ssl/src/test/java/io/quarkus/it/kafka/SslKafkaConsumerTest.java
+++ b/integration-tests/kafka-ssl/src/test/java/io/quarkus/it/kafka/SslKafkaConsumerTest.java
@@ -25,7 +25,7 @@ import me.escoffier.certs.junit5.Certificates;
 
 @Certificates(certificates = {
         @Certificate(name = "kafka", formats = { Format.PKCS12, Format.JKS,
-                Format.PEM }, alias = "kafka-test-store", password = "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L")
+                Format.PEM }, password = "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L")
 }, baseDir = "target/certs")
 @QuarkusTest
 @QuarkusTestResource(KafkaSSLTestResource.class)


### PR DESCRIPTION
This PR focuses on refining the handling of TLS certificates, specifically addressing issues related to aliases and Server Name Indication (SNI).

This PR includes:
- Fixing gRPC TLS server configuration to support aliases and alias passwords properly.
- Verifying gRPC handling of aliases for both clients and servers.
- Ensuring HTTP (main and management) support for aliases.
- Verifying HTTP server SNI support.

One limitation of SNI when using P12 or JKS is that all the aliases must use the same password.