### PR TITLE
ArC: fix creation of synthetic beans

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeanBuildItem.java
@@ -193,6 +193,10 @@ public final class SyntheticBeanBuildItem extends MultiBuildItem {
             return qualifiers;
         }
 
+        String getIdentifier() {
+            return identifier;
+        }
+
         Supplier<?> getSupplier() {
             return supplier;
         }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeansProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeansProcessor.java
@@ -94,7 +94,8 @@ public class SyntheticBeansProcessor {
 
     private String createName(ExtendedBeanConfigurator configurator) {
         return configurator.getImplClazz().toString().replace(".", "_") + "_"
-                + HashUtil.sha1(configurator.getTypes().toString() + configurator.getQualifiers().toString());
+                + HashUtil.sha1(configurator.getTypes().toString() + configurator.getQualifiers().toString()
+                        + (configurator.getIdentifier() != null ? configurator.getIdentifier() : ""));
     }
 
     private Consumer<MethodCreator> creator(String name, SyntheticBeanBuildItem bean) {

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/synthetic/SyntheticBeanBuildItemProxyTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/synthetic/SyntheticBeanBuildItemProxyTest.java
@@ -2,7 +2,7 @@ package io.quarkus.arc.test.synthetic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -98,10 +98,20 @@ public class SyntheticBeanBuildItemProxyTest {
     public void testBeans() {
         List<InstanceHandle<SynthBean>> beans = Arc.container().listAll(SynthBean.class);
         assertEquals(2, beans.size());
+        int countOk = 0;
+        int countNok = 0;
         for (InstanceHandle<SynthBean> handle : beans) {
             String val = handle.get().getValue();
-            assertTrue("ok".equals(val) || "nok".equals(val));
+            if ("ok".equals(val)) {
+                countOk++;
+            } else if ("nok".equals(val)) {
+                countNok++;
+            } else {
+                fail("Expected 'ok' or 'nok'");
+            }
         }
+        assertEquals(1, countOk);
+        assertEquals(1, countNok);
     }
 
     @Vetoed


### PR DESCRIPTION
If a synthetic bean creation function is backed by a `Supplier`, `Function`, `RuntimeValue` or a runtime proxy, that creation function is stored into a `Map` during application startup and later retrieved when needed.

The key under which it is stored into the `Map` is wrong, as it only contains the name of the implementation class and a hash of bean types and qualifiers. When there are multiple synthetic beans with the same implementation class, types and qualifiers, only one creation function is used for all of them.

This commit fixes that by including the synthetic bean identifier in the hash, making creation function key unique for each synthetic bean.

Fixes #39310