### PR TITLE
Fix resource registration for native compilation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageResourceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageResourceBuildItem.java
@@ -7,7 +7,11 @@ import java.util.List;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * A build item that indicates that a static resource should be included in the native image
+ * A build item that indicates that a static resource should be included in the native image.
+ * <p>
+ * A static resource is a file that is not processed by the build steps, but is included in the native image as-is.
+ * The resource path passed to the constructor is a {@code /}-separated path name (with the same semantics as the parameters
+ * passed to {@link java.lang.ClassLoader#getResources(String)}.
  * <p>
  * Related build items:
  * <ul>

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageResourceConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageResourceConfigStep.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import io.quarkus.builder.Json;
 import io.quarkus.builder.Json.JsonArrayBuilder;
@@ -16,7 +17,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuil
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourcePatternsBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
-import io.quarkus.util.GlobUtil;
 
 public class NativeImageResourceConfigStep {
 
@@ -35,14 +35,13 @@ public class NativeImageResourceConfigStep {
         for (NativeImageResourceBuildItem i : resources) {
             for (String path : i.getResources()) {
                 JsonObjectBuilder pat = Json.object();
-                pat.put("pattern", GlobUtil.toRegexPattern(path));
+                pat.put("pattern", Pattern.quote(path));
                 includes.add(pat);
             }
-            addListToJsonArray(includes, i.getResources());
         }
 
         for (ServiceProviderBuildItem i : serviceProviderBuildItems) {
-            includes.add(Json.object().put("pattern", GlobUtil.toRegexPattern(i.serviceDescriptorFile())));
+            includes.add(Json.object().put("pattern", Pattern.quote(i.serviceDescriptorFile())));
         }
 
         for (NativeImageResourcePatternsBuildItem resourcePatternsItem : resourcePatterns) {


### PR DESCRIPTION
NativeImageResourceBuildItem and ServiceProviderBuildItem contain a path
of the resource we should include and not a pattern or a glob. As a
result, `Pattern.quote` is the right method to use in order to produce a
pattern that would match the path.

The patch also remove the wrong addition of the paths "as is" to the
includes json array.

Fix up of b7f49dd9d952a46fde3f0abaabcc08b1a2e5f067 (https://github.com/quarkusio/quarkus/pull/31185)
