### PR TITLE
Bump kubernetes-client-bom from 6.10.0 to 6.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
         <!-- Dependency versions -->
         <jacoco.version>0.8.11</jacoco.version>
-        <kubernetes-client.version>6.10.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.11.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.62.2</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->


### PR DESCRIPTION
Kubernetes Client 6.11.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.11.0

/cc @metacosm