### PR TITLE
Remove explicitly ignored split packages

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SplitPackageProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SplitPackageProcessor.java
@@ -39,16 +39,6 @@ public class SplitPackageProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(SplitPackageProcessor.class);
 
-    private static final Predicate<String> IGNORE_PACKAGE = new Predicate<>() {
-
-        @Override
-        public boolean test(String packageName) {
-            // Remove the elements from this list when the original issue is fixed
-            // so that we can detect further issues.
-            return packageName.startsWith("io.fabric8.kubernetes");
-        }
-    };
-
     @BuildStep
     void splitPackageDetection(ApplicationArchivesBuildItem archivesBuildItem,
             ArcConfig config,
@@ -82,9 +72,6 @@ public class SplitPackageProcessor {
         // - "com.me.app.sub" found in [archiveA, archiveB]
         StringBuilder splitPackagesWarning = new StringBuilder();
         for (String packageName : packageToArchiveMap.keySet()) {
-            if (IGNORE_PACKAGE.test(packageName)) {
-                continue;
-            }
 
             // skip packages based on pre-built predicates
             boolean skipEvaluation = false;


### PR DESCRIPTION
Address issue https://github.com/quarkusio/quarkus/issues/39300 by removing the included IGNORE_PACKAGES predicate as the last remaining entry (io.fabric8.kubernetes) is now resolved and it is not expected that there will be a future requirement to use the predicate