### PR TITLE
Fix formatter-maven-plugin build cache misses

### DIFF
--- a/independent-projects/ide-config/pom.xml
+++ b/independent-projects/ide-config/pom.xml
@@ -61,6 +61,14 @@
                         <argLine>${jacoco.agent.argLine}</argLine>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <archive>
+                            <index>false</index>
+                        </archive>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
### Issue
The Quarkus build gets some cache misses on the `formatter-maven-plugin` goal due to its "goal implementation changed":
![Screenshot 2024-03-19 at 2 08 17 PM](https://github.com/quarkusio/quarkus/assets/10243934/a7db0274-59d5-4f7c-8db4-32a7bda1cd8d)

In my experience, the cost is 3 minutes of CPU time on a 4 minutes build:
![Screenshot 2024-03-19 at 2 07 56 PM](https://github.com/quarkusio/quarkus/assets/10243934/1cb9443c-1f1e-43ed-abd5-b76eaae5fa03)

The reason is that the `INDEX.LIST` file from the `quarkus-ide-config` jar (containing the formatter configuration) is changing across builds:
![Screenshot 2024-03-19 at 2 07 24 PM](https://github.com/quarkusio/quarkus/assets/10243934/274ec146-f3db-4d08-915f-0caaedb7546f)

### Steps to reproduce
Use the [Develocity build validation scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Maven.md) and run:
```
./02-validate-local-build-caching-different-locations.sh -r https://github.com/quarkusio/quarkus -g 'install' -a '-Dquickly -T2C'
```

_Note:_
It is not systematic and the build parallelization certainly plays a role into that, whether `quarkus-revapi` module is built before / after `quarkus-ide-config`

### Fix
Enforce Jar consistency by not generating the jar index list