### PR TITLE
Docs OIDC Client - Inconsistent variable naming, OidcClientCreator example

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -410,7 +410,7 @@ import io.quarkus.oidc.client.runtime.TokensHelper;
 public class OidcClientResource {
 
     @Inject
-    OidcClientCreator clients;
+    OidcClientCreator oidcClientCreator;
     TokensHelper tokenHelper = new TokensHelper();
 
     @Inject


### PR DESCRIPTION
This pull request addresses a minor issue in docs:
- /guides/security-openid-connect-client-reference#use-oidc-clients

Inconsistent variable naming, which was introduced at the last doc update.