### PR TITLE
Only Add OTel Security Events when span is recording

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/security/SecurityEventUtil.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/security/SecurityEventUtil.java
@@ -113,7 +113,7 @@ public final class SecurityEventUtil {
 
     private static void addEvent(String eventName, Attributes attributes) {
         Span span = Arc.container().select(Span.class).get();
-        if (span.getSpanContext().isValid()) {
+        if (span.getSpanContext().isValid() && span.isRecording()) {
             span.addEvent(eventName, attributes, Instant.now());
         }
     }


### PR DESCRIPTION
Addresses @brunobat suggestion to not add events when a Span is not recording. It looks like Span should be effectively no-op when not recording https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#isrecording, but there are exceptions mentioned in the specs. I suppose it's safer to check.