### PR TITLE
Bump kubernetes-client-bom from 6.11.0 to 6.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
         <!-- Dependency versions -->
         <jacoco.version>0.8.12</jacoco.version>
-        <kubernetes-client.version>6.11.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.12.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.4.0</rest-assured.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
         <!-- Dependency versions -->
         <jacoco.version>0.8.12</jacoco.version>
-        <kubernetes-client.version>6.12.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.12.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.4.0</rest-assured.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->


### PR DESCRIPTION
Kubernetes Client 6.12.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.12.0
Kubernetes Client 6.12.1 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.12.1

/cc @metacosm