### PR TITLE
Bump Strimzi Oauth Client version in bom from 0.14.0 to 0.15.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -217,7 +217,7 @@
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with aesh-readline and dekorate -->
         <jgit.version>6.9.0.202403050737-r</jgit.version>
         <!-- these two artifacts needs to be compatible together -->
-        <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>9.37.3</strimzi-oauth.nimbus.version>
         <jose4j.version>0.9.6</jose4j.version>
         <java-buildpack-client.version>0.0.6</java-buildpack-client.version>

--- a/integration-tests/kafka-oauth-keycloak/pom.xml
+++ b/integration-tests/kafka-oauth-keycloak/pom.xml
@@ -44,11 +44,6 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-client</artifactId>
         </dependency>
-        <!-- required for native compilation as strimzi substitutions require these classes -->
-        <dependency>
-            <groupId>io.strimzi</groupId>
-            <artifactId>kafka-oauth-common</artifactId>
-        </dependency>
 
         <!-- test dependencies -->
         <dependency>


### PR DESCRIPTION
Removes the workaround added in 3.6 : https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.6#kafka-extension-strimzi-oauth-support-known-issue