### PR TITLE
Use Quarkus wide version of jna-platform in azure-functions

### DIFF
--- a/extensions/azure-functions/deployment/pom.xml
+++ b/extensions/azure-functions/deployment/pom.xml
@@ -78,7 +78,6 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
-            <version>5.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>


### PR DESCRIPTION
As jna-platform version is deffined in bom, this extension should probably use same version as other.

If you disagree feel free to close this PR! 