### PR TITLE
Replace wrong Vertx direct allocator with Netty one

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/AppendBuffer.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/AppendBuffer.java
@@ -10,7 +10,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.util.internal.PlatformDependent;
-import io.vertx.core.buffer.impl.PartialPooledByteBufAllocator;
 import io.vertx.core.buffer.impl.VertxByteBufAllocator;
 
 /**
@@ -134,8 +133,7 @@ final class AppendBuffer {
             // VertxByteBufAllocator allocates cheaper heap buffers ie which doesn't use reference counting
             tmpBuf = VertxByteBufAllocator.DEFAULT.heapBuffer(chunkCapacity);
         } else {
-            // Vertx should replace the "standerd" PooledByteBufAllocator.DEFAULT this one
-            tmpBuf = PartialPooledByteBufAllocator.INSTANCE.directBuffer(chunkCapacity);
+            tmpBuf = PooledByteBufAllocator.DEFAULT.directBuffer(chunkCapacity);
         }
         try {
             tmpBuf.writeBytes(bytes, off, toWrite);


### PR DESCRIPTION
I've misread https://github.com/eclipse-vertx/vert.x/blob/5832acf2fb22ed0301c396d4c3a7c316005e2939/src/main/java/io/vertx/core/spi/transport/Transport.java#L120 and **only** datagram cases are using a different allocator from the Netty one. 