### PR TITLE
Fix codestarts compatibility with older CLI

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/base/README.tpl.qute.md
@@ -1,0 +1,1 @@
+{#include readme-header /}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
@@ -1,0 +1,1 @@
+{#include index-entry path=resource.path/}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/codestart.yml
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/codestart.yml
@@ -1,0 +1,20 @@
+# We need this for compat with older CLI versions
+name: resteasy-reactive-codestart
+ref: resteasy-reactive
+type: code
+tags: extension-codestart
+metadata:
+  title: REST
+  description: Easily start your REST Web Services
+  related-guide-section: https://quarkus.io/guides/getting-started-reactive#reactive-jax-rs-resources
+language:
+  base:
+    data:
+      resource:
+        class-name: GreetingResource
+        path: "/hello"
+        response: "Hello from Quarkus REST"
+    dependencies:
+      - io.quarkus:quarkus-rest
+    test-dependencies:
+      - io.rest-assured:rest-assured

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("{resource.path}")
+public class {resource.class-name} {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "{resource.response}";
+    }
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/native-test/java/org/acme/{resource.class-name}IT.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/native-test/java/org/acme/{resource.class-name}IT.tpl.qute.java
@@ -1,0 +1,8 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class {resource.class-name}IT extends {resource.class-name}Test {
+    // Execute the same tests but in packaged mode.
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/test/java/org/acme/{resource.class-name}Test.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/test/java/org/acme/{resource.class-name}Test.tpl.qute.java
@@ -1,0 +1,20 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+class {resource.class-name}Test {
+    @Test
+    void testHelloEndpoint() {
+        given()
+          .when().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(is("{resource.response}"));
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/main/kotlin/org/acme/{resource.class-name}.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/main/kotlin/org/acme/{resource.class-name}.tpl.qute.kt
@@ -1,0 +1,14 @@
+package org.acme
+
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+
+@Path("{resource.path}")
+class {resource.class-name} {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    fun hello() = "{resource.response}"
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/native-test/kotlin/org/acme/{resource.class-name}IT.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/native-test/kotlin/org/acme/{resource.class-name}IT.tpl.qute.kt
@@ -1,0 +1,6 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+@QuarkusIntegrationTest
+class {resource.class-name}IT : {resource.class-name}Test()

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/test/kotlin/org/acme/{resource.class-name}Test.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/test/kotlin/org/acme/{resource.class-name}Test.tpl.qute.kt
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class {resource.class-name}Test {
+
+    @Test
+    fun testHelloEndpoint() {
+        given()
+          .`when`().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(`is`("{resource.response}"))
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/main/scala/org/acme/{resource.class-name}.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/main/scala/org/acme/{resource.class-name}.tpl.qute.scala
@@ -1,0 +1,12 @@
+package org.acme
+
+import jakarta.ws.rs.\{GET, Path, Produces}
+import jakarta.ws.rs.core.MediaType
+
+@Path("{resource.path}")
+class {resource.class-name} {
+
+    @GET
+    @Produces(Array[String](MediaType.TEXT_PLAIN))
+    def hello() = "{resource.response}"
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/native-test/scala/org/acme/{resource.class-name}IT.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/native-test/scala/org/acme/{resource.class-name}IT.tpl.qute.scala
@@ -1,0 +1,6 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+@QuarkusIntegrationTest
+class {resource.class-name}IT extends {resource.class-name}Test

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class {resource.class-name}Test {
+
+    @Test
+    def testHelloEndpoint() = {
+        given()
+          .`when`().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(`is`("{resource.response}"))
+    }
+
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
@@ -34,7 +34,6 @@ import io.quarkus.platform.catalog.processor.ExtensionProcessor;
 import io.quarkus.platform.descriptor.loader.json.ResourceLoader;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
-import io.smallrye.common.version.VersionScheme;
 
 public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<QuarkusCodestartProjectInput> {
 
@@ -138,13 +137,17 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
                 .filter(c -> !isExample(c) || projectInput.getExample() == null || c.matches(projectInput.getExample()))
                 .collect(Collectors.toCollection(ArrayList::new));
 
-        // include default codestarts depending on the versions and the extensions being chosen or not
-        Optional<String> selectedDefaultCodeStart = getSelectedDefaultCodeStart(projectInput);
+        // include default codestart depending on the versions and the extensions being chosen or not
+        Optional<String> selectedDefaultCodeStart = Optional.ofNullable(projectInput.getDefaultCodestart());
 
+        // if there is no extension selected or only language extensions, we should add the default code start
+        // this has been settled in https://github.com/quarkusio/quarkus/pull/39467
+        final boolean shouldAddDefaultCodeStart = projectInput.getExtensions().isEmpty() ||
+                (projectInput.getExtensions().size() == 1
+                        && isLanguageExtension(projectInput.getExtensions().iterator().next()));
         if (projectInput.getAppContent().contains(CODE)
                 && selectedDefaultCodeStart.isPresent()
-                && projectCodestarts.stream()
-                        .noneMatch(c -> c.getType() == CodestartType.CODE && !c.getSpec().isPreselected())) {
+                && shouldAddDefaultCodeStart) {
             final Codestart defaultCodestart = codestarts.stream()
                     .filter(c -> c.matches(selectedDefaultCodeStart.get()))
                     .findFirst().orElseThrow(() -> new CodestartStructureException(
@@ -176,36 +179,6 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
         projectInput.getData().putAll(generateSelectionData(projectInput, projectCodestarts));
 
         return projectCodestarts;
-    }
-
-    private Optional<String> getSelectedDefaultCodeStart(QuarkusCodestartProjectInput projectInput) {
-        // This is very hackyish, we need a better data structure to do better
-        Optional<ArtifactCoords> quarkusBom = projectInput.getBoms().stream()
-                .map(ArtifactCoords::fromString)
-                .filter(b -> isCoreBom(b) || isPlatformBom(b) || isUniverseBom(b))
-                .findFirst();
-
-        String bomVersion = null;
-
-        if (quarkusBom.isPresent()) {
-            bomVersion = quarkusBom.get().getVersion();
-        }
-
-        if (bomVersion == null || VersionScheme.MAVEN.compare(bomVersion, "2.8") >= 0) {
-            if (projectInput.getExtensions().isEmpty() ||
-                    (projectInput.getExtensions().size() == 1
-                            && isLanguageExtension(projectInput.getExtensions().iterator().next()))) {
-                var defaultCodestart = projectInput.getDefaultCodestart();
-                if (defaultCodestart == null) {
-                    defaultCodestart = QuarkusCodestartCatalog.ExtensionCodestart.REST.key();
-                }
-                return Optional.of(defaultCodestart);
-            }
-
-            return Optional.empty();
-        }
-
-        return Optional.of(ExtensionCodestart.RESTEASY.key());
     }
 
     private boolean isCoreBom(ArtifactCoords artifactCoords) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -252,6 +252,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
     }
 
     private static String getDefaultCodestart(ExtensionCatalog catalog) {
+        // Recent versions of the catalog have a default-codestart in the project metadata (2.10+)
         var map = catalog.getMetadata();
         if (map != null && !map.isEmpty()) {
             var projectMetadata = map.get("project");
@@ -264,6 +265,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
                 }
             }
         }
-        return null;
+        // Let's use resteasy-reactive for older versions
+        return "resteasy-reactive";
     }
 }


### PR DESCRIPTION
This should fix https://github.com/quarkusio/quarkus/issues/25101#issuecomment-1999002812

This remove some hacky workaround to define the default codestarts for Quarkus version before 2.8

From this PR, the default codestart is:
- 2.10+ => defined from metadata
- older => resteasy-reactive