### PR TITLE
Applying the QE feedback to the Logging guide

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -74,6 +74,7 @@ The same flow can be applied with any of the <<logging-apis,supported logging AP
 [source,java]
 ----
 package com.example;
+
 import org.jboss.logging.Logger;
 
 public class MyService {
@@ -129,6 +130,8 @@ Once injected, you can use the `log` object to invoke logging methods.
 .An example of two different types of logger injection:
 [source, java]
 ----
+package com.example;
+
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -203,9 +206,8 @@ FINEST:: Increased debug output compared to `TRACE`, which might have a higher f
 
 == Configure the log level, category, and format
 
-JBoss Logging is built into Quarkus and provides link:https://quarkus.io/developer-joy/[unified configuration] for all <<logging-apis,supported logging APIs>>.
-
-Configure the runtime logging in the `application.properties` file.
+JBoss Logging, integrated into Quarkus, offers a unified configuration for all <<logging-apis,supported logging APIs>> through a single configuration file that sets up all available extensions.
+To adjust runtime logging, modify the `application.properties` file.
 
 .An example of how you can set the default log level to `INFO` logging and include Hibernate `DEBUG` logs:
 [source, properties]
@@ -347,9 +349,9 @@ The logging format string supports the following symbols:
 |%t|Thread name|Render the thread name.
 |%t{id}|Thread ID|Render the thread ID.
 |%z{<zone name>}|Time zone|Set the time zone of the output to `<zone name>`.
-|%X{<MDC property name>}|Mapped Diagnostic Context Value|Renders the value from Mapped Diagnostic Context
-|%X|Mapped Diagnostic Context Values|Renders all the values from Mapped Diagnostic Context in format {property.key=property.value}
-|%x|Nested Diagnostics context values|Renders all the values from Nested Diagnostics Context in format {value1.value2}
+|%X{<MDC property name>}|Mapped Diagnostic Context Value|Renders the value from Mapped Diagnostic Context.
+|%X|Mapped Diagnostic Context Values|Renders all the values from Mapped Diagnostic Context in format `{property.key=property.value}`.
+|%x|Nested Diagnostics context values|Renders all the values from Nested Diagnostics Context in format `{value1.value2}`.
 |===
 
 
@@ -364,8 +366,8 @@ Changing the console log format is useful, for example, when the console output 
 
 The `quarkus-logging-json` extension may be employed to add support for the JSON logging format and its related configuration.
 
-Add this extension to your build file as the following snippet illustrates:
-
+. Add this extension to your build file as the following snippet illustrates:
++
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
 ----
@@ -374,20 +376,21 @@ Add this extension to your build file as the following snippet illustrates:
     <artifactId>quarkus-logging-json</artifactId>
 </dependency>
 ----
-
++
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
 implementation("io.quarkus:quarkus-logging-json")
 ----
-
++
 By default, the presence of this extension replaces the output format configuration from the console configuration, and the format string and the color settings (if any) are ignored.
 The other console configuration items, including those controlling asynchronous logging and the log level, will continue to be applied.
-
++
 For some, it will make sense to use humanly readable (unstructured) logging in dev mode and JSON logging (structured) in production mode.
 This can be achieved using different profiles, as shown in the following configuration.
-
-.Disable JSON logging in application.properties for dev and test mode
++
+. Disable JSON logging in application.properties for dev and test mode:
++
 [source, properties]
 ----
 %dev.quarkus.log.console.json=false
@@ -514,6 +517,8 @@ To register a logging filter:
 .An example of writing a filter:
 [source,java]
 ----
+package com.example;
+
 import io.quarkus.logging.LoggingFilter;
 import java.util.logging.Filter;
 import java.util.logging.LogRecord;

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/AdditionalFieldConfig.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/AdditionalFieldConfig.java
@@ -16,7 +16,7 @@ public class AdditionalFieldConfig {
 
     /**
      * Additional field type specification.
-     * Supported types: string, int, long
+     * Supported types: {@code string}, {@code int}, and {@code long}.
      * String is the default if not specified.
      */
     @ConfigItem(defaultValue = "string")


### PR DESCRIPTION
This PR is an application of the QE review @michalvavrik has provided me several weeks ago. This is part of the revision of all RHBQ docs, the fixes of which needs to be applied "Upstream first".

While most of changes are general review and suggestions, we have one footnote issue here, since the newer Asciidoc footnote macro applied in the Logging guide doesn't work in RHBQ docs, thanks to the obsolete version of the bccutil.
We can push any updates there or request any maintenance. Thus, I asked @jmartisk for a SED that would search n replace all these footnotes and put them in their older shape, that still works well in Upstream (based on my local test and build I made). @gsmet Guiilame, I wrote you about this in an email last weak or so. Do you think we can keep it as it is or you would prefer to add this SED command to our downstreaming script so that Upstream is untouched and RHBQ gets what is capable to render?

```
# footnote:x[] -> footnoteref:[x]
for i in `find . -name "*.adoc"`; do sed 's/footnote:\([a-zA-Z]\+\)\[\]/footnoteref:[\1]/g' -i $i; done
# footnote:x[y] -> footnoteref:[x,y]
for i in `find . -name "*.adoc"`; do sed 's/footnote:\([a-zA-Z]\+\)\[\(.*\)\]/footnoteref:[\1, \2]/g' -i $i; done
```

This patch is suitable for 3.2 and 3.8 because of their RHBQ Release Notes.

Thank you!