### PR TITLE
Properly handle array class types to be looked up

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
@@ -132,7 +132,7 @@ public class RegisterForReflectionBuildStep {
         }
 
         try {
-            Class<?>[] declaredClasses = classLoader.loadClass(className).getDeclaredClasses();
+            Class<?>[] declaredClasses = Class.forName(className, false, classLoader).getDeclaredClasses();
             for (Class<?> clazz : declaredClasses) {
                 registerClass(classLoader, clazz.getName(), methods, fields, false, serialization, unsafeAllocated,
                         reflectiveClass,


### PR DESCRIPTION
This properly only manifests with something like:

```java
@RegisterForReflection(targets = URI[].class, ignoreNested=false)
```

and we never saw it before 3.9 because `ignoreNested` defaulted to `false` before that release.

Originally reported [here](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/quarkus.203.2E9/near/430034416)
