### PR TITLE
Enforce OIDC code flow access token verification only if JWT is in the application code

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -86,6 +86,9 @@ public class OidcBuildStep {
     private static final DotName JSON_WEB_TOKEN_NAME = DotName.createSimple(JsonWebToken.class);
     private static final DotName ID_TOKEN_NAME = DotName.createSimple(IdToken.class);
 
+    private static final String QUARKUS_TOKEN_PROPAGATION_PACKAGE = "io.quarkus.oidc.token.propagation";
+    private static final String SMALLRYE_JWT_PACKAGE = "io.smallrye.jwt";
+
     @BuildStep
     public void provideSecurityInformation(BuildProducer<SecurityInformationBuildItem> securityInformationProducer) {
         // TODO: By default quarkus.oidc.application-type = service
@@ -323,11 +326,19 @@ public class OidcBuildStep {
             DotName withoutQualifier) {
         for (InjectionPointInfo injectionPoint : beanRegistrationPhaseBuildItem.getInjectionPoints()) {
             if (requiredType.equals(injectionPoint.getRequiredType().name())
+                    && isApplicationPackage(injectionPoint.getTargetInfo())
                     && (withoutQualifier == null || injectionPoint.getRequiredQualifier(withoutQualifier) == null)) {
+                LOG.debugf("%s injection point: %s", requiredType.toString(), injectionPoint.getTargetInfo());
                 return true;
             }
         }
         return false;
+    }
+
+    private static boolean isApplicationPackage(String injectionPointTargetInfo) {
+        return injectionPointTargetInfo != null
+                && !injectionPointTargetInfo.startsWith(QUARKUS_TOKEN_PROPAGATION_PACKAGE)
+                && !injectionPointTargetInfo.startsWith(SMALLRYE_JWT_PACKAGE);
     }
 
     private static String toTargetName(AnnotationTarget target) {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyAccessTokenDisabled.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyAccessTokenDisabled.java
@@ -1,0 +1,54 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class CodeFlowVerifyAccessTokenDisabled {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ProtectedResourceWithoutJwtAccessToken.class)
+                    .addAsResource("application-verify-access-token-disabled.properties", "application.properties"));
+
+    @Test
+    public void testVerifyAccessTokenDisabled() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage page = webClient.getPage("http://localhost:8081/protected");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getInputByName("login").click();
+
+            assertEquals("alice:false", page.getBody().asNormalizedText());
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResourceWithoutJwtAccessToken.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResourceWithoutJwtAccessToken.java
@@ -1,0 +1,28 @@
+package io.quarkus.oidc.test;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.oidc.IdToken;
+import io.quarkus.oidc.runtime.OidcConfig;
+import io.quarkus.security.Authenticated;
+
+@Path("/protected")
+@Authenticated
+public class ProtectedResourceWithoutJwtAccessToken {
+
+    @Inject
+    @IdToken
+    JsonWebToken idToken;
+
+    @Inject
+    OidcConfig config;
+
+    @GET
+    public String getName() {
+        return idToken.getName() + ":" + config.defaultTenant.authentication.verifyAccessToken;
+    }
+}

--- a/extensions/oidc/deployment/src/test/resources/application-verify-access-token-disabled.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-verify-access-token-disabled.properties
@@ -1,0 +1,4 @@
+quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.client-id=quarkus-web-app
+quarkus.oidc.credentials.secret=secret
+quarkus.oidc.application-type=web-app


### PR DESCRIPTION
Fixes #39717 

This PR avoids enforcing the code flow access token `JsonWebToken` is the application code does not use it.
Just to summarize, with the authorization code flow, ID token is always verified. But the code flow access token is verified optionally because it is not used for the local security decisions, unless the user requests with `quarkus.oidc.authentication.verify-access-token=true`. Bearer access tokens are always verified or it is expected to contain the roles.

We made, IMHO, a good hardening fix with #39458, which will minimize the risk of the user code working with the unverified code flow access tokens and making some decisions, by forgetting to request its verification. This feature has been requested a few times, Paulo was asling about it. We just have to be careful because some access tokens are binary ones, from Google, etc, which can not be verified without the user enabling the indirect user info verification which may not always work. In fact I already enabled it by default awhile back and had to immediately revert it for this reason. 

So the fix from Michal is much better - we enable it if we detect the user code has an intention to use the code flow JWT access token but it picks up `JsonWebToken` from smallrye-jwt.

So this PR filters out smallrye-jwt and the OIDC token propagation, the only known OIDC related dependencies that have `JsonWebToken` injected. smallrye-jwt has a producer which may not be used at all in the application code, and the OIDC token propagation (resteasy based one) has a feature related to `JsonWebToken`, if it is available.

We can still imagine some custom producers working with `JsonWebToken` - but in that case the users will have a control around it - and remove the dependency if they don't need `JsonWebToken` in the code. And if really necessary, they can disable the verification with `quarkus.oidc.authentication.verify-access-token=false`, IMHO we should try to keep the hardening fix by all means.

@pedroigor @gastaldi If @michalvavrik approves, then IMHO it is good to go, in which case, please approve if you don't have any other concerns, as #39717 is a 3.9.0 regression . We don't change the OIDC logic at all, only would like to enforce the code flow access token verification whenever possible