### PR TITLE
Migrate the Security extension config classes to `@ConfigMapping`

### DIFF
--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
@@ -4,31 +4,32 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  *
  */
-@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
-public final class SecurityConfig {
+@ConfigMapping(prefix = "quarkus.security")
+@ConfigRoot
+public interface SecurityConfig {
 
     /**
      * Whether authorization is enabled in dev mode or not. In other launch modes authorization is always enabled.
      */
-    @ConfigItem(name = "auth.enabled-in-dev-mode", defaultValue = "true")
-    public boolean authorizationEnabledInDevMode;
+    @WithName("auth.enabled-in-dev-mode")
+    @WithDefault("true")
+    boolean authorizationEnabledInDevMode();
 
     /**
      * List of security providers to register
      */
-    @ConfigItem
-    public Optional<Set<String>> securityProviders;
+    Optional<Set<String>> securityProviders();
 
     /**
      * Security provider configuration
      */
-    @ConfigItem
-    public Map<String, String> securityProviderConfig;
+    Map<String, String> securityProviderConfig();
 }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityBuildTimeConfig.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityBuildTimeConfig.java
@@ -1,14 +1,17 @@
 package io.quarkus.security.runtime;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  */
-@ConfigRoot(name = "security", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class SecurityBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.security")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface SecurityBuildTimeConfig {
     /**
      * If set to true, access to all methods of beans that have any security annotations on other members will be denied by
      * default.
@@ -27,7 +30,8 @@ public class SecurityBuildTimeConfig {
      *   }
      * </pre>
      */
-    @ConfigItem(name = "deny-unannotated-members")
-    public boolean denyUnannotated;
+    @WithName("deny-unannotated-members")
+    @WithDefault("false")
+    boolean denyUnannotated();
 
 }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/PermissionSecurityCheck.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/PermissionSecurityCheck.java
@@ -71,10 +71,14 @@ public abstract class PermissionSecurityCheck<T> implements SecurityCheck {
     }
 
     private static void throwException(SecurityIdentity identity) {
+        throw getException(identity);
+    }
+
+    private static RuntimeException getException(SecurityIdentity identity) {
         if (identity.isAnonymous()) {
-            throw new UnauthorizedException();
+            return new UnauthorizedException();
         } else {
-            throw new ForbiddenException();
+            return new ForbiddenException();
         }
     }
 
@@ -103,7 +107,7 @@ public abstract class PermissionSecurityCheck<T> implements SecurityCheck {
                             public Uni<?> apply(Boolean hasPermission) {
                                 if (FALSE.equals(hasPermission)) {
                                     // check failed
-                                    throwException(identity);
+                                    return Uni.createFrom().failure(getException(identity));
                                 }
 
                                 return SUCCESSFUL_CHECK;
@@ -214,7 +218,7 @@ public abstract class PermissionSecurityCheck<T> implements SecurityCheck {
                             final boolean hasAnotherPermission = i + 1 < permissions.length;
                             if (!hasAnotherPermission) {
                                 // check failed
-                                throwException(identity);
+                                return Uni.createFrom().failure(getException(identity));
                             }
 
                             // check next permission


### PR DESCRIPTION
Migrates Security config from config classes to the `@ConfigMapping`, more specifically:

- `SecurityConfig` that is build time only, hence it would have to be extension, but outside of this Quarkus project, only `Quarkus Google Cloud Services Common Runtime` from Quarkiverse extensions is [using the Security extension directly](https://mvnrepository.com/artifact/io.quarkus.security/quarkus-security/usages?p=1)  (checked it => this PR is not breaking it as the extension doesn't use these classes). About transitive usage I don't know, but it's unlikely they need this class at all.
- `SecurityBuildTimeConfig` is build and runtime fixed, but it contains single property `deny-unannotated-members` and IMHO it is unlikely anyone else but us needs it. Though I wonder why is it runtime fixed, we don't need it at runtime, I didn't find an explanation.
- there is little tiny refactoring in Security extension too small and unimportant to add anywhere else