### PR TITLE
Allow finer tuning of shared network usage by DevServices

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesSharedNetworkBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesSharedNetworkBuildItem.java
@@ -9,14 +9,42 @@ import java.util.function.Function;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildStepBuilder;
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 
 /**
  * A marker build item that indicates, if any instances are provided during the build, the containers started by DevServices
- * will use a shared network.
+ * may use a shared network.
  * This is mainly useful in integration tests where the application container needs to be able
  * to communicate with the service containers.
  */
 public final class DevServicesSharedNetworkBuildItem extends MultiBuildItem {
+
+    private final String source;
+
+    /** Create a build item without identifying the creator source. */
+    public DevServicesSharedNetworkBuildItem() {
+        this.source = UNKNOWN_SOURCE;
+    }
+
+    /**
+     * Create a build item identifying the creator source.
+     *
+     * @param source The identifier of the creator
+     */
+    public DevServicesSharedNetworkBuildItem(String source) {
+        this.source = source;
+    }
+
+    /** The creator source of this build item. May be useful to decide whether a DevService should join a shared network. */
+    public String getSource() {
+        return source;
+    }
+
+    /* Property used by factory to retrieve the source of instanciation. */
+    public static final String SOURCE_PROPERTY = "source";
+
+    /* Value of source field when instanciation origin is unknown. */
+    public static final String UNKNOWN_SOURCE = "unknown";
 
     /**
      * Generates a {@code List<Consumer<BuildChainBuilder>> build chain builder} which creates a build step
@@ -28,10 +56,28 @@ public final class DevServicesSharedNetworkBuildItem extends MultiBuildItem {
         public List<Consumer<BuildChainBuilder>> apply(final Map<String, Object> props) {
             return Collections.singletonList((builder) -> {
                 BuildStepBuilder stepBuilder = builder.addBuildStep((ctx) -> {
-                    ctx.produce(new DevServicesSharedNetworkBuildItem());
+                    DevServicesSharedNetworkBuildItem buildItem;
+                    if (props != null && props.containsKey(SOURCE_PROPERTY)) {
+                        buildItem = new DevServicesSharedNetworkBuildItem(props.get(SOURCE_PROPERTY).toString());
+                    } else {
+                        buildItem = new DevServicesSharedNetworkBuildItem();
+                    }
+                    ctx.produce(buildItem);
                 });
                 stepBuilder.produces(DevServicesSharedNetworkBuildItem.class).build();
             });
         }
+    }
+
+    /**
+     * Helper method for DevServices processors that tells if joining the shared network is required.
+     * Joining this network may be required if explicitily asked by user properties or if running a containerized
+     * application during integration tests.
+     */
+    public static boolean isSharedNetworkRequired(GlobalDevServicesConfig globalDevServicesConfig,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
+        return globalDevServicesConfig.launchOnSharedNetwork ||
+                (!devServicesSharedNetworkBuildItem.isEmpty()
+                        && devServicesSharedNetworkBuildItem.get(0).getSource().equals("io.quarkus.test.junit"));
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/GlobalDevServicesConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/GlobalDevServicesConfig.java
@@ -17,6 +17,12 @@ public class GlobalDevServicesConfig {
     boolean enabled;
 
     /**
+     * Global flag that can be used to force the attachmment of Dev Services to shared netxork. Default is false.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean launchOnSharedNetwork;
+
+    /**
      * The timeout for starting a container
      */
     @ConfigItem

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -20,6 +20,7 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.devservices.common.Labels;
@@ -35,16 +36,20 @@ public class MariaDBDevServicesProcessor {
 
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupMariaDB(
-            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            GlobalDevServicesConfig globalDevServicesConfig) {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.MARIADB, new DevServicesDatasourceProvider() {
             @SuppressWarnings("unchecked")
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     String datasourceName, DevServicesDatasourceContainerConfig containerConfig,
                     LaunchMode launchMode, Optional<Duration> startupTimeout) {
+
+                boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(globalDevServicesConfig,
+                        devServicesSharedNetworkBuildItem);
                 QuarkusMariaDBContainer container = new QuarkusMariaDBContainer(containerConfig.getImageName(),
                         containerConfig.getFixedExposedPort(),
-                        !devServicesSharedNetworkBuildItem.isEmpty());
+                        useSharedNetwork);
                 startupTimeout.ifPresent(container::withStartupTimeout);
 
                 String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -17,6 +17,7 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.devservices.common.Labels;
@@ -34,13 +35,17 @@ public class MSSQLDevServicesProcessor {
 
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupMSSQL(
-            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            GlobalDevServicesConfig globalDevServicesConfig) {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.MSSQL, new DevServicesDatasourceProvider() {
             @SuppressWarnings("unchecked")
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     String datasourceName, DevServicesDatasourceContainerConfig containerConfig,
                     LaunchMode launchMode, Optional<Duration> startupTimeout) {
+
+                boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(globalDevServicesConfig,
+                        devServicesSharedNetworkBuildItem);
                 QuarkusMSSQLServerContainer container = new QuarkusMSSQLServerContainer(containerConfig.getImageName(),
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -20,6 +20,7 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.devservices.common.Labels;
@@ -34,16 +35,20 @@ public class MySQLDevServicesProcessor {
 
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupMysql(
-            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            GlobalDevServicesConfig globalDevServicesConfig) {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.MYSQL, new DevServicesDatasourceProvider() {
             @SuppressWarnings("unchecked")
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     String datasourceName, DevServicesDatasourceContainerConfig containerConfig,
                     LaunchMode launchMode, Optional<Duration> startupTimeout) {
+
+                boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(globalDevServicesConfig,
+                        devServicesSharedNetworkBuildItem);
                 QuarkusMySQLContainer container = new QuarkusMySQLContainer(containerConfig.getImageName(),
                         containerConfig.getFixedExposedPort(),
-                        !devServicesSharedNetworkBuildItem.isEmpty());
+                        useSharedNetwork);
                 startupTimeout.ifPresent(container::withStartupTimeout);
 
                 String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -20,6 +20,7 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.devservices.common.Labels;
@@ -39,15 +40,19 @@ public class OracleDevServicesProcessor {
 
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupOracle(
-            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            GlobalDevServicesConfig globalDevServicesConfig) {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.ORACLE, new DevServicesDatasourceProvider() {
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     String datasourceName, DevServicesDatasourceContainerConfig containerConfig,
                     LaunchMode launchMode, Optional<Duration> startupTimeout) {
+
+                boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(globalDevServicesConfig,
+                        devServicesSharedNetworkBuildItem);
                 QuarkusOracleServerContainer container = new QuarkusOracleServerContainer(containerConfig.getImageName(),
                         containerConfig.getFixedExposedPort(),
-                        !devServicesSharedNetworkBuildItem.isEmpty());
+                        useSharedNetwork);
                 startupTimeout.ifPresent(container::withStartupTimeout);
 
                 String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -95,8 +95,10 @@ public class DevServicesElasticsearchProcessor {
                 (launchMode.isTest() ? "(test) " : "") + "Dev Services for Elasticsearch starting:",
                 consoleInstalledBuildItem, loggingSetupBuildItem);
         try {
+            boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
+                    devServicesSharedNetworkBuildItem);
             devService = startElasticsearch(dockerStatusBuildItem, configuration, buildItemsConfig, launchMode,
-                    !devServicesSharedNetworkBuildItem.isEmpty(),
+                    useSharedNetwork,
                     devServicesConfig.timeout);
             if (devService == null) {
                 compressor.closeAndDumpCaptured();

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -93,8 +93,10 @@ public class DevServicesMongoProcessor {
                     (launchMode.isTest() ? "(test) " : "") + "Mongo Dev Services Starting:", consoleInstalledBuildItem,
                     loggingSetupBuildItem);
             try {
+                boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(globalDevServicesConfig,
+                        devServicesSharedNetworkBuildItem);
                 devService = startMongo(dockerStatusBuildItem, connectionName, currentCapturedProperties.get(connectionName),
-                        !devServicesSharedNetworkBuildItem.isEmpty(), globalDevServicesConfig.timeout);
+                        useSharedNetwork, globalDevServicesConfig.timeout);
                 if (devService == null) {
                     compressor.closeAndDumpCaptured();
                 } else {

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -100,10 +100,12 @@ public class DevServicesRedisProcessor {
         try {
             for (Entry<String, DevServiceConfiguration> entry : currentDevServicesConfiguration.entrySet()) {
                 String connectionName = entry.getKey();
+                boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
+                        devServicesSharedNetworkBuildItem);
                 RunningDevService devService = startContainer(dockerStatusBuildItem, connectionName,
                         entry.getValue().devservices(),
                         launchMode.getLaunchMode(),
-                        !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout);
+                        useSharedNetwork, devServicesConfig.timeout);
                 if (devService == null) {
                     continue;
                 }

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
@@ -79,8 +79,10 @@ public class DevServicesApicurioRegistryProcessor {
                 (launchMode.isTest() ? "(test) " : "") + "Apicurio Registry Dev Services Starting:",
                 consoleInstalledBuildItem, loggingSetupBuildItem);
         try {
+            boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
+                    devServicesSharedNetworkBuildItem);
             devService = startApicurioRegistry(dockerStatusBuildItem, configuration, launchMode,
-                    !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout);
+                    useSharedNetwork, devServicesConfig.timeout);
             compressor.close();
         } catch (Throwable t) {
             compressor.closeAndDumpCaptured();

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -289,7 +289,9 @@ public final class IntegrationTestUtil {
             // when the application is going to be launched as a docker container, we need to make containers started by DevServices
             // use a shared network that the application container can then use as well
             augmentAction = curatedApplication.createAugmentor(
-                    "io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem$Factory", Collections.emptyMap());
+                    "io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem$Factory",
+                    Map.of(io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem.SOURCE_PROPERTY,
+                            "io.quarkus.test.junit"));
         } else {
             augmentAction = curatedApplication.createAugmentor();
         }


### PR DESCRIPTION
This PR follows up on this discussion: https://github.com/quarkusio/quarkus/discussions/38398
and embeds enhancement for this issue: https://github.com/quarkusio/quarkus/issues/39156

It allows finer tuning of shared network usage by DevServices.

By default, database-related DevServices make their container join the shared network as soon as it exists. At first, it was
only when running integration tests using a containerized application. However, there exist situations where the user wants to force the usage of a shared network, or other DevServices may require a shared network in dev or test mode (see the discussion and issue).

The proposed change allows us to clearly determine if joining a shared network is required (by the user, by integration test) so that DevServices can only join on purpose.

I'll prepare another PR for documentation update as explained in contribution guide.

Signed-off-by: Laurent Broudoux <laurent.broudoux@gmail.com>

- Closes: #39156