### PR TITLE
Speedup of Hibernate ORM's processing of very large models

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/DeferredClassLoader.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/DeferredClassLoader.java
@@ -1,0 +1,132 @@
+package io.quarkus.hibernate.orm.deployment.integration;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.stream.Stream;
+
+/**
+ * This is meant to be passed exclusively to the ByteBuddy based entity Enhancer of Hibernate ORM.
+ *
+ * High couple warning: we rely on the knowledge that ByteBuddy will exclusively invoke method
+ * {@link ClassLoader#getResourceAsStream(String)} on the passed classloader; to verify that
+ * this assumption doesn't break in the future we throw exceptions on all other operations.
+ *
+ * Why do we do this?
+ * We need the Enhancer to source such resources from the thread context classloader which is set during the
+ * enhancement process, but we can't capture this yet as it hasn't been created at the point in which we
+ * need to pass a ClassLoader to the Hibernate ORM context.
+ * On the other hand, deferring the creation of the ORM enhancer implies needing to create a new enhancer
+ * instance for each processed entity, which very significantly slows down the process.
+ */
+final class DeferredClassLoader extends ClassLoader {
+
+    public static final ClassLoader INSTANCE = new DeferredClassLoader();
+
+    protected DeferredClassLoader() {
+        super();
+    }
+
+    @Override
+    public String getName() {
+        return "Defferred Enhancement Classloader";
+    }
+
+    @Override
+    public Class<?> loadClass(String name) {
+        throw dontUse();
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        throw dontUse();
+    }
+
+    @Override
+    protected Object getClassLoadingLock(String className) {
+        throw dontUse();
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        throw dontUse();
+    }
+
+    @Override
+    protected Class<?> findClass(String moduleName, String name) {
+        throw dontUse();
+    }
+
+    @Override
+    protected URL findResource(String moduleName, String name) throws IOException {
+        throw dontUse();
+    }
+
+    @Override
+    public URL getResource(String name) {
+        throw dontUse();
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) {
+        throw dontUse();
+    }
+
+    @Override
+    public Stream<URL> resources(String name) {
+        throw dontUse();
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        throw dontUse();
+    }
+
+    @Override
+    protected Enumeration<URL> findResources(String name) {
+        throw dontUse();
+    }
+
+    /**
+     * The only implemented method: delegate to the currently set context classloader.
+     */
+    @Override
+    public InputStream getResourceAsStream(String name) {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream(name);
+    }
+
+    @Override
+    protected Package definePackage(
+            String name,
+            String specTitle,
+            String specVersion,
+            String specVendor,
+            String implTitle,
+            String implVersion,
+            String implVendor,
+            URL sealBase) {
+        throw dontUse();
+    }
+
+    @Override
+    protected Package getPackage(String name) {
+        throw dontUse();
+    }
+
+    @Override
+    protected Package[] getPackages() {
+        throw dontUse();
+    }
+
+    @Override
+    protected String findLibrary(String libname) {
+        throw dontUse();
+    }
+
+    private UnsupportedOperationException dontUse() {
+        return new UnsupportedOperationException(
+                "This classloader only supports the #getResourceAsStream() operation and should not be used for anything else");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/QuarkusEnhancementContext.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/QuarkusEnhancementContext.java
@@ -1,0 +1,21 @@
+package io.quarkus.hibernate.orm.deployment.integration;
+
+import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
+import org.hibernate.bytecode.enhance.spi.UnloadedField;
+
+public final class QuarkusEnhancementContext extends DefaultEnhancementContext {
+
+    @Override
+    public boolean doBiDirectionalAssociationManagement(final UnloadedField field) {
+        //Don't enable automatic association management as it's often too surprising.
+        //Also, there's several cases in which its semantics are of unspecified,
+        //such as what should happen when dealing with ordered collections.
+        return false;
+    }
+
+    @Override
+    public ClassLoader getLoadingClassLoader() {
+        return DeferredClassLoader.INSTANCE;
+    }
+
+}


### PR DESCRIPTION
These two commits implement two different optimisations which will enhance the live-reload experience for non-trivial entity models.

A reference "benchmark" we have ( https://github.com/topicusonderwijs/tribe-krd-quarkus ) improves with this by about 40%.
I'm hoping for much stronger improvements, but the other problems I see need to be addressed in Hibernate ORM - some of which are being addressed in ORM 7.

So this doesn't entirely solve the problem yet, but it's a solid milestone in the right direction.

My particular machine has several cores and after this patch is applied the next bottleneck happens to become contention [on some internal caches](https://github.com/hibernate/hibernate-orm/pull/8204) we use during enhancement - my "40% improvement" is measured after taking out that contention point as well, so I'm not sure how this patch by itself might translate to another system.

cc/ @dashorst @yrodiere 