### PR TITLE
Add mongo commands to otel span attributes

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientBuildTimeConfig.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientBuildTimeConfig.java
@@ -25,6 +25,12 @@ public class MongoClientBuildTimeConfig {
     public boolean forceDefaultClients;
 
     /**
+     * Whether or not tracing spans of driver commands are sent in case the quarkus-opentelemetry extension is present.
+     */
+    @ConfigItem(name = "tracing.enabled")
+    public boolean tracingEnabled;
+
+    /**
      * Configuration for DevServices. DevServices allows Quarkus to automatically start MongoDB in dev and test mode.
      */
     @ConfigItem

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>quarkus-mutiny-reactive-streams-operators</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
         </dependency>

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
@@ -1,0 +1,92 @@
+package io.quarkus.mongodb.tracing;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.Nullable;
+
+import jakarta.inject.Inject;
+
+import org.jboss.logging.Logger;
+
+import com.mongodb.event.*;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+
+public class MongoTracingCommandListener implements CommandListener {
+    private static final org.jboss.logging.Logger LOGGER = Logger.getLogger(MongoTracingCommandListener.class);
+    private static final String KEY = "mongodb.command";
+    private final Map<Integer, ContextEvent> requestMap;
+    private final Instrumenter<CommandStartedEvent, Void> instrumenter;
+
+    private record ContextEvent(Context context, CommandStartedEvent commandEvent) {
+    }
+
+    @Inject
+    public MongoTracingCommandListener(OpenTelemetry openTelemetry) {
+        requestMap = new ConcurrentHashMap<>();
+        SpanNameExtractor<CommandStartedEvent> spanNameExtractor = CommandEvent::getCommandName;
+        instrumenter = Instrumenter.<CommandStartedEvent, Void> builder(
+                openTelemetry, "quarkus-mongodb-client", spanNameExtractor)
+                .addAttributesExtractor(new CommandEventAttrExtractor())
+                .buildInstrumenter(SpanKindExtractor.alwaysClient());
+        LOGGER.debugf("MongoTracingCommandListener created");
+    }
+
+    @Override
+    public void commandStarted(CommandStartedEvent event) {
+        LOGGER.tracef("commandStarted event %s", event.getCommandName());
+
+        Context parentContext = Context.current();
+        if (instrumenter.shouldStart(parentContext, event)) {
+            Context context = instrumenter.start(parentContext, event);
+            requestMap.put(event.getRequestId(), new ContextEvent(context, event));
+        }
+    }
+
+    @Override
+    public void commandSucceeded(CommandSucceededEvent event) {
+        LOGGER.tracef("commandSucceeded event %s", event.getCommandName());
+        ContextEvent contextEvent = requestMap.remove(event.getRequestId());
+        if (contextEvent != null) {
+            instrumenter.end(contextEvent.context(), contextEvent.commandEvent(), null, null);
+        }
+    }
+
+    @Override
+    public void commandFailed(CommandFailedEvent event) {
+        LOGGER.tracef("commandFailed event %s", event.getCommandName());
+        ContextEvent contextEvent = requestMap.remove(event.getRequestId());
+        if (contextEvent != null) {
+            instrumenter.end(
+                    contextEvent.context(),
+                    contextEvent.commandEvent(),
+                    null,
+                    event.getThrowable());
+        }
+    }
+
+    private static class CommandEventAttrExtractor implements AttributesExtractor<CommandStartedEvent, Void> {
+        @Override
+        public void onStart(AttributesBuilder attributesBuilder,
+                Context context,
+                CommandStartedEvent commandStartedEvent) {
+            attributesBuilder.put(KEY, commandStartedEvent.getCommand().toJson());
+        }
+
+        @Override
+        public void onEnd(AttributesBuilder attributesBuilder,
+                Context context,
+                CommandStartedEvent commandStartedEvent,
+                @Nullable Void unused,
+                @Nullable Throwable throwable) {
+
+        }
+    }
+}

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/tracing/MongoTracingCommandListenerTest.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/tracing/MongoTracingCommandListenerTest.java
@@ -1,0 +1,103 @@
+package io.quarkus.mongodb.tracing;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.ClusterId;
+import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.connection.ServerId;
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.event.CommandSucceededEvent;
+
+import io.opentelemetry.api.OpenTelemetry;
+
+class MongoTracingCommandListenerTest {
+    private ConnectionDescription connDescr;
+    private MongoTracingCommandListener listener;
+    private BsonDocument command;
+
+    @BeforeEach
+    void setUp() {
+        connDescr = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()));
+        listener = new MongoTracingCommandListener(OpenTelemetry.noop());
+        command = new BsonDocument();
+    }
+
+    @Test
+    void commandStarted() {
+        var startEvent = new CommandStartedEvent(
+                null,
+                1L,
+                10,
+                connDescr,
+                "db",
+                "find",
+                command);
+        assertThatNoException().isThrownBy(() -> listener.commandStarted(startEvent));
+
+        CommandSucceededEvent successEvent = new CommandSucceededEvent(null,
+                startEvent.getOperationId(),
+                startEvent.getRequestId(),
+                connDescr,
+                startEvent.getDatabaseName(),
+                startEvent.getCommandName(),
+                startEvent.getCommand(),
+                10L);
+        assertThatNoException().isThrownBy(() -> listener.commandSucceeded(successEvent));
+    }
+
+    @Test
+    void commandSucceeded() {
+        CommandSucceededEvent cmd = new CommandSucceededEvent(null,
+                1L,
+                10,
+                connDescr,
+                "db",
+                "find",
+                command,
+                10L);
+        assertThatNoException().isThrownBy(() -> listener.commandSucceeded(cmd));
+    }
+
+    @Test
+    void commandFailed() {
+        var startedEvent = new CommandStartedEvent(
+                null,
+                1L,
+                10,
+                connDescr,
+                "db",
+                "find",
+                command);
+        assertThatNoException().isThrownBy(() -> listener.commandStarted(startedEvent));
+
+        CommandFailedEvent failedEvent = new CommandFailedEvent(null,
+                1L,
+                10,
+                connDescr,
+                "db",
+                "find",
+                10L,
+                new IllegalStateException("command failed"));
+        assertThatNoException().isThrownBy(() -> listener.commandFailed(failedEvent));
+    }
+
+    @Test
+    void commandFailedNoEvent() {
+        CommandFailedEvent cmd = new CommandFailedEvent(null,
+                1L,
+                10,
+                connDescr,
+                "db",
+                "find",
+                10L,
+                new IllegalStateException("command failed"));
+        assertThatNoException().isThrownBy(() -> listener.commandFailed(cmd));
+    }
+
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/pom.xml
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/pom.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-opentelemetry-mongodb-client-instrumentation</artifactId>
+    <name>Quarkus - Integration Tests - OpenTelemetry Mongo Db Client instrumentation</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mongodb-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+
+        <!-- Needed for InMemorySpanExporter to verify captured traces -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mongodb-client-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>
+                                            ${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/java/io/quarkus/it/opentelemetry/Book.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/java/io/quarkus/it/opentelemetry/Book.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.opentelemetry;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record Book(String author, String title) {
+
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/java/io/quarkus/it/opentelemetry/BookResource.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/java/io/quarkus/it/opentelemetry/BookResource.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.opentelemetry;
+
+import static com.mongodb.client.model.Filters.eq;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Response;
+
+import org.bson.Document;
+
+import com.mongodb.WriteConcern;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+
+import io.smallrye.common.annotation.Blocking;
+
+@Path("/books")
+@Blocking
+public class BookResource {
+
+    @Inject
+    MongoClient client;
+
+    private MongoCollection<Book> getCollection() {
+        return client.getDatabase("books").getCollection("my-collection", Book.class);
+    }
+
+    @DELETE
+    public Response clearBooks() {
+        getCollection().deleteMany(new Document());
+        return Response.ok().build();
+    }
+
+    @GET
+    public List<Book> getBooks() {
+        FindIterable<Book> iterable = getCollection().find();
+        List<Book> books = new ArrayList<>();
+        WriteConcern writeConcern = client.getDatabase("temp").getWriteConcern();
+        // force a test failure if we're not getting the correct, and correctly configured named mongodb client
+        if (Boolean.TRUE.equals(writeConcern.getJournal())) {
+            for (Book doc : iterable) {
+                books.add(doc);
+            }
+        }
+        return books;
+    }
+
+    @POST
+    public Response addBook(Book book) {
+        getCollection().insertOne(book);
+        return Response.accepted().build();
+    }
+
+    @GET
+    @Path("/{author}")
+    public List<Book> getBooksByAuthor(@PathParam("author") String author) {
+        FindIterable<Book> iterable = getCollection().find(eq("author", author));
+        List<Book> books = new ArrayList<>();
+        for (Book doc : iterable) {
+            String title = doc.title();
+            books.add(new Book(author, title));
+        }
+        return books;
+    }
+
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/java/io/quarkus/it/opentelemetry/ExporterResource.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/java/io/quarkus/it/opentelemetry/ExporterResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.opentelemetry;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+@Path("")
+public class ExporterResource {
+    @Inject
+    InMemorySpanExporter inMemorySpanExporter;
+
+    @GET
+    @Path("/reset")
+    public Response reset() {
+        inMemorySpanExporter.reset();
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/export")
+    public List<SpanData> export() {
+        return inMemorySpanExporter.getFinishedSpanItems()
+                .stream()
+                .filter(sd -> !sd.getName().contains("export") && !sd.getName().contains("reset"))
+                .collect(Collectors.toList());
+    }
+
+    @ApplicationScoped
+    static class InMemorySpanExporterProducer {
+        @Produces
+        @Singleton
+        InMemorySpanExporter inMemorySpanExporter() {
+            return InMemorySpanExporter.create();
+        }
+    }
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/java/io/quarkus/it/opentelemetry/ReactiveBookResource.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/java/io/quarkus/it/opentelemetry/ReactiveBookResource.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.opentelemetry;
+
+import static com.mongodb.client.model.Filters.eq;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Response;
+
+import org.bson.Document;
+
+import io.quarkus.mongodb.reactive.ReactiveMongoClient;
+import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
+
+@Path("/reactive-books")
+public class ReactiveBookResource {
+
+    @Inject
+    ReactiveMongoClient client;
+
+    private ReactiveMongoCollection<Book> getCollection() {
+        return client.getDatabase("books").getCollection("my-reactive-collection", Book.class);
+    }
+
+    @DELETE
+    public CompletableFuture<Response> clearCollection() {
+        return getCollection()
+                .deleteMany(new Document())
+                .onItem().transform(x -> Response.ok().build())
+                .subscribeAsCompletionStage();
+    }
+
+    @GET
+    public CompletionStage<List<Book>> getBooks() {
+        return getCollection().find().collect().asList().subscribeAsCompletionStage();
+    }
+
+    @POST
+    public CompletionStage<Response> addBook(Book book) {
+        return getCollection().insertOne(book)
+                .onItem().transform(x -> Response.accepted().build())
+                .subscribeAsCompletionStage();
+    }
+
+    @GET
+    @Path("/{author}")
+    public CompletionStage<List<Book>> getBooksByAuthor(@PathParam("author") String author) {
+        return getCollection().find(eq("author", author))
+                .collect().asList()
+                .subscribeAsCompletionStage();
+    }
+
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/META-INF/resources/test.html
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/META-INF/resources/test.html
@@ -1,0 +1,1 @@
+<html><body>Test</body></html>

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+# Setting these for tests explicitly. Not required in normal application
+quarkus.application.name=opentelemetry-mongodb-client-instrumentation-it
+quarkus.application.version=999-SNAPSHOT
+
+quarkus.datasource.devservices.enabled=false
+quarkus.devservices.enabled=false
+
+quarkus.mongodb.connection-string=mongodb://localhost:27017
+
+# speed up build
+quarkus.otel.bsp.schedule.delay=100
+quarkus.otel.bsp.export.timeout=5s
+quarkus.mongodb.tracing.enabled=true

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceIT.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.opentelemetry;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class BookResourceIT extends BookResourceTest {
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceTest.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceTest.java
@@ -1,0 +1,106 @@
+package io.quarkus.it.opentelemetry;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.mongodb.MongoTestResource;
+import io.restassured.common.mapper.TypeRef;
+
+@QuarkusTest
+@QuarkusTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = MongoTestResource.VERSION, value = "V6_0"))
+class BookResourceTest {
+
+    private final TypeRef<List<Book>> bookListType = new TypeRef<>() {
+    };
+
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        given().get("/reset").then().statusCode(HTTP_OK);
+        await().atMost(Duration.ofSeconds(30L)).until(() -> {
+            // make sure spans are cleared
+            List<Map<String, Object>> spans = getSpans();
+            if (!spans.isEmpty()) {
+                given().get("/reset").then().statusCode(HTTP_OK);
+            }
+            return spans.isEmpty();
+        });
+    }
+
+    @Test
+    void blockingClient() {
+        testInsertBooks("/books");
+        assertTraceAvailable("my-collection");
+    }
+
+    @Test
+    void reactiveClient() {
+        testInsertBooks("/reactive-books");
+        assertTraceAvailable("my-reactive-collection");
+    }
+
+    private void assertTraceAvailable(String dbCollectionName) {
+        await().atMost(Duration.ofSeconds(30L)).untilAsserted(() -> {
+            boolean traceAvailable = false;
+            for (Map<String, Object> spanData : getSpans()) {
+                if (spanData.get("attributes") instanceof Map attr) {
+                    var cmd = (String) attr.get("mongodb.command");
+                    if (cmd != null) {
+                        assertThat(cmd).contains(dbCollectionName, "books");
+                        traceAvailable = true;
+                    }
+                }
+            }
+            assertThat(traceAvailable).as("Mongodb statement was not traced.").isTrue();
+        });
+    }
+
+    private void testInsertBooks(String endpoint) {
+        given()
+                .delete(endpoint)
+                .then()
+                .assertThat()
+                .statusCode(200);
+
+        assertThat(get(endpoint).as(bookListType)).isEmpty();
+
+        saveBook(new Book("Victor Hugo", "Les Misérables"), endpoint);
+        saveBook(new Book("Victor Hugo", "Notre-Dame de Paris"), endpoint);
+        await().atMost(Duration.ofSeconds(60L))
+                .untilAsserted(() -> assertThat(get(endpoint).as(bookListType)).hasSize(2));
+
+        saveBook(new Book("Charles Baudelaire", "Les fleurs du mal"), endpoint);
+
+        assertThat(get(endpoint).as(bookListType)).hasSize(3);
+
+        List<Book> books = get("%s/Victor Hugo".formatted(endpoint)).as(bookListType);
+        assertThat(books).hasSize(2);
+    }
+
+    private static void saveBook(Book book, String endpoint) {
+        given()
+                .header("Content-Type", "application/json")
+                .body(book)
+                .post(endpoint)
+                .then().assertThat().statusCode(202);
+    }
+
+    private List<Map<String, Object>> getSpans() {
+        return get("/export").body().as(new TypeRef<>() {
+        });
+    }
+}


### PR DESCRIPTION
Solving https://github.com/quarkusio/quarkus/issues/28473

A simple approach to add mongo commands to traces using CommandListener. Similar approach as it was in quarkus-opentracing but without relying on https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/mongo/mongo-3.1/library, but using the similiar though simpler code.

