### PR TITLE
Use OAuth2 access token expiry time to set an internal ID token age

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1102,8 +1102,12 @@ To support the integration with such OAuth2 servers, `quarkus-oidc` needs to be 
 [NOTE]
 ====
 Even though you configure the extension to support the authorization code flows without `IdToken`, an internal `IdToken` is generated to standardize the way `quarkus-oidc` operates.
-You use an `IdToken` to support the authentication session and to avoid redirecting the user to the provider,  such as GitHub, on every request.
-In this case, the session lifespan is set to 5 minutes, which you can extend further as described in the <<session-management,session management>> section.
+You use an internal `IdToken` to support the authentication session and to avoid redirecting the user to the provider,  such as GitHub, on every request.
+In this case, the `IdToken` age is set to the value of a standard `expires_in` property in the authorization code flow response.
+You can use a `quarkus.oidc.authentication.internal-id-token-lifespan`property to customize the ID token age.
+The default ID token age is 5 minutes.
+
+, which you can extend further as described in the <<session-management,session management>> section.
 
 This simplifies how you handle an application that supports multiple OIDC providers.
 ====

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthorizationCodeTokens.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthorizationCodeTokens.java
@@ -8,37 +8,94 @@ public class AuthorizationCodeTokens {
     private String idToken;
     private String accessToken;
     private String refreshToken;
+    private Long accessTokenExpiresIn;
 
     public AuthorizationCodeTokens() {
     }
 
     public AuthorizationCodeTokens(String idToken, String accessToken, String refreshToken) {
-        this.setIdToken(idToken);
-        this.setAccessToken(accessToken);
-        this.setRefreshToken(refreshToken);
+        this(idToken, accessToken, refreshToken, null);
     }
 
+    public AuthorizationCodeTokens(String idToken, String accessToken, String refreshToken, Long accessTokenExpiresIn) {
+        this.idToken = idToken;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
+    }
+
+    /**
+     * Get the ID token
+     *
+     * @return ID token
+     */
     public String getIdToken() {
         return idToken;
     }
 
+    /**
+     * Set the ID token
+     *
+     * @param idToken ID token
+     */
     public void setIdToken(String idToken) {
         this.idToken = idToken;
     }
 
+    /**
+     * Get the access token
+     *
+     * @return the access token
+     */
     public String getAccessToken() {
         return accessToken;
     }
 
+    /**
+     * Set the access token
+     *
+     * @param accessToken the access token
+     */
     public void setAccessToken(String accessToken) {
         this.accessToken = accessToken;
     }
 
+    /**
+     * Get the refresh token
+     *
+     * @return refresh token
+     */
     public String getRefreshToken() {
         return refreshToken;
     }
 
+    /**
+     * Set the refresh token
+     *
+     * @param refreshToken refresh token
+     */
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    /**
+     * Get the access token expires_in value in seconds.
+     * It is relative to the time the access token is issued at.
+     *
+     * @return access token expires_in value in seconds.
+     */
+    public Long getAccessTokenExpiresIn() {
+        return accessTokenExpiresIn;
+    }
+
+    /**
+     * Set the access token expires_in value in seconds.
+     * It is relative to the time the access token is issued at.
+     * This property is only checked when an authorization code flow grant completes and does not have to be persisted..
+     *
+     * @param accessTokenExpiresIn access token expires_in value in seconds.
+     */
+    public void setAccessTokenExpiresIn(Long accessTokenExpiresIn) {
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -211,7 +211,14 @@ public class OidcProviderClient implements Closeable {
         final String idToken = json.getString(OidcConstants.ID_TOKEN_VALUE);
         final String accessToken = json.getString(OidcConstants.ACCESS_TOKEN_VALUE);
         final String refreshToken = json.getString(OidcConstants.REFRESH_TOKEN_VALUE);
-        return new AuthorizationCodeTokens(idToken, accessToken, refreshToken);
+        Long tokenExpiresIn = null;
+        Object tokenExpiresInObj = json.getValue(OidcConstants.EXPIRES_IN);
+        if (tokenExpiresInObj != null) {
+            tokenExpiresIn = tokenExpiresInObj instanceof Number ? ((Number) tokenExpiresInObj).longValue()
+                    : Long.parseLong(tokenExpiresInObj.toString());
+        }
+
+        return new AuthorizationCodeTokens(idToken, accessToken, refreshToken, tokenExpiresIn);
     }
 
     private UserInfo getUserInfo(HttpResponse<Buffer> resp) {


### PR DESCRIPTION
Fixes #39556.

This PR is a follow up to #39967 to make a user experience better when OAuth2 only is used.

So, with OIDC, we have ID token which represents a user authentication and its lifespan is used to determine how long the Quarkus user session will last. OIC also gives the access token (and possibly refresh token). Here, the ID token controls the session, while Quarkus can use the access token to access something downstream on behalf of the currently authenticated user, and it can do so until the user session, i.e, ID token, has expired, when it might or might not be refreshed which is out of scope for this PR.

With OAuth2, we only get an access token (an possibly a refresh token). To represent a session and a common code path for both OIDC and OAuth2, Quarkus creates a so called internal ID token, simply to have a session representation.
For some reasons (likely because I was not sure how long this session can last), initially I set it by default to 5 mins, which means, every 5 mins the user is redirected - which can't really work in any prod. 
And I added a property `quarkus.oidc.authentication.internal-id-token-lifespan` to set to whatever users prefer, instead of 5 mins, 5 hours or 1 day, etc.
However setting this property is required anyway for any decent experience, and several colleagues pinged me and had to point to this property.
But, while it is useful to have an option for users set a specific session time, it should not be required to be set. The reason for that is that an OAuth2 authorization code flow response returns a standard `expires_in` property for the access token.
And since this access token is meant to do something for authenticated user, it makes total sense to control this user's session lifespan, i.e, the internal ID token and this access token will expire more or less at the same time.

in fact, with OIDC, it is quite often the case, users set ID token and access token duration be the same, with the refresh token living longer, for it to refresh the expired ID/access tokens.

Added the test confirming that the access token expiry is now used by default for the internal ID token. We also have a few tests where `quarkus.oidc.authentication.internal-id-token-lifespan` is used instead.


CC @Sanne, I also updated Pedro on these updates. 