### PR TITLE
Exclude org.graalvm.polyglot:polyglot from graal-sdk

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4428,10 +4428,22 @@
                 <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>${jakarta.ws.rs-api.version}</version>
             </dependency>
+            <!-- graal-sdk should be avoided, keeping it temporarily for compatibility reasons -->
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>
                 <artifactId>graal-sdk</artifactId>
                 <version>${graal-sdk.version}</version>
+                <!--
+                  This is used as a workaround to avoid having polyglot in the classpath when graal-sdk is added.
+                  Polyglot wasn't around until now with the old graal-sdk so it should be relatively safe
+                  until we drop graal-sdk entirely from the BOM.
+                -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.graalvm.polyglot</groupId>
+                        <artifactId>polyglot</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1019,6 +1019,14 @@ public class JarResultBuildStep {
             removedArtifacts.add("org.graalvm.sdk:word");
             removedArtifacts.add("org.graalvm.sdk:collections");
 
+            // complain if graal-sdk is present as a dependency as nativeimage should be preferred
+            if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream()
+                    .anyMatch(d -> d.getGroupId().equals("org.graalvm.sdk") && d.getArtifactId().equals("graal-sdk"))) {
+                log.warn("org.graalvm.sdk:graal-sdk is present in the classpath. "
+                        + "From Quarkus 3.8 and onwards, org.graalvm.sdk:nativeimage should be preferred. "
+                        + "Make sure you report the issue to the maintainers of the extensions that bring it.");
+            }
+
             doLegacyThinJarGeneration(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
                     applicationArchivesBuildItem, applicationInfo, packageConfig, generatedResources, libDir, allClasses,
                     runnerZipFs, mainClassBuildItem, classLoadingConfig);


### PR DESCRIPTION
graal-sdk now brings polyglot with it which creates issues.
We now rely on nativeimage for substitutions annotations but external
extensions might still rely on graal-sdk.
We make sure relying on graal-sdk don't bring polyglot.

Fixes https://github.com/quarkusio/quarkus/issues/39440

Also I added a warning.

/cc @jerboaa too