### PR TITLE
Rewrite footnotes for downstream documentation

### DIFF
--- a/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
@@ -61,6 +61,7 @@ public class AssembleDownstreamDocumentation {
             Pattern.CASE_INSENSITIVE + Pattern.MULTILINE);
     private static final String SOURCE_BLOCK_PREFIX = "[source";
     private static final String SOURCE_BLOCK_DELIMITER = "--";
+    private static final Pattern FOOTNOTE_PATTERN = Pattern.compile("footnote:([a-z0-9_-]+)\\[(\\])?");
 
     private static final String PROJECT_NAME_ATTRIBUTE = "{project-name}";
     private static final String RED_HAT_BUILD_OF_QUARKUS = "Red Hat build of Quarkus";
@@ -386,7 +387,7 @@ public class AssembleDownstreamDocumentation {
 
                 if (currentBuffer.length() > 0) {
                     rewrittenGuide.append(
-                            rewriteLinks(sourceFile.getFileName().toString(), currentBuffer.toString(), downstreamGuides,
+                            rewriteContent(sourceFile.getFileName().toString(), currentBuffer.toString(), downstreamGuides,
                                     titlesByReference, linkRewritingErrors));
                     currentBuffer.setLength(0);
                 }
@@ -399,7 +400,7 @@ public class AssembleDownstreamDocumentation {
 
         if (currentBuffer.length() > 0) {
             rewrittenGuide.append(
-                    rewriteLinks(sourceFile.getFileName().toString(), currentBuffer.toString(), downstreamGuides,
+                    rewriteContent(sourceFile.getFileName().toString(), currentBuffer.toString(), downstreamGuides,
                             titlesByReference, linkRewritingErrors));
         }
 
@@ -413,7 +414,7 @@ public class AssembleDownstreamDocumentation {
         Files.writeString(targetFile, rewrittenGuideWithoutTabs.trim());
     }
 
-    private static String rewriteLinks(String fileName,
+    private static String rewriteContent(String fileName,
             String content,
             Set<String> downstreamGuides,
             Map<String, String> titlesByReference,
@@ -452,6 +453,14 @@ public class AssembleDownstreamDocumentation {
 
         content = ANCHOR_PATTERN.matcher(content).replaceAll(mr -> {
             return "[[" + mr.group(1) + "]]";
+        });
+
+        content = FOOTNOTE_PATTERN.matcher(content).replaceAll(mr -> {
+            if (mr.group(2) != null) {
+                return "footnoteref:[" + mr.group(1) + "]";
+            }
+
+            return "footnoteref:[" + mr.group(1) + ", ";
         });
 
         return content;


### PR DESCRIPTION
The modern version of footnotes is not supported in the downstream tooling and we can't use the older version in our doc as it triggers warnings.
Thus we rewrite the new format to the old format specifically for downstream doc.

@MichalMaler I end up with the following diff, can you check this is what you expect?

```diff
 |%%|`%`|Renders a simple `%` character.
 |%c|Category|Renders the category name.
-|%C|Source class|Renders the source class name.footnote:calc[Format sequences which examine caller information may affect performance]
+|%C|Source class|Renders the source class name.footnoteref:[calc, Format sequences which examine caller information may affect performance]
 |%d{xxx}|Date|Renders a date with the given date format string, which uses the syntax defined by `java.text.SimpleDateFormat`.
 |%e|Exception|Renders the thrown exception, if any.
-|%F|Source file|Renders the source file name.footnote:calc[]
+|%F|Source file|Renders the source file name.footnoteref:[calc]
 |%h|Host name|Renders the system simple host name.
 |%H|Qualified host name|Renders the system's fully qualified host name, which may be the same as the simple host name, depending on operating system configuration.
 |%i|Process ID|Render the current process PID.
-|%l|Source location|Renders the source location information, which includes source file name, line number, class name, and method name.footnote:calc[]
-|%L|Source line|Renders the source line number.footnote:calc[]
+|%l|Source location|Renders the source location information, which includes source file name, line number, class name, and method name.footnoteref:[calc]
+|%L|Source line|Renders the source line number.footnoteref:[calc]
 |%m|Full Message|Renders the log message plus exception (if any).
-|%M|Source method|Renders the source method name.footnote:calc[]
+|%M|Source method|Renders the source method name.footnoteref:[calc]
 |%n|Newline|Renders the platform-specific line separator string.
 |%N|Process name|Render the name of the current process.
 |%p|Level|Render the log level of the message.
```