### PR TITLE
Move the import of smallrye-common-bom higher up

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -268,6 +268,15 @@
 
             <!-- External BOMs -->
 
+            <!-- Smallrye Common dependencies, imported as a BOM -->
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-bom</artifactId>
+                <version>${smallrye-common.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
             <!-- Netty dependencies, imported as a BOM -->
             <dependency>
                 <groupId>io.netty</groupId>
@@ -338,15 +347,6 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-bom</artifactId>
                 <version>${grpc.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-            <!-- Smallrye Common dependencies, imported as a BOM -->
-            <dependency>
-                <groupId>io.smallrye.common</groupId>
-                <artifactId>smallrye-common-bom</artifactId>
-                <version>${smallrye-common.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
This is to make sure other BOMs don't accidentally bring in unexpected versions of smallrye-common-* before they are imported from smallrye-common-bom. The main branch looks good for now, however quarkus-bom:3.8.3 contains SmallRye Common 2.1.2 instead of the expected 2.2.0.