### PR TITLE
Add mvnpm support in webjar-locator

### DIFF
--- a/extensions/webjars-locator/deployment/pom.xml
+++ b/extensions/webjars-locator/deployment/pom.xml
@@ -16,6 +16,7 @@
         <!-- do not update these dependencies, they are only used for testing -->
         <webjar.momentjs.version>2.24.0</webjar.momentjs.version>
         <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
+        <mvnpm.bootstrap.version>4.5.2</mvnpm.bootstrap.version>
     </properties>
 
     <dependencies>
@@ -30,6 +31,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-webjars-locator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.mvnpm</groupId>
+            <artifactId>importmap</artifactId>
         </dependency>
 
         <!-- Tests -->
@@ -64,6 +69,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mvnpm</groupId>
+            <artifactId>bootstrap</artifactId>
+            <version>${mvnpm.bootstrap.version}</version>
+            <scope>test</scope>
+        </dependency>
+    
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-deployment</artifactId>
             <scope>test</scope>
@@ -90,6 +102,7 @@
                     <systemPropertyVariables>
                         <webjar.jquery-ui.version>${webjar.jquery-ui.version}</webjar.jquery-ui.version>
                         <webjar.momentjs.version>${webjar.momentjs.version}</webjar.momentjs.version>
+                        <mvnpm.bootstrap.version>${mvnpm.bootstrap.version}</mvnpm.bootstrap.version>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/ImportMapBuildItem.java
+++ b/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/ImportMapBuildItem.java
@@ -1,0 +1,15 @@
+package io.quarkus.webjar.locator.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class ImportMapBuildItem extends SimpleBuildItem {
+    private final String importmap;
+
+    public ImportMapBuildItem(String importmap) {
+        this.importmap = importmap;
+    }
+
+    public String getImportMap() {
+        return this.importmap;
+    }
+}

--- a/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorConfig.java
+++ b/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorConfig.java
@@ -1,0 +1,26 @@
+package io.quarkus.webjar.locator.deployment;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Build time configuration for WebJar Locator.
+ */
+@ConfigRoot
+public class WebJarLocatorConfig {
+
+    /**
+     * If the version reroute is enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean versionReroute;
+
+    /**
+     * User defined import mappings
+     */
+    @ConfigItem
+    public Map<String, String> importMappings;
+
+}

--- a/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorStandaloneBuildStep.java
+++ b/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorStandaloneBuildStep.java
@@ -2,16 +2,20 @@ package io.quarkus.webjar.locator.deployment;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 
+import io.mvnpm.importmap.Aggregator;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
@@ -26,75 +30,142 @@ import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.webjar.locator.runtime.WebJarLocatorRecorder;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
 
 public class WebJarLocatorStandaloneBuildStep {
 
     private static final String WEBJARS_PREFIX = "META-INF/resources/webjars";
+    private static final String WEBJARS_NAME = "webjars";
+
+    private static final String MVNPM_PREFIX = "META-INF/resources/_static";
+    private static final String MVNPM_NAME = "mvnpm";
+
     private static final Logger log = Logger.getLogger(WebJarLocatorStandaloneBuildStep.class.getName());
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     public void findWebjarsAndCreateHandler(
+            WebJarLocatorConfig config,
             HttpBuildTimeConfig httpConfig,
             BuildProducer<FeatureBuildItem> feature,
             BuildProducer<RouteBuildItem> routes,
+            BuildProducer<ImportMapBuildItem> im,
             CurateOutcomeBuildItem curateOutcome,
             WebJarLocatorRecorder recorder) throws Exception {
 
-        final List<ClassPathElement> providers = QuarkusClassLoader.getElements(WEBJARS_PREFIX, false);
-        Map<String, String> webjarNameToVersionMap = Collections.emptyMap();
+        LibInfo webjarsLibInfo = getLibInfo(curateOutcome, WEBJARS_PREFIX, WEBJARS_NAME);
+        LibInfo mvnpmNameLibInfo = getLibInfo(curateOutcome, MVNPM_PREFIX, MVNPM_NAME);
+
+        if (webjarsLibInfo != null || mvnpmNameLibInfo != null) {
+            feature.produce(new FeatureBuildItem(Feature.WEBJARS_LOCATOR));
+
+            if (webjarsLibInfo != null) {
+                if (config.versionReroute) {
+                    Handler<RoutingContext> handler = recorder.getHandler(getRootPath(httpConfig, "webjars"),
+                            webjarsLibInfo.nameVersionMap);
+                    routes.produce(RouteBuildItem.builder().route("/webjars/*").handler(handler).build());
+                }
+            } else {
+                log.warn(
+                        "No WebJars were found in the project. Requests to the /webjars/ path will always return 404 (Not Found)");
+            }
+            if (mvnpmNameLibInfo != null) {
+                if (config.versionReroute) {
+                    Handler<RoutingContext> handler = recorder.getHandler(getRootPath(httpConfig, "_static"),
+                            mvnpmNameLibInfo.nameVersionMap);
+                    routes.produce(RouteBuildItem.builder().route("/_static/*").handler(handler).build());
+                }
+                // Also create a importmap endpoint
+                Aggregator aggregator = new Aggregator(mvnpmNameLibInfo.jars);
+                if (!config.importMappings.isEmpty()) {
+                    aggregator.addMappings(config.importMappings);
+                }
+
+                String importMap = aggregator.aggregateAsJson(false);
+                im.produce(new ImportMapBuildItem(importMap));
+                String path = getRootPath(httpConfig, IMPORTMAP_ROOT) + IMPORTMAP_FILENAME;
+                Handler<RoutingContext> importMapHandler = recorder.getImportMapHandler(path,
+                        importMap);
+                routes.produce(
+                        RouteBuildItem.builder().route("/" + IMPORTMAP_ROOT + "/" + IMPORTMAP_FILENAME)
+                                .handler(importMapHandler).build());
+            } else {
+                log.warn(
+                        "No Mvnpm jars were found in the project. Requests to the /_static/ path will always return 404 (Not Found)");
+            }
+        }
+    }
+
+    private LibInfo getLibInfo(CurateOutcomeBuildItem curateOutcome, String prefix, String name) {
+
+        final List<ClassPathElement> providers = QuarkusClassLoader.getElements(prefix, false);
         if (!providers.isEmpty()) {
-            final Map<ArtifactKey, ClassPathElement> webJarKeys = new HashMap<>(providers.size());
+            final Map<ArtifactKey, ClassPathElement> keys = new HashMap<>(providers.size());
             for (ClassPathElement provider : providers) {
-                if (provider.getDependencyKey() == null || !provider.isRuntime()) {
-                    log.warn("webjars content found in " + provider.getRoot()
-                            + " won't be available. Please, report this issue.");
-                } else {
-                    webJarKeys.put(provider.getDependencyKey(), provider);
+                if (provider.getDependencyKey() != null && provider.isRuntime()) {
+                    keys.put(provider.getDependencyKey(), provider);
                 }
             }
-            if (!webJarKeys.isEmpty()) {
-                final Map<String, String> webjarMap = new HashMap<>(webJarKeys.size());
+            if (!keys.isEmpty()) {
+                final Map<String, String> map = new HashMap<>(keys.size());
+                final Set<URL> jars = new HashSet<>();
                 for (ResolvedDependency dep : curateOutcome.getApplicationModel().getDependencies()) {
                     if (!dep.isRuntimeCp()) {
                         continue;
                     }
-                    final ClassPathElement provider = webJarKeys.get(dep.getKey());
+
+                    final ClassPathElement provider = keys.get(dep.getKey());
                     if (provider == null) {
                         continue;
                     }
                     provider.apply(tree -> {
-                        final Path webjarsDir = tree.getPath(WEBJARS_PREFIX);
+                        final Path dir = tree.getPath(prefix);
                         final Path nameDir;
-                        try (Stream<Path> webjarsDirPaths = Files.list(webjarsDir)) {
-                            nameDir = webjarsDirPaths.filter(Files::isDirectory).findFirst().get();
+                        try (Stream<Path> dirPaths = Files.list(dir)) {
+                            nameDir = dirPaths.filter(Files::isDirectory).findFirst().get();
                         } catch (IOException e) {
                             throw new UncheckedIOException(e);
                         }
                         if (nameDir == null) {
-                            log.warn("Failed to determine the name for webjars included in "
+                            log.warn("Failed to determine the name for " + name + " included in "
                                     + tree.getOriginalTree().getRoots());
                             return null;
                         }
                         final String version = Files.isDirectory(nameDir.resolve(dep.getVersion())) ? dep.getVersion() : null;
-                        webjarMap.put(nameDir.getFileName().toString(), version);
+                        map.put(nameDir.getFileName().toString(), version);
+                        try {
+                            jars.add(dep.getResolvedPaths().getSinglePath().toUri().toURL());
+                        } catch (MalformedURLException ex) {
+                            throw new RuntimeException(ex);
+                        }
                         return null;
                     });
                 }
-                webjarNameToVersionMap = webjarMap;
+
+                return new LibInfo(map, jars);
             }
         }
-
-        if (!webjarNameToVersionMap.isEmpty()) {
-            // The context path + the resources path
-            String rootPath = httpConfig.rootPath;
-            String webjarRootPath = (rootPath.endsWith("/")) ? rootPath + "webjars/" : rootPath + "/webjars/";
-            feature.produce(new FeatureBuildItem(Feature.WEBJARS_LOCATOR));
-            routes.produce(
-                    RouteBuildItem.builder().route("/webjars/*")
-                            .handler(recorder.getHandler(webjarRootPath, webjarNameToVersionMap)).build());
-        } else {
-            log.warn("No WebJars were found in the project. Requests to the /webjars/ path will always return 404 (Not Found)");
-        }
+        return null;
     }
+
+    private String getRootPath(HttpBuildTimeConfig httpConfig, String path) {
+        // The context path + the resources path
+        String rootPath = httpConfig.rootPath;
+        return (rootPath.endsWith("/")) ? rootPath + path + "/" : rootPath + "/" + path + "/";
+    }
+
+    static class LibInfo {
+        Map<String, String> nameVersionMap;
+        Set<URL> jars;
+
+        LibInfo(Map<String, String> nameVersionMap, Set<URL> jars) {
+            this.nameVersionMap = nameVersionMap;
+            this.jars = jars;
+        }
+
+    }
+
+    private static final String IMPORTMAP_ROOT = "_importmap";
+    private static final String IMPORTMAP_FILENAME = "generated_importmap.js";
 }

--- a/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/devui/WebJarLibrariesBuildItem.java
+++ b/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/devui/WebJarLibrariesBuildItem.java
@@ -2,17 +2,22 @@ package io.quarkus.webjar.locator.deployment.devui;
 
 import java.util.List;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.builder.item.MultiBuildItem;
 
-public final class WebJarLibrariesBuildItem extends SimpleBuildItem {
-
+public final class WebJarLibrariesBuildItem extends MultiBuildItem {
+    private final String provider;
     private final List<WebJarLibrary> webJarLibraries;
 
-    public WebJarLibrariesBuildItem(List<WebJarLibrary> webJarLibraries) {
+    public WebJarLibrariesBuildItem(String provider, List<WebJarLibrary> webJarLibraries) {
+        this.provider = provider;
         this.webJarLibraries = webJarLibraries;
     }
 
     public List<WebJarLibrary> getWebJarLibraries() {
-        return webJarLibraries;
+        return this.webJarLibraries;
+    }
+
+    public String getProvider() {
+        return this.provider;
     }
 }

--- a/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/devui/WebJarLocatorDevUIProcessor.java
+++ b/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/devui/WebJarLocatorDevUIProcessor.java
@@ -1,22 +1,29 @@
 package io.quarkus.webjar.locator.deployment.devui;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
+import io.quarkus.webjar.locator.deployment.ImportMapBuildItem;
 
 public class WebJarLocatorDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public void createPages(BuildProducer<CardPageBuildItem> cardPageProducer,
-            WebJarLibrariesBuildItem webJarLibrariesBuildItem) {
+            List<WebJarLibrariesBuildItem> webJarLibrariesBuildItems,
+            Optional<ImportMapBuildItem> importMapBuildItem) {
+
+        List<WebJarLibrary> webJarLibraries = new ArrayList<>();
+        for (WebJarLibrariesBuildItem webJarLibrariesBuildItem : webJarLibrariesBuildItems) {
+            webJarLibraries.addAll(webJarLibrariesBuildItem.getWebJarLibraries());
+        }
 
         CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
-        List<WebJarLibrary> webJarLibraries = webJarLibrariesBuildItem.getWebJarLibraries();
-
         if (!webJarLibraries.isEmpty()) {
             // WebJar Libraries
             cardPageBuildItem.addBuildTimeData("webJarLibraries", webJarLibraries);
@@ -24,9 +31,21 @@ public class WebJarLocatorDevUIProcessor {
             // WebJar Asset List
             cardPageBuildItem.addPage(Page.webComponentPageBuilder()
                     .componentLink("qwc-webjar-locator-webjar-libraries.js")
-                    .title("WebJar Libraries")
+                    .title("Web libraries")
                     .icon("font-awesome-solid:folder-tree")
                     .staticLabel(String.valueOf(webJarLibraries.size())));
+
+            if (importMapBuildItem.isPresent()) {
+                cardPageBuildItem.addBuildTimeData("importMap", importMapBuildItem.get().getImportMap());
+
+                // ImportMap
+                cardPageBuildItem.addPage(Page.webComponentPageBuilder()
+                        .componentLink("qwc-webjar-locator-importmap.js")
+                        .title("Import Map")
+                        .icon("font-awesome-solid:diagram-project"));
+
+            }
+
         }
 
         cardPageProducer.produce(cardPageBuildItem);

--- a/extensions/webjars-locator/deployment/src/main/resources/dev-ui/qwc-webjar-locator-importmap.js
+++ b/extensions/webjars-locator/deployment/src/main/resources/dev-ui/qwc-webjar-locator-importmap.js
@@ -1,0 +1,48 @@
+import {LitElement, html, css} from 'lit';
+import {importMap} from 'build-time-data';
+
+import '@quarkus-webcomponents/codeblock';
+
+export class QwcWebjarLocatorImportmap extends LitElement {
+
+    static styles = css`
+        :host{
+            display: flex;
+            flex-direction: column;
+            gap: 15px;
+            padding: 10px;
+            height: 100%;
+        }
+    `;
+
+    static properties = {
+        _importMap: {type: String}
+    };
+
+    constructor() {
+        super();
+        this._importMap = importMap;
+    }
+
+    render() {
+        return html`
+            To use this in your app, add this to the head of your main html:
+            <div class="codeBlock">
+                <qui-code-block
+                    mode='javascrip'
+                    content='<script src="/_importmap/generated_importmap.js"></script>'>
+                </qui-code-block>
+            </div>
+            
+            Here is the generated import map:
+            <div class="codeBlock">
+                <qui-code-block
+                    mode='json'
+                    content='${this._importMap}'>
+                </qui-code-block>
+            </div>
+        `;
+    }
+}
+
+customElements.define('qwc-webjar-locator-importmap', QwcWebjarLocatorImportmap)

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/ImportMapTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/ImportMapTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.webjar.locator.test;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ImportMapTest extends WebJarLocatorTestSupport {
+    private static final String META_INF_RESOURCES = "META-INF/resources/";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("<html>Hello!<html>"), META_INF_RESOURCES + "/index.html")
+                    .addAsResource(new StringAsset("Test"), META_INF_RESOURCES + "/some/path/test.txt"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("org.mvnpm", "bootstrap", BOOTSTRAP_VERSION)));
+
+    @Test
+    public void test() {
+        // Test normal files
+        RestAssured.get("/_importmap/generated_importmap.js").then()
+                .statusCode(200)
+                .body(containsString("\"bootstrap/\" : \"/_static/bootstrap/" + BOOTSTRAP_VERSION + "/dist/\""));
+
+    }
+}

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
@@ -46,11 +46,15 @@ public class WebJarLocatorDevModeTest extends WebJarLocatorTestSupport {
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
                 .statusCode(200);
+        RestAssured.get("/_static/bootstrap/dist/js/bootstrap.min.js").then()
+                .statusCode(200);
 
         // Test using version in url of existing Web Jar
         RestAssured.get("/webjars/jquery-ui/" + JQUERY_UI_VERSION + "/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/_static/bootstrap/" + BOOTSTRAP_VERSION + "/dist/js/bootstrap.min.js").then()
                 .statusCode(200);
 
         // Test non-existing Web Jar
@@ -59,6 +63,8 @@ public class WebJarLocatorDevModeTest extends WebJarLocatorTestSupport {
         RestAssured.get("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").then()
                 .statusCode(404);
         RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/_static/foundation-sites/6.8.1/dist/js/foundation.esm.js").then()
                 .statusCode(404);
 
         // Test webjar that does not have a version in the jar path
@@ -93,11 +99,15 @@ public class WebJarLocatorDevModeTest extends WebJarLocatorTestSupport {
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
                 .statusCode(200);
+        RestAssured.get("/_static/bootstrap/dist/js/bootstrap.min.js").then()
+                .statusCode(200);
 
         // Test using version in url of existing Web Jar
         RestAssured.get("/webjars/jquery-ui/" + JQUERY_UI_VERSION + "/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/_static/bootstrap/" + BOOTSTRAP_VERSION + "/dist/js/bootstrap.min.js").then()
                 .statusCode(200);
 
         // Test non-existing Web Jar
@@ -106,6 +116,8 @@ public class WebJarLocatorDevModeTest extends WebJarLocatorTestSupport {
         RestAssured.get("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").then()
                 .statusCode(404);
         RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/_static/foundation-sites/6.8.1/dist/js/foundation.esm.js").then()
                 .statusCode(404);
     }
 }

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorRootPathTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorRootPathTest.java
@@ -21,8 +21,10 @@ public class WebJarLocatorRootPathTest extends WebJarLocatorTestSupport {
                     .addAsResource(new StringAsset("<html>Hello!<html>"), META_INF_RESOURCES + "index.html")
                     .addAsResource(new StringAsset("Test"), META_INF_RESOURCES + "some/path/test.txt"))
             .overrideConfigKey("quarkus.http.root-path", "/app")
-            .setForcedDependencies(List.of(Dependency.of("org.webjars", "jquery-ui", JQUERY_UI_VERSION),
-                    Dependency.of("org.webjars", "momentjs", MOMENTJS_VERSION)));
+            .setForcedDependencies(List.of(
+                    Dependency.of("org.webjars", "jquery-ui", JQUERY_UI_VERSION),
+                    Dependency.of("org.webjars", "momentjs", MOMENTJS_VERSION),
+                    Dependency.of("org.mvnpm", "bootstrap", BOOTSTRAP_VERSION)));
 
     @Test
     public void test() {
@@ -43,11 +45,15 @@ public class WebJarLocatorRootPathTest extends WebJarLocatorTestSupport {
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
                 .statusCode(200);
+        RestAssured.get("/_static/bootstrap/dist/js/bootstrap.min.js").then()
+                .statusCode(200);
 
         // Test using version in url of existing Web Jar
         RestAssured.get("/webjars/jquery-ui/" + JQUERY_UI_VERSION + "/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/_static/bootstrap/" + BOOTSTRAP_VERSION + "/dist/js/bootstrap.min.js").then()
                 .statusCode(200);
 
         // Test non-existing Web Jar
@@ -56,6 +62,8 @@ public class WebJarLocatorRootPathTest extends WebJarLocatorTestSupport {
         RestAssured.get("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").then()
                 .statusCode(404);
         RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/_static/foundation-sites/6.8.1/dist/js/foundation.esm.js").then()
                 .statusCode(404);
 
         // Test webjar that does not have a version in the jar path

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
@@ -22,7 +22,8 @@ public class WebJarLocatorTest extends WebJarLocatorTestSupport {
                     .addAsResource(new StringAsset("Test"), META_INF_RESOURCES + "/some/path/test.txt"))
             .setForcedDependencies(List.of(
                     Dependency.of("org.webjars", "jquery-ui", JQUERY_UI_VERSION),
-                    Dependency.of("org.webjars", "momentjs", MOMENTJS_VERSION)));
+                    Dependency.of("org.webjars", "momentjs", MOMENTJS_VERSION),
+                    Dependency.of("org.mvnpm", "bootstrap", BOOTSTRAP_VERSION)));
 
     @Test
     public void test() {
@@ -44,11 +45,15 @@ public class WebJarLocatorTest extends WebJarLocatorTestSupport {
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
                 .statusCode(200);
+        RestAssured.get("/_static/bootstrap/dist/js/bootstrap.min.js").then()
+                .statusCode(200);
 
         // Test using version in url of existing Web Jar
         RestAssured.get("/webjars/jquery-ui/" + JQUERY_UI_VERSION + "/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/_static/bootstrap/" + BOOTSTRAP_VERSION + "/dist/js/bootstrap.min.js").then()
                 .statusCode(200);
 
         // Test non-existing Web Jar
@@ -57,6 +62,8 @@ public class WebJarLocatorTest extends WebJarLocatorTestSupport {
         RestAssured.get("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").then()
                 .statusCode(404);
         RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/_static/foundation-sites/6.8.1/dist/js/foundation.esm.js").then()
                 .statusCode(404);
 
         // Test webjar that does not have a version in the jar path

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTestSupport.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTestSupport.java
@@ -4,4 +4,5 @@ class WebJarLocatorTestSupport {
 
     static final String JQUERY_UI_VERSION = System.getProperty("webjar.jquery-ui.version");
     static final String MOMENTJS_VERSION = System.getProperty("webjar.momentjs.version");
+    static final String BOOTSTRAP_VERSION = System.getProperty("mvnpm.bootstrap.version");
 }


### PR DESCRIPTION
This PR adds support for mvnpm in the webjar-locator extension. 
As discussed, we probably need to rename the extension.

In this PR:

- mvnpm libraries can now also be referenced directly without needing the version in the url, example: `<script src="_static/bootstrap/dist/js/bootstrap.min.js"></script>` in the html.
- mvnpm libraries can also now be used with an importmap. The importmap can be added to the html: `<script src="/_importmap/generated_importmap.js"></script>`
- With the importmap, any library can then be use with imports : `<script type="module">import '@vaadin/date-picker';</script>`
- User can also map their own folder/files to be included with the importmap. This can be done with config. Example: `quarkus.web-jar-locator.import-mappings.app/ = /app/` . Then it can be use example: `<script type="module">import 'app/demo-app.js';</script>`
- Because the user might only use importmaps and only mvnpm, there is also now an option to turn off the version reroute, as this will not be needed when using importmaps
Once this PR is merged and the rename has happened, we still need to update the documentation to include above.

![mvnpm-locator](https://github.com/quarkusio/quarkus/assets/6836179/fd19a1cc-badb-44d7-9f18-e9708ff383be)

![Screenshot_20240409_214856](https://github.com/quarkusio/quarkus/assets/6836179/62ab1968-e46e-4907-930f-e60230df50fe)
