### PR TITLE
Change to receive files outside the classpath in mongodb liquibase

### DIFF
--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
@@ -1,5 +1,7 @@
 package io.quarkus.liquibase.mongodb;
 
+import java.io.FileNotFoundException;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -8,12 +10,16 @@ import java.util.stream.Collectors;
 import io.quarkus.liquibase.mongodb.runtime.LiquibaseMongodbBuildTimeConfig;
 import io.quarkus.liquibase.mongodb.runtime.LiquibaseMongodbConfig;
 import io.quarkus.mongodb.runtime.MongoClientConfig;
+import io.quarkus.runtime.util.StringUtil;
 import liquibase.Contexts;
 import liquibase.LabelExpression;
 import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.CompositeResourceAccessor;
+import liquibase.resource.DirectoryResourceAccessor;
+import liquibase.resource.ResourceAccessor;
 
 public class LiquibaseMongodbFactory {
 
@@ -32,9 +38,42 @@ public class LiquibaseMongodbFactory {
         this.mongoClientConfig = mongoClientConfig;
     }
 
+    private ResourceAccessor resolveResourceAccessor() throws FileNotFoundException {
+
+        if (liquibaseMongodbBuildTimeConfig.changeLog.startsWith("classpath:")) {
+            return new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader());
+        }
+
+        if (!liquibaseMongodbBuildTimeConfig.changeLog.startsWith("filesystem:") &&
+                liquibaseMongodbBuildTimeConfig.searchPath.size() == 1 &&
+                liquibaseMongodbBuildTimeConfig.searchPath.get(0).equals("/")) {
+            return new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader());
+        }
+
+        CompositeResourceAccessor compositeResourceAccessor = new CompositeResourceAccessor();
+
+        for (String searchPath : liquibaseMongodbBuildTimeConfig.searchPath) {
+            compositeResourceAccessor.addResourceAccessor(new DirectoryResourceAccessor(Paths.get(searchPath)));
+        }
+
+        return compositeResourceAccessor;
+    }
+
+    private String parseChangeLog(String changeLog) {
+        if (changeLog.startsWith("filesystem:")) {
+            return StringUtil.changePrefix(changeLog, "filesystem:", "");
+        }
+
+        if (changeLog.startsWith("classpath:")) {
+            return StringUtil.changePrefix(changeLog, "classpath:", "");
+        }
+
+        return changeLog;
+    }
+
     public Liquibase createLiquibase() {
-        try (ClassLoaderResourceAccessor resourceAccessor = new ClassLoaderResourceAccessor(
-                Thread.currentThread().getContextClassLoader())) {
+        try (ResourceAccessor resourceAccessor = resolveResourceAccessor()) {
+            String parsedChangeLog = parseChangeLog(liquibaseMongodbBuildTimeConfig.changeLog);
             String connectionString = this.mongoClientConfig.connectionString.orElse("mongodb://localhost:27017");
 
             // Every MongoDB client configuration must be added to the connection string, we didn't add all as it would be too much to support.
@@ -83,7 +122,7 @@ public class LiquibaseMongodbFactory {
                     database.setDefaultSchemaName(liquibaseMongodbConfig.defaultSchemaName.get());
                 }
             }
-            Liquibase liquibase = new Liquibase(liquibaseMongodbBuildTimeConfig.changeLog, resourceAccessor, database);
+            Liquibase liquibase = new Liquibase(parsedChangeLog, resourceAccessor, database);
 
             for (Map.Entry<String, String> entry : liquibaseMongodbConfig.changeLogParameters.entrySet()) {
                 liquibase.getChangeLogParameters().set(entry.getKey(), entry.getValue());

--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbBuildTimeConfig.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbBuildTimeConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.liquibase.mongodb.runtime;
 
+import java.util.List;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -15,4 +17,10 @@ public class LiquibaseMongodbBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "db/changeLog.xml")
     public String changeLog;
+
+    /**
+     * The search path for DirectoryResourceAccessor
+     */
+    @ConfigItem(defaultValue = "/")
+    public List<String> searchPath;
 }


### PR DESCRIPTION
Due to the nature in which the resourceAccessor was created and injected when instantiating the Liquibase class
in LiquibaseMongodbFactory.createLiquibase()

` try (ClassLoaderResourceAccessor resourceAccessor = new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader()))`

it was not possible to pass a changeLog outside the classpath via `liquibase-mongodb.change-log` property. For people like me who want to use the quarkus-liquibase-mongodb extension only with the dev and test profiles in conjunction with the devservices and in productive environments use the liquibase cli directly this implementation is a bit problematic.

I also took the opportunity to implement the search-path property described in: [docs.liquibase](https://docs.liquibase.com/parameters/search-path.html) which allows me to limit the scope of the DirectoryResourceAccessor and not give it the default value of `DirectoryResourceAccessor(Paths.get("/"))`.

- Closes: #39683