### PR TITLE
Properly use headers from RestMulti when the multi is empty

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/streams/StreamResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/streams/StreamResource.java
@@ -199,6 +199,19 @@ public class StreamResource {
                 Wrapper::getStatus);
     }
 
+    @Path("restmulti/empty")
+    @GET
+    @Produces(RestMediaType.APPLICATION_JSON)
+    public Multi<Message> restMultiEmptyJson() {
+        return RestMulti.fromUniResponse(
+                Uni.createFrom().item(
+                        () -> new Wrapper(Multi.createFrom().empty(),
+                                new AbstractMap.SimpleEntry<>("foo", "bar"), 222)),
+                Wrapper::getData,
+                Wrapper::getHeaders,
+                Wrapper::getStatus);
+    }
+
     @Path("stream-json/multi")
     @GET
     @Produces(RestMediaType.APPLICATION_STREAM_JSON)

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/streams/StreamTestCase.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/streams/StreamTestCase.java
@@ -175,6 +175,14 @@ public class StreamTestCase {
     }
 
     @Test
+    public void testRestMultiEmptyJson() {
+        when().get(uri.toString() + "streams/restmulti/empty")
+                .then().statusCode(222)
+                .body(is("[]"))
+                .header("foo", "bar");
+    }
+
+    @Test
     public void testStreamJsonMultiFromMulti() {
         when().get(uri.toString() + "streams/stream-json/multi")
                 .then().statusCode(HttpStatus.SC_OK)

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/PublisherResponseHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/PublisherResponseHandler.java
@@ -151,7 +151,7 @@ public class PublisherResponseHandler implements ServerRestHandler {
         @Override
         public void onComplete() {
             if (!hadItem) {
-                StreamingUtil.setHeaders(requestContext, requestContext.serverResponse(), staticCustomizers);
+                StreamingUtil.setHeaders(requestContext, requestContext.serverResponse(), this.determineCustomizers(true));
             }
             if (json) {
                 String postfix = onCompleteText();


### PR DESCRIPTION
Replace the use of `staticCustomizers` by a call to `determineCustomizers` on the `onComplete` if the multi did not yield any objects.

- Fixes #39586.

