### PR TITLE
Remove unused import

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithInterfaceTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithInterfaceTestCase.java
@@ -1,6 +1,5 @@
 package io.quarkus.smallrye.openapi.test.jaxrs;
 
-import static io.quarkus.smallrye.openapi.test.jaxrs.AutoSecurityRolesAllowedTestCase.schemeArray;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.emptyIterable;


### PR DESCRIPTION
Sorry @geoand . I just seen I left an unused import in code from  #39980. This removes it.