### PR TITLE
Change quarkus-webjars-locator relocation message

### DIFF
--- a/relocations/generaterelocations.java
+++ b/relocations/generaterelocations.java
@@ -146,7 +146,7 @@ public class generaterelocations implements Runnable {
         RELOCATIONS.put("quarkus-smallrye-reactive-messaging-rabbitmq-deployment", smallryeReactiveMessagingRelocation);
 
         Function<String, Relocation>  webjarsLocatorRelocation = a -> Relocation.ofArtifactId(a, a.replace("webjars-locator", "web-dependency-locator"),
-                "3.10");
+                "3.11");
         RELOCATIONS.put("quarkus-webjars-locator", webjarsLocatorRelocation);
         RELOCATIONS.put("quarkus-webjars-locator-deployment", webjarsLocatorRelocation);
     }

--- a/relocations/quarkus-webjars-locator-deployment/pom.xml
+++ b/relocations/quarkus-webjars-locator-deployment/pom.xml
@@ -16,7 +16,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-web-dependency-locator-deployment</artifactId>
             <version>${project.version}</version>
-            <message>Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.10 for more information.</message>
+            <message>Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.11 for more information.</message>
         </relocation>
     </distributionManagement>
 </project>

--- a/relocations/quarkus-webjars-locator/pom.xml
+++ b/relocations/quarkus-webjars-locator/pom.xml
@@ -16,7 +16,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-web-dependency-locator</artifactId>
             <version>${project.version}</version>
-            <message>Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.10 for more information.</message>
+            <message>Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.11 for more information.</message>
         </relocation>
     </distributionManagement>
 </project>


### PR DESCRIPTION
The message for `quarkus-webjars-locator` pointing to 3.10 migration guide but this change wasn't part of 3.10 but will be in 3.11.

