### PR TITLE
Publish Gradle Build Scans to Quarkus Develocity instance

### DIFF
--- a/devtools/gradle/settings.gradle.kts
+++ b/devtools/gradle/settings.gradle.kts
@@ -3,12 +3,21 @@ plugins {
 }
 
 gradleEnterprise {
+    // plugin configuration
+    //See also: https://docs.gradle.com/enterprise/gradle-plugin/
+
+    val isAuthenticated = !System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY").isNullOrEmpty()
+    if(isAuthenticated) {
+        server = "https://ge.quarkus.io"
+    }
+
     buildScan {
-        // plugin configuration
-        //See also: https://docs.gradle.com/enterprise/gradle-plugin/
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+        if (!isAuthenticated) {
+            termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            termsOfServiceAgree = "yes"
+        }
         publishOnFailure()
+        isUploadInBackground = System.getenv("CI").isNullOrEmpty()
     }
 }
 


### PR DESCRIPTION
### Fix
With this change, failed builds of the Gradle plugin will be published to https://ge.quarkus.io if an access key is provisioned in the environment.

### Limitation
Local builds are usually authenticated with a key in `.gradle-enterprise/keys.properties` ([documentation](https://docs.gradle.com/enterprise/maven-extension/#authenticating_with_gradle_enterprise)) and failed build scans will keep being published to the public Develocity instance
