### PR TITLE
Update suggested command for busy port detection during the start

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -183,7 +183,8 @@ public class ApplicationLifecycleManager {
                     } else {
                         for (Integer port : ports) {
                             applicationLogger
-                                    .warnf("Use 'netstat -anop | grep %d' to identify the process occupying the port.", port);
+                                    .warnf("Use 'ss -anop | grep %d' or 'netstat -anop | grep %d' to identify the process occupying the port.",
+                                            port);
                         }
                         applicationLogger.warn("You can try to kill it with 'kill -9 <pid>'.");
                     }


### PR DESCRIPTION
Change the suggested command for busy port detection with the utility to dump socket statistics.

The command `netstat` was deprecated in linux and it is being retired from the default installed networking tools. The suggested command to look for the busy port may not be installed by default on the latest linux distributions (as it happened to me).

Find more information on the new tools on the article :
https://www.redhat.com/sysadmin/deprecated-linux-command-replacements

or the replacement announcement :
https://lists.debian.org/debian-devel/2009/03/msg00780.html
