### PR TITLE
Use URL path template when tracing REST clients where possible

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTextMapPropagatorCustomizerTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTextMapPropagatorCustomizerTest.java
@@ -56,7 +56,7 @@ public class OpenTelemetryTextMapPropagatorCustomizerTest {
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
         SpanData clientSpan = getSpanByKindAndParentId(spans, SpanKind.CLIENT, "0000000000000000");
-        assertEquals("GET", clientSpan.getName());
+        assertEquals("GET /hello", clientSpan.getName());
 
         // There is a parent id, therefore propagation is working.
         SpanData serverSpan = getSpanByKindAndParentId(spans, SpanKind.SERVER, clientSpan.getSpanId());

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientOpenTelemetryTest.java
@@ -71,7 +71,7 @@ public class RestClientOpenTelemetryTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
-        assertEquals("GET", client.getName());
+        assertEquals("GET /hello", client.getName());
         assertSemanticAttribute(client, (long) HTTP_OK, HTTP_STATUS_CODE);
         assertSemanticAttribute(client, HttpMethod.GET, HTTP_METHOD);
         assertSemanticAttribute(client, uri.toString() + "hello", HTTP_URL);
@@ -96,7 +96,7 @@ public class RestClientOpenTelemetryTest {
 
         SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(CLIENT, client.getKind());
-        assertEquals("GET", client.getName());
+        assertEquals("GET /hello", client.getName());
         assertSemanticAttribute(client, (long) HTTP_OK, HTTP_STATUS_CODE);
         assertSemanticAttribute(client, HttpMethod.GET, HTTP_METHOD);
         assertSemanticAttribute(client, uri.toString() + "hello?query=1", HTTP_URL);
@@ -132,7 +132,7 @@ public class RestClientOpenTelemetryTest {
 
         SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(CLIENT, client.getKind());
-        assertEquals("GET", client.getName());
+        assertEquals("GET /hello/{path}", client.getName());
         assertSemanticAttribute(client, (long) HTTP_OK, HTTP_STATUS_CODE);
         assertSemanticAttribute(client, HttpMethod.GET, HTTP_METHOD);
         assertSemanticAttribute(client, uri.toString() + "hello/another", HTTP_URL);

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientObservabilityHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientObservabilityHandler.java
@@ -18,5 +18,6 @@ public class ClientObservabilityHandler implements ClientRestHandler {
     @Override
     public void handle(RestClientRequestContext requestContext) throws Exception {
         requestContext.getClientFilterProperties().put("UrlPathTemplate", templatePath);
+        requestContext.getOrCreateClientRequestContext().getContext().putLocal("ClientUrlPathTemplate", templatePath);
     }
 }

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
@@ -57,7 +57,7 @@ public class OpenTelemetryReactiveClientTest {
         // First span is the client call. It does not have a parent span.
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
-        assertEquals("GET", client.get("name"));
+        assertEquals("GET /reactive", client.get("name"));
         assertEquals(HTTP_OK, ((Map<?, ?>) client.get("attributes")).get(HTTP_STATUS_CODE.getKey()));
         assertEquals(HttpMethod.GET.name(), ((Map<?, ?>) client.get("attributes")).get(HTTP_METHOD.getKey()));
 
@@ -92,7 +92,7 @@ public class OpenTelemetryReactiveClientTest {
         // First span is the client call. It does not have a parent span.
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
-        assertEquals("POST", client.get("name"));
+        assertEquals("POST /reactive", client.get("name"));
         assertEquals(HTTP_OK, ((Map<?, ?>) client.get("attributes")).get(HTTP_STATUS_CODE.getKey()));
         assertEquals(HttpMethod.POST.name(), ((Map<?, ?>) client.get("attributes")).get(HTTP_METHOD.getKey()));
 

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryWithSpanAtStartupTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryWithSpanAtStartupTest.java
@@ -47,7 +47,7 @@ public class OpenTelemetryWithSpanAtStartupTest {
 
         // We should get one client span, from the internal method.
         Map<String, Object> server = getSpanByKindAndParentId(spans, CLIENT, client.get("spanId"));
-        assertEquals("GET", server.get("name"));
+        assertEquals("GET /stub", server.get("name"));
     }
 
     @Startup

--- a/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTest.java
+++ b/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTest.java
@@ -140,7 +140,7 @@ public class OpenTelemetryTest {
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
         assertEquals(CLIENT.toString(), client.get("kind"));
         verifyResource(client);
-        assertEquals("GET", client.get("name"));
+        assertEquals("GET /", client.get("name"));
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
         assertTrue((Boolean) client.get("ended"));
         assertTrue((Boolean) client.get("parent_valid"));
@@ -206,7 +206,7 @@ public class OpenTelemetryTest {
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
         assertEquals(CLIENT.toString(), client.get("kind"));
-        assertEquals("GET", client.get("name"));
+        assertEquals("GET /", client.get("name"));
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
         assertTrue((Boolean) client.get("ended"));
         assertTrue((Boolean) client.get("parent_valid"));
@@ -261,7 +261,7 @@ public class OpenTelemetryTest {
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
         assertEquals(CLIENT.toString(), client.get("kind"));
-        assertEquals("GET", client.get("name"));
+        assertEquals("GET /from-baggage", client.get("name"));
         assertEquals("http://localhost:8081/from-baggage", client.get("attr_http.url"));
         assertEquals("200", client.get("attr_http.status_code"));
         assertEquals(client.get("parentSpanId"), server.get("spanId"));
@@ -467,7 +467,7 @@ public class OpenTelemetryTest {
         assertNotNull(server.get("attr_user_agent.original"));
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
-        assertEquals("GET", client.get("name"));
+        assertEquals("GET /client/pong/{message}", client.get("name"));
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
         assertTrue((Boolean) client.get("ended"));
         assertTrue((Boolean) client.get("parent_valid"));
@@ -530,7 +530,7 @@ public class OpenTelemetryTest {
         assertNotNull(server.get("attr_user_agent.original"));
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
-        assertEquals("GET", client.get("name"));
+        assertEquals("GET /client/pong/{message}", client.get("name"));
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
         assertTrue((Boolean) client.get("ended"));
         assertTrue((Boolean) client.get("parent_valid"));
@@ -602,7 +602,7 @@ public class OpenTelemetryTest {
         assertEquals("one", fromInterceptor.get("attr_message"));
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, fromInterceptor.get("spanId"));
-        assertEquals("GET", client.get("name"));
+        assertEquals("GET /client/pong/{message}", client.get("name"));
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
         assertTrue((Boolean) client.get("ended"));
         assertTrue((Boolean) client.get("parent_valid"));


### PR DESCRIPTION
Use URL path template in the REST client span names where possible.

Using raw Vert.x web client is not possible right now since all the instrumentation happens after `UriTemplate` is applied so we have only the full URI... this would make is have infinite cardinality since a path variable can lead to infinite URLs. Ideally the Vert.x web client could expose the used `UriTemplate` during tracing or for `metrics` (as we have with VertxRoute right now) so we could extract it and build the span name with the template as well.

Now RestEasy clients using Vert.x or not will be with a span name of `{method} {urlPathTemplate}` as we had before =]

- Closes https://github.com/quarkusio/quarkus/issues/39457