### PR TITLE
Move reinitialization of vertx classes out of NettyProcessor

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -171,14 +171,8 @@ class NettyProcessor {
         if (QuarkusClassLoader.isClassPresentAtRuntime("io.netty.buffer.UnpooledByteBufAllocator")) {
             builder.addRuntimeReinitializedClass("io.netty.buffer.UnpooledByteBufAllocator")
                     .addRuntimeReinitializedClass("io.netty.buffer.Unpooled")
-                    .addRuntimeReinitializedClass("io.vertx.core.http.impl.Http1xServerResponse")
                     .addRuntimeReinitializedClass("io.netty.handler.codec.http.HttpObjectAggregator")
-                    .addRuntimeReinitializedClass("io.netty.handler.codec.ReplayingDecoderByteBuf")
-                    .addRuntimeReinitializedClass("io.vertx.core.parsetools.impl.RecordParserImpl");
-
-            if (QuarkusClassLoader.isClassPresentAtRuntime("io.vertx.ext.web.client.impl.MultipartFormUpload")) {
-                builder.addRuntimeReinitializedClass("io.vertx.ext.web.client.impl.MultipartFormUpload");
-            }
+                    .addRuntimeReinitializedClass("io.netty.handler.codec.ReplayingDecoderByteBuf");
 
             if (QuarkusClassLoader
                     .isClassPresentAtRuntime("org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartFormUpload")) {


### PR DESCRIPTION
Vert.x is not a dependency of netty, meaning that the classes may not
always be on the classpath.

Fixes https://github.com/quarkusio/quarkus/issues/40243

Supersedes https://github.com/quarkusio/quarkus/pull/40248
