### PR TITLE
Use explicit jar reference instead of GAV to avoid duplicate log warning

### DIFF
--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -64,7 +64,7 @@ If you want to use a specific version, you can directly target a version:
 [source,bash]
 ----
 # Create an alias in order to use a specific version
-jbang app install --name qs2.2.5 io.quarkus:quarkus-cli:2.2.5.Final:runner
+jbang app install --name qs3.5.0 https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.5.0/quarkus-cli-3.5.0-runner.jar
 ----
 
 If you have built Quarkus locally, you can use that version:


### PR DESCRIPTION
fixes #27374

using GAV runner technically works but generates warning since the pom.xml for that GAV states it needs dependencies but it is a fat jar.