### PR TITLE
Qute: ultimate fix for the problem with registering NativeImageResourceBuildItem correctly on Windows

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -133,9 +133,9 @@
             "os-name": "ubuntu-latest"
         },
         {
-            "category": "Windows - RESTEasy Jackson",
-            "timeout": 25,
-            "test-modules": "resteasy-jackson",
+            "category": "Windows support",
+            "timeout": 50,
+            "test-modules": "resteasy-jackson, qute",
             "os-name": "windows-latest"
         },
         {

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -3355,31 +3355,29 @@ public class QuteProcessor {
      * @param templatePaths
      * @param watchedPaths
      * @param nativeImageResources
-     * @param osSpecificResourcePath The OS-specific resource path, i.e. templates\nested\foo.html
+     * @param resourcePath The relative resource path, including the template root
      * @param templatePath The path relative to the template root; using the {@code /} path separator
      * @param originalPath
      * @param config
      */
     private static void produceTemplateBuildItems(BuildProducer<TemplatePathBuildItem> templatePaths,
             BuildProducer<HotDeploymentWatchedFileBuildItem> watchedPaths,
-            BuildProducer<NativeImageResourceBuildItem> nativeImageResources, String osSpecificResourcePath,
+            BuildProducer<NativeImageResourceBuildItem> nativeImageResources, String resourcePath,
             String templatePath,
             Path originalPath, QuteConfig config) {
         if (templatePath.isEmpty()) {
             return;
         }
-        // OS-agnostic full path, i.e. templates/foo.html
-        String osAgnosticResourcePath = toOsAgnosticPath(osSpecificResourcePath, originalPath.getFileSystem());
         LOGGER.debugf("Produce template build items [templatePath: %s, osSpecificResourcePath: %s, originalPath: %s",
                 templatePath,
-                osSpecificResourcePath,
+                resourcePath,
                 originalPath);
         boolean restartNeeded = true;
         if (config.devMode.noRestartTemplates.isPresent()) {
-            restartNeeded = !config.devMode.noRestartTemplates.get().matcher(osAgnosticResourcePath).matches();
+            restartNeeded = !config.devMode.noRestartTemplates.get().matcher(resourcePath).matches();
         }
-        watchedPaths.produce(new HotDeploymentWatchedFileBuildItem(osAgnosticResourcePath, restartNeeded));
-        nativeImageResources.produce(new NativeImageResourceBuildItem(osSpecificResourcePath));
+        watchedPaths.produce(new HotDeploymentWatchedFileBuildItem(resourcePath, restartNeeded));
+        nativeImageResources.produce(new NativeImageResourceBuildItem(resourcePath));
         templatePaths.produce(
                 new TemplatePathBuildItem(templatePath, originalPath,
                         readTemplateContent(originalPath, config.defaultCharset)));
@@ -3399,7 +3397,7 @@ public class QuteProcessor {
                     return;
                 }
                 produceTemplateBuildItems(templatePaths, watchedPaths, nativeImageResources,
-                        visit.getRelativePath(visit.getPath().getFileSystem().getSeparator()),
+                        visit.getRelativePath("/"),
                         templatePath, visit.getPath(), config);
             }
         });

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templateroot/AdditionalTemplateRootTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templateroot/AdditionalTemplateRootTest.java
@@ -51,11 +51,8 @@ public class AdditionalTemplateRootTest {
                         List<NativeImageResourceBuildItem> items = context.consumeMulti(NativeImageResourceBuildItem.class);
                         for (NativeImageResourceBuildItem item : items) {
                             if (item.getResources().contains("web/public/hello.txt")
-                                    || item.getResources().contains("web\\public\\hello.txt")
                                     || item.getResources().contains("templates/hi.txt")
-                                    || item.getResources().contains("templates\\hi.txt")
-                                    || item.getResources().contains("templates/nested/hoho.txt")
-                                    || item.getResources().contains("templates\\nested\\hoho.txt")) {
+                                    || item.getResources().contains("templates/nested/hoho.txt")) {
                                 found++;
                             }
                         }


### PR DESCRIPTION
This pull request should contain the ultimate fix for the problem with registering `NativeImageResourceBuildItem` correctly on Windows.

It also fixes #40055.

There's a zulip topic about the contract of `NativeImageResourceBuildItem`: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/NativeImageResourceBuildItem.20-.20format.20of.20resource.20params.3F. However, this problem will be probably addressed in a separate PR.

We've also added the `quarkus-qute-integration-test` module into the native Windows CI category. Hopefully, this will improve our ability to detect this kind of problems.