### PR TITLE
Use cache-control header to make sure health checks aren't cached

### DIFF
--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckProducerDefaultScopeTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/HealthCheckProducerDefaultScopeTest.java
@@ -31,10 +31,12 @@ class HealthCheckProducerDefaultScopeTest {
         try {
             RestAssured.defaultParser = Parser.JSON;
             when().get("/q/health/ready").then()
+                    .header("cache-control", "no-store")
                     .body("status", is("UP"),
                             "checks.status", hasItems("UP", "UP"),
                             "checks.name", hasItems("alpha1", "bravo1"));
             when().get("/q/health/ready").then()
+                    .header("cache-control", "no-store")
                     .body("status", is("UP"),
                             "checks.status", hasItems("UP", "UP"),
                             "checks.name", hasItems("alpha1", "bravo2"));

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
@@ -59,7 +59,9 @@ public abstract class SmallRyeHealthHandlerBase implements Handler<RoutingContex
             if (health.isDown()) {
                 resp.setStatusCode(503);
             }
-            resp.headers().set(HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8");
+            resp.headers()
+                    .set(HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8")
+                    .set(HttpHeaders.CACHE_CONTROL, "no-store");
             Buffer buffer = Buffer.buffer(256); // this size seems to cover the basic health checks
             try (BufferOutputStream outputStream = new BufferOutputStream(buffer);) {
                 reporter.reportHealth(outputStream, health);


### PR DESCRIPTION
- Resolves: #39868