### PR TITLE
Small documentation enhancement/formating

### DIFF
--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -256,7 +256,7 @@ converted default value. However, when the property is explicitly empty, the def
 [source,properties]
 ----
 # missing value, optional property
-greeting.name =
+greeting.name=
 ----
 
 In this case, since `greeting.name` was configured to be `Optional*` up above, the corresponding property value will
@@ -268,7 +268,7 @@ On the other hand, this example:
 [source,properties]
 ----
 # missing value, non-optional
-greeting.suffix =
+greeting.suffix=
 ----
 
 will result in a `java.util.NoSuchElementException: SRCFG02004: Required property greeting.message not found` on

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -58,8 +58,8 @@ Edit the file with the following content:
 [source,properties]
 ----
 # Your configuration properties
-greeting.message = hello
-greeting.name = quarkus
+greeting.message=hello
+greeting.name=quarkus
 ----
 
 == Create a REST resource

--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -387,7 +387,7 @@ For more information, see link:https://quarkus.io/blog/path-resolution-in-quarku
 === Map `SecurityIdentity` roles
 
 Winning role-based policy can map the `SecurityIdentity` roles to the deployment-specific roles.
-These roles are then applicable for endpoint authorization by using the @RolesAllowed annotation.
+These roles are then applicable for endpoint authorization by using the `@RolesAllowed` annotation.
 
 [source,properties]
 ----

--- a/docs/src/main/asciidoc/security-basic-authentication.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication.adoc
@@ -66,7 +66,7 @@ For more information about how you can secure your Quarkus applications by using
 
 == Role-based access control
 
-{project-name} also includes built-in security to allow for role-based access control (RBAC) based on the common security annotations @RolesAllowed, @DenyAll, @PermitAll on REST endpoints and CDI beans.
+{project-name} also includes built-in security to allow for role-based access control (RBAC) based on the common security annotations `@RolesAllowed`, `@DenyAll`, `@PermitAll` on REST endpoints and CDI beans.
 For more information, see the Quarkus xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints] guide.
 
 == References

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -252,7 +252,7 @@ public class TokenSecuredResource {
 ----
 <1> Here we inject `JsonWebToken`
 <2> This new endpoint will be located at /secured/roles-allowed
-<3> @RolesAllowed is a Jakarta common security annotation that indicates that the given endpoint is accessible by a caller if
+<3> `@RolesAllowed` is a Jakarta common security annotation that indicates that the given endpoint is accessible by a caller if
 they have either a "User" or "Admin" role assigned.
 <4> Here we build the reply the same way as in the `hello` method but also add a value of the JWT `birthdate` claim by directly calling the injected `JsonWebToken`.
 

--- a/docs/src/main/asciidoc/spring-boot-properties.adoc
+++ b/docs/src/main/asciidoc/spring-boot-properties.adoc
@@ -111,7 +111,7 @@ Define this property in your `src/main/resources/application.properties` file:
 [source,properties]
 ----
 # Your configuration properties
-greeting.text = hello
+greeting.text=hello
 ----
 
 Now modify `GreetingResource` to start using the `GreetingProperties`:
@@ -359,7 +359,7 @@ Let's update the properties file and the `GreetingResource` class.
 [source,properties]
 ----
 # Your configuration properties
-greeting.message.text = hello
+greeting.message.text=hello
 ----
 
 [source,java]


### PR DESCRIPTION
Updating the docs. Even if properties work with spaces it's somehow unsual to have them.
For `@RolesAllowed, @DenyAll, @PermitAll` these annotation should be wrapped with \` \` as elsewhere in docs