### PR TITLE
Fix a remaining reference to quarkus.resteasy-reactive. prefix

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveServerConfig.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveServerConfig.java
@@ -6,7 +6,7 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 
-@ConfigMapping(prefix = "quarkus.resteasy-reactive")
+@ConfigMapping(prefix = "quarkus.rest")
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public interface ResteasyReactiveServerConfig {
 


### PR DESCRIPTION
I think it shouldn't break applications, it's just that you get a warning.
Not sure how I missed it in the renaming given the number of manual checks I did...