### PR TITLE
Skeleton unit tests for annotation processor

### DIFF
--- a/core/processor/pom.xml
+++ b/core/processor/pom.xml
@@ -59,6 +59,17 @@
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope> 
         </dependency>
+        <dependency>
+            <groupId>com.karuslabs</groupId>
+            <artifactId>elementary</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-builder</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -130,7 +130,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
     public void doProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         for (TypeElement annotation : annotations) {
-            switch (annotation.getQualifiedName().toString()) {
+            switch (annotation.getQualifiedName()
+                    .toString()) {
                 case Constants.ANNOTATION_BUILD_STEP:
                     trackAnnotationUsed(Constants.ANNOTATION_BUILD_STEP);
                     processBuildStep(roundEnv, annotation);
@@ -162,16 +163,19 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         try {
             tempResource = filer.createResource(StandardLocation.SOURCE_OUTPUT, Constants.EMPTY, "ignore.tmp");
         } catch (IOException e) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Unable to create temp output file: " + e);
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.ERROR, "Unable to create temp output file: " + e);
             return;
         }
         final URI uri = tempResource.toUri();
         //        tempResource.delete();
         Path path;
         try {
-            path = Paths.get(uri).getParent();
+            path = Paths.get(uri)
+                    .getParent();
         } catch (RuntimeException e) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Resource path URI is invalid: " + uri);
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.ERROR, "Resource path URI is invalid: " + uri);
             return;
         }
         Collection<String> bscListClasses = new TreeSet<>();
@@ -185,7 +189,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 }
 
                 public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) {
-                    final String nameStr = file.getFileName().toString();
+                    final String nameStr = file.getFileName()
+                            .toString();
                     if (nameStr.endsWith(".bsc")) {
                         readFile(file, bscListClasses);
                     } else if (nameStr.endsWith(".cr")) {
@@ -195,8 +200,9 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                         try (BufferedReader br = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
                             p.load(br);
                         } catch (IOException e) {
-                            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                                    "Failed to read file " + file + ": " + e);
+                            processingEnv.getMessager()
+                                    .printMessage(Diagnostic.Kind.ERROR,
+                                            "Failed to read file " + file + ": " + e);
                         }
                         final Set<String> names = p.stringPropertyNames();
                         for (String name : names) {
@@ -208,8 +214,9 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 }
 
                 public FileVisitResult visitFileFailed(final Path file, final IOException exc) {
-                    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                            "Failed to visit file " + file + ": " + exc);
+                    processingEnv.getMessager()
+                            .printMessage(Diagnostic.Kind.ERROR,
+                                    "Failed to visit file " + file + ": " + exc);
                     return FileVisitResult.CONTINUE;
                 }
 
@@ -218,7 +225,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 }
             });
         } catch (IOException e) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "File walk failed: " + e);
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.ERROR, "File walk failed: " + e);
         }
         if (!bscListClasses.isEmpty())
             try {
@@ -226,7 +234,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                         "META-INF/quarkus-build-steps.list");
                 writeListResourceFile(bscListClasses, listResource);
             } catch (IOException e) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to write build steps listing: " + e);
+                processingEnv.getMessager()
+                        .printMessage(Diagnostic.Kind.ERROR, "Failed to write build steps listing: " + e);
                 return;
             }
         if (!crListClasses.isEmpty()) {
@@ -235,7 +244,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                         "META-INF/quarkus-config-roots.list");
                 writeListResourceFile(crListClasses, listResource);
             } catch (IOException e) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to write config roots listing: " + e);
+                processingEnv.getMessager()
+                        .printMessage(Diagnostic.Kind.ERROR, "Failed to write config roots listing: " + e);
                 return;
             }
         }
@@ -254,7 +264,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                     }
                 }
             } catch (IOException e) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to write javadoc properties: " + e);
+                processingEnv.getMessager()
+                        .printMessage(Diagnostic.Kind.ERROR, "Failed to write javadoc properties: " + e);
                 return;
             }
         }
@@ -269,7 +280,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 }
             }
         } catch (IOException e) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to generate extension doc: " + e);
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.ERROR, "Failed to generate extension doc: " + e);
             return;
 
         }
@@ -277,8 +289,11 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
     private void validateAnnotationUsage() {
         if (isAnnotationUsed(Constants.ANNOTATION_BUILD_STEP) && isAnnotationUsed(Constants.ANNOTATION_RECORDER)) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                    "Detected use of @Recorder annotation in 'deployment' module. Classes annotated with @Recorder must be part of the extension's 'runtime' module");
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.ERROR,
+                            "Detected use of @Recorder annotation in 'deployment' module. Classes annotated with @Recorder must be "
+                                    +
+                                    "part of the extension's 'runtime' module");
         }
     }
 
@@ -315,8 +330,9 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 }
             }
         } catch (IOException e) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                    "Failed to read file " + file + ": " + e);
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.ERROR,
+                            "Failed to read file " + file + ": " + e);
         }
     }
 
@@ -329,29 +345,36 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 continue;
             }
 
-            final PackageElement pkg = processingEnv.getElementUtils().getPackageOf(clazz);
+            final PackageElement pkg = processingEnv.getElementUtils()
+                    .getPackageOf(clazz);
             if (pkg == null) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                        "Element " + clazz + " has no enclosing package");
+                processingEnv.getMessager()
+                        .printMessage(Diagnostic.Kind.ERROR,
+                                "Element " + clazz + " has no enclosing package");
                 continue;
             }
 
-            final String binaryName = processingEnv.getElementUtils().getBinaryName(clazz).toString();
+            final String binaryName = processingEnv.getElementUtils()
+                    .getBinaryName(clazz)
+                    .toString();
             if (processorClassNames.add(binaryName)) {
                 validateRecordBuildSteps(clazz);
                 recordConfigJavadoc(clazz);
                 generateAccessor(clazz);
                 final StringBuilder rbn = getRelativeBinaryName(clazz, new StringBuilder());
                 try {
-                    final FileObject itemResource = processingEnv.getFiler().createResource(
-                            StandardLocation.SOURCE_OUTPUT,
-                            pkg.getQualifiedName().toString(),
-                            rbn.toString() + ".bsc",
-                            clazz);
+                    final FileObject itemResource = processingEnv.getFiler()
+                            .createResource(
+                                    StandardLocation.SOURCE_OUTPUT,
+                                    pkg.getQualifiedName()
+                                            .toString(),
+                                    rbn.toString() + ".bsc",
+                                    clazz);
                     writeResourceFile(binaryName, itemResource);
                 } catch (IOException e1) {
-                    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                            "Failed to create " + rbn + " in " + pkg + ": " + e1, clazz);
+                    processingEnv.getMessager()
+                            .printMessage(Diagnostic.Kind.ERROR,
+                                    "Failed to create " + rbn + " in " + pkg + ": " + e1, clazz);
                 }
             }
         }
@@ -373,21 +396,28 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
             boolean hasRecorder = false;
             boolean allTypesResolvable = true;
             for (VariableElement parameter : ex.getParameters()) {
-                String parameterClassName = parameter.asType().toString();
-                TypeElement parameterTypeElement = processingEnv.getElementUtils().getTypeElement(parameterClassName);
+                String parameterClassName = parameter.asType()
+                        .toString();
+                TypeElement parameterTypeElement = processingEnv.getElementUtils()
+                        .getTypeElement(parameterClassName);
                 if (parameterTypeElement == null) {
                     allTypesResolvable = false;
                 } else {
                     if (isAnnotationPresent(parameterTypeElement, Constants.ANNOTATION_RECORDER)) {
-                        if (parameterTypeElement.getModifiers().contains(Modifier.FINAL)) {
-                            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                                    "Class '" + parameterTypeElement.getQualifiedName()
-                                            + "' is annotated with @Recorder and therefore cannot be made as a final class.");
+                        if (parameterTypeElement.getModifiers()
+                                .contains(Modifier.FINAL)) {
+                            processingEnv.getMessager()
+                                    .printMessage(Diagnostic.Kind.ERROR,
+                                            "Class '" + parameterTypeElement.getQualifiedName()
+                                                    + "' is annotated with @Recorder and therefore cannot be made as a final class.");
                         } else if (getPackageName(clazz).equals(getPackageName(parameterTypeElement))) {
-                            processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING,
-                                    "Build step class '" + clazz.getQualifiedName()
-                                            + "' and recorder '" + parameterTypeElement
-                                            + "' share the same package. This is highly discouraged as it can lead to unexpected results.");
+                            processingEnv.getMessager()
+                                    .printMessage(Diagnostic.Kind.WARNING,
+                                            "Build step class '" + clazz.getQualifiedName()
+                                                    + "' and recorder '" + parameterTypeElement
+                                                    + "' share the same package. This is highly discouraged as it can lead to "
+                                                    +
+                                                    "unexpected results.");
                         }
                         hasRecorder = true;
                         break;
@@ -396,15 +426,20 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
             }
 
             if (!hasRecorder && allTypesResolvable) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Build Step '" + clazz.getQualifiedName() + "#"
-                        + ex.getSimpleName()
-                        + "' which is annotated with '@Record' does not contain a method parameter whose type is annotated with '@Recorder'.");
+                processingEnv.getMessager()
+                        .printMessage(Diagnostic.Kind.ERROR, "Build Step '" + clazz.getQualifiedName() + "#"
+                                + ex.getSimpleName()
+                                + "' which is annotated with '@Record' does not contain a method parameter whose type is annotated "
+                                +
+                                "with '@Recorder'.");
             }
         }
     }
 
     private Name getPackageName(TypeElement clazz) {
-        return processingEnv.getElementUtils().getPackageOf(clazz).getQualifiedName();
+        return processingEnv.getElementUtils()
+                .getPackageOf(clazz)
+                .getQualifiedName();
     }
 
     private StringBuilder getRelativeBinaryName(TypeElement te, StringBuilder b) {
@@ -421,7 +456,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         Element t = e;
         while (!(t instanceof TypeElement)) {
             if (t == null) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Element " + e + " has no enclosing class");
+                processingEnv.getMessager()
+                        .printMessage(Diagnostic.Kind.ERROR, "Element " + e + " has no enclosing class");
                 return null;
             }
             t = t.getEnclosingElement();
@@ -430,7 +466,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     }
 
     private void recordConfigJavadoc(TypeElement clazz) {
-        String className = clazz.getQualifiedName().toString();
+        String className = clazz.getQualifiedName()
+                .toString();
         if (!generatedJavaDocs.add(className))
             return;
         Properties javadocProps = new Properties();
@@ -470,7 +507,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     }
 
     private void recordMappingJavadoc(TypeElement clazz) {
-        String className = clazz.getQualifiedName().toString();
+        String className = clazz.getQualifiedName()
+                .toString();
         if (!generatedJavaDocs.add(className))
             return;
         if (!isAnnotationPresent(clazz, ANNOTATION_CONFIG_MAPPING)) {
@@ -484,7 +522,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     }
 
     private void recordMappingJavadoc(final TypeElement clazz, final Properties javadocProps) {
-        String className = clazz.getQualifiedName().toString();
+        String className = clazz.getQualifiedName()
+                .toString();
         for (Element e : clazz.getEnclosedElements()) {
             switch (e.getKind()) {
                 case INTERFACE: {
@@ -504,9 +543,11 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     }
 
     private boolean isEnclosedByMapping(Element clazz) {
-        if (clazz.getKind().equals(ElementKind.INTERFACE)) {
+        if (clazz.getKind()
+                .equals(ElementKind.INTERFACE)) {
             Element enclosingElement = clazz.getEnclosingElement();
-            if (enclosingElement.getKind().equals(ElementKind.INTERFACE)) {
+            if (enclosingElement.getKind()
+                    .equals(ElementKind.INTERFACE)) {
                 if (isAnnotationPresent(enclosingElement, ANNOTATION_CONFIG_MAPPING)) {
                     return true;
                 } else {
@@ -520,30 +561,37 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     private void writeJavadocProperties(final TypeElement clazz, final Properties javadocProps) {
         if (javadocProps.isEmpty())
             return;
-        final PackageElement pkg = processingEnv.getElementUtils().getPackageOf(clazz);
-        final String rbn = getRelativeBinaryName(clazz, new StringBuilder()).append(".jdp").toString();
+        final PackageElement pkg = processingEnv.getElementUtils()
+                .getPackageOf(clazz);
+        final String rbn = getRelativeBinaryName(clazz, new StringBuilder()).append(".jdp")
+                .toString();
         try {
-            FileObject file = processingEnv.getFiler().createResource(
-                    StandardLocation.SOURCE_OUTPUT,
-                    pkg.getQualifiedName().toString(),
-                    rbn,
-                    clazz);
+            FileObject file = processingEnv.getFiler()
+                    .createResource(
+                            StandardLocation.SOURCE_OUTPUT,
+                            pkg.getQualifiedName()
+                                    .toString(),
+                            rbn,
+                            clazz);
             try (Writer writer = file.openWriter()) {
                 PropertyUtils.store(javadocProps, writer);
             }
         } catch (IOException e) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to persist resource " + rbn + ": " + e);
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.ERROR, "Failed to persist resource " + rbn + ": " + e);
         }
     }
 
     private void processFieldConfigItem(VariableElement field, Properties javadocProps, String className) {
-        javadocProps.put(className + Constants.DOT + field.getSimpleName().toString(), getRequiredJavadoc(field));
+        javadocProps.put(className + Constants.DOT + field.getSimpleName()
+                .toString(), getRequiredJavadoc(field));
     }
 
     private void processEnumConstant(Element field, Properties javadocProps, String className) {
         String javaDoc = getJavadoc(field);
         if (javaDoc != null && !javaDoc.isBlank()) {
-            javadocProps.put(className + Constants.DOT + field.getSimpleName().toString(), javaDoc);
+            javadocProps.put(className + Constants.DOT + field.getSimpleName()
+                    .toString(), javaDoc);
         }
     }
 
@@ -557,20 +605,26 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     private void processMethodConfigItem(ExecutableElement method, Properties javadocProps, String className) {
         final String docComment = getRequiredJavadoc(method);
         final StringBuilder buf = new StringBuilder();
-        buf.append(method.getSimpleName().toString());
+        buf.append(method.getSimpleName()
+                .toString());
         appendParamTypes(method, buf);
         javadocProps.put(className + Constants.DOT + buf, docComment);
     }
 
     private void processMethodConfigMapping(ExecutableElement method, Properties javadocProps, String className) {
-        if (method.getModifiers().contains(Modifier.ABSTRACT)) {
+        if (method.getModifiers()
+                .contains(Modifier.ABSTRACT)) {
             // Skip toString method, because mappings can include it and generate it
-            if (method.getSimpleName().contentEquals("toString") && method.getParameters().size() == 0) {
+            if (method.getSimpleName()
+                    .contentEquals("toString")
+                    && method.getParameters()
+                            .size() == 0) {
                 return;
             }
 
             String docComment = getRequiredJavadoc(method);
-            javadocProps.put(className + Constants.DOT + method.getSimpleName().toString(), docComment);
+            javadocProps.put(className + Constants.DOT + method.getSimpleName()
+                    .toString(), docComment);
 
             // Find groups without annotation
             TypeMirror returnType = method.getReturnType();
@@ -593,7 +647,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         }
 
         DeclaredType declaredType = (DeclaredType) typeMirror;
-        String name = declaredType.asElement().toString();
+        String name = declaredType.asElement()
+                .toString();
         List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
         if (typeArguments.size() == 0) {
             if (!name.startsWith("java.")) {
@@ -616,9 +671,11 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     private void processConfigGroup(RoundEnvironment roundEnv, TypeElement annotation) {
         final Set<String> groupClassNames = new HashSet<>();
         for (TypeElement i : typesIn(roundEnv.getElementsAnnotatedWith(annotation))) {
-            if (groupClassNames.add(i.getQualifiedName().toString())) {
+            if (groupClassNames.add(i.getQualifiedName()
+                    .toString())) {
                 generateAccessor(i);
-                if (isEnclosedByMapping(i) || i.getKind().equals(ElementKind.INTERFACE)) {
+                if (isEnclosedByMapping(i) || i.getKind()
+                        .equals(ElementKind.INTERFACE)) {
                     recordMappingJavadoc(i);
                 } else {
                     recordConfigJavadoc(i);
@@ -634,10 +691,12 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         final Set<String> rootClassNames = new HashSet<>();
 
         for (TypeElement clazz : typesIn(roundEnv.getElementsAnnotatedWith(annotation))) {
-            final PackageElement pkg = processingEnv.getElementUtils().getPackageOf(clazz);
+            final PackageElement pkg = processingEnv.getElementUtils()
+                    .getPackageOf(clazz);
             if (pkg == null) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                        "Element " + clazz + " has no enclosing package");
+                processingEnv.getMessager()
+                        .printMessage(Diagnostic.Kind.ERROR,
+                                "Element " + clazz + " has no enclosing package");
                 continue;
             }
 
@@ -645,7 +704,9 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 configDocItemScanner.addConfigRoot(pkg, clazz);
             }
 
-            final String binaryName = processingEnv.getElementUtils().getBinaryName(clazz).toString();
+            final String binaryName = processingEnv.getElementUtils()
+                    .getBinaryName(clazz)
+                    .toString();
             if (rootClassNames.add(binaryName)) {
                 // new class
                 if (isAnnotationPresent(clazz, ANNOTATION_CONFIG_MAPPING)) {
@@ -656,15 +717,18 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 }
                 final StringBuilder rbn = getRelativeBinaryName(clazz, new StringBuilder());
                 try {
-                    final FileObject itemResource = processingEnv.getFiler().createResource(
-                            StandardLocation.SOURCE_OUTPUT,
-                            pkg.getQualifiedName().toString(),
-                            rbn + ".cr",
-                            clazz);
+                    final FileObject itemResource = processingEnv.getFiler()
+                            .createResource(
+                                    StandardLocation.SOURCE_OUTPUT,
+                                    pkg.getQualifiedName()
+                                            .toString(),
+                                    rbn + ".cr",
+                                    clazz);
                     writeResourceFile(binaryName, itemResource);
                 } catch (IOException e1) {
-                    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                            "Failed to create " + rbn + " in " + pkg + ": " + e1, clazz);
+                    processingEnv.getMessager()
+                            .printMessage(Diagnostic.Kind.ERROR,
+                                    "Failed to create " + rbn + " in " + pkg + ": " + e1, clazz);
                 }
             }
         }
@@ -686,7 +750,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     private void processRecorder(RoundEnvironment roundEnv, TypeElement annotation) {
         final Set<String> groupClassNames = new HashSet<>();
         for (TypeElement i : typesIn(roundEnv.getElementsAnnotatedWith(annotation))) {
-            if (groupClassNames.add(i.getQualifiedName().toString())) {
+            if (groupClassNames.add(i.getQualifiedName()
+                    .toString())) {
                 generateAccessor(i);
                 recordConfigJavadoc(i);
             }
@@ -694,28 +759,35 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     }
 
     private void generateAccessor(final TypeElement clazz) {
-        if (!generatedAccessors.add(clazz.getQualifiedName().toString()))
+        if (!generatedAccessors.add(clazz.getQualifiedName()
+                .toString()))
             return;
         final FormatPreferences fp = new FormatPreferences();
         final JSources sources = JDeparser.createSources(JFiler.newInstance(processingEnv.getFiler()), fp);
-        final PackageElement packageElement = processingEnv.getElementUtils().getPackageOf(clazz);
-        final String className = getRelativeBinaryName(clazz, new StringBuilder()).append("$$accessor").toString();
-        final JSourceFile sourceFile = sources.createSourceFile(packageElement.getQualifiedName().toString(), className);
+        final PackageElement packageElement = processingEnv.getElementUtils()
+                .getPackageOf(clazz);
+        final String className = getRelativeBinaryName(clazz, new StringBuilder()).append("$$accessor")
+                .toString();
+        final JSourceFile sourceFile = sources.createSourceFile(packageElement.getQualifiedName()
+                .toString(), className);
         JType clazzType = JTypes.typeOf(clazz.asType());
         if (clazz.asType() instanceof DeclaredType) {
             DeclaredType declaredType = ((DeclaredType) clazz.asType());
             TypeMirror enclosingType = declaredType.getEnclosingType();
             if (enclosingType != null && enclosingType.getKind() == TypeKind.DECLARED
-                    && clazz.getModifiers().contains(Modifier.STATIC)) {
+                    && clazz.getModifiers()
+                            .contains(Modifier.STATIC)) {
                 // Ugly workaround for Eclipse APT and static nested types
                 clazzType = unnestStaticNestedType(declaredType);
             }
         }
         final JClassDef classDef = sourceFile._class(JMod.PUBLIC | JMod.FINAL, className);
         classDef.constructor(JMod.PRIVATE); // no construction
-        classDef.annotate(QUARKUS_GENERATED).value("Quarkus annotation processor");
+        classDef.annotate(QUARKUS_GENERATED)
+                .value("Quarkus annotation processor");
         final JAssignableExpr instanceName = JExprs.name(Constants.INSTANCE_SYM);
-        boolean isEnclosingClassPublic = clazz.getModifiers().contains(Modifier.PUBLIC);
+        boolean isEnclosingClassPublic = clazz.getModifiers()
+                .contains(Modifier.PUBLIC);
         // iterate fields
         boolean generationNeeded = false;
         for (VariableElement field : fieldsIn(clazz.getEnclosedElements())) {
@@ -733,7 +805,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 if (fieldType instanceof DeclaredType) {
                     final DeclaredType declaredType = (DeclaredType) fieldType;
                     final TypeElement typeElement = (TypeElement) declaredType.asElement();
-                    if (typeElement.getModifiers().contains(Modifier.PUBLIC)) {
+                    if (typeElement.getModifiers()
+                            .contains(Modifier.PUBLIC)) {
                         continue;
                     }
                 } else {
@@ -746,24 +819,32 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
             final JType realType = JTypes.typeOf(fieldType);
             final JType publicType = fieldType instanceof PrimitiveType ? realType : JType.OBJECT;
 
-            final String fieldName = field.getSimpleName().toString();
+            final String fieldName = field.getSimpleName()
+                    .toString();
             final JMethodDef getter = classDef.method(JMod.PUBLIC | JMod.STATIC, publicType, "get_" + fieldName);
-            getter.annotate(SuppressWarnings.class).value("unchecked");
+            getter.annotate(SuppressWarnings.class)
+                    .value("unchecked");
             getter.param(JType.OBJECT, Constants.INSTANCE_SYM);
-            getter.body()._return(instanceName.cast(clazzType).field(fieldName));
+            getter.body()
+                    ._return(instanceName.cast(clazzType)
+                            .field(fieldName));
             final JMethodDef setter = classDef.method(JMod.PUBLIC | JMod.STATIC, JType.VOID, "set_" + fieldName);
-            setter.annotate(SuppressWarnings.class).value("unchecked");
+            setter.annotate(SuppressWarnings.class)
+                    .value("unchecked");
             setter.param(JType.OBJECT, Constants.INSTANCE_SYM);
             setter.param(publicType, fieldName);
             final JAssignableExpr fieldExpr = JExprs.name(fieldName);
-            setter.body().assign(instanceName.cast(clazzType).field(fieldName),
-                    (publicType.equals(realType) ? fieldExpr : fieldExpr.cast(realType)));
+            setter.body()
+                    .assign(instanceName.cast(clazzType)
+                            .field(fieldName),
+                            (publicType.equals(realType) ? fieldExpr : fieldExpr.cast(realType)));
         }
 
         // we need to generate an accessor if the class isn't public
         if (!isEnclosingClassPublic) {
             for (ExecutableElement ctor : constructorsIn(clazz.getEnclosedElements())) {
-                if (ctor.getModifiers().contains(Modifier.PRIVATE)) {
+                if (ctor.getModifiers()
+                        .contains(Modifier.PRIVATE)) {
                     // skip it
                     continue;
                 }
@@ -771,7 +852,9 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 StringBuilder b = new StringBuilder();
                 for (VariableElement parameter : ctor.getParameters()) {
                     b.append('_');
-                    b.append(parameter.asType().toString().replace('.', '_'));
+                    b.append(parameter.asType()
+                            .toString()
+                            .replace('.', '_'));
                 }
                 String codedName = b.toString();
                 final JMethodDef ctorMethod = classDef.method(JMod.PUBLIC | JMod.STATIC, JType.OBJECT, "construct" + codedName);
@@ -780,12 +863,14 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                     final TypeMirror paramType = parameter.asType();
                     final JType realType = JTypes.typeOf(paramType);
                     final JType publicType = paramType instanceof PrimitiveType ? realType : JType.OBJECT;
-                    final String name = parameter.getSimpleName().toString();
+                    final String name = parameter.getSimpleName()
+                            .toString();
                     ctorMethod.param(publicType, name);
                     final JAssignableExpr nameExpr = JExprs.name(name);
                     ctorCall.arg(publicType.equals(realType) ? nameExpr : nameExpr.cast(realType));
                 }
-                ctorMethod.body()._return(ctorCall);
+                ctorMethod.body()
+                        ._return(ctorCall);
             }
         }
 
@@ -794,7 +879,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
             try {
                 sources.writeSources();
             } catch (IOException e) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to generate source file: " + e, clazz);
+                processingEnv.getMessager()
+                        .printMessage(Diagnostic.Kind.ERROR, "Failed to generate source file: " + e, clazz);
             }
         }
     }
@@ -802,7 +888,8 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     private JType unnestStaticNestedType(DeclaredType declaredType) {
         final TypeElement typeElement = (TypeElement) declaredType.asElement();
 
-        final String name = typeElement.getQualifiedName().toString();
+        final String name = typeElement.getQualifiedName()
+                .toString();
         final JType rawType = JTypes.typeNamed(name);
         final List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
         if (typeArguments.isEmpty()) {
@@ -819,18 +906,25 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     private void appendParamTypes(ExecutableElement ex, final StringBuilder buf) {
         final List<? extends VariableElement> params = ex.getParameters();
         if (params.isEmpty()) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Expected at least one parameter", ex);
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.ERROR, "Expected at least one parameter", ex);
             return;
         }
         VariableElement param = params.get(0);
         DeclaredType dt = (DeclaredType) param.asType();
-        String typeName = processingEnv.getElementUtils().getBinaryName(((TypeElement) dt.asElement())).toString();
-        buf.append('(').append(typeName);
+        String typeName = processingEnv.getElementUtils()
+                .getBinaryName(((TypeElement) dt.asElement()))
+                .toString();
+        buf.append('(')
+                .append(typeName);
         for (int i = 1; i < params.size(); ++i) {
             param = params.get(i);
             dt = (DeclaredType) param.asType();
-            typeName = processingEnv.getElementUtils().getBinaryName(((TypeElement) dt.asElement())).toString();
-            buf.append(',').append(typeName);
+            typeName = processingEnv.getElementUtils()
+                    .getBinaryName(((TypeElement) dt.asElement()))
+                    .toString();
+            buf.append(',')
+                    .append(typeName);
         }
         buf.append(')');
     }
@@ -839,15 +933,17 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         String javaDoc = getJavadoc(e);
 
         if (javaDoc == null) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                    "Unable to find javadoc for config item " + e.getEnclosingElement() + " " + e, e);
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.ERROR,
+                            "Unable to find javadoc for config item " + e.getEnclosingElement() + " " + e, e);
             return "";
         }
         return javaDoc;
     }
 
     private String getJavadoc(Element e) {
-        String docComment = processingEnv.getElementUtils().getDocComment(e);
+        String docComment = processingEnv.getElementUtils()
+                .getDocComment(e);
 
         if (docComment == null) {
             return null;
@@ -855,14 +951,18 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
         // javax.lang.model keeps the leading space after the "*" so we need to remove it.
 
-        return REMOVE_LEADING_SPACE.matcher(docComment).replaceAll("").trim();
+        return REMOVE_LEADING_SPACE.matcher(docComment)
+                .replaceAll("")
+                .trim();
     }
 
     private static boolean isDocumentedConfigItem(Element element) {
         boolean hasAnnotation = false;
         for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
-            String annotationName = ((TypeElement) annotationMirror.getAnnotationType().asElement())
-                    .getQualifiedName().toString();
+            String annotationName = ((TypeElement) annotationMirror.getAnnotationType()
+                    .asElement())
+                    .getQualifiedName()
+                    .toString();
             if (Constants.ANNOTATION_CONFIG_ITEM.equals(annotationName)) {
                 hasAnnotation = true;
                 Object generateDocumentation = getAnnotationAttribute(annotationMirror, "generateDocumentation()");
@@ -879,8 +979,10 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
     private static boolean isConfigMappingMethodIgnored(Element element) {
         for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
-            String annotationName = ((TypeElement) annotationMirror.getAnnotationType().asElement())
-                    .getQualifiedName().toString();
+            String annotationName = ((TypeElement) annotationMirror.getAnnotationType()
+                    .asElement())
+                    .getQualifiedName()
+                    .toString();
             if (Constants.ANNOTATION_CONFIG_DOC_IGNORE.equals(annotationName)) {
                 return true;
             }
@@ -890,9 +992,12 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
     private static Object getAnnotationAttribute(AnnotationMirror annotationMirror, String attributeName) {
         for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror
-                .getElementValues().entrySet()) {
-            final String key = entry.getKey().toString();
-            final Object value = entry.getValue().getValue();
+                .getElementValues()
+                .entrySet()) {
+            final String key = entry.getKey()
+                    .toString();
+            final Object value = entry.getValue()
+                    .getValue();
             if (attributeName.equals(key)) {
                 return value;
             }
@@ -913,7 +1018,9 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     private static boolean isAnnotationPresent(Element element, String... annotationNames) {
         Set<String> annotations = new HashSet<>(Arrays.asList(annotationNames));
         for (AnnotationMirror i : element.getAnnotationMirrors()) {
-            String annotationName = ((TypeElement) i.getAnnotationType().asElement()).getQualifiedName().toString();
+            String annotationName = ((TypeElement) i.getAnnotationType()
+                    .asElement()).getQualifiedName()
+                    .toString();
             if (annotations.contains(annotationName)) {
                 return true;
             }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -183,7 +183,7 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         Properties javaDocProperties = new Properties();
 
         try {
-            Files.walkFileTree(path, new FileVisitor<Path>() {
+            Files.walkFileTree(path, new FileVisitor<>() {
                 public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) {
                     return FileVisitResult.CONTINUE;
                 }
@@ -282,8 +282,6 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         } catch (IOException e) {
             processingEnv.getMessager()
                     .printMessage(Diagnostic.Kind.ERROR, "Failed to generate extension doc: " + e);
-            return;
-
         }
     }
 
@@ -368,8 +366,7 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                                     StandardLocation.SOURCE_OUTPUT,
                                     pkg.getQualifiedName()
                                             .toString(),
-                                    rbn.toString() + ".bsc",
-                                    clazz);
+                                    rbn + ".bsc", clazz);
                     writeResourceFile(binaryName, itemResource);
                 } catch (IOException e1) {
                     processingEnv.getMessager()
@@ -618,7 +615,7 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
             if (method.getSimpleName()
                     .contentEquals("toString")
                     && method.getParameters()
-                            .size() == 0) {
+                            .isEmpty()) {
                 return;
             }
 
@@ -650,7 +647,7 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         String name = declaredType.asElement()
                 .toString();
         List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
-        if (typeArguments.size() == 0) {
+        if (typeArguments.isEmpty()) {
             if (!name.startsWith("java.")) {
                 return (TypeElement) declaredType.asElement();
             }

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessorTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessorTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.annotation.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.tools.JavaFileObject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.karuslabs.elementary.Results;
+import com.karuslabs.elementary.junit.JavacExtension;
+import com.karuslabs.elementary.junit.annotations.Classpath;
+import com.karuslabs.elementary.junit.annotations.Processors;
+
+import io.quarkus.annotation.processor.fs.CustomMemoryFileSystemProvider;
+
+@ExtendWith(JavacExtension.class)
+@Processors({ ExtensionAnnotationProcessor.class })
+class ExtensionAnnotationProcessorTest {
+
+    @BeforeEach
+    void beforeEach() {
+        // This is of limited use, since the filesystem doesn't seem to directly generate files, in the current usage
+        CustomMemoryFileSystemProvider.reset();
+    }
+
+    @Test
+    @Classpath("org.acme.examples.ClassWithBuildStep")
+    void shouldProcessClassWithBuildStepWithoutErrors(Results results) throws IOException {
+        assertNoErrrors(results);
+    }
+
+    @Test
+    @Classpath("org.acme.examples.ClassWithBuildStep")
+    void shouldGenerateABscFile(Results results) throws IOException {
+        assertNoErrrors(results);
+        List<JavaFileObject> sources = results.sources;
+        JavaFileObject bscFile = sources.stream()
+                .filter(source -> source.getName()
+                        .endsWith(".bsc"))
+                .findAny()
+                .orElse(null);
+        assertNotNull(bscFile);
+
+        String contents = removeLineBreaks(new String(bscFile
+                .openInputStream()
+                .readAllBytes(), StandardCharsets.UTF_8));
+        assertEquals("org.acme.examples.ClassWithBuildStep", contents);
+    }
+
+    private String removeLineBreaks(String s) {
+        return s.replace(System.getProperty("line.separator"), "")
+                .replace("\n", "");
+    }
+
+    @Test
+    @Classpath("org.acme.examples.ClassWithoutBuildStep")
+    void shouldProcessEmptyClassWithoutErrors(Results results) {
+        assertNoErrrors(results);
+    }
+
+    private static void assertNoErrrors(Results results) {
+        assertEquals(0, results.find()
+                .errors()
+                .count(),
+                "Errors were: " + results.find()
+                        .errors()
+                        .diagnostics());
+    }
+}

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/fs/CustomMemoryFileSystem.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/fs/CustomMemoryFileSystem.java
@@ -1,0 +1,158 @@
+package io.quarkus.annotation.processor.fs;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class CustomMemoryFileSystem extends FileSystem {
+
+    private final Map<URI, ByteBuffer> fileContents = new HashMap<>();
+    private final CustomMemoryFileSystemProvider provider;
+
+    public CustomMemoryFileSystem(CustomMemoryFileSystemProvider provider) {
+        this.provider = provider;
+    }
+
+    @Override
+    public FileSystemProvider provider() {
+        return provider;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // No resources to close
+    }
+
+    @Override
+    public boolean isOpen() {
+        return true; // Always open
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false; // This filesystem is writable
+    }
+
+    @Override
+    public String getSeparator() {
+        return "/"; // Unix-style separator
+    }
+
+    @Override
+    public Iterable<Path> getRootDirectories() {
+        return Collections.singleton(Paths.get("/")); // Single root directory
+    }
+
+    @Override
+    public Iterable<FileStore> getFileStores() {
+        return Collections.emptyList(); // No file stores
+    }
+
+    @Override
+    public Set<String> supportedFileAttributeViews() {
+        return Collections.emptySet(); // No supported file attribute views
+    }
+
+    @Override
+    public Path getPath(String first, String... more) {
+        String path = first;
+        for (String segment : more) {
+            path += "/" + segment;
+        }
+        return Paths.get(path);
+    }
+
+    @Override
+    public PathMatcher getPathMatcher(String syntaxAndPattern) {
+        return null;
+    }
+
+    @Override
+    public UserPrincipalLookupService getUserPrincipalLookupService() {
+        return null;
+    }
+
+    @Override
+    public WatchService newWatchService() throws IOException {
+        return null;
+    }
+
+    public void addFile(URI uri, byte[] content) {
+        fileContents.put(uri, ByteBuffer.wrap(content));
+    }
+
+    static class CustomMemorySeekableByteChannel implements SeekableByteChannel {
+
+        private final ByteBuffer buffer;
+
+        CustomMemorySeekableByteChannel(ByteBuffer buffer) {
+            this.buffer = buffer;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            int remaining = buffer.remaining();
+            int count = Math.min(remaining, dst.remaining());
+            if (count > 0) {
+                ByteBuffer slice = buffer.slice();
+                slice.limit(count);
+                dst.put(slice);
+                buffer.position(buffer.position() + count);
+            }
+            return count;
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            int count = src.remaining();
+            buffer.put(src);
+            return count;
+        }
+
+        @Override
+        public long position() throws IOException {
+            return buffer.position();
+        }
+
+        @Override
+        public SeekableByteChannel position(long newPosition) throws IOException {
+            buffer.position((int) newPosition);
+            return this;
+        }
+
+        @Override
+        public long size() throws IOException {
+            return buffer.limit();
+        }
+
+        @Override
+        public SeekableByteChannel truncate(long size) throws IOException {
+            buffer.limit((int) size);
+            return this;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return true; // Always open
+        }
+
+        @Override
+        public void close() throws IOException {
+            // No resources to close
+        }
+    }
+
+}

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/fs/CustomMemoryFileSystemProvider.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/fs/CustomMemoryFileSystemProvider.java
@@ -1,0 +1,152 @@
+package io.quarkus.annotation.processor.fs;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class CustomMemoryFileSystemProvider extends FileSystemProvider {
+
+    private static final String MEM = "mem";
+
+    private static Map<URI, ByteBuffer> fileContents = new HashMap();
+
+    public static void reset() {
+        fileContents = new HashMap();
+    }
+
+    public static Set<URI> getCreatedFiles() {
+        return fileContents.keySet();
+    }
+
+    @Override
+    public String getScheme() {
+        return MEM;
+    }
+
+    @Override
+    public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
+        // There's a bit of a disconnect here between the Elementary JavaFileManager and the memory filesystem,
+        // even though both are in-memory filesystems
+        return new CustomMemoryFileSystem(this);
+    }
+
+    @Override
+    public FileSystem getFileSystem(URI uri) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Path getPath(URI uri) {
+
+        if (uri.getScheme() == null || !uri.getScheme()
+                .equalsIgnoreCase(MEM)) {
+            throw new IllegalArgumentException("For URI " + uri + ", URI scheme is not '" + MEM + "'");
+
+        }
+
+        // TODO what should we do here? Can we use the java file manager used by Elementary?
+        try {
+            return Path.of(File.createTempFile("mem-fs", "adhoc")
+                    .toURI());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs)
+            throws IOException {
+        if (fileContents.containsKey(path.toUri())) {
+            ByteBuffer buffer = fileContents.get(path.toUri());
+            return new CustomMemoryFileSystem.CustomMemorySeekableByteChannel(buffer);
+        } else {
+            throw new NoSuchFileException(path.toString());
+        }
+    }
+
+    @Override
+    public DirectoryStream<Path> newDirectoryStream(Path dir, DirectoryStream.Filter<? super Path> filter) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createDirectory(Path dir, FileAttribute<?>... attrs) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void delete(Path path) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void copy(Path source, Path target, CopyOption... options) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void move(Path source, Path target, CopyOption... options) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSameFile(Path path1, Path path2) throws IOException {
+        return path1.equals(path2);
+    }
+
+    @Override
+    public boolean isHidden(Path path) throws IOException {
+        return false;
+    }
+
+    @Override
+    public FileStore getFileStore(Path path) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void checkAccess(Path path, AccessMode... modes) throws IOException {
+        if (!fileContents.containsKey(path.toUri())) {
+            throw new NoSuchFileException(path.toString());
+        }
+    }
+
+    @Override
+    public <V extends java.nio.file.attribute.FileAttributeView> V getFileAttributeView(Path path, Class<V> type,
+            LinkOption... options) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options)
+            throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAttribute(Path path, String attribute, Object value, LinkOption... options) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/processor/src/test/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
+++ b/core/processor/src/test/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,1 @@
+io.quarkus.annotation.processor.fs.CustomMemoryFileSystemProvider

--- a/core/processor/src/test/resources/io/quarkus/deployment/annotations/BuildStep.java
+++ b/core/processor/src/test/resources/io/quarkus/deployment/annotations/BuildStep.java
@@ -1,0 +1,13 @@
+package io.quarkus.deployment.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface BuildStep {
+    // FAKE! FAKE! This is only here so we can test without introducing a circular dependency
+
+}

--- a/core/processor/src/test/resources/org/acme/examples/ArbitraryBuildItem.java
+++ b/core/processor/src/test/resources/org/acme/examples/ArbitraryBuildItem.java
@@ -1,0 +1,6 @@
+package org.acme.examples;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class ArbitraryBuildItem extends MultiBuildItem {
+}

--- a/core/processor/src/test/resources/org/acme/examples/ClassWithBuildStep.java
+++ b/core/processor/src/test/resources/org/acme/examples/ClassWithBuildStep.java
@@ -1,0 +1,10 @@
+package org.acme.examples;
+
+import io.quarkus.deployment.annotations.BuildStep;
+
+public class ClassWithBuildStep {
+    @BuildStep
+    ArbitraryBuildItem feature() {
+        return new ArbitraryBuildItem();
+    }
+}

--- a/core/processor/src/test/resources/org/acme/examples/ClassWithoutBuildStep.java
+++ b/core/processor/src/test/resources/org/acme/examples/ClassWithoutBuildStep.java
@@ -1,0 +1,6 @@
+package org.acme.examples;
+
+public class ClassWithoutBuildStep {
+
+
+}


### PR DESCRIPTION
I've started working on the build-time support for https://github.com/quarkusio/extensions/issues/983. The annotation processor is the logical place to generate the metadata about dev services. When I started coding, I realised there was no unit test for me to hang my work on. And then I realised that this is because testing annotation processors is hard. 

After reviewing https://stackoverflow.com/questions/1811967/how-to-write-automated-unit-tests-for-java-annotation-processor and https://mccue.dev/pages/3-18-21-the-problem-with-annotation-processors, I decided to attempt some tests using [Elementary](https://github.com/Pante/elementary).  

My goal wasn't really to add a whole regression suite for the annotation processor, so my tests are just a skeleton, but hopefully the infrastructure be useful for my next piece of work, and also to others. 

Annoyingly, almost all the volume of this change is filesystem boilerplate that I had to put in to avoid a `java.nio.file.FileSystemNotFoundException: Provider "mem" not installed` error when we try and read create a URI in the Elementary environment. I've raised https://github.com/Pante/elementary/issues/315. 

*Notes:*

- For reasons I don't understand, editing the file generated a big formatting diff. I thought that's why we had maven formatting enforced, but the 'after' formatting is definitely different from the 'before'. I've separated the formatting out into its own diff to make review easier. 
- I applied a few little linting suggestions. I think all are safe, and one (removing the .toString()) makes the code slightly safer by removing the risk of NPE on that line.
- My pom changes introduced a circular dependency, and IDEA was upset by it and refused to compile. The internet says it's supposed to tolerate circular dependencies, so I don't know if it was just my local IDEA being grumpy (fine), or if I did something that will be annoying to everybody (v bad) -> **edit** OK, the CI was also upset by the circular dependency. So I've removed it by duplicating an annotation into the test codebase.