### PR TITLE
Make Hibernate / Micrometer integration run after schema creation

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/metrics/HibernateOrmMetricsProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/metrics/HibernateOrmMetricsProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import java.util.List;
 import java.util.Optional;
 
+import io.quarkus.agroal.spi.JdbcDataSourceSchemaReadyBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -28,6 +29,7 @@ public final class HibernateOrmMetricsProcessor {
     public void metrics(HibernateOrmConfig config,
             HibernateMetricsRecorder metricsRecorder,
             List<PersistenceProviderSetUpBuildItem> persistenceUnitsStarted,
+            List<JdbcDataSourceSchemaReadyBuildItem> jdbcDataSourceSchemaReadyBuildItems,
             Optional<MetricsCapabilityBuildItem> metricsConfiguration,
             BuildProducer<MetricsFactoryConsumerBuildItem> datasourceMetrics) {
 


### PR DESCRIPTION
This is done to ensure that the use of Metrics does not force the creation of `EntityManagerFactory` before extensions like Liquibase or Flyway have had the chance to update the database schema.

- Fixes: #39145