### PR TITLE
Warn users when using older GraalVM or Mandrel versions

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -186,8 +186,21 @@ public final class GraalVM {
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", "21", Distribution.GRAALVM);
         public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", "22", Distribution.GRAALVM);
 
+        /**
+         * The minimum version of GraalVM supported by Quarkus.
+         * Versions prior to this are expected to cause major issues.
+         */
         public static final Version MINIMUM = VERSION_22_2_0;
+        /**
+         * The current version of GraalVM supported by Quarkus.
+         * This version is the one actively being tested and is expected to give the best experience.
+         */
         public static final Version CURRENT = VERSION_23_1_0;
+        /**
+         * The minimum version of GraalVM officially supported by Quarkus.
+         * Versions prior to this are expected to work but are not given the same level of testing or priority.
+         */
+        public static final Version MINIMUM_SUPPORTED = CURRENT;
 
         final String fullVersion;
         public final Runtime.Version javaVersion;
@@ -225,6 +238,10 @@ public final class GraalVM {
 
         boolean isObsolete() {
             return this.compareTo(MINIMUM) < 0;
+        }
+
+        boolean isSupported() {
+            return this.compareTo(MINIMUM_SUPPORTED) >= 0;
         }
 
         boolean isMandrel() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -473,9 +473,15 @@ public class NativeImageBuildStep {
         log.info("Running Quarkus native-image plugin on " + version.distribution.name() + " " + version.getVersionAsString()
                 + " JDK " + version.javaVersion);
         if (version.isObsolete()) {
-            throw new IllegalStateException("Out of date version of GraalVM detected: " + version.getVersionAsString() + "."
+            throw new IllegalStateException(
+                    "Out of date version of GraalVM or Mandrel detected: " + version.getVersionAsString() + "."
+                            + " Quarkus currently supports " + GraalVM.Version.CURRENT.getVersionAsString()
+                            + ". Please upgrade to this version.");
+        }
+        if (!version.isSupported()) {
+            log.warn("You are using an older version of GraalVM or Mandrel : " + version.getVersionAsString() + "."
                     + " Quarkus currently supports " + GraalVM.Version.CURRENT.getVersionAsString()
-                    + ". Please upgrade GraalVM to this version.");
+                    + ". Please upgrade to this version.");
         }
     }
 


### PR DESCRIPTION
Although we try to keep backwards compatibility with older GraalVM or
Mandrel versions, these versions should not be considered as fully
supported by the users, as the compatibility might break at any
time (even at a minor level patch).
