### PR TITLE
Fix OIDC cookie related tenant id and chunk calculation issues

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -590,62 +590,20 @@ However, this time, you are going to authenticate by using a different realm.
 In both cases, the landing page shows the user's name and email if the user is successfully authenticated.
 Although `alice` exists in both tenants, the application treats them as distinct users in separate realms.
 
-[[static-tenant-resolution]]
-== Static tenant configuration resolution
+[[tenant-resolution-order]]
+== Tenant resolution order
 
-When you set multiple tenant configurations in the `application.properties` file, you only need to specify how the tenant identifier gets resolved.
-To configure the resolution of the tenant identifier, use one of the following options:
+OIDC tenants are resolved in the following order:
+1. `io.quarkus.oidc.Tenant` annotation is checked first if the proactive authentication is disabled.
+2. Dynamic tenant resolution using a custom `TenantConfigResolver`.
+3. Static tenant resolution using one of these options: custom `TenantResolver`, configured tenant paths, and defaulting to the last request path segment as a tenant id.
+4. Default OIDC tenant is selected if a tenant id has not been resolved after the preceeding steps.
 
-* <<tenant-resolver>>
+See the following sections for more information:
+
 * <<annotations-tenant-resolver>>
-* <<configuration-based-tenant-resolver>>
-* <<default-tenant-resolver>>
-
-These tenant resolution options are tried in the order they are listed until the tenant id gets resolved.
-If the tenant id remains unresolved (`null`), the default (unnamed) tenant configuration is selected.
-
-[[tenant-resolver]]
-=== Resolve with `TenantResolver`
-
-The following `application.properties` example shows how you can resolve the tenant identifier of two tenants named `a` and `b` by using the `TenantResolver` method:
-
-[source,properties]
-----
-# Tenant 'a' configuration
-quarkus.oidc.a.auth-server-url=http://localhost:8180/realms/quarkus-a
-quarkus.oidc.a.client-id=client-a
-quarkus.oidc.a.credentials.secret=client-a-secret
-
-# Tenant 'b' configuration
-quarkus.oidc.b.auth-server-url=http://localhost:8180/realms/quarkus-b
-quarkus.oidc.b.client-id=client-b
-quarkus.oidc.b.credentials.secret=client-b-secret
-----
-
-You can return the tenant id of either `a` or `b` from `quarkus.oidc.TenantResolver`:
-
-[source,java]
-----
-import quarkus.oidc.TenantResolver;
-
-public class CustomTenantResolver implements TenantResolver {
-
-    @Override
-    public String resolve(RoutingContext context) {
-        String path = context.request().path();
-        if (path.endsWith("a")) {
-            return "a";
-        } else if (path.endsWith("b")) {
-            return "b";
-        } else {
-            // default tenant
-            return null;
-        }
-    }
-}
-----
-
-In this example, the value of the last request path segment is a tenant id, but if required, you can implement a more complex tenant identifier resolution logic.
+* <<tenant-config-resolver>>
+* <<static-tenant-resolution>>
 
 [[annotations-tenant-resolver]]
 === Resolve with annotations
@@ -698,8 +656,8 @@ quarkus.http.auth.permission.authenticated.applies-to=JAXRS <1>
 ----
 <1> Tell Quarkus to run the HTTP permission check after the tenant has been selected with the `@Tenant` annotation.
 
-[[configuration-based-tenant-resolver]]
-=== Resolve with configuration
+[[configure-tenant-paths]]
+=== Configure tenant paths
 
 You can use the `quarkus.oidc.tenant-paths` configuration property for resolving the tenant identifier as an alternative to using `io.quarkus.oidc.TenantResolver`.
 Here is how you can select the `hr` tenant for the `sayHello` endpoint of the `HelloResource` resource used in the previous example:
@@ -715,46 +673,6 @@ quarkus.oidc.b.tenant-paths=/*/hello <3>
 <3> The wildcard in the `/*/hello` represents exactly one path segment. Nevertheless, the wildcard is less specific than the `api`, therefore the `hr` tenant will be used.
 
 TIP: Path-matching mechanism works exactly same as in the xref:security-authorize-web-endpoints-reference.adoc#authorization-using-configuration[Authorization using configuration].
-
-[[default-tenant-resolver]]
-=== Default resolution
-
-The default resolution for a tenant identifier is convention based, whereby the authentication request must include the tenant identifier in the last segment of the request path.
-
-The following `application.properties` example shows how you can configure two tenants named `google` and `github`:
-
-[source,properties]
-----
-# Tenant 'google' configuration
-quarkus.oidc.google.provider=google
-quarkus.oidc.google.client-id=${google-client-id}
-quarkus.oidc.google.credentials.secret=${google-client-secret}
-quarkus.oidc.google.authentication.redirect-path=/signed-in
-
-# Tenant 'github' configuration
-quarkus.oidc.github.provider=google
-quarkus.oidc.github.client-id=${github-client-id}
-quarkus.oidc.github.credentials.secret=${github-client-secret}
-quarkus.oidc.github.authentication.redirect-path=/signed-in
-----
-
-In the provided example, both tenants configure OIDC `web-app` applications to use an authorization code flow to authenticate users and require session cookies to be generated after authentication.
-After Google or GitHub authenticates the current user, the user gets returned to the `/signed-in` area for authenticated users, such as a secured resource path on the JAX-RS endpoint.
-
-Finally, to complete the default tenant resolution, set the following configuration property:
-
-[source,properties]
-----
-quarkus.http.auth.permission.login.paths=/google,/github
-quarkus.http.auth.permission.login.policy=authenticated
-----
-
-If the endpoint is running on `http://localhost:8080`, you can also provide UI options for users to log in to either `http://localhost:8080/google` or `http://localhost:8080/github`, without having to add specific `/google` or `/github` JAX-RS resource paths.
-Tenant identifiers are also recorded in the session cookie names after the authentication is completed.
-Therefore, authenticated users can access the secured application area without requiring either the `google` or `github` path values to be included in the secured URL.
-
-Default resolution can also work for Bearer token authentication.
-Still, it might be less practical because a tenant identifier must always be set as the last path segment value.
 
 [[tenant-config-resolver]]
 == Dynamic tenant configuration resolution
@@ -824,62 +742,314 @@ You can populate it by using any settings supported by the `quarkus-oidc` extens
 
 If the dynamic tenant resolver returns `null`, a <<static-tenant-resolution>> is attempted next.
 
-=== Tenant resolution for OIDC web-app applications
+[[static-tenant-resolution]]
+== Static tenant configuration resolution
 
-The simplest option for resolving the OIDC `web-app` application configuration is to follow the steps described in the <<default-tenant-resolver>> section.
+When you set multiple tenant configurations in the `application.properties` file, you only need to specify how the tenant identifier gets resolved.
+To configure the resolution of the tenant identifier, use one of the following options:
 
-Try one of the options below if the default resolution strategy does not work for your application setup.
+* <<tenant-resolver>>
+* <<configure-tenant-paths>>
+* <<default-tenant-resolver>>
 
-Several options are available for selecting the tenant configuration that should be used to secure the current HTTP request for both `service` and `web-app` OIDC applications, such as:
+These tenant resolution options are tried in the order they are listed until the tenant id gets resolved.
+If the tenant id remains unresolved (`null`), the default (unnamed) tenant configuration is selected.
 
-- Check the URL paths.
-For example, a `tenant-service` configuration must be used for the `/service` paths, while a `tenant-manage` configuration must be used for the `/management` paths.
-- Check the HTTP headers.
-For example, with a URL path always being `/service`, a header such as `Realm: service` or `Realm: management` can help to select between the `tenant-service` and `tenant-manage` configurations.
-- Check the URL query parameters.
-It can work similarly to the way the headers are used to select the tenant configuration.
+[[tenant-resolver]]
+=== Resolve with `TenantResolver`
 
-All these options can be easily implemented with the custom `TenantResolver` and `TenantConfigResolver` implementations for the OIDC `service` applications.
+The following `application.properties` example shows how you can resolve the tenant identifier of two tenants named `a` and `b` by using the `TenantResolver` method:
 
-However, due to an HTTP redirect required to complete the code authentication flow for the OIDC `web-app` applications, a custom HTTP cookie might be needed to select the same tenant configuration before and after this redirect request because:
+[source,properties]
+----
+# Tenant 'a' configuration
+quarkus.oidc.a.auth-server-url=http://localhost:8180/realms/quarkus-a
+quarkus.oidc.a.client-id=client-a
+quarkus.oidc.a.credentials.secret=client-a-secret
 
-- The URL path might not be the same after the redirect request if a single redirect URL has been registered in the OIDC provider.
-The original request path can be restored after the tenant configuration has been resolved.
-- The HTTP headers used during the original request are unavailable after the redirect.
-- The custom URL query parameters are restored after the redirect but only after the tenant configuration is resolved.
+# Tenant 'b' configuration
+quarkus.oidc.b.auth-server-url=http://localhost:8180/realms/quarkus-b
+quarkus.oidc.b.client-id=client-b
+quarkus.oidc.b.credentials.secret=client-b-secret
+----
 
-One option to ensure the information for resolving the tenant configurations for `web-app` applications is available before and after the redirect is to use a cookie, for example:
+You can return the tenant id of either `a` or `b` from `quarkus.oidc.TenantResolver`:
 
 [source,java]
 ----
-package org.acme.quickstart.oidc;
+import quarkus.oidc.TenantResolver;
 
-import java.util.List;
-
-import jakarta.enterprise.context.ApplicationScoped;
-
-import io.quarkus.oidc.TenantResolver;
-import io.vertx.core.http.Cookie;
-import io.vertx.ext.web.RoutingContext;
-
-@ApplicationScoped
 public class CustomTenantResolver implements TenantResolver {
 
     @Override
     public String resolve(RoutingContext context) {
-        List<String> tenantIdQuery = context.queryParam("tenantId");
-        if (!tenantIdQuery.isEmpty()) {
-            String tenantId = tenantIdQuery.get(0);
-            context.response().addCookie(Cookie.cookie("tenant", tenantId));
-            return tenantId;
-        } else if (!context.request().cookies("tenant").isEmpty()) {
-            return context.request().getCookie("tenant").getValue();
+        String path = context.request().path();
+        if (path.endsWith("a")) {
+            return "a";
+        } else if (path.endsWith("b")) {
+            return "b";
+        } else {
+            // default tenant
+            return null;
         }
-
-        return null;
     }
 }
 ----
+
+In this example, the value of the last request path segment is a tenant id, but if required, you can implement a more complex tenant identifier resolution logic.
+
+[[default-tenant-resolver]]
+=== Default resolution
+
+The default resolution for a tenant identifier is convention based, whereby the authentication request must include the tenant identifier in the last segment of the request path.
+
+The following `application.properties` example shows how you can configure two tenants named `google` and `github`:
+
+[source,properties]
+----
+# Tenant 'google' configuration
+quarkus.oidc.google.provider=google
+quarkus.oidc.google.client-id=${google-client-id}
+quarkus.oidc.google.credentials.secret=${google-client-secret}
+quarkus.oidc.google.authentication.redirect-path=/signed-in
+
+# Tenant 'github' configuration
+quarkus.oidc.github.provider=google
+quarkus.oidc.github.client-id=${github-client-id}
+quarkus.oidc.github.credentials.secret=${github-client-secret}
+quarkus.oidc.github.authentication.redirect-path=/signed-in
+----
+
+In the provided example, both tenants configure OIDC `web-app` applications to use an authorization code flow to authenticate users and require session cookies to be generated after authentication.
+After Google or GitHub authenticates the current user, the user gets returned to the `/signed-in` area for authenticated users, such as a secured resource path on the JAX-RS endpoint.
+
+Finally, to complete the default tenant resolution, set the following configuration property:
+
+[source,properties]
+----
+quarkus.http.auth.permission.login.paths=/google,/github
+quarkus.http.auth.permission.login.policy=authenticated
+----
+
+If the endpoint is running on `http://localhost:8080`, you can also provide UI options for users to log in to either `http://localhost:8080/google` or `http://localhost:8080/github`, without having to add specific `/google` or `/github` JAX-RS resource paths.
+Tenant identifiers are also recorded in the session cookie names after the authentication is completed.
+Therefore, authenticated users can access the secured application area without requiring either the `google` or `github` path values to be included in the secured URL.
+
+Default resolution can also work for Bearer token authentication.
+Still, it might be less practical because a tenant identifier must always be set as the last path segment value.
+
+=== Tenant resolution for OIDC web-app applications
+
+Tenant resolution for the OIDC `web-app` applications must be done at least 3 times during an authorization code flow, when the OIDC tenant-specific configuration affects how each of the following steps is run.
+
+==== Step 1: Unauthenticated user accesses an endpoint and is redirected to OIDC provider
+
+When an unauthenticated user accesses a secured path, the user is redirected to the OIDC provider to authenticate and the tenant configuration is used to build the redirect URI.
+
+All the static and dynamic tenant resolution options listed in the <<static-tenant-resolution>> and <<tenant-config-resolver>> sections can be used to resolve a tenant.
+
+==== Step 2: The user is redirected back to the endpoint
+
+After the provider authentication, the user is redirected back to the Quarkus endpoint and the tenant configuration is used to complete the authorization code flow.
+
+All the static and dynamic tenant resolution options listed in the <<static-tenant-resolution>> and <<tenant-config-resolver>> sections can be used to resolve a tenant. Before the tenant resolution begins, the authorization code flow `state cookie` is used to set the already resolved tenant configuration id as a RoutingContext `tenant-id` attribute: both custom dynamic `TenantConfigResolver` and static `TenantResolver` tenant resolvers can check it.
+
+==== Step 3: Authenticated user accesses the secured path using the session cookie: the tenant configuration determines how the session cookie is verified and refreshed. Before the tenant resolution begins, the authorization code flow `session cookie` is used to set the already resolved tenant configuration id as a RoutingContext `tenant-id` attribute: both custom dynamic `TenantConfigResolver` and static `TenantResolver` tenant resolvers can check it.
+
+For example, here is how a custom `TenantConfigResolver` can avoid creating the already resolved tenant configuration, that may otherwise require blocking reads from the database or other remote sources:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomTenantConfigResolver implements TenantConfigResolver {
+
+    @Override
+    public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
+        String resolvedTenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
+        if (resolvedTenantId != null) { <1>
+            return null;
+        }
+
+        String path = context.request().path(); <2>
+        if (path.endsWith("tenant-a")) {
+            return Uni.createFromItem(createTenantConfig("tenant-a", "client-a", "secret-a"));
+        } else if (path.endsWith("tenant-b")) {
+            return Uni.createFromItem(createTenantConfig("tenant-b", "client-b", "secret-b"));
+        }
+
+        // Default tenant id
+        return null;
+    }
+
+    private OidcTenantConfig createTenantConfig(String tenantId, String clientId, String secret) {
+        final OidcTenantConfig config = new OidcTenantConfig();
+        config.setTenantId(tenantId);
+        config.setAuthServerUrl("http://localhost:8180/realms/"  + tenantId);
+        config.setClientId(clientId);
+        config.getCredentials().setSecret(secret);
+        config.setApplicationType(ApplicationType.WEB_APP);
+        return config;
+    }
+}
+----
+<1> Let Quarkus use the already resolved tenant configuration if it has been resolved earlier.
+<2> Check the request path to create tenant configurations.
+
+The default configuration may look like this:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/realms/default
+quarkus.oidc.client-id=client-default
+quarkus.oidc.credentials.secret=secret-default
+quarkus.oidc.application-type=web-app
+----
+
+The preceeding example assumes that the `tenant-a`, `tenant-b` and default tenants are all used to protect the same endpoint paths. In other words, after the user has authenticated with the `tenant-a` configuration, this user will not be able to choose to authenticate with the `tenant-b` or default configuration before this user logs out and has a session cookie cleared or expired.
+
+The situtaion where multiple OIDC `web-app` tenants protect the tenant-specific paths is less typical and also requires an extra care.
+When multiple OIDC `web-app` tenants such as `tenant-a`, `tenant-b` and default tenants are used to control access to the tenant specific paths, the users authenticated with one OIDC provider must not be able to access the paths requiring an authentication with another provider, otherwise the results can be unpredictable, most likely causing unexpected authentication failures.
+For example, if the `tenant-a` authentication requires a Keycloak authentication and the `tenant-b` authentication requires an Auth0 authentication, then, if the `tenant-a` authenticated user attempts to access a path secured by the `tenant-b` configuration, then the session cookie will not be verified, since the Auth0 public verification keys can not be used to verify the tokens signed by Keycloak.
+An easy, recommended way to avoid multiple `web-app` tenants conflicting with each other is to set the tenant specific session path as shown in the following example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomTenantConfigResolver implements TenantConfigResolver {
+
+    @Override
+    public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
+        String resolvedTenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
+        if (resolvedTenantId != null) { <1>
+            return null;
+        }
+
+        String path = context.request().path(); <2>
+        if (path.endsWith("tenant-a")) {
+            return Uni.createFromItem(createTenantConfig("tenant-a", "/tenant-a", "client-a", "secret-a"));
+        } else if (path.endsWith("tenant-b")) {
+            return Uni.createFromItem(createTenantConfig("tenant-b", "/tenant-b", "client-b", "secret-b"));
+        }
+
+        // Default tenant id
+        return null;
+    }
+
+    private OidcTenantConfig createTenantConfig(String tenantId, String cookiePath, String clientId, String secret) {
+        final OidcTenantConfig config = new OidcTenantConfig();
+        config.setTenantId(tenantId);
+        config.setAuthServerUrl("http://localhost:8180/realms/"  + tenantId);
+        config.setClientId(clientId);
+        config.getCredentials().setSecret(secret);
+        config.setApplicationType(ApplicationType.WEB_APP);
+        config.getAuthentication().setCookiePath(cookiePath); <3>
+        return config;
+    }
+}
+----
+<1> Let Quarkus use the already resolved tenant configuration if it has been resolved earlier.
+<2> Check the request path to create tenant configurations.
+<3> Set the tenant-specific cookie paths which makes sure the session cookie is only visible to the tenant which created it.
+
+The default tenant configuration should be adjusted like this:
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/realms/default
+quarkus.oidc.client-id=client-default
+quarkus.oidc.credentials.secret=secret-default
+quarkus.oidc.authentication.cookie-path=/default
+quarkus.oidc.application-type=web-app
+----
+
+Having the same session cookie path when multiple OIDC `web-app` tenants protect the tenant-specific paths is not recommended and should be avoided
+as it requires even more care from the custom resolvers, for example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomTenantConfigResolver implements TenantConfigResolver {
+
+    @Override
+    public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
+
+        String path = context.request().path(); <1>
+        if (path.endsWith("tenant-a")) {
+            String resolvedTenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
+	    if (resolvedTenantId != null) {
+	        if ("tenant-a".equals(resolvedTenantId)) { <2>
+	            return null;
+	        } else {
+	           // Require a "tenant-a" authentication
+                   context.remove(OidcUtils.TENANT_ID_ATTRIBUTE); <3>
+	        }
+            }
+            return Uni.createFromItem(createTenantConfig("tenant-a", "client-a", "secret-a"));
+        } else if (path.endsWith("tenant-b")) {
+            String resolvedTenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
+	    if (resolvedTenantId != null) {
+	        if ("tenant-b".equals(resolvedTenantId)) { <2>
+	            return null;
+	        } else {
+	            // Require a "tenant-b" authentication
+                   context.remove(OidcUtils.TENANT_ID_ATTRIBUTE); <3>
+	        }
+            }
+            return Uni.createFromItem(createTenantConfig("tenant-b", "client-b", "secret-b"));
+        }
+
+        // Set default tenant id
+        context.put(OidcUtils.TENANT_ID_ATTRIBUTE, OidcUtils.DEFAULT_TENANT_ID); <4>
+        return null;
+    }
+
+    private OidcTenantConfig createTenantConfig(String tenantId, String clientId, String secret) {
+        final OidcTenantConfig config = new OidcTenantConfig();
+        config.setTenantId(tenantId);
+        config.setAuthServerUrl("http://localhost:8180/realms/"  + tenantId);
+        config.setClientId(clientId);
+        config.getCredentials().setSecret(secret);
+        config.setApplicationType(ApplicationType.WEB_APP);
+        return config;
+    }
+}
+----
+<1> Check the request path to create tenant configurations.
+<2> Let Quarkus use the already resolved tenant configuration if the already resolved tenant is expected for the current path.
+<3> Remove the `tenant-id` attribute if the already resolved tenant configuration is not expected for the current path.
+<4> Use the default tenant for all other paths. It is equivalent to removing the `tenant-id` attribute.
 
 [[disable-tenant]]
 == Disabling tenant configurations

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeTenantReauthenticateTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeTenantReauthenticateTestCase.java
@@ -1,0 +1,173 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.TextPage;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.util.Cookie;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class CodeTenantReauthenticateTestCase {
+    private static Class<?>[] testClasses = {
+            TenantReauthentication.class,
+            CustomTenantResolver.class,
+            CustomTenantConfigResolver.class
+    };
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(testClasses)
+                    .addAsResource("application-tenant-reauthenticate.properties", "application.properties"));
+
+    @Test
+    public void testDefaultTenant() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            callTenant(webClient, null, "/protected", "alice");
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testTenantResolver() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            callTenant(webClient, "tenant-resolver", "/protected/tenant/tenant-resolver", "tenant-resolver:alice");
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testTenantConfigResolver() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            callTenant(webClient, "tenant-config-resolver", "/protected/tenant/tenant-config-resolver",
+                    "tenant-config-resolver:alice");
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testSwitchFromTenantResolverToDefaultTenant() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            callTenant(webClient, "tenant-resolver", "/protected/tenant/tenant-resolver", "tenant-resolver:alice");
+            expectReauthentication(webClient, "/protected", "tenant-resolver");
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testSwitchFromDefaultTenantToTenantResover() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            callTenant(webClient, null, "/protected", "alice");
+            expectReauthentication(webClient, "/protected/tenant/tenant-resolver", null);
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testSwitchFromTenantConfigResolverToDefaultTenant() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            callTenant(webClient, "tenant-config-resolver", "/protected/tenant/tenant-config-resolver",
+                    "tenant-config-resolver:alice");
+            expectReauthentication(webClient, "/protected", "tenant-config-resolver");
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testSwitchFromDefaultTenantToTenantConfigResolver() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            callTenant(webClient, null, "/protected", "alice");
+            expectReauthentication(webClient, "/protected/tenant/tenant-config-resolver", null);
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testSwitchFromTenantResolverToTenantConfigResolver() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            callTenant(webClient, "tenant-resolver", "/protected/tenant/tenant-resolver", "tenant-resolver:alice");
+            expectReauthentication(webClient, "/protected/tenant/tenant-config-resolver", "tenant-resolver");
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testSwitchFromTenantConfigResolverToTenantResolver() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            callTenant(webClient, "tenant-config-resolver", "/protected/tenant/tenant-config-resolver",
+                    "tenant-config-resolver:alice");
+            expectReauthentication(webClient, "/protected/tenant/tenant-resolver", "tenant-config-resolver");
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private static void callTenant(WebClient webClient, String tenant, String relativePath, String expectedResponse)
+            throws Exception {
+        HtmlPage page = webClient.getPage("http://localhost:8081" + relativePath);
+
+        assertEquals("Sign in to quarkus", page.getTitleText());
+
+        HtmlForm loginForm = page.getForms().get(0);
+
+        loginForm.getInputByName("username").setValueAttribute("alice");
+        loginForm.getInputByName("password").setValueAttribute("alice");
+
+        page = loginForm.getInputByName("login").click();
+
+        assertEquals(expectedResponse, page.getBody().asNormalizedText());
+        assertNotNull(getSessionCookie(webClient, tenant));
+    }
+
+    private static void expectReauthentication(WebClient webClient, String relativePath,
+            String oldTenant) throws Exception {
+        webClient.getOptions().setRedirectEnabled(false);
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+        TextPage textPage = webClient.getPage("http://localhost:8081" + relativePath);
+        assertEquals(302, textPage.getWebResponse().getStatusCode());
+        assertNull(getSessionCookie(webClient, oldTenant));
+    }
+
+    private static WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+
+    private static Cookie getSessionCookie(WebClient webClient, String tenantId) {
+        return webClient.getCookieManager().getCookie("q_session" + (tenantId == null ? "" : "_" + tenantId));
+    }
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
@@ -2,10 +2,13 @@ package io.quarkus.oidc.test;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.runtime.OidcUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
@@ -22,6 +25,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             config.setApplicationType(ApplicationType.WEB_APP);
             return Uni.createFrom().item(config);
         }
+        context.remove(OidcUtils.TENANT_ID_ATTRIBUTE);
         if (context.request().path().endsWith("/null-tenant")) {
             return null;
         }
@@ -29,6 +33,6 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
     }
 
     private String getIssuerUrl() {
-        return System.getProperty("keycloak.url");
+        return ConfigProvider.getConfig().getValue("keycloak.url", String.class);
     }
 }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantResolver.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantResolver.java
@@ -1,0 +1,19 @@
+package io.quarkus.oidc.test;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.oidc.TenantResolver;
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomTenantResolver implements TenantResolver {
+    @Override
+    public String resolve(RoutingContext context) {
+        if (context.request().path().endsWith("/tenant-resolver")) {
+            return "tenant-resolver";
+        }
+        context.put(OidcUtils.TENANT_ID_ATTRIBUTE, OidcUtils.DEFAULT_TENANT_ID);
+        return null;
+    }
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/TenantReauthentication.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/TenantReauthentication.java
@@ -1,0 +1,35 @@
+package io.quarkus.oidc.test;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.oidc.IdToken;
+import io.quarkus.oidc.OidcSession;
+import io.quarkus.security.Authenticated;
+
+@Path("/protected")
+@Authenticated
+public class TenantReauthentication {
+
+    @Inject
+    @IdToken
+    JsonWebToken idToken;
+
+    @Inject
+    OidcSession session;
+
+    @GET
+    public String getName() {
+        return idToken.getName();
+    }
+
+    @GET
+    @Path("tenant/{id}")
+    public String getTenantName(@PathParam("id") String tenantId) {
+        return tenantId + ":" + idToken.getName();
+    }
+}

--- a/extensions/oidc/deployment/src/test/resources/application-tenant-reauthenticate.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-tenant-reauthenticate.properties
@@ -1,0 +1,11 @@
+quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.client-id=quarkus-web-app
+quarkus.oidc.credentials.secret=secret
+quarkus.oidc.application-type=web-app
+
+quarkus.oidc.tenant-resolver.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-resolver.client-id=quarkus-web-app
+quarkus.oidc.tenant-resolver.credentials.secret=secret
+quarkus.oidc.tenant-resolver.application-type=web-app
+
+quarkus.log.category."com.gargoylesoftware.htmlunit".level=ERROR

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -377,4 +377,19 @@ public class DefaultTenantConfigResolver {
         }
     }
 
+    public OidcTenantConfig getResolvedConfig(String sessionTenantId) {
+        if (OidcUtils.DEFAULT_TENANT_ID.equals(sessionTenantId)) {
+            return tenantConfigBean.getDefaultTenant().getOidcTenantConfig();
+        }
+
+        if (tenantConfigBean.getStaticTenantsConfig().containsKey(sessionTenantId)) {
+            return tenantConfigBean.getStaticTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
+        }
+
+        if (tenantConfigBean.getDynamicTenantsConfig().containsKey(sessionTenantId)) {
+            return tenantConfigBean.getDynamicTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
+        }
+        return null;
+    }
+
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
@@ -44,7 +44,6 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
     @Override
     public Uni<SecurityIdentity> authenticate(RoutingContext context,
             IdentityProviderManager identityProviderManager) {
-        setTenantIdAttribute(context);
         return resolve(context).chain(new Function<>() {
             @Override
             public Uni<? extends SecurityIdentity> apply(OidcTenantConfig oidcConfig) {
@@ -59,7 +58,6 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
 
     @Override
     public Uni<ChallengeData> getChallenge(RoutingContext context) {
-        setTenantIdAttribute(context);
         return resolve(context).chain(new Function<>() {
             @Override
             public Uni<? extends ChallengeData> apply(OidcTenantConfig oidcTenantConfig) {
@@ -73,6 +71,13 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
     }
 
     private Uni<OidcTenantConfig> resolve(RoutingContext context) {
+        OidcTenantConfig resolvedConfig = context.get(OidcTenantConfig.class.getName());
+        if (resolvedConfig != null) {
+            return Uni.createFrom().item(resolvedConfig);
+        }
+
+        setTenantIdAttribute(context);
+
         return resolver.resolveConfig(context).map(new Function<>() {
             @Override
             public OidcTenantConfig apply(OidcTenantConfig oidcTenantConfig) {
@@ -80,6 +85,7 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
                     throw new OIDCException("Tenant configuration has not been resolved");
                 }
                 LOG.debugf("Resolved OIDC tenant id: %s", oidcTenantConfig.tenantId.orElse(OidcUtils.DEFAULT_TENANT_ID));
+                context.put(OidcTenantConfig.class.getName(), oidcTenantConfig);
                 return oidcTenantConfig;
             };
         });
@@ -100,7 +106,6 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
 
     @Override
     public Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context) {
-        setTenantIdAttribute(context);
         return resolve(context).onItem().transform(new Function<OidcTenantConfig, HttpCredentialTransport>() {
             @Override
             public HttpCredentialTransport apply(OidcTenantConfig oidcTenantConfig) {
@@ -115,29 +120,24 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
     }
 
     private static void setTenantIdAttribute(RoutingContext context) {
-        for (String cookieName : context.cookieMap().keySet()) {
-            if (OidcUtils.isSessionCookie(cookieName)) {
-                setTenantIdAttribute(context, OidcUtils.SESSION_COOKIE_NAME, cookieName, true);
-            } else if (cookieName.startsWith(OidcUtils.STATE_COOKIE_NAME)) {
-                setTenantIdAttribute(context, OidcUtils.STATE_COOKIE_NAME, cookieName, false);
+        if (context.get(OidcUtils.TENANT_ID_ATTRIBUTE) == null) {
+            for (String cookieName : context.cookieMap().keySet()) {
+                if (OidcUtils.isSessionCookie(cookieName)) {
+                    setTenantIdAttribute(context, OidcUtils.SESSION_COOKIE_NAME, cookieName, true);
+                    break;
+                } else if (cookieName.startsWith(OidcUtils.STATE_COOKIE_NAME)) {
+                    setTenantIdAttribute(context, OidcUtils.STATE_COOKIE_NAME, cookieName, false);
+                    break;
+                }
             }
         }
     }
 
     private static void setTenantIdAttribute(RoutingContext context, String cookiePrefix, String cookieName,
             boolean sessionCookie) {
-        // It has already been checked the cookieName starts with the cookiePrefix
-        String tenantId;
-        if (cookieName.length() == cookiePrefix.length()) {
-            tenantId = OidcUtils.DEFAULT_TENANT_ID;
-            context.put(OidcUtils.TENANT_ID_ATTRIBUTE, tenantId);
-        } else {
-            String suffix = cookieName.substring(cookiePrefix.length() + 1);
-            // It can be either a tenant_id, or a tenant_id and cookie suffix property, example, q_session_github or q_session_github_test
-            int index = suffix.indexOf("_");
-            tenantId = index == -1 ? suffix : suffix.substring(0, index);
-            context.put(OidcUtils.TENANT_ID_ATTRIBUTE, tenantId);
-        }
+        String tenantId = OidcUtils.getTenantIdFromCookie(cookiePrefix, cookieName, sessionCookie);
+
+        context.put(OidcUtils.TENANT_ID_ATTRIBUTE, tenantId);
         context.put(sessionCookie ? OidcUtils.TENANT_ID_SET_BY_SESSION_COOKIE : OidcUtils.TENANT_ID_SET_BY_STATE_COOKIE,
                 tenantId);
         LOG.debugf("%s cookie set a '%s' tenant id on the %s request path", cookieName, tenantId, context.request().path());

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -322,6 +322,16 @@ public class OidcUtilsTest {
         assertFalse(OidcUtils.isSessionCookie(OidcUtils.SESSION_AT_COOKIE_NAME + "1"));
     }
 
+    @Test
+    public void testGetSessionCookieTenantId() throws Exception {
+        assertEquals(OidcUtils.DEFAULT_TENANT_ID,
+                OidcUtils.getTenantIdFromCookie(OidcUtils.SESSION_COOKIE_NAME, "q_session", true));
+        assertEquals(OidcUtils.DEFAULT_TENANT_ID,
+                OidcUtils.getTenantIdFromCookie(OidcUtils.SESSION_COOKIE_NAME, "q_session_chunk_1", true));
+        assertEquals("a", OidcUtils.getTenantIdFromCookie(OidcUtils.SESSION_COOKIE_NAME, "q_session_a", true));
+        assertEquals("a", OidcUtils.getTenantIdFromCookie(OidcUtils.SESSION_COOKIE_NAME, "q_session_a_chunk_1", true));
+    }
+
     public static JsonObject read(InputStream input) throws IOException {
         try (BufferedReader buffer = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             return new JsonObject(buffer.lines().collect(Collectors.joining("\n")));

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import com.gargoylesoftware.htmlunit.CookieManager;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebResponse;
@@ -228,9 +229,17 @@ public class CodeFlowTest {
             assertEquals("tenant-https:reauthenticated", page.getBody().asNormalizedText());
 
             List<Cookie> sessionCookies = verifyTenantHttpTestCookies(webClient);
-
             assertEquals("strict", sessionCookies.get(0).getSameSite());
             assertEquals("strict", sessionCookies.get(1).getSameSite());
+
+            // Check both session cookie chunks are removed if the new authentication is enforced
+            webClient.getOptions().setRedirectEnabled(false);
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+            TextPage textPage = webClient.getPage("http://localhost:8081/index.html");
+            assertEquals(302, textPage.getWebResponse().getStatusCode());
+            assertNull(getSessionCookies(webClient, "tenant-https"));
+
             webClient.getCookieManager().clearCookies();
         }
     }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -295,6 +295,7 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
             assertEquals("tenant-web-app:alice:reauthenticated", page.getBody().asNormalizedText());
+            assertNotNull(getSessionCookie(webClient, "tenant-web-app"));
             // tenant-web-app2
             page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app2/api/user/webapp2");
             assertNull(getStateCookieSavedPath(webClient, "tenant-web-app2"));
@@ -304,7 +305,8 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
             assertEquals("tenant-web-app2:alice", page.getBody().asNormalizedText());
-
+            assertNull(getSessionCookie(webClient, "tenant-web-app"));
+            assertNotNull(getSessionCookie(webClient, "tenant-web-app2"));
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
Fixes #39849.
Fixes #39417.
Fixes #38535.

This PR fixes several issues related to the OIDC tenant resolution and the session management, all discovered while looking at the test failure as a result of the initial work with #39417.
As it happens,  the initial #39417 fix exposed these problems, how the OIDC quickstart tenancy test was passing when the tenants are switched with the same session cookie path before is still a mystery to me.

So, this PR does the following:
* Makes sure that if the tenant id has been changed after it was set by the session cookie, then, before the reauthentication, it removes now obsolete session cookie(s) belonging to the old tenant
* Avoids calling `OidcAuthenticationMechanism#resolve` 3 times 
* Decreases the max session cookie value to 4056 bytes, otherwise the browsers will drop the session cookie chunks if the automatic session cookie splitting is enabled (it is by default)
* Fixed the multi-tenant docs describing the correct sequence of the resolution
* Replacing a totally inadequate section on how to manage web-app tenants with hopefully a more useful advice
* Improved the existing tests, added new ones 

This is a technical PR which tries to cover the grey areas related to the session cookie splitting, and provide the better advice on how to manage tenants