### PR TITLE
Allow Snappy to be loaded from a shared classloader

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaBuildTimeConfig.java
@@ -24,6 +24,14 @@ public class KafkaBuildTimeConfig {
     public boolean snappyEnabled;
 
     /**
+     * Whether to load the Snappy native library from the shared classloader.
+     * This setting is only used in tests if the tests are using different profiles, which would lead to
+     * unsatisfied link errors when loading Snappy.
+     */
+    @ConfigItem(name = "snappy.load-from-shared-classloader", defaultValue = "false")
+    public boolean snappyLoadFromSharedClassLoader;
+
+    /**
      * Configuration for DevServices. DevServices allows Quarkus to automatically start Kafka in dev and test mode.
      */
     @ConfigItem

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -72,6 +72,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LogCategoryBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
@@ -304,8 +305,12 @@ public class KafkaProcessor {
 
     @BuildStep(onlyIf = HasSnappy.class)
     @Record(ExecutionTime.RUNTIME_INIT)
-    void loadSnappyIfEnabled(SnappyRecorder recorder, KafkaBuildTimeConfig config) {
-        recorder.loadSnappy();
+    void loadSnappyIfEnabled(LaunchModeBuildItem launch, SnappyRecorder recorder, KafkaBuildTimeConfig config) {
+        boolean loadFromSharedClassLoader = false;
+        if (launch.isTest()) {
+            loadFromSharedClassLoader = config.snappyLoadFromSharedClassLoader;
+        }
+        recorder.loadSnappy(loadFromSharedClassLoader);
     }
 
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/SnappyLoader.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/SnappyLoader.java
@@ -1,0 +1,18 @@
+package io.quarkus.kafka.client.runtime;
+
+import java.io.File;
+
+public class SnappyLoader {
+
+    /*
+     * This class is intended to be loaded from a shared classloader (e.g., the system classloader) to avoid
+     * unsatisfied link errors when the native library is loaded from a different classloader.
+     * See https://github.com/quarkusio/quarkus/issues/39767.
+     *
+     * This class is only used in tests if the `quarkus.kafka.snappy.load-from-shared-classloader=true` is set.
+     */
+    static {
+        File out = SnappyRecorder.getLibraryFile();
+        System.load(out.getAbsolutePath());
+    }
+}


### PR DESCRIPTION
This commit introduces a solution for loading the Snappy native library across multiple test profiles. Due to the constraint that native libraries can only be loaded from a single classloader, a shared classloader is now utilized for loading Snappy in test mode.

Please note, this feature is exclusively applicable when running tests.

Fixes: https://github.com/quarkusio/quarkus/issues/39767
