### PR TITLE
Validate Tenant annotation is applied before authentication happened and fail if wrong tenant was used to authenticate the HTTP request

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/JakartaRestResourceHttpPermissionTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/JakartaRestResourceHttpPermissionTest.java
@@ -12,10 +12,12 @@ import jakarta.ws.rs.Path;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusUnitTest;
@@ -40,18 +42,23 @@ public class JakartaRestResourceHttpPermissionTest {
             "quarkus.http.auth.permission.root.paths=/\n" +
             "quarkus.http.auth.permission.root.policy=authenticated\n" +
             "quarkus.http.auth.permission.dot.paths=dot,dot/\n" +
-            "quarkus.http.auth.permission.dot.policy=authenticated\n";
+            "quarkus.http.auth.permission.dot.policy=authenticated\n" +
+            "quarkus.http.auth.permission.jax-rs.paths=jax-rs\n" +
+            "quarkus.http.auth.permission.jax-rs.policy=admin-role\n" +
+            "quarkus.http.auth.policy.admin-role.roles-allowed=admin";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(TestIdentityProvider.class, TestIdentityController.class, ApiResource.class,
-                            RootResource.class, PublicResource.class)
+                            RootResource.class, PublicResource.class, JaxRsResource.class)
                     .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
 
     @BeforeAll
     public static void setup() {
-        TestIdentityController.resetRoles().add("test", "test", "test");
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("test", "test", "test");
     }
 
     @TestHTTPResource
@@ -97,11 +104,32 @@ public class JakartaRestResourceHttpPermissionTest {
         assurePathAuthenticated(path, 404);
     }
 
+    @Test
+    public void testJaxRsRolesHttpSecurityPolicy() {
+        // insufficient role, expected admin
+        assurePath("/jax-rs", 401);
+        assurePath("///jax-rs///", 401);
+
+        assurePath("/jax-rs", 200, "admin", true, "admin:admin");
+    }
+
     private static String getLastNonEmptySegmentContent(String path) {
         while (path.endsWith("/") || path.endsWith(".")) {
             path = path.substring(0, path.length() - 1);
         }
         return path.substring(path.lastIndexOf('/') + 1);
+    }
+
+    @Path("jax-rs")
+    public static class JaxRsResource {
+
+        @Inject
+        SecurityIdentity identity;
+
+        @GET
+        public String getPrincipalName() {
+            return identity.getPrincipal().getName();
+        }
     }
 
     @Path("/api")
@@ -201,13 +229,17 @@ public class JakartaRestResourceHttpPermissionTest {
     }
 
     private void assurePath(String path, int expectedStatusCode, String body, boolean auth) {
+        assurePath(path, expectedStatusCode, body, auth, "test:test");
+    }
+
+    private void assurePath(String path, int expectedStatusCode, String body, boolean auth, String credentials) {
         var httpClient = vertx.createHttpClient();
         try {
             httpClient
                     .request(HttpMethod.GET, url.getPort(), url.getHost(), path)
                     .map(r -> {
                         if (auth) {
-                            r.putHeader("Authorization", "Basic " + encodeBase64URLSafeString("test:test".getBytes()));
+                            r.putHeader("Authorization", "Basic " + encodeBase64URLSafeString(credentials.getBytes()));
                         }
                         return r;
                     })

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantEchoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantEchoResource.java
@@ -54,6 +54,19 @@ public class TenantEchoResource {
         return getTenantInternal();
     }
 
+    @Path("/http-security-policy-applies-all-diff")
+    @GET
+    public String httpSecurityPolicyAppliesAllDiff() {
+        throw new IllegalStateException("An exception should have been thrown because authentication happened" +
+                " before Tenant was selected with the @Tenant annotation");
+    }
+
+    @Path("/http-security-policy-applies-all-same")
+    @GET
+    public String httpSecurityPolicyAppliesAllSame() {
+        return getTenantInternal();
+    }
+
     private String getTenantInternal() {
         return OidcUtils.TENANT_ID_ATTRIBUTE + "=" + routingContext.get(OidcUtils.TENANT_ID_ATTRIBUTE)
                 + ", static.tenant.id=" + routingContext.get("static.tenant.id")


### PR DESCRIPTION
- adds validation that `@Tenant` annotation is applied before authentication has begin
- authentication fails if resolved tenant is not the one selected with the `@Tenant` annotation
- adds JAX-RS HTTP Security Policy tests that assures it's always applied