### PR TITLE
Always record profiles

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -10,6 +10,8 @@ import static io.quarkus.runtime.configuration.PropertiesUtil.filterPropertiesIn
 import static io.smallrye.config.ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix;
 import static io.smallrye.config.Expressions.withoutExpansion;
 import static io.smallrye.config.PropertiesConfigSourceProvider.classPathSources;
+import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_PROFILE;
+import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_PROFILE_PARENT;
 import static io.smallrye.config.SmallRyeConfigBuilder.META_INF_MICROPROFILE_CONFIG_PROPERTIES;
 import static java.util.stream.Collectors.toSet;
 
@@ -1104,8 +1106,8 @@ public final class BuildTimeConfigurationReader {
                             Map.of("quarkus.profile", "",
                                     "quarkus.config.profile.parent", "",
                                     "quarkus.test.profile", "",
-                                    SmallRyeConfig.SMALLRYE_CONFIG_PROFILE, "",
-                                    SmallRyeConfig.SMALLRYE_CONFIG_PROFILE_PARENT, "",
+                                    SMALLRYE_CONFIG_PROFILE, "",
+                                    SMALLRYE_CONFIG_PROFILE_PARENT, "",
                                     Config.PROFILE, ""),
                             Integer.MAX_VALUE) {
                         @Override
@@ -1154,6 +1156,28 @@ public final class BuildTimeConfigurationReader {
                 }
                 builder.withSources(configSource);
             }
+            builder.withSources(new AbstractConfigSource("Profiles", Integer.MAX_VALUE) {
+                private final Set<String> profiles = Set.of(
+                        "quarkus.profile",
+                        "quarkus.config.profile.parent",
+                        "quarkus.test.profile",
+                        SMALLRYE_CONFIG_PROFILE,
+                        SMALLRYE_CONFIG_PROFILE_PARENT,
+                        Config.PROFILE);
+
+                @Override
+                public Set<String> getPropertyNames() {
+                    return Collections.emptySet();
+                }
+
+                @Override
+                public String getValue(final String propertyName) {
+                    if (profiles.contains(propertyName)) {
+                        return config.getConfigValue(propertyName).getValue();
+                    }
+                    return null;
+                };
+            });
             return builder.build();
         }
 

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/RuntimeDefaultsTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/RuntimeDefaultsTest.java
@@ -52,4 +52,11 @@ public class RuntimeDefaultsTest {
         assertEquals("properties", defaultValues.get().getValue("%test.bt.profile.record"));
         assertNull(defaultValues.get().getValue("bt.profile.record"));
     }
+
+    @Test
+    void recordProfile() {
+        Optional<ConfigSource> defaultValues = config.getConfigSource("DefaultValuesConfigSource");
+        assertTrue(defaultValues.isPresent());
+        assertEquals("record", config.getRawValue("quarkus.profile"));
+    }
 }

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/EnvBuildTimeConfigSource.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/EnvBuildTimeConfigSource.java
@@ -7,6 +7,7 @@ import io.smallrye.config.EnvConfigSource;
 public class EnvBuildTimeConfigSource extends EnvConfigSource {
     public EnvBuildTimeConfigSource() {
         super(Map.of(
+                "QUARKUS_PROFILE", "record",
                 "QUARKUS_MAPPING_RT_DO_NOT_RECORD", "value",
                 "BT_OK_TO_RECORD", "from-env",
                 "BT_DO_NOT_RECORD", "value",


### PR DESCRIPTION
- Fixes #39776

With https://github.com/quarkusio/quarkus/pull/39604, we wanted to prevent the recording of configuration values in the resulting binary to prevent issues like https://github.com/quarkusio/quarkus/issues/39388.

A side effect is that if the profile is set from what is considered a local source (like system properties), it is not recorded. A profile is always required to start Quarkus, and we set it up to be `prod` by default. I believe it does make sense to start Quarkus with the profile used to build it, which requires it to be recorded. Of course, the profile can be overridden.

Remember, the profile is required to start the STATIC_INIT Config, which happens at build time for the native image. We have to pick something different from what the user wants to use for runtime. Right now, we do allow to override the profile for the native image with a warning.