### PR TITLE
Make REST Assured version available in the build

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -138,7 +138,6 @@
         <derby-jdbc.version>10.14.2.0</derby-jdbc.version>
         <db2-jdbc.version>11.5.8.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
-        <rest-assured.version>5.4.0</rest-assured.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <infinispan.version>15.0.0.Final</infinispan.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <!-- Dependency versions -->
         <jacoco.version>0.8.12</jacoco.version>
         <kubernetes-client.version>6.11.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <rest-assured.version>5.4.0</rest-assured.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.62.2</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->


### PR DESCRIPTION
It is actually used (but missing!) when we build the platform descriptor.
Moving it to the parent POM to be available everywhere.

@aloubyansky this should fix what you reported to me.