### PR TITLE
Migrate the Quarkus SmallRye JWT config classes to `@ConfigMapping`

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtBuildTimeConfig.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtBuildTimeConfig.java
@@ -1,23 +1,25 @@
 package io.quarkus.smallrye.jwt.deployment;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 /**
  * deployment configuration
  */
-@ConfigRoot(name = "smallrye-jwt")
-public class SmallRyeJwtBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.smallrye-jwt")
+@ConfigRoot
+public interface SmallRyeJwtBuildTimeConfig {
 
     /**
      * The MP-JWT configuration object
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enabled = true;
+    @WithDefault("true")
+    boolean enabled();
 
     /**
      * The name of the {@linkplain java.security.Provider} that supports SHA256withRSA signatures
      */
-    @ConfigItem(defaultValue = "SunRsaSign")
-    public String rsaSigProvider;
+    @WithDefault("SunRsaSign")
+    String rsaSigProvider();
 }

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -91,7 +91,7 @@ class SmallRyeJwtProcessor {
     @BuildStep
     void registerAdditionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
-        if (config.enabled) {
+        if (config.enabled()) {
             AdditionalBeanBuildItem.Builder unremovable = AdditionalBeanBuildItem.builder().setUnremovable();
             unremovable.addBeanClass(MpJwtValidator.class);
             unremovable.addBeanClass(JsonWebTokenCredentialProducer.class);
@@ -156,7 +156,7 @@ class SmallRyeJwtProcessor {
      */
     @BuildStep
     JCAProviderBuildItem registerRSASigProvider() {
-        return new JCAProviderBuildItem(config.rsaSigProvider);
+        return new JCAProviderBuildItem(config.rsaSigProvider());
     }
 
     @BuildStep
@@ -213,7 +213,7 @@ class SmallRyeJwtProcessor {
         SmallRyeJwtBuildTimeConfig config;
 
         public boolean getAsBoolean() {
-            return config.enabled;
+            return config.enabled();
         }
     }
 }

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
@@ -46,11 +46,11 @@ public class JWTAuthMechanism implements HttpAuthenticationMechanism {
      */
     private final boolean propagateTokenCredentialWithDuplicatedCtx;
     @Inject
-    private JWTAuthContextInfo authContextInfo;
+    JWTAuthContextInfo authContextInfo;
     private final boolean silent;
 
     public JWTAuthMechanism(SmallRyeJwtConfig config) {
-        this.silent = config == null ? false : config.silent;
+        this.silent = config == null ? false : config.silent();
         // we use system property in order to keep this option internal and avoid introducing SPI
         this.propagateTokenCredentialWithDuplicatedCtx = Boolean
                 .getBoolean("io.quarkus.smallrye.jwt.runtime.auth.JWTAuthMechanism." +

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/MpJwtValidator.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/MpJwtValidator.java
@@ -40,7 +40,7 @@ public class MpJwtValidator implements IdentityProvider<TokenAuthenticationReque
     @Inject
     public MpJwtValidator(JWTParser parser, SmallRyeJwtConfig config) {
         this.parser = parser;
-        this.blockingAuthentication = config == null ? false : config.blockingAuthentication;
+        this.blockingAuthentication = config == null ? false : config.blockingAuthentication();
     }
 
     @Override

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/SmallRyeJwtConfig.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/SmallRyeJwtConfig.java
@@ -1,18 +1,20 @@
 package io.quarkus.smallrye.jwt.runtime.auth;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "smallrye-jwt", phase = ConfigPhase.RUN_TIME)
-public class SmallRyeJwtConfig {
+@ConfigMapping(prefix = "quarkus.smallrye-jwt")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface SmallRyeJwtConfig {
 
     /**
      * Enable this property if fetching the remote keys can be a time-consuming operation.
      * Do not enable it if you use the local keys.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean blockingAuthentication;
+    @WithDefault("false")
+    boolean blockingAuthentication();
 
     /**
      * Always create HTTP 401 challenge, even for requests containing no authentication credentials.
@@ -25,7 +27,7 @@ public class SmallRyeJwtConfig {
      * by setting this property to 'true'.
      *
      */
-    @ConfigItem
-    public boolean silent;
+    @WithDefault("false")
+    boolean silent();
 
 }


### PR DESCRIPTION
There are 2 Quarkiverse extensions depending on the Quarkus SmallRye JWT directly https://mvnrepository.com/artifact/io.quarkus/quarkus-smallrye-jwt/usages?p=1 , I've cloned:

- `git@github.com:quarkiverse/quarkus-microprofile.git`
- `git@github.com:quarkiverse/quarkus-renarde.git`

and checked code, they are not using migrated config classes.