### PR TITLE
Migrate Keycloak Authorization config classes to the `@ConfigMapping`

### DIFF
--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
@@ -71,7 +71,7 @@ public class KeycloakPolicyEnforcerBuildStep {
         KeycloakPolicyEnforcerBuildTimeConfig config;
 
         public boolean getAsBoolean() {
-            return config.policyEnforcer.enable;
+            return config.policyEnforcer().enable();
         }
     }
 }

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerBuildTimeConfig.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerBuildTimeConfig.java
@@ -1,28 +1,29 @@
 package io.quarkus.keycloak.pep.runtime;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 /**
  * Build time configuration for Keycloak Authorization.
  */
-@ConfigRoot(name = "keycloak")
-public class KeycloakPolicyEnforcerBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.keycloak")
+@ConfigRoot
+public interface KeycloakPolicyEnforcerBuildTimeConfig {
 
     /**
      * Policy enforcement enable status
      */
-    @ConfigItem
-    public KeycloakPolicyEnforcerEnableStatus policyEnforcer = new KeycloakPolicyEnforcerEnableStatus();
+    KeycloakPolicyEnforcerEnableStatus policyEnforcer();
 
     @ConfigGroup
-    public static class KeycloakPolicyEnforcerEnableStatus {
+    interface KeycloakPolicyEnforcerEnableStatus {
 
         /**
          * Enables policy enforcement.
          */
-        @ConfigItem
-        public boolean enable;
+        @WithDefault("false")
+        boolean enable();
     }
 }

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerConfig.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerConfig.java
@@ -4,24 +4,26 @@ import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
 
-@ConfigRoot(name = "keycloak", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class KeycloakPolicyEnforcerConfig {
+@ConfigMapping(prefix = "quarkus.keycloak")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface KeycloakPolicyEnforcerConfig {
 
     /**
      * The default tenant.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public KeycloakPolicyEnforcerTenantConfig defaultTenant;
+    @WithParentName
+    KeycloakPolicyEnforcerTenantConfig defaultTenant();
 
     /**
      * Additional named tenants.
      */
     @ConfigDocSection
     @ConfigDocMapKey("tenant")
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, KeycloakPolicyEnforcerTenantConfig> namedTenants;
+    @WithParentName
+    Map<String, KeycloakPolicyEnforcerTenantConfig> namedTenants();
 }

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
@@ -38,10 +38,10 @@ public class KeycloakPolicyEnforcerRecorder {
         return new BooleanSupplier() {
             @Override
             public boolean getAsBoolean() {
-                if (isBodyHandlerRequired(config.defaultTenant)) {
+                if (isBodyHandlerRequired(config.defaultTenant())) {
                     return true;
                 }
-                for (KeycloakPolicyEnforcerTenantConfig tenantConfig : config.namedTenants.values()) {
+                for (KeycloakPolicyEnforcerTenantConfig tenantConfig : config.namedTenants().values()) {
                     if (isBodyHandlerRequired(tenantConfig)) {
                         return true;
                     }
@@ -53,9 +53,10 @@ public class KeycloakPolicyEnforcerRecorder {
 
     public Supplier<PolicyEnforcerResolver> setup(OidcConfig oidcConfig, KeycloakPolicyEnforcerConfig config,
             TlsConfig tlsConfig, HttpConfiguration httpConfiguration) {
-        PolicyEnforcer defaultPolicyEnforcer = createPolicyEnforcer(oidcConfig.defaultTenant, config.defaultTenant, tlsConfig);
+        PolicyEnforcer defaultPolicyEnforcer = createPolicyEnforcer(oidcConfig.defaultTenant, config.defaultTenant(),
+                tlsConfig);
         Map<String, PolicyEnforcer> policyEnforcerTenants = new HashMap<String, PolicyEnforcer>();
-        for (Map.Entry<String, KeycloakPolicyEnforcerTenantConfig> tenant : config.namedTenants.entrySet()) {
+        for (Map.Entry<String, KeycloakPolicyEnforcerTenantConfig> tenant : config.namedTenants().entrySet()) {
             OidcTenantConfig oidcTenantConfig = oidcConfig.namedTenants.get(tenant.getKey());
             if (oidcTenantConfig == null) {
                 throw new ConfigurationException("Failed to find a matching OidcTenantConfig for tenant: " + tenant.getKey());
@@ -106,7 +107,7 @@ public class KeycloakPolicyEnforcerRecorder {
                 adapterConfig.setAllowAnyHostname(true);
             }
         }
-        adapterConfig.setConnectionPoolSize(keycloakPolicyEnforcerConfig.connectionPoolSize);
+        adapterConfig.setConnectionPoolSize(keycloakPolicyEnforcerConfig.connectionPoolSize());
 
         if (oidcConfig.proxy.host.isPresent()) {
             String host = oidcConfig.proxy.host.get();
@@ -145,12 +146,34 @@ public class KeycloakPolicyEnforcerRecorder {
     private static Map<String, Map<String, Object>> getClaimInformationPointConfig(ClaimInformationPointConfig config) {
         Map<String, Map<String, Object>> cipConfig = new HashMap<>();
 
-        for (Map.Entry<String, Map<String, String>> entry : config.simpleConfig.entrySet()) {
-            cipConfig.put(entry.getKey(), new HashMap<>(entry.getValue()));
+        for (Map.Entry<String, Map<String, String>> entry : config.simpleConfig().entrySet()) {
+            if (!entry.getValue().isEmpty()) {
+                Map<String, Object> newConfig = new HashMap<>();
+                for (Map.Entry<String, String> e : entry.getValue().entrySet()) {
+                    if (isNotComplexConfigKey(e.getKey())) {
+                        newConfig.put(e.getKey(), e.getValue());
+                    }
+                }
+                if (!newConfig.isEmpty()) {
+                    cipConfig.put(entry.getKey(), newConfig);
+                }
+            }
         }
 
-        for (Map.Entry<String, Map<String, Map<String, String>>> entry : config.complexConfig.entrySet()) {
-            cipConfig.computeIfAbsent(entry.getKey(), s -> new HashMap<>()).putAll(new HashMap<>(entry.getValue()));
+        for (Map.Entry<String, Map<String, Map<String, String>>> entry : config.complexConfig().entrySet()) {
+            if (!entry.getValue().isEmpty()) {
+                Map<String, Object> newConfig = new HashMap<>();
+                for (Map.Entry<String, Map<String, String>> e : entry.getValue().entrySet()) {
+                    if (e.getValue() != null && !e.getValue().isEmpty()) {
+                        // value can be empty when this key comes from the simple config
+                        // see https://github.com/quarkusio/quarkus/issues/39315#issuecomment-1991604044
+                        newConfig.put(e.getKey(), e.getValue());
+                    }
+                }
+                if (!newConfig.isEmpty()) {
+                    cipConfig.computeIfAbsent(entry.getKey(), s -> new HashMap<>()).putAll(newConfig);
+                }
+            }
         }
 
         return cipConfig;
@@ -159,20 +182,20 @@ public class KeycloakPolicyEnforcerRecorder {
     private static PolicyEnforcerConfig getPolicyEnforcerConfig(KeycloakPolicyEnforcerTenantConfig config) {
         PolicyEnforcerConfig enforcerConfig = new PolicyEnforcerConfig();
 
-        enforcerConfig.setLazyLoadPaths(config.policyEnforcer.lazyLoadPaths);
-        enforcerConfig.setEnforcementMode(config.policyEnforcer.enforcementMode);
-        enforcerConfig.setHttpMethodAsScope(config.policyEnforcer.httpMethodAsScope);
+        enforcerConfig.setLazyLoadPaths(config.policyEnforcer().lazyLoadPaths());
+        enforcerConfig.setEnforcementMode(config.policyEnforcer().enforcementMode());
+        enforcerConfig.setHttpMethodAsScope(config.policyEnforcer().httpMethodAsScope());
 
-        PathCacheConfig pathCache = config.policyEnforcer.pathCache;
+        PathCacheConfig pathCache = config.policyEnforcer().pathCache();
 
         PolicyEnforcerConfig.PathCacheConfig pathCacheConfig = new PolicyEnforcerConfig.PathCacheConfig();
-        pathCacheConfig.setLifespan(pathCache.lifespan);
-        pathCacheConfig.setMaxEntries(pathCache.maxEntries);
+        pathCacheConfig.setLifespan(pathCache.lifespan());
+        pathCacheConfig.setMaxEntries(pathCache.maxEntries());
         enforcerConfig.setPathCacheConfig(pathCacheConfig);
 
         enforcerConfig.setClaimInformationPointConfig(
-                getClaimInformationPointConfig(config.policyEnforcer.claimInformationPoint));
-        enforcerConfig.setPaths(config.policyEnforcer.paths.values().stream().flatMap(
+                getClaimInformationPointConfig(config.policyEnforcer().claimInformationPoint()));
+        enforcerConfig.setPaths(config.policyEnforcer().paths().values().stream().flatMap(
                 new Function<PathConfig, Stream<? extends PolicyEnforcerConfig.PathConfig>>() {
                     @Override
                     public Stream<? extends PolicyEnforcerConfig.PathConfig> apply(PathConfig pathConfig) {
@@ -195,11 +218,11 @@ public class KeycloakPolicyEnforcerRecorder {
 
     private static Set<String> getPathConfigPaths(PathConfig pathConfig) {
         Set<String> paths = new HashSet<>();
-        if (pathConfig.path.isPresent()) {
-            paths.add(pathConfig.path.get());
+        if (pathConfig.path().isPresent()) {
+            paths.add(pathConfig.path().get());
         }
-        if (pathConfig.paths.isPresent()) {
-            paths.addAll(pathConfig.paths.get());
+        if (pathConfig.paths().isPresent()) {
+            paths.addAll(pathConfig.paths().get());
         }
         return paths;
     }
@@ -207,34 +230,33 @@ public class KeycloakPolicyEnforcerRecorder {
     private static PolicyEnforcerConfig.PathConfig createKeycloakPathConfig(PathConfig pathConfig, String path) {
         PolicyEnforcerConfig.PathConfig config1 = new PolicyEnforcerConfig.PathConfig();
 
-        config1.setName(pathConfig.name.orElse(null));
+        config1.setName(pathConfig.name().orElse(null));
         config1.setPath(path);
-        config1.setEnforcementMode(pathConfig.enforcementMode);
-        config1.setMethods(pathConfig.methods.values().stream().map(
+        config1.setEnforcementMode(pathConfig.enforcementMode());
+        config1.setMethods(pathConfig.methods().values().stream().map(
                 new Function<MethodConfig, PolicyEnforcerConfig.MethodConfig>() {
                     @Override
                     public PolicyEnforcerConfig.MethodConfig apply(MethodConfig methodConfig) {
                         PolicyEnforcerConfig.MethodConfig mConfig = new PolicyEnforcerConfig.MethodConfig();
 
-                        mConfig.setMethod(methodConfig.method);
-                        mConfig.setScopes(methodConfig.scopes);
-                        mConfig.setScopesEnforcementMode(methodConfig.scopesEnforcementMode);
+                        mConfig.setMethod(methodConfig.method());
+                        mConfig.setScopes(methodConfig.scopes());
+                        mConfig.setScopesEnforcementMode(methodConfig.scopesEnforcementMode());
 
                         return mConfig;
                     }
                 }).collect(Collectors.toList()));
         config1.setClaimInformationPointConfig(
-                getClaimInformationPointConfig(pathConfig.claimInformationPoint));
+                getClaimInformationPointConfig(pathConfig.claimInformationPoint()));
         return config1;
     }
 
     private static boolean isBodyHandlerRequired(KeycloakPolicyEnforcerTenantConfig config) {
-        if (isBodyClaimInformationPointDefined(config.policyEnforcer.claimInformationPoint.simpleConfig)) {
+        if (isBodyClaimInformationPointDefined(config.policyEnforcer().claimInformationPoint().simpleConfig())) {
             return true;
         }
-        for (PathConfig path : config.policyEnforcer.paths
-                .values()) {
-            if (isBodyClaimInformationPointDefined(path.claimInformationPoint.simpleConfig)) {
+        for (PathConfig path : config.policyEnforcer().paths().values()) {
+            if (isBodyClaimInformationPointDefined(path.claimInformationPoint().simpleConfig())) {
                 return true;
             }
         }
@@ -253,5 +275,11 @@ public class KeycloakPolicyEnforcerRecorder {
         }
 
         return false;
+    }
+
+    private static boolean isNotComplexConfigKey(String key) {
+        // ignore complexConfig keys for reasons explained in the following comment:
+        // https://github.com/quarkusio/quarkus/issues/39315#issuecomment-1991604044
+        return !key.contains(".");
     }
 }

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerTenantConfig.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerTenantConfig.java
@@ -7,37 +7,36 @@ import java.util.Optional;
 import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithParentName;
 
 @ConfigGroup
-public class KeycloakPolicyEnforcerTenantConfig {
+public interface KeycloakPolicyEnforcerTenantConfig {
 
     /**
      * Adapters will make separate HTTP invocations to the Keycloak server to turn an access code into an access token.
      * This config option defines how many connections to the Keycloak server should be pooled
      */
-    @ConfigItem(defaultValue = "20")
-    int connectionPoolSize;
+    @WithDefault("20")
+    int connectionPoolSize();
 
     /**
      * Policy enforcement configuration when using Keycloak Authorization Services
      */
-    @ConfigItem
-    public KeycloakConfigPolicyEnforcer policyEnforcer = new KeycloakConfigPolicyEnforcer();
+    KeycloakConfigPolicyEnforcer policyEnforcer();
 
     @ConfigGroup
-    public static class KeycloakConfigPolicyEnforcer {
+    interface KeycloakConfigPolicyEnforcer {
         /**
          * Specifies how policies are enforced.
          */
-        @ConfigItem(defaultValue = "enforcing")
-        public PolicyEnforcerConfig.EnforcementMode enforcementMode;
+        @WithDefault("enforcing")
+        PolicyEnforcerConfig.EnforcementMode enforcementMode();
 
         /**
          * Specifies the paths to protect.
          */
-        @ConfigItem
-        public Map<String, PathConfig> paths;
+        Map<String, PathConfig> paths();
 
         /**
          * Defines how the policy enforcer should track associations between paths in your application and resources defined in
@@ -45,8 +44,7 @@ public class KeycloakPolicyEnforcerTenantConfig {
          * The cache is needed to avoid unnecessary requests to a Keycloak server by caching associations between paths and
          * protected resources
          */
-        @ConfigItem
-        public PathCacheConfig pathCache = new PathCacheConfig();
+        PathCacheConfig pathCache();
 
         /**
          * Specifies how the adapter should fetch the server for resources associated with paths in your application. If true,
@@ -54,121 +52,113 @@ public class KeycloakPolicyEnforcerTenantConfig {
          * policy
          * enforcer is going to fetch resources on-demand accordingly with the path being requested
          */
-        @ConfigItem(defaultValue = "true")
-        public boolean lazyLoadPaths;
+        @WithDefault("true")
+        boolean lazyLoadPaths();
 
         /**
          * Defines a set of one or more claims that must be resolved and pushed to the Keycloak server in order to make these
          * claims available to policies
          */
-        @ConfigItem
-        public ClaimInformationPointConfig claimInformationPoint;
+        ClaimInformationPointConfig claimInformationPoint();
 
         /**
          * Specifies how scopes should be mapped to HTTP methods. If set to true, the policy enforcer will use the HTTP method
          * from
          * the current request to check whether access should be granted
          */
-        @ConfigItem
-        public boolean httpMethodAsScope;
+        @WithDefault("false")
+        boolean httpMethodAsScope();
 
         @ConfigGroup
-        public static class PathConfig {
+        interface PathConfig {
 
             /**
              * The name of a resource on the server that is to be associated with a given path
              */
-            @ConfigItem
-            public Optional<String> name;
+            Optional<String> name();
 
             /**
              * A URI relative to the application’s context path that should be protected by the policy enforcer
              */
             @Deprecated(since = "Quarkus 3.10") // use the 'paths' configuration property
-            @ConfigItem
-            public Optional<String> path;
+            Optional<String> path();
 
             /**
              * HTTP request paths that should be protected by the policy enforcer
              */
-            @ConfigItem
-            public Optional<List<String>> paths;
+            Optional<List<String>> paths();
 
             /**
              * The HTTP methods (for example, GET, POST, PATCH) to protect and how they are associated with the scopes for a
              * given
              * resource in the server
              */
-            @ConfigItem
-            public Map<String, MethodConfig> methods;
+            Map<String, MethodConfig> methods();
 
             /**
              * Specifies how policies are enforced
              */
-            @ConfigItem(defaultValue = "enforcing")
-            public PolicyEnforcerConfig.EnforcementMode enforcementMode;
+            @WithDefault("enforcing")
+            PolicyEnforcerConfig.EnforcementMode enforcementMode();
 
             /**
              * Defines a set of one or more claims that must be resolved and pushed to the Keycloak server in order to make
              * these
              * claims available to policies
              */
-            @ConfigItem
-            public ClaimInformationPointConfig claimInformationPoint;
+            ClaimInformationPointConfig claimInformationPoint();
         }
 
         @ConfigGroup
-        public static class MethodConfig {
+        interface MethodConfig {
 
             /**
              * The name of the HTTP method
              */
-            @ConfigItem
-            public String method;
+            String method();
 
             /**
              * An array of strings with the scopes associated with the method
              */
-            @ConfigItem
-            public List<String> scopes;
+            List<String> scopes();
 
             /**
              * A string referencing the enforcement mode for the scopes associated with a method
              */
-            @ConfigItem(defaultValue = "all")
-            public PolicyEnforcerConfig.ScopeEnforcementMode scopesEnforcementMode;
+            @WithDefault("all")
+            PolicyEnforcerConfig.ScopeEnforcementMode scopesEnforcementMode();
         }
 
         @ConfigGroup
-        public static class PathCacheConfig {
+        interface PathCacheConfig {
 
             /**
              * Defines the limit of entries that should be kept in the cache
              */
-            @ConfigItem(defaultValue = "1000")
-            public int maxEntries = 1000;
+            @WithDefault("1000")
+            int maxEntries();
 
             /**
              * Defines the time in milliseconds when the entry should be expired
              */
-            @ConfigItem(defaultValue = "30000")
-            public long lifespan = 30000;
+            @WithDefault("30000")
+            long lifespan();
         }
 
         @ConfigGroup
-        public static class ClaimInformationPointConfig {
+        interface ClaimInformationPointConfig {
 
             /**
              *
              */
-            @ConfigItem(name = ConfigItem.PARENT)
-            public Map<String, Map<String, Map<String, String>>> complexConfig;
+            @WithParentName
+            Map<String, Map<String, Map<String, String>>> complexConfig();
 
             /**
              *
              */
-            @ConfigItem(name = ConfigItem.PARENT)
-            public Map<String, Map<String, String>> simpleConfig;
+            @WithParentName
+            Map<String, Map<String, String>> simpleConfig();
         }
     }
 }


### PR DESCRIPTION
Migrates Keycloak Authorization extension config classes to the `@ConfigMapping`. This is yet another prestep for #17664 because users shoudl use build to create API (interface) instead of deprecated config classes. The migration aligns with migration of other Security extensions. There are no Quarkiverse extensions https://mvnrepository.com/artifact/io.quarkus/quarkus-keycloak-authorization/usages that are broken by this migration. Right now, users don't need to work with these config classes (didn't find it in reference guide). The PR also changes phase of tenant config which was meant to be done in the #39512.