### PR TITLE
Improve the multipart encoded mode handling in the rest client

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -417,6 +417,14 @@ public ClientMultipartForm buildClientMultipartForm(MultiPartPayloadFormData inp
 <2> Adding attribute `jsonPayload` directly to `ClientMultipartForm`
 <3> Adding `FileUpload` objects to `ClientMultipartForm` as binaryFileUpload with contentType.
 
+[NOTE]
+====
+When sending multipart data that uses the same name, problems can arise if the client and server do not use the same multipart encoder mode.
+By default, the REST Client uses `RFC1738`, but depending on the situation, clients may need to be configured with `HTML5` or `RFC3986` mode.
+
+This configuration can be achieved via the `quarkus.rest-client.multipart-post-encoder-mode` property.
+====
+
 === Sending large payloads
 
 The REST Client is capable of sending arbitrarily large HTTP bodies without buffering the contents in memory, if one of the following types is used:

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
@@ -27,6 +27,7 @@ public class RestClientConfig {
         EMPTY.connectTimeout = Optional.empty();
         EMPTY.readTimeout = Optional.empty();
         EMPTY.followRedirects = Optional.empty();
+        EMPTY.multipartPostEncoderMode = Optional.empty();
         EMPTY.proxyAddress = Optional.empty();
         EMPTY.proxyUser = Optional.empty();
         EMPTY.proxyPassword = Optional.empty();
@@ -96,6 +97,19 @@ public class RestClientConfig {
      */
     @ConfigItem
     public Optional<Boolean> followRedirects;
+
+    /**
+     * Mode in which the form data are encoded. Possible values are `HTML5`, `RFC1738` and `RFC3986`.
+     * The modes are described in the
+     * <a href="https://netty.io/4.1/api/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.EncoderMode.html">Netty
+     * documentation</a>
+     * <p>
+     * By default, Rest Client Reactive uses RFC1738.
+     * <p>
+     * This property is not applicable to the RESTEasy Client.
+     */
+    @ConfigItem
+    public Optional<String> multipartPostEncoderMode;
 
     /**
      * A string value in the form of `<proxyHost>:<proxyPort>` that specifies the HTTP proxy server hostname
@@ -287,6 +301,7 @@ public class RestClientConfig {
         instance.connectTimeout = getConfigValue(configKey, "connect-timeout", Long.class);
         instance.readTimeout = getConfigValue(configKey, "read-timeout", Long.class);
         instance.followRedirects = getConfigValue(configKey, "follow-redirects", Boolean.class);
+        instance.multipartPostEncoderMode = getConfigValue(configKey, "multipart-post-encoder-mode", String.class);
         instance.proxyAddress = getConfigValue(configKey, "proxy-address", String.class);
         instance.proxyUser = getConfigValue(configKey, "proxy-user", String.class);
         instance.proxyPassword = getConfigValue(configKey, "proxy-password", String.class);

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
@@ -179,6 +179,14 @@ public interface QuarkusRestClientBuilder extends Configurable<QuarkusRestClient
     QuarkusRestClientBuilder followRedirects(boolean follow);
 
     /**
+     * Mode in which the form data are encoded. Possible values are `HTML5`, `RFC1738` and `RFC3986`.
+     * The modes are described in the
+     * <a href="https://netty.io/4.1/api/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.EncoderMode.html">Netty
+     * documentation</a>
+     */
+    QuarkusRestClientBuilder multipartPostEncoderMode(String mode);
+
+    /**
      * Specifies the HTTP proxy hostname/IP address and port to use for requests from client instances.
      *
      * @param proxyHost hostname or IP address of proxy server - must be non-null

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
@@ -121,6 +121,12 @@ public class QuarkusRestClientBuilderImpl implements QuarkusRestClientBuilder {
     }
 
     @Override
+    public QuarkusRestClientBuilder multipartPostEncoderMode(String mode) {
+        proxy.multipartPostEncoderMode(mode);
+        return this;
+    }
+
+    @Override
     public QuarkusRestClientBuilder queryParamStyle(QueryParamStyle style) {
         proxy.queryParamStyle(style);
         return this;

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -10,6 +10,7 @@ import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +35,7 @@ import org.jboss.resteasy.reactive.client.handlers.RedirectHandler;
 import org.jboss.resteasy.reactive.client.impl.ClientBuilderImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientImpl;
 import org.jboss.resteasy.reactive.client.impl.WebTargetImpl;
+import org.jboss.resteasy.reactive.client.impl.multipart.PausableHttpPostRequestEncoder;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
 import org.jboss.resteasy.reactive.common.jaxrs.MultiQueryParamMode;
 
@@ -63,6 +65,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
     private boolean followRedirects;
     private QueryParamStyle queryParamStyle;
 
+    private String multipartPostEncoderMode;
     private String proxyHost;
     private Integer proxyPort;
     private String proxyUser;
@@ -164,6 +167,11 @@ public class RestClientBuilderImpl implements RestClientBuilder {
 
     public RestClientBuilderImpl nonProxyHosts(String nonProxyHosts) {
         this.nonProxyHosts = nonProxyHosts;
+        return this;
+    }
+
+    public RestClientBuilderImpl multipartPostEncoderMode(String mode) {
+        this.multipartPostEncoderMode = mode;
         return this;
     }
 
@@ -435,6 +443,21 @@ public class RestClientBuilderImpl implements RestClientBuilder {
             configureProxy(globalProxy.host, globalProxy.port, restClientsConfig.proxyUser.orElse(null),
                     restClientsConfig.proxyPassword.orElse(null), restClientsConfig.nonProxyHosts.orElse(null));
         }
+
+        if (!clientBuilder.getConfiguration().hasProperty(QuarkusRestClientProperties.MULTIPART_ENCODER_MODE)) {
+            PausableHttpPostRequestEncoder.EncoderMode multipartPostEncoderMode = null;
+            if (this.multipartPostEncoderMode != null) {
+                multipartPostEncoderMode = PausableHttpPostRequestEncoder.EncoderMode
+                        .valueOf(this.multipartPostEncoderMode.toUpperCase(Locale.ROOT));
+            } else if (restClientsConfig.multipartPostEncoderMode.isPresent()) {
+                multipartPostEncoderMode = PausableHttpPostRequestEncoder.EncoderMode
+                        .valueOf(restClientsConfig.multipartPostEncoderMode.get().toUpperCase(Locale.ROOT));
+            }
+            if (multipartPostEncoderMode != null) {
+                clientBuilder.property(QuarkusRestClientProperties.MULTIPART_ENCODER_MODE, multipartPostEncoderMode);
+            }
+        }
+
         ClientImpl client = clientBuilder.build();
         WebTargetImpl target = (WebTargetImpl) client.target(uri);
         target.setParamConverterProviders(paramConverterProviders);

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -77,7 +77,8 @@ public class RestClientCDIDelegateBuilder<T> {
     }
 
     private void configureCustomProperties(QuarkusRestClientBuilder builder) {
-        Optional<String> encoder = configRoot.multipartPostEncoderMode;
+        Optional<String> encoder = oneOf(clientConfigByClassName().multipartPostEncoderMode,
+                clientConfigByConfigKey().multipartPostEncoderMode, configRoot.multipartPostEncoderMode);
         if (encoder != null && encoder.isPresent()) {
             PausableHttpPostRequestEncoder.EncoderMode mode = PausableHttpPostRequestEncoder.EncoderMode
                     .valueOf(encoder.get().toUpperCase(Locale.ROOT));

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.reactive.client.api;
 
+import org.jboss.resteasy.reactive.client.impl.multipart.PausableHttpPostRequestEncoder;
+
 public class QuarkusRestClientProperties {
 
     /**
@@ -27,7 +29,7 @@ public class QuarkusRestClientProperties {
     public static final String READ_TIMEOUT = "io.quarkus.rest.client.read-timeout";
 
     /**
-     * See {@link EncoderMode}, RFC1738 by default
+     * See {@link PausableHttpPostRequestEncoder.EncoderMode}, RFC1738 by default
      */
     public static final String MULTIPART_ENCODER_MODE = "io.quarkus.rest.client.multipart-post-encoder-mode";
 


### PR DESCRIPTION
- Add named configuration value for multipartPostEncoderMode
- Add note about multipart encoder mode in the docs
- Introduce option for multipartPostEncoderMode in REST Client builder

The issue came up in discussion #39751 and took a while to track down.