### PR TITLE
DOC: Using the rest client  - Fix rest-client-jackson add extension name

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -45,7 +45,7 @@ This command generates the Maven project with a REST endpoint and imports:
 If you already have your Quarkus project configured, you can add the `rest-client-jackson` extension
 to your project by running the following command in your project base directory:
 
-:add-extension-extensions: rest-client-reactive-jackson
+:add-extension-extensions: rest-client-jackson
 include::{includes}/devtools/extension-add.adoc[]
 
 This will add the following to your build file:


### PR DESCRIPTION
As per the statement right before the described command, I think the extension being added should be "rest-client-jackson" instead of "rest-client-reactive-jackson"

![image](https://github.com/quarkusio/quarkus/assets/19965610/1af19369-3156-4471-9eac-61b22666cee7)
