### PR TITLE
Use --no-daemon when calling gradle update

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -156,6 +156,7 @@ public class GradleRunner implements BuildSystemRunner {
         args.add("-PquarkusPluginVersion=" + ToolsUtils.getGradlePluginVersion(props));
         args.add("--console");
         args.add("plain");
+        args.add("--no-daemon");
         args.add("--stacktrace");
         args.add("quarkusUpdate");
         if (!StringUtil.isNullOrEmpty(targetQuarkusVersion.platformVersion)) {


### PR DESCRIPTION
This is to avoid cache issue when building after an update. like this:

```shell
~/s/code-with-gradle> ./gradlew build
> Task :quarkusAppPartsBuild FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':quarkusAppPartsBuild'.
> There was a failure while executing work items
   > A failure occurred while executing io.quarkus.gradle.tasks.worker.BuildWorker
      > io.quarkus.builder.BuildException: Build failure: Build failed due to errors
                [error]: Build step io.quarkus.deployment.steps.CurateOutcomeBuildStep#curateOutcome threw an exception: java.lang.RuntimeException: Imported BOMs io.quarkus.platform:quarkus-bom::pom:3.7.4, io.quarkus.platform:quarkus-bom::pom:3.8.3, io.quarkus.platform:quarkus-bom::pom:3.8.3, io.quarkus.platform:quarkus-bom::pom:3.8.3, io.quarkus.platform:quarkus-bom::pom:3.8.3, io.quarkus.platform:quarkus-bom::pom:3.8.3, io.quarkus.platform:quarkus-bom::pom:3.8.3 belong to different platform streams io.quarkus.bootstrap.model.PlatformStreamInfo@6ae9d3c0, io.quarkus.bootstrap.model.PlatformStreamInfo@3c1ead5f while only one stream per platform is allowed.
                at io.quarkus.bootstrap.model.PlatformInfo.getPossibleAlignments(PlatformInfo.java:51)
                at io.quarkus.bootstrap.model.PlatformImportsImpl.getPossibleAlignemnts(PlatformImportsImpl.java:200)
                at io.quarkus.bootstrap.model.PlatformImportsImpl.getMisalignmentReport(PlatformImportsImpl.java:143)
                at io.quarkus.deployment.builditem.AppModelProviderBuildItem.validateAndGet(AppModelProviderBuildItem.java:26)
                at io.quarkus.deployment.steps.CurateOutcomeBuildStep.curateOutcome(CurateOutcomeBuildStep.java:20)
                at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
                at java.base/java.lang.reflect.Method.invoke(Method.java:580)
                at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:849)
                at io.quarkus.builder.BuildContext.run(BuildContext.java:256)
                at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
                at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
                at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
                at java.base/java.lang.Thread.run(Thread.java:1583)
                at org.jboss.threads.JBossThread.run(JBossThread.java:501)


* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 1s
9 actionable tasks: 1 executed, 8 up-to-date
```