### PR TITLE
Avoid registering all config classes/interfaces for reflection

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -103,13 +103,8 @@ public class ConfigMappingUtils {
             // This is the generated implementation of the mapping by SmallRye Config.
             generatedClasses.produce(new GeneratedClassBuildItem(isApplicationClass, mappingMetadata.getClassName(),
                     mappingMetadata.getClassBytes()));
-            // Register the interface and implementation methods for reflection. This is required for Bean Validation.
-            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(mappingMetadata.getInterfaceType()).methods().build());
-            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(mappingMetadata.getClassName()).methods().build());
-            // Register also the interface hierarchy
-            for (Class<?> parent : getHierarchy(mappingMetadata.getInterfaceType())) {
-                reflectiveClasses.produce(ReflectiveClassBuildItem.builder(parent).methods().build());
-            }
+            // Register the implementation for reflection.
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(mappingMetadata.getClassName()).build());
 
             processProperties(mappingMetadata.getInterfaceType(), reflectiveClasses);
         });


### PR DESCRIPTION
This was apparently required for Hibernate Validator but Hibernate Validator already takes care of it and with a more fine grained approach.

Creating as draft to see what CI coverage has to say.