### PR TITLE
Push project version to RESTEasy Reactive TCK

### DIFF
--- a/tcks/resteasy-reactive/pom.xml
+++ b/tcks/resteasy-reactive/pom.xml
@@ -73,7 +73,7 @@
                         </goals>
                         <configuration>
                             <executable>${maven.multiModuleProjectDirectory}/mvnw</executable>
-                            <commandlineArgs>-e -B --settings ${session.request.userSettingsFile.path} clean install ${resteasy-reactive-testsuite.mvn.args}</commandlineArgs>
+                            <commandlineArgs>-e -B --settings ${session.request.userSettingsFile.path} clean install ${resteasy-reactive-testsuite.mvn.args} -Dquarkus.platform.version=${project.version} -Dquarkus-plugin.version=${project.version}</commandlineArgs>
                             <skip>${resteasy-reactive-testsuite.test.skip}</skip>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Until now, we needed one sha per version but it is far easier to push the version when executing the tests.

This is important for PRs like: https://github.com/quarkusio/quarkus/pull/39396 .