### PR TITLE
Update OpenTelemetry exporter link

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -628,7 +628,7 @@ The exporter is automatically wired with CDI, that's why the `quarkus.otel.trace
 The `quarkus.otel.exporter.otlp.traces.protocol` default to `grpc` and `http/protobuf` can also be used.
 
 === On Quarkiverse
-Additional exporters will be available in the Quarkiverse https://github.com/quarkiverse/quarkus-opentelemetry-exporter/blob/main/README.md[quarkus-opentelemetry-exporter] project.
+Additional exporters will be available in the Quarkiverse https://docs.quarkiverse.io/quarkus-opentelemetry-exporter/dev/index.html[quarkus-opentelemetry-exporter] project.
 
 [[quarkus-extensions-using-opentelemetry]]
 == Quarkus core extensions instrumented with OpenTelemetry tracing


### PR DESCRIPTION
The previous link pointed to a Github file, not to a webiste

cc @brunobat 