### PR TITLE
WebSocket Next: endpoint callback arguments injection

### DIFF
--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgument.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgument.java
@@ -1,0 +1,114 @@
+package io.quarkus.websockets.next.deployment;
+
+import java.util.Set;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
+
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.WebSocketServerException;
+
+/**
+ * Provides arguments for method parameters of a callback method declared on a WebSocket endpoint.
+ */
+interface CallbackArgument {
+
+    /**
+     *
+     * @param context
+     * @return {@code true} if this provider matches the given parameter context, {@code false} otherwise
+     * @throws WebSocketServerException If an invalid parameter is detected
+     */
+    boolean matches(ParameterContext context);
+
+    /**
+     * This method is only used if {@link #matches(ParameterContext)} previously returned {@code true} for the same parameter
+     * context.
+     *
+     * @param context
+     * @return the result handle to be passed as an argument to a callback method
+     */
+    ResultHandle get(InvocationBytecodeContext context);
+
+    /**
+     *
+     * @return the priority
+     */
+    default int priotity() {
+        return DEFAULT_PRIORITY;
+    }
+
+    static final int DEFAULT_PRIORITY = 1;
+
+    interface ParameterContext {
+
+        /**
+         *
+         * @return the endpoint path
+         */
+        String endpointPath();
+
+        /**
+         *
+         * @return the callback marker annotation
+         */
+        AnnotationInstance callbackAnnotation();
+
+        /**
+         *
+         * @return the Java method parameter
+         */
+        MethodParameterInfo parameter();
+
+        /**
+         *
+         * @return the set of parameter annotations, potentially transformed
+         */
+        Set<AnnotationInstance> parameterAnnotations();
+
+        default boolean acceptsMessage() {
+            return WebSocketDotNames.ON_BINARY_MESSAGE.equals(callbackAnnotation().name())
+                    || WebSocketDotNames.ON_TEXT_MESSAGE.equals(callbackAnnotation().name())
+                    || WebSocketDotNames.ON_PONG_MESSAGE.equals(callbackAnnotation().name());
+        }
+
+    }
+
+    interface InvocationBytecodeContext extends ParameterContext {
+
+        /**
+         *
+         * @return the bytecode
+         */
+        BytecodeCreator bytecode();
+
+        /**
+         * Obtains the message directly in the bytecode.
+         *
+         * @return the message object or {@code null} for {@link OnOpen} and {@link OnClose} callbacks
+         */
+        ResultHandle getMessage();
+
+        /**
+         * Attempts to obtain the decoded message directly in the bytecode.
+         *
+         * @param parameterType
+         * @return the decoded message object or {@code null} for {@link OnOpen} and {@link OnClose} callbacks
+         */
+        ResultHandle getDecodedMessage(Type parameterType);
+
+        /**
+         * Obtains the current connection directly in the bytecode.
+         *
+         * @return the current {@link WebSocketConnection}, never {@code null}
+         */
+        ResultHandle getConnection();
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgumentBuildItem.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgumentBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.websockets.next.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+final class CallbackArgumentBuildItem extends MultiBuildItem {
+
+    private final CallbackArgument provider;
+
+    CallbackArgumentBuildItem(CallbackArgument provider) {
+        this.provider = provider;
+    }
+
+    CallbackArgument getProvider() {
+        return provider;
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgumentsBuildItem.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgumentsBuildItem.java
@@ -1,0 +1,32 @@
+package io.quarkus.websockets.next.deployment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.websockets.next.deployment.CallbackArgument.ParameterContext;
+
+final class CallbackArgumentsBuildItem extends SimpleBuildItem {
+
+    final List<CallbackArgument> sortedArguments;
+
+    CallbackArgumentsBuildItem(List<CallbackArgument> providers) {
+        this.sortedArguments = providers;
+    }
+
+    /**
+     *
+     * @param context
+     * @return all matching providers, never {@code null}
+     */
+    List<CallbackArgument> findMatching(ParameterContext context) {
+        List<CallbackArgument> matching = new ArrayList<>();
+        for (CallbackArgument argument : sortedArguments) {
+            if (argument.matches(context)) {
+                matching.add(argument);
+            }
+        }
+        return matching;
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/ConnectionCallbackArgument.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/ConnectionCallbackArgument.java
@@ -1,0 +1,17 @@
+package io.quarkus.websockets.next.deployment;
+
+import io.quarkus.gizmo.ResultHandle;
+
+class ConnectionCallbackArgument implements CallbackArgument {
+
+    @Override
+    public boolean matches(ParameterContext context) {
+        return context.parameter().type().name().equals(WebSocketDotNames.WEB_SOCKET_CONNECTION);
+    }
+
+    @Override
+    public ResultHandle get(InvocationBytecodeContext context) {
+        return context.getConnection();
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/HandshakeRequestCallbackArgument.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/HandshakeRequestCallbackArgument.java
@@ -1,0 +1,21 @@
+package io.quarkus.websockets.next.deployment;
+
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.websockets.next.WebSocketConnection;
+
+class HandshakeRequestCallbackArgument implements CallbackArgument {
+
+    @Override
+    public boolean matches(ParameterContext context) {
+        return context.parameter().type().name().equals(WebSocketDotNames.HANDSHAKE_REQUEST);
+    }
+
+    @Override
+    public ResultHandle get(InvocationBytecodeContext context) {
+        ResultHandle connection = context.getConnection();
+        return context.bytecode().invokeInterfaceMethod(MethodDescriptor.ofMethod(WebSocketConnection.class, "handshakeRequest",
+                WebSocketConnection.HandshakeRequest.class), connection);
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/MessageCallbackArgument.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/MessageCallbackArgument.java
@@ -1,0 +1,22 @@
+package io.quarkus.websockets.next.deployment;
+
+import io.quarkus.gizmo.ResultHandle;
+
+class MessageCallbackArgument implements CallbackArgument {
+
+    @Override
+    public boolean matches(ParameterContext context) {
+        return context.acceptsMessage() && context.parameterAnnotations().isEmpty();
+    }
+
+    @Override
+    public ResultHandle get(InvocationBytecodeContext context) {
+        return context.getDecodedMessage(context.parameter().type());
+    }
+
+    @Override
+    public int priotity() {
+        return DEFAULT_PRIORITY - 1;
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/PathParamCallbackArgument.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/PathParamCallbackArgument.java
@@ -1,0 +1,78 @@
+package io.quarkus.websockets.next.deployment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+
+import io.quarkus.arc.processor.Annotations;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.WebSocketServerException;
+
+class PathParamCallbackArgument implements CallbackArgument {
+
+    @Override
+    public boolean matches(ParameterContext context) {
+        String paramName = getParamName(context);
+        if (paramName != null) {
+            if (!context.parameter().type().name().equals(WebSocketDotNames.STRING)) {
+                throw new WebSocketServerException("Method parameter annotated with @PathParam must be java.lang.String: "
+                        + WebSocketServerProcessor.callbackToString(context.parameter().method()));
+            }
+            List<String> pathParams = getPathParamNames(context.endpointPath());
+            if (!pathParams.contains(paramName)) {
+                throw new WebSocketServerException(
+                        String.format(
+                                "@PathParam name [%s] must be used in the endpoint path [%s]: %s", paramName,
+                                context.endpointPath(),
+                                WebSocketServerProcessor.callbackToString(context.parameter().method())));
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public ResultHandle get(InvocationBytecodeContext context) {
+        ResultHandle connection = context.getConnection();
+        String paramName = getParamName(context);
+        return context.bytecode().invokeInterfaceMethod(
+                MethodDescriptor.ofMethod(WebSocketConnection.class, "pathParam", String.class, String.class), connection,
+                context.bytecode().load(paramName));
+    }
+
+    private String getParamName(ParameterContext context) {
+        AnnotationInstance pathParamAnnotation = Annotations.find(context.parameterAnnotations(), WebSocketDotNames.PATH_PARAM);
+        if (pathParamAnnotation != null) {
+            String paramName;
+            AnnotationValue nameVal = pathParamAnnotation.value();
+            if (nameVal != null) {
+                paramName = nameVal.asString();
+            } else {
+                // Try to use the element name
+                paramName = context.parameter().name();
+            }
+            if (paramName == null) {
+                throw new WebSocketServerException(String.format(
+                        "Unable to extract the path parameter name - method parameter names not recorded for %s: compile the class with -parameters",
+                        context.parameter().method().declaringClass().name()));
+            }
+            return paramName;
+        }
+        return null;
+    }
+
+    static List<String> getPathParamNames(String path) {
+        List<String> names = new ArrayList<>();
+        Matcher m = WebSocketServerProcessor.TRANSLATED_PATH_PARAM_PATTERN.matcher(path);
+        while (m.find()) {
+            names.add(m.group().substring(1));
+        }
+        return names;
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketDotNames.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketDotNames.java
@@ -7,6 +7,7 @@ import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.OnPongMessage;
 import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.PathParam;
 import io.quarkus.websockets.next.WebSocket;
 import io.quarkus.websockets.next.WebSocketConnection;
 import io.smallrye.common.annotation.Blocking;
@@ -35,4 +36,6 @@ final class WebSocketDotNames {
     static final DotName JSON_OBJECT = DotName.createSimple(JsonObject.class);
     static final DotName JSON_ARRAY = DotName.createSimple(JsonArray.class);
     static final DotName VOID = DotName.createSimple(Void.class);
+    static final DotName PATH_PARAM = DotName.createSimple(PathParam.class);
+    static final DotName HANDSHAKE_REQUEST = DotName.createSimple(WebSocketConnection.HandshakeRequest.class);
 }

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketEndpointBuildItem.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketEndpointBuildItem.java
@@ -1,16 +1,32 @@
 package io.quarkus.websockets.next.deployment;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 
+import io.quarkus.arc.deployment.TransformedAnnotationsBuildItem;
+import io.quarkus.arc.processor.Annotations;
 import io.quarkus.arc.processor.BeanInfo;
+import io.quarkus.arc.processor.DotNames;
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.deployment.CallbackArgument.InvocationBytecodeContext;
+import io.quarkus.websockets.next.deployment.CallbackArgument.ParameterContext;
 import io.quarkus.websockets.next.runtime.WebSocketEndpoint.ExecutionModel;
+import io.quarkus.websockets.next.runtime.WebSocketEndpointBase;
 
 /**
  * This build item represents a WebSocket endpoint class.
@@ -44,8 +60,11 @@ public final class WebSocketEndpointBuildItem extends MultiBuildItem {
         public final MethodInfo method;
         public final ExecutionModel executionModel;
         public final MessageType messageType;
+        public final List<CallbackArgument> arguments;
 
-        public Callback(AnnotationInstance annotation, MethodInfo method, ExecutionModel executionModel) {
+        public Callback(AnnotationInstance annotation, MethodInfo method, ExecutionModel executionModel,
+                CallbackArgumentsBuildItem callbackArguments, TransformedAnnotationsBuildItem transformedAnnotations,
+                String endpointPath) {
             this.method = method;
             this.annotation = annotation;
             this.executionModel = executionModel;
@@ -58,6 +77,15 @@ public final class WebSocketEndpointBuildItem extends MultiBuildItem {
             } else {
                 this.messageType = MessageType.NONE;
             }
+            this.arguments = collectArguments(annotation, method, callbackArguments, transformedAnnotations, endpointPath);
+        }
+
+        public boolean isOnOpen() {
+            return annotation.name().equals(WebSocketDotNames.ON_OPEN);
+        }
+
+        public boolean isOnClose() {
+            return annotation.name().equals(WebSocketDotNames.ON_CLOSE);
         }
 
         public Type returnType() {
@@ -118,11 +146,152 @@ public final class WebSocketEndpointBuildItem extends MultiBuildItem {
             return null;
         }
 
-        enum MessageType {
+        public enum MessageType {
             NONE,
             PONG,
             TEXT,
             BINARY
+        }
+
+        public List<CallbackArgument> messageArguments() {
+            if (arguments.isEmpty()) {
+                return List.of();
+            }
+            List<CallbackArgument> ret = new ArrayList<>();
+            for (CallbackArgument arg : arguments) {
+                if (arg instanceof MessageCallbackArgument) {
+                    ret.add(arg);
+                }
+            }
+            return ret;
+        }
+
+        public ResultHandle[] generateArguments(BytecodeCreator bytecode,
+                TransformedAnnotationsBuildItem transformedAnnotations, String endpointPath) {
+            if (arguments.isEmpty()) {
+                return new ResultHandle[] {};
+            }
+            ResultHandle[] resultHandles = new ResultHandle[arguments.size()];
+            int idx = 0;
+            for (CallbackArgument argument : arguments) {
+                resultHandles[idx] = argument.get(
+                        invocationBytecodeContext(annotation, method.parameters().get(idx), transformedAnnotations,
+                                endpointPath, bytecode));
+                idx++;
+            }
+            return resultHandles;
+        }
+
+        static List<CallbackArgument> collectArguments(AnnotationInstance annotation, MethodInfo method,
+                CallbackArgumentsBuildItem callbackArguments, TransformedAnnotationsBuildItem transformedAnnotations,
+                String endpointPath) {
+            List<MethodParameterInfo> parameters = method.parameters();
+            if (parameters.isEmpty()) {
+                return List.of();
+            }
+            List<CallbackArgument> arguments = new ArrayList<>(parameters.size());
+            for (MethodParameterInfo parameter : parameters) {
+                List<CallbackArgument> found = callbackArguments
+                        .findMatching(parameterContext(annotation, parameter, transformedAnnotations, endpointPath));
+                if (found.isEmpty()) {
+                    String msg = String.format("Unable to inject @%s callback parameter '%s' declared on %s: no injector found",
+                            DotNames.simpleName(annotation.name()),
+                            parameter.name() != null ? parameter.name() : "#" + parameter.position(),
+                            WebSocketServerProcessor.callbackToString(method));
+                    throw new WebSocketServerException(msg);
+                } else if (found.size() > 1 && (found.get(0).priotity() == found.get(1).priotity())) {
+                    String msg = String.format(
+                            "Unable to inject @%s callback parameter '%s' declared on %s: ambiguous injectors found: %s",
+                            DotNames.simpleName(annotation.name()),
+                            parameter.name() != null ? parameter.name() : "#" + parameter.position(),
+                            WebSocketServerProcessor.callbackToString(method),
+                            found.stream().map(p -> p.getClass().getSimpleName() + ":" + p.priotity()));
+                    throw new WebSocketServerException(msg);
+                }
+                arguments.add(found.get(0));
+            }
+            return arguments;
+        }
+
+        static ParameterContext parameterContext(AnnotationInstance callbackAnnotation, MethodParameterInfo parameter,
+                TransformedAnnotationsBuildItem transformedAnnotations, String endpointPath) {
+            return new ParameterContext() {
+
+                @Override
+                public MethodParameterInfo parameter() {
+                    return parameter;
+                }
+
+                @Override
+                public Set<AnnotationInstance> parameterAnnotations() {
+                    return Annotations.getParameterAnnotations(
+                            transformedAnnotations::getAnnotations, parameter.method(), parameter.position());
+                }
+
+                @Override
+                public AnnotationInstance callbackAnnotation() {
+                    return callbackAnnotation;
+                }
+
+                @Override
+                public String endpointPath() {
+                    return endpointPath;
+                }
+
+            };
+        }
+
+        private InvocationBytecodeContext invocationBytecodeContext(AnnotationInstance callbackAnnotation,
+                MethodParameterInfo parameter, TransformedAnnotationsBuildItem transformedAnnotations, String endpointPath,
+                BytecodeCreator bytecode) {
+            return new InvocationBytecodeContext() {
+
+                @Override
+                public AnnotationInstance callbackAnnotation() {
+                    return callbackAnnotation;
+                }
+
+                @Override
+                public MethodParameterInfo parameter() {
+                    return parameter;
+                }
+
+                @Override
+                public Set<AnnotationInstance> parameterAnnotations() {
+                    return Annotations.getParameterAnnotations(
+                            transformedAnnotations::getAnnotations, parameter.method(), parameter.position());
+                }
+
+                @Override
+                public String endpointPath() {
+                    return endpointPath;
+                }
+
+                @Override
+                public BytecodeCreator bytecode() {
+                    return bytecode;
+                }
+
+                @Override
+                public ResultHandle getMessage() {
+                    return acceptsMessage() ? bytecode.getMethodParam(0) : null;
+                }
+
+                @Override
+                public ResultHandle getDecodedMessage(Type parameterType) {
+                    return acceptsMessage()
+                            ? WebSocketServerProcessor.decodeMessage(bytecode, acceptsBinaryMessage(), parameterType,
+                                    getMessage(), Callback.this)
+                            : null;
+                }
+
+                @Override
+                public ResultHandle getConnection() {
+                    return bytecode.readInstanceField(
+                            FieldDescriptor.of(WebSocketEndpointBase.class, "connection", WebSocketConnection.class),
+                            bytecode.getThis());
+                }
+            };
         }
 
     }

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/devui/WebSocketServerDevUIProcessor.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/devui/WebSocketServerDevUIProcessor.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import io.quarkus.deployment.IsDevelopment;
@@ -17,6 +16,7 @@ import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.websockets.next.deployment.GeneratedEndpointBuildItem;
 import io.quarkus.websockets.next.deployment.WebSocketEndpointBuildItem;
+import io.quarkus.websockets.next.deployment.WebSocketServerProcessor;
 import io.quarkus.websockets.next.runtime.devui.WebSocketNextJsonRPCService;
 
 public class WebSocketServerDevUIProcessor {
@@ -74,11 +74,9 @@ public class WebSocketServerDevUIProcessor {
         }
     }
 
-    private static final Pattern PATH_PARAM_PATTERN = Pattern.compile(":[a-zA-Z0-9_]+");
-
     static String getOriginalPath(String path) {
         StringBuilder sb = new StringBuilder();
-        Matcher m = PATH_PARAM_PATTERN.matcher(path);
+        Matcher m = WebSocketServerProcessor.TRANSLATED_PATH_PARAM_PATTERN.matcher(path);
         while (m.find()) {
             // Replace :foo with {foo}
             String match = m.group();

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/ConnectionArgumentTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/ConnectionArgumentTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.websockets.next.test.args;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.core.json.JsonObject;
+
+public class ConnectionArgumentTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(Echo.class, WSClient.class);
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("echo")
+    URI testUri;
+
+    @Test
+    void testArgument() {
+        String message = "ok";
+        String header = "fool";
+        WSClient client = WSClient.create(vertx).connect(new WebSocketConnectOptions().addHeader("X-Test", header),
+                testUri);
+        JsonObject reply = client.sendAndAwaitReply(message).toJsonObject();
+        assertEquals(header, reply.getString("header"), reply.toString());
+        assertEquals(message, reply.getString("message"), reply.toString());
+    }
+
+    @WebSocket(path = "/echo")
+    public static class Echo {
+
+        @Inject
+        WebSocketConnection c;
+
+        @OnTextMessage
+        Uni<Void> process(WebSocketConnection connection, String message) throws InterruptedException {
+            assertEquals(c.id(), connection.id());
+            return connection.sendText(
+                    new JsonObject()
+                            .put("id", connection.id())
+                            .put("message", message)
+                            .put("header", connection.handshakeRequest().header("X-Test")));
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/HandshakeRequestArgumentTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/HandshakeRequestArgumentTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.websockets.next.test.args;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection.HandshakeRequest;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketConnectOptions;
+
+public class HandshakeRequestArgumentTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(XTest.class, WSClient.class);
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("xtest")
+    URI testUri;
+
+    @Test
+    void testArgument() {
+        WSClient client = WSClient.create(vertx).connect(new WebSocketConnectOptions().addHeader("X-Test", "fool"),
+                testUri);
+        client.waitForMessages(1);
+        assertEquals("fool", client.getLastMessage().toString());
+    }
+
+    @WebSocket(path = "/xtest")
+    public static class XTest {
+
+        @OnOpen
+        String open(HandshakeRequest request) {
+            return request.header("X-Test");
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/OnCloseInvalidArgumentTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/OnCloseInvalidArgumentTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.websockets.next.test.args;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketServerException;
+
+public class OnCloseInvalidArgumentTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(Endpoint.class);
+            })
+            .setExpectedException(WebSocketServerException.class);
+
+    @Test
+    void testInvalidArgument() {
+        fail();
+    }
+
+    @WebSocket(path = "/end")
+    public static class Endpoint {
+
+        @OnClose
+        void close(List<String> unsupported) {
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/OnOpenInvalidArgumentTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/OnOpenInvalidArgumentTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.websockets.next.test.args;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketServerException;
+
+public class OnOpenInvalidArgumentTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(Endpoint.class);
+            })
+            .setExpectedException(WebSocketServerException.class);
+
+    @Test
+    void testInvalidArgument() {
+        fail();
+    }
+
+    @WebSocket(path = "/end")
+    public static class Endpoint {
+
+        @OnOpen
+        void open(List<String> unsupported) {
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentExplicitNameTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentExplicitNameTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.websockets.next.test.args;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.PathParam;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+
+public class PathParamArgumentExplicitNameTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(MontyEcho.class, WSClient.class);
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("echo/monty")
+    URI testUri;
+
+    @Test
+    void testArgument() {
+        WSClient client = WSClient.create(vertx).connect(testUri);
+        assertEquals("python:monty", client.sendAndAwaitReply("python").toString());
+    }
+
+    @WebSocket(path = "/echo/{grail}")
+    public static class MontyEcho {
+
+        @OnTextMessage
+        String process(@PathParam("grail") String life, String message) throws InterruptedException {
+            return message + ":" + life;
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentInvalidNameTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentInvalidNameTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.websockets.next.test.args;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.PathParam;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketServerException;
+
+public class PathParamArgumentInvalidNameTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(MontyEcho.class);
+            }).setExpectedException(WebSocketServerException.class);
+
+    @Test
+    void testInvalidArgument() {
+        fail();
+    }
+
+    @WebSocket(path = "/echo/{grail}")
+    public static class MontyEcho {
+
+        @OnTextMessage
+        String process(@PathParam String life, String message) throws InterruptedException {
+            return message + ":" + life;
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentInvalidTypeTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentInvalidTypeTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.websockets.next.test.args;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.PathParam;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketServerException;
+
+public class PathParamArgumentInvalidTypeTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(MontyEcho.class);
+            }).setExpectedException(WebSocketServerException.class);
+
+    @Test
+    void testInvalidArgument() {
+        fail();
+    }
+
+    @WebSocket(path = "/echo/{grail}")
+    public static class MontyEcho {
+
+        @OnTextMessage
+        String process(@PathParam Double grail, String message) throws InterruptedException {
+            return message + ":" + grail;
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.websockets.next.test.args;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.PathParam;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+
+public class PathParamArgumentTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(MontyEcho.class, WSClient.class);
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("echo/monty")
+    URI testUri;
+
+    @Test
+    void testArgument() {
+        WSClient client = WSClient.create(vertx).connect(testUri);
+        assertEquals("python:monty", client.sendAndAwaitReply("python").toString());
+    }
+
+    @WebSocket(path = "/echo/{grail}")
+    public static class MontyEcho {
+
+        @OnTextMessage
+        String process(@PathParam String grail, String message) throws InterruptedException {
+            return message + ":" + grail;
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamConnectionArgumentTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamConnectionArgumentTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.websockets.next.test.args;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.PathParam;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketConnectOptions;
+
+public class PathParamConnectionArgumentTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(MontyEcho.class, WSClient.class);
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("echo/monty/and/foo")
+    URI testUri;
+
+    @Test
+    void testArguments() {
+        String header = "fool";
+        WSClient client = WSClient.create(vertx).connect(new WebSocketConnectOptions().addHeader("X-Test", header), testUri);
+        assertEquals("foo:python:monty:fool", client.sendAndAwaitReply("python").toString());
+    }
+
+    @WebSocket(path = "/echo/{grail}/and/{life}")
+    public static class MontyEcho {
+
+        @OnTextMessage
+        String process(@PathParam String life, @PathParam String grail, String message, WebSocketConnection connection)
+                throws InterruptedException {
+            return life + ":" + message + ":" + grail + ":" + connection.handshakeRequest().header("X-Test");
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/PathParam.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/PathParam.java
@@ -1,0 +1,34 @@
+package io.quarkus.websockets.next;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Identifies an endpoint callback method parameter that should be injected with a value returned from
+ * {@link WebSocketConnection#pathParam(String)}.
+ * <p>
+ * The parameter type must be {@link String} and the name must be defined in the relevant endpoint path, otherwise
+ * the build fails.
+ *
+ * @see WebSocketConnection#pathParam(String)
+ * @see WebSocket
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface PathParam {
+
+    /**
+     * Constant value for {@link #value()} indicating that the annotated element's name should be used as-is.
+     */
+    String ELEMENT_NAME = "<<element name>>";
+
+    /**
+     * The name of the parameter. By default, the element's name is used as-is.
+     *
+     * @return the name of the parameter
+     */
+    String value() default ELEMENT_NAME;
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
@@ -13,11 +13,15 @@ import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import io.quarkus.vertx.core.runtime.VertxBufferImpl;
 import io.quarkus.websockets.next.WebSocketConnection;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.vertx.UniHelper;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.buffer.impl.BufferImpl;
 import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
 class WebSocketConnectionImpl implements WebSocketConnection {
@@ -75,7 +79,17 @@ class WebSocketConnectionImpl implements WebSocketConnection {
 
     @Override
     public <M> Uni<Void> sendText(M message) {
-        return UniHelper.toUni(webSocket.writeTextMessage(codecs.textEncode(message, null).toString()));
+        String text;
+        // Use the same conversion rules as defined for the OnTextMessage
+        if (message instanceof JsonObject || message instanceof JsonArray || message instanceof BufferImpl
+                || message instanceof VertxBufferImpl) {
+            text = message.toString();
+        } else if (message.getClass().isArray() && message.getClass().arrayType().equals(byte.class)) {
+            text = Buffer.buffer((byte[]) message).toString();
+        } else {
+            text = codecs.textEncode(message, null);
+        }
+        return sendText(text);
     }
 
     @Override

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpointBase.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpointBase.java
@@ -27,7 +27,8 @@ public abstract class WebSocketEndpointBase implements WebSocketEndpoint {
 
     private static final Logger LOG = Logger.getLogger(WebSocketEndpointBase.class);
 
-    protected final WebSocketConnection connection;
+    // Keep this field public - there's a problem with ConnectionArgumentProvider reading the protected field in the test mode
+    public final WebSocketConnection connection;
 
     protected final Codecs codecs;
 


### PR DESCRIPTION
- supported arguments include `WebSocketConnection`, `HandshakeRequest` and
  path parameters - `String` annotated with `@io.quarkus.websockets.next.PathParam`
- resolves #39224