### PR TITLE
Save concat indy allocations on JarResource::getResourceURL

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -114,12 +114,25 @@ public class JarResource implements ClassLoadingResource {
                 // first create a URI which includes both the jar file path and the relative resource name
                 // and then invoke a toURL on it. The URI reconstruction allows for any encoding to be done
                 // for the "path" which includes the "realName"
-                final URL resUrl = new URI(jarUri.getScheme(), jarUri.getPath() + "!/" + realName, null).toURL();
+                var ssp = new StringBuilder(jarUri.getPath().length() + realName.length() + 2);
+                ssp.append(jarUri.getPath());
+                ssp.append("!/");
+                ssp.append(realName);
+                final URL resUrl = new URI(jarUri.getScheme(), ssp.toString(), null).toURL();
                 // wrap it up into a "jar" protocol URL
                 //horrible hack to deal with '?' characters in the URL
                 //seems to be the only way, the URI constructor just does not let you handle them in a sane way
-                return new URL("jar", null, resUrl.getProtocol() + ':' + resUrl.getPath()
-                        + (resUrl.getQuery() == null ? "" : ("%3F" + resUrl.getQuery())));
+                var file = new StringBuilder((resUrl.getProtocol() == null ? 4 : resUrl.getProtocol().length()) + 1 +
+                        resUrl.getPath().length() + (resUrl.getQuery() == null ? 0 : 3 + resUrl.getQuery().length()));
+                // protocol shouldn't be null, but let's be safe
+                file.append(resUrl.getProtocol());
+                file.append(':');
+                file.append(resUrl.getPath());
+                if (resUrl.getQuery() != null) {
+                    file.append("%3F");
+                    file.append(resUrl.getQuery());
+                }
+                return new URL("jar", null, file.toString());
             } catch (MalformedURLException | URISyntaxException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
This is still related analysis of getting-started startup allocations, in violet

![image](https://github.com/quarkusio/quarkus/assets/13125299/f44d707d-d25d-4474-aaba-be919b5b65f4)

which is ~8% of the overall allocations on `Config` static construction which is ~500K (half MB!) on the heap, and likely not less off-heap too.

As said: code here is slightly less maintainable and will likely be slightly slower at runtime (on the getting started that code path happen just 8 times, or less) - although making such to compile an indy bytecode just for few invocations seems a waste, that's why i've sent this PR.

