### PR TITLE
Update - Only consider recipes when generating the list of recipes

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -42,7 +42,7 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
 
     /**
      * Version of the target platform (e.g: 2.0.0.Final)
-     * You may instead use streamId to target the latest version of a specific platform stream.
+     * You may instead use stream to target the latest version of a specific platform stream.
      */
     @Parameter(property = "platformVersion", required = false)
     private String platformVersion;

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateRecipe.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateRecipe.java
@@ -51,6 +51,10 @@ public class QuarkusUpdateRecipe {
         if (!recipe.containsKey("name") || !(recipe.get("name") instanceof String)) {
             throw new IllegalArgumentException("Recipe name is required");
         }
+        // some YAML documents might not be recipes. For instance, they could be categories.
+        if (!recipe.containsKey("type") || !recipe.get("type").toString().endsWith("/recipe")) {
+            return this;
+        }
         this.recipes.add(recipe);
         return this;
     }


### PR DESCRIPTION
Only documents of type /recipe should be taken into account when generating the list of recipes.

See
https://github.com/quarkusio/quarkus-updates/blob/db61f918fce71751a50a9f69a98a451ebadf07df/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3alpha.yaml#L27-L32 for an example of the problem.

FWIW, this problem would lead to these non-fatal errors:

> [INFO] --- rewrite-maven-plugin:5.25.0:run (default-cli) @ quarkus-bot ---
> [INFO] Using active recipe(s) [io.quarkus.openrewrite.Quarkus]
> [INFO] Using active styles(s) []
> [INFO] Validating active recipes...
> [ERROR] Recipe validation error in io.quarkus.openrewrite.Quarkus.recipeList[88] (in file:/tmp/quarkus-project-recipe-14501541571856957500.yaml): recipe 'Camel 3.x' does not exist.
> [ERROR] Recipe validation error in io.quarkus.openrewrite.Quarkus.recipeList[88] (in file:/tmp/quarkus-project-recipe-14501541571856957500.yaml): recipe 'Camel 3.x' does not exist.
> [ERROR] Recipe validation error in io.quarkus.openrewrite.Quarkus.recipeList[88] (in file:/tmp/quarkus-project-recipe-14501541571856957500.yaml): recipe 'Camel 3.x' does not exist.