### PR TITLE
Make reinitialization of vertx classes conditional in NettyProcessor

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -171,10 +171,16 @@ class NettyProcessor {
         if (QuarkusClassLoader.isClassPresentAtRuntime("io.netty.buffer.UnpooledByteBufAllocator")) {
             builder.addRuntimeReinitializedClass("io.netty.buffer.UnpooledByteBufAllocator")
                     .addRuntimeReinitializedClass("io.netty.buffer.Unpooled")
-                    .addRuntimeReinitializedClass("io.vertx.core.http.impl.Http1xServerResponse")
                     .addRuntimeReinitializedClass("io.netty.handler.codec.http.HttpObjectAggregator")
-                    .addRuntimeReinitializedClass("io.netty.handler.codec.ReplayingDecoderByteBuf")
-                    .addRuntimeReinitializedClass("io.vertx.core.parsetools.impl.RecordParserImpl");
+                    .addRuntimeReinitializedClass("io.netty.handler.codec.ReplayingDecoderByteBuf");
+
+            if (QuarkusClassLoader.isClassPresentAtRuntime("io.vertx.core.http.impl.Http1xServerResponse")) {
+                builder.addRuntimeReinitializedClass("io.vertx.core.http.impl.Http1xServerResponse")
+            }
+
+            if (QuarkusClassLoader.isClassPresentAtRuntime("io.vertx.core.parsetools.impl.RecordParserImpl")) {
+                builder.addRuntimeReinitializedClass("io.vertx.core.parsetools.impl.RecordParserImpl");
+            }
 
             if (QuarkusClassLoader.isClassPresentAtRuntime("io.vertx.ext.web.client.impl.MultipartFormUpload")) {
                 builder.addRuntimeReinitializedClass("io.vertx.ext.web.client.impl.MultipartFormUpload");


### PR DESCRIPTION
Vert.x is not a dependency of netty, meaning that the classes may not
always be on the classpath.

Fixes https://github.com/quarkusio/quarkus/issues/40243

Not sure whether this is the best approach, or whether we should move the registrations to the `VertxProcessor`. I kept them in the Netty processor as the reason we reinitialize them in the first place is because they cause issues in Netty.