### PR TITLE
Detect basic authentication is implicitly required when it can be safely determined and enable the basic auth by default for such scenarios

### DIFF
--- a/extensions/oidc/deployment/pom.xml
+++ b/extensions/oidc/deployment/pom.xml
@@ -100,6 +100,11 @@
             <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndBearerAuthCombinationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndBearerAuthCombinationTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.oidc.test;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.BearerTokenAuthentication;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+import io.quarkus.vertx.http.runtime.security.annotation.BasicAuthentication;
+import io.restassured.RestAssured;
+
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class ImplicitBasicAuthAndBearerAuthCombinationTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BasicBearerResource.class)
+                    .addAsResource(
+                            new StringAsset("""
+                                    quarkus.security.users.embedded.enabled=true
+                                    quarkus.security.users.embedded.plain-text=true
+                                    quarkus.security.users.embedded.users.alice=alice
+                                    quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+                                    quarkus.oidc.client-id=quarkus-service-app
+                                    quarkus.oidc.credentials.secret=secret
+                                    quarkus.http.auth.proactive=false
+                                    """),
+                            "application.properties"));
+
+    @Test
+    public void testBasicEnabledAsSelectedWithAnnotation() {
+        // endpoint is annotated with 'BasicAuthentication', so basic auth must be enabled
+        RestAssured.given().auth().oauth2(getAccessToken()).get("/basic-bearer/bearer")
+                .then().statusCode(200).body(Matchers.is("alice"));
+        RestAssured.given().auth().basic("alice", "alice").get("/basic-bearer/basic")
+                .then().statusCode(204);
+        RestAssured.given().auth().basic("alice", "alice").get("/basic-bearer/bearer")
+                .then().statusCode(401);
+        RestAssured.given().auth().oauth2(getAccessToken()).get("/basic-bearer/basic")
+                .then().statusCode(401);
+    }
+
+    private static String getAccessToken() {
+        return KeycloakTestResourceLifecycleManager.getAccessToken("alice");
+    }
+
+    @BearerTokenAuthentication
+    @Path("basic-bearer")
+    public static class BasicBearerResource {
+
+        @Inject
+        JsonWebToken accessToken;
+
+        @GET
+        @BasicAuthentication
+        @Path("basic")
+        public String basic() {
+            return accessToken.getName();
+        }
+
+        @GET
+        @Path("bearer")
+        public String bearer() {
+            return accessToken.getName();
+        }
+    }
+
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndCodeFlowAuthCombinationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndCodeFlowAuthCombinationTest.java
@@ -1,0 +1,118 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import io.quarkus.oidc.IdToken;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+import io.restassured.RestAssured;
+
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class ImplicitBasicAuthAndCodeFlowAuthCombinationTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BasicCodeFlowResource.class)
+                    .addAsResource(
+                            new StringAsset("""
+                                    quarkus.security.users.embedded.enabled=true
+                                    quarkus.security.users.embedded.plain-text=true
+                                    quarkus.security.users.embedded.users.alice=alice
+                                    quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+                                    quarkus.oidc.client-id=quarkus-web-app
+                                    quarkus.oidc.credentials.secret=secret
+                                    quarkus.oidc.application-type=web-app
+                                    quarkus.http.auth.permission.code-flow.paths=/basic-code-flow/code-flow
+                                    quarkus.http.auth.permission.code-flow.policy=authenticated
+                                    quarkus.http.auth.permission.code-flow.auth-mechanism=code
+                                    quarkus.http.auth.permission.basic.paths=/basic-code-flow/basic
+                                    quarkus.http.auth.permission.basic.policy=authenticated
+                                    quarkus.http.auth.permission.basic.auth-mechanism=basic
+                                    """),
+                            "application.properties"));
+
+    @Test
+    public void testBasicEnabledAsSelectedWithHttpPerm() throws IOException, InterruptedException {
+        // endpoint is annotated with 'BasicAuthentication', so basic auth must be enabled
+        RestAssured.given().auth().basic("alice", "alice").get("/basic-code-flow/basic")
+                .then().statusCode(204);
+        RestAssured.given().auth().basic("alice", "alice").redirects().follow(false)
+                .get("/basic-code-flow/code-flow").then().statusCode(302);
+
+        try (final WebClient webClient = createWebClient()) {
+
+            try {
+                webClient.getPage("http://localhost:8080/basic-code-flow/basic");
+                fail("Exception is expected because by the basic auth is required");
+            } catch (FailingHttpStatusCodeException ex) {
+                // Reported by Quarkus
+                assertEquals(401, ex.getStatusCode());
+            }
+            HtmlPage page = webClient.getPage("http://localhost:8080/basic-code-flow/code-flow");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getInputByName("login").click();
+
+            assertEquals("alice", page.getBody().asNormalizedText());
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+
+    private static String getAccessToken() {
+        return KeycloakTestResourceLifecycleManager.getAccessToken("alice");
+    }
+
+    @Path("basic-code-flow")
+    public static class BasicCodeFlowResource {
+
+        @Inject
+        @IdToken
+        JsonWebToken idToken;
+
+        @GET
+        @Path("basic")
+        public String basic() {
+            return idToken.getName();
+        }
+
+        @GET
+        @Path("code-flow")
+        public String codeFlow() {
+            return idToken.getName();
+        }
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
@@ -14,7 +14,8 @@ public class AuthConfig {
     /**
      * If basic auth should be enabled. If both basic and form auth is enabled then basic auth will be enabled in silent mode.
      *
-     * If no authentication mechanisms are configured basic auth is the default.
+     * The basic auth is enabled by default if no authentication mechanisms are configured or Quarkus can safely
+     * determine that basic authentication is required.
      */
     @ConfigItem
     public Optional<Boolean> basic;


### PR DESCRIPTION
closes: #39912

Adds basic auth when it is already a default bean and we can quite safely say it is needed (it is selected via HTTP Perms or `@BasicAuthentication` and there is no HTTP Auth Mechanisms provided by the application itsels). I didn't dare to cover all cases because the credential transport type is determined dynamically during the HTTP request and there would be potential for breaking changes. Users have very simple alternative when we do not manage to detect that basic auth is needed, just use `quarkus.http.auth.basic=true`.

- changes in `quarkus-integration-test-oidc-code-flow` helps to test auto enabling for `@BasicAuthentication`

Situation in management interface is blocked for now, one of the reasons is #39926.