### PR TITLE
Context Propagation performance issue and init issue

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -65,6 +65,7 @@ import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.oidc.runtime.TenantConfigBean;
 import io.quarkus.oidc.runtime.providers.AzureAccessTokenCustomizer;
 import io.quarkus.runtime.TlsConfig;
+import io.quarkus.smallrye.context.deployment.ContextPropagationInitializedBuildItem;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.EagerSecurityInterceptorBindingBuildItem;
 import io.quarkus.vertx.http.deployment.HttpAuthMechanismAnnotationBuildItem;
@@ -220,7 +221,9 @@ public class OidcBuildStep {
             OidcConfig config,
             OidcRecorder recorder,
             CoreVertxBuildItem vertxBuildItem,
-            TlsConfig tlsConfig) {
+            TlsConfig tlsConfig,
+            // this is required for setup ordering: we need CP set up
+            ContextPropagationInitializedBuildItem cpInitializedBuildItem) {
         return SyntheticBeanBuildItem.configure(TenantConfigBean.class).unremovable().types(TenantConfigBean.class)
                 .supplier(recorder.setup(config, vertxBuildItem.getVertx(), tlsConfig))
                 .destroyer(TenantConfigBean.Destroyer.class)

--- a/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/ContextPropagationInitializedBuildItem.java
+++ b/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/ContextPropagationInitializedBuildItem.java
@@ -1,0 +1,11 @@
+package io.quarkus.smallrye.context.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Marker build item for build ordering. Signifies that CP is set up
+ * and ready for use.
+ */
+public final class ContextPropagationInitializedBuildItem extends SimpleBuildItem {
+
+}

--- a/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
+++ b/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
@@ -96,6 +96,7 @@ class SmallRyeContextPropagationProcessor {
     void build(SmallRyeContextPropagationRecorder recorder,
             ExecutorBuildItem executorBuildItem,
             ShutdownContextBuildItem shutdownContextBuildItem,
+            BuildProducer<ContextPropagationInitializedBuildItem> cpInitializedBuildItem,
             BuildProducer<FeatureBuildItem> feature,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
         feature.produce(new FeatureBuildItem(Feature.SMALLRYE_CONTEXT_PROPAGATION));
@@ -111,6 +112,8 @@ class SmallRyeContextPropagationProcessor {
                         .unremovable()
                         .supplier(recorder.initializeManagedExecutor(executorBuildItem.getExecutorProxy()))
                         .setRuntimeInit().done());
+
+        cpInitializedBuildItem.produce(new ContextPropagationInitializedBuildItem());
     }
 
     // transform IPs for ManagedExecutor/ThreadContext that use config annotation and don't yet have @NamedInstance

--- a/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/QuarkusContextManagerProvider.java
+++ b/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/QuarkusContextManagerProvider.java
@@ -1,0 +1,42 @@
+package io.quarkus.smallrye.context.runtime;
+
+import org.eclipse.microprofile.context.spi.ContextManager;
+
+import io.smallrye.context.SmallRyeContextManager;
+import io.smallrye.context.SmallRyeContextManagerProvider;
+
+/**
+ * Quarkus doesn't need one manager per CL, we only have the one
+ */
+public class QuarkusContextManagerProvider extends SmallRyeContextManagerProvider {
+
+    private SmallRyeContextManager contextManager;
+
+    @Override
+    public SmallRyeContextManager getContextManager(ClassLoader classLoader) {
+        return contextManager;
+    }
+
+    @Override
+    public SmallRyeContextManager getContextManager() {
+        return contextManager;
+    }
+
+    @Override
+    public ContextManager findContextManager(ClassLoader classLoader) {
+        return contextManager;
+    }
+
+    @Override
+    public void registerContextManager(ContextManager manager, ClassLoader classLoader) {
+        if (manager instanceof SmallRyeContextManager == false) {
+            throw new IllegalArgumentException("Only instances of SmallRyeContextManager are supported: " + manager);
+        }
+        contextManager = (SmallRyeContextManager) manager;
+    }
+
+    @Override
+    public void releaseContextManager(ContextManager manager) {
+        contextManager = null;
+    }
+}

--- a/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
+++ b/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
@@ -1,11 +1,18 @@
 package io.quarkus.smallrye.context.runtime;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.context.spi.ContextManager.Builder;
 import org.eclipse.microprofile.context.spi.ContextManagerExtension;
 import org.eclipse.microprofile.context.spi.ContextManagerProvider;
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
@@ -23,6 +30,92 @@ import io.smallrye.context.SmallRyeThreadContext;
 @Recorder
 public class SmallRyeContextPropagationRecorder {
 
+    private static final ExecutorService NOPE_EXECUTOR_SERVICE = new ExecutorService() {
+
+        @Override
+        public void execute(Runnable command) {
+            nope();
+        }
+
+        @Override
+        public void shutdown() {
+            nope();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            nope();
+            return null;
+        }
+
+        @Override
+        public boolean isShutdown() {
+            nope();
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            nope();
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            nope();
+            return false;
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            nope();
+            return null;
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            nope();
+            return null;
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            nope();
+            return null;
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+            nope();
+            return null;
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException {
+            nope();
+            return null;
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+                throws InterruptedException, ExecutionException {
+            nope();
+            return null;
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException {
+            nope();
+            return null;
+        }
+
+        private void nope() {
+            throw new RuntimeException(
+                    "Trying to invoke ContextPropagation on a partially-configured ContextManager instance. You should wait until runtime init is done. You can do that by consuming the ContextPropagationBuildItem.");
+        }
+    };
     private static SmallRyeContextManager.Builder builder;
 
     public void configureStaticInit(List<ThreadContextProvider> discoveredProviders,
@@ -39,6 +132,16 @@ public class SmallRyeContextPropagationRecorder {
                 .getContextManagerBuilder();
         builder.withThreadContextProviders(discoveredProviders.toArray(new ThreadContextProvider[0]));
         builder.withContextManagerExtensions(discoveredExtensions.toArray(new ContextManagerExtension[0]));
+
+        // During boot, if anyone is using CP, they will get no propagation and an error if they try to use
+        // the executor. This is (so far) only for spring-cloud-config-client which uses Vert.x via Mutiny
+        // to load config before we're ready for runtime init
+        SmallRyeContextManager.Builder noContextBuilder = (SmallRyeContextManager.Builder) ContextManagerProvider.instance()
+                .getContextManagerBuilder();
+        noContextBuilder.withThreadContextProviders(new ThreadContextProvider[0]);
+        noContextBuilder.withContextManagerExtensions(new ContextManagerExtension[0]);
+        noContextBuilder.withDefaultExecutorService(NOPE_EXECUTOR_SERVICE);
+        ContextManagerProvider.instance().registerContextManager(noContextBuilder.build(), null /* not used */);
     }
 
     public void configureRuntime(ExecutorService executorService, ShutdownContext shutdownContext) {
@@ -58,7 +161,7 @@ public class SmallRyeContextPropagationRecorder {
             }
         });
         //Avoid leaking the classloader:
-        this.builder = null;
+        SmallRyeContextPropagationRecorder.builder = null;
     }
 
     public Supplier<Object> initializeManagedExecutor(ExecutorService executorService) {

--- a/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
+++ b/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
@@ -14,7 +14,6 @@ import io.quarkus.arc.Arc;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.context.SmallRyeContextManager;
-import io.smallrye.context.SmallRyeContextManagerProvider;
 import io.smallrye.context.SmallRyeManagedExecutor;
 import io.smallrye.context.SmallRyeThreadContext;
 
@@ -31,7 +30,7 @@ public class SmallRyeContextPropagationRecorder {
         // build the manager at static init time
         // in the live-reload mode, the provider instance may be already set in the previous start
         if (ContextManagerProvider.INSTANCE.get() == null) {
-            ContextManagerProvider contextManagerProvider = new SmallRyeContextManagerProvider();
+            ContextManagerProvider contextManagerProvider = new QuarkusContextManagerProvider();
             ContextManagerProvider.register(contextManagerProvider);
         }
 

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -50,6 +50,7 @@ import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
@@ -87,7 +88,8 @@ public class SmallRyeFaultToleranceProcessor {
             CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod,
-            BuildProducer<RunTimeConfigurationDefaultBuildItem> config) {
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> config,
+            BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClassBuildItems) {
 
         feature.produce(new FeatureBuildItem(Feature.SMALLRYE_FAULT_TOLERANCE));
 
@@ -95,6 +97,8 @@ public class SmallRyeFaultToleranceProcessor {
                 ContextPropagationRequestContextControllerProvider.class.getName()));
         serviceProvider.produce(new ServiceProviderBuildItem(RunnableWrapper.class.getName(),
                 ContextPropagationRunnableWrapper.class.getName()));
+        // make sure this is initialised at runtime, otherwise it will get a non-initialised ContextPropagationManager
+        runtimeInitializedClassBuildItems.produce(new RuntimeInitializedClassBuildItem(RunnableWrapper.class.getName()));
 
         IndexView index = combinedIndexBuildItem.getIndex();
 


### PR DESCRIPTION
The original issue I wanted to fix is a performance issue noticed by @franz1981 at https://github.com/smallrye/smallrye-context-propagation/pull/443#event-12402814297, because in Quarkus, we don't need a per-classloader `Map` since we have a single class loader and a single `ContextManager`.

Doing this, I noticed that some extensions were using CP between static init and runtime init. They were relying on CP auto-booting itself during that period, so it "worked", but it had only a partial number of contexts to propagate, and it started an `ExecutorService` instead of using the Quarkus one, which is only available at runtime init.

There were four types of problematic users:

- Extensions that did not wait for Mutiny or CP to be initialised. For this I added a `ContextPropagationInitializedBuildItem` to consume.
- Extensions that used CP during class init, which caused problems when building a native-image which initialises classes at build time. For this I delayed the problematic class initialisation until runtime.
- Extensions that used Vert.x, via Mutiny before runtime init, such as spring-cloud-config-client which is a config-reading extension, so it can't run before runtime init. I didn't find how to make this wait for our initialisation, I don't think it's possible, because the executor needs config loaded to be created, so it's a chicken/egg problem.
- The MP TCK which fails in OT for _some_ reason that I'm not sure is really caused by this.

For the last two issues, I created a no-config/no-executor `ContextManager` that lives between static and runtime init, before it's replaced by the properly initialised one. 

This is not perfect, because this might be used by something initialised too early and live on past runtime init and keep not propagating any contexts, but this was already the case before this PR. I could log something, but it'd have to be a `WARN` and any user of `spring-cloud-config-client` would have that warning. Perhaps it's acceptable?

At least, if anybody tries to use the temporary executor, they will get a meaningful exception to let them know not to do it. And we avoid creating an executor, also.

Anyway, let's see how far CI goes, with this.

Note that Mutiny suffers from the same issue that a lot of extensions are using it before it's fully initialised (for the same reason) and it also doesn't have a build item to depend on.