### PR TITLE
Handle trailing/leading spaces in all relevant datasource configuration properties

### DIFF
--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.datasource.runtime;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
 
@@ -44,6 +45,7 @@ public interface DataSourceBuildTimeConfig {
      *
      * @asciidoclet
      */
+    @WithConverter(TrimmedStringConverter.class)
     Optional<String> dbVersion();
 
     /**

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
 
 @ConfigGroup
@@ -25,6 +27,7 @@ public interface DevServicesBuildTimeConfig {
      * <p>
      * This has no effect if the provider is not a container-based database, such as H2 or Derby.
      */
+    @WithConverter(TrimmedStringConverter.class)
     Optional<String> imageName();
 
     /**
@@ -57,6 +60,7 @@ public interface DevServicesBuildTimeConfig {
      * <p>
      * This has no effect if the provider is not a container-based database, such as H2 or Derby.
      */
+    @WithConverter(TrimmedStringConverter.class)
     Optional<String> command();
 
     /**

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionExtraSpaceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionExtraSpaceTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.hibernate.orm.config.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.hibernate.orm.runtime.config.DialectVersions;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DbVersionExtraSpaceTest {
+
+    private static final String ACTUAL_H2_VERSION = DialectVersions.Defaults.H2;
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(SmokeTestUtils.class)
+                    .addClass(MyEntity.class))
+            .withConfigurationResource("application.properties")
+            // IMPORTANT: we insert spaces here -- both before and after, as this seems to trigger different behavior.
+            // See https://github.com/quarkusio/quarkus/issues/39395
+            .overrideConfigKey("quarkus.datasource.db-version", " " + ACTUAL_H2_VERSION + " ")
+            // Expect no warnings (in particular from Hibernate ORM)
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
+                    // Ignore these particular warnings: they are not relevant to this test.
+                    && !record.getMessage().contains("has been blocked for") //sometimes CI has a super slow moment and this triggers the blocked thread detector
+                    && !record.getMessage().contains("Agroal")
+                    && !record.getMessage().contains("Netty DefaultChannelId initialization"))
+            .assertLogRecords(records -> assertThat(records)
+                    .extracting(LogRecord::getMessage) // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
+                    .isEmpty());
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Inject
+    Session session;
+
+    @Test
+    public void dialectVersion() {
+        var dialectVersion = sessionFactory.unwrap(SessionFactoryImplementor.class).getJdbcServices().getDialect().getVersion();
+        assertThat(DialectVersions.toString(dialectVersion)).isEqualTo(ACTUAL_H2_VERSION);
+    }
+
+    @Test
+    @Transactional
+    public void smokeTest() {
+        SmokeTestUtils.testSimplePersistRetrieveUpdateDelete(session,
+                MyEntity.class, MyEntity::new,
+                MyEntity::getId,
+                MyEntity::setName, MyEntity::getName);
+    }
+}


### PR DESCRIPTION
Fixes #39395 

I didn't change the converter for:

* `username`/`password` for devservices, because @gsmet specifically avoided doing that for the non-devservice `username`/`password` in a previous PR: https://github.com/quarkusio/quarkus/commit/bfabc1c06609c99115cb4dc78a73c96c6f3c2df9
* Paths, because who knows what weird paths people use
* `Map<String,String>` config, e.g. properties, environment variables, volumes, for the same reason

I'm on the fence for `command`. I can drop it if you want.