### PR TITLE
Ignore the split access and refresh token cookies for resolving the tenant

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -16,9 +16,6 @@ import io.vertx.ext.web.RoutingContext;
 @ApplicationScoped
 public class DefaultTokenStateManager implements TokenStateManager {
 
-    private static final String SESSION_AT_COOKIE_NAME = OidcUtils.SESSION_COOKIE_NAME + "_at";
-    private static final String SESSION_RT_COOKIE_NAME = OidcUtils.SESSION_COOKIE_NAME + "_rt";
-
     @Override
     public Uni<String> createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
             AuthorizationCodeTokens tokens, OidcRequestContext<String> requestContext) {
@@ -137,12 +134,12 @@ public class DefaultTokenStateManager implements TokenStateManager {
 
     private static String getAccessTokenCookieName(OidcTenantConfig oidcConfig) {
         String cookieSuffix = OidcUtils.getCookieSuffix(oidcConfig);
-        return SESSION_AT_COOKIE_NAME + cookieSuffix;
+        return OidcUtils.SESSION_AT_COOKIE_NAME + cookieSuffix;
     }
 
     private static String getRefreshTokenCookieName(OidcTenantConfig oidcConfig) {
         String cookieSuffix = OidcUtils.getCookieSuffix(oidcConfig);
-        return SESSION_RT_COOKIE_NAME + cookieSuffix;
+        return OidcUtils.SESSION_RT_COOKIE_NAME + cookieSuffix;
     }
 
     private String encryptToken(String token, RoutingContext context, OidcTenantConfig oidcConfig) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
@@ -116,7 +116,7 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
 
     private static void setTenantIdAttribute(RoutingContext context) {
         for (String cookieName : context.cookieMap().keySet()) {
-            if (cookieName.startsWith(OidcUtils.SESSION_COOKIE_NAME)) {
+            if (OidcUtils.isSessionCookie(cookieName)) {
                 setTenantIdAttribute(context, OidcUtils.SESSION_COOKIE_NAME, cookieName);
             } else if (cookieName.startsWith(OidcUtils.STATE_COOKIE_NAME)) {
                 setTenantIdAttribute(context, OidcUtils.STATE_COOKIE_NAME, cookieName);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -79,6 +79,10 @@ public final class OidcUtils {
     public static final String DEFAULT_TENANT_ID = "Default";
     public static final String SESSION_COOKIE_NAME = "q_session";
     public static final String SESSION_COOKIE_CHUNK = "_chunk_";
+    public static final String ACCESS_TOKEN_COOKIE_SUFFIX = "_at";
+    public static final String REFRESH_TOKEN_COOKIE_SUFFIX = "_rt";
+    public static final String SESSION_AT_COOKIE_NAME = SESSION_COOKIE_NAME + ACCESS_TOKEN_COOKIE_SUFFIX;
+    public static final String SESSION_RT_COOKIE_NAME = SESSION_COOKIE_NAME + REFRESH_TOKEN_COOKIE_SUFFIX;
     public static final String STATE_COOKIE_NAME = "q_auth";
     public static final Integer MAX_COOKIE_VALUE_LENGTH = 4096;
     public static final String POST_LOGOUT_COOKIE_NAME = "q_post_logout";
@@ -687,5 +691,11 @@ public final class OidcUtils {
         }
 
         return scopes;
+    }
+
+    public static boolean isSessionCookie(String cookieName) {
+        return cookieName.startsWith(SESSION_COOKIE_NAME)
+                && !cookieName.regionMatches(SESSION_COOKIE_NAME.length(), ACCESS_TOKEN_COOKIE_SUFFIX, 0, 3)
+                && !cookieName.regionMatches(SESSION_COOKIE_NAME.length(), REFRESH_TOKEN_COOKIE_SUFFIX, 0, 3);
     }
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -310,6 +310,18 @@ public class OidcUtilsTest {
         assertEquals("openid%2Ca%3A1%2Cb%3A2%2Cc%2Cd", OidcUtils.encodeScopes(config));
     }
 
+    @Test
+    public void testSessionCookieCheck() throws Exception {
+        assertTrue(OidcUtils.isSessionCookie(OidcUtils.SESSION_COOKIE_NAME));
+        assertTrue(OidcUtils.isSessionCookie(OidcUtils.SESSION_COOKIE_NAME + "_tenant1"));
+        assertFalse(OidcUtils.isSessionCookie(OidcUtils.SESSION_AT_COOKIE_NAME));
+        assertFalse(OidcUtils.isSessionCookie(OidcUtils.SESSION_AT_COOKIE_NAME + "_tenant1"));
+        assertFalse(OidcUtils.isSessionCookie(OidcUtils.SESSION_RT_COOKIE_NAME));
+        assertFalse(OidcUtils.isSessionCookie(OidcUtils.SESSION_RT_COOKIE_NAME + "_tenant1"));
+
+        assertFalse(OidcUtils.isSessionCookie(OidcUtils.SESSION_AT_COOKIE_NAME + "1"));
+    }
+
     public static JsonObject read(InputStream input) throws IOException {
         try (BufferedReader buffer = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             return new JsonObject(buffer.lines().collect(Collectors.joining("\n")));


### PR DESCRIPTION
Problem was noticed while working on #39417 but not really resolves that issue.
OIDC token state manager can be configured to split the tokens, with 3 session cookies created, one representing the actual session cookie and 2 others - access and refresh token respectively and those access and refresh token cookies if sorted in front of the main session cookie would cause wrong tenant id resolution which would lead to the verification failures - does not seem anyone has been hit by this issue yet, but it just has to be fixed