### PR TITLE
Allow two star role-name in web-fragment.xml as described in servlet spec

### DIFF
--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -551,7 +551,7 @@ public class UndertowBuildStep {
                 if (constraint.getAuthConstraint() == null) {
                     // no auth constraint means we permit the empty roles
                     securityConstraint.setEmptyRoleSemantic(PERMIT);
-                } else if (roleNames.size() == 1 && roleNames.contains("*")) {
+                } else if (roleNames.size() == 1 && (roleNames.contains("*") || roleNames.contains("**"))) {
                     securityConstraint.setEmptyRoleSemantic(AUTHENTICATE);
                 } else {
                     securityConstraint.addRolesAllowed(roleNames);


### PR DESCRIPTION
I use a dependency with a web-fragment.xml like this 
```		
<auth-constraint>
   <role-name>**</role-name>
</auth-constraint>
```

This causes all calls to the servlets to be denied. 

It would work with `<role-name>*</role-name>`
According to the [servlet specification](https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0.pdf) section 13.8, both "*" and "**" should be fine. This pr fixes the issue (firstly i thought also other parts of undertow would have to be changed, but this change alone is sufficient), i tried it out locally.
