### PR TITLE
Fix collapsing in config reference

### DIFF
--- a/docs/src/main/asciidoc/javascript/config.js
+++ b/docs/src/main/asciidoc/javascript/config.js
@@ -270,13 +270,15 @@ function makeCollapsibleHandler(descDiv, td, row,
         if( isCollapsed ) {
             collapsibleSpan.childNodes.item(0).nodeValue = 'Show less';
             iconDecoration.classList.replace('fa-chevron-down', 'fa-chevron-up');
+            descDiv.classList.remove('description-collapsed');
+            descDiv.classList.add('description-expanded');
         }
         else {
             collapsibleSpan.childNodes.item(0).nodeValue = 'Show more';
             iconDecoration.classList.replace('fa-chevron-up', 'fa-chevron-down');
+            descDiv.classList.add('description-collapsed');
+            descDiv.classList.remove('description-expanded');
         }
-        descDiv.classList.toggle('description-collapsed');
-        descDiv.classList.toggle('description-expanded');
         row.classList.toggle('row-collapsed');
     };
 }


### PR DESCRIPTION
I'm not sure when it got broken but the current toggling is not working very well at least in some browsers.
Using good old add/remove was able to fix it so I didn't dig too much either.

(I already pushed the fix for the doc of the current guides on the website)