### PR TITLE
Fix datasource devservices restarting

### DIFF
--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -316,6 +316,8 @@ public class DevServicesDatasourceProcessor {
                             e.getValue());
                 }
             }
+            setDataSourceProperties(propertiesMap, dbName, devServicesPrefix + "reuse",
+                    String.valueOf(dataSourceBuildTimeConfig.devservices().reuse()));
 
             Map<String, String> devDebProperties = new HashMap<>();
             for (DevServicesDatasourceConfigurationHandlerBuildItem devDbConfigurationHandlerBuildItem : configHandlers) {


### PR DESCRIPTION
The reuse property was not added to the cached map between restarts, so the restart of the containers was always triggered.

- Fixes #40015 