### PR TITLE
Qute: do not register TemplateInstance as non-blocking type by default

### DIFF
--- a/extensions/resteasy-reactive/rest-qute/deployment/src/main/java/io/quarkus/resteasy/reactive/qute/deployment/RestQuteConfig.java
+++ b/extensions/resteasy-reactive/rest-qute/deployment/src/main/java/io/quarkus/resteasy/reactive/qute/deployment/RestQuteConfig.java
@@ -1,0 +1,22 @@
+package io.quarkus.resteasy.reactive.qute.deployment;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.rest.qute")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface RestQuteConfig {
+
+    /**
+     * If set to {@code true} then the {@link io.quarkus.qute.TemplateInstance} is registered as a non-blocking return type for
+     * JAX-RS resource methods.
+     *
+     * @deprecated This config item will be removed at some time after Quarkus 3.16
+     */
+    @Deprecated(forRemoval = true, since = "3.10")
+    @WithDefault("false")
+    boolean templateInstanceNonBlockingType();
+
+}

--- a/extensions/resteasy-reactive/rest-qute/deployment/src/main/java/io/quarkus/resteasy/reactive/qute/deployment/ResteasyReactiveQuteProcessor.java
+++ b/extensions/resteasy-reactive/rest-qute/deployment/src/main/java/io/quarkus/resteasy/reactive/qute/deployment/ResteasyReactiveQuteProcessor.java
@@ -18,6 +18,7 @@ import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
 import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
 
 import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
@@ -49,8 +50,10 @@ public class ResteasyReactiveQuteProcessor {
     }
 
     @BuildStep
-    NonBlockingReturnTypeBuildItem nonBlockingTemplateInstance() {
-        return new NonBlockingReturnTypeBuildItem(TEMPLATE_INSTANCE);
+    void nonBlockingTemplateInstance(RestQuteConfig config, BuildProducer<NonBlockingReturnTypeBuildItem> nonBlockingType) {
+        if (config.templateInstanceNonBlockingType()) {
+            nonBlockingType.produce(new NonBlockingReturnTypeBuildItem(TEMPLATE_INSTANCE));
+        }
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/TemplateInstanceNonBlockingEnabledTest.java
+++ b/extensions/resteasy-reactive/rest-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/TemplateInstanceNonBlockingEnabledTest.java
@@ -18,17 +18,19 @@ import io.quarkus.qute.TemplateInstance;
 import io.quarkus.runtime.BlockingOperationControl;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class TemplateInstanceNonBlockingTest {
+public class TemplateInstanceNonBlockingEnabledTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(TestResource.class)
+                    .addAsResource(new StringAsset("quarkus.rest.qute.template-instance-non-blocking-type=true"),
+                            "application.properties")
                     .addAsResource(new StringAsset("Blocking allowed: {blockingAllowed}"), "templates/item.txt"));
 
     @Test
     public void test() {
-        when().get("/test").then().statusCode(200).body(Matchers.is("Blocking allowed: true"));
+        when().get("/test").then().statusCode(200).body(Matchers.is("Blocking allowed: false"));
     }
 
     @Path("test")

--- a/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/NonBlockingReturnTypeBuildItem.java
+++ b/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/NonBlockingReturnTypeBuildItem.java
@@ -6,7 +6,10 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * Register a type as non-blocking by default when used as a return type of JAX-RS Resource
+ *
+ * @deprecated This build item will be removed at some time after Quarkus 3.16
  */
+@Deprecated(forRemoval = true, since = "3.10")
 public final class NonBlockingReturnTypeBuildItem extends MultiBuildItem {
 
     private final DotName type;


### PR DESCRIPTION
- make it possible to enable the old behavior (for backrward compatibility)
- deprecate NonBlockingReturnTypeBuildItem
- related to #39971