### PR TITLE
Improve documentation for AMQP client options about setting a heartbeat

### DIFF
--- a/docs/src/main/asciidoc/amqp-reference.adoc
+++ b/docs/src/main/asciidoc/amqp-reference.adoc
@@ -463,6 +463,21 @@ You need to indicate the name of the client using the `client-options-name` attr
 mp.messaging.incoming.prices.client-options-name=my-named-options
 ----
 
+If you experience frequent disconnections from the broker, the `AmqpClientOptions` can also be used to set a heartbeat if you need to keep the AMQP connection permanently.
+Some brokers might terminate the AMQP connection after a certain idle timeout. 
+You can provide a heartbeat value which will be used by the Vert.x proton client to advertise the idle timeout when opening transport to a remote peer.
+
+[source, java]
+----
+@Produces
+@Identifier("my-named-options")
+public AmqpClientOptions getNamedOptions() {
+  // set a heartbeat of 30s (in milliseconds)
+  return new AmqpClientOptions()
+        .setHeartbeat(30000);
+}
+----
+
 == Health reporting
 
 If you use the AMQP connector with the `quarkus-smallrye-health` extension, it contributes to the readiness and liveness probes.


### PR DESCRIPTION
After some discussion about how to remediate to frequent disconnections from some AMQP brokers. We decided to add some details about it to the doc, on how this could be done with setting a heartbeat when customizing the underlying AMQP client. 

Discussion: https://github.com/quarkusio/quarkus/discussions/39365