### PR TITLE
Bump maven-model-helper to 36

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -182,6 +182,7 @@ updates:
       - dependency-name: org.apache.qpid:*
       - dependency-name: biz.paluch.logging:logstash-gelf
       - dependency-name: org.bitbucket.b_c:jose4j
+      - dependency-name: io.fabric8:maven-model-helper
     ignore:
       # this one cannot be upgraded due to the usage of proxies in new versions
       # the proxy implements interfaces in a random order which causes issues

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -27,7 +27,7 @@
         <asciidoctorj-pdf.version>1.5.0-beta.8</asciidoctorj-pdf.version>
         <asciidoctor.fail-if>WARN</asciidoctor.fail-if>
         <roaster-jdt.version>2.26.0.Final</roaster-jdt.version>
-        <maven-model-helper.version>35</maven-model-helper.version>
+        <maven-model-helper.version>36</maven-model-helper.version>
         <eclipse-collections.version>11.1.0</eclipse-collections.version>
         <jgit.version>6.9.0.202403050737-r</jgit.version>
 

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -80,7 +80,7 @@
         <org-crac.version>0.1.3</org-crac.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
-        <maven-model-helper.version>35</maven-model-helper.version>
+        <maven-model-helper.version>36</maven-model-helper.version>
     </properties>
     <modules>
         <module>bom</module>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -58,7 +58,7 @@
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <quarkus.version>${project.version}</quarkus.version>
-        <maven-model-helper.version>35</maven-model-helper.version>
+        <maven-model-helper.version>36</maven-model-helper.version>
         <jandex.version>3.1.7</jandex.version>
         <system-stubs-jupiter.version>2.0.2</system-stubs-jupiter.version>
         <awaitility.version>4.2.1</awaitility.version>


### PR DESCRIPTION
It also enables it in Dependabot

## What's Changed
* Remove unused methods by @gastaldi in https://github.com/fabric8-launcher/maven-model-helper/pull/134
* build(deps-dev): bump com.approvaltests:approvaltests from 23.0.0 to 23.0.1 by @dependabot in https://github.com/fabric8-launcher/maven-model-helper/pull/135
* Avoid setting SortedProperties twice by @gastaldi in https://github.com/fabric8-launcher/maven-model-helper/pull/136


**Full Changelog**: https://github.com/fabric8-launcher/maven-model-helper/compare/v35...v36