### PR TITLE
Qute: type-safe messages - add test for localized enum

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -789,8 +789,13 @@ public class MessageBundleProcessor {
         Map<String, String> keyToTemplate = new HashMap<>();
         for (ListIterator<String> it = Files.readAllLines(localizedFile).listIterator(); it.hasNext();) {
             String line = it.next();
-            if (line.startsWith("#") || line.isBlank()) {
-                // Comments and blank lines are skipped
+            if (line.isBlank()) {
+                // Blank lines are skipped
+                continue;
+            }
+            line = line.strip();
+            if (line.startsWith("#")) {
+                // Comments are skipped
                 continue;
             }
             int eqIdx = line.indexOf('=');

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleDefaultedNameTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleDefaultedNameTest.java
@@ -2,8 +2,6 @@ package io.quarkus.qute.deployment.i18n;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Locale;
-
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -13,7 +11,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.qute.Engine;
 import io.quarkus.qute.i18n.Message;
 import io.quarkus.qute.i18n.MessageBundle;
-import io.quarkus.qute.i18n.MessageBundles;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class MessageBundleDefaultedNameTest {
@@ -43,8 +40,7 @@ public class MessageBundleDefaultedNameTest {
     public void testBundles() {
         assertEquals("Hello world!",
                 Controller.Templates.index("world").render());
-        assertEquals("Ahoj svete!", Controller.Templates.index("svete")
-                .setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag("cs")).render());
+        assertEquals("Ahoj svete!", Controller.Templates.index("svete").setLocale("cs").render());
 
         assertEquals("Hello world!", engine.getTemplate("app").render());
         assertEquals("Hello alpha!", engine.getTemplate("alpha").render());

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLocaleTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLocaleTest.java
@@ -2,8 +2,6 @@ package io.quarkus.qute.deployment.i18n;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Locale;
-
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -13,7 +11,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.i18n.Message;
 import io.quarkus.qute.i18n.MessageBundle;
-import io.quarkus.qute.i18n.MessageBundles;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class MessageBundleLocaleTest {
@@ -31,8 +28,7 @@ public class MessageBundleLocaleTest {
 
     @Test
     public void testResolvers() {
-        assertEquals("Ahoj svete!",
-                foo.instance().setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag("cs")).render());
+        assertEquals("Ahoj svete!", foo.instance().setLocale("cs").render());
     }
 
     @MessageBundle(locale = "cs")

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLogicalLineTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLogicalLineTest.java
@@ -3,8 +3,6 @@ package io.quarkus.qute.deployment.i18n;
 import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Locale;
-
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -12,9 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateEnum;
 import io.quarkus.qute.i18n.Message;
 import io.quarkus.qute.i18n.MessageBundle;
-import io.quarkus.qute.i18n.MessageBundles;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class MessageBundleLogicalLineTest {
@@ -25,7 +23,7 @@ public class MessageBundleLogicalLineTest {
                     .addClasses(Messages.class)
                     .addAsResource("messages/msg_cs.properties")
                     .addAsResource(new StringAsset(
-                            "{msg:hello('Edgar')} {msg:helloNextLine('Edgar')} ::{msg:fruits}"),
+                            "{msg:hello('Edgar')}::{msg:helloNextLine('Edgar')}::{msg:fruits}::{msg:myEnum(MyEnum:OFF)}"),
                             "templates/foo.html"));
 
     @Inject
@@ -33,10 +31,10 @@ public class MessageBundleLogicalLineTest {
 
     @Test
     public void testResolvers() {
-        assertEquals("Hello Edgar! Hello \n Edgar! ::apple, banana, pear, watermelon, kiwi, mango",
+        assertEquals("Hello Edgar!::Hello \n Edgar!::apple, banana, pear, watermelon, kiwi, mango::Off",
                 foo.render());
-        assertEquals("Ahoj Edgar a dobrý den! Ahoj \n Edgar! ::apple, banana, pear, watermelon, kiwi, mango",
-                foo.instance().setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag("cs")).render());
+        assertEquals("Ahoj Edgar a dobrý den!::Ahoj \n Edgar!::jablko, banan, hruska, meloun, kiwi, mango::Vypnuto",
+                foo.instance().setLocale("cs").render());
     }
 
     @MessageBundle(value = DEFAULT_NAME, locale = "en")
@@ -50,6 +48,21 @@ public class MessageBundleLogicalLineTest {
 
         @Message("apple, banana, pear, watermelon, kiwi, mango")
         String fruits();
+
+        @Message("{#when myEnum}"
+                + "{#is ON}On"
+                + "{#is OFF}Off"
+                + "{#else}Undefined"
+                + "{/when}")
+        String myEnum(MyEnum myEnum);
+
+    }
+
+    @TemplateEnum
+    public enum MyEnum {
+        ON,
+        OFF,
+        UNDEFINED
     }
 
 }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTest.java
@@ -84,7 +84,7 @@ public class MessageBundleTest {
         assertEquals("Hello world! Ahoj Jachym! Hello you guys! Hello alpha! Hello! Hello foo from alpha!",
                 foo.instance().setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag("cs")).render());
         assertEquals("Hallo Welt! Hallo Jachym! Hello you guys! Hello alpha! Hello! Hello foo from alpha!",
-                foo.instance().setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.GERMAN).render());
+                foo.instance().setLocale(Locale.GERMAN).render());
         assertEquals("Dot test!", engine.parse("{msg:['dot.test']}").render());
         assertEquals("Hello world! Hello Malachi Constant!",
                 engine.getTemplate("dynamic").data("key", "hello_fullname").data("surname", "Constant").render());

--- a/extensions/qute/deployment/src/test/resources/messages/msg_cs.properties
+++ b/extensions/qute/deployment/src/test/resources/messages/msg_cs.properties
@@ -3,7 +3,14 @@ hello=Ahoj \
    dobrý den!
   
 helloNextLine=Ahoj \n {name}!
- fruits =        apple, banana, pear, \
-                  watermelon, \
+ fruits =        jablko, banan, hruska, \
+                  meloun, \
                  kiwi, mango
+                 
+  # This is an example how to localize an enum value
+myEnum={#when myEnum}\
+        {#is ON}Zapnuto\
+        {#is OFF}Vypnuto\
+        {#else}Nedefinovano\
+       {/when}
  


### PR DESCRIPTION
- related to #40089
- also use the convenient TemplateInstance#setLocale() method