### PR TITLE
Update to Brotli4J 1.16.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -145,7 +145,7 @@
         <infinispan.protostream.version>5.0.0.CR2</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
         <netty.version>4.1.107.Final</netty.version>
-        <brotli4j.version>1.14.0</brotli4j.version>
+        <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>
         <mutiny.version>2.5.8</mutiny.version>

--- a/extensions/netty/runtime/pom.xml
+++ b/extensions/netty/runtime/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>com.aayushatharva.brotli4j</groupId>
             <artifactId>brotli4j</artifactId>
-            <version>1.7.1</version> <!-- TODO Extract this version -->
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This update bump the Brotli4J version to 1.16.0, bringing it in-sync with the version utilized by Netty 4.1.107, which is already in use.

 Furthermore, it aligns with the upcoming update to version 1.16.0 planned for Vert.x 4.5.5.
