### PR TITLE
Quarkus Messaging Blocking Signatures execution mode fix for inner channels

### DIFF
--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/BlockingSignatureExecutionModeTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/BlockingSignatureExecutionModeTest.java
@@ -31,7 +31,7 @@ public class BlockingSignatureExecutionModeTest {
                             BlockingConsumerFromConnector.class,
                             ConsumerFromConnector.class,
                             ConsumerFromInnerChannel.class))
-            .overrideConfigKey("mp.messaging.incoming.a.connector", "dummy")
+            // .overrideConfigKey("mp.messaging.incoming.a.connector", "dummy") // discovered by the extension
             .overrideConfigKey("mp.messaging.incoming.a.values", "bonjour")
             .overrideConfigKey("mp.messaging.incoming.b.connector", "dummy")
             .overrideConfigKey("mp.messaging.incoming.b.values", "bonjour")


### PR DESCRIPTION
The previous code tried to extract inner channels but failed to take into account the orphaned channels that work linked to the only connector found in the classpath. This change looks at the ConnectorManagedChannels directly.