### PR TITLE
Avoid identity hashcode on the production runtime classloader

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -316,4 +316,23 @@ public final class RunnerClassLoader extends ClassLoader {
         public void afterRestore(Context<? extends Resource> ctx) {
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        //see comment in hashCode
+        return this == o;
+    }
+
+    @Override
+    public int hashCode() {
+        //We can return a constant as we expect to have a single instance of these;
+        //this is useful to avoid triggering a call to the identity hashcode,
+        //which could be rather inefficient as there's good chances that some component
+        //will have inflated the monitor of this instance.
+        //A hash collision would be unfortunate but unexpected, and shouldn't be a problem
+        //as the equals implementation still does honour the identity contract .
+        //See also discussion on https://github.com/smallrye/smallrye-context-propagation/pull/443
+        return 1;
+    }
+
 }


### PR DESCRIPTION
See discussions on:
 - https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Beware.20locking.20on.20objects.20used.20on.20maps.20with.20no.20hashcode.20impl
 - https://github.com/smallrye/smallrye-context-propagation/pull/443

The Context Propagation issue might be resolved in the CP PR, but patching this here would prevent similar issues being triggered by other frameworks or components and keep it simple.