### PR TITLE
Don't run CDI interceptors on class-level exception mappers

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -2242,8 +2242,16 @@ public class Endpoint {
 }
 ----
 
-NOTE: exception mappers defined in REST endpoint classes will only be called if the
-exception is thrown in the same class. If you want to define global exception mappers,
+[TIP]
+====
+By default, methods annotated with `@ServerExceptionMapper` do **not** run CDI interceptors that apply to the other methods of the class (like ones needed for implementing security method level security).
+
+Users however can opt into interceptors by adding the corresponding annotations to the method.
+====
+
+[NOTE]
+====
+Εxception mappers defined in REST endpoint classes will only be called if the  exception is thrown in the same class. If you want to define global exception mappers,
 simply define them outside a REST endpoint class:
 
 [source,java]
@@ -2262,6 +2270,7 @@ class ExceptionMappers {
 ----
 
 You can also declare link:{jaxrsspec}#exceptionmapper[exception mappers in the Jakarta REST way].
+====
 
 Your exception mapper may declare any of the following parameter types:
 

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/DotNames.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/DotNames.java
@@ -8,6 +8,8 @@ import java.nio.file.Path;
 import org.jboss.jandex.DotName;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
 
+import io.quarkus.arc.NoClassInterceptors;
+
 final class DotNames {
 
     static final String POPULATE_METHOD_NAME = "populate";
@@ -19,6 +21,8 @@ final class DotNames {
     static final DotName FIELD_UPLOAD_NAME = DotName.createSimple(FileUpload.class.getName());
     static final DotName PATH_NAME = DotName.createSimple(Path.class.getName());
     static final DotName FILE_NAME = DotName.createSimple(File.class.getName());
+
+    static final DotName NO_CLASS_INTERCEPTORS = DotName.createSimple(NoClassInterceptors.class);
 
     private DotNames() {
     }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/CustomClassLevelExceptionMapperTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/CustomClassLevelExceptionMapperTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static io.restassured.RestAssured.when;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.UnauthorizedException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CustomClassLevelExceptionMapperTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloResource.class));
+
+    @Test
+    public void shouldDenyUnannotated() {
+        when().get("hello")
+                .then()
+                .statusCode(999);
+    }
+
+    @Path("hello")
+    @RolesAllowed("test")
+    public static final class HelloResource {
+
+        @GET
+        public String hello() {
+            return "hello world";
+        }
+
+        @ServerExceptionMapper(UnauthorizedException.class)
+        public Response forbidden() {
+            return Response.status(999).build();
+        }
+    }
+}


### PR DESCRIPTION
The previous behavior was pretty weird and prevented us from using `@ServerExceptionMapper` in classes that were annotated with security annotations

The longer discussion is [here](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Bean.20scope.20is.20changed.20when.20adding.20a.20.40ServerExceptionMapper.20.3F/near/427889997)