### PR TITLE
Add key listeners to the log in Dev UI

### DIFF
--- a/bom/dev-ui/pom.xml
+++ b/bom/dev-ui/pom.xml
@@ -13,7 +13,7 @@
     <description>Dependency management for dev-ui. Importable by third party extension developers.</description>
 
     <properties>
-        <vaadin.version>24.3.7</vaadin.version>
+        <vaadin.version>24.3.8</vaadin.version>
         <lit.version>3.1.2</lit.version>
         <lit-element.version>4.0.4</lit-element.version>
         <lit-html.version>3.1.2</lit-html.version>

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/DevConsoleManager.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/DevConsoleManager.java
@@ -123,6 +123,17 @@ public class DevConsoleManager {
      * Invokes a registered action
      *
      * @param name the name of the action
+     * @return the result of the invocation. An empty map is returned for action not returning any result.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T invoke(String name) {
+        return DevConsoleManager.invoke(name, Map.of());
+    }
+
+    /**
+     * Invokes a registered action
+     *
+     * @param name the name of the action
      * @param params the named parameters
      * @return the result of the invocation. An empty map is returned for action not returning any result.
      */

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -102,6 +102,7 @@ public class BuildTimeContentProcessor {
         internalImportMapBuildItem.add("qwc/", contextRoot + "qwc/");
         internalImportMapBuildItem.add("qwc-no-data", contextRoot + "qwc/qwc-no-data.js");
         internalImportMapBuildItem.add("qwc-hot-reload-element", contextRoot + "qwc/qwc-hot-reload-element.js");
+        internalImportMapBuildItem.add("qwc-abstract-log-element", contextRoot + "qwc/qwc-abstract-log-element.js");
         internalImportMapBuildItem.add("qwc-server-log", contextRoot + "qwc/qwc-server-log.js");
         internalImportMapBuildItem.add("qwc-extension-link", contextRoot + "qwc/qwc-extension-link.js");
         // Quarkus UI

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.devui.deployment.logstream;
 
+import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -8,7 +9,12 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.StreamingLogHandlerBuildItem;
+import io.quarkus.deployment.dev.RuntimeUpdatesProcessor;
+import io.quarkus.deployment.dev.testing.TestSupport;
+import io.quarkus.dev.console.DevConsoleManager;
+import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.devui.runtime.logstream.LogStreamBroadcaster;
 import io.quarkus.devui.runtime.logstream.LogStreamJsonRPCService;
 import io.quarkus.devui.runtime.logstream.LogStreamRecorder;
@@ -38,8 +44,97 @@ public class LogStreamProcessor {
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    JsonRPCProvidersBuildItem createJsonRPCService() {
+    JsonRPCProvidersBuildItem createJsonRPCService(LaunchModeBuildItem launchModeBuildItem) {
+        Optional<TestSupport> ts = TestSupport.instance();
+
+        DevConsoleManager.register("logstream-force-restart", ignored -> {
+            RuntimeUpdatesProcessor.INSTANCE.doScan(true, true);
+            return Map.of();
+        });
+
+        DevConsoleManager.register("logstream-rerun-all-tests", ignored -> {
+            if (testsDisabled(launchModeBuildItem, ts)) {
+                return Map.of();
+            }
+            if (ts.get().isStarted()) {
+                ts.get().runAllTests();
+                return Map.of();
+            } else {
+                ts.get().start();
+                return Map.of("running", ts.get().isRunning());
+            }
+        });
+
+        DevConsoleManager.register("logstream-rerun-failed-tests", ignored -> {
+            if (testsDisabled(launchModeBuildItem, ts)) {
+                return Map.of();
+            }
+            ts.get().runFailedTests();
+            return Map.of();
+        });
+
+        DevConsoleManager.register("logstream-toggle-broken-only", ignored -> {
+            if (testsDisabled(launchModeBuildItem, ts)) {
+                return Map.of();
+            }
+            boolean brokenOnlyMode = ts.get().toggleBrokenOnlyMode();
+            return Map.of("brokenOnlyMode", brokenOnlyMode);
+        });
+
+        DevConsoleManager.register("logstream-print-failures", ignored -> {
+            if (testsDisabled(launchModeBuildItem, ts)) {
+                return Map.of();
+            }
+            ts.get().printFullResults();
+            return Map.of();
+        });
+
+        DevConsoleManager.register("logstream-toggle-test-output", ignored -> {
+            if (testsDisabled(launchModeBuildItem, ts)) {
+                return Map.of();
+            }
+            boolean isTestOutput = ts.get().toggleTestOutput();
+            return Map.of("isTestOutput", isTestOutput);
+        });
+
+        DevConsoleManager.register("logstream-toggle-instrumentation-reload", ignored -> {
+            boolean instrumentationEnabled = RuntimeUpdatesProcessor.INSTANCE.toggleInstrumentation();
+            return Map.of("instrumentationEnabled", instrumentationEnabled);
+        });
+
+        DevConsoleManager.register("logstream-pause-tests", ignored -> {
+            if (testsDisabled(launchModeBuildItem, ts)) {
+                return Map.of();
+            }
+            if (ts.get().isStarted()) {
+                ts.get().stop();
+                return Map.of("running", ts.get().isRunning());
+            }
+            return Map.of();
+        });
+
+        DevConsoleManager.register("logstream-toggle-live-reload", ignored -> {
+            if (testsDisabled(launchModeBuildItem, ts)) {
+                return Map.of();
+            }
+            boolean liveReloadEnabled = ts.get().toggleLiveReloadEnabled();
+            return Map.of("liveReloadEnabled", liveReloadEnabled);
+        });
+
+        DevConsoleManager.register("logstream-toggle-live-reload", ignored -> {
+
+            if (testsDisabled(launchModeBuildItem, ts)) {
+                return Map.of();
+            }
+            boolean liveReloadEnabled = ts.get().toggleLiveReloadEnabled();
+            return Map.of("liveReloadEnabled", liveReloadEnabled);
+        });
+
         return new JsonRPCProvidersBuildItem("devui-logstream", LogStreamJsonRPCService.class);
+    }
+
+    private boolean testsDisabled(LaunchModeBuildItem launchModeBuildItem, Optional<TestSupport> ts) {
+        return ts.isEmpty() || launchModeBuildItem.getDevModeType().orElse(null) != DevModeType.LOCAL;
     }
 
 }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/log-controller.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/log-controller.js
@@ -57,7 +57,7 @@ export class LogController {
     }
 
     _createItem(icon, title, color) {
-        var style = `font-size: small;cursor: pointer;color: ${color};`;
+        var style = `font-size: small;cursor: pointer;color: ${color};background-color: transparent;`;
         const item = document.createElement('vaadin-context-menu-item');
         const vaadinicon = document.createElement('vaadin-icon');
         item.setAttribute('aria-label', `${title}`);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-abstract-log-element.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-abstract-log-element.js
@@ -1,0 +1,54 @@
+import { QwcHotReloadElement, html, css} from 'qwc-hot-reload-element';
+export * from 'lit';
+
+/**
+ * This is an abstract component that handle some common event for logs
+ */
+class QwcAbstractLogElement extends QwcHotReloadElement {
+    
+    constructor() {
+        super();
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.setAttribute('tabindex', '0');
+        this.bindKeyHandler = this._handleKeyPress.bind(this);
+        this.bindScrollHandler = this._handleScroll.bind(this);
+        this.addEventListener('keydown', this.bindKeyHandler);
+        this.addEventListener('wheel', this.bindScrollHandler, { passive: false });
+    }
+      
+    disconnectedCallback() {
+        this.removeEventListener('keydown', this.bindKeyHandler);
+        this.removeEventListener('wheel', this.bindScrollHandler);
+        super.disconnectedCallback();
+    }
+
+    _handleScroll(event){
+        if (event.ctrlKey) {
+            // Prevent the default zoom action when Ctrl + scroll is detected
+            event.preventDefault();
+            if (event.deltaY < 0) {
+              this._handleZoomIn(event);
+            } else if (event.deltaY > 0) {
+              this._handleZoomOut(event);
+            }
+          }
+    }
+    
+    _handleKeyPress(event) {
+        throw new Error("Method '_handleKeyPress(event)' must be implemented.");
+    }
+    
+    _handleZoomIn(event){
+        throw new Error("Method '_handleZoomIn(event)' must be implemented.");
+    }
+    
+    _handleZoomOut(event){
+        throw new Error("Method '_handleZoomOut(event)' must be implemented.");
+    }
+
+}
+
+export { QwcAbstractLogElement };

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer.js
@@ -101,9 +101,13 @@ export class QwcFooter extends observeState(LitElement) {
         } 
         
         vaadin-menu-bar-button {
-            background: var(--lumo-contrast-5pct);
+            background-color: transparent;
         }
         
+        vaadin-menu-bar-button:hover {
+            background-color: transparent;
+        }
+    
         .dragOpen:hover {
             background: var(--quarkus-blue);
         }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-jsonrpc-messages.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-jsonrpc-messages.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css} from 'lit';
+import { QwcAbstractLogElement, html, css} from 'qwc-abstract-log-element';
 import { repeat } from 'lit/directives/repeat.js';
 import { LogController } from 'log-controller';
 import { StorageController } from 'storage-controller';
@@ -6,7 +6,7 @@ import { StorageController } from 'storage-controller';
 /**
  * This component represent the Dev UI Json RPC Message log
  */
-export class QwcJsonrpcMessages extends LitElement {
+export class QwcJsonrpcMessages extends QwcAbstractLogElement {
     
     logControl = new LogController(this);
     storageControl = new StorageController(this);
@@ -44,7 +44,7 @@ export class QwcJsonrpcMessages extends LitElement {
         _zoom: {state:true},
         _increment: {state: false},
         _followLog: {state: false},
-        _isOn: {state: false},
+        _isOn: {state: false}
     };
     
     constructor() {
@@ -83,8 +83,8 @@ export class QwcJsonrpcMessages extends LitElement {
     }
     
     disconnectedCallback() {
-        super.disconnectedCallback();
         this._toggleOnOff(false);
+        super.disconnectedCallback();
     }
     
     render() {
@@ -106,6 +106,8 @@ export class QwcJsonrpcMessages extends LitElement {
     _renderLogEntry(message){
         if(message.isLine){
             return html`<hr class="line"/>`;
+        }else if(message.isBlank){
+            return html`<br/>`;
         }else{
             return html`
                 ${this._renderTimestamp(message.time)}
@@ -201,6 +203,30 @@ export class QwcJsonrpcMessages extends LitElement {
     _zoomIn(){
         this._zoom = parseFloat(parseFloat(this._zoom) + parseFloat(this._increment)).toFixed(2);
     }
+    
+    hotReload(){
+        
+    }
+    
+    _handleZoomIn(event){
+        this._zoomIn();
+    }
+    
+    _handleZoomOut(event){
+        this._zoomOut();
+    }
+    
+    _handleKeyPress(event) {
+        if (event.key === 'Enter') {
+            // Create a blank line in the console.
+            var blankEntry = new Object();
+            blankEntry.id = Math.floor(Math.random() * 999999);
+            blankEntry.isBlank = true;
+            this._addLogEntry(blankEntry);
+        }
+    }
+    
+    
 }
 
 customElements.define('qwc-jsonrpc-messages', QwcJsonrpcMessages);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamJsonRPCService.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamJsonRPCService.java
@@ -3,6 +3,7 @@ package io.quarkus.devui.runtime.logstream;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
 
@@ -10,6 +11,7 @@ import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.Logger;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.dev.console.DevConsoleManager;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
 import io.vertx.core.json.JsonObject;
@@ -23,6 +25,51 @@ public class LogStreamJsonRPCService {
     @NonBlocking
     public String ping() {
         return "pong";
+    }
+
+    @NonBlocking
+    public Map forceRestart() {
+        return DevConsoleManager.invoke("logstream-force-restart");
+    }
+
+    @NonBlocking
+    public Map rerunAllTests() {
+        return DevConsoleManager.invoke("logstream-rerun-all-tests");
+    }
+
+    @NonBlocking
+    public Map rerunFailedTests() {
+        return DevConsoleManager.invoke("logstream-rerun-failed-tests");
+    }
+
+    @NonBlocking
+    public Map toggleBrokenOnly() {
+        return DevConsoleManager.invoke("logstream-toggle-broken-only");
+    }
+
+    @NonBlocking
+    public Map printFailures() {
+        return DevConsoleManager.invoke("logstream-print-failures");
+    }
+
+    @NonBlocking
+    public Map toggleTestOutput() {
+        return DevConsoleManager.invoke("logstream-toggle-test-output");
+    }
+
+    @NonBlocking
+    public Map toggleInstrumentationReload() {
+        return DevConsoleManager.invoke("logstream-toggle-instrumentation-reload");
+    }
+
+    @NonBlocking
+    public Map pauseTests() {
+        return DevConsoleManager.invoke("logstream-pause-tests");
+    }
+
+    @NonBlocking
+    public Map toggleLiveReload() {
+        return DevConsoleManager.invoke("logstream-toggle-live-reload");
     }
 
     @NonBlocking


### PR DESCRIPTION
Fix #37875

This PR add support for keystrokes in the Dev UI Logs. 

- `Enter` will add a blank line, allowing you to add space in a log
- `Ctrl` + `Mouse wheel up` will zoom in
- `Ctrl` + `Mouse wheel down` will zoom out

Then a subset of the keys as in the Quarkus log is supported:

- [r] - Resume testing / Re-run all tests
- [f] - Re-run failed tests
- [b] - Toggle 'broken only' mode, where only failing tests are run
- [v] - Print failures from the last test run
- [p] - Pause tests
- [o] - Toggle test output
- [s] - Force restart
- [i] - Toggle instrumentation based reload
- [l] - Toggle live reload
- [h] - Show the help

![keysindevui](https://github.com/quarkusio/quarkus/assets/6836179/abcc2b7f-7cf3-43df-b280-b3248df5e4c9)
