### PR TITLE
Adjust some user-visible references to RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jaxrs/kotlin/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/kotlin/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-client-jaxrs-kotlin</artifactId>
     <name>Quarkus - REST - Kotlin</name>
-    <description>Provides Kotlin support for RESTEasy Reactive</description>
+    <description>Provides Kotlin support for Quarkus REST</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -203,7 +203,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
     @Override
     public RestClientBuilderImpl executorService(ExecutorService executor) {
         throw new IllegalArgumentException("Specifying executor service is not supported. " +
-                "The underlying call in RestEasy Reactive is non-blocking, " +
+                "The underlying call is non-blocking, " +
                 "there is no reason to offload the call to a separate thread pool.");
     }
 

--- a/extensions/resteasy-reactive/rest-common/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-common/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-common</artifactId>
     <name>Quarkus - REST - Common - Runtime</name>
-    <description>Common runtime parts of Quarkus RESTEasy Reactive</description>
+    <description>Common runtime parts of Quarkus REST</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-jackson-common/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-jackson-common/runtime/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>quarkus-rest-jackson-common</artifactId>
     <name>Quarkus - REST - Jackson Common Bits - Runtime</name>
-    <description>Common classes for Jackson serialization support for RESTEasy Reactive</description>
+    <description>Common classes for Jackson serialization support for Quarkus REST</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-jackson/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-jackson</artifactId>
     <name>Quarkus - REST - Jackson - Runtime</name>
-    <description>Jackson serialization support for RESTEasy Reactive. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it</description>
+    <description>Jackson serialization support for Quarkus REST. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-jaxb/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-jaxb/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-jaxb</artifactId>
     <name>Quarkus - REST - JAXB - Runtime</name>
-    <description>JAXB serialization support for RESTEasy Reactive. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.</description>
+    <description>JAXB serialization support for Quarkus REST. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-jsonb-common/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-jsonb-common/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-jsonb-common</artifactId>
     <name>Quarkus - REST - JSON-B Common Bits - Runtime</name>
-    <description>Common classes for JSON-B serialization support for RESTEasy Reactive</description>
+    <description>Common classes for JSON-B serialization support for Quarkus REST</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-jsonb/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-jsonb/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-jsonb</artifactId>
     <name>Quarkus - REST - JSON-B - Runtime</name>
-    <description>JSON-B serialization support for RESTEasy Reactive. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.</description>
+    <description>JSON-B serialization support for Quarkus REST. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-kotlin-serialization/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-kotlin-serialization/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-rest-kotlin-serialization</artifactId>
     <name>Quarkus - REST - Kotlin Serialization - Runtime</name>
-    <description>Kotlin Serialization support for RESTEasy Reactive. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.</description>
+    <description>Kotlin Serialization support for Quarkus REST. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-kotlin/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-kotlin/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-kotlin</artifactId>
     <name>Quarkus - REST - Kotlin - Runtime</name>
-    <description>Provides Kotlin support for RESTEasy Reactive</description>
+    <description>Provides Kotlin support for Quarkus REST</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-links/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-links/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-links</artifactId>
     <name>Quarkus - REST - Links - Runtime</name>
-    <description>Web Links support for RESTEasy Reactive. Inject web links into response HTTP headers by annotating your endpoint resources.</description>
+    <description>Web Links support for Quarkus REST. Inject web links into response HTTP headers by annotating your endpoint resources.</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-qute/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-qute/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-qute</artifactId>
     <name>Quarkus - REST - Qute - Runtime</name>
-    <description>Qute integration for RESTEasy Reactive. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.</description>
+    <description>Qute integration for Quarkus REST. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest-servlet/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-servlet/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-rest-servlet</artifactId>
     <name>Quarkus - REST Servlet - Runtime</name>
-    <description>Servlet support for Quarkus RESTEasy Reactive</description>
+    <description>Servlet support for Quarkus REST</description>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/rest/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-endpoint-scores.js
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-endpoint-scores.js
@@ -1,5 +1,5 @@
-import { QwcHotReloadElement, html, css} from 'qwc-hot-reload-element';
-import { JsonRpc } from 'jsonrpc';
+import {css, html, QwcHotReloadElement} from 'qwc-hot-reload-element';
+import {JsonRpc} from 'jsonrpc';
 
 import '@vaadin/details';
 import '@vaadin/horizontal-layout';
@@ -103,7 +103,7 @@ export class QwcResteasyReactiveEndpointScores extends QwcHotReloadElement {
         }
         return html`<qwc-no-data message="You do not have any REST endpoints." 
                                     link="https://quarkus.io/guides/resteasy-reactive"
-                                    linkText="Learn how to write REST Services with RESTEasy Reactive">
+                                    linkText="Learn how to write REST Services with Quarkus REST">
                 </qwc-no-data>
             `;
     }

--- a/extensions/spring-web/resteasy-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-web/resteasy-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "Spring Web RESTEasy Reactive"
+name: "Spring Web REST"
 metadata:
   unlisted: true

--- a/integration-tests/amazon-lambda-http-resteasy-reactive/pom.xml
+++ b/integration-tests/amazon-lambda-http-resteasy-reactive/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-integration-test-amazon-lambda-http-resteasy-reactive</artifactId>
     <name>Quarkus - Integration Tests - Amazon Lambda HTTP RESTEasy Reactive</name>
-    <description>Test with Resteasy Reactive and Amazon Lambda HTTP</description>
+    <description>Test with Quarkus REST and Amazon Lambda HTTP</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/amazon-lambda-rest-resteasy-reactive/pom.xml
+++ b/integration-tests/amazon-lambda-rest-resteasy-reactive/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-integration-test-amazon-lambda-rest-resteasy-reactive</artifactId>
     <name>Quarkus - Integration Tests - Amazon Lambda AWS Gateway REST API</name>
-    <description>Module that contains Amazon Lambda related tests for RESTEasy Reactive</description>
+    <description>Module that contains Amazon Lambda related tests for Quarkus REST</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/hibernate-validator-resteasy-reactive/pom.xml
+++ b/integration-tests/hibernate-validator-resteasy-reactive/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-integration-test-hibernate-validator-resteasy-reactive</artifactId>
     <name>Quarkus - Integration Tests - Hibernate Validator</name>
-    <description>Module that contains Hibernate Validator/Bean Validation related tests using RESTEasy Reactive</description>
+    <description>Module that contains Hibernate Validator/Bean Validation related tests using Quarkus REST</description>
 
     <dependencies>
         <dependency>

--- a/integration-tests/oidc-client-reactive/pom.xml
+++ b/integration-tests/oidc-client-reactive/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-integration-test-oidc-client-reactive</artifactId>
     <name>Quarkus - Integration Tests - OpenID Connect Client Reactive</name>
-    <description>Module that contains OpenID Connect Client tests using RESTEasy Reactive</description>
+    <description>Module that contains OpenID Connect Client tests using Quarkus REST</description>
 
     <properties>
         <keycloak.url>http://localhost:8180/auth</keycloak.url>

--- a/integration-tests/resteasy-reactive-kotlin/pom.xml
+++ b/integration-tests/resteasy-reactive-kotlin/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>quarkus-integration-test-resteasy-reactive-kotlin-parent</artifactId>
-    <name>Quarkus - Integration Tests - RESTEasy Reactive Kotlin - Parent</name>
+    <name>Quarkus - Integration Tests - Quarkus REST Kotlin - Parent</name>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Tags: Big Reactive Rename, #BigReactiveRename, #BRR, 🥶

While practicing a demo for JProfessionals, I noticed a message in the dev UI that said “Learn how to write REST Services with RESTEasy Reactive.” (For some reason the Dev UI was a bit slow to detect the endpoints that definitely existed, but that's a different issue.)

When I looked in the code I saw that message was definitely still in the codebase, so it wasn't just a caching thing. In fact, there are quite a few references to RESTEasy Reactive. Fixing them all looked like it would be hard work to do and then hard to review, so I've tackled one chunk of the elephant, and done the reference that I saw, plus any that are visible in http://extensions.quarkus.io.

See, for example, 

<img width="727" alt="image" src="https://github.com/quarkusio/quarkus/assets/11509290/b2fce676-56d1-43b6-aa41-1653cea80e90">

<img width="1104" alt="image" src="https://github.com/quarkusio/quarkus/assets/11509290/deb34a7f-a69a-4902-95bb-3666e82f960a">

<img width="1072" alt="image" src="https://github.com/quarkusio/quarkus/assets/11509290/78214990-3596-4d39-97b1-e4c0f0f27a4c">



