### PR TITLE
Save regexp Pattern allocation on config name renaming

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/util/StringUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/StringUtil.java
@@ -13,6 +13,20 @@ public final class StringUtil {
     private StringUtil() {
     }
 
+    public static String changePrefix(String name, String oldPrefix, String newPrefix) {
+        if (!name.startsWith(oldPrefix)) {
+            return name;
+        }
+        // don't use here String::replaceFirst because it uses regex
+        final int oldLen = oldPrefix.length();
+        final int diff = newPrefix.length() - oldLen;
+        final int nameLen = name.length();
+        final var builder = new StringBuilder(nameLen + diff);
+        builder.append(newPrefix);
+        builder.append(name, oldLen, nameLen);
+        return builder.toString();
+    }
+
     public static Iterator<String> camelHumpsIterator(String str) {
         return new Iterator<String>() {
             int idx;

--- a/core/runtime/src/test/java/io/quarkus/runtime/util/StringUtilTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/util/StringUtilTestCase.java
@@ -98,4 +98,12 @@ public class StringUtilTestCase {
         result = join(withoutSuffix(lowerCase(camelHumpsIterator("SomeRootClass")), "config", "class"));
         assertEquals("someroot", result);
     }
+
+    @Test
+    public void testChangePrefix() {
+        assertEquals("quarkus.new-prefix.configuration-property", StringUtil
+                .changePrefix("quarkus.old-prefix.configuration-property", "quarkus.old-prefix.", "quarkus.new-prefix."));
+        assertEquals("quarkus.other-prefix.configuration-property", StringUtil
+                .changePrefix("quarkus.other-prefix.configuration-property", "quarkus.old-prefix.", "quarkus.new-prefix."));
+    }
 }

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/OidcClientFilterConfigFallbackInterceptor.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/OidcClientFilterConfigFallbackInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.oidc.client.filter.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class OidcClientFilterConfigFallbackInterceptor extends FallbackConfigSou
 
     private static final String OLD_PREFIX = "quarkus.oidc-client-filter.";
     private static final String NEW_PREFIX = "quarkus.resteasy-client-oidc-filter.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, NEW_PREFIX, OLD_PREFIX);
+        }
+    };
 
     public OidcClientFilterConfigFallbackInterceptor() {
-        super(OidcClientFilterConfigFallbackInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(NEW_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(NEW_PREFIX, OLD_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/OidcClientFilterConfigRelocateInterceptor.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/OidcClientFilterConfigRelocateInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.oidc.client.filter.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class OidcClientFilterConfigRelocateInterceptor extends RelocateConfigSou
 
     private static final String OLD_PREFIX = "quarkus.oidc-client-filter.";
     private static final String NEW_PREFIX = "quarkus.resteasy-client-oidc-filter.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, OLD_PREFIX, NEW_PREFIX);
+        }
+    };
 
     public OidcClientFilterConfigRelocateInterceptor() {
-        super(OidcClientFilterConfigRelocateInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(OLD_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(OLD_PREFIX, NEW_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/OidcClientReactiveFilterConfigFallbackInterceptor.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/OidcClientReactiveFilterConfigFallbackInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.oidc.client.reactive.filter.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class OidcClientReactiveFilterConfigFallbackInterceptor extends FallbackC
 
     private static final String OLD_PREFIX = "quarkus.oidc-client-reactive-filter.";
     private static final String NEW_PREFIX = "quarkus.rest-client-oidc-filter.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, NEW_PREFIX, OLD_PREFIX);
+        }
+    };
 
     public OidcClientReactiveFilterConfigFallbackInterceptor() {
-        super(OidcClientReactiveFilterConfigFallbackInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(NEW_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(NEW_PREFIX, OLD_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/OidcClientReactiveFilterConfigRelocateInterceptor.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/OidcClientReactiveFilterConfigRelocateInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.oidc.client.reactive.filter.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class OidcClientReactiveFilterConfigRelocateInterceptor extends RelocateC
 
     private static final String OLD_PREFIX = "quarkus.oidc-client-reactive-filter.";
     private static final String NEW_PREFIX = "quarkus.rest-client-oidc-filter.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, OLD_PREFIX, NEW_PREFIX);
+        }
+    };
 
     public OidcClientReactiveFilterConfigRelocateInterceptor() {
-        super(OidcClientReactiveFilterConfigRelocateInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(OLD_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(OLD_PREFIX, NEW_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveConfigFallbackInterceptor.java
+++ b/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveConfigFallbackInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.oidc.token.propagation.reactive;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class OidcTokenPropagationReactiveConfigFallbackInterceptor extends Fallb
 
     private static final String OLD_PREFIX = "quarkus.oidc-token-propagation.";
     private static final String NEW_PREFIX = "quarkus.rest-client-oidc-token-propagation.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, NEW_PREFIX, OLD_PREFIX);
+        }
+    };
 
     public OidcTokenPropagationReactiveConfigFallbackInterceptor() {
-        super(OidcTokenPropagationReactiveConfigFallbackInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(NEW_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(NEW_PREFIX, OLD_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveConfigRelocateInterceptor.java
+++ b/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveConfigRelocateInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.oidc.token.propagation.reactive;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class OidcTokenPropagationReactiveConfigRelocateInterceptor extends Reloc
 
     private static final String OLD_PREFIX = "quarkus.oidc-token-propagation.";
     private static final String NEW_PREFIX = "quarkus.rest-client-oidc-token-propagation.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, OLD_PREFIX, NEW_PREFIX);
+        }
+    };
 
     public OidcTokenPropagationReactiveConfigRelocateInterceptor() {
-        super(OidcTokenPropagationReactiveConfigRelocateInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(OLD_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(OLD_PREFIX, NEW_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/runtime/OidcTokenPropagationConfigFallbackInterceptor.java
+++ b/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/runtime/OidcTokenPropagationConfigFallbackInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.oidc.token.propagation.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class OidcTokenPropagationConfigFallbackInterceptor extends FallbackConfi
 
     private static final String OLD_PREFIX = "quarkus.oidc-token-propagation.";
     private static final String NEW_PREFIX = "quarkus.resteasy-client-oidc-token-propagation.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, NEW_PREFIX, OLD_PREFIX);
+        }
+    };
 
     public OidcTokenPropagationConfigFallbackInterceptor() {
-        super(OidcTokenPropagationConfigFallbackInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(NEW_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(NEW_PREFIX, OLD_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/runtime/OidcTokenPropagationConfigRelocateInterceptor.java
+++ b/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/runtime/OidcTokenPropagationConfigRelocateInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.oidc.token.propagation.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class OidcTokenPropagationConfigRelocateInterceptor extends RelocateConfi
 
     private static final String OLD_PREFIX = "quarkus.oidc-token-propagation.";
     private static final String NEW_PREFIX = "quarkus.resteasy-client-oidc-token-propagation.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, OLD_PREFIX, NEW_PREFIX);
+        }
+    };
 
     public OidcTokenPropagationConfigRelocateInterceptor() {
-        super(OidcTokenPropagationConfigRelocateInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(OLD_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(OLD_PREFIX, NEW_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfigFallbackInterceptor.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfigFallbackInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.rest.client.reactive.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class RestClientReactiveConfigFallbackInterceptor extends FallbackConfigS
 
     private static final String OLD_PREFIX = "quarkus.rest-client-reactive.";
     private static final String NEW_PREFIX = "quarkus.rest-client.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, NEW_PREFIX, OLD_PREFIX);
+        }
+    };
 
     public RestClientReactiveConfigFallbackInterceptor() {
-        super(RestClientReactiveConfigFallbackInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(NEW_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(NEW_PREFIX, OLD_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfigRelocateInterceptor.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfigRelocateInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.rest.client.reactive.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,15 @@ public class RestClientReactiveConfigRelocateInterceptor extends RelocateConfigS
 
     private static final String OLD_PREFIX = "quarkus.rest-client-reactive.";
     private static final String NEW_PREFIX = "quarkus.rest-client.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, OLD_PREFIX, NEW_PREFIX);
+        }
+    };
 
     public RestClientReactiveConfigRelocateInterceptor() {
-        super(RestClientReactiveConfigRelocateInterceptor::rename);
+        super(RENAME_FUNCTION);
     }
 
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(OLD_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(OLD_PREFIX, NEW_PREFIX);
-    }
 }

--- a/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfigFallbackInterceptor.java
+++ b/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfigFallbackInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.resteasy.reactive.common.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,15 @@ public class ResteasyReactiveConfigFallbackInterceptor extends FallbackConfigSou
 
     private static final String OLD_PREFIX = "quarkus.resteasy-reactive.";
     private static final String NEW_PREFIX = "quarkus.rest.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, NEW_PREFIX, OLD_PREFIX);
+        }
+    };
 
     public ResteasyReactiveConfigFallbackInterceptor() {
-        super(ResteasyReactiveConfigFallbackInterceptor::rename);
+        super(RENAME_FUNCTION);
     }
 
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(NEW_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(NEW_PREFIX, OLD_PREFIX);
-    }
 }

--- a/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfigRelocateInterceptor.java
+++ b/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfigRelocateInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.resteasy.reactive.common.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class ResteasyReactiveConfigRelocateInterceptor extends RelocateConfigSou
 
     private static final String OLD_PREFIX = "quarkus.resteasy-reactive.";
     private static final String NEW_PREFIX = "quarkus.rest.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, OLD_PREFIX, NEW_PREFIX);
+        }
+    };
 
     public ResteasyReactiveConfigRelocateInterceptor() {
-        super(ResteasyReactiveConfigRelocateInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(OLD_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(OLD_PREFIX, NEW_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfigFallbackInterceptor.java
+++ b/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfigFallbackInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.csrf.reactive.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,15 @@ public class CsrfReactiveConfigFallbackInterceptor extends FallbackConfigSourceI
 
     private static final String OLD_PREFIX = "quarkus.csrf-reactive.";
     private static final String NEW_PREFIX = "quarkus.rest-csrf.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, NEW_PREFIX, OLD_PREFIX);
+        }
+    };
 
     public CsrfReactiveConfigFallbackInterceptor() {
-        super(CsrfReactiveConfigFallbackInterceptor::rename);
+        super(RENAME_FUNCTION);
     }
 
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(NEW_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(NEW_PREFIX, OLD_PREFIX);
-    }
 }

--- a/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfigRelocateInterceptor.java
+++ b/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfigRelocateInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.csrf.reactive.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class CsrfReactiveConfigRelocateInterceptor extends RelocateConfigSourceI
 
     private static final String OLD_PREFIX = "quarkus.csrf-reactive.";
     private static final String NEW_PREFIX = "quarkus.rest-csrf.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, OLD_PREFIX, NEW_PREFIX);
+        }
+    };
 
     public CsrfReactiveConfigRelocateInterceptor() {
-        super(CsrfReactiveConfigRelocateInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(OLD_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(OLD_PREFIX, NEW_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingConfigFallbackInterceptor.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingConfigFallbackInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.smallrye.reactivemessaging.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class ReactiveMessagingConfigFallbackInterceptor extends FallbackConfigSo
 
     private static final String OLD_PREFIX = "quarkus.reactive-messaging.";
     private static final String NEW_PREFIX = "quarkus.messaging.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, NEW_PREFIX, OLD_PREFIX);
+        }
+    };
 
     public ReactiveMessagingConfigFallbackInterceptor() {
-        super(ReactiveMessagingConfigFallbackInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(NEW_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(NEW_PREFIX, OLD_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingConfigRelocateInterceptor.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingConfigRelocateInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.smallrye.reactivemessaging.runtime;
 
+import java.util.function.Function;
+
+import io.quarkus.runtime.util.StringUtil;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 
 /**
@@ -10,16 +13,14 @@ public class ReactiveMessagingConfigRelocateInterceptor extends RelocateConfigSo
 
     private static final String OLD_PREFIX = "quarkus.reactive-messaging.";
     private static final String NEW_PREFIX = "quarkus.messaging.";
+    private static final Function<String, String> RENAME_FUNCTION = new Function<String, String>() {
+        @Override
+        public String apply(String s) {
+            return StringUtil.changePrefix(s, OLD_PREFIX, NEW_PREFIX);
+        }
+    };
 
     public ReactiveMessagingConfigRelocateInterceptor() {
-        super(ReactiveMessagingConfigRelocateInterceptor::rename);
-    }
-
-    private static String rename(String originalName) {
-        if (!originalName.startsWith(OLD_PREFIX)) {
-            return originalName;
-        }
-
-        return originalName.replaceFirst(OLD_PREFIX, NEW_PREFIX);
+        super(RENAME_FUNCTION);
     }
 }


### PR DESCRIPTION
This is addressing a small regression in case some old names are used, saving allocating (for each replacement) a whole new regexp `Pattern` and creating a reusable function which does it "right" if compared to `String:.replaceFirst`.

I've than removed the method reference lambda generation to match what we do elsewhere, but I have not a strong opinion here, considered that it mostly affect RSS footprint while the application doesn't do anything interesting (sadly a case still valuable in public benchmarks :/ ) - see https://github.com/quarkusio/quarkus/issues/36204#issuecomment-1752989061  for more info at `java/lang/invoke/LambdaForm.compileToBytecode`.
In JDK 21 it's likely lambdas RSS footprint is reduced and who knows for later releases, so, as said, I've performed the change here, but I could have made the interceptors to implements `Function<String, String` and just pass `this` to their `super` constructor too, not getting lambdas nor anonymous class loaded, at all.