### PR TITLE
Allow extensions to inject a `MavenArtifactResolver`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -17,6 +17,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.builder.BuildChain;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildExecutionBuilder;
@@ -62,6 +63,7 @@ public class QuarkusAugmentor {
     private final boolean auxiliaryApplication;
     private final Optional<DevModeType> auxiliaryDevModeType;
     private final boolean test;
+    private final MavenArtifactResolver mavenArtifactResolver;
 
     QuarkusAugmentor(Builder builder) {
         this.classLoader = builder.classLoader;
@@ -83,6 +85,7 @@ public class QuarkusAugmentor {
         this.auxiliaryApplication = builder.auxiliaryApplication;
         this.auxiliaryDevModeType = Optional.ofNullable(builder.auxiliaryDevModeType);
         this.test = builder.test;
+        this.mavenArtifactResolver = builder.mavenArtifactResolver;
     }
 
     public BuildResult run() throws Exception {
@@ -106,7 +109,7 @@ public class QuarkusAugmentor {
             //in additional stuff from the deployment leaking in, this is unlikely but has a bit of a smell.
             ExtensionLoader.loadStepsFrom(deploymentClassLoader,
                     buildSystemProperties == null ? new Properties() : buildSystemProperties,
-                    effectiveModel, launchMode, devModeType)
+                    mavenArtifactResolver, effectiveModel, launchMode, devModeType)
                     .accept(chainBuilder);
 
             Thread.currentThread().setContextClassLoader(classLoader);
@@ -218,6 +221,7 @@ public class QuarkusAugmentor {
         DevModeType devModeType;
         boolean test;
         boolean auxiliaryApplication;
+        MavenArtifactResolver mavenArtifactResolver;
 
         public Builder addBuildChainCustomizer(Consumer<BuildChainBuilder> customizer) {
             this.buildChainCustomizers.add(customizer);
@@ -355,6 +359,11 @@ public class QuarkusAugmentor {
 
         public Builder setDeploymentClassLoader(ClassLoader deploymentClassLoader) {
             this.deploymentClassLoader = deploymentClassLoader;
+            return this;
+        }
+
+        public Builder setMavenArchiveResolver(final MavenArtifactResolver mavenArtifactResolver) {
+            this.mavenArtifactResolver = mavenArtifactResolver;
             return this;
         }
     }

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -288,6 +288,7 @@ public class AugmentActionImpl implements AugmentAction {
                     .setClassLoader(classLoader)
                     .setTargetDir(quarkusBootstrap.getTargetDirectory())
                     .setDeploymentClassLoader(deploymentClassLoader)
+                    .setMavenArchiveResolver(quarkusBootstrap.mavenArtifactResolver())
                     .setBuildSystemProperties(quarkusBootstrap.getBuildSystemProperties())
                     .setEffectiveModel(curatedApplication.getApplicationModel());
             if (quarkusBootstrap.getBaseName() != null) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -204,7 +204,8 @@ public class QuarkusBootstrapProvider implements Closeable {
 
         private CuratedApplication doBootstrap(QuarkusBootstrapMojo mojo, LaunchMode mode)
                 throws MojoExecutionException {
-            final BootstrapAppModelResolver modelResolver = new BootstrapAppModelResolver(artifactResolver(mojo, mode))
+            MavenArtifactResolver resolver = artifactResolver(mojo, mode);
+            final BootstrapAppModelResolver modelResolver = new BootstrapAppModelResolver(resolver)
                     .setDevMode(mode == LaunchMode.DEVELOPMENT)
                     .setTest(mode == LaunchMode.TEST)
                     .setCollectReloadableDependencies(mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST);
@@ -246,7 +247,8 @@ public class QuarkusBootstrapProvider implements Closeable {
                     .setBaseName(mojo.finalName())
                     .setOriginalBaseName(mojo.mavenProject().getBuild().getFinalName())
                     .setTargetDirectory(mojo.buildDir().toPath())
-                    .setForcedDependencies(forcedDependencies);
+                    .setForcedDependencies(forcedDependencies)
+                    .setMavenArtifactResolver(resolver);
 
             try {
                 return builder.build().bootstrap();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -23,6 +23,7 @@ import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathList;
+import io.smallrye.common.constraint.Assert;
 
 /**
  * The entry point for starting/building a Quarkus application. This class sets up the base class loading
@@ -293,6 +294,10 @@ public class QuarkusBootstrap implements Serializable {
 
     public boolean isTest() {
         return test;
+    }
+
+    public MavenArtifactResolver mavenArtifactResolver() {
+        return mavenArtifactResolver;
     }
 
     public static class Builder {


### PR DESCRIPTION
In order for the qbicc extension to work, qbicc needs to be able to download additional Maven dependencies (specifically, the qbicc JDK JARs). We want to use the same Maven resolver which Quarkus is using so we do not end up with disparate configurations which could manifest in weird ways.

This PR allows extensions to inject the `MavenArtifactResolver`. The code to handle the injection has a one-off check for that specific type. We could expand this to support general injection, but before we do that we might consider actually having a general DI container of some sort for extensions instead. Opened as a draft to foster some discussion.