### PR TITLE
Update Hibernate ORM package/class processing rules

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -1356,7 +1356,8 @@ public final class HibernateOrmProcessor {
         }
 
         for (String modelPackageName : jpaModel.getAllModelPackageNames()) {
-            Set<String> persistenceUnitNames = packageRules.get(modelPackageName);
+            // Package rules keys are "normalized" package names, so we want to normalize the package on lookup:
+            Set<String> persistenceUnitNames = packageRules.get(normalizePackage(modelPackageName));
             if (persistenceUnitNames == null) {
                 continue;
             }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packages/PackageLevelAnnotationWithExplicitPackagePropertyTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packages/PackageLevelAnnotationWithExplicitPackagePropertyTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.hibernate.orm.packages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.UserTransaction;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.TransactionTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PackageLevelAnnotationWithExplicitPackagePropertyTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(TransactionTestUtils.class)
+                    .addPackage(PackageLevelAnnotationWithExplicitPackagePropertyTest.class.getPackage()))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.packages", "io.quarkus.hibernate.orm.packages");
+
+    @Inject
+    EntityManager entityManager;
+
+    @Inject
+    UserTransaction transaction;
+
+    @Test
+    public void test() {
+        ParentEntity parent1 = new ParentEntity("parent1");
+
+        inTransaction(() -> {
+            entityManager.persist(parent1);
+        });
+
+        inTransaction(() -> {
+            final List<ParentEntity> list = entityManager.createNamedQuery("test", ParentEntity.class)
+                    .getResultList();
+            assertThat(list.size()).isEqualTo(1);
+        });
+    }
+
+    private void inTransaction(Runnable runnable) {
+        TransactionTestUtils.inTransaction(transaction, runnable);
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packages/ParentEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packages/ParentEntity.java
@@ -4,7 +4,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 
+import org.hibernate.annotations.Filter;
+
 @Entity
+@Filter(name = "filter")
 public class ParentEntity {
 
     @Id

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packages/package-info.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/packages/package-info.java
@@ -1,4 +1,6 @@
 @NamedQuery(name = "test", query = "from ParentEntity")
+@FilterDef(name = "filter", defaultCondition = "true")
 package io.quarkus.hibernate.orm.packages;
 
+import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.NamedQuery;

--- a/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
+++ b/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
@@ -32,6 +32,9 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.it.jpa.postgresql.defaultpu.EntityWithXml;
+import io.quarkus.it.jpa.postgresql.defaultpu.Person;
+import io.quarkus.it.jpa.postgresql.defaultpu.SequencedAddress;
 import io.quarkus.it.jpa.postgresql.otherpu.EntityWithXmlOtherPU;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 

--- a/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/EntityWithXml.java
+++ b/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/EntityWithXml.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import java.time.LocalDate;
 

--- a/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Person.java
+++ b/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Person.java
@@ -1,9 +1,6 @@
-package io.quarkus.it.jpa.postgresql;
-
-import java.time.Duration;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -13,11 +10,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.JdbcType;
-import org.hibernate.dialect.PostgreSQLIntervalSecondJdbcType;
-
 @Entity
-@Table(schema = "myschema")
+@Table
 @NamedQuery(name = "get_person_by_name", query = "select p from Person p where name = :name")
 public class Person {
 
@@ -25,7 +19,6 @@ public class Person {
     private String name;
     private SequencedAddress address;
     private Status status;
-    private Duration latestLunchBreakDuration = Duration.ZERO;
 
     public Person() {
     }
@@ -71,27 +64,8 @@ public class Person {
         this.status = status;
     }
 
-    /**
-     * Need to explicitly set the scale (and the precision so that the scale will actually be read from the annotation).
-     * Postgresql would only allow maximum scale of 6 for a `interval second`.
-     *
-     * @see org.hibernate.type.descriptor.sql.internal.Scale6IntervalSecondDdlType
-     */
-    @Column(precision = 5, scale = 5)
-    //NOTE: while https://hibernate.atlassian.net/browse/HHH-16591 is open we cannot replace the currently used @JdbcType annotation
-    // with a @JdbcTypeCode( INTERVAL_SECOND )
-    @JdbcType(PostgreSQLIntervalSecondJdbcType.class)
-    public Duration getLatestLunchBreakDuration() {
-        return latestLunchBreakDuration;
-    }
-
-    public void setLatestLunchBreakDuration(Duration duration) {
-        this.latestLunchBreakDuration = duration;
-    }
-
     public void describeFully(StringBuilder sb) {
         sb.append("Person with id=").append(id).append(", name='").append(name).append("', status='").append(status)
-                .append("', latestLunchBreakDuration='").append(latestLunchBreakDuration)
                 .append("', address { ");
         getAddress().describeFully(sb);
         sb.append(" }");

--- a/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/SequencedAddress.java
+++ b/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/SequencedAddress.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Status.java
+++ b/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Status.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 public enum Status {
     LIVING,

--- a/integration-tests/jpa-postgresql-withxml/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql-withxml/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.jdbc.url=${postgres.url}
 quarkus.datasource.jdbc.max-size=8
 
-quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql
+quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql.defaultpu
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 #Necessary for assertions in JPAFunctionalityInGraalITCase:
@@ -15,3 +15,4 @@ quarkus.native.additional-build-args=-J-Dio.quarkus.jdbc.postgresql.graalvm.diag
 # Define non-default PU so that we can configure a custom XML format mapper. The default PU is using the default mapper.
 quarkus.hibernate-orm."other".datasource=<default>
 quarkus.hibernate-orm."other".packages=io.quarkus.it.jpa.postgresql.otherpu
+quarkus.hibernate-orm."other".database.generation=drop-and-create

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
@@ -16,6 +16,10 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.it.jpa.postgresql.defaultpu.EntityWithJson;
+import io.quarkus.it.jpa.postgresql.defaultpu.MyUUIDEntity;
+import io.quarkus.it.jpa.postgresql.defaultpu.Person;
+import io.quarkus.it.jpa.postgresql.defaultpu.SequencedAddress;
 import io.quarkus.it.jpa.postgresql.otherpu.EntityWithJsonOtherPU;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPATestReflectionEndpoint.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPATestReflectionEndpoint.java
@@ -16,6 +16,11 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import io.quarkus.it.jpa.postgresql.defaultpu.Address;
+import io.quarkus.it.jpa.postgresql.defaultpu.Customer;
+import io.quarkus.it.jpa.postgresql.defaultpu.NotAnEntityNotReferenced;
+import io.quarkus.it.jpa.postgresql.defaultpu.WorkAddress;
+
 /**
  * Various tests for the JPA integration.
  * WARNING: these tests will ONLY pass in native mode, as it also verifies reflection non-functionality.
@@ -32,8 +37,9 @@ public class JPATestReflectionEndpoint {
         makeSureNonAnnotatedEmbeddableAreAccessibleViaReflection(errors);
         makeSureAnnotatedEmbeddableAreAccessibleViaReflection(errors);
         String packageName = this.getClass().getPackage().getName();
-        makeSureClassAreAccessibleViaReflection(packageName + ".Human", "Unable to enlist @MappedSuperclass", errors);
-        makeSureClassAreAccessibleViaReflection(packageName + ".Animal", "Unable to enlist entity superclass", errors);
+        makeSureClassAreAccessibleViaReflection(packageName + ".defaultpu.Human", "Unable to enlist @MappedSuperclass", errors);
+        makeSureClassAreAccessibleViaReflection(packageName + ".defaultpu.Animal", "Unable to enlist entity superclass",
+                errors);
         if (errors.isEmpty()) {
             return "OK";
         } else {

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Address.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Address.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import jakarta.persistence.Embeddable;
 

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Animal.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Animal.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 /**
  * @author Emmanuel Bernard emmanuel@hibernate.org

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Customer.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Customer.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/EntityWithJson.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/EntityWithJson.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import java.time.LocalDate;
 

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Human.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Human.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import jakarta.persistence.MappedSuperclass;
 

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/MyUUIDEntity.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/MyUUIDEntity.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import java.util.UUID;
 

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/NotAnEntityNotReferenced.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/NotAnEntityNotReferenced.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 /**
  * Should not be referenced by the code

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/SequencedAddress.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/SequencedAddress.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Status.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/Status.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 public enum Status {
     LIVING,

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/WorkAddress.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/defaultpu/WorkAddress.java
@@ -1,4 +1,4 @@
-package io.quarkus.it.jpa.postgresql;
+package io.quarkus.it.jpa.postgresql.defaultpu;
 
 import jakarta.persistence.Embeddable;
 

--- a/integration-tests/jpa-postgresql/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql/src/main/resources/application.properties
@@ -3,12 +3,14 @@ quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.jdbc.url=${postgres.url}
 quarkus.datasource.jdbc.max-size=8
 
-quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql
+quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql.defaultpu
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.database.generation.create-schemas=true
 # Define non-default PU so that we can configure a custom JSON format mapper. The default PU is using the default mapper.
 quarkus.hibernate-orm."other".datasource=<default>
 quarkus.hibernate-orm."other".packages=io.quarkus.it.jpa.postgresql.otherpu
+quarkus.hibernate-orm."other".database.generation=drop-and-create
+quarkus.hibernate-orm."other".database.generation.create-schemas=true
 
 #Necessary for assertions in JPAFunctionalityInGraalITCase:
 quarkus.native.enable-reports=true


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/39299

I am not 100% sure about the changes in the first commit, but I'd expect that the package list should be explicit and not include subpackages. With the current behaviour DB objects for `other` PU in our tests were created by "accident" since the other pu did not explicitly define the properties to create them...