### PR TITLE
Qute: fix NativeImageResourceBuildItem registration on Windows

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templateroot/AdditionalTemplateRootTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templateroot/AdditionalTemplateRootTest.java
@@ -28,6 +28,7 @@ public class AdditionalTemplateRootTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(root -> root
                     .addAsResource(new StringAsset("Hi {name}!"), "templates/hi.txt")
+                    .addAsResource(new StringAsset("Hoho {name}!"), "templates/nested/hoho.txt")
                     .addAsResource(new StringAsset("Hello {name}!"), "web/public/hello.txt"))
             .addBuildChainCustomizer(buildCustomizer());
 
@@ -52,11 +53,13 @@ public class AdditionalTemplateRootTest {
                             if (item.getResources().contains("web/public/hello.txt")
                                     || item.getResources().contains("web\\public\\hello.txt")
                                     || item.getResources().contains("templates/hi.txt")
-                                    || item.getResources().contains("templates\\hi.txt")) {
+                                    || item.getResources().contains("templates\\hi.txt")
+                                    || item.getResources().contains("templates/nested/hoho.txt")
+                                    || item.getResources().contains("templates\\nested\\hoho.txt")) {
                                 found++;
                             }
                         }
-                        if (found != 2) {
+                        if (found != 3) {
                             throw new IllegalStateException(items.stream().flatMap(i -> i.getResources().stream())
                                     .collect(Collectors.toList()).toString());
                         }
@@ -79,6 +82,7 @@ public class AdditionalTemplateRootTest {
     public void testTemplate() {
         assertEquals("Hi M!", engine.getTemplate("hi").data("name", "M").render());
         assertEquals("Hello M!", hello.data("name", "M").render());
+        assertEquals("Hoho M!", engine.getTemplate("nested/hoho").data("name", "M").render());
     }
 
 }


### PR DESCRIPTION
- previously, a NativeImageResourceBuildItem with a wrong path was produced for a template located in a nested directory