### PR TITLE
Core: fail if null is produced for a SimpleBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -496,7 +496,14 @@ public final class ExtensionLoader {
                         final Class<? extends SimpleBuildItem> buildItemClass = parameterClass
                                 .asSubclass(SimpleBuildItem.class);
                         methodStepConfig = methodStepConfig.andThen(bsb -> bsb.consumes(buildItemClass));
-                        methodParamFns.add((bc, bri) -> bc.consume(buildItemClass));
+                        methodParamFns.add((bc, bri) -> {
+                            SimpleBuildItem bi = bc.consume(buildItemClass);
+                            if (bi == null) {
+                                throw reportError(parameter,
+                                        "Cannot consume 'null' build item, use java.util.Optional build step method parameter instead");
+                            }
+                            return bi;
+                        });
                     } else if (isAnEmptyBuildItemConsumer(parameterType)) {
                         throw reportError(parameter,
                                 "Cannot consume an empty build item, use @Consume(class) on the build step method instead");

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -82,7 +82,6 @@ import io.quarkus.deployment.console.SetCompleter;
 import io.quarkus.deployment.dev.ExceptionNotificationBuildItem;
 import io.quarkus.deployment.dev.testing.MessageFormat;
 import io.quarkus.deployment.dev.testing.TestSetupBuildItem;
-import io.quarkus.deployment.ide.EffectiveIdeBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.metrics.MetricsFactoryConsumerBuildItem;
 import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
@@ -367,7 +366,7 @@ public final class LoggingResourceProcessor {
     @Produce(TestSetupBuildItem.class)
     @Produce(LogConsoleFormatBuildItem.class)
     @Consume(ConsoleInstalledBuildItem.class)
-    void setupStackTraceFormatter(ApplicationArchivesBuildItem item, EffectiveIdeBuildItem ideSupport,
+    void setupStackTraceFormatter(ApplicationArchivesBuildItem item,
             BuildSystemTargetBuildItem buildSystemTargetBuildItem,
             List<ExceptionNotificationBuildItem> exceptionNotificationBuildItems,
             CuratedApplicationShutdownBuildItem curatedApplicationShutdownBuildItem) {


### PR DESCRIPTION
- to avoid unexpected NullPointerException
- build steps should consume java.util.Optional instead
- follow-up to https://github.com/quarkusio/quarkus/issues/39408