### PR TITLE
Improve JAXB Exception handling

### DIFF
--- a/extensions/resteasy-reactive/rest-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/SimpleXmlTest.java
+++ b/extensions/resteasy-reactive/rest-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/SimpleXmlTest.java
@@ -76,6 +76,17 @@ public class SimpleXmlTest {
     }
 
     @Test
+    public void testInvalidXml() {
+        RestAssured
+                .with()
+                .body("<person><first>Bob</first></invalid>")
+                .contentType("application/xml")
+                .post("/simple/person")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
     public void testLargeXmlPost() {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < 10000; ++i) {

--- a/extensions/resteasy-reactive/rest-jaxb/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/runtime/serialisers/ServerJaxbMessageBodyReader.java
+++ b/extensions/resteasy-reactive/rest-jaxb/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/runtime/serialisers/ServerJaxbMessageBodyReader.java
@@ -12,10 +12,12 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Providers;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.UnmarshalException;
 import jakarta.xml.bind.Unmarshaller;
 
 import org.jboss.resteasy.reactive.common.util.StreamUtil;
@@ -73,6 +75,8 @@ public class ServerJaxbMessageBodyReader implements ServerMessageBodyReader<Obje
             JAXBElement<Object> item = getUnmarshall(type)
                     .unmarshal(new StreamSource(entityStream), type);
             return item.getValue();
+        } catch (UnmarshalException e) {
+            throw new WebApplicationException(e, Response.Status.BAD_REQUEST);
         } catch (JAXBException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
I tested the issue with resteasy-reactive-jaxb and confirmed that the response is Internal Server Error (500) when posting an invalid xml body.
I tried to reproduce the issue in the existing `jaxb` integration test, but that one returns Bad Request (400). I added tests for confirming this.
I had to create a new integration test module `resteasy-reactive-jaxb` to be able to reproduce the issue with the reactive implementation. That test has been implemented to expect Bad Request (400) so at the moment the test is failing until the exception handling is fixed.

- Fixes #39375