### PR TITLE
Update one of OIDC certificate chain tests to use TenantConfigResolver

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -270,6 +270,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public void setLeafCertificateName(String leafCertificateName) {
             this.leafCertificateName = Optional.of(leafCertificateName);
         }
+
+        public Optional<String> getTrustStorePassword() {
+            return trustStorePassword;
+        }
+
+        public void setTrustStorePassword(String trustStorePassword) {
+            this.trustStorePassword = Optional.ofNullable(trustStorePassword);
+        }
     }
 
     /**

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CertChainPublicKeyResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CertChainPublicKeyResolver.java
@@ -22,12 +22,12 @@ public class CertChainPublicKeyResolver implements RefreshableVerificationKeyRes
     final Optional<String> expectedLeafCertificateName;
 
     public CertChainPublicKeyResolver(CertificateChain chain) {
-        if (chain.trustStorePassword.isEmpty()) {
+        if (chain.getTrustStorePassword().isEmpty()) {
             throw new ConfigurationException(
                     "Truststore with configured password which keeps thumbprints of the trusted certificates must be present");
         }
         this.thumbprints = TrustStoreUtils.getTrustedCertificateThumbprints(chain.trustStoreFile.get(),
-                chain.trustStorePassword.get(), chain.trustStoreCertAlias, chain.getTrustStoreFileType());
+                chain.getTrustStorePassword().get(), chain.trustStoreCertAlias, chain.getTrustStoreFileType());
         this.expectedLeafCertificateName = chain.leafCertificateName;
     }
 

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.keycloak;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
 
@@ -42,6 +43,13 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             config.getCodeGrant().setHeaders(Map.of("X-Custom", "XCustomHeaderValue"));
             config.getCodeGrant().setExtraParams(Map.of("extra-param", "extra-param-value"));
             config.getAuthentication().setInternalIdTokenLifespan(Duration.ofSeconds(301));
+            return Uni.createFrom().item(config);
+        } else if (path.endsWith("bearer-certificate-full-chain-root-only")) {
+            OidcTenantConfig config = new OidcTenantConfig();
+            config.setTenantId("bearer-certificate-full-chain-root-only");
+            config.getCertificateChain().setTrustStoreFile(Path.of("truststore-rootcert.p12"));
+            config.getCertificateChain().setTrustStorePassword("storepassword");
+            config.getCertificateChain().setLeafCertificateName("www.quarkustest.com");
             return Uni.createFrom().item(config);
         }
 

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -180,10 +180,6 @@ quarkus.oidc.bearer-no-introspection.token.allow-jwt-introspection=false
 quarkus.oidc.bearer-certificate-full-chain.certificate-chain.trust-store-file=truststore.p12
 quarkus.oidc.bearer-certificate-full-chain.certificate-chain.trust-store-password=storepassword
 
-quarkus.oidc.bearer-certificate-full-chain-root-only.certificate-chain.trust-store-file=truststore-rootcert.p12
-quarkus.oidc.bearer-certificate-full-chain-root-only.certificate-chain.trust-store-password=storepassword
-quarkus.oidc.bearer-certificate-full-chain-root-only.certificate-chain.leaf-certificate-name=www.quarkustest.com
-
 quarkus.oidc.bearer-certificate-full-chain-root-only-wrongcname.certificate-chain.trust-store-file=truststore-rootcert.p12
 quarkus.oidc.bearer-certificate-full-chain-root-only-wrongcname.certificate-chain.trust-store-password=storepassword
 quarkus.oidc.bearer-certificate-full-chain-root-only-wrongcname.certificate-chain.leaf-certificate-name=www.quarkusio.com


### PR DESCRIPTION
CC @calvernaz

This PR only updates one of the few OIDC tests where a token with the inlined certificate chain is verified to use `TenantConfigResolver` to resolve the corresponding OIDC configuration, as opposed to using `application.properties` to make sure it works as expected