### PR TITLE
[3.2] Upgrade kindcontainer to 1.4.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -210,7 +210,7 @@
         <apicurio-common-rest-client.version>0.1.17.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <testcontainers.version>1.18.3</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
         <docker-java.version>3.3.0</docker-java.version> <!-- must be the version Testcontainers use -->
-        <com.dajudge.kindcontainer>1.3.0</com.dajudge.kindcontainer>
+        <com.dajudge.kindcontainer>1.4.5</com.dajudge.kindcontainer>
         <aesh.version>2.7</aesh.version>
         <aesh-readline.version>2.4</aesh-readline.version>
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with aesh-readline and dekorate -->


### PR DESCRIPTION
This version of the library uses a more recent version of BC targeting jdk 8. The one targeting jdk1.5 is not maintained anymore it seems.

It's quite a bump, let's see whether it works.

FYI @jmartisk @sberyozkin @rsvoboda @gsmet