### PR TITLE
Fix url encoding issue for Dev UI Page with unusual chars

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/router-controller.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/router-controller.js
@@ -176,7 +176,6 @@ export class RouterController {
     
     addRoute(path, component, name, page, defaultRoute = false) {
         path = this.getPageUrlFor(page);
-        var currentSelection = window.location.pathname;
         const search = new URLSearchParams(window.location.search);
         if (!this.isExistingPath(path)) {
             RouterController.pageMap.set(path, page);

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
@@ -1,5 +1,8 @@
 package io.quarkus.devui.spi.page;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -61,6 +64,12 @@ public class Page {
 
     public String getId() {
         String id = this.title.toLowerCase().replaceAll(SPACE, DASH);
+        try {
+            id = URLEncoder.encode(id, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException ex) {
+            throw new RuntimeException(ex);
+        }
+
         if (!this.isInternal() && this.namespace != null) {
             // This is extension pages in Dev UI
             id = this.namespace.toLowerCase() + SLASH + id;

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/PageBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/PageBuilder.java
@@ -42,7 +42,10 @@ public abstract class PageBuilder<T> {
 
     @SuppressWarnings("unchecked")
     public T staticLabel(String staticLabel) {
-        this.staticLabel = staticLabel;
+        if (this.staticLabel == null) {
+            this.staticLabel = "";
+        }
+        this.staticLabel = this.staticLabel + " " + staticLabel;
         return (T) this;
     }
 


### PR DESCRIPTION
Fix #39992

This PR does:
1) Removes a unused line of JS.
2) Encode the page id
3) Allow multiple static labels