### PR TITLE
Allow occasional pin events in ShouldNotPin

### DIFF
--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -46,6 +46,7 @@
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
 
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <assertj.version>3.25.3</assertj.version>
     </properties>
 
 
@@ -55,6 +56,12 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>compile</scope>
             <version>${junit.jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/independent-projects/junit5-virtual-threads/src/main/java/io/quarkus/test/junit5/virtual/ShouldNotPin.java
+++ b/independent-projects/junit5-virtual-threads/src/main/java/io/quarkus/test/junit5/virtual/ShouldNotPin.java
@@ -8,9 +8,16 @@ import java.lang.annotation.Target;
 /**
  * Marker indicating that the test method or class should not pin the carrier thread.
  * If, during the execution of the test, a virtual thread pins the carrier thread, the test fails.
+ * However, occasional pin can still be allowed by setting {@code atMost} value
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 public @interface ShouldNotPin {
 
+    /**
+     * Set value to allow occasional pin events
+     *
+     * @return
+     */
+    int atMost() default 0;
 }

--- a/independent-projects/junit5-virtual-threads/src/main/java/io/quarkus/test/junit5/virtual/internal/VirtualThreadExtension.java
+++ b/independent-projects/junit5-virtual-threads/src/main/java/io/quarkus/test/junit5/virtual/internal/VirtualThreadExtension.java
@@ -131,7 +131,7 @@ public class VirtualThreadExtension
         }
 
         if (notpin != null) {
-            if (!pinEvents.isEmpty()) {
+            if (!pinEvents.isEmpty() && pinEvents.size() > notpin.atMost()) {
                 throw new AssertionError(
                         "The test " + extensionContext.getDisplayName() + " was expected to NOT pin the carrier thread"
                                 + ", but we collected " + pinEvents.size() + " event(s)\n" + dump(pinEvents));

--- a/independent-projects/junit5-virtual-threads/src/test/java/io/quarkus/test/junit5/virtual/internal/LoomUnitExampleOnClassTest.java
+++ b/independent-projects/junit5-virtual-threads/src/test/java/io/quarkus/test/junit5/virtual/internal/LoomUnitExampleOnClassTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.test.junit5.virtual.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import io.quarkus.test.junit5.virtual.ShouldNotPin;
+import io.quarkus.test.junit5.virtual.ShouldPin;
+import io.quarkus.test.junit5.virtual.VirtualThreadUnit;
+
+@VirtualThreadUnit
+@ShouldNotPin // You can use @ShouldNotPin or @ShouldPin on the class itself, it's applied to each method.
+public class LoomUnitExampleOnClassTest {
+
+    @Test
+    public void testThatShouldNotPin() {
+        // ...
+    }
+
+    @Test
+    @ShouldPin(atMost = 1) // Method annotation overrides the class annotation
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    public void testThatShouldPinAtMostOnce() {
+        TestPinJfrEvent.pin();
+    }
+
+    @Test
+    @ShouldNotPin(atMost = 1) // Method annotation overrides the class annotation
+    public void testThatShouldNotPinAtMostOnce() {
+        TestPinJfrEvent.pin();
+    }
+
+}

--- a/independent-projects/junit5-virtual-threads/src/test/java/io/quarkus/test/junit5/virtual/internal/LoomUnitExampleTest.java
+++ b/independent-projects/junit5-virtual-threads/src/test/java/io/quarkus/test/junit5/virtual/internal/LoomUnitExampleTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.test.junit5.virtual.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import io.quarkus.test.junit5.virtual.ShouldNotPin;
+import io.quarkus.test.junit5.virtual.ShouldPin;
+import io.quarkus.test.junit5.virtual.VirtualThreadUnit;
+
+@VirtualThreadUnit
+public class LoomUnitExampleTest {
+
+    @Test
+    @ShouldNotPin
+    void methodShouldNotPin() {
+    }
+
+    @Test
+    @ShouldNotPin(atMost = 1)
+    void methodShouldNotPinAtMost1() {
+        TestPinJfrEvent.pin();
+    }
+
+    @Test
+    @ShouldPin
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void methodShouldPin() {
+        TestPinJfrEvent.pin();
+    }
+
+    @Test
+    void methodNoAnnotation() {
+    }
+
+}

--- a/independent-projects/junit5-virtual-threads/src/test/java/io/quarkus/test/junit5/virtual/internal/TestPinJfrEvent.java
+++ b/independent-projects/junit5-virtual-threads/src/test/java/io/quarkus/test/junit5/virtual/internal/TestPinJfrEvent.java
@@ -1,0 +1,24 @@
+package io.quarkus.test.junit5.virtual.internal;
+
+import static io.quarkus.test.junit5.virtual.internal.Collector.CARRIER_PINNED_EVENT_NAME;
+
+import jdk.jfr.*;
+
+@Label("Test Custom Event")
+@Category("Application Events")
+@Description("This event is for testing thread pinning")
+@Name(CARRIER_PINNED_EVENT_NAME)
+public class TestPinJfrEvent extends Event {
+
+    @Label("Pin Message")
+    private final String message;
+
+    public TestPinJfrEvent(String message) {
+        this.message = message;
+    }
+
+    static void pin() {
+        TestPinJfrEvent event = new TestPinJfrEvent("Hello, JFR!");
+        event.commit();
+    }
+}

--- a/independent-projects/junit5-virtual-threads/src/test/java/io/quarkus/test/junit5/virtual/internal/VirtualThreadExtensionTest.java
+++ b/independent-projects/junit5-virtual-threads/src/test/java/io/quarkus/test/junit5/virtual/internal/VirtualThreadExtensionTest.java
@@ -1,0 +1,284 @@
+package io.quarkus.test.junit5.virtual.internal;
+
+import static io.quarkus.test.junit5.virtual.internal.VirtualThreadExtension._COLLECTOR_KEY;
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExecutableInvoker;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstances;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.quarkus.test.junit5.virtual.ShouldNotPin;
+import io.quarkus.test.junit5.virtual.ShouldPin;
+import jdk.jfr.consumer.RecordedEvent;
+
+class VirtualThreadExtensionTest {
+
+    private VirtualThreadExtension extension;
+    private TestExtensionContext extensionContext;
+    private final ExtensionContext.Namespace namespace = ExtensionContext.Namespace.create("loom-unit");
+
+    @BeforeEach
+    void setUp() {
+        extensionContext = new TestExtensionContext();
+        extension = new VirtualThreadExtension();
+        extension.beforeAll(extensionContext);
+    }
+
+    @Test
+    void beforeAll() {
+        extension.beforeAll(extensionContext);
+        assertThat(extensionContext.getStore(namespace).get(_COLLECTOR_KEY)).isNotNull();
+    }
+
+    @Test
+    void afterAll() {
+        extension.beforeAll(extensionContext);
+        assertThatNoException().isThrownBy(() -> extension.afterAll(extensionContext));
+        assertThat(extensionContext.getStore(namespace).get(_COLLECTOR_KEY)).isNotNull();
+    }
+
+    @Test
+    void beforeEachShouldNotPin() throws NoSuchMethodException {
+        extensionContext.setMethod(TestClass.class.getDeclaredMethod("methodShouldNotPin"));
+        extension.beforeEach(extensionContext);
+        assertThatNoException().isThrownBy(() -> extension.beforeEach(extensionContext));
+    }
+
+    @Test
+    void beforeEachShouldNotPinAtMost1() throws NoSuchMethodException {
+        extensionContext.setMethod(TestClass.class.getDeclaredMethod("methodShouldNotPinAtMost1"));
+        extension.beforeEach(extensionContext);
+        assertThatNoException().isThrownBy(() -> extension.beforeEach(extensionContext));
+    }
+
+    @Test
+    void beforeEachNotAnnotated() throws NoSuchMethodException {
+        extensionContext.setMethod(TestClass.class.getDeclaredMethod("methodNoAnnotation"));
+        extension.beforeEach(extensionContext);
+        assertThatNoException().isThrownBy(() -> extension.beforeEach(extensionContext));
+    }
+
+    @Test
+    void afterEachShouldNotPin() throws NoSuchMethodException {
+        extensionContext.setMethod(TestClass.class.getDeclaredMethod("methodShouldNotPin"));
+        assertThatNoException().isThrownBy(() -> extension.afterEach(extensionContext));
+    }
+
+    @Test
+    void afterEachShouldNotPinAtMost1() throws NoSuchMethodException {
+        extensionContext.setMethod(TestClass.class.getDeclaredMethod("methodShouldNotPinAtMost1"));
+        assertThatNoException().isThrownBy(() -> extension.afterEach(extensionContext));
+    }
+
+    @Test
+    void afterEachShouldPinButNoEvents() throws NoSuchMethodException {
+        extensionContext.setMethod(TestClass.class.getDeclaredMethod("methodShouldPinButDoesnt"));
+        assertThatThrownBy(() -> extension.afterEach(extensionContext))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("was expected to pin the carrier thread");
+    }
+
+    @Test
+    void afterEachNotAnnotated() throws NoSuchMethodException {
+        extensionContext.setMethod(TestClass.class.getDeclaredMethod("methodNoAnnotation"));
+        assertThatNoException().isThrownBy(() -> extension.afterEach(extensionContext));
+    }
+
+    private static class TestClass {
+        @ShouldNotPin
+        void methodShouldNotPin() {
+        }
+
+        @ShouldNotPin(atMost = 1)
+        void methodShouldNotPinAtMost1() {
+            TestPinJfrEvent.pin();
+        }
+
+        @ShouldPin
+        void methodShouldPinButDoesnt() {
+        }
+
+        void methodNoAnnotation() {
+        }
+
+    }
+
+    private static class TestExtensionContext implements ExtensionContext {
+        private final TestStore store = new TestStore();
+        private Method method;
+
+        @Override
+        public Optional<ExtensionContext> getParent() {
+            return Optional.empty();
+        }
+
+        @Override
+        public ExtensionContext getRoot() {
+            return this;
+        }
+
+        @Override
+        public String getUniqueId() {
+            return "";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "unit test context";
+        }
+
+        @Override
+        public Set<String> getTags() {
+            return Set.of();
+        }
+
+        @Override
+        public Optional<AnnotatedElement> getElement() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Class<?>> getTestClass() {
+            return Optional.of(TestClass.class);
+        }
+
+        @Override
+        public Optional<TestInstance.Lifecycle> getTestInstanceLifecycle() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Object> getTestInstance() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<TestInstances> getTestInstances() {
+            return Optional.empty();
+        }
+
+        public void setMethod(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public Optional<Method> getTestMethod() {
+            return Optional.ofNullable(method);
+        }
+
+        @Override
+        public Optional<Throwable> getExecutionException() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> getConfigurationParameter(String s) {
+            return Optional.empty();
+        }
+
+        @Override
+        public <T> Optional<T> getConfigurationParameter(String s, Function<String, T> function) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void publishReportEntry(Map<String, String> map) {
+
+        }
+
+        @Override
+        public TestStore getStore(Namespace namespace) {
+            return store;
+        }
+
+        @Override
+        public ExecutionMode getExecutionMode() {
+            return ExecutionMode.SAME_THREAD;
+        }
+
+        @Override
+        public ExecutableInvoker getExecutableInvoker() {
+            return null;
+        }
+    }
+
+    private static class TestCollector extends Collector {
+        private final List<RecordedEvent> mockEvents;
+
+        private TestCollector(List<RecordedEvent> mockEvents) {
+            this.mockEvents = mockEvents;
+        }
+
+        @Override
+        public List<RecordedEvent> stop() {
+            var parentEvents = super.stop();
+            return mockEvents.isEmpty() ? parentEvents : mockEvents;
+        }
+    }
+
+    private static class TestStore implements ExtensionContext.Store {
+
+        private final Map<Object, Object> store = new ConcurrentHashMap<>();
+        private TestCollector testCollector;
+
+        @Override
+        public Object get(Object o) {
+            return store.get(o);
+        }
+
+        public void setTestCollector(TestCollector testCollector) {
+            this.testCollector = testCollector;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <V> V get(Object o, Class<V> aClass) {
+            if (aClass.equals(TestCollector.class) && testCollector != null) {
+                return (V) testCollector;
+            }
+            return aClass.cast(store.get(o));
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <K, V> Object getOrComputeIfAbsent(K key, Function<K, V> function) {
+            return store.computeIfAbsent(key, o -> function.apply((K) o));
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <K, V> V getOrComputeIfAbsent(K key, Function<K, V> function, Class<V> aClass) {
+            return aClass.cast(store.computeIfAbsent(key, o -> function.apply((K) o)));
+        }
+
+        @Override
+        public void put(Object o, Object o1) {
+            store.put(o, o1);
+        }
+
+        @Override
+        public Object remove(Object o) {
+            return store.remove(o);
+        }
+
+        @Override
+        public <V> V remove(Object o, Class<V> aClass) {
+            return aClass.cast(store.remove(o));
+        }
+
+    }
+
+}


### PR DESCRIPTION
ShouldNotPin annotation doesn't currently allow any pin events to happen. However, in some
situations one still wants to allow an occasional pin to happen, as they are not always a problem

Adding a parameter to ShouldNotPin makes it now possible.

@cescoffier  as discussed in the loom-unit opening the PR here