### PR TITLE
Ensure augmented SecurityIdentity is used in SecurityEvents and move configuration-based roles-mapping to authentication phase

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/JaxRsPermissionChecker.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/JaxRsPermissionChecker.java
@@ -82,7 +82,7 @@ public class JaxRsPermissionChecker {
             }
         } else if (checkResult.getAugmentedIdentity() != identityAssociation.getIdentity()) {
             newIdentity = checkResult.getAugmentedIdentity();
-            routingContext.setUser(new QuarkusHttpUser(newIdentity));
+            QuarkusHttpUser.setIdentity(newIdentity, routingContext);
             identityAssociation.setIdentity(newIdentity);
         } else {
             newIdentity = checkResult.getAugmentedIdentity();

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityContext.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityContext.java
@@ -144,7 +144,7 @@ public class EagerSecurityContext {
                             newIdentity = checkWithIdentity.identity();
                         } else if (checkResult.getAugmentedIdentity() != checkWithIdentity.identity()) {
                             newIdentity = checkResult.getAugmentedIdentity();
-                            routingContext.setUser(new QuarkusHttpUser(newIdentity));
+                            QuarkusHttpUser.setIdentity(newIdentity, routingContext);
                             identityAssociation.get().setIdentity(newIdentity);
                         } else {
                             newIdentity = checkResult.getAugmentedIdentity();

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ManagementInterfaceSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ManagementInterfaceSecurityProcessor.java
@@ -1,21 +1,29 @@
 package io.quarkus.vertx.http.deployment;
 
+import java.util.Optional;
+
 import jakarta.inject.Singleton;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.HttpSecurityProcessor.IsApplicationBasicAuthRequired;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementInterfaceConfiguration;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceSecurityRecorder;
 import io.quarkus.vertx.http.runtime.security.BasicAuthenticationMechanism;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.AuthenticationHandler;
 import io.quarkus.vertx.http.runtime.security.ManagementInterfaceHttpAuthorizer;
 import io.quarkus.vertx.http.runtime.security.ManagementPathMatchingHttpSecurityPolicy;
 
@@ -44,10 +52,8 @@ public class ManagementInterfaceSecurityProcessor {
             ManagementInterfaceSecurityRecorder recorder,
             BuildProducer<ManagementInterfaceFilterBuildItem> filterBuildItemBuildProducer,
             BuildProducer<AdditionalBeanBuildItem> beanProducer,
-            Capabilities capabilities,
-            ManagementInterfaceBuildTimeConfig buildTimeConfig) {
-        if (buildTimeConfig.auth.basic.orElse(false)
-                && capabilities.isPresent(Capability.SECURITY)) {
+            Optional<ManagementAuthenticationHandlerBuildItem> managementAuthenticationHandlerBuildItem) {
+        if (managementAuthenticationHandlerBuildItem.isPresent()) {
             beanProducer
                     .produce(AdditionalBeanBuildItem.builder().setUnremovable()
                             .addBeanClass(HttpAuthenticator.class)
@@ -55,11 +61,41 @@ public class ManagementInterfaceSecurityProcessor {
                             .addBeanClass(ManagementInterfaceHttpAuthorizer.class).build());
             filterBuildItemBuildProducer
                     .produce(new ManagementInterfaceFilterBuildItem(
-                            recorder.authenticationMechanismHandler(buildTimeConfig.auth.proactive),
+                            recorder.getAuthenticationHandler(managementAuthenticationHandlerBuildItem.get().handler),
                             ManagementInterfaceFilterBuildItem.AUTHENTICATION));
             filterBuildItemBuildProducer
                     .produce(new ManagementInterfaceFilterBuildItem(recorder.permissionCheckHandler(),
                             ManagementInterfaceFilterBuildItem.AUTHORIZATION));
         }
     }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void createManagementAuthMechHandler(ManagementInterfaceSecurityRecorder recorder, Capabilities capabilities,
+            ManagementInterfaceBuildTimeConfig buildTimeConfig,
+            BuildProducer<ManagementAuthenticationHandlerBuildItem> managementAuthMechHandlerProducer) {
+        if (buildTimeConfig.auth.basic.orElse(false) && capabilities.isPresent(Capability.SECURITY)) {
+            managementAuthMechHandlerProducer.produce(new ManagementAuthenticationHandlerBuildItem(
+                    recorder.managementAuthenticationHandler(buildTimeConfig.auth.proactive)));
+        }
+    }
+
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep
+    @Consume(BeanContainerBuildItem.class)
+    void initializeAuthMechanismHandler(Optional<ManagementAuthenticationHandlerBuildItem> managementAuthenticationHandler,
+            ManagementInterfaceSecurityRecorder recorder, ManagementInterfaceConfiguration runTimeConfig) {
+        if (managementAuthenticationHandler.isPresent()) {
+            recorder.initializeAuthenticationHandler(managementAuthenticationHandler.get().handler, runTimeConfig);
+        }
+    }
+
+    static final class ManagementAuthenticationHandlerBuildItem extends SimpleBuildItem {
+        private final RuntimeValue<AuthenticationHandler> handler;
+
+        private ManagementAuthenticationHandlerBuildItem(RuntimeValue<AuthenticationHandler> handler) {
+            this.handler = handler;
+        }
+    }
+
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceSecurityRecorder.java
@@ -2,23 +2,33 @@ package io.quarkus.vertx.http.runtime.management;
 
 import java.util.function.Supplier;
 
-import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.vertx.http.runtime.security.AbstractPathMatchingHttpSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.BasicAuthenticationMechanism;
-import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.AbstractAuthenticationHandler;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.AuthenticationHandler;
 import io.quarkus.vertx.http.runtime.security.ManagementInterfaceHttpAuthorizer;
 import io.quarkus.vertx.http.runtime.security.ManagementPathMatchingHttpSecurityPolicy;
+import io.quarkus.vertx.http.runtime.security.RolesMapping;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class ManagementInterfaceSecurityRecorder {
 
-    public Handler<RoutingContext> authenticationMechanismHandler(boolean proactiveAuthentication) {
-        return new ManagementAuthenticationHandler(proactiveAuthentication);
+    public RuntimeValue<AuthenticationHandler> managementAuthenticationHandler(boolean proactiveAuthentication) {
+        return new RuntimeValue<>(new AuthenticationHandler(proactiveAuthentication));
+    }
+
+    public Handler<RoutingContext> getAuthenticationHandler(RuntimeValue<AuthenticationHandler> handlerRuntimeValue) {
+        return handlerRuntimeValue.getValue();
+    }
+
+    public void initializeAuthenticationHandler(RuntimeValue<AuthenticationHandler> handler,
+            ManagementInterfaceConfiguration runTimeConfig) {
+        handler.getValue().init(ManagementPathMatchingHttpSecurityPolicy.class,
+                RolesMapping.of(runTimeConfig.auth.rolesMapping));
     }
 
     public Handler<RoutingContext> permissionCheckHandler() {
@@ -44,31 +54,5 @@ public class ManagementInterfaceSecurityRecorder {
                 return new BasicAuthenticationMechanism(null, false);
             }
         };
-    }
-
-    static class ManagementAuthenticationHandler extends AbstractAuthenticationHandler {
-
-        volatile ManagementPathMatchingHttpSecurityPolicy pathMatchingPolicy;
-
-        public ManagementAuthenticationHandler(boolean proactiveAuthentication) {
-            super(proactiveAuthentication);
-        }
-
-        @Override
-        protected void setPathMatchingPolicy(RoutingContext event) {
-            if (pathMatchingPolicy == null) {
-                Instance<ManagementPathMatchingHttpSecurityPolicy> pathMatchingPolicyInstance = CDI.current()
-                        .select(ManagementPathMatchingHttpSecurityPolicy.class);
-                pathMatchingPolicy = pathMatchingPolicyInstance.isResolvable() ? pathMatchingPolicyInstance.get() : null;
-            }
-            if (pathMatchingPolicy != null) {
-                event.put(AbstractPathMatchingHttpSecurityPolicy.class.getName(), pathMatchingPolicy);
-            }
-        }
-
-        @Override
-        protected boolean httpPermissionsEmpty() {
-            return CDI.current().select(ManagementInterfaceConfiguration.class).get().auth.permissions.isEmpty();
-        }
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicy.java
@@ -116,7 +116,11 @@ public class AbstractPathMatchingHttpSecurityPolicy {
                     @Override
                     public Uni<? extends CheckResult> apply(CheckResult checkResult) {
                         if (!checkResult.isPermitted()) {
-                            return Uni.createFrom().item(CheckResult.DENY);
+                            if (checkResult.getAugmentedIdentity() == null) {
+                                return Uni.createFrom().item(CheckResult.DENY);
+                            } else {
+                                return Uni.createFrom().item(new CheckResult(false, checkResult.getAugmentedIdentity()));
+                            }
                         } else {
                             if (checkResult.getAugmentedIdentity() != null) {
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.http.runtime.security;
 
 import static io.quarkus.security.spi.runtime.SecurityEventHelper.AUTHENTICATION_FAILURE;
 import static io.quarkus.security.spi.runtime.SecurityEventHelper.AUTHENTICATION_SUCCESS;
+import static io.quarkus.vertx.http.runtime.security.RolesMapping.ROLES_MAPPING_KEY;
 import static java.lang.Boolean.TRUE;
 
 import java.util.ArrayList;
@@ -186,6 +187,10 @@ public class HttpAuthenticator {
                             return mech.authenticate(routingContext, identityProviderManager);
                         }
                     });
+        }
+
+        if (routingContext.get(ROLES_MAPPING_KEY) != null) {
+            result = result.onItem().ifNotNull().transform(routingContext.get(ROLES_MAPPING_KEY));
         }
 
         // fire security events if required

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
@@ -15,7 +15,6 @@ import io.quarkus.security.spi.runtime.AuthorizationController;
 import io.quarkus.security.spi.runtime.AuthorizationFailureEvent;
 import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
 
 /**
  * Class that is responsible for running the HTTP based permission checks
@@ -27,10 +26,9 @@ public class HttpAuthorizer extends AbstractHttpAuthorizer {
             AuthorizationController controller, Instance<HttpSecurityPolicy> installedPolicies,
             BlockingSecurityExecutor blockingExecutor, BeanManager beanManager,
             Event<AuthorizationFailureEvent> authZFailureEvent, Event<AuthorizationSuccessEvent> authZSuccessEvent,
-            @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled,
-            HttpConfiguration httpConfig) {
+            @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled) {
         super(httpAuthenticator, identityProviderManager, controller, toList(installedPolicies), beanManager, blockingExecutor,
-                authZFailureEvent, authZSuccessEvent, securityEventsEnabled, httpConfig.auth.rolesMapping);
+                authZFailureEvent, authZSuccessEvent, securityEventsEnabled);
     }
 
     private static List<HttpSecurityPolicy> toList(Instance<HttpSecurityPolicy> installedPolicies) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementInterfaceHttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementInterfaceHttpAuthorizer.java
@@ -14,7 +14,6 @@ import io.quarkus.security.spi.runtime.AuthorizationController;
 import io.quarkus.security.spi.runtime.AuthorizationFailureEvent;
 import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceConfiguration;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
@@ -29,8 +28,7 @@ public class ManagementInterfaceHttpAuthorizer extends AbstractHttpAuthorizer {
             AuthorizationController controller, ManagementPathMatchingHttpSecurityPolicy installedPolicy,
             BlockingSecurityExecutor blockingExecutor, Event<AuthorizationFailureEvent> authZFailureEvent,
             Event<AuthorizationSuccessEvent> authZSuccessEvent, BeanManager beanManager,
-            @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled,
-            ManagementInterfaceConfiguration runTimeConfig) {
+            @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled) {
         super(httpAuthenticator, identityProviderManager, controller,
                 List.of(new HttpSecurityPolicy() {
 
@@ -40,7 +38,6 @@ public class ManagementInterfaceHttpAuthorizer extends AbstractHttpAuthorizer {
                         return installedPolicy.checkPermission(request, identity, requestContext);
                     }
 
-                }), beanManager, blockingExecutor, authZFailureEvent, authZSuccessEvent, securityEventsEnabled,
-                runTimeConfig.auth.rolesMapping);
+                }), beanManager, blockingExecutor, authZFailureEvent, authZSuccessEvent, securityEventsEnabled);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUser.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUser.java
@@ -142,7 +142,7 @@ public class QuarkusHttpUser implements User {
         return identityUni;
     }
 
-    static SecurityIdentity setIdentity(SecurityIdentity identity, RoutingContext routingContext) {
+    public static SecurityIdentity setIdentity(SecurityIdentity identity, RoutingContext routingContext) {
         routingContext.setUser(new QuarkusHttpUser(identity));
         routingContext.put(QuarkusHttpUser.DEFERRED_IDENTITY_KEY, Uni.createFrom().item(identity));
         return identity;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/RolesAllowedHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/RolesAllowedHttpSecurityPolicy.java
@@ -37,7 +37,7 @@ public class RolesAllowedHttpSecurityPolicy extends RolesMapping implements Http
                                 return new CheckResult(true, augmented);
                             }
                         }
-                        return CheckResult.DENY;
+                        return new CheckResult(false, augmented);
                     }
                 }
                 for (String i : rolesAllowed) {

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AuthEventObserver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AuthEventObserver.java
@@ -1,0 +1,51 @@
+package io.quarkus.it.keycloak;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.security.spi.runtime.AuthenticationSuccessEvent;
+import io.quarkus.security.spi.runtime.AuthorizationFailureEvent;
+import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
+
+@Dependent
+@IfBuildProfile("jax-rs-http-perms-test")
+public class AuthEventObserver {
+
+    private static final List<AuthorizationSuccessEvent> authorizationSuccessEvents = new CopyOnWriteArrayList<>();
+    private static final List<AuthorizationFailureEvent> authorizationFailureEvents = new CopyOnWriteArrayList<>();
+    private static final List<AuthenticationSuccessEvent> authenticationSuccessEvents = new CopyOnWriteArrayList<>();
+
+    void observe(@Observes AuthorizationSuccessEvent authZSuccess) {
+        authorizationSuccessEvents.add(authZSuccess);
+    }
+
+    void observe(@Observes AuthorizationFailureEvent authZFailure) {
+        authorizationFailureEvents.add(authZFailure);
+    }
+
+    void observe(@Observes AuthenticationSuccessEvent authenticationSuccessEvent) {
+        authenticationSuccessEvents.add(authenticationSuccessEvent);
+    }
+
+    public static List<AuthorizationSuccessEvent> getAuthorizationSuccessEvents() {
+        return List.copyOf(authorizationSuccessEvents);
+    }
+
+    public static List<AuthorizationFailureEvent> getAuthorizationFailureEvents() {
+        return List.copyOf(authorizationFailureEvents);
+    }
+
+    public static List<AuthenticationSuccessEvent> getAuthenticationSuccessEvents() {
+        return List.copyOf(authenticationSuccessEvents);
+    }
+
+    public static void clearEvents() {
+        authorizationFailureEvents.clear();
+        authorizationSuccessEvents.clear();
+        authenticationSuccessEvents.clear();
+    }
+}


### PR DESCRIPTION
#39563 pre-step. Changes also make sense standalone.

- uses augmented identity added to the authZ failure events instead of original one (IMO original behavior was a bug, we need to use the one used for the authZ)
- if identity got augmented during authorization (HTTP Permissions can augment the identity), we add event property that signal it happened - this provides additional information for those interested in later `SecurityIdentity` changes
- makes identity augmentation via `quarkus.http.auth.roles-mapping` part of the authentication process, so that when the authenticatione event is fired, the identity is already augmented
- in order to do above-mentioned refactors authentication handler, which allows to drop `synchronized` method and reduce (runtime) logic inside authentication handler