### PR TITLE
Update to Vert.x 4.5.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -61,7 +61,7 @@
         <smallrye-context-propagation.version>2.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.10.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.11.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.18.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.6.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
@@ -122,7 +122,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.3.1.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.1.Final</jboss-threads.version>
-        <vertx.version>4.5.4</vertx.version>
+        <vertx.version>4.5.5</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -138,7 +138,7 @@ class VertxCoreProcessor {
                                     };
                                 }
 
-                                if (name.equals("getLocal")) {
+                                if (name.equals("getLocal") && descriptor.equals("(Ljava/lang/Object;)Ljava/lang/Object;")) {
                                     return new MethodVisitor(Gizmo.ASM_API_VERSION, visitor) {
                                         @Override
                                         public void visitCode() {
@@ -154,7 +154,7 @@ class VertxCoreProcessor {
                                     };
                                 }
 
-                                if (name.equals("putLocal")) {
+                                if (name.equals("putLocal") && descriptor.equals("(Ljava/lang/Object;Ljava/lang/Object;)V")) {
                                     return new MethodVisitor(Gizmo.ASM_API_VERSION, visitor) {
                                         @Override
                                         public void visitCode() {
@@ -171,7 +171,7 @@ class VertxCoreProcessor {
                                     };
                                 }
 
-                                if (name.equals("removeLocal")) {
+                                if (name.equals("removeLocal") && descriptor.equals("(Ljava/lang/Object;)Z")) {
                                     return new MethodVisitor(Gizmo.ASM_API_VERSION, visitor) {
                                         @Override
                                         public void visitCode() {

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -61,7 +61,7 @@
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <mutiny.version>2.5.8</mutiny.version>
         <smallrye-common.version>2.3.0</smallrye-common.version>
-        <vertx.version>4.5.4</vertx.version>
+        <vertx.version>4.5.5</vertx.version>
         <rest-assured.version>5.4.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.17.0</jackson-bom.version>


### PR DESCRIPTION
This PR includes the following changes:

- Update the Vert.x version to 4.5.5 (see https://github.com/vert-x3/wiki/wiki/4.5.5-Release-Notes for details)
- Resolve issues with the context local access safety guard as the Vert.x API changed
- Align Mutiny bindings which use the same Vert.x version
