### PR TITLE
Bump MINIMUM working mandrel/graalvm version to 22.3

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -181,7 +181,6 @@ public final class GraalVM {
         static final Version VERSION_21_3 = new Version("GraalVM 21.3", "21.3", Distribution.GRAALVM);
         static final Version VERSION_21_3_0 = new Version("GraalVM 21.3.0", "21.3.0", Distribution.GRAALVM);
         public static final Version VERSION_22_3_0 = new Version("GraalVM 22.3.0", "22.3.0", "17", Distribution.GRAALVM);
-        public static final Version VERSION_22_2_0 = new Version("GraalVM 22.2.0", "22.2.0", "17", Distribution.GRAALVM);
         public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", "17", Distribution.GRAALVM);
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", "21", Distribution.GRAALVM);
         public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", "22", Distribution.GRAALVM);
@@ -190,7 +189,7 @@ public final class GraalVM {
          * The minimum version of GraalVM supported by Quarkus.
          * Versions prior to this are expected to cause major issues.
          */
-        public static final Version MINIMUM = VERSION_22_2_0;
+        public static final Version MINIMUM = VERSION_22_3_0;
         /**
          * The current version of GraalVM supported by Quarkus.
          * This version is the one actively being tested and is expected to give the best experience.


### PR DESCRIPTION
Follow up to https://github.com/quarkusio/quarkus/pull/37828#issuecomment-1862796025 and https://github.com/quarkusio/quarkus/pull/39866#discussion_r1550072028

`main` tested with 22.3 in https://github.com/graalvm/mandrel/actions/runs/8552569916 (except for `integration-test/main` due to https://github.com/graalvm/mandrel/pull/708)