### PR TITLE
Update SmallRye Config to 3.7.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>3.1.1</microprofile-openapi.version>
         <smallrye-common.version>2.3.0</smallrye-common.version>
-        <smallrye-config.version>3.6.1</smallrye-config.version>
+        <smallrye-config.version>3.7.0</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>3.10.0</smallrye-open-api.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ plugin-publish = "1.2.1"
 
 # updating Kotlin here makes QuarkusPluginTest > shouldNotFailOnProjectDependenciesWithoutMain(Path) fail
 kotlin = "1.9.23"
-smallrye-config = "3.6.1"
+smallrye-config = "3.7.0"
 
 junit5 = "5.10.2"
 assertj = "3.25.3"


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
<h2>3.7.0</h2>
<ul>
<li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1134">#1134</a> Release 3.7.0</li>
<li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1132">#1132</a> Fallback to inline Map conversion instead of being the primary option</li>
<li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1129">#1129</a> Bump kotlin.version from 1.9.22 to 1.9.23</li>
<li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1128">#1128</a> Allow interceptors to interpose between &quot;regular&quot; sources and default sources</li>
</ul>
</blockquote>

<summary>Quarkus Fixes:</summary>
- Fixes #39315