### PR TITLE
Fail to deploy application when http and https ports are the same

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -1187,8 +1187,10 @@ public class VertxHttpRecorder {
 
                         if (https) {
                             actualHttpsPort = actualPort;
+                            validateHttpPorts(actualHttpPort, actualHttpsPort);
                         } else {
                             actualHttpPort = actualPort;
+                            validateHttpPorts(actualHttpPort, actualHttpsPort);
                         }
                         if (actualPort != options.getPort()) {
                             // Override quarkus.http(s)?.(test-)?port
@@ -1218,6 +1220,12 @@ public class VertxHttpRecorder {
                             startFuture.complete(null);
                         }
 
+                    }
+                }
+
+                private void validateHttpPorts(int httpPort, int httpsPort) {
+                    if (httpsPort == httpPort) {
+                        throw new IllegalArgumentException("Both http and https servers started on port " + httpPort);
                     }
                 }
             });


### PR DESCRIPTION
Vert.x seems not thrown any exception in this scenario, but it then throws NPEs in either the secure or insecure handling of requests. This behavior is very odd and provides users no good ways of diagnosing the problem

- Closes: #39289