### PR TITLE
Enable gRPC code generation to utilize argument file

### DIFF
--- a/docs/src/main/asciidoc/grpc-generation-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-generation-reference.adoc
@@ -288,3 +288,12 @@ plugins {
 
 IMPORTANT: It is recommended to package the `proto` files in a dependency instead of the generated classes, so Quarkus can generate optimized classes.
 Refer to the <<scan-for-proto, dedicated section>> for more information.
+
+== Argument files
+
+When the `protoc` command line exceeds the maximum command length, you can ask Quarkus to use an argument file to pass the arguments to the `protoc` command.
+
+To enable this feature, set the `quarkus.generate-code.grpc.use-arg-file` property in your `application.properties` file to `true`.
+
+If you are on Windows, and the command line exceeds 8190 characters, Quarkus automatically uses an argument file to pass the arguments to the `protoc` command.
+

--- a/integration-tests/grpc-plain-text-gzip/src/main/resources/application.properties
+++ b/integration-tests/grpc-plain-text-gzip/src/main/resources/application.properties
@@ -12,3 +12,6 @@ quarkus.http.enable-compression=true
 %vertx.quarkus.grpc.clients.hello.port=8081
 %vertx.quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
 %vertx.quarkus.grpc.server.use-separate-server=false
+
+# Force the usage of an arg file
+quarkus.generate-code.grpc.use-arg-file=true


### PR DESCRIPTION
This PR enables the gRPC code generation process to utilize an argument file. This approach helps prevent command length exceeding the operating system limit, particularly on platforms like Windows. This feature is automatically enabled on Windows if the command line exceeds 8191 characters.

- Fixes #38759