### PR TITLE
Enable usage of random port for the Management Interface

### DIFF
--- a/docs/src/main/asciidoc/management-interface-reference.adoc
+++ b/docs/src/main/asciidoc/management-interface-reference.adoc
@@ -260,3 +260,24 @@ quarkus.management.auth.permission.metrics.policy=authenticated
 ----
 
 More details about Basic authentication in Quarkus can be found in the xref:security-basic-authentication-howto.adoc[Basic authentication guide].
+
+== Injecting management URL in tests
+
+When testing your application, you can inject the management URL using the `@TestHTTPResource` annotation:
+
+[source,java]
+----
+@TestHTTPResource(value="/management", management=true)
+URL management;
+----
+
+The `management` attribute is set to `true` to indicate that the injected URL is for the management interface.
+The `context-root` is automatically added.
+Thus, in the previous example, the injected URL is `http://localhost:9001/q/management`.
+
+`@TestHTTPResource` is particularly useful when setting the management `test-port` to 0, which indicates that the system will assign a random port to the management interface:
+
+[source, properties]
+----]
+quarkus.management.test-port=0
+----

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementAndPrimaryOnPortZeroTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementAndPrimaryOnPortZeroTest.java
@@ -1,12 +1,15 @@
 package io.quarkus.vertx.http.management;
 
+import java.net.URL;
 import java.util.function.Consumer;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Singleton;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -14,16 +17,19 @@ import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildStep;
 import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.restassured.RestAssured;
 import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
-public class ManagementAndRootPathTest {
+public class ManagementAndPrimaryOnPortZeroTest {
     private static final String APP_PROPS = """
             quarkus.management.enabled=true
-            quarkus.management.root-path=/management
+            quarkus.management.test-port=0
+            quarkus.http.test-port=0
             """;
 
     @RegisterExtension
@@ -43,7 +49,7 @@ public class ManagementAndRootPathTest {
                         NonApplicationRootPathBuildItem buildItem = context.consume(NonApplicationRootPathBuildItem.class);
                         context.produce(buildItem.routeBuilder()
                                 .management()
-                                .route("management-relative")
+                                .route("management")
                                 .handler(new MyHandler())
                                 .blockingRoute()
                                 .build());
@@ -60,19 +66,44 @@ public class ManagementAndRootPathTest {
         public void handle(RoutingContext routingContext) {
             routingContext.response()
                     .setStatusCode(200)
-                    .end(routingContext.request().path());
+                    .end("Hello management");
         }
     }
 
+    @TestHTTPResource(value = "/route")
+    URL url;
+
+    @TestHTTPResource(value = "/management", management = true)
+    URL management;
+
+    @ConfigProperty(name = "quarkus.management.test-port")
+    int managementPort;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    int primaryPort;
+
     @Test
-    public void testNonApplicationEndpointDirect() {
-        // Note RestAssured knows the path prefix is /api
-        RestAssured.given().get("http://0.0.0.0:9001/management/management-relative")
-                .then().statusCode(200).body(Matchers.equalTo("/management/management-relative"));
+    public void test() {
+        Assertions.assertNotEquals(url.getPort(), management.getPort());
+        Assertions.assertEquals(url.getPort(), primaryPort);
+        Assertions.assertEquals(management.getPort(), managementPort);
+
+        for (int i = 0; i < 10; i++) {
+            RestAssured.given().get(url.toExternalForm()).then().body(Matchers.is("Hello primary"));
+        }
+
+        for (int i = 0; i < 10; i++) {
+            RestAssured.given().get(management.toExternalForm()).then().body(Matchers.is("Hello management"));
+        }
+
     }
 
     @Singleton
     static class MyObserver {
+
+        void register(@Observes Router router) {
+            router.get("/route").handler(rc -> rc.response().end("Hello primary"));
+        }
 
         void test(@Observes String event) {
             //Do Nothing

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -32,6 +32,21 @@ import io.vertx.core.net.*;
 public class HttpServerOptionsUtils {
 
     /**
+     * When the http port is set to 0, replace it by this value to let Vert.x choose a random port
+     */
+    public static final int RANDOM_PORT_MAIN_HTTP = -1;
+
+    /**
+     * When the https port is set to 0, replace it by this value to let Vert.x choose a random port
+     */
+    public static final int RANDOM_PORT_MAIN_TLS = -2;
+
+    /**
+     * When the management port is set to 0, replace it by this value to let Vert.x choose a random port
+     */
+    public static final int RANDOM_PORT_MANAGEMENT = -3;
+
+    /**
      * Get an {@code HttpServerOptions} for this server configuration, or null if SSL should not be enabled
      */
     public static HttpServerOptions createSslOptions(HttpBuildTimeConfig buildTimeConfig, HttpConfiguration httpConfiguration,
@@ -108,7 +123,7 @@ public class HttpServerOptionsUtils {
         serverOptions.setSni(sslConfig.sni);
         int sslPort = httpConfiguration.determineSslPort(launchMode);
         // -2 instead of -1 (see http) to have vert.x assign two different random ports if both http and https shall be random
-        serverOptions.setPort(sslPort == 0 ? -2 : sslPort);
+        serverOptions.setPort(sslPort == 0 ? RANDOM_PORT_MAIN_TLS : sslPort);
         serverOptions.setClientAuth(buildTimeConfig.tlsClientAuth);
 
         applyCommonOptions(serverOptions, buildTimeConfig, httpConfiguration, websocketSubProtocols);
@@ -194,8 +209,8 @@ public class HttpServerOptionsUtils {
         serverOptions.setSsl(true);
         serverOptions.setSni(sslConfig.sni);
         int sslPort = httpConfiguration.determinePort(launchMode);
-        // -2 instead of -1 (see http) to have vert.x assign two different random ports if both http and https shall be random
-        serverOptions.setPort(sslPort == 0 ? -2 : sslPort);
+
+        serverOptions.setPort(sslPort == 0 ? RANDOM_PORT_MANAGEMENT : sslPort);
         serverOptions.setClientAuth(buildTimeConfig.tlsClientAuth);
 
         applyCommonOptionsForManagementInterface(serverOptions, buildTimeConfig, httpConfiguration, websocketSubProtocols);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPConfigSourceProvider.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPConfigSourceProvider.java
@@ -16,11 +16,20 @@ public class TestHTTPConfigSourceProvider implements ConfigSourceProvider {
     static final String TEST_URL_VALUE = "http://${quarkus.http.host:localhost}:${quarkus.http.test-port:8081}${quarkus.http.root-path:${quarkus.servlet.context-path:}}";
     static final String TEST_URL_KEY = "test.url";
 
+    static final String TEST_MANAGEMENT_URL_VALUE = "http://${quarkus.management.host:localhost}:${quarkus.management.test-port:9001}${quarkus.management.root-path:/q}";
+    static final String TEST_MANAGEMENT_URL_KEY = "test.management.url";
+
     static final String TEST_URL_SSL_VALUE = "https://${quarkus.http.host:localhost}:${quarkus.http.test-ssl-port:8444}${quarkus.http.root-path:${quarkus.servlet.context-path:}}";
     static final String TEST_URL_SSL_KEY = "test.url.ssl";
 
-    static final Map<String, String> entries = Map.of(TEST_URL_KEY, sanitizeURL(TEST_URL_VALUE),
+    static final String TEST_MANAGEMENT_URL_SSL_VALUE = "https://${quarkus.management.host:localhost}:${quarkus.management.test-ssl-port:9001}${quarkus.management.root-path:/q}";
+    static final String TEST_MANAGEMENT_URL_SSL_KEY = "test.management.url.ssl";
+
+    static final Map<String, String> entries = Map.of(
+            TEST_URL_KEY, sanitizeURL(TEST_URL_VALUE),
             TEST_URL_SSL_KEY, sanitizeURL(TEST_URL_SSL_VALUE),
+            TEST_MANAGEMENT_URL_KEY, sanitizeURL(TEST_MANAGEMENT_URL_VALUE),
+            TEST_MANAGEMENT_URL_SSL_KEY, sanitizeURL(TEST_MANAGEMENT_URL_SSL_VALUE),
             "%dev." + TEST_URL_KEY, sanitizeURL(
                     "http://${quarkus.http.host:localhost}:${quarkus.http.test-port:8080}${quarkus.http.root-path:${quarkus.servlet.context-path:}}"));
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPResource.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPResource.java
@@ -8,9 +8,9 @@ import java.lang.annotation.Target;
 /**
  * Indicates that a field should be injected with a resource that is pre-configured
  * to use the correct test URL.
- *
+ * <p>
  * This could be a String or URL object, or some other HTTP/Websocket based client.
- *
+ * <p>
  * This mechanism is pluggable, via {@link TestHTTPResourceProvider}
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -18,14 +18,24 @@ import java.lang.annotation.Target;
 public @interface TestHTTPResource {
 
     /**
-     *
      * @return The path part of the URL
      */
     String value() default "";
 
     /**
-     *
      * @return If the URL should use the HTTPS protocol and SSL port
+     * @deprecated use #tls instead
      */
+    @Deprecated
     boolean ssl() default false;
+
+    /**
+     * @return if the url should use the management interface
+     */
+    boolean management() default false;
+
+    /**
+     * @return If the URL should use the HTTPS protocol and TLS port
+     */
+    boolean tls() default false;
 }


### PR DESCRIPTION
Setting the management interface port to a random value in testing scenarios can be beneficial. This can be achieved by configuring `quarkus.management.test-port` to `0`. However, retrieving the actual port in tests was not feasible previously.

This PR addresses this limitation by introducing the following enhancements:

* It stores the actual management port in a system property when it differs from the configured port.
* It enables injecting the actual management port using `@TestHTTPResource(management=true,...)`.



- Fixes: https://github.com/quarkusio/quarkus/issues/39555
- Fixes: https://github.com/quarkusio/quarkus/issues/35952