### PR TITLE
Logging Guide: Remove duplicated statements

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -446,7 +446,6 @@ To log events to a file on the application's host, use the Quarkus file log hand
 The file log handler is disabled by default, so you must first enable it.
 
 The Quarkus file log handler supports log file rotation.
-Log file rotation ensures effective log file management over time by maintaining a specified number of backup log files, while also keeping the primary log file up-to-date and manageable.
 
 Log file rotation ensures effective log file management over time by maintaining a specified number of backup log files, while keeping the primary log file up-to-date and manageable.
 


### PR DESCRIPTION
Update file log handler description
Remove duplicated statements on the "File log handler" section