### PR TITLE
SmallRye OpenAPI: add missing @Inject annotation

### DIFF
--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.openapi.OASFilter;
@@ -36,6 +37,7 @@ public class OpenApiDocumentService implements OpenApiDocumentHolder {
     private final OpenApiDocumentHolder documentHolder;
     private final String previousOpenApiServersSystemPropertyValue;
 
+    @Inject
     public OpenApiDocumentService(OASFilter autoSecurityFilter,
             OpenApiRecorder.UserDefinedRuntimeFilters userDefinedRuntimeFilters, Config config) {
         String servers = config.getOptionalValue("quarkus.smallrye-openapi.servers", String.class).orElse(null);


### PR DESCRIPTION
This makes sure the code works in CDI strict mode as well.

Fixes #39779