### PR TITLE
Bump JDK version to 17 as an aws lambda runtime in aws-lambda related extensions

### DIFF
--- a/docs/src/main/asciidoc/aws-lambda-http.adoc
+++ b/docs/src/main/asciidoc/aws-lambda-http.adoc
@@ -265,7 +265,7 @@ Do not change the Lambda handler name.
 ----
      Properties:
         Handler: io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
-        Runtime: java11
+        Runtime: java17
 ----
 
 This handler is a bridge between the lambda runtime and the Quarkus HTTP framework you are using (Jakarta REST, Servlet, etc.)

--- a/extensions/amazon-lambda-http/deployment/src/main/resources/http/sam.jvm.yaml
+++ b/extensions/amazon-lambda-http/deployment/src/main/resources/http/sam.jvm.yaml
@@ -12,7 +12,7 @@
       Type: AWS::Serverless::Function
       Properties:
         Handler: io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
-        Runtime: java11
+        Runtime: java17
         CodeUri: function.zip
         MemorySize: 512
         Policies: AWSLambdaBasicExecutionRole

--- a/extensions/amazon-lambda-rest/deployment/src/main/resources/http/sam.jvm.yaml
+++ b/extensions/amazon-lambda-rest/deployment/src/main/resources/http/sam.jvm.yaml
@@ -12,7 +12,7 @@
       Type: AWS::Serverless::Function
       Properties:
         Handler: io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
-        Runtime: java11
+        Runtime: java17
         CodeUri: function.zip
         MemorySize: 512
         Policies: AWSLambdaBasicExecutionRole

--- a/extensions/amazon-lambda/common-deployment/src/main/resources/lambda/manage.sh
+++ b/extensions/amazon-lambda/common-deployment/src/main/resources/lambda/manage.sh
@@ -51,7 +51,7 @@ function cmd_update() {
 
 FUNCTION_NAME=${lambdaName}
 HANDLER=${handler}
-RUNTIME=java11
+RUNTIME=java17
 ZIP_FILE=${targetUri}
 
 function usage() {

--- a/extensions/amazon-lambda/common-deployment/src/main/resources/lambda/sam.jvm.yaml
+++ b/extensions/amazon-lambda/common-deployment/src/main/resources/lambda/sam.jvm.yaml
@@ -12,7 +12,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: ${handler}
-      Runtime: java11
+      Runtime: java17
       CodeUri: function.zip
       MemorySize: 256
       Timeout: 15


### PR DESCRIPTION
JDK 17 is the minimal JDK version since quarkus 3.7.