### PR TITLE
Use Maven batch mode when executing codestart tests

### DIFF
--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/WrapperRunner.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/WrapperRunner.java
@@ -23,7 +23,7 @@ public final class WrapperRunner {
 
     public enum Wrapper {
         GRADLE("gradlew", "gradlew.bat", new String[] { "--no-daemon", "build", "--info", "--stacktrace" }),
-        MAVEN("mvnw", "mvnw.cmd", new String[] { "package" });
+        MAVEN("mvnw", "mvnw.cmd", new String[] { "-B", "package" });
 
         private final String execUnix;
         private final String execWindows;
@@ -51,7 +51,7 @@ public final class WrapperRunner {
                 case "gradle-kotlin-dsl":
                     return GRADLE;
                 default:
-                    throw new IllegalStateException("No wrapper linked to buildtool: " + buildtool);
+                    throw new IllegalStateException("No wrapper linked to build tool: " + buildtool);
             }
         }
 


### PR DESCRIPTION
This avoids verbose logging of Maven downloads.