### PR TITLE
Allow not JAX-RS parameters within resource methods

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -183,6 +183,7 @@ import io.quarkus.resteasy.reactive.server.runtime.security.EagerSecurityContext
 import io.quarkus.resteasy.reactive.server.runtime.security.EagerSecurityHandler;
 import io.quarkus.resteasy.reactive.server.runtime.security.EagerSecurityInterceptorHandler;
 import io.quarkus.resteasy.reactive.server.runtime.security.SecurityContextOverrideHandler;
+import io.quarkus.resteasy.reactive.server.spi.AllowNotRestParametersBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.AnnotationsTransformerBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.ContextTypeBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.HandlerConfigurationProviderBuildItem;
@@ -413,8 +414,8 @@ public class ResteasyReactiveProcessor {
             List<ContextTypeBuildItem> contextTypeBuildItems,
             CompiledJavaVersionBuildItem compiledJavaVersionBuildItem,
             ResourceInterceptorsBuildItem resourceInterceptorsBuildItem,
-            Capabilities capabilities)
-            throws NoSuchMethodException {
+            Capabilities capabilities,
+            Optional<AllowNotRestParametersBuildItem> allowNotRestParametersBuildItem) {
 
         if (!resourceScanningResultBuildItem.isPresent()) {
             // no detected @Path, bail out
@@ -633,6 +634,8 @@ public class ResteasyReactiveProcessor {
                             return recorder.disableIfPropertyMatches(propertyName, propertyValue, disableIfMissing);
                         }
                     });
+
+            serverEndpointIndexerBuilder.skipNotRestParameters(allowNotRestParametersBuildItem.isPresent());
 
             if (!serverDefaultProducesHandlers.isEmpty()) {
                 List<DefaultProducesHandler> handlers = new ArrayList<>(serverDefaultProducesHandlers.size());

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/AllowNotResteasyParametersTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/AllowNotResteasyParametersTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.resteasy.reactive.server.spi.AllowNotRestParametersBuildItem;
+import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.MixedParameterResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * @tpSubChapter Resources
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Test resources with not all method parameters related to RESTEasy.
+ */
+@DisplayName("Allow Not RESTEasy Method Parameters")
+public class AllowNotResteasyParametersTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest quarkusUnitTest = new QuarkusUnitTest()
+            .addBuildChainCustomizer(new Consumer<BuildChainBuilder>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            context.produce(new AllowNotRestParametersBuildItem());
+                        }
+                    }).produces(AllowNotRestParametersBuildItem.class).build();
+                }
+            })
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MixedParameterResource.class));
+
+    @Test
+    @DisplayName("Test Resource Method with one param not related to RESTEasy")
+    public void shouldOkEvenNotResteasyParameterPresence() {
+        given()
+                .body("value")
+                .post("/" + MixedParameterResource.class.getSimpleName() + "/mixed?foo=bar")
+                .then().statusCode(200).body(is("bar.value"));
+    }
+
+    @Test
+    @DisplayName("Test Resource Method with only one param not related to RESTEasy")
+    public void shouldOkEvenNotResteasySingleParameterPresence() {
+        given()
+                .body("value")
+                .get("/" + MixedParameterResource.class.getSimpleName() + "/single")
+                .then().statusCode(200);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/MixedParameterResource.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/MixedParameterResource.java
@@ -1,0 +1,44 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic.resource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+@Path("/MixedParameterResource")
+public class MixedParameterResource {
+
+    @POST
+    @Path("/mixed")
+    public String mixedParam(@OtherAnnotation MyOtherObject otherObject, @QueryParam("foo") String query, String body) {
+        return query.concat(".").concat(body);
+    }
+
+    @GET
+    @Path("/single")
+    public String singleParam(@OtherAnnotation MyOtherObject otherObject) {
+        return "ok";
+    }
+
+    public static class MyOtherObject {
+        String param;
+
+        public String getParam() {
+            return param;
+        }
+
+        public void setParam(String param) {
+            this.param = param;
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.FIELD, ElementType.PARAMETER })
+    public @interface OtherAnnotation {
+    }
+}

--- a/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/AllowNotRestParametersBuildItem.java
+++ b/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/AllowNotRestParametersBuildItem.java
@@ -1,0 +1,11 @@
+package io.quarkus.resteasy.reactive.server.spi;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * A build item which extensions can generate when they want to allow RESTEasy Reactive methods
+ * with parameters that are annotated with not REST annotations. This allows RESTEasy Reactive to let mixed parameters coexist
+ * within resource methods signature
+ */
+public final class AllowNotRestParametersBuildItem extends SimpleBuildItem {
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -25,6 +25,7 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.HTTP_HEADERS;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.INSTANT;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.INTEGER;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.JAX_RS_ANNOTATIONS_FOR_FIELDS;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.LIST;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.LOCAL_DATE;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.LOCAL_DATE_TIME;
@@ -237,6 +238,8 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
     private final Function<ClassInfo, Supplier<Boolean>> isDisabledCreator;
 
     private final Predicate<Map<DotName, AnnotationInstance>> skipMethodParameter;
+    private final boolean skipNotRestParameters;
+
     private SerializerScanningResult serializerScanningResult;
 
     protected EndpointIndexer(Builder<T, ?, METHOD> builder) {
@@ -262,6 +265,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         this.targetJavaVersion = builder.targetJavaVersion;
         this.isDisabledCreator = builder.isDisabledCreator;
         this.skipMethodParameter = builder.skipMethodParameter;
+        this.skipNotRestParameters = builder.skipNotRestParameters;
     }
 
     public Optional<ResourceClass> createEndpoints(ClassInfo classInfo, boolean considerApplication) {
@@ -576,7 +580,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                 Type paramType = currentMethodInfo.parameterType(i);
                 String errorLocation = "method " + currentMethodInfo + " on class " + currentMethodInfo.declaringClass();
 
-                if (skipParameter(anns)) {
+                if (skipParameter(anns) || skipNotRestParameters(skipNotRestParameters).apply(anns)) {
                     parameterResult = createIndexedParam()
                             .setCurrentClassInfo(currentClassInfo)
                             .setActualEndpointInfo(actualEndpointInfo)
@@ -780,6 +784,19 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
     protected void warnAboutMissUsedBodyParameter(DotName httpMethod, MethodInfo methodInfo) {
         log.warn("Using a body parameter with " + httpMethod + " is strongly discouraged. Offending method is '"
                 + methodInfo.declaringClass().name() + "#" + methodInfo + "'");
+    }
+
+    private Function<Map<DotName, AnnotationInstance>, Boolean> skipNotRestParameters(boolean skipAllNotMethodParameter) {
+        return new Function<Map<DotName, AnnotationInstance>, Boolean>() {
+            @Override
+            public Boolean apply(Map<DotName, AnnotationInstance> anns) {
+                if (skipAllNotMethodParameter) {
+                    return anns.size() > 0
+                            && JAX_RS_ANNOTATIONS_FOR_FIELDS.stream().noneMatch(dotName -> anns.containsKey(dotName));
+                }
+                return false;
+            }
+        };
     }
 
     protected boolean skipParameter(Map<DotName, AnnotationInstance> anns) {
@@ -1679,6 +1696,8 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
 
         private Predicate<Map<DotName, AnnotationInstance>> skipMethodParameter = null;
 
+        private boolean skipNotRestParameters = false;
+
         public B setMultipartReturnTypeIndexerExtension(MultipartReturnTypeIndexerExtension multipartReturnTypeHandler) {
             this.multipartReturnTypeIndexerExtension = multipartReturnTypeHandler;
             return (B) this;
@@ -1798,6 +1817,11 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         public B setSkipMethodParameter(
                 Predicate<Map<DotName, AnnotationInstance>> skipMethodParameter) {
             this.skipMethodParameter = skipMethodParameter;
+            return (B) this;
+        }
+
+        public B skipNotRestParameters(boolean skipNotRestParameters) {
+            this.skipNotRestParameters = skipNotRestParameters;
             return (B) this;
         }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -353,6 +353,8 @@ public class RuntimeResourceDeployment {
         addHandlers(handlers, clazz, method, info, HandlerChainCustomizer.Phase.RESOLVE_METHOD_PARAMETERS);
         for (int i = 0; i < parameters.length; i++) {
             ServerMethodParameter param = (ServerMethodParameter) parameters[i];
+            if (param.parameterType.equals(ParameterType.SKIPPED))
+                continue;
             ParameterExtractor extractor = parameterExtractor(pathParameterIndexes, locatableResource, param);
             ParameterConverter converter = null;
             ParamConverterProviders paramConverterProviders = info.getParamConverterProviders();


### PR DESCRIPTION
This allows to ignore params that are not related to JAX-RS fields, marking them as SKIPPED in order to use different annotated params with respect JAX-RS api in same method. This feature can be used by extension that generate a dedicate build item to init skipping feature