### PR TITLE
Move Keycloak Authorization Enforcer Tenant config to runtime and improve usability with aggregated policy enforcer paths

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -413,7 +413,7 @@ There's no need to deactivate policy checks for a Keycloak Authorization Policy 
 
 [source,properties]
 ----
-quarkus.keycloak.policy-enforcer.paths.1.path=/api/public
+quarkus.keycloak.policy-enforcer.paths.1.paths=/api/public
 quarkus.keycloak.policy-enforcer.paths.1.enforcement-mode=DISABLED
 ----
 
@@ -421,7 +421,7 @@ To block access to the public resource to anonymous users, you can create an enf
 
 [source,properties]
 ----
-quarkus.keycloak.policy-enforcer.paths.1.path=/api/public-enforcing
+quarkus.keycloak.policy-enforcer.paths.1.paths=/api/public-enforcing
 quarkus.keycloak.policy-enforcer.paths.1.enforcement-mode=ENFORCING
 ----
 
@@ -438,15 +438,13 @@ For example:
 ----
 # path policy with enforced scope 'read' for method 'GET'
 quarkus.keycloak.policy-enforcer.paths.1.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.1.path=/api/protected/standard-way
+quarkus.keycloak.policy-enforcer.paths.1.paths=/api/protected/standard-way
 quarkus.keycloak.policy-enforcer.paths.1.methods.get.method=GET
 quarkus.keycloak.policy-enforcer.paths.1.methods.get.scopes=read <1>
 
 # path policies without scope
 quarkus.keycloak.policy-enforcer.paths.2.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.2.path=/api/protected/programmatic-way
-quarkus.keycloak.policy-enforcer.paths.3.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.3.path=/api/protected/annotation-way
+quarkus.keycloak.policy-enforcer.paths.2.paths=/api/protected/programmatic-way,/api/protected/annotation-way
 ----
 <1> User must have resource permission 'Scope Permission Resource' and scope 'read'
 
@@ -532,7 +530,7 @@ quarkus.oidc.credentials.secret=secret
 
 quarkus.keycloak.policy-enforcer.enforcement-mode=PERMISSIVE
 quarkus.keycloak.policy-enforcer.paths.1.name=Permission Resource
-quarkus.keycloak.policy-enforcer.paths.1.path=/api/permission
+quarkus.keycloak.policy-enforcer.paths.1.paths=/api/permission
 quarkus.keycloak.policy-enforcer.paths.1.claim-information-point.claims.static-claim=static-claim
 
 # Service Tenant
@@ -543,7 +541,7 @@ quarkus.oidc.service-tenant.credentials.secret=secret
 
 quarkus.keycloak.service-tenant.policy-enforcer.enforcement-mode=PERMISSIVE
 quarkus.keycloak.service-tenant.policy-enforcer.paths.1.name=Permission Resource Service
-quarkus.keycloak.service-tenant.policy-enforcer.paths.1.path=/api/permission
+quarkus.keycloak.service-tenant.policy-enforcer.paths.1.paths=/api/permission
 quarkus.keycloak.service-tenant.policy-enforcer.paths.1.claim-information-point.claims.static-claim=static-claim
 
 
@@ -557,7 +555,7 @@ quarkus.oidc.webapp-tenant.roles.source=accesstoken
 
 quarkus.keycloak.webapp-tenant.policy-enforcer.enforcement-mode=PERMISSIVE
 quarkus.keycloak.webapp-tenant.policy-enforcer.paths.1.name=Permission Resource WebApp
-quarkus.keycloak.webapp-tenant.policy-enforcer.paths.1.path=/api/permission
+quarkus.keycloak.webapp-tenant.policy-enforcer.paths.1.paths=/api/permission
 quarkus.keycloak.webapp-tenant.policy-enforcer.paths.1.claim-information-point.claims.static-claim=static-claim
 ----
 

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
@@ -1,6 +1,5 @@
 package io.quarkus.keycloak.pep.deployment;
 
-import java.util.Map;
 import java.util.function.BooleanSupplier;
 
 import jakarta.inject.Singleton;
@@ -17,60 +16,29 @@ import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerAuthorizer;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerBuildTimeConfig;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerConfig;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerRecorder;
-import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerTenantConfig;
-import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerTenantConfig.KeycloakConfigPolicyEnforcer.PathConfig;
 import io.quarkus.keycloak.pep.runtime.PolicyEnforcerResolver;
 import io.quarkus.oidc.deployment.OidcBuildTimeConfig;
 import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
+import io.quarkus.vertx.http.runtime.HttpConfiguration;
 
 @BuildSteps(onlyIf = KeycloakPolicyEnforcerBuildStep.IsEnabled.class)
 public class KeycloakPolicyEnforcerBuildStep {
 
+    @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    RequireBodyHandlerBuildItem requireBody(OidcBuildTimeConfig oidcBuildTimeConfig, KeycloakPolicyEnforcerConfig config) {
+    RequireBodyHandlerBuildItem requireBody(OidcBuildTimeConfig oidcBuildTimeConfig,
+            KeycloakPolicyEnforcerRecorder recorder,
+            KeycloakPolicyEnforcerConfig runtimeConfig) {
         if (oidcBuildTimeConfig.enabled) {
-            if (isBodyHandlerRequired(config.defaultTenant)) {
-                return new RequireBodyHandlerBuildItem();
-            }
-            for (KeycloakPolicyEnforcerTenantConfig tenantConfig : config.namedTenants.values()) {
-                if (isBodyHandlerRequired(tenantConfig)) {
-                    return new RequireBodyHandlerBuildItem();
-                }
-            }
+            return new RequireBodyHandlerBuildItem(recorder.createBodyHandlerRequiredEvaluator(runtimeConfig));
         }
         return null;
     }
 
-    private static boolean isBodyHandlerRequired(KeycloakPolicyEnforcerTenantConfig config) {
-        if (isBodyClaimInformationPointDefined(config.policyEnforcer.claimInformationPoint.simpleConfig)) {
-            return true;
-        }
-        for (PathConfig path : config.policyEnforcer.paths.values()) {
-            if (isBodyClaimInformationPointDefined(path.claimInformationPoint.simpleConfig)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isBodyClaimInformationPointDefined(Map<String, Map<String, String>> claims) {
-        for (Map.Entry<String, Map<String, String>> entry : claims.entrySet()) {
-            Map<String, String> value = entry.getValue();
-
-            for (String nestedValue : value.values()) {
-                if (nestedValue.contains("request.body")) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
     @BuildStep
-    public AdditionalBeanBuildItem beans(OidcBuildTimeConfig oidcBuildTimeConfig, KeycloakPolicyEnforcerConfig config) {
+    public AdditionalBeanBuildItem beans(OidcBuildTimeConfig oidcBuildTimeConfig) {
         if (oidcBuildTimeConfig.enabled) {
             return AdditionalBeanBuildItem.builder().setUnremovable()
                     .addBeanClass(KeycloakPolicyEnforcerAuthorizer.class).build();
@@ -86,12 +54,12 @@ public class KeycloakPolicyEnforcerBuildStep {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     public SyntheticBeanBuildItem setup(OidcBuildTimeConfig oidcBuildTimeConfig, OidcConfig oidcRunTimeConfig,
-            TlsConfig tlsConfig,
-            KeycloakPolicyEnforcerConfig keycloakConfig, KeycloakPolicyEnforcerRecorder recorder) {
+            TlsConfig tlsConfig, KeycloakPolicyEnforcerConfig keycloakConfig, KeycloakPolicyEnforcerRecorder recorder,
+            HttpConfiguration httpConfiguration) {
         if (oidcBuildTimeConfig.enabled) {
             return SyntheticBeanBuildItem.configure(PolicyEnforcerResolver.class).unremovable()
                     .types(PolicyEnforcerResolver.class)
-                    .supplier(recorder.setup(oidcRunTimeConfig, keycloakConfig, tlsConfig))
+                    .supplier(recorder.setup(oidcRunTimeConfig, keycloakConfig, tlsConfig, httpConfiguration))
                     .scope(Singleton.class)
                     .setRuntimeInit()
                     .done();

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerTenantConfig.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerTenantConfig.java
@@ -84,8 +84,15 @@ public class KeycloakPolicyEnforcerTenantConfig {
             /**
              * A URI relative to the application’s context path that should be protected by the policy enforcer
              */
+            @Deprecated(since = "Quarkus 3.10") // use the 'paths' configuration property
             @ConfigItem
             public Optional<String> path;
+
+            /**
+             * HTTP request paths that should be protected by the policy enforcer
+             */
+            @ConfigItem
+            public Optional<List<String>> paths;
 
             /**
              * The HTTP methods (for example, GET, POST, PATCH) to protect and how they are associated with the scopes for a

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RequireBodyHandlerBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RequireBodyHandlerBuildItem.java
@@ -1,10 +1,54 @@
 package io.quarkus.vertx.http.deployment;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 
 /**
  * This is a marker that indicates that the body handler should be installed
  * on all routes, as an extension requires the request to be fully buffered.
  */
 public final class RequireBodyHandlerBuildItem extends MultiBuildItem {
+
+    private final BooleanSupplier bodyHandlerRequiredCondition;
+
+    /**
+     * Creates {@link RequireBodyHandlerBuildItem} that requires body handler unconditionally installed on all routes.
+     */
+    public RequireBodyHandlerBuildItem() {
+        bodyHandlerRequiredCondition = null;
+    }
+
+    /**
+     * Creates {@link RequireBodyHandlerBuildItem} that requires body handler installed on all routes if the supplier returns
+     * true.
+     *
+     * @param bodyHandlerRequiredCondition supplier that returns true at runtime if the body handler should be created
+     */
+    public RequireBodyHandlerBuildItem(BooleanSupplier bodyHandlerRequiredCondition) {
+        this.bodyHandlerRequiredCondition = bodyHandlerRequiredCondition;
+    }
+
+    private BooleanSupplier getBodyHandlerRequiredCondition() {
+        return bodyHandlerRequiredCondition;
+    }
+
+    public static BooleanSupplier[] getBodyHandlerRequiredConditions(List<RequireBodyHandlerBuildItem> bodyHandlerBuildItems) {
+        if (bodyHandlerBuildItems.isEmpty()) {
+            return new BooleanSupplier[] {};
+        }
+        BooleanSupplier[] customRuntimeConditions = bodyHandlerBuildItems
+                .stream()
+                .map(RequireBodyHandlerBuildItem::getBodyHandlerRequiredCondition)
+                .filter(Objects::nonNull)
+                .toArray(BooleanSupplier[]::new);
+        if (customRuntimeConditions.length == bodyHandlerBuildItems.size()) {
+            return customRuntimeConditions;
+        }
+        // at least one item requires body handler unconditionally
+        return new BooleanSupplier[] { new VertxHttpRecorder.AlwaysCreateBodyHandlerSupplier() };
+    }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.deployment;
 
 import static io.quarkus.runtime.TemplateHtmlBuilder.adjustRoot;
+import static io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem.getBodyHandlerRequiredConditions;
 import static io.quarkus.vertx.http.deployment.RouteBuildItem.RouteType.FRAMEWORK_ROUTE;
 
 import java.io.IOException;
@@ -67,11 +68,9 @@ import io.quarkus.vertx.http.runtime.cors.CORSRecorder;
 import io.quarkus.vertx.http.runtime.filters.Filter;
 import io.quarkus.vertx.http.runtime.filters.GracefulShutdownFilter;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
-import io.vertx.core.Handler;
 import io.vertx.core.http.impl.Http1xServerRequest;
 import io.vertx.core.impl.VertxImpl;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
 
 class VertxHttpProcessor {
 
@@ -362,10 +361,6 @@ class VertxHttpProcessor {
                 .filter(f -> f.getHandler() != null)
                 .map(ManagementInterfaceFilterBuildItem::toFilter).collect(Collectors.toList());
 
-        //if the body handler is required then we know it is installed for all routes, so we don't need to register it here
-        Handler<RoutingContext> bodyHandler = !requireBodyHandlerBuildItems.isEmpty() ? bodyHandlerBuildItem.getHandler()
-                : null;
-
         Optional<RuntimeValue<Router>> mainRouter = httpRouteRouter.getMainRouter() != null
                 ? Optional.of(httpRouteRouter.getMainRouter())
                 : Optional.empty();
@@ -396,8 +391,8 @@ class VertxHttpProcessor {
                 httpRootPathBuildItem.getRootPath(),
                 nonApplicationRootPathBuildItem.getNonApplicationRootPath(),
                 launchMode.getLaunchMode(),
-                !requireBodyHandlerBuildItems.isEmpty(), bodyHandler, gracefulShutdownFilter,
-                shutdownConfig, executorBuildItem.getExecutorProxy());
+                getBodyHandlerRequiredConditions(requireBodyHandlerBuildItems), bodyHandlerBuildItem.getHandler(),
+                gracefulShutdownFilter, shutdownConfig, executorBuildItem.getExecutorProxy());
 
         return new ServiceStartBuildItem("vertx-http");
     }

--- a/integration-tests/keycloak-authorization/src/main/resources/application.properties
+++ b/integration-tests/keycloak-authorization/src/main/resources/application.properties
@@ -21,11 +21,11 @@ quarkus.keycloak.policy-enforcer.paths.1.path=/api/permission
 quarkus.keycloak.policy-enforcer.paths.1.claim-information-point.claims.static-claim=static-claim
 
 # Defines a claim which value references a request parameter
-quarkus.keycloak.policy-enforcer.paths.2.path=/api/permission/claim-protected
+quarkus.keycloak.policy-enforcer.paths.2.paths=/api/permission/claim-protected
 quarkus.keycloak.policy-enforcer.paths.2.claim-information-point.claims.grant={request.parameter['grant']}
 
 # Defines a claim which value is based on the response from an external service
-quarkus.keycloak.policy-enforcer.paths.3.path=/api/permission/http-response-claim-protected
+quarkus.keycloak.policy-enforcer.paths.3.paths=/api/permission/http-response-claim-protected
 quarkus.keycloak.policy-enforcer.paths.3.claim-information-point.http.claims.user-name=/userName
 quarkus.keycloak.policy-enforcer.paths.3.claim-information-point.http.url=http://localhost:8081/api/users/me
 quarkus.keycloak.policy-enforcer.paths.3.claim-information-point.http.method=GET
@@ -33,61 +33,40 @@ quarkus.keycloak.policy-enforcer.paths.3.claim-information-point.http.headers.Co
 quarkus.keycloak.policy-enforcer.paths.3.claim-information-point.http.headers.Authorization=Bearer {keycloak.access_token}
 
 # Disables policy enforcement for a path
-quarkus.keycloak.policy-enforcer.paths.4.path=/api/public
+quarkus.keycloak.policy-enforcer.paths.4.paths=/api/public,/api/public-token
 quarkus.keycloak.policy-enforcer.paths.4.enforcement-mode=DISABLED
 
 # Defines a claim which value is based on the response from an external service
-quarkus.keycloak.policy-enforcer.paths.5.path=/api/permission/body-claim
+quarkus.keycloak.policy-enforcer.paths.5.paths=/api/permission/body-claim
 quarkus.keycloak.policy-enforcer.paths.5.claim-information-point.claims.from-body={request.body['/from-body']}
 
 quarkus.keycloak.policy-enforcer.paths.6.name=Root
-quarkus.keycloak.policy-enforcer.paths.6.path=/*
+quarkus.keycloak.policy-enforcer.paths.6.paths=/*
 quarkus.keycloak.policy-enforcer.paths.6.enforcement-mode=DISABLED
 
 quarkus.keycloak.policy-enforcer.paths.7.name=API
-quarkus.keycloak.policy-enforcer.paths.7.path=/api2/*
+quarkus.keycloak.policy-enforcer.paths.7.paths=/api2/*
 quarkus.keycloak.policy-enforcer.paths.7.enforcement-mode=ENFORCING
 
 quarkus.keycloak.policy-enforcer.paths.8.name=Public
-quarkus.keycloak.policy-enforcer.paths.8.path=/hello
+quarkus.keycloak.policy-enforcer.paths.8.paths=/hello
 quarkus.keycloak.policy-enforcer.paths.8.enforcement-mode=DISABLED
 
 quarkus.keycloak.policy-enforcer.paths.9.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.9.path=/api/permission/scope
+quarkus.keycloak.policy-enforcer.paths.9.paths=/api/permission/scope,/api/permission/scopes/annotation-way-denied,/api/permission/scopes/programmatic-way-denied,/api/permission/annotation/scope-read,/api/permission/annotation/scope-write,/api/permission/scopes/programmatic-way,/api/permission/scopes/annotation-way
 
-quarkus.keycloak.policy-enforcer.paths.10.path=/api/public-enforcing
+quarkus.keycloak.policy-enforcer.paths.10.paths=/api/public-enforcing
 quarkus.keycloak.policy-enforcer.paths.10.enforcement-mode=ENFORCING
 
-quarkus.keycloak.policy-enforcer.paths.11.path=/api/public-token
-quarkus.keycloak.policy-enforcer.paths.11.enforcement-mode=DISABLED
+quarkus.keycloak.policy-enforcer.paths.11.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.11.paths=/api/permission/scopes/standard-way
+quarkus.keycloak.policy-enforcer.paths.11.methods.get.method=GET
+quarkus.keycloak.policy-enforcer.paths.11.methods.get.scopes=read
 
 quarkus.keycloak.policy-enforcer.paths.12.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.12.path=/api/permission/annotation/scope-read
-
-quarkus.keycloak.policy-enforcer.paths.13.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.13.path=/api/permission/annotation/scope-write
-
-quarkus.keycloak.policy-enforcer.paths.14.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.14.path=/api/permission/scopes/programmatic-way
-
-quarkus.keycloak.policy-enforcer.paths.15.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.15.path=/api/permission/scopes/standard-way
-quarkus.keycloak.policy-enforcer.paths.15.methods.get.method=GET
-quarkus.keycloak.policy-enforcer.paths.15.methods.get.scopes=read
-
-quarkus.keycloak.policy-enforcer.paths.16.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.16.path=/api/permission/scopes/annotation-way
-
-quarkus.keycloak.policy-enforcer.paths.17.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.17.path=/api/permission/scopes/standard-way-denied
-quarkus.keycloak.policy-enforcer.paths.17.methods.get.method=GET
-quarkus.keycloak.policy-enforcer.paths.17.methods.get.scopes=write
-
-quarkus.keycloak.policy-enforcer.paths.18.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.18.path=/api/permission/scopes/annotation-way-denied
-
-quarkus.keycloak.policy-enforcer.paths.19.name=Scope Permission Resource
-quarkus.keycloak.policy-enforcer.paths.19.path=/api/permission/scopes/programmatic-way-denied
+quarkus.keycloak.policy-enforcer.paths.12.paths=/api/permission/scopes/standard-way-denied
+quarkus.keycloak.policy-enforcer.paths.12.methods.get.method=GET
+quarkus.keycloak.policy-enforcer.paths.12.methods.get.scopes=write
 
 # Service Tenant
 quarkus.oidc.api-permission-tenant.auth-server-url=${quarkus.oidc.auth-server-url}
@@ -95,7 +74,7 @@ quarkus.oidc.api-permission-tenant.client-id=quarkus-app
 quarkus.oidc.api-permission-tenant.credentials.secret=secret
 
 quarkus.keycloak.api-permission-tenant.policy-enforcer.paths.1.name=Permission Resource Tenant
-quarkus.keycloak.api-permission-tenant.policy-enforcer.paths.1.path=/api-permission-tenant
+quarkus.keycloak.api-permission-tenant.policy-enforcer.paths.1.paths=/api-permission-tenant
 quarkus.keycloak.api-permission-tenant.policy-enforcer.paths.1.claim-information-point.claims.static-claim=static-claim
 
 # Web App Tenant
@@ -106,7 +85,7 @@ quarkus.oidc.api-permission-webapp.application-type=web-app
 quarkus.oidc.api-permission-webapp.roles.source=accesstoken
 
 quarkus.keycloak.api-permission-webapp.policy-enforcer.paths.1.name=Permission Resource WebApp
-quarkus.keycloak.api-permission-webapp.policy-enforcer.paths.1.path=/api-permission-webapp
+quarkus.keycloak.api-permission-webapp.policy-enforcer.paths.1.paths=/api-permission-webapp
 quarkus.keycloak.api-permission-webapp.policy-enforcer.paths.1.claim-information-point.claims.static-claim=static-claim
 
 admin-url=${keycloak.url}


### PR DESCRIPTION
- closes: #14851
- one of prerequisities for: #17664

Changes: 
- move tenant config to runtime as we already create them at runtime and do not leverage tenat knowledge at build time. Dynamic tenants will also be created at runtime. Experience from HTTP permissions says some users want to configure similar stuff during runtime, for which reason we moved them to the runtime. No Quarkiverse extension uses this extension https://mvnrepository.com/artifact/io.quarkus/quarkus-keycloak-authorization/usages therefore we are unlikely to break things
- allow to specify more than one path per enforcer (usability improvement - #14851)
- fixes documentation statement, paths are not relative to the application context if that means HTTP app / non-app root path. if original note means something else, it's not descriptive enough as it confused at least one user https://github.com/quarkusio/quarkus/issues/14851#issuecomment-1827262509 (plus me)