### PR TITLE
Run CI when title starts with WIP

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -93,18 +93,12 @@ jobs:
     name: "Initial JDK 17 Build"
     runs-on: ubuntu-latest
     # Skip main in forks
-    # Skip draft PRs and those with WIP in the subject, rerun as soon as its removed
+    # Skip draft PRs, rerun as soon as its removed
     if: "(github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')) && ( \
            github.event_name != 'pull_request' || ( \
              github.event.pull_request.draft == false && \
              github.event.pull_request.state != 'closed' && \
-             contains(github.event.pull_request.title, 'wip ') == false && \
-             contains(github.event.pull_request.title, '[wip]') == false && \
-             (
-               github.event.action != 'edited' || \
-               contains(github.event.changes.title.from, 'wip ') || \
-               contains(github.event.changes.title.from, '[wip]') \
-             ) \
+             github.event.action != 'edited' \
            ) \
          )"
     outputs:


### PR DESCRIPTION
We introduced this check when draft PRs weren't a thing but nowadays, it's nice to be able to convey the fact that we don't want the PR to get merged but still want main CI to run.

@mkouba you asked for this
@yrodiere you didn't ask but complained about the behavior so here you are :)