### PR TITLE
WebSockets Next: client endpoints

### DIFF
--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/Callback.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/Callback.java
@@ -1,0 +1,322 @@
+package io.quarkus.websockets.next.deployment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
+
+import io.quarkus.arc.deployment.TransformedAnnotationsBuildItem;
+import io.quarkus.arc.processor.Annotations;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.websockets.next.WebSocketException;
+import io.quarkus.websockets.next.deployment.CallbackArgument.InvocationBytecodeContext;
+import io.quarkus.websockets.next.deployment.CallbackArgument.ParameterContext;
+import io.quarkus.websockets.next.runtime.WebSocketConnectionBase;
+import io.quarkus.websockets.next.runtime.WebSocketEndpoint.ExecutionModel;
+import io.quarkus.websockets.next.runtime.WebSocketEndpointBase;
+
+/**
+ * Represents either an endpoint callback or a global error handler.
+ */
+public class Callback {
+
+    public final Target target;
+    public final String endpointPath;
+    public final AnnotationInstance annotation;
+    public final MethodInfo method;
+    public final ExecutionModel executionModel;
+    public final MessageType messageType;
+    public final List<CallbackArgument> arguments;
+
+    public Callback(Target target, AnnotationInstance annotation, MethodInfo method, ExecutionModel executionModel,
+            CallbackArgumentsBuildItem callbackArguments, TransformedAnnotationsBuildItem transformedAnnotations,
+            String endpointPath, IndexView index) {
+        this.target = target;
+        this.method = method;
+        this.annotation = annotation;
+        this.executionModel = executionModel;
+        if (WebSocketDotNames.ON_BINARY_MESSAGE.equals(annotation.name())) {
+            this.messageType = MessageType.BINARY;
+        } else if (WebSocketDotNames.ON_TEXT_MESSAGE.equals(annotation.name())) {
+            this.messageType = MessageType.TEXT;
+        } else if (WebSocketDotNames.ON_PONG_MESSAGE.equals(annotation.name())) {
+            this.messageType = MessageType.PONG;
+        } else {
+            this.messageType = MessageType.NONE;
+        }
+        this.endpointPath = endpointPath;
+        this.arguments = collectArguments(annotation, method, callbackArguments, transformedAnnotations, index);
+    }
+
+    public boolean isGlobal() {
+        return endpointPath == null;
+    }
+
+    public boolean isClient() {
+        return target == Target.CLIENT;
+    }
+
+    public boolean isServer() {
+        return target == Target.SERVER;
+    }
+
+    public boolean isOnOpen() {
+        return annotation.name().equals(WebSocketDotNames.ON_OPEN);
+    }
+
+    public boolean isOnClose() {
+        return annotation.name().equals(WebSocketDotNames.ON_CLOSE);
+    }
+
+    public boolean isOnError() {
+        return annotation.name().equals(WebSocketDotNames.ON_ERROR);
+    }
+
+    public Type returnType() {
+        return method.returnType();
+    }
+
+    public Type messageParamType() {
+        return acceptsMessage() ? method.parameterType(0) : null;
+    }
+
+    public boolean isReturnTypeVoid() {
+        return returnType().kind() == Kind.VOID;
+    }
+
+    public boolean isReturnTypeUni() {
+        return WebSocketDotNames.UNI.equals(returnType().name());
+    }
+
+    public boolean isReturnTypeMulti() {
+        return WebSocketDotNames.MULTI.equals(returnType().name());
+    }
+
+    public boolean acceptsMessage() {
+        return messageType != MessageType.NONE;
+    }
+
+    public boolean acceptsBinaryMessage() {
+        return messageType == MessageType.BINARY || messageType == MessageType.PONG;
+    }
+
+    public boolean acceptsMulti() {
+        return acceptsMessage() && method.parameterType(0).name().equals(WebSocketDotNames.MULTI);
+    }
+
+    public Callback.MessageType messageType() {
+        return messageType;
+    }
+
+    public boolean broadcast() {
+        AnnotationValue broadcastValue = annotation.value("broadcast");
+        return broadcastValue != null && broadcastValue.asBoolean();
+    }
+
+    public DotName getInputCodec() {
+        return getCodec("codec");
+    }
+
+    public DotName getOutputCodec() {
+        DotName output = getCodec("outputCodec");
+        return output != null ? output : getInputCodec();
+    }
+
+    public String asString() {
+        return method.declaringClass().name() + "#" + method.name() + "()";
+    }
+
+    private DotName getCodec(String valueName) {
+        AnnotationValue codecValue = annotation.value(valueName);
+        if (codecValue != null) {
+            return codecValue.asClass().name();
+        }
+        return null;
+    }
+
+    public enum MessageType {
+        NONE,
+        PONG,
+        TEXT,
+        BINARY
+    }
+
+    public enum Target {
+        CLIENT,
+        SERVER,
+        UNDEFINED
+    }
+
+    public ResultHandle[] generateArguments(ResultHandle endpointThis, BytecodeCreator bytecode,
+            TransformedAnnotationsBuildItem transformedAnnotations, IndexView index) {
+        if (arguments.isEmpty()) {
+            return new ResultHandle[] {};
+        }
+        ResultHandle[] resultHandles = new ResultHandle[arguments.size()];
+        int idx = 0;
+        for (CallbackArgument argument : arguments) {
+            resultHandles[idx] = argument.get(
+                    invocationBytecodeContext(annotation, method.parameters().get(idx), transformedAnnotations, index,
+                            endpointThis, bytecode));
+            idx++;
+        }
+        return resultHandles;
+    }
+
+    private List<CallbackArgument> collectArguments(AnnotationInstance annotation, MethodInfo method,
+            CallbackArgumentsBuildItem callbackArguments, TransformedAnnotationsBuildItem transformedAnnotations,
+            IndexView index) {
+        List<MethodParameterInfo> parameters = method.parameters();
+        if (parameters.isEmpty()) {
+            return List.of();
+        }
+        List<CallbackArgument> arguments = new ArrayList<>(parameters.size());
+        for (MethodParameterInfo parameter : parameters) {
+            List<CallbackArgument> found = callbackArguments
+                    .findMatching(parameterContext(annotation, parameter, transformedAnnotations, index));
+            if (found.isEmpty()) {
+                String msg = String.format("Unable to inject @%s callback parameter '%s' declared on %s: no injector found",
+                        DotNames.simpleName(annotation.name()),
+                        parameter.name() != null ? parameter.name() : "#" + parameter.position(),
+                        asString());
+                throw new WebSocketException(msg);
+            } else if (found.size() > 1 && (found.get(0).priotity() == found.get(1).priotity())) {
+                String msg = String.format(
+                        "Unable to inject @%s callback parameter '%s' declared on %s: ambiguous injectors found: %s",
+                        DotNames.simpleName(annotation.name()),
+                        parameter.name() != null ? parameter.name() : "#" + parameter.position(),
+                        asString(),
+                        found.stream().map(p -> p.getClass().getSimpleName() + ":" + p.priotity()));
+                throw new WebSocketException(msg);
+            }
+            arguments.add(found.get(0));
+        }
+        return List.copyOf(arguments);
+    }
+
+    Type argumentType(Predicate<CallbackArgument> filter) {
+        for (int i = 0; i < arguments.size(); i++) {
+            if (filter.test(arguments.get(i))) {
+                return method.parameterType(i);
+            }
+        }
+        return null;
+    }
+
+    private ParameterContext parameterContext(AnnotationInstance callbackAnnotation, MethodParameterInfo parameter,
+            TransformedAnnotationsBuildItem transformedAnnotations, IndexView index) {
+        return new ParameterContext() {
+
+            @Override
+            public Target callbackTarget() {
+                return target;
+            }
+
+            @Override
+            public MethodParameterInfo parameter() {
+                return parameter;
+            }
+
+            @Override
+            public Set<AnnotationInstance> parameterAnnotations() {
+                return Annotations.getParameterAnnotations(
+                        transformedAnnotations::getAnnotations, parameter.method(), parameter.position());
+            }
+
+            @Override
+            public AnnotationInstance callbackAnnotation() {
+                return callbackAnnotation;
+            }
+
+            @Override
+            public String endpointPath() {
+                return endpointPath;
+            }
+
+            @Override
+            public IndexView index() {
+                return index;
+            }
+
+        };
+    }
+
+    private InvocationBytecodeContext invocationBytecodeContext(AnnotationInstance callbackAnnotation,
+            MethodParameterInfo parameter, TransformedAnnotationsBuildItem transformedAnnotations, IndexView index,
+            ResultHandle endpointThis, BytecodeCreator bytecode) {
+        return new InvocationBytecodeContext() {
+
+            @Override
+            public Target callbackTarget() {
+                return target;
+            }
+
+            @Override
+            public AnnotationInstance callbackAnnotation() {
+                return callbackAnnotation;
+            }
+
+            @Override
+            public MethodParameterInfo parameter() {
+                return parameter;
+            }
+
+            @Override
+            public Set<AnnotationInstance> parameterAnnotations() {
+                return Annotations.getParameterAnnotations(
+                        transformedAnnotations::getAnnotations, parameter.method(), parameter.position());
+            }
+
+            @Override
+            public String endpointPath() {
+                return endpointPath;
+            }
+
+            @Override
+            public IndexView index() {
+                return index;
+            }
+
+            @Override
+            public BytecodeCreator bytecode() {
+                return bytecode;
+            }
+
+            @Override
+            public ResultHandle getPayload() {
+                return acceptsMessage() || callbackAnnotation.name().equals(WebSocketDotNames.ON_ERROR)
+                        ? bytecode.getMethodParam(0)
+                        : null;
+            }
+
+            @Override
+            public ResultHandle getDecodedMessage(Type parameterType) {
+                return acceptsMessage()
+                        ? WebSocketProcessor.decodeMessage(endpointThis, bytecode, acceptsBinaryMessage(),
+                                parameterType,
+                                getPayload(), Callback.this)
+                        : null;
+            }
+
+            @Override
+            public ResultHandle getConnection() {
+                return bytecode.readInstanceField(
+                        FieldDescriptor.of(WebSocketEndpointBase.class, "connection", WebSocketConnectionBase.class),
+                        endpointThis);
+            }
+        };
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgument.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgument.java
@@ -13,7 +13,8 @@ import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.WebSocketConnection;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
+import io.quarkus.websockets.next.deployment.Callback.Target;
 
 /**
  * Provides arguments for method parameters of a callback method declared on a WebSocket endpoint.
@@ -24,7 +25,7 @@ interface CallbackArgument {
      *
      * @param context
      * @return {@code true} if this provider matches the given parameter context, {@code false} otherwise
-     * @throws WebSocketServerException If an invalid parameter is detected
+     * @throws WebSocketException If an invalid parameter is detected
      */
     boolean matches(ParameterContext context);
 
@@ -48,6 +49,12 @@ interface CallbackArgument {
     static final int DEFAULT_PRIORITY = 1;
 
     interface ParameterContext {
+
+        /**
+         *
+         * @return the callback target
+         */
+        Target callbackTarget();
 
         /**
          *

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/ConnectionCallbackArgument.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/ConnectionCallbackArgument.java
@@ -1,12 +1,30 @@
 package io.quarkus.websockets.next.deployment;
 
+import org.jboss.jandex.DotName;
+
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.websockets.next.WebSocketException;
+import io.quarkus.websockets.next.deployment.Callback.Target;
 
 class ConnectionCallbackArgument implements CallbackArgument {
 
     @Override
     public boolean matches(ParameterContext context) {
-        return context.parameter().type().name().equals(WebSocketDotNames.WEB_SOCKET_CONNECTION);
+        DotName paramTypeName = context.parameter().type().name();
+        if (context.callbackTarget() == Target.SERVER) {
+            if (WebSocketDotNames.WEB_SOCKET_CONNECTION.equals(paramTypeName)) {
+                return true;
+            } else if (WebSocketDotNames.WEB_SOCKET_CLIENT_CONNECTION.equals(paramTypeName)) {
+                throw new WebSocketException("@WebSocket callback method may not accept WebSocketClientConnection");
+            }
+        } else if (context.callbackTarget() == Target.CLIENT) {
+            if (WebSocketDotNames.WEB_SOCKET_CLIENT_CONNECTION.equals(paramTypeName)) {
+                return true;
+            } else if (WebSocketDotNames.WEB_SOCKET_CONNECTION.equals(paramTypeName)) {
+                throw new WebSocketException("@WebSocketClient callback method may not accept WebSocketConnection");
+            }
+        }
+        return false;
     }
 
     @Override

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/GeneratedEndpointBuildItem.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/GeneratedEndpointBuildItem.java
@@ -3,7 +3,7 @@ package io.quarkus.websockets.next.deployment;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * A generated representation of a {@link io.quarkus.websockets.next.runtime.WebSocketEndpoint}.
+ * A generated representation of a WebSocket endpoint.
  */
 public final class GeneratedEndpointBuildItem extends MultiBuildItem {
 
@@ -11,12 +11,39 @@ public final class GeneratedEndpointBuildItem extends MultiBuildItem {
     public final String endpointClassName;
     public final String generatedClassName;
     public final String path;
+    public final boolean isClient;
 
-    GeneratedEndpointBuildItem(String endpointId, String endpointClassName, String generatedClassName, String path) {
+    GeneratedEndpointBuildItem(String endpointId, String endpointClassName, String generatedClassName, String path,
+            boolean isClient) {
         this.endpointId = endpointId;
         this.endpointClassName = endpointClassName;
         this.generatedClassName = generatedClassName;
         this.path = path;
+        this.isClient = isClient;
+    }
+
+    public boolean isServer() {
+        return !isClient;
+    }
+
+    public boolean isClient() {
+        return isClient;
+    }
+
+    public String getEndpointId() {
+        return endpointId;
+    }
+
+    public String getEndpointClassName() {
+        return endpointClassName;
+    }
+
+    public String getGeneratedClassName() {
+        return generatedClassName;
+    }
+
+    public String getPath() {
+        return path;
     }
 
 }

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/GlobalErrorHandlersBuildItem.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/GlobalErrorHandlersBuildItem.java
@@ -3,7 +3,8 @@ package io.quarkus.websockets.next.deployment;
 import java.util.List;
 
 import io.quarkus.builder.item.SimpleBuildItem;
-import io.quarkus.websockets.next.deployment.WebSocketServerProcessor.GlobalErrorHandler;
+import io.quarkus.websockets.next.deployment.Callback.Target;
+import io.quarkus.websockets.next.deployment.WebSocketProcessor.GlobalErrorHandler;
 
 final class GlobalErrorHandlersBuildItem extends SimpleBuildItem {
 
@@ -13,4 +14,11 @@ final class GlobalErrorHandlersBuildItem extends SimpleBuildItem {
         this.handlers = handlers;
     }
 
+    List<GlobalErrorHandler> forServer() {
+        return handlers.stream().filter(h -> h.callback().isServer() || h.callback().target == Target.UNDEFINED).toList();
+    }
+
+    List<GlobalErrorHandler> forClient() {
+        return handlers.stream().filter(h -> h.callback().isClient() || h.callback().target == Target.UNDEFINED).toList();
+    }
 }

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/HandshakeRequestCallbackArgument.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/HandshakeRequestCallbackArgument.java
@@ -2,7 +2,8 @@ package io.quarkus.websockets.next.deployment;
 
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
-import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.HandshakeRequest;
+import io.quarkus.websockets.next.runtime.WebSocketConnectionBase;
 
 class HandshakeRequestCallbackArgument implements CallbackArgument {
 
@@ -13,9 +14,9 @@ class HandshakeRequestCallbackArgument implements CallbackArgument {
 
     @Override
     public ResultHandle get(InvocationBytecodeContext context) {
-        ResultHandle connection = context.getConnection();
-        return context.bytecode().invokeInterfaceMethod(MethodDescriptor.ofMethod(WebSocketConnection.class, "handshakeRequest",
-                WebSocketConnection.HandshakeRequest.class), connection);
+        return context.bytecode()
+                .invokeVirtualMethod(MethodDescriptor.ofMethod(WebSocketConnectionBase.class, "handshakeRequest",
+                        HandshakeRequest.class), context.getConnection());
     }
 
 }

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/PathParamCallbackArgument.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/PathParamCallbackArgument.java
@@ -10,8 +10,8 @@ import org.jboss.jandex.AnnotationValue;
 import io.quarkus.arc.processor.Annotations;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
-import io.quarkus.websockets.next.WebSocketConnection;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
+import io.quarkus.websockets.next.runtime.WebSocketConnectionBase;
 
 class PathParamCallbackArgument implements CallbackArgument {
 
@@ -20,20 +20,20 @@ class PathParamCallbackArgument implements CallbackArgument {
         String name = getParamName(context);
         if (name != null) {
             if (!context.parameter().type().name().equals(WebSocketDotNames.STRING)) {
-                throw new WebSocketServerException("Method parameter annotated with @PathParam must be java.lang.String: "
-                        + WebSocketServerProcessor.callbackToString(context.parameter().method()));
+                throw new WebSocketException("Method parameter annotated with @PathParam must be java.lang.String: "
+                        + WebSocketProcessor.methodToString(context.parameter().method()));
             }
             if (context.endpointPath() == null) {
-                throw new WebSocketServerException("Global error handlers may not accept @PathParam parameters: "
-                        + WebSocketServerProcessor.callbackToString(context.parameter().method()));
+                throw new WebSocketException("Global error handlers may not accept @PathParam parameters: "
+                        + WebSocketProcessor.methodToString(context.parameter().method()));
             }
             List<String> pathParams = getPathParamNames(context.endpointPath());
             if (!pathParams.contains(name)) {
-                throw new WebSocketServerException(
+                throw new WebSocketException(
                         String.format(
                                 "@PathParam name [%s] must be used in the endpoint path [%s]: %s", name,
                                 context.endpointPath(),
-                                WebSocketServerProcessor.callbackToString(context.parameter().method())));
+                                WebSocketProcessor.methodToString(context.parameter().method())));
             }
             return true;
         }
@@ -42,10 +42,10 @@ class PathParamCallbackArgument implements CallbackArgument {
 
     @Override
     public ResultHandle get(InvocationBytecodeContext context) {
-        ResultHandle connection = context.getConnection();
         String paramName = getParamName(context);
-        return context.bytecode().invokeInterfaceMethod(
-                MethodDescriptor.ofMethod(WebSocketConnection.class, "pathParam", String.class, String.class), connection,
+        return context.bytecode().invokeVirtualMethod(
+                MethodDescriptor.ofMethod(WebSocketConnectionBase.class, "pathParam", String.class, String.class),
+                context.getConnection(),
                 context.bytecode().load(paramName));
     }
 
@@ -61,7 +61,7 @@ class PathParamCallbackArgument implements CallbackArgument {
                 name = context.parameter().name();
             }
             if (name == null) {
-                throw new WebSocketServerException(String.format(
+                throw new WebSocketException(String.format(
                         "Unable to extract the path parameter name - method parameter names not recorded for %s: compile the class with -parameters",
                         context.parameter().method().declaringClass().name()));
             }
@@ -72,7 +72,7 @@ class PathParamCallbackArgument implements CallbackArgument {
 
     static List<String> getPathParamNames(String path) {
         List<String> names = new ArrayList<>();
-        Matcher m = WebSocketServerProcessor.TRANSLATED_PATH_PARAM_PATTERN.matcher(path);
+        Matcher m = WebSocketProcessor.TRANSLATED_PATH_PARAM_PATTERN.matcher(path);
         while (m.find()) {
             names.add(m.group().substring(1));
         }

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketDotNames.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketDotNames.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.jboss.jandex.DotName;
 
+import io.quarkus.websockets.next.HandshakeRequest;
 import io.quarkus.websockets.next.OnBinaryMessage;
 import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.OnError;
@@ -12,7 +13,10 @@ import io.quarkus.websockets.next.OnPongMessage;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.PathParam;
 import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketClientConnection;
 import io.quarkus.websockets.next.WebSocketConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.common.annotation.RunOnVirtualThread;
@@ -25,7 +29,10 @@ import io.vertx.core.json.JsonObject;
 final class WebSocketDotNames {
 
     static final DotName WEB_SOCKET = DotName.createSimple(WebSocket.class);
+    static final DotName WEB_SOCKET_CLIENT = DotName.createSimple(WebSocketClient.class);
     static final DotName WEB_SOCKET_CONNECTION = DotName.createSimple(WebSocketConnection.class);
+    static final DotName WEB_SOCKET_CLIENT_CONNECTION = DotName.createSimple(WebSocketClientConnection.class);
+    static final DotName WEB_SOCKET_CONNECTOR = DotName.createSimple(WebSocketConnector.class);
     static final DotName ON_OPEN = DotName.createSimple(OnOpen.class);
     static final DotName ON_TEXT_MESSAGE = DotName.createSimple(OnTextMessage.class);
     static final DotName ON_BINARY_MESSAGE = DotName.createSimple(OnBinaryMessage.class);
@@ -43,7 +50,7 @@ final class WebSocketDotNames {
     static final DotName JSON_ARRAY = DotName.createSimple(JsonArray.class);
     static final DotName VOID = DotName.createSimple(Void.class);
     static final DotName PATH_PARAM = DotName.createSimple(PathParam.class);
-    static final DotName HANDSHAKE_REQUEST = DotName.createSimple(WebSocketConnection.HandshakeRequest.class);
+    static final DotName HANDSHAKE_REQUEST = DotName.createSimple(HandshakeRequest.class);
     static final DotName THROWABLE = DotName.createSimple(Throwable.class);
 
     static final List<DotName> CALLBACK_ANNOTATIONS = List.of(ON_OPEN, ON_CLOSE, ON_BINARY_MESSAGE, ON_TEXT_MESSAGE,

--- a/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketEndpointBuildItem.java
+++ b/extensions/websockets-next/server/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketEndpointBuildItem.java
@@ -1,44 +1,28 @@
 package io.quarkus.websockets.next.deployment;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.function.Predicate;
 
-import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
-import org.jboss.jandex.IndexView;
-import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.MethodParameterInfo;
-import org.jboss.jandex.Type;
-import org.jboss.jandex.Type.Kind;
 
-import io.quarkus.arc.deployment.TransformedAnnotationsBuildItem;
-import io.quarkus.arc.processor.Annotations;
 import io.quarkus.arc.processor.BeanInfo;
-import io.quarkus.arc.processor.DotNames;
 import io.quarkus.builder.item.MultiBuildItem;
-import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.websockets.next.InboundProcessingMode;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketConnection;
-import io.quarkus.websockets.next.WebSocketServerException;
-import io.quarkus.websockets.next.deployment.CallbackArgument.InvocationBytecodeContext;
-import io.quarkus.websockets.next.deployment.CallbackArgument.ParameterContext;
-import io.quarkus.websockets.next.runtime.WebSocketEndpoint.ExecutionModel;
-import io.quarkus.websockets.next.runtime.WebSocketEndpointBase;
+import io.quarkus.websockets.next.WebSocketClient;
 
 /**
- * This build item represents a WebSocket endpoint class.
+ * This build item represents a WebSocket endpoint class, i.e. class annotated with {@link WebSocket} or
+ * {@link WebSocketClient}.
  */
 public final class WebSocketEndpointBuildItem extends MultiBuildItem {
 
+    public final boolean isClient;
     public final BeanInfo bean;
+    // The path is using Vertx syntax for path params, i.e. /foo/:bar
     public final String path;
-    public final String endpointId;
-    public final WebSocket.ExecutionMode executionMode;
+    // @WebSocket#endpointId() or @WebSocketClient#clientId()
+    public final String id;
+    public final InboundProcessingMode inboundProcessingMode;
     public final Callback onOpen;
     public final Callback onTextMessage;
     public final Callback onBinaryMessage;
@@ -46,14 +30,15 @@ public final class WebSocketEndpointBuildItem extends MultiBuildItem {
     public final Callback onClose;
     public final List<Callback> onErrors;
 
-    WebSocketEndpointBuildItem(BeanInfo bean, String path, String endpointId, WebSocket.ExecutionMode executionMode,
-            Callback onOpen,
-            Callback onTextMessage, Callback onBinaryMessage, Callback onPongMessage, Callback onClose,
+    WebSocketEndpointBuildItem(boolean isClient, BeanInfo bean, String path, String id,
+            InboundProcessingMode inboundProcessingMode,
+            Callback onOpen, Callback onTextMessage, Callback onBinaryMessage, Callback onPongMessage, Callback onClose,
             List<Callback> onErrors) {
+        this.isClient = isClient;
         this.bean = bean;
         this.path = path;
-        this.endpointId = endpointId;
-        this.executionMode = executionMode;
+        this.id = id;
+        this.inboundProcessingMode = inboundProcessingMode;
         this.onOpen = onOpen;
         this.onTextMessage = onTextMessage;
         this.onBinaryMessage = onBinaryMessage;
@@ -62,266 +47,16 @@ public final class WebSocketEndpointBuildItem extends MultiBuildItem {
         this.onErrors = onErrors;
     }
 
-    public static class Callback {
+    public boolean isClient() {
+        return isClient;
+    }
 
-        public final String endpointPath;
-        public final AnnotationInstance annotation;
-        public final MethodInfo method;
-        public final ExecutionModel executionModel;
-        public final MessageType messageType;
-        public final List<CallbackArgument> arguments;
+    public boolean isServer() {
+        return !isClient;
+    }
 
-        public Callback(AnnotationInstance annotation, MethodInfo method, ExecutionModel executionModel,
-                CallbackArgumentsBuildItem callbackArguments, TransformedAnnotationsBuildItem transformedAnnotations,
-                String endpointPath, IndexView index) {
-            this.method = method;
-            this.annotation = annotation;
-            this.executionModel = executionModel;
-            if (WebSocketDotNames.ON_BINARY_MESSAGE.equals(annotation.name())) {
-                this.messageType = MessageType.BINARY;
-            } else if (WebSocketDotNames.ON_TEXT_MESSAGE.equals(annotation.name())) {
-                this.messageType = MessageType.TEXT;
-            } else if (WebSocketDotNames.ON_PONG_MESSAGE.equals(annotation.name())) {
-                this.messageType = MessageType.PONG;
-            } else {
-                this.messageType = MessageType.NONE;
-            }
-            this.endpointPath = endpointPath;
-            this.arguments = collectArguments(annotation, method, callbackArguments, transformedAnnotations, index);
-        }
-
-        public boolean isGlobal() {
-            return endpointPath == null;
-        }
-
-        public boolean isOnOpen() {
-            return annotation.name().equals(WebSocketDotNames.ON_OPEN);
-        }
-
-        public boolean isOnClose() {
-            return annotation.name().equals(WebSocketDotNames.ON_CLOSE);
-        }
-
-        public boolean isOnError() {
-            return annotation.name().equals(WebSocketDotNames.ON_ERROR);
-        }
-
-        public Type returnType() {
-            return method.returnType();
-        }
-
-        public Type messageParamType() {
-            return acceptsMessage() ? method.parameterType(0) : null;
-        }
-
-        public boolean isReturnTypeVoid() {
-            return returnType().kind() == Kind.VOID;
-        }
-
-        public boolean isReturnTypeUni() {
-            return WebSocketDotNames.UNI.equals(returnType().name());
-        }
-
-        public boolean isReturnTypeMulti() {
-            return WebSocketDotNames.MULTI.equals(returnType().name());
-        }
-
-        public boolean acceptsMessage() {
-            return messageType != MessageType.NONE;
-        }
-
-        public boolean acceptsBinaryMessage() {
-            return messageType == MessageType.BINARY || messageType == MessageType.PONG;
-        }
-
-        public boolean acceptsMulti() {
-            return acceptsMessage() && method.parameterType(0).name().equals(WebSocketDotNames.MULTI);
-        }
-
-        public MessageType messageType() {
-            return messageType;
-        }
-
-        public boolean broadcast() {
-            AnnotationValue broadcastValue = annotation.value("broadcast");
-            return broadcastValue != null && broadcastValue.asBoolean();
-        }
-
-        public DotName getInputCodec() {
-            return getCodec("codec");
-        }
-
-        public DotName getOutputCodec() {
-            DotName output = getCodec("outputCodec");
-            return output != null ? output : getInputCodec();
-        }
-
-        private DotName getCodec(String valueName) {
-            AnnotationValue codecValue = annotation.value(valueName);
-            if (codecValue != null) {
-                return codecValue.asClass().name();
-            }
-            return null;
-        }
-
-        public enum MessageType {
-            NONE,
-            PONG,
-            TEXT,
-            BINARY
-        }
-
-        public ResultHandle[] generateArguments(ResultHandle endpointThis, BytecodeCreator bytecode,
-                TransformedAnnotationsBuildItem transformedAnnotations, IndexView index) {
-            if (arguments.isEmpty()) {
-                return new ResultHandle[] {};
-            }
-            ResultHandle[] resultHandles = new ResultHandle[arguments.size()];
-            int idx = 0;
-            for (CallbackArgument argument : arguments) {
-                resultHandles[idx] = argument.get(
-                        invocationBytecodeContext(annotation, method.parameters().get(idx), transformedAnnotations, index,
-                                endpointThis, bytecode));
-                idx++;
-            }
-            return resultHandles;
-        }
-
-        private List<CallbackArgument> collectArguments(AnnotationInstance annotation, MethodInfo method,
-                CallbackArgumentsBuildItem callbackArguments, TransformedAnnotationsBuildItem transformedAnnotations,
-                IndexView index) {
-            List<MethodParameterInfo> parameters = method.parameters();
-            if (parameters.isEmpty()) {
-                return List.of();
-            }
-            List<CallbackArgument> arguments = new ArrayList<>(parameters.size());
-            for (MethodParameterInfo parameter : parameters) {
-                List<CallbackArgument> found = callbackArguments
-                        .findMatching(parameterContext(annotation, parameter, transformedAnnotations, index));
-                if (found.isEmpty()) {
-                    String msg = String.format("Unable to inject @%s callback parameter '%s' declared on %s: no injector found",
-                            DotNames.simpleName(annotation.name()),
-                            parameter.name() != null ? parameter.name() : "#" + parameter.position(),
-                            WebSocketServerProcessor.callbackToString(method));
-                    throw new WebSocketServerException(msg);
-                } else if (found.size() > 1 && (found.get(0).priotity() == found.get(1).priotity())) {
-                    String msg = String.format(
-                            "Unable to inject @%s callback parameter '%s' declared on %s: ambiguous injectors found: %s",
-                            DotNames.simpleName(annotation.name()),
-                            parameter.name() != null ? parameter.name() : "#" + parameter.position(),
-                            WebSocketServerProcessor.callbackToString(method),
-                            found.stream().map(p -> p.getClass().getSimpleName() + ":" + p.priotity()));
-                    throw new WebSocketServerException(msg);
-                }
-                arguments.add(found.get(0));
-            }
-            return List.copyOf(arguments);
-        }
-
-        Type argumentType(Predicate<CallbackArgument> filter) {
-            int idx = 0;
-            for (int i = 0; i < arguments.size(); i++) {
-                if (filter.test(arguments.get(idx))) {
-                    return method.parameterType(i);
-                }
-            }
-            return null;
-        }
-
-        private ParameterContext parameterContext(AnnotationInstance callbackAnnotation, MethodParameterInfo parameter,
-                TransformedAnnotationsBuildItem transformedAnnotations, IndexView index) {
-            return new ParameterContext() {
-
-                @Override
-                public MethodParameterInfo parameter() {
-                    return parameter;
-                }
-
-                @Override
-                public Set<AnnotationInstance> parameterAnnotations() {
-                    return Annotations.getParameterAnnotations(
-                            transformedAnnotations::getAnnotations, parameter.method(), parameter.position());
-                }
-
-                @Override
-                public AnnotationInstance callbackAnnotation() {
-                    return callbackAnnotation;
-                }
-
-                @Override
-                public String endpointPath() {
-                    return endpointPath;
-                }
-
-                @Override
-                public IndexView index() {
-                    return index;
-                }
-
-            };
-        }
-
-        private InvocationBytecodeContext invocationBytecodeContext(AnnotationInstance callbackAnnotation,
-                MethodParameterInfo parameter, TransformedAnnotationsBuildItem transformedAnnotations, IndexView index,
-                ResultHandle endpointThis, BytecodeCreator bytecode) {
-            return new InvocationBytecodeContext() {
-
-                @Override
-                public AnnotationInstance callbackAnnotation() {
-                    return callbackAnnotation;
-                }
-
-                @Override
-                public MethodParameterInfo parameter() {
-                    return parameter;
-                }
-
-                @Override
-                public Set<AnnotationInstance> parameterAnnotations() {
-                    return Annotations.getParameterAnnotations(
-                            transformedAnnotations::getAnnotations, parameter.method(), parameter.position());
-                }
-
-                @Override
-                public String endpointPath() {
-                    return endpointPath;
-                }
-
-                @Override
-                public IndexView index() {
-                    return index;
-                }
-
-                @Override
-                public BytecodeCreator bytecode() {
-                    return bytecode;
-                }
-
-                @Override
-                public ResultHandle getPayload() {
-                    return acceptsMessage() || callbackAnnotation.name().equals(WebSocketDotNames.ON_ERROR)
-                            ? bytecode.getMethodParam(0)
-                            : null;
-                }
-
-                @Override
-                public ResultHandle getDecodedMessage(Type parameterType) {
-                    return acceptsMessage()
-                            ? WebSocketServerProcessor.decodeMessage(endpointThis, bytecode, acceptsBinaryMessage(),
-                                    parameterType,
-                                    getPayload(), Callback.this)
-                            : null;
-                }
-
-                @Override
-                public ResultHandle getConnection() {
-                    return bytecode.readInstanceField(
-                            FieldDescriptor.of(WebSocketEndpointBase.class, "connection", WebSocketConnection.class),
-                            endpointThis);
-                }
-            };
-        }
-
+    public DotName beanClassName() {
+        return bean.getImplClazz().name();
     }
 
 }

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/deployment/WebSocketProcessorTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/deployment/WebSocketProcessorTest.java
@@ -7,26 +7,26 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.websockets.next.WebSocketServerException;
 
-public class WebSocketServerProcessorTest {
+public class WebSocketProcessorTest {
 
     @Test
     public void testGetPath() {
-        assertEquals("/foo/:id", WebSocketServerProcessor.getPath("/foo/{id}"));
-        assertEquals("/foo/:id/bar/:id2", WebSocketServerProcessor.getPath("/foo/{id}/bar/{id2}"));
-        assertEquals("/foo/:bar-:baz", WebSocketServerProcessor.getPath("/foo/{bar}-{baz}"));
-        assertEquals("/ws/v:version", WebSocketServerProcessor.getPath("/ws/v{version}"));
+        assertEquals("/foo/:id", WebSocketProcessor.getPath("/foo/{id}"));
+        assertEquals("/foo/:id/bar/:id2", WebSocketProcessor.getPath("/foo/{id}/bar/{id2}"));
+        assertEquals("/foo/:bar-:baz", WebSocketProcessor.getPath("/foo/{bar}-{baz}"));
+        assertEquals("/ws/v:version", WebSocketProcessor.getPath("/ws/v{version}"));
         WebSocketServerException e = assertThrows(WebSocketServerException.class,
-                () -> WebSocketServerProcessor.getPath("/foo/v{bar}/{baz}and{alpha_1}-{name}"));
+                () -> WebSocketProcessor.getPath("/foo/v{bar}/{baz}and{alpha_1}-{name}"));
         assertEquals(
                 "Path parameter {baz} may not be followed by an alphanumeric character or underscore: /foo/v{bar}/{baz}and{alpha_1}-{name}",
                 e.getMessage());
         e = assertThrows(WebSocketServerException.class,
-                () -> WebSocketServerProcessor.getPath("/foo/v{bar}/{baz}_{alpha_1}-{name}"));
+                () -> WebSocketProcessor.getPath("/foo/v{bar}/{baz}_{alpha_1}-{name}"));
         assertEquals(
                 "Path parameter {baz} may not be followed by an alphanumeric character or underscore: /foo/v{bar}/{baz}_{alpha_1}-{name}",
                 e.getMessage());
         e = assertThrows(WebSocketServerException.class,
-                () -> WebSocketServerProcessor.getPath("/foo/v{bar}/{baz}1-{name}"));
+                () -> WebSocketProcessor.getPath("/foo/v{bar}/{baz}1-{name}"));
         assertEquals(
                 "Path parameter {baz} may not be followed by an alphanumeric character or underscore: /foo/v{bar}/{baz}1-{name}",
                 e.getMessage());
@@ -34,9 +34,9 @@ public class WebSocketServerProcessorTest {
 
     @Test
     public void testMergePath() {
-        assertEquals("foo/bar", WebSocketServerProcessor.mergePath("foo/", "/bar"));
-        assertEquals("foo/bar", WebSocketServerProcessor.mergePath("foo", "/bar"));
-        assertEquals("foo/bar", WebSocketServerProcessor.mergePath("foo/", "bar"));
+        assertEquals("foo/bar", WebSocketProcessor.mergePath("foo/", "/bar"));
+        assertEquals("foo/bar", WebSocketProcessor.mergePath("foo", "/bar"));
+        assertEquals("foo/bar", WebSocketProcessor.mergePath("foo/", "bar"));
     }
 
 }

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/HandshakeRequestArgumentTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/HandshakeRequestArgumentTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.HandshakeRequest;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketConnection.HandshakeRequest;
 import io.quarkus.websockets.next.test.utils.WSClient;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.WebSocketConnectOptions;

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/OnCloseInvalidArgumentTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/OnCloseInvalidArgumentTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class OnCloseInvalidArgumentTest {
 
@@ -19,7 +19,7 @@ public class OnCloseInvalidArgumentTest {
             .withApplicationRoot(root -> {
                 root.addClasses(Endpoint.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void testInvalidArgument() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/OnOpenInvalidArgumentTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/OnOpenInvalidArgumentTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class OnOpenInvalidArgumentTest {
 
@@ -19,7 +19,7 @@ public class OnOpenInvalidArgumentTest {
             .withApplicationRoot(root -> {
                 root.addClasses(Endpoint.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void testInvalidArgument() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentInvalidNameTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentInvalidNameTest.java
@@ -9,7 +9,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.PathParam;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class PathParamArgumentInvalidNameTest {
 
@@ -17,7 +17,7 @@ public class PathParamArgumentInvalidNameTest {
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
                 root.addClasses(MontyEcho.class);
-            }).setExpectedException(WebSocketServerException.class);
+            }).setExpectedException(WebSocketException.class);
 
     @Test
     void testInvalidArgument() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentInvalidTypeTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/args/PathParamArgumentInvalidTypeTest.java
@@ -9,7 +9,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.PathParam;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class PathParamArgumentInvalidTypeTest {
 
@@ -17,7 +17,7 @@ public class PathParamArgumentInvalidTypeTest {
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
                 root.addClasses(MontyEcho.class);
-            }).setExpectedException(WebSocketServerException.class);
+            }).setExpectedException(WebSocketException.class);
 
     @Test
     void testInvalidArgument() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/BasicConnectorTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/BasicConnectorTest.java
@@ -1,0 +1,137 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.BasicWebSocketConnector;
+import io.quarkus.websockets.next.BasicWebSocketConnector.ExecutionModel;
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.PathParam;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.vertx.core.Context;
+
+public class BasicConnectorTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class);
+            });
+
+    @Inject
+    BasicWebSocketConnector connector;
+
+    @TestHTTPResource("/end")
+    URI uri;
+
+    static final CountDownLatch MESSAGE_LATCH = new CountDownLatch(2);
+
+    static final List<String> MESSAGES = new CopyOnWriteArrayList<>();
+
+    static final CountDownLatch CLOSED_LATCH = new CountDownLatch(1);
+
+    @Test
+    void testClient() throws InterruptedException {
+
+        assertThrows(NullPointerException.class, () -> connector.baseUri(null));
+        assertThrows(NullPointerException.class, () -> connector.path(null));
+        assertThrows(NullPointerException.class, () -> connector.addHeader(null, "foo"));
+        assertThrows(NullPointerException.class, () -> connector.addHeader("foo", null));
+        assertThrows(NullPointerException.class, () -> connector.pathParam(null, "foo"));
+        assertThrows(NullPointerException.class, () -> connector.pathParam("foo", null));
+        assertThrows(NullPointerException.class, () -> connector.addSubprotocol(null));
+        assertThrows(NullPointerException.class, () -> connector.executionModel(null));
+        assertThrows(NullPointerException.class, () -> connector.onBinaryMessage(null));
+        assertThrows(NullPointerException.class, () -> connector.onTextMessage(null));
+        assertThrows(NullPointerException.class, () -> connector.onOpen(null));
+        assertThrows(NullPointerException.class, () -> connector.onClose(null));
+        assertThrows(NullPointerException.class, () -> connector.onPong(null));
+        assertThrows(NullPointerException.class, () -> connector.onError(null));
+
+        WebSocketClientConnection connection1 = connector
+                .baseUri(uri)
+                .path("/{name}")
+                .pathParam("name", "Lu")
+                .onTextMessage((c, m) -> {
+                    assertTrue(Context.isOnWorkerThread());
+                    String name = c.pathParam("name");
+                    MESSAGE_LATCH.countDown();
+                    MESSAGES.add(name + ":" + m);
+                })
+                .onClose((c, s) -> CLOSED_LATCH.countDown())
+                .connectAndAwait();
+        assertEquals("Lu", connection1.pathParam("name"));
+        connection1.sendTextAndAwait("Hi!");
+
+        assertTrue(MESSAGE_LATCH.await(5, TimeUnit.SECONDS));
+        // Note that ordering is not guaranteed
+        assertThat(MESSAGES.get(0)).isIn("Lu:Hello Lu!", "Lu:Hi!");
+        assertThat(MESSAGES.get(1)).isIn("Lu:Hello Lu!", "Lu:Hi!");
+
+        connection1.closeAndAwait();
+        assertTrue(CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(ServerEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+
+        CountDownLatch CONN2_LATCH = new CountDownLatch(1);
+        WebSocketClientConnection connection2 = BasicWebSocketConnector
+                .create()
+                .baseUri(uri)
+                .path("/Cool")
+                .executionModel(ExecutionModel.NON_BLOCKING)
+                .addHeader("X-Test", "foo")
+                .onTextMessage((c, m) -> {
+                    assertTrue(Context.isOnEventLoopThread());
+                    // Path params not set
+                    assertNull(c.pathParam("name"));
+                    assertTrue(c.handshakeRequest().path().endsWith("Cool"));
+                    assertEquals("foo", c.handshakeRequest().header("X-Test"));
+                    CONN2_LATCH.countDown();
+                })
+                .connectAndAwait();
+        assertNotNull(connection2);
+        assertTrue(CONN2_LATCH.await(5, TimeUnit.SECONDS));
+    }
+
+    @WebSocket(path = "/end/{name}")
+    public static class ServerEndpoint {
+
+        static final CountDownLatch CLOSED_LATCH = new CountDownLatch(1);
+
+        @OnOpen
+        String open(@PathParam String name) {
+            return "Hello " + name + "!";
+        }
+
+        @OnTextMessage
+        String echo(String message) {
+            return message;
+        }
+
+        @OnClose
+        void close() {
+            CLOSED_LATCH.countDown();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/BroadCastOnClientTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/BroadCastOnClientTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketClientException;
+
+public class BroadCastOnClientTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class, ClientEndpoint.class);
+            })
+            .setExpectedException(WebSocketClientException.class, true);
+
+    @Test
+    void testInvalidBroadcast() {
+        fail();
+    }
+
+    @WebSocket(path = "/end")
+    public static class ServerEndpoint {
+
+        @OnOpen
+        void open() {
+        }
+
+    }
+
+    @WebSocketClient(path = "/end")
+    public static class ClientEndpoint {
+
+        @OnTextMessage(broadcast = true)
+        String echo(String message) {
+            return message;
+        }
+
+    }
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientAutoPingIntervalTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientAutoPingIntervalTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnPongMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketConnector;
+import io.vertx.core.buffer.Buffer;
+
+public class ClientAutoPingIntervalTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class, ClientEndpoint.class);
+            }).overrideConfigKey("quarkus.websockets-next.client.auto-ping-interval", "200ms");
+
+    @TestHTTPResource("/")
+    URI uri;
+
+    @Inject
+    WebSocketConnector<ClientEndpoint> connector;
+
+    @Test
+    public void testPingPong() throws InterruptedException, ExecutionException {
+        connector.baseUri(uri).connectAndAwait();
+        // Ping messages are sent automatically
+        assertTrue(ClientEndpoint.PONG.await(5, TimeUnit.SECONDS));
+    }
+
+    @WebSocket(path = "/end")
+    public static class ServerEndpoint {
+
+        @OnOpen
+        void open() {
+        }
+
+    }
+
+    @WebSocketClient(path = "/end")
+    public static class ClientEndpoint {
+
+        static final CountDownLatch PONG = new CountDownLatch(3);
+
+        @OnPongMessage
+        void pong(Buffer data) {
+            PONG.countDown();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientEndpointTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientEndpointTest.java
@@ -1,0 +1,107 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.PathParam;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+public class ClientEndpointTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class, ClientEndpoint.class);
+            });
+
+    @Inject
+    WebSocketConnector<ClientEndpoint> connector;
+
+    @TestHTTPResource("/")
+    URI uri;
+
+    @Test
+    void testClient() throws InterruptedException {
+        WebSocketClientConnection connection = connector
+                .baseUri(uri)
+                .pathParam("name", "Lu")
+                .connectAndAwait();
+        assertEquals("Lu", connection.pathParam("name"));
+        connection.sendTextAndAwait("Hi!");
+
+        assertTrue(ClientEndpoint.MESSAGE_LATCH.await(5, TimeUnit.SECONDS));
+        assertEquals("Lu:Hello Lu!", ClientEndpoint.MESSAGES.get(0));
+        assertEquals("Lu:Hi!", ClientEndpoint.MESSAGES.get(1));
+
+        connection.closeAndAwait();
+        assertTrue(ClientEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(ServerEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+    }
+
+    @WebSocket(path = "/endpoint/{name}")
+    public static class ServerEndpoint {
+
+        static final CountDownLatch CLOSED_LATCH = new CountDownLatch(1);
+
+        @OnOpen
+        String open(@PathParam String name) {
+            return "Hello " + name + "!";
+        }
+
+        @OnTextMessage
+        String echo(String message) {
+            return message;
+        }
+
+        @OnClose
+        void close() {
+            CLOSED_LATCH.countDown();
+        }
+
+    }
+
+    @WebSocketClient(path = "/endpoint/{name}")
+    public static class ClientEndpoint {
+
+        static final CountDownLatch MESSAGE_LATCH = new CountDownLatch(2);
+
+        static final List<String> MESSAGES = new CopyOnWriteArrayList<>();
+
+        static final CountDownLatch CLOSED_LATCH = new CountDownLatch(1);
+
+        @OnTextMessage
+        void onMessage(@PathParam String name, String message, WebSocketClientConnection connection) {
+            if (!name.equals(connection.pathParam("name"))) {
+                throw new IllegalArgumentException();
+            }
+            MESSAGE_LATCH.countDown();
+            MESSAGES.add(name + ":" + message);
+        }
+
+        @OnClose
+        void close() {
+            CLOSED_LATCH.countDown();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientIdConfigBaseUriTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientIdConfigBaseUriTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+public class ClientIdConfigBaseUriTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class, ClientEndpoint.class);
+            });
+
+    @TestHTTPResource("/")
+    URI uri;
+
+    @Inject
+    WebSocketConnector<ClientEndpoint> connector;
+
+    @Test
+    public void testConfiguredBaseUri() throws InterruptedException, ExecutionException {
+        String key = "c1.base-uri";
+        String prev = System.getProperty(key);
+        System.setProperty(key, uri.toString());
+        try {
+            // No need to pass baseUri
+            connector.connectAndAwait();
+            assertTrue(ServerEndpoint.OPEN_LATCH.await(5, TimeUnit.SECONDS));
+            assertTrue(ClientEndpoint.OPEN_LATCH.await(5, TimeUnit.SECONDS));
+        } finally {
+            if (prev != null) {
+                System.setProperty(key, prev);
+            }
+        }
+    }
+
+    @WebSocket(path = "/end")
+    public static class ServerEndpoint {
+
+        static final CountDownLatch OPEN_LATCH = new CountDownLatch(1);
+
+        @OnOpen
+        void open() {
+            OPEN_LATCH.countDown();
+        }
+
+    }
+
+    @WebSocketClient(path = "/end", clientId = "c1")
+    public static class ClientEndpoint {
+
+        static final CountDownLatch OPEN_LATCH = new CountDownLatch(1);
+
+        @OnOpen
+        void open() {
+            OPEN_LATCH.countDown();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/InvalidConnectorInjectionPointTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/InvalidConnectorInjectionPointTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.WebSocketClientException;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+public class InvalidConnectorInjectionPointTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(Service.class);
+            })
+            .setExpectedException(WebSocketClientException.class, true);
+
+    @Test
+    void testInvalidInjectionPoint() {
+        fail();
+    }
+
+    @Unremovable
+    @Singleton
+    public static class Service {
+
+        @Inject
+        WebSocketConnector<String> invalid;
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/OpenClientConnectionsTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/client/OpenClientConnectionsTest.java
@@ -1,0 +1,121 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.BasicWebSocketConnector;
+import io.quarkus.websockets.next.HandshakeRequest;
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OpenClientConnections;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+public class OpenClientConnectionsTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class, ClientEndpoint.class);
+            });
+
+    @Inject
+    OpenClientConnections connections;
+
+    @Inject
+    WebSocketConnector<ClientEndpoint> connector;
+
+    @Inject
+    BasicWebSocketConnector basicConnector;
+
+    @TestHTTPResource("/")
+    URI uri;
+
+    @Test
+    void testClient() throws InterruptedException {
+        for (WebSocketClientConnection c : connections) {
+            fail("No connection should be found: " + c);
+        }
+
+        WebSocketClientConnection connection1 = connector
+                .baseUri(uri)
+                .addHeader("X-Test", "foo")
+                .connectAndAwait();
+
+        WebSocketClientConnection connection2 = connector
+                .baseUri(uri)
+                .addHeader("X-Test", "bar")
+                .connectAndAwait();
+
+        CountDownLatch CONN3_OPEN_LATCH = new CountDownLatch(1);
+        WebSocketClientConnection connection3 = basicConnector
+                .baseUri(uri)
+                .onOpen(c -> CONN3_OPEN_LATCH.countDown())
+                .path("end")
+                .connectAndAwait();
+
+        assertTrue(ServerEndpoint.OPEN_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(ClientEndpoint.OPEN_LATCH.await(5, TimeUnit.SECONDS));
+
+        assertNotNull(connections.findByConnectionId(connection1.id()));
+        assertNotNull(connections.findByConnectionId(connection2.id()));
+        assertNotNull(connections.findByConnectionId(connection3.id()));
+        assertEquals(3, connections.listAll().size());
+        assertEquals(2, connections.findByClientId("client").size());
+        assertEquals(1, connections.findByClientId(BasicWebSocketConnector.class.getName()).size());
+
+        connection2.closeAndAwait();
+        assertTrue(ClientEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+        assertEquals(2, connections.stream().toList().size());
+    }
+
+    @WebSocket(path = "/end")
+    public static class ServerEndpoint {
+
+        static final CountDownLatch OPEN_LATCH = new CountDownLatch(2);
+
+        @OnOpen
+        void open(HandshakeRequest handshakeRequest) {
+            if (handshakeRequest.header("X-Test") != null) {
+                OPEN_LATCH.countDown();
+            }
+        }
+
+    }
+
+    @WebSocketClient(path = "/end", clientId = "client")
+    public static class ClientEndpoint {
+
+        static final CountDownLatch OPEN_LATCH = new CountDownLatch(2);
+        static final CountDownLatch CLOSED_LATCH = new CountDownLatch(1);
+
+        @OnOpen
+        void open(HandshakeRequest handshakeRequest) {
+            if (handshakeRequest.header("X-Test") != null) {
+                OPEN_LATCH.countDown();
+            }
+        }
+
+        @OnClose
+        void close() {
+            CLOSED_LATCH.countDown();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnCloseInSubEndpointTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnCloseInSubEndpointTest.java
@@ -7,7 +7,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class TooManyOnCloseInSubEndpointTest {
 
@@ -16,7 +16,7 @@ public class TooManyOnCloseInSubEndpointTest {
             .withApplicationRoot(root -> {
                 root.addClasses(ParentEndpoint.class, ParentEndpoint.SubEndpointWithTooManyOnClose.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void verifyThatSubEndpointWithoutTooManyOnCloseFailsToDeploy() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnCloseTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnCloseTest.java
@@ -7,7 +7,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class TooManyOnCloseTest {
 
@@ -16,7 +16,7 @@ public class TooManyOnCloseTest {
             .withApplicationRoot(root -> {
                 root.addClasses(TooManyOnClose.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void verifyThatEndpointWithMultipleOnCloseMethodsFailsToDeploy() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnMessageInSubEndpointTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnMessageInSubEndpointTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class TooManyOnMessageInSubEndpointTest {
 
@@ -15,7 +15,7 @@ public class TooManyOnMessageInSubEndpointTest {
             .withApplicationRoot(root -> {
                 root.addClasses(ParentEndpoint.class, ParentEndpoint.SubEndpointWithTooManyOnMessage.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void verifyThatSubEndpointWithoutTooManyOnMessageFailsToDeploy() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnMessageTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnMessageTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class TooManyOnMessageTest {
 
@@ -15,7 +15,7 @@ public class TooManyOnMessageTest {
             .withApplicationRoot(root -> {
                 root.addClasses(TooManyOnMessage.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void verifyThatEndpointWithMultipleOnMessageMethodsFailsToDeploy() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnOpenInSubEndpointTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnOpenInSubEndpointTest.java
@@ -7,7 +7,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class TooManyOnOpenInSubEndpointTest {
 
@@ -16,7 +16,7 @@ public class TooManyOnOpenInSubEndpointTest {
             .withApplicationRoot(root -> {
                 root.addClasses(ParentEndpoint.class, ParentEndpoint.SubEndpointWithTooManyOnOpen.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void verifyThatSubEndpointWithoutTooManyOnOpenFailsToDeploy() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnOpenTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/endpoints/TooManyOnOpenTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class TooManyOnOpenTest {
 
@@ -15,7 +15,7 @@ public class TooManyOnOpenTest {
             .withApplicationRoot(root -> {
                 root.addClasses(TooManyOnOpen.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void verifyThatEndpointWithMultipleOnOpenMethodsFailsToDeploy() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/errors/GlobalErrorHandlerWithPathParamTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/errors/GlobalErrorHandlerWithPathParamTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.PathParam;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class GlobalErrorHandlerWithPathParamTest {
 
@@ -19,7 +19,7 @@ public class GlobalErrorHandlerWithPathParamTest {
             .withApplicationRoot(root -> {
                 root.addClasses(GlobalErrorHandlers.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void testMultipleAmbiguousErrorHandlers() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/errors/MultipleAmbiguousErrorHandlersTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/errors/MultipleAmbiguousErrorHandlersTest.java
@@ -9,7 +9,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.WebSocket;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class MultipleAmbiguousErrorHandlersTest {
 
@@ -18,7 +18,7 @@ public class MultipleAmbiguousErrorHandlersTest {
             .withApplicationRoot(root -> {
                 root.addClasses(Endpoint.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void testMultipleAmbiguousErrorHandlers() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/errors/MultipleAmbiguousGlobalErrorHandlersTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/errors/MultipleAmbiguousGlobalErrorHandlersTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.websockets.next.OnError;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 
 public class MultipleAmbiguousGlobalErrorHandlersTest {
 
@@ -19,7 +19,7 @@ public class MultipleAmbiguousGlobalErrorHandlersTest {
             .withApplicationRoot(root -> {
                 root.addClasses(GlobalErrorHandlers.class);
             })
-            .setExpectedException(WebSocketServerException.class);
+            .setExpectedException(WebSocketException.class);
 
     @Test
     void testMultipleAmbiguousErrorHandlers() {

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/subprotocol/SubprotocolSelectedTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/subprotocol/SubprotocolSelectedTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.websockets.next.test.subprotocol;
 
-import static io.quarkus.websockets.next.WebSocketConnection.HandshakeRequest.SEC_WEBSOCKET_PROTOCOL;
+import static io.quarkus.websockets.next.HandshakeRequest.SEC_WEBSOCKET_PROTOCOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
@@ -1,0 +1,181 @@
+package io.quarkus.websockets.next;
+
+import java.net.URI;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import io.quarkus.arc.Arc;
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * This basic connector can be used to configure and open new client connections. Unlike with {@link WebSocketConnector} a
+ * client endpoint class is not needed.
+ * <p>
+ * This construct is not thread-safe and should not be used concurrently.
+ *
+ * @see WebSocketClientConnection
+ */
+@Experimental("This API is experimental and may change in the future")
+public interface BasicWebSocketConnector {
+
+    /**
+     * Obtains a new basic connector. An alternative to {@code @Inject BasicWebSocketConnector}.
+     *
+     * @return a new basic connector
+     */
+    static BasicWebSocketConnector create() {
+        return Arc.container().instance(BasicWebSocketConnector.class).get();
+    }
+
+    /**
+     * Set the base URI.
+     *
+     * @param uri
+     * @return self
+     */
+    BasicWebSocketConnector baseUri(URI uri);
+
+    /**
+     * Set the path that should be appended to the path of the URI set by {@link #baseUri(URI)}.
+     * <p>
+     * The path may contain path parameters as defined by {@link WebSocketClient#path()}. In this case, the
+     * {@link #pathParam(String, String)} method must be used to pass path param values.
+     *
+     * @param path
+     * @return self
+     */
+    BasicWebSocketConnector path(String path);
+
+    /**
+     * Set the path param.
+     *
+     * @param name
+     * @param value
+     * @return self
+     * @throws IllegalArgumentException If the path set by {@link #path(String)} does not contain a parameter with the given
+     *         name
+     */
+    BasicWebSocketConnector pathParam(String name, String value);
+
+    /**
+     * Add a header used during the initial handshake request.
+     *
+     * @param name
+     * @param value
+     * @return self
+     * @see HandshakeRequest
+     */
+    BasicWebSocketConnector addHeader(String name, String value);
+
+    /**
+     * Add the subprotocol.
+     *
+     * @param name
+     * @param value
+     * @return self
+     */
+    BasicWebSocketConnector addSubprotocol(String value);
+
+    /**
+     * Set the execution model for callback handlers.
+     * <p>
+     * By default, {@link ExecutionModel#BLOCKING} is used.
+     *
+     * @return self
+     * @see #onTextMessage(BiConsumer)
+     * @see #onBinaryMessage(BiConsumer)
+     * @see #onPong(BiConsumer)
+     * @see #onOpen(Consumer)
+     * @see #onClose(BiConsumer)
+     * @see #onError(BiConsumer)
+     */
+    BasicWebSocketConnector executionModel(ExecutionModel model);
+
+    /**
+     * Set a callback to be invoked when a connection to the server is open.
+     *
+     * @param consumer
+     * @return self
+     * @see #executionModel(ExecutionModel)
+     */
+    BasicWebSocketConnector onOpen(Consumer<WebSocketClientConnection> consumer);
+
+    /**
+     * Set a callback to be invoked when a text message is received from the server.
+     *
+     * @param consumer
+     * @return self
+     * @see #executionModel(ExecutionModel)
+     */
+    BasicWebSocketConnector onTextMessage(BiConsumer<WebSocketClientConnection, String> consumer);
+
+    /**
+     * Set a callback to be invoked when a binary message is received from the server.
+     *
+     * @param consumer
+     * @return self
+     * @see #executionModel(ExecutionModel)
+     */
+    BasicWebSocketConnector onBinaryMessage(BiConsumer<WebSocketClientConnection, Buffer> consumer);
+
+    /**
+     * Set a callback to be invoked when a pong message is received from the server.
+     *
+     * @param consumer
+     * @return self
+     * @see #executionModel(ExecutionModel)
+     */
+    BasicWebSocketConnector onPong(BiConsumer<WebSocketClientConnection, Buffer> consumer);
+
+    /**
+     * Set a callback to be invoked when a connection to the server is closed.
+     *
+     * @param consumer
+     * @return self
+     * @see #executionModel(ExecutionModel)
+     */
+    BasicWebSocketConnector onClose(BiConsumer<WebSocketClientConnection, Short> consumer);
+
+    /**
+     * Set a callback to be invoked when an error occurs.
+     *
+     * @param consumer
+     * @return self
+     * @see #executionModel(ExecutionModel)
+     */
+    BasicWebSocketConnector onError(BiConsumer<WebSocketClientConnection, Throwable> consumer);
+
+    /**
+     *
+     * @return a new {@link Uni} with a {@link WebSocketClientConnection} item
+     */
+    @CheckReturnValue
+    Uni<WebSocketClientConnection> connect();
+
+    /**
+     *
+     * @return the client connection
+     */
+    default WebSocketClientConnection connectAndAwait() {
+        return connect().await().indefinitely();
+    }
+
+    enum ExecutionModel {
+        /**
+         * Callback may block the current thread.
+         */
+        BLOCKING,
+        /**
+         * Callback is executed on the event loop and may not block the current thread.
+         */
+        NON_BLOCKING,
+        /**
+         * Callback is executed on a virtual thread.
+         */
+        VIRTUAL_THREAD,
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/BinaryDecodeException.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/BinaryDecodeException.java
@@ -8,7 +8,7 @@ import io.vertx.core.buffer.Buffer;
  * @see BinaryMessageCodec
  */
 @Experimental("This API is experimental and may change in the future")
-public class BinaryDecodeException extends WebSocketServerException {
+public class BinaryDecodeException extends WebSocketException {
 
     private static final long serialVersionUID = 6814319993301938091L;
 

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/BinaryEncodeException.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/BinaryEncodeException.java
@@ -7,7 +7,7 @@ import io.smallrye.common.annotation.Experimental;
  * @see BinaryMessageCodec
  */
 @Experimental("This API is experimental and may change in the future")
-public class BinaryEncodeException extends WebSocketServerException {
+public class BinaryEncodeException extends WebSocketException {
 
     private static final long serialVersionUID = -8042792962717461873L;
 

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/HandshakeRequest.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/HandshakeRequest.java
@@ -1,0 +1,89 @@
+package io.quarkus.websockets.next;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides some useful information about the initial handshake request.
+ */
+public interface HandshakeRequest {
+
+    /**
+     * The name is case insensitive.
+     *
+     * @param name
+     * @return the first header value for the given header name, or {@code null}
+     */
+    String header(String name);
+
+    /**
+     * The name is case insensitive.
+     *
+     * @param name
+     * @return an immutable list of header values for the given header name, never {@code null}
+     */
+    List<String> headers(String name);
+
+    /**
+     * Returned header names are lower case.
+     *
+     * @return an immutable map of header names to header values
+     */
+    Map<String, List<String>> headers();
+
+    /**
+     *
+     * @return the scheme
+     */
+    String scheme();
+
+    /**
+     *
+     * @return the host
+     */
+    String host();
+
+    /**
+     *
+     * @return the port
+     */
+    int port();
+
+    /**
+     *
+     * @return the path
+     */
+    String path();
+
+    /**
+     *
+     * @return the query string
+     */
+    String query();
+
+    /**
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-57">The WebSocket Protocol</a>.
+     */
+    public static final String SEC_WEBSOCKET_KEY = "Sec-WebSocket-Key";
+
+    /**
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-58">The WebSocket Protocol</a>.
+     */
+    public static final String SEC_WEBSOCKET_EXTENSIONS = "Sec-WebSocket-Extensions";
+
+    /**
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-58">The WebSocket Protocol</a>.
+     */
+    public static final String SEC_WEBSOCKET_ACCEPT = "Sec-WebSocket-Accept";
+
+    /**
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-59">The WebSocket Protocol</a>.
+     */
+    public static final String SEC_WEBSOCKET_PROTOCOL = "Sec-WebSocket-Protocol";
+
+    /**
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-60">The WebSocket Protocol</a>.
+     */
+    public static final String SEC_WEBSOCKET_VERSION = "Sec-WebSocket-Version";
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/InboundProcessingMode.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/InboundProcessingMode.java
@@ -1,0 +1,24 @@
+package io.quarkus.websockets.next;
+
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * Defines the mode used to process incoming messages for a specific connection.
+ *
+ * @see WebSocketConnection
+ * @see WebSocketClientConnection
+ */
+@Experimental("This API is experimental and may change in the future")
+public enum InboundProcessingMode {
+
+    /**
+     * Messages are processed serially, ordering is guaranteed.
+     */
+    SERIAL,
+
+    /**
+     * Messages are processed concurrently, there are no ordering guarantees.
+     */
+    CONCURRENT,
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnBinaryMessage.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnBinaryMessage.java
@@ -6,11 +6,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.quarkus.websockets.next.WebSocketConnection.HandshakeRequest;
 import io.smallrye.common.annotation.Experimental;
 
 /**
- * A {@link WebSocket} endpoint method annotated with this annotation consumes binary messages.
+ * {@link WebSocket} and {@link WebSocketClient} endpoint methods annotated with this annotation consume binary messages.
  * <p>
  * The method must accept exactly one message parameter. A binary message is always represented as a
  * {@link io.vertx.core.buffer.Buffer}. Therefore, the following conversion rules
@@ -31,7 +30,7 @@ import io.smallrye.common.annotation.Experimental;
  * <p>
  * The method may also accept the following parameters:
  * <ul>
- * <li>{@link WebSocketConnection}</li>
+ * <li>{@link WebSocketConnection}/{@link WebSocketClientConnection}; depending on the endpoint type</li>
  * <li>{@link HandshakeRequest}</li>
  * <li>{@link String} parameters annotated with {@link PathParam}</li>
  * </ul>
@@ -44,6 +43,7 @@ import io.smallrye.common.annotation.Experimental;
 public @interface OnBinaryMessage {
 
     /**
+     * Broadcasting is only supported for server endpoints annotated with {@link WebSocket}.
      *
      * @return {@code true} if all the connected clients should receive the objects returned by the annotated method
      * @see WebSocketConnection#broadcast()

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnClose.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnClose.java
@@ -6,17 +6,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.quarkus.websockets.next.WebSocketConnection.HandshakeRequest;
 import io.smallrye.common.annotation.Experimental;
 
 /**
- * A {@link WebSocket} endpoint method annotated with this annotation is invoked when the client disconnects from the
- * socket.
+ * {@link WebSocket} and {@link WebSocketClient} endpoint methods annotated with this annotation are invoked when a connection
+ * is closed.
  * <p>
  * The method must return {@code void} or {@code io.smallrye.mutiny.Uni<Void>}.
  * The method may accept the following parameters:
  * <ul>
- * <li>{@link WebSocketConnection}</li>
+ * <li>{@link WebSocketConnection}/{@link WebSocketClientConnection}; depending on the endpoint type</li>
  * <li>{@link HandshakeRequest}</li>
  * <li>{@link String} parameters annotated with {@link PathParam}</li>
  * </ul>

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnError.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnError.java
@@ -6,11 +6,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.quarkus.websockets.next.WebSocketConnection.HandshakeRequest;
 import io.smallrye.common.annotation.Experimental;
 
 /**
- * A {@link WebSocket} endpoint method annotated with this annotation is invoked when an error occurs.
+ * {@link WebSocket} and {@link WebSocketClient} endpoint methods annotated with this annotation are invoked when an error
+ * occurs.
  * <p>
  * It is used when an endpoint callback throws a runtime error, or when a conversion errors occurs, or when a returned
  * {@link io.smallrye.mutiny.Uni} receives a failure.
@@ -18,7 +18,7 @@ import io.smallrye.common.annotation.Experimental;
  * The method must accept exactly one "error" parameter, i.e. a parameter that is assignable from {@link java.lang.Throwable}.
  * The method may also accept the following parameters:
  * <ul>
- * <li>{@link WebSocketConnection}</li>
+ * <li>{@link WebSocketConnection}/{@link WebSocketClientConnection}; depending on the endpoint type</li>
  * <li>{@link HandshakeRequest}</li>
  * <li>{@link String} parameters annotated with {@link PathParam}</li>
  * </ul>
@@ -26,9 +26,12 @@ import io.smallrye.common.annotation.Experimental;
  * An endpoint may declare multiple methods annotated with this annotation. However, each method must declare a different error
  * parameter. The method that declares a most-specific supertype of the actual exception is selected.
  * <p>
- * This annotation can be also used to declare a global error handler, i.e. a method that is not declared on a {@link WebSocket}
- * endpoint. Such a method may not accept {@link PathParam} paremeters. Error handlers declared on an endpoint take
- * precedence over the global error handlers.
+ * This annotation can be also used to declare a global error handler, i.e. a method that is not declared on a
+ * {@link WebSocket}/{@link WebSocketClient} endpoint. Such a method may not accept {@link PathParam} paremeters. If a global
+ * error handler accepts {@link WebSocketConnection} then it's only applied to server-side errors. If a global error
+ * handler accepts {@link WebSocketClientConnection} then it's only applied to client-side errors.
+ *
+ * Error handlers declared on an endpoint take precedence over the global error handlers.
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnOpen.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnOpen.java
@@ -6,16 +6,15 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.quarkus.websockets.next.WebSocketConnection.HandshakeRequest;
 import io.smallrye.common.annotation.Experimental;
 
 /**
- * A {@link WebSocket} endpoint method annotated with this annotation is invoked when the client connects to a web socket
- * endpoint.
+ * {@link WebSocket} and {@link WebSocketClient} endpoint methods annotated with this annotation are invoked when a new
+ * connection is opened.
  * <p>
  * The method may accept the following parameters:
  * <ul>
- * <li>{@link WebSocketConnection}</li>
+ * <li>{@link WebSocketConnection}/{@link WebSocketClientConnection}; depending on the endpoint type</li>
  * <li>{@link HandshakeRequest}</li>
  * <li>{@link String} parameters annotated with {@link PathParam}</li>
  * </ul>
@@ -28,6 +27,8 @@ import io.smallrye.common.annotation.Experimental;
 public @interface OnOpen {
 
     /**
+     * Broadcasting is only supported for server endpoints annotated with {@link WebSocket}.
+     *
      * @return {@code true} if all the connected clients should receive the objects emitted by the annotated method
      * @see WebSocketConnection#broadcast()
      */

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnPongMessage.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnPongMessage.java
@@ -6,16 +6,15 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.quarkus.websockets.next.WebSocketConnection.HandshakeRequest;
 import io.smallrye.common.annotation.Experimental;
 
 /**
- * A {@link WebSocket} endpoint method annotated with this annotation consumes pong messages.
+ * {@link WebSocket} and {@link WebSocketClient} endpoint methods annotated with this annotation consume pong messages.
  *
  * The method must accept exactly one pong message parameter represented as a {@link io.vertx.core.buffer.Buffer}. The method
  * may also accept the following parameters:
  * <ul>
- * <li>{@link WebSocketConnection}</li>
+ * <li>{@link WebSocketConnection}/{@link WebSocketClientConnection}; depending on the endpoint type</li>
  * <li>{@link HandshakeRequest}</li>
  * <li>{@link String} parameters annotated with {@link PathParam}</li>
  * </ul>

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnTextMessage.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OnTextMessage.java
@@ -6,11 +6,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.quarkus.websockets.next.WebSocketConnection.HandshakeRequest;
 import io.smallrye.common.annotation.Experimental;
 
 /**
- * A {@link WebSocket} endpoint method annotated with this annotation consumes text messages.
+ * {@link WebSocket} and {@link WebSocketClient} endpoint methods annotated with this annotation consume text messages.
  * <p>
  * The method must accept exactly one message parameter. A text message is always represented as a {@link String}. Therefore,
  * the following conversion rules apply. The types listed
@@ -30,7 +29,7 @@ import io.smallrye.common.annotation.Experimental;
  * <p>
  * The method may also accept the following parameters:
  * <ul>
- * <li>{@link WebSocketConnection}</li>
+ * <li>{@link WebSocketConnection}/{@link WebSocketClientConnection}; depending on the endpoint type</li>
  * <li>{@link HandshakeRequest}</li>
  * <li>{@link String} parameters annotated with {@link PathParam}</li>
  * </ul>
@@ -43,6 +42,7 @@ import io.smallrye.common.annotation.Experimental;
 public @interface OnTextMessage {
 
     /**
+     * Broadcasting is only supported for server endpoints annotated with {@link WebSocket}.
      *
      * @return {@code true} if all the connected clients should receive the objects returned by the annotated method
      * @see WebSocketConnection#broadcast()

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OpenClientConnections.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OpenClientConnections.java
@@ -1,0 +1,55 @@
+package io.quarkus.websockets.next;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * Provides convenient access to all open client connections.
+ * <p>
+ * Quarkus provides a built-in CDI bean with the {@link jakarta.inject.Singleton} scope that implements this interface.
+ */
+@Experimental("This API is experimental and may change in the future")
+public interface OpenClientConnections extends Iterable<WebSocketClientConnection> {
+
+    /**
+     * Returns an immutable snapshot of all open connections at the given time.
+     *
+     * @return an immutable collection of all open connections
+     */
+    default Collection<WebSocketClientConnection> listAll() {
+        return stream().toList();
+    }
+
+    /**
+     * Returns an immutable snapshot of all open connections for the given client id.
+     *
+     * @param endpointId
+     * @return an immutable collection of all open connections for the given client id
+     * @see WebSocketClient#clientId()
+     */
+    default Collection<WebSocketClientConnection> findByClientId(String clientId) {
+        return stream().filter(c -> c.clientId().equals(clientId)).toList();
+    }
+
+    /**
+     * Returns the open connection with the given id.
+     *
+     * @param connectionId
+     * @return the open connection or empty {@link Optional} if no open connection with the given id exists
+     * @see WebSocketConnection#id()
+     */
+    default Optional<WebSocketClientConnection> findByConnectionId(String connectionId) {
+        return stream().filter(c -> c.id().equals(connectionId)).findFirst();
+    }
+
+    /**
+     * Returns the stream of all open connections at the given time.
+     *
+     * @return the stream of open connections
+     */
+    Stream<WebSocketClientConnection> stream();
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OpenConnections.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/OpenConnections.java
@@ -7,7 +7,7 @@ import java.util.stream.Stream;
 import io.smallrye.common.annotation.Experimental;
 
 /**
- * Provides convenient access to all open connections from clients to {@link WebSocket} endpoints on the server.
+ * Provides convenient access to all open connections.
  * <p>
  * Quarkus provides a built-in CDI bean with the {@link jakarta.inject.Singleton} scope that implements this interface.
  */

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/TextDecodeException.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/TextDecodeException.java
@@ -7,7 +7,7 @@ import io.smallrye.common.annotation.Experimental;
  * @see TextMessageCodec
  */
 @Experimental("This API is experimental and may change in the future")
-public class TextDecodeException extends WebSocketServerException {
+public class TextDecodeException extends WebSocketException {
 
     private static final long serialVersionUID = 6814319993301938091L;
 

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/TextEncodeException.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/TextEncodeException.java
@@ -7,7 +7,7 @@ import io.smallrye.common.annotation.Experimental;
  * @see TextMessageCodec
  */
 @Experimental("This API is experimental and may change in the future")
-public class TextEncodeException extends WebSocketServerException {
+public class TextEncodeException extends WebSocketException {
 
     private static final long serialVersionUID = 837621296462089705L;
 

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocket.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocket.java
@@ -48,32 +48,13 @@ public @interface WebSocket {
     public String endpointId() default FCQN_NAME;
 
     /**
-     * The execution mode used to process incoming messages for a specific connection.
+     * The mode used to process incoming messages for a specific connection.
      */
-    public ExecutionMode executionMode() default ExecutionMode.SERIAL;
+    public InboundProcessingMode inboundProcessingMode() default InboundProcessingMode.SERIAL;
 
     /**
      * Constant value for {@link #endpointId()} indicating that the fully qualified name of the annotated class should be used.
      */
     String FCQN_NAME = "<<fcqn name>>";
-
-    /**
-     * Defines the execution mode used to process incoming messages for a specific connection.
-     *
-     * @see WebSocketConnection
-     */
-    enum ExecutionMode {
-
-        /**
-         * Messages are processed serially, ordering is guaranteed.
-         */
-        SERIAL,
-
-        /**
-         * Messages are processed concurrently, there are no ordering guarantees.
-         */
-        CONCURRENT,
-
-    }
 
 }

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClient.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClient.java
@@ -1,0 +1,60 @@
+package io.quarkus.websockets.next;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Singleton;
+
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * Denotes a WebSocket client endpoint.
+ * <p>
+ * An endpoint must declare a method annotated with {@link OnTextMessage}, {@link OnBinaryMessage}, {@link OnPongMessage} or
+ * {@link OnOpen}. An endpoint may declare a method annotated with {@link OnClose}.
+ *
+ * <h2>Lifecycle and concurrency</h2>
+ * Client endpoint implementation class must be a CDI bean. If no scope annotation is defined then {@link Singleton} is used.
+ * {@link ApplicationScoped} and {@link Singleton} client endpoints are shared accross all WebSocket client connections.
+ * Therefore, implementations should be either stateless or thread-safe.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@Experimental("This API is experimental and may change in the future")
+public @interface WebSocketClient {
+
+    /**
+     * The path of the endpoint on the server.
+     * <p>
+     * It is possible to match path parameters. The placeholder of a path parameter consists of the parameter name surrounded by
+     * curly brackets. The actual value of a path parameter can be obtained using
+     * {@link WebSocketClientConnection#pathParam(String)}. For example, the path <code>/foo/{bar}</code> defines the path
+     * parameter {@code bar}.
+     *
+     * @see WebSocketConnection#pathParam(String)
+     */
+    public String path();
+
+    /**
+     * By default, the fully qualified name of the annotated class is used.
+     *
+     * @return the endpoint id
+     * @see WebSocketClientConnection#clientId()
+     */
+    public String clientId() default FCQN_NAME;
+
+    /**
+     * The execution mode used to process incoming messages for a specific connection.
+     */
+    public InboundProcessingMode inboundProcessingMode() default InboundProcessingMode.SERIAL;
+
+    /**
+     * Constant value for {@link #clientId()} indicating that the fully qualified name of the annotated class should be used.
+     */
+    String FCQN_NAME = "<<fcqn name>>";
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClientConnection.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClientConnection.java
@@ -1,0 +1,74 @@
+package io.quarkus.websockets.next;
+
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * This interface represents a client connection to a WebSocket endpoint.
+ * <p>
+ * Quarkus provides a built-in CDI bean that implements this interface and can be injected in a {@link WebSocketClient}
+ * endpoint and used to interact with the connected server.
+ */
+@Experimental("This API is experimental and may change in the future")
+public interface WebSocketClientConnection extends Sender, BlockingSender {
+
+    /**
+     *
+     * @return the unique identifier assigned to this connection
+     */
+    String id();
+
+    /*
+     * @return the client id
+     */
+    String clientId();
+
+    /**
+     *
+     * @param name
+     * @return the actual value of the path parameter or null
+     * @see WebSocketClient#path()
+     */
+    String pathParam(String name);
+
+    /**
+     * @return {@code true} if the HTTP connection is encrypted via SSL/TLS
+     */
+    boolean isSecure();
+
+    /**
+     * @return {@code true} if the WebSocket is closed
+     */
+    boolean isClosed();
+
+    /**
+     *
+     * @return {@code true} if the WebSocket is open
+     */
+    default boolean isOpen() {
+        return !isClosed();
+    }
+
+    /**
+     * Close the connection.
+     *
+     * @return a new {@link Uni} with a {@code null} item
+     */
+    @CheckReturnValue
+    Uni<Void> close();
+
+    /**
+     * Close the connection.
+     */
+    default void closeAndAwait() {
+        close().await().indefinitely();
+    }
+
+    /**
+     *
+     * @return the handshake request
+     */
+    HandshakeRequest handshakeRequest();
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClientException.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClientException.java
@@ -1,0 +1,22 @@
+package io.quarkus.websockets.next;
+
+import io.smallrye.common.annotation.Experimental;
+
+@Experimental("This API is experimental and may change in the future")
+public class WebSocketClientException extends WebSocketException {
+
+    private static final long serialVersionUID = -4213710383874397185L;
+
+    public WebSocketClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public WebSocketClientException(String message) {
+        super(message);
+    }
+
+    public WebSocketClientException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnection.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnection.java
@@ -1,8 +1,6 @@
 package io.quarkus.websockets.next;
 
 import java.time.Instant;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -124,91 +122,6 @@ public interface WebSocketConnection extends Sender, BlockingSender {
          *         the given filter predicate
          */
         BroadcastSender filter(Predicate<WebSocketConnection> predicate);
-
-    }
-
-    /**
-     * Provides some useful information about the initial handshake request.
-     */
-    interface HandshakeRequest {
-
-        /**
-         * The name is case insensitive.
-         *
-         * @param name
-         * @return the first header value for the given header name, or {@code null}
-         */
-        String header(String name);
-
-        /**
-         * The name is case insensitive.
-         *
-         * @param name
-         * @return an immutable list of header values for the given header name, never {@code null}
-         */
-        List<String> headers(String name);
-
-        /**
-         * Returned header names are lower case.
-         *
-         * @return an immutable map of header names to header values
-         */
-        Map<String, List<String>> headers();
-
-        /**
-         *
-         * @return the scheme
-         */
-        String scheme();
-
-        /**
-         *
-         * @return the host
-         */
-        String host();
-
-        /**
-         *
-         * @return the port
-         */
-        int port();
-
-        /**
-         *
-         * @return the path
-         */
-        String path();
-
-        /**
-         *
-         * @return the query string
-         */
-        String query();
-
-        /**
-         * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-57">The WebSocket Protocol</a>.
-         */
-        public static final String SEC_WEBSOCKET_KEY = "Sec-WebSocket-Key";
-
-        /**
-         * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-58">The WebSocket Protocol</a>.
-         */
-        public static final String SEC_WEBSOCKET_EXTENSIONS = "Sec-WebSocket-Extensions";
-
-        /**
-         * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-58">The WebSocket Protocol</a>.
-         */
-        public static final String SEC_WEBSOCKET_ACCEPT = "Sec-WebSocket-Accept";
-
-        /**
-         * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-59">The WebSocket Protocol</a>.
-         */
-        public static final String SEC_WEBSOCKET_PROTOCOL = "Sec-WebSocket-Protocol";
-
-        /**
-         * See <a href="https://datatracker.ietf.org/doc/html/rfc6455#page-60">The WebSocket Protocol</a>.
-         */
-        public static final String SEC_WEBSOCKET_VERSION = "Sec-WebSocket-Version";
 
     }
 

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnector.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnector.java
@@ -1,0 +1,74 @@
+package io.quarkus.websockets.next;
+
+import java.net.URI;
+
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * This connector can be used to configure and open new client connections using a client endpoint class.
+ * <p>
+ * This construct is not thread-safe and should not be used concurrently.
+ *
+ * @param <CLIENT> The client endpoint class
+ * @see WebSocketClient
+ * @see WebSocketClientConnection
+ */
+@Experimental("This API is experimental and may change in the future")
+public interface WebSocketConnector<CLIENT> {
+
+    /**
+     * Set the base URI.
+     *
+     * @param baseUri
+     * @return self
+     */
+    WebSocketConnector<CLIENT> baseUri(URI baseUri);
+
+    /**
+     * Set the path param.
+     *
+     * @param name
+     * @param value
+     * @return self
+     * @throws IllegalArgumentException If the client endpoint path does not contain a parameter with the given name
+     * @see WebSocketClient#path()
+     */
+    WebSocketConnector<CLIENT> pathParam(String name, String value);
+
+    /**
+     * Add a header used during the initial handshake request.
+     *
+     * @param name
+     * @param value
+     * @return self
+     * @see HandshakeRequest
+     */
+    WebSocketConnector<CLIENT> addHeader(String name, String value);
+
+    /**
+     * Add the subprotocol.
+     *
+     * @param name
+     * @param value
+     * @return self
+     */
+    WebSocketConnector<CLIENT> addSubprotocol(String value);
+
+    /**
+     *
+     * @return a new {@link Uni} with a {@link WebSocketClientConnection} item
+     */
+    @CheckReturnValue
+    Uni<WebSocketClientConnection> connect();
+
+    /**
+     *
+     * @return the client connection
+     */
+    default WebSocketClientConnection connectAndAwait() {
+        return connect().await().indefinitely();
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketException.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketException.java
@@ -1,0 +1,22 @@
+package io.quarkus.websockets.next;
+
+import io.smallrye.common.annotation.Experimental;
+
+@Experimental("This API is experimental and may change in the future")
+public class WebSocketException extends RuntimeException {
+
+    private static final long serialVersionUID = 903932032264812404L;
+
+    public WebSocketException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public WebSocketException(String message) {
+        super(message);
+    }
+
+    public WebSocketException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketServerException.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketServerException.java
@@ -3,9 +3,9 @@ package io.quarkus.websockets.next;
 import io.smallrye.common.annotation.Experimental;
 
 @Experimental("This API is experimental and may change in the future")
-public class WebSocketServerException extends RuntimeException {
+public class WebSocketServerException extends WebSocketException {
 
-    private static final long serialVersionUID = 903932032264812404L;
+    private static final long serialVersionUID = 815788270725783535L;
 
     public WebSocketServerException(String message, Throwable cause) {
         super(message, cause);

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsClientRuntimeConfig.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsClientRuntimeConfig.java
@@ -1,0 +1,43 @@
+package io.quarkus.websockets.next;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.websockets-next.client")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface WebSocketsClientRuntimeConfig {
+
+    /**
+     * Compression Extensions for WebSocket are supported by default.
+     * <p>
+     * See also <a href="https://datatracker.ietf.org/doc/html/rfc7692">RFC 7692</a>
+     */
+    @WithDefault("false")
+    boolean offerPerMessageCompression();
+
+    /**
+     * The compression level must be a value between 0 and 9. The default value is
+     * {@value io.vertx.core.http.HttpClientOptions#DEFAULT_WEBSOCKET_COMPRESSION_LEVEL}.
+     */
+    OptionalInt compressionLevel();
+
+    /**
+     * The maximum size of a message in bytes. The default values is
+     * {@value io.vertx.core.http.HttpClientOptions#DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE}.
+     */
+    OptionalInt maxMessageSize();
+
+    /**
+     * The interval after which, when set, the client sends a ping message to a connected server automatically.
+     * <p>
+     * Ping messages are not sent automatically by default.
+     */
+    Optional<Duration> autoPingInterval();
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsServerRuntimeConfig.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsServerRuntimeConfig.java
@@ -9,7 +9,6 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
-import io.vertx.core.http.HttpServerOptions;
 
 @ConfigMapping(prefix = "quarkus.websockets-next.server")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
@@ -30,13 +29,13 @@ public interface WebSocketsServerRuntimeConfig {
 
     /**
      * The compression level must be a value between 0 and 9. The default value is
-     * {@value HttpServerOptions#DEFAULT_WEBSOCKET_COMPRESSION_LEVEL}.
+     * {@value io.vertx.core.http.HttpServerOptions#DEFAULT_WEBSOCKET_COMPRESSION_LEVEL}.
      */
     OptionalInt compressionLevel();
 
     /**
      * The maximum size of a message in bytes. The default values is
-     * {@value HttpServerOptions#DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE}.
+     * {@value io.vertx.core.http.HttpServerOptions#DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE}.
      */
     OptionalInt maxMessageSize();
 

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/BasicWebSocketConnectorImpl.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/BasicWebSocketConnectorImpl.java
@@ -1,0 +1,292 @@
+package io.quarkus.websockets.next.runtime;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Typed;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.virtual.threads.VirtualThreadsRecorder;
+import io.quarkus.websockets.next.BasicWebSocketConnector;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketClientException;
+import io.quarkus.websockets.next.WebSocketsClientRuntimeConfig;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.UniHelper;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketClientOptions;
+import io.vertx.core.http.WebSocketConnectOptions;
+
+@Typed(BasicWebSocketConnector.class)
+@Dependent
+public class BasicWebSocketConnectorImpl extends WebSocketConnectorBase<BasicWebSocketConnectorImpl>
+        implements BasicWebSocketConnector {
+
+    private static final Logger LOG = Logger.getLogger(BasicWebSocketConnectorImpl.class);
+
+    // mutable state
+
+    private ExecutionModel executionModel = ExecutionModel.BLOCKING;
+
+    private Consumer<WebSocketClientConnection> openHandler;
+
+    private BiConsumer<WebSocketClientConnection, String> textMessageHandler;
+
+    private BiConsumer<WebSocketClientConnection, Buffer> binaryMessageHandler;
+
+    private BiConsumer<WebSocketClientConnection, Buffer> pongMessageHandler;
+
+    private BiConsumer<WebSocketClientConnection, Short> closeHandler;
+
+    private BiConsumer<WebSocketClientConnection, Throwable> errorHandler;
+
+    BasicWebSocketConnectorImpl(Vertx vertx, Codecs codecs, ClientConnectionManager connectionManager,
+            WebSocketsClientRuntimeConfig config) {
+        super(vertx, codecs, connectionManager, config);
+    }
+
+    @Override
+    public BasicWebSocketConnector executionModel(ExecutionModel model) {
+        this.executionModel = Objects.requireNonNull(model);
+        return self();
+    }
+
+    @Override
+    public BasicWebSocketConnector path(String path) {
+        setPath(Objects.requireNonNull(path));
+        return self();
+    }
+
+    @Override
+    public BasicWebSocketConnector onOpen(Consumer<WebSocketClientConnection> consumer) {
+        this.openHandler = Objects.requireNonNull(consumer);
+        return self();
+    }
+
+    @Override
+    public BasicWebSocketConnector onTextMessage(BiConsumer<WebSocketClientConnection, String> consumer) {
+        this.textMessageHandler = Objects.requireNonNull(consumer);
+        return self();
+    }
+
+    @Override
+    public BasicWebSocketConnector onBinaryMessage(BiConsumer<WebSocketClientConnection, Buffer> consumer) {
+        this.binaryMessageHandler = Objects.requireNonNull(consumer);
+        return self();
+    }
+
+    @Override
+    public BasicWebSocketConnector onPong(BiConsumer<WebSocketClientConnection, Buffer> consumer) {
+        this.pongMessageHandler = Objects.requireNonNull(consumer);
+        return self();
+    }
+
+    @Override
+    public BasicWebSocketConnector onClose(BiConsumer<WebSocketClientConnection, Short> consumer) {
+        this.closeHandler = Objects.requireNonNull(consumer);
+        return self();
+    }
+
+    @Override
+    public BasicWebSocketConnector onError(BiConsumer<WebSocketClientConnection, Throwable> consumer) {
+        this.errorHandler = Objects.requireNonNull(consumer);
+        return self();
+    }
+
+    @Override
+    public Uni<WebSocketClientConnection> connect() {
+        if (baseUri == null) {
+            throw new WebSocketClientException("Endpoint URI not set!");
+        }
+
+        // Currently we create a new client for each connection
+        // The client is closed when the connection is closed
+        // TODO would it make sense to share clients?
+        WebSocketClientOptions clientOptions = new WebSocketClientOptions();
+        if (config.offerPerMessageCompression()) {
+            clientOptions.setTryUsePerMessageCompression(true);
+            if (config.compressionLevel().isPresent()) {
+                clientOptions.setCompressionLevel(config.compressionLevel().getAsInt());
+            }
+        }
+        if (config.maxMessageSize().isPresent()) {
+            clientOptions.setMaxMessageSize(config.maxMessageSize().getAsInt());
+        }
+
+        WebSocketClient client = vertx.createWebSocketClient();
+
+        WebSocketConnectOptions connectOptions = new WebSocketConnectOptions()
+                .setSsl(baseUri.getScheme().equals("https"))
+                .setHost(baseUri.getHost())
+                .setPort(baseUri.getPort());
+        StringBuilder requestUri = new StringBuilder();
+        String mergedPath = mergePath(baseUri.getPath(), replacePathParameters(path));
+        requestUri.append(mergedPath);
+        if (baseUri.getQuery() != null) {
+            requestUri.append("?").append(baseUri.getQuery());
+        }
+        connectOptions.setURI(requestUri.toString());
+        for (Entry<String, List<String>> e : headers.entrySet()) {
+            for (String val : e.getValue()) {
+                connectOptions.addHeader(e.getKey(), val);
+            }
+        }
+        subprotocols.forEach(connectOptions::addSubProtocol);
+
+        URI serverEndpointUri;
+        try {
+            serverEndpointUri = new URI(baseUri.getScheme(), baseUri.getUserInfo(), baseUri.getHost(), baseUri.getPort(),
+                    mergedPath,
+                    baseUri.getQuery(), baseUri.getFragment());
+        } catch (URISyntaxException e) {
+            throw new WebSocketClientException(e);
+        }
+
+        return UniHelper.toUni(client.connect(connectOptions))
+                .map(ws -> {
+                    String clientId = BasicWebSocketConnector.class.getName();
+                    WebSocketClientConnectionImpl connection = new WebSocketClientConnectionImpl(clientId, ws,
+                            codecs,
+                            pathParams,
+                            serverEndpointUri,
+                            headers);
+                    LOG.debugf("Client connection created: %s", connection);
+                    connectionManager.add(BasicWebSocketConnectorImpl.class.getName(), connection);
+
+                    if (openHandler != null) {
+                        doExecute(connection, null, (c, ignored) -> openHandler.accept(c));
+                    }
+
+                    if (textMessageHandler != null) {
+                        ws.textMessageHandler(new Handler<String>() {
+                            @Override
+                            public void handle(String event) {
+                                doExecute(connection, event, textMessageHandler);
+                            }
+                        });
+                    }
+
+                    if (binaryMessageHandler != null) {
+                        ws.binaryMessageHandler(new Handler<Buffer>() {
+
+                            @Override
+                            public void handle(Buffer event) {
+                                doExecute(connection, event, binaryMessageHandler);
+                            }
+                        });
+                    }
+
+                    if (pongMessageHandler != null) {
+                        ws.pongHandler(new Handler<Buffer>() {
+
+                            @Override
+                            public void handle(Buffer event) {
+                                doExecute(connection, event, pongMessageHandler);
+                            }
+                        });
+                    }
+
+                    if (errorHandler != null) {
+                        ws.exceptionHandler(new Handler<Throwable>() {
+
+                            @Override
+                            public void handle(Throwable event) {
+                                doExecute(connection, event, errorHandler);
+                            }
+                        });
+                    }
+
+                    ws.closeHandler(new Handler<Void>() {
+
+                        @Override
+                        public void handle(Void event) {
+                            if (closeHandler != null) {
+                                doExecute(connection, ws.closeStatusCode(), closeHandler);
+                            }
+                            connectionManager.remove(BasicWebSocketConnectorImpl.class.getName(), connection);
+                            client.close();
+                        }
+
+                    });
+
+                    return connection;
+                });
+    }
+
+    private <MESSAGE> void doExecute(WebSocketClientConnectionImpl connection, MESSAGE message,
+            BiConsumer<WebSocketClientConnection, MESSAGE> consumer) {
+        // We always invoke callbacks on a new duplicated context and offload if blocking/virtualThread is needed
+        Context context = vertx.getOrCreateContext();
+        ContextSupport.createNewDuplicatedContext(context, connection).runOnContext(new Handler<Void>() {
+            @Override
+            public void handle(Void event) {
+                if (executionModel == ExecutionModel.VIRTUAL_THREAD) {
+                    VirtualThreadsRecorder.getCurrent().execute(new Runnable() {
+                        public void run() {
+                            try {
+                                consumer.accept(connection, message);
+                            } catch (Exception e) {
+                                LOG.errorf(e, "Unable to call handler: " + connection);
+                            }
+                        }
+                    });
+                } else if (executionModel == ExecutionModel.BLOCKING) {
+                    vertx.executeBlocking(new Callable<Void>() {
+                        @Override
+                        public Void call() {
+                            try {
+                                consumer.accept(connection, message);
+                            } catch (Exception e) {
+                                LOG.errorf(e, "Unable to call handler: " + connection);
+                            }
+                            return null;
+                        }
+                    }, false);
+                } else {
+                    // Non-blocking -> event loop
+                    try {
+                        consumer.accept(connection, message);
+                    } catch (Exception e) {
+                        LOG.errorf(e, "Unable to call handler: " + connection);
+                    }
+                }
+            }
+        });
+    }
+
+    private String mergePath(String path1, String path2) {
+        StringBuilder path = new StringBuilder();
+        if (path1 != null) {
+            path.append(path1);
+        }
+        if (path2 != null) {
+            if (path1.endsWith("/")) {
+                if (path2.startsWith("/")) {
+                    path.append(path2.substring(1));
+                } else {
+                    path.append(path2);
+                }
+            } else {
+                if (path2.startsWith("/")) {
+                    path.append(path2);
+                } else {
+                    path.append(path2.substring(1));
+                }
+            }
+        }
+        return path.toString();
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/ClientConnectionManager.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/ClientConnectionManager.java
@@ -1,0 +1,102 @@
+package io.quarkus.websockets.next.runtime;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.websockets.next.OpenClientConnections;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+
+@Singleton
+public class ClientConnectionManager implements OpenClientConnections {
+
+    private static final Logger LOG = Logger.getLogger(ClientConnectionManager.class);
+
+    private final ConcurrentMap<String, Set<WebSocketClientConnection>> endpointToConnections = new ConcurrentHashMap<>();
+
+    private final List<ClientConnectionListener> listeners = new CopyOnWriteArrayList<>();
+
+    @Override
+    public Iterator<WebSocketClientConnection> iterator() {
+        return stream().iterator();
+    }
+
+    @Override
+    public Stream<WebSocketClientConnection> stream() {
+        return endpointToConnections.values().stream().flatMap(Set::stream).filter(WebSocketClientConnection::isOpen);
+    }
+
+    void add(String endpoint, WebSocketClientConnection connection) {
+        LOG.debugf("Add client connection: %s", connection);
+        if (endpointToConnections.computeIfAbsent(endpoint, e -> ConcurrentHashMap.newKeySet()).add(connection)) {
+            if (!listeners.isEmpty()) {
+                for (ClientConnectionListener listener : listeners) {
+                    try {
+                        listener.connectionAdded(endpoint, connection);
+                    } catch (Exception e) {
+                        LOG.warnf("Unable to call listener#connectionAdded() on [%s]: %s", listener.getClass(),
+                                e.toString());
+                    }
+                }
+            }
+        }
+    }
+
+    void remove(String endpoint, WebSocketClientConnection connection) {
+        LOG.debugf("Remove client connection: %s", connection);
+        Set<WebSocketClientConnection> connections = endpointToConnections.get(endpoint);
+        if (connections != null) {
+            if (connections.remove(connection)) {
+                if (!listeners.isEmpty()) {
+                    for (ClientConnectionListener listener : listeners) {
+                        try {
+                            listener.connectionRemoved(endpoint, connection.id());
+                        } catch (Exception e) {
+                            LOG.warnf("Unable to call listener#connectionRemoved() on [%s]: %s", listener.getClass(),
+                                    e.toString());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     *
+     * @param endpoint
+     * @return the connections for the given client endpoint, never {@code null}
+     */
+    public Set<WebSocketClientConnection> getConnections(String endpoint) {
+        Set<WebSocketClientConnection> ret = endpointToConnections.get(endpoint);
+        if (ret == null) {
+            return Set.of();
+        }
+        return ret;
+    }
+
+    public void addListener(ClientConnectionListener listener) {
+        this.listeners.add(listener);
+    }
+
+    @PreDestroy
+    void destroy() {
+        endpointToConnections.clear();
+    }
+
+    public interface ClientConnectionListener {
+
+        void connectionAdded(String endpoint, WebSocketClientConnection connection);
+
+        void connectionRemoved(String endpoint, String connectionId);
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/Codecs.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/Codecs.java
@@ -13,7 +13,7 @@ import io.quarkus.websockets.next.MessageCodec;
 import io.quarkus.websockets.next.TextDecodeException;
 import io.quarkus.websockets.next.TextEncodeException;
 import io.quarkus.websockets.next.TextMessageCodec;
-import io.quarkus.websockets.next.WebSocketServerException;
+import io.quarkus.websockets.next.WebSocketException;
 import io.vertx.core.buffer.Buffer;
 
 @Singleton
@@ -139,7 +139,7 @@ public class Codecs {
         throw noCodecToEncode(true, message, type);
     }
 
-    WebSocketServerException noCodecToDecode(String text, Buffer bytes, Type type) {
+    WebSocketException noCodecToDecode(String text, Buffer bytes, Type type) {
         String message = String.format("No %s codec handles the type %s", bytes != null ? "binary" : "text", type);
         if (bytes != null) {
             return new BinaryDecodeException(bytes, message);
@@ -148,7 +148,7 @@ public class Codecs {
         }
     }
 
-    WebSocketServerException noCodecToEncode(boolean binary, Object encodedObject, Type type) {
+    WebSocketException noCodecToEncode(boolean binary, Object encodedObject, Type type) {
         String message = String.format("No %s codec handles the type %s", binary ? "binary" : "text", type);
         if (binary) {
             return new BinaryEncodeException(encodedObject, message);
@@ -157,7 +157,7 @@ public class Codecs {
         }
     }
 
-    WebSocketServerException unableToEncode(boolean binary, MessageCodec<?, ?> codec, Object encodedObject, Exception e) {
+    WebSocketException unableToEncode(boolean binary, MessageCodec<?, ?> codec, Object encodedObject, Exception e) {
         String message = String.format("Unable to encode %s message with %s", binary ? "binary" : "text",
                 codec.getClass().getName());
         if (binary) {
@@ -167,7 +167,7 @@ public class Codecs {
         }
     }
 
-    WebSocketServerException unableToDecode(String text, Buffer bytes, MessageCodec<?, ?> codec, Exception e) {
+    WebSocketException unableToDecode(String text, Buffer bytes, MessageCodec<?, ?> codec, Exception e) {
         String message = String.format("Unable to decode %s message with %s", bytes != null ? "binary" : "text",
                 codec.getClass().getName());
         if (bytes != null) {
@@ -177,7 +177,7 @@ public class Codecs {
         }
     }
 
-    WebSocketServerException forcedCannotEncode(boolean binary, MessageCodec<?, ?> codec, Object encodedObject) {
+    WebSocketException forcedCannotEncode(boolean binary, MessageCodec<?, ?> codec, Object encodedObject) {
         String message = String.format("Forced %s codec [%s] cannot handle the type %s", binary ? "binary" : "text",
                 codec.getClass().getName(), encodedObject.getClass());
         if (binary) {
@@ -187,7 +187,7 @@ public class Codecs {
         }
     }
 
-    WebSocketServerException forcedCannotDecode(String text, Buffer bytes, MessageCodec<?, ?> codec, Type type) {
+    WebSocketException forcedCannotDecode(String text, Buffer bytes, MessageCodec<?, ?> codec, Type type) {
         String message = String.format("Forced %s codec [%s] cannot decode the type %s", bytes != null ? "binary" : "text",
                 codec.getClass().getName(), type);
         if (bytes != null) {

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/ConcurrencyLimiter.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/ConcurrencyLimiter.java
@@ -5,7 +5,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.websockets.next.WebSocketConnection;
 import io.smallrye.mutiny.helpers.queues.Queues;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
@@ -18,12 +17,12 @@ class ConcurrencyLimiter {
 
     private static final Logger LOG = Logger.getLogger(ConcurrencyLimiter.class);
 
-    private final WebSocketConnection connection;
+    private final WebSocketConnectionBase connection;
     private final Queue<Action> queue;
     private final AtomicLong uncompleted;
     private final AtomicLong queueCounter;
 
-    ConcurrencyLimiter(WebSocketConnection connection) {
+    ConcurrencyLimiter(WebSocketConnectionBase connection) {
         this.connection = connection;
         this.uncompleted = new AtomicLong();
         this.queueCounter = new AtomicLong();

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/ContextSupport.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/ContextSupport.java
@@ -5,7 +5,6 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.InjectableContext.ContextState;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
-import io.quarkus.websockets.next.WebSocketConnection;
 import io.quarkus.websockets.next.runtime.WebSocketSessionContext.SessionContextState;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
@@ -14,12 +13,14 @@ public class ContextSupport {
 
     private static final Logger LOG = Logger.getLogger(ContextSupport.class);
 
-    private final WebSocketConnection connection;
+    static final String WEB_SOCKET_CONN_KEY = WebSocketConnectionBase.class.getName();
+
+    private final WebSocketConnectionBase connection;
     private final SessionContextState sessionContextState;
     private final WebSocketSessionContext sessionContext;
     private final ManagedContext requestContext;
 
-    ContextSupport(WebSocketConnection connection, SessionContextState sessionContextState,
+    ContextSupport(WebSocketConnectionBase connection, SessionContextState sessionContextState,
             WebSocketSessionContext sessionContext,
             ManagedContext requestContext) {
         this.connection = connection;
@@ -72,12 +73,12 @@ public class ContextSupport {
         return requestContext.getStateIfActive();
     }
 
-    static Context createNewDuplicatedContext(Context context, WebSocketConnection connection) {
+    static Context createNewDuplicatedContext(Context context, WebSocketConnectionBase connection) {
         Context duplicated = VertxContext.createNewDuplicatedContext(context);
         VertxContextSafetyToggle.setContextSafe(duplicated, true);
         // We need to store the connection in the duplicated context
         // It's used to initialize the synthetic bean later on
-        duplicated.putLocal(WebSocketServerRecorder.WEB_SOCKET_CONN_KEY, connection);
+        duplicated.putLocal(ContextSupport.WEB_SOCKET_CONN_KEY, connection);
         LOG.debugf("New vertx duplicated context [%s] created: %s", duplicated, connection);
         return duplicated;
     }

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/Endpoints.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/Endpoints.java
@@ -1,0 +1,303 @@
+package io.quarkus.websockets.next.runtime;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import jakarta.enterprise.context.SessionScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.websockets.next.WebSocketException;
+import io.quarkus.websockets.next.runtime.WebSocketSessionContext.SessionContextState;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.WebSocketBase;
+
+class Endpoints {
+
+    private static final Logger LOG = Logger.getLogger(Endpoints.class);
+
+    static void initialize(Vertx vertx, ArcContainer container, Codecs codecs, WebSocketConnectionBase connection,
+            WebSocketBase ws, String generatedEndpointClass, Optional<Duration> autoPingInterval, Runnable onClose) {
+
+        Context context = vertx.getOrCreateContext();
+
+        // Initialize and capture the session context state that will be activated
+        // during message processing
+        WebSocketSessionContext sessionContext = sessionContext(container);
+        SessionContextState sessionContextState = sessionContext.initializeContextState();
+        ContextSupport contextSupport = new ContextSupport(connection, sessionContextState,
+                sessionContext(container),
+                container.requestContext());
+
+        // Create an endpoint that delegates callbacks to the endpoint bean
+        WebSocketEndpoint endpoint = createEndpoint(generatedEndpointClass, context, connection, codecs, contextSupport);
+
+        // A broadcast processor is only needed if Multi is consumed by the callback
+        BroadcastProcessor<Object> textBroadcastProcessor = endpoint.consumedTextMultiType() != null
+                ? BroadcastProcessor.create()
+                : null;
+        BroadcastProcessor<Object> binaryBroadcastProcessor = endpoint.consumedBinaryMultiType() != null
+                ? BroadcastProcessor.create()
+                : null;
+
+        // NOTE: We always invoke callbacks on a new duplicated context
+        // and the endpoint is responsible to make the switch if blocking/virtualThread
+
+        Context onOpenContext = ContextSupport.createNewDuplicatedContext(context, connection);
+        onOpenContext.runOnContext(new Handler<Void>() {
+            @Override
+            public void handle(Void event) {
+                endpoint.onOpen().onComplete(r -> {
+                    if (r.succeeded()) {
+                        LOG.debugf("@OnOpen callback completed: %s", connection);
+                        // If Multi is consumed we need to invoke the callback eagerly
+                        // but after @OnOpen completes
+                        if (textBroadcastProcessor != null) {
+                            Multi<Object> multi = textBroadcastProcessor.onCancellation().call(connection::close);
+                            onOpenContext.runOnContext(new Handler<Void>() {
+                                @Override
+                                public void handle(Void event) {
+                                    endpoint.onTextMessage(multi).onComplete(r -> {
+                                        if (r.succeeded()) {
+                                            LOG.debugf("@OnTextMessage callback consuming Multi completed: %s",
+                                                    connection);
+                                        } else {
+                                            LOG.errorf(r.cause(),
+                                                    "Unable to complete @OnTextMessage callback consuming Multi: %s",
+                                                    connection);
+                                        }
+                                    });
+                                }
+                            });
+                        }
+                        if (binaryBroadcastProcessor != null) {
+                            Multi<Object> multi = binaryBroadcastProcessor.onCancellation().call(connection::close);
+                            onOpenContext.runOnContext(new Handler<Void>() {
+                                @Override
+                                public void handle(Void event) {
+                                    endpoint.onBinaryMessage(multi).onComplete(r -> {
+                                        if (r.succeeded()) {
+                                            LOG.debugf("@OnBinaryMessage callback consuming Multi completed: %s",
+                                                    connection);
+                                        } else {
+                                            LOG.errorf(r.cause(),
+                                                    "Unable to complete @OnBinaryMessage callback consuming Multi: %s",
+                                                    connection);
+                                        }
+                                    });
+                                }
+                            });
+                        }
+                    } else {
+                        LOG.errorf(r.cause(), "Unable to complete @OnOpen callback: %s", connection);
+                    }
+                });
+            }
+        });
+
+        if (textBroadcastProcessor == null) {
+            // Multi not consumed - invoke @OnTextMessage callback for each message received
+            textMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
+                endpoint.onTextMessage(m).onComplete(r -> {
+                    if (r.succeeded()) {
+                        LOG.debugf("@OnTextMessage callback consumed text message: %s", connection);
+                    } else {
+                        LOG.errorf(r.cause(), "Unable to consume text message in @OnTextMessage callback: %s",
+                                connection);
+                    }
+                });
+            }, true);
+        } else {
+            textMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
+                contextSupport.start();
+                try {
+                    textBroadcastProcessor.onNext(endpoint.decodeTextMultiItem(m));
+                    LOG.debugf("Text message >> Multi: %s", connection);
+                } catch (Throwable throwable) {
+                    endpoint.doOnError(throwable).subscribe().with(
+                            v -> LOG.debugf("Text message >> Multi: %s", connection),
+                            t -> LOG.errorf(t, "Unable to send text message to Multi: %s", connection));
+                } finally {
+                    contextSupport.end(false);
+                }
+            }, false);
+        }
+
+        if (binaryBroadcastProcessor == null) {
+            // Multi not consumed - invoke @OnBinaryMessage callback for each message received
+            binaryMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
+                endpoint.onBinaryMessage(m).onComplete(r -> {
+                    if (r.succeeded()) {
+                        LOG.debugf("@OnBinaryMessage callback consumed text message: %s", connection);
+                    } else {
+                        LOG.errorf(r.cause(), "Unable to consume text message in @OnBinaryMessage callback: %s",
+                                connection);
+                    }
+                });
+            }, true);
+        } else {
+            binaryMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
+                contextSupport.start();
+                try {
+                    binaryBroadcastProcessor.onNext(endpoint.decodeBinaryMultiItem(m));
+                    LOG.debugf("Binary message >> Multi: %s", connection);
+                } catch (Throwable throwable) {
+                    endpoint.doOnError(throwable).subscribe().with(
+                            v -> LOG.debugf("Binary message >> Multi: %s", connection),
+                            t -> LOG.errorf(t, "Unable to send binary message to Multi: %s", connection));
+                } finally {
+                    contextSupport.end(false);
+                }
+            }, false);
+        }
+
+        pongMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
+            endpoint.onPongMessage(m).onComplete(r -> {
+                if (r.succeeded()) {
+                    LOG.debugf("@OnPongMessage callback consumed text message: %s", connection);
+                } else {
+                    LOG.errorf(r.cause(), "Unable to consume text message in @OnPongMessage callback: %s",
+                            connection);
+                }
+            });
+        });
+
+        Long timerId;
+        if (autoPingInterval.isPresent()) {
+            timerId = vertx.setPeriodic(autoPingInterval.get().toMillis(), new Handler<Long>() {
+                @Override
+                public void handle(Long timerId) {
+                    connection.sendAutoPing();
+                }
+            });
+        } else {
+            timerId = null;
+        }
+
+        ws.closeHandler(new Handler<Void>() {
+            @Override
+            public void handle(Void event) {
+                ContextSupport.createNewDuplicatedContext(context, connection).runOnContext(new Handler<Void>() {
+                    @Override
+                    public void handle(Void event) {
+                        endpoint.onClose().onComplete(r -> {
+                            if (r.succeeded()) {
+                                LOG.debugf("@OnClose callback completed: %s", connection);
+                            } else {
+                                LOG.errorf(r.cause(), "Unable to complete @OnClose callback: %s", connection);
+                            }
+                            onClose.run();
+                            if (timerId != null) {
+                                vertx.cancelTimer(timerId);
+                            }
+                        });
+                    }
+                });
+            }
+        });
+
+        ws.exceptionHandler(new Handler<Throwable>() {
+            @Override
+            public void handle(Throwable t) {
+                ContextSupport.createNewDuplicatedContext(context, connection).runOnContext(new Handler<Void>() {
+                    @Override
+                    public void handle(Void event) {
+                        endpoint.doOnError(t).subscribe().with(
+                                v -> LOG.debugf("Error [%s] processed: %s", t.getClass(), connection),
+                                t -> LOG.errorf(t, "Unhandled error occured: %s", t.toString(),
+                                        connection));
+                    }
+                });
+            }
+        });
+    }
+
+    private static void textMessageHandler(WebSocketConnectionBase connection, WebSocketEndpoint endpoint, WebSocketBase ws,
+            Context context, Consumer<String> textAction, boolean newDuplicatedContext) {
+        ws.textMessageHandler(new Handler<String>() {
+            @Override
+            public void handle(String message) {
+                Context duplicatedContext = newDuplicatedContext
+                        ? ContextSupport.createNewDuplicatedContext(context, connection)
+                        : context;
+                duplicatedContext.runOnContext(new Handler<Void>() {
+                    @Override
+                    public void handle(Void event) {
+                        textAction.accept(message);
+                    }
+                });
+            }
+        });
+    }
+
+    private static void binaryMessageHandler(WebSocketConnectionBase connection, WebSocketEndpoint endpoint, WebSocketBase ws,
+            Context context, Consumer<Buffer> binaryAction, boolean newDuplicatedContext) {
+        ws.binaryMessageHandler(new Handler<Buffer>() {
+            @Override
+            public void handle(Buffer message) {
+                Context duplicatedContext = newDuplicatedContext
+                        ? ContextSupport.createNewDuplicatedContext(context, connection)
+                        : context;
+                duplicatedContext.runOnContext(new Handler<Void>() {
+                    @Override
+                    public void handle(Void event) {
+                        binaryAction.accept(message);
+                    }
+                });
+            }
+        });
+    }
+
+    private static void pongMessageHandler(WebSocketConnectionBase connection, WebSocketEndpoint endpoint, WebSocketBase ws,
+            Context context, Consumer<Buffer> pongAction) {
+        ws.pongHandler(new Handler<Buffer>() {
+            @Override
+            public void handle(Buffer message) {
+                Context duplicatedContext = ContextSupport.createNewDuplicatedContext(context, connection);
+                duplicatedContext.runOnContext(new Handler<Void>() {
+                    @Override
+                    public void handle(Void event) {
+                        pongAction.accept(message);
+                    }
+                });
+            }
+        });
+    }
+
+    private static WebSocketEndpoint createEndpoint(String endpointClassName, Context context,
+            WebSocketConnectionBase connection,
+            Codecs codecs, ContextSupport contextSupport) {
+        try {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            if (cl == null) {
+                cl = WebSocketServerRecorder.class.getClassLoader();
+            }
+            @SuppressWarnings("unchecked")
+            Class<? extends WebSocketEndpoint> endpointClazz = (Class<? extends WebSocketEndpoint>) cl
+                    .loadClass(endpointClassName);
+            WebSocketEndpoint endpoint = (WebSocketEndpoint) endpointClazz
+                    .getDeclaredConstructor(WebSocketConnectionBase.class, Codecs.class, ContextSupport.class)
+                    .newInstance(connection, codecs, contextSupport);
+            return endpoint;
+        } catch (Exception e) {
+            throw new WebSocketException("Unable to create endpoint instance: " + endpointClassName, e);
+        }
+    }
+
+    private static WebSocketSessionContext sessionContext(ArcContainer container) {
+        for (InjectableContext injectableContext : container.getContexts(SessionScoped.class)) {
+            if (WebSocketSessionContext.class.equals(injectableContext.getClass())) {
+                return (WebSocketSessionContext) injectableContext;
+            }
+        }
+        throw new WebSocketException("CDI session context not registered");
+    }
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketClientConnectionImpl.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketClientConnectionImpl.java
@@ -1,0 +1,117 @@
+package io.quarkus.websockets.next.runtime;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import io.quarkus.websockets.next.HandshakeRequest;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketBase;
+
+class WebSocketClientConnectionImpl extends WebSocketConnectionBase implements WebSocketClientConnection {
+
+    private final String clientId;
+
+    private final WebSocket webSocket;
+
+    WebSocketClientConnectionImpl(String clientId, WebSocket webSocket, Codecs codecs,
+            Map<String, String> pathParams, URI serverEndpointUri, Map<String, List<String>> headers) {
+        super(Map.copyOf(pathParams), codecs, new ClientHandshakeRequestImpl(serverEndpointUri, headers));
+        this.clientId = clientId;
+        this.webSocket = Objects.requireNonNull(webSocket);
+    }
+
+    @Override
+    WebSocketBase webSocket() {
+        return webSocket;
+    }
+
+    @Override
+    public String clientId() {
+        return clientId;
+    }
+
+    @Override
+    public String toString() {
+        return "WebSocket client connection [id=" + identifier + ", clientId=" + clientId + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        WebSocketClientConnectionImpl other = (WebSocketClientConnectionImpl) obj;
+        return Objects.equals(identifier, other.identifier);
+    }
+
+    private static class ClientHandshakeRequestImpl implements HandshakeRequest {
+
+        private final URI serverEndpointUrl;
+        private final Map<String, List<String>> headers;
+
+        ClientHandshakeRequestImpl(URI serverEndpointUrl, Map<String, List<String>> headers) {
+            this.serverEndpointUrl = serverEndpointUrl;
+            Map<String, List<String>> copy = new HashMap<>();
+            for (Entry<String, List<String>> e : headers.entrySet()) {
+                copy.put(e.getKey().toLowerCase(), List.copyOf(e.getValue()));
+            }
+            this.headers = copy;
+        }
+
+        @Override
+        public String header(String name) {
+            List<String> values = headers(name);
+            return values.isEmpty() ? null : values.get(0);
+        }
+
+        @Override
+        public List<String> headers(String name) {
+            return headers.getOrDefault(Objects.requireNonNull(name).toLowerCase(), List.of());
+        }
+
+        @Override
+        public Map<String, List<String>> headers() {
+            return headers;
+        }
+
+        @Override
+        public String scheme() {
+            return serverEndpointUrl.getScheme();
+        }
+
+        @Override
+        public String host() {
+            return serverEndpointUrl.getHost();
+        }
+
+        @Override
+        public int port() {
+            return serverEndpointUrl.getPort();
+        }
+
+        @Override
+        public String path() {
+            return serverEndpointUrl.getPath();
+        }
+
+        @Override
+        public String query() {
+            return serverEndpointUrl.getQuery();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketClientRecorder.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketClientRecorder.java
@@ -1,0 +1,72 @@
+package io.quarkus.websockets.next.runtime;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.quarkus.runtime.annotations.RecordableConstructor;
+import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.websockets.next.WebSocketClientException;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Recorder
+public class WebSocketClientRecorder {
+
+    public Supplier<Object> connectionSupplier() {
+        return new Supplier<Object>() {
+
+            @Override
+            public Object get() {
+                Context context = Vertx.currentContext();
+                if (context != null && VertxContext.isDuplicatedContext(context)) {
+                    Object connection = context.getLocal(ContextSupport.WEB_SOCKET_CONN_KEY);
+                    if (connection != null) {
+                        return connection;
+                    }
+                }
+                throw new WebSocketClientException("Unable to obtain the connection from the Vert.x duplicated context");
+            }
+        };
+    }
+
+    public Supplier<Object> createContext(Map<String, ClientEndpoint> endpointMap) {
+        return new Supplier<Object>() {
+            @Override
+            public Object get() {
+                return new ClientEndpointsContext() {
+
+                    @Override
+                    public ClientEndpoint endpoint(String endpointClass) {
+                        return endpointMap.get(endpointClass);
+                    }
+
+                };
+            }
+        };
+    }
+
+    public interface ClientEndpointsContext {
+
+        ClientEndpoint endpoint(String endpointClass);
+
+    }
+
+    public static class ClientEndpoint {
+
+        public final String clientId;
+
+        public final String path;
+
+        public final String generatedEndpointClass;
+
+        @RecordableConstructor
+        public ClientEndpoint(String clientId, String path, String generatedEndpointClass) {
+            this.clientId = clientId;
+            this.path = path;
+            this.generatedEndpointClass = generatedEndpointClass;
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
@@ -1,0 +1,113 @@
+package io.quarkus.websockets.next.runtime;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.vertx.core.runtime.VertxBufferImpl;
+import io.quarkus.websockets.next.HandshakeRequest;
+import io.quarkus.websockets.next.WebSocketConnection.BroadcastSender;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.UniHelper;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.buffer.impl.BufferImpl;
+import io.vertx.core.http.WebSocketBase;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public abstract class WebSocketConnectionBase {
+
+    private static final Logger LOG = Logger.getLogger(WebSocketConnectionBase.class);
+
+    protected final String identifier;
+
+    protected final Map<String, String> pathParams;
+
+    protected final Codecs codecs;
+
+    protected final HandshakeRequest handshakeRequest;
+
+    protected final Instant creationTime;
+
+    WebSocketConnectionBase(Map<String, String> pathParams, Codecs codecs, HandshakeRequest handshakeRequest) {
+        this.identifier = UUID.randomUUID().toString();
+        this.pathParams = pathParams;
+        this.codecs = codecs;
+        this.handshakeRequest = handshakeRequest;
+        this.creationTime = Instant.now();
+    }
+
+    abstract WebSocketBase webSocket();
+
+    public String id() {
+        return identifier;
+    }
+
+    public String pathParam(String name) {
+        return pathParams.get(name);
+    }
+
+    public Uni<Void> sendText(String message) {
+        return UniHelper.toUni(webSocket().writeTextMessage(message));
+    }
+
+    public Uni<Void> sendBinary(Buffer message) {
+        return UniHelper.toUni(webSocket().writeBinaryMessage(message));
+    }
+
+    public <M> Uni<Void> sendText(M message) {
+        String text;
+        // Use the same conversion rules as defined for the OnTextMessage
+        if (message instanceof JsonObject || message instanceof JsonArray || message instanceof BufferImpl
+                || message instanceof VertxBufferImpl) {
+            text = message.toString();
+        } else if (message.getClass().isArray() && message.getClass().arrayType().equals(byte.class)) {
+            text = Buffer.buffer((byte[]) message).toString();
+        } else {
+            text = codecs.textEncode(message, null);
+        }
+        return sendText(text);
+    }
+
+    public Uni<Void> sendPing(Buffer data) {
+        return UniHelper.toUni(webSocket().writePing(data));
+    }
+
+    void sendAutoPing() {
+        webSocket().writePing(Buffer.buffer("ping")).onComplete(r -> {
+            if (r.failed()) {
+                LOG.warnf("Unable to send auto-ping for %s: %s", this, r.cause().toString());
+            }
+        });
+    }
+
+    public Uni<Void> sendPong(Buffer data) {
+        return UniHelper.toUni(webSocket().writePong(data));
+    }
+
+    public Uni<Void> close() {
+        return UniHelper.toUni(webSocket().close());
+    }
+
+    public boolean isSecure() {
+        return webSocket().isSsl();
+    }
+
+    public boolean isClosed() {
+        return webSocket().isClosed();
+    }
+
+    public HandshakeRequest handshakeRequest() {
+        return handshakeRequest;
+    }
+
+    public Instant creationTime() {
+        return creationTime;
+    }
+
+    public BroadcastSender broadcast() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
@@ -1,0 +1,129 @@
+package io.quarkus.websockets.next.runtime;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.quarkus.websockets.next.WebSocketClientException;
+import io.quarkus.websockets.next.WebSocketsClientRuntimeConfig;
+import io.vertx.core.Vertx;
+
+abstract class WebSocketConnectorBase<THIS extends WebSocketConnectorBase<THIS>> {
+
+    protected static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{[a-zA-Z0-9_]+\\}");
+
+    // mutable state
+
+    protected URI baseUri;
+
+    protected final Map<String, String> pathParams;
+
+    protected final Map<String, List<String>> headers;
+
+    protected final Set<String> subprotocols;
+
+    protected String path;
+
+    protected Set<String> pathParamNames;
+
+    // injected dependencies
+
+    protected final Vertx vertx;
+
+    protected final Codecs codecs;
+
+    protected final ClientConnectionManager connectionManager;
+
+    protected final WebSocketsClientRuntimeConfig config;
+
+    WebSocketConnectorBase(Vertx vertx, Codecs codecs,
+            ClientConnectionManager connectionManager, WebSocketsClientRuntimeConfig config) {
+        this.headers = new HashMap<>();
+        this.subprotocols = new HashSet<>();
+        this.pathParams = new HashMap<>();
+        this.vertx = vertx;
+        this.codecs = codecs;
+        this.connectionManager = connectionManager;
+        this.config = config;
+        this.pathParamNames = Set.of();
+    }
+
+    public THIS baseUri(URI baseUri) {
+        this.baseUri = Objects.requireNonNull(baseUri);
+        return self();
+    }
+
+    public THIS addHeader(String name, String value) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(value);
+        List<String> values = headers.get(name);
+        if (values == null) {
+            values = new ArrayList<>();
+            headers.put(name, values);
+        }
+        values.add(value);
+        return self();
+    }
+
+    public THIS pathParam(String name, String value) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(value);
+        if (!pathParamNames.contains(name)) {
+            throw new IllegalArgumentException(
+                    String.format("[%s] is not a valid path parameter in the path %s", name, path));
+        }
+        pathParams.put(name, value);
+        return self();
+    }
+
+    public THIS addSubprotocol(String value) {
+        subprotocols.add(Objects.requireNonNull(value));
+        return self();
+    }
+
+    void setPath(String path) {
+        this.path = path;
+        this.pathParamNames = getPathParamNames(path);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected THIS self() {
+        return (THIS) this;
+    }
+
+    Set<String> getPathParamNames(String path) {
+        Set<String> names = new HashSet<>();
+        Matcher m = PATH_PARAM_PATTERN.matcher(path);
+        while (m.find()) {
+            String match = m.group();
+            String paramName = match.substring(1, match.length() - 1);
+            names.add(paramName);
+        }
+        return names;
+    }
+
+    String replacePathParameters(String path) {
+        StringBuilder sb = new StringBuilder();
+        Matcher m = PATH_PARAM_PATTERN.matcher(path);
+        while (m.find()) {
+            // Replace {foo} with the param value
+            String match = m.group();
+            String paramName = match.substring(1, match.length() - 1);
+            String val = pathParams.get(paramName);
+            if (val == null) {
+                throw new WebSocketClientException("Unable to obtain the path param for: " + paramName);
+            }
+            m.appendReplacement(sb, val);
+        }
+        m.appendTail(sb);
+        return path.startsWith("/") ? sb.toString() : "/" + sb.toString();
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
@@ -1,0 +1,135 @@
+package io.quarkus.websockets.next.runtime;
+
+import java.lang.reflect.ParameterizedType;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Typed;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketClientException;
+import io.quarkus.websockets.next.WebSocketConnector;
+import io.quarkus.websockets.next.WebSocketsClientRuntimeConfig;
+import io.quarkus.websockets.next.runtime.WebSocketClientRecorder.ClientEndpoint;
+import io.quarkus.websockets.next.runtime.WebSocketClientRecorder.ClientEndpointsContext;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.UniHelper;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketClientOptions;
+import io.vertx.core.http.WebSocketConnectOptions;
+
+@Typed(WebSocketConnector.class)
+@Dependent
+public class WebSocketConnectorImpl<CLIENT> extends WebSocketConnectorBase<WebSocketConnectorImpl<CLIENT>>
+        implements WebSocketConnector<CLIENT> {
+
+    private static final Logger LOG = Logger.getLogger(WebSocketConnectorImpl.class);
+
+    // derived properties
+
+    private final ClientEndpoint clientEndpoint;
+
+    WebSocketConnectorImpl(InjectionPoint injectionPoint, Codecs codecs, Vertx vertx, ClientConnectionManager connectionManager,
+            ClientEndpointsContext endpointsContext, WebSocketsClientRuntimeConfig config) {
+        super(vertx, codecs, connectionManager, config);
+        this.clientEndpoint = Objects.requireNonNull(endpointsContext.endpoint(getEndpointClass(injectionPoint)));
+        setPath(clientEndpoint.path);
+    }
+
+    @Override
+    public Uni<WebSocketClientConnection> connect() {
+        // Currently we create a new client for each connection
+        // The client is closed when the connection is closed
+        // TODO would it make sense to share clients?
+        WebSocketClientOptions clientOptions = new WebSocketClientOptions();
+        if (config.offerPerMessageCompression()) {
+            clientOptions.setTryUsePerMessageCompression(true);
+            if (config.compressionLevel().isPresent()) {
+                clientOptions.setCompressionLevel(config.compressionLevel().getAsInt());
+            }
+        }
+        if (config.maxMessageSize().isPresent()) {
+            clientOptions.setMaxMessageSize(config.maxMessageSize().getAsInt());
+        }
+
+        WebSocketClient client = vertx.createWebSocketClient();
+
+        StringBuilder serverEndpoint = new StringBuilder();
+        if (baseUri != null) {
+            serverEndpoint.append(baseUri.toString());
+        } else {
+            // Obtain the base URI from the config
+            String key = clientEndpoint.clientId + ".base-uri";
+            Optional<String> maybeBaseUri = ConfigProvider.getConfig().getOptionalValue(key, String.class);
+            if (maybeBaseUri.isEmpty()) {
+                throw new WebSocketClientException("Unable to obtain the config value for: " + key);
+            }
+            serverEndpoint.append(maybeBaseUri.get());
+        }
+        serverEndpoint.append(replacePathParameters(clientEndpoint.path));
+
+        URI serverEndpointUri;
+        try {
+            serverEndpointUri = new URI(serverEndpoint.toString());
+        } catch (URISyntaxException e) {
+            throw new WebSocketClientException(e);
+        }
+
+        WebSocketConnectOptions connectOptions = new WebSocketConnectOptions()
+                .setSsl(serverEndpointUri.getScheme().equals("https"))
+                .setHost(serverEndpointUri.getHost())
+                .setPort(serverEndpointUri.getPort());
+        StringBuilder uri = new StringBuilder();
+        if (serverEndpointUri.getPath() != null) {
+            uri.append(serverEndpointUri.getPath());
+        }
+        if (serverEndpointUri.getQuery() != null) {
+            uri.append("?").append(serverEndpointUri.getQuery());
+        }
+        connectOptions.setURI(uri.toString());
+        for (Entry<String, List<String>> e : headers.entrySet()) {
+            for (String val : e.getValue()) {
+                connectOptions.addHeader(e.getKey(), val);
+            }
+        }
+        subprotocols.forEach(connectOptions::addSubProtocol);
+
+        return UniHelper.toUni(client.connect(connectOptions))
+                .map(ws -> {
+                    WebSocketClientConnectionImpl connection = new WebSocketClientConnectionImpl(clientEndpoint.clientId, ws,
+                            codecs,
+                            pathParams,
+                            serverEndpointUri, headers);
+                    LOG.debugf("Client connection created: %s", connection);
+                    connectionManager.add(clientEndpoint.generatedEndpointClass, connection);
+
+                    Endpoints.initialize(vertx, Arc.container(), codecs, connection, ws,
+                            clientEndpoint.generatedEndpointClass, config.autoPingInterval(),
+                            () -> {
+                                connectionManager.remove(clientEndpoint.generatedEndpointClass, connection);
+                                client.close();
+                            });
+
+                    return connection;
+                });
+    }
+
+    String getEndpointClass(InjectionPoint injectionPoint) {
+        // The type is validated during build - if it does not represent a client endpoint the build fails
+        // WebSocketConnectorImpl<org.acme.Foo> -> org.acme.Foo
+        ParameterizedType parameterizedType = (ParameterizedType) injectionPoint.getType();
+        return parameterizedType.getActualTypeArguments()[0].getTypeName();
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpoint.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpoint.java
@@ -2,7 +2,7 @@ package io.quarkus.websockets.next.runtime;
 
 import java.lang.reflect.Type;
 
-import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.InboundProcessingMode;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -10,16 +10,15 @@ import io.vertx.core.buffer.Buffer;
 /**
  * Internal representation of a WebSocket endpoint.
  * <p>
- * A new instance is created for each client connection.
+ * A new instance is created for each connection.
  */
 public interface WebSocketEndpoint {
 
     /**
      *
-     * @see WebSocket#executionMode()
-     * @return the execution mode
+     * @return the inbound processing mode
      */
-    WebSocket.ExecutionMode executionMode();
+    InboundProcessingMode inboundProcessingMode();
 
     // @OnOpen
 

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpointBase.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpointBase.java
@@ -15,9 +15,7 @@ import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableContext.ContextState;
 import io.quarkus.virtual.threads.VirtualThreadsRecorder;
-import io.quarkus.websockets.next.WebSocket.ExecutionMode;
-import io.quarkus.websockets.next.WebSocketConnection;
-import io.quarkus.websockets.next.WebSocketsServerRuntimeConfig;
+import io.quarkus.websockets.next.InboundProcessingMode;
 import io.quarkus.websockets.next.runtime.ConcurrencyLimiter.PromiseComplete;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -34,14 +32,11 @@ public abstract class WebSocketEndpointBase implements WebSocketEndpoint {
     private static final Logger LOG = Logger.getLogger(WebSocketEndpointBase.class);
 
     // Keep this field public - there's a problem with ConnectionArgumentProvider reading the protected field in the test mode
-    public final WebSocketConnection connection;
+    public final WebSocketConnectionBase connection;
 
     protected final Codecs codecs;
 
     private final ConcurrencyLimiter limiter;
-
-    @SuppressWarnings("unused")
-    private final WebSocketsServerRuntimeConfig config;
 
     private final ArcContainer container;
 
@@ -50,12 +45,10 @@ public abstract class WebSocketEndpointBase implements WebSocketEndpoint {
     private final InjectableBean<?> bean;
     private final Object beanInstance;
 
-    public WebSocketEndpointBase(WebSocketConnection connection, Codecs codecs,
-            WebSocketsServerRuntimeConfig config, ContextSupport contextSupport) {
+    public WebSocketEndpointBase(WebSocketConnectionBase connection, Codecs codecs, ContextSupport contextSupport) {
         this.connection = connection;
         this.codecs = codecs;
-        this.limiter = executionMode() == ExecutionMode.SERIAL ? new ConcurrencyLimiter(connection) : null;
-        this.config = config;
+        this.limiter = inboundProcessingMode() == InboundProcessingMode.SERIAL ? new ConcurrencyLimiter(connection) : null;
         this.container = Arc.container();
         this.contextSupport = contextSupport;
         InjectableBean<?> bean = container.bean(beanIdentifier());

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
@@ -1,29 +1,20 @@
 package io.quarkus.websockets.next.runtime;
 
-import java.util.function.Consumer;
 import java.util.function.Supplier;
-
-import jakarta.enterprise.context.SessionScoped;
 
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
-import io.quarkus.arc.InjectableContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
-import io.quarkus.websockets.next.WebSocketConnection;
 import io.quarkus.websockets.next.WebSocketServerException;
 import io.quarkus.websockets.next.WebSocketsServerRuntimeConfig;
-import io.quarkus.websockets.next.runtime.WebSocketSessionContext.SessionContextState;
 import io.smallrye.common.vertx.VertxContext;
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.ext.web.RoutingContext;
 
@@ -31,8 +22,6 @@ import io.vertx.ext.web.RoutingContext;
 public class WebSocketServerRecorder {
 
     private static final Logger LOG = Logger.getLogger(WebSocketServerRecorder.class);
-
-    static final String WEB_SOCKET_CONN_KEY = WebSocketConnection.class.getName();
 
     private final WebSocketsServerRuntimeConfig config;
 
@@ -47,7 +36,7 @@ public class WebSocketServerRecorder {
             public Object get() {
                 Context context = Vertx.currentContext();
                 if (context != null && VertxContext.isDuplicatedContext(context)) {
-                    Object connection = context.getLocal(WEB_SOCKET_CONN_KEY);
+                    Object connection = context.getLocal(ContextSupport.WEB_SOCKET_CONN_KEY);
                     if (connection != null) {
                         return connection;
                     }
@@ -68,288 +57,17 @@ public class WebSocketServerRecorder {
                 Future<ServerWebSocket> future = ctx.request().toWebSocket();
                 future.onSuccess(ws -> {
                     Vertx vertx = VertxCoreRecorder.getVertx().get();
-                    Context context = vertx.getOrCreateContext();
 
                     WebSocketConnectionImpl connection = new WebSocketConnectionImpl(generatedEndpointClass, endpointId, ws,
                             connectionManager, codecs, ctx);
                     connectionManager.add(generatedEndpointClass, connection);
                     LOG.debugf("Connection created: %s", connection);
 
-                    // Initialize and capture the session context state that will be activated
-                    // during message processing
-                    WebSocketSessionContext sessionContext = sessionContext(container);
-                    SessionContextState sessionContextState = sessionContext.initializeContextState();
-                    ContextSupport contextSupport = new ContextSupport(connection, sessionContextState,
-                            sessionContext(container),
-                            container.requestContext());
-
-                    // Create an endpoint that delegates callbacks to the @WebSocket bean
-                    WebSocketEndpoint endpoint = createEndpoint(generatedEndpointClass, context, connection, codecs, config,
-                            contextSupport);
-
-                    // A broadcast processor is only needed if Multi is consumed by the callback
-                    BroadcastProcessor<Object> textBroadcastProcessor = endpoint.consumedTextMultiType() != null
-                            ? BroadcastProcessor.create()
-                            : null;
-                    BroadcastProcessor<Object> binaryBroadcastProcessor = endpoint.consumedBinaryMultiType() != null
-                            ? BroadcastProcessor.create()
-                            : null;
-
-                    // NOTE: We always invoke callbacks on a new duplicated context
-                    // and the endpoint is responsible to make the switch if blocking/virtualThread
-
-                    Context onOpenContext = ContextSupport.createNewDuplicatedContext(context, connection);
-                    onOpenContext.runOnContext(new Handler<Void>() {
-                        @Override
-                        public void handle(Void event) {
-                            endpoint.onOpen().onComplete(r -> {
-                                if (r.succeeded()) {
-                                    LOG.debugf("@OnOpen callback completed: %s", connection);
-                                    // If Multi is consumed we need to invoke the callback eagerly
-                                    // but after @OnOpen completes
-                                    if (textBroadcastProcessor != null) {
-                                        Multi<Object> multi = textBroadcastProcessor.onCancellation().call(connection::close);
-                                        onOpenContext.runOnContext(new Handler<Void>() {
-                                            @Override
-                                            public void handle(Void event) {
-                                                endpoint.onTextMessage(multi).onComplete(r -> {
-                                                    if (r.succeeded()) {
-                                                        LOG.debugf("@OnTextMessage callback consuming Multi completed: %s",
-                                                                connection);
-                                                    } else {
-                                                        LOG.errorf(r.cause(),
-                                                                "Unable to complete @OnTextMessage callback consuming Multi: %s",
-                                                                connection);
-                                                    }
-                                                });
-                                            }
-                                        });
-                                    }
-                                    if (binaryBroadcastProcessor != null) {
-                                        Multi<Object> multi = binaryBroadcastProcessor.onCancellation().call(connection::close);
-                                        onOpenContext.runOnContext(new Handler<Void>() {
-                                            @Override
-                                            public void handle(Void event) {
-                                                endpoint.onBinaryMessage(multi).onComplete(r -> {
-                                                    if (r.succeeded()) {
-                                                        LOG.debugf("@OnBinaryMessage callback consuming Multi completed: %s",
-                                                                connection);
-                                                    } else {
-                                                        LOG.errorf(r.cause(),
-                                                                "Unable to complete @OnBinaryMessage callback consuming Multi: %s",
-                                                                connection);
-                                                    }
-                                                });
-                                            }
-                                        });
-                                    }
-                                } else {
-                                    LOG.errorf(r.cause(), "Unable to complete @OnOpen callback: %s", connection);
-                                }
-                            });
-                        }
-                    });
-
-                    if (textBroadcastProcessor == null) {
-                        // Multi not consumed - invoke @OnTextMessage callback for each message received
-                        textMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
-                            endpoint.onTextMessage(m).onComplete(r -> {
-                                if (r.succeeded()) {
-                                    LOG.debugf("@OnTextMessage callback consumed text message: %s", connection);
-                                } else {
-                                    LOG.errorf(r.cause(), "Unable to consume text message in @OnTextMessage callback: %s",
-                                            connection);
-                                }
-                            });
-                        }, true);
-                    } else {
-                        textMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
-                            contextSupport.start();
-                            try {
-                                textBroadcastProcessor.onNext(endpoint.decodeTextMultiItem(m));
-                                LOG.debugf("Text message >> Multi: %s", connection);
-                            } catch (Throwable throwable) {
-                                endpoint.doOnError(throwable).subscribe().with(
-                                        v -> LOG.debugf("Text message >> Multi: %s", connection),
-                                        t -> LOG.errorf(t, "Unable to send text message to Multi: %s", connection));
-                            } finally {
-                                contextSupport.end(false);
-                            }
-                        }, false);
-                    }
-
-                    if (binaryBroadcastProcessor == null) {
-                        // Multi not consumed - invoke @OnBinaryMessage callback for each message received
-                        binaryMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
-                            endpoint.onBinaryMessage(m).onComplete(r -> {
-                                if (r.succeeded()) {
-                                    LOG.debugf("@OnBinaryMessage callback consumed text message: %s", connection);
-                                } else {
-                                    LOG.errorf(r.cause(), "Unable to consume text message in @OnBinaryMessage callback: %s",
-                                            connection);
-                                }
-                            });
-                        }, true);
-                    } else {
-                        binaryMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
-                            contextSupport.start();
-                            try {
-                                binaryBroadcastProcessor.onNext(endpoint.decodeBinaryMultiItem(m));
-                                LOG.debugf("Binary message >> Multi: %s", connection);
-                            } catch (Throwable throwable) {
-                                endpoint.doOnError(throwable).subscribe().with(
-                                        v -> LOG.debugf("Binary message >> Multi: %s", connection),
-                                        t -> LOG.errorf(t, "Unable to send binary message to Multi: %s", connection));
-                            } finally {
-                                contextSupport.end(false);
-                            }
-                        }, false);
-                    }
-
-                    pongMessageHandler(connection, endpoint, ws, onOpenContext, m -> {
-                        endpoint.onPongMessage(m).onComplete(r -> {
-                            if (r.succeeded()) {
-                                LOG.debugf("@OnPongMessage callback consumed text message: %s", connection);
-                            } else {
-                                LOG.errorf(r.cause(), "Unable to consume text message in @OnPongMessage callback: %s",
-                                        connection);
-                            }
-                        });
-                    });
-
-                    Long timerId;
-                    if (config.autoPingInterval().isPresent()) {
-                        timerId = vertx.setPeriodic(config.autoPingInterval().get().toMillis(), new Handler<Long>() {
-                            @Override
-                            public void handle(Long timerId) {
-                                connection.sendAutoPing();
-                            }
-                        });
-                    } else {
-                        timerId = null;
-                    }
-
-                    ws.closeHandler(new Handler<Void>() {
-                        @Override
-                        public void handle(Void event) {
-                            ContextSupport.createNewDuplicatedContext(context, connection).runOnContext(new Handler<Void>() {
-                                @Override
-                                public void handle(Void event) {
-                                    endpoint.onClose().onComplete(r -> {
-                                        if (r.succeeded()) {
-                                            LOG.debugf("@OnClose callback completed: %s", connection);
-                                        } else {
-                                            LOG.errorf(r.cause(), "Unable to complete @OnClose callback: %s", connection);
-                                        }
-                                        connectionManager.remove(generatedEndpointClass, connection);
-                                        if (timerId != null) {
-                                            vertx.cancelTimer(timerId);
-                                        }
-                                    });
-                                }
-                            });
-                        }
-                    });
-
-                    ws.exceptionHandler(new Handler<Throwable>() {
-                        @Override
-                        public void handle(Throwable t) {
-                            ContextSupport.createNewDuplicatedContext(context, connection).runOnContext(new Handler<Void>() {
-                                @Override
-                                public void handle(Void event) {
-                                    endpoint.doOnError(t).subscribe().with(
-                                            v -> LOG.debugf("Error [%s] processed: %s", t.getClass(), connection),
-                                            t -> LOG.errorf(t, "Unhandled error occured: %s", t.toString(),
-                                                    connection));
-                                }
-                            });
-                        }
-                    });
-
+                    Endpoints.initialize(vertx, container, codecs, connection, ws, generatedEndpointClass,
+                            config.autoPingInterval(), () -> connectionManager.remove(generatedEndpointClass, connection));
                 });
             }
         };
-    }
-
-    private void textMessageHandler(WebSocketConnection connection, WebSocketEndpoint endpoint, ServerWebSocket ws,
-            Context context, Consumer<String> textAction, boolean newDuplicatedContext) {
-        ws.textMessageHandler(new Handler<String>() {
-            @Override
-            public void handle(String message) {
-                Context duplicatedContext = newDuplicatedContext
-                        ? ContextSupport.createNewDuplicatedContext(context, connection)
-                        : context;
-                duplicatedContext.runOnContext(new Handler<Void>() {
-                    @Override
-                    public void handle(Void event) {
-                        textAction.accept(message);
-                    }
-                });
-            }
-        });
-    }
-
-    private void binaryMessageHandler(WebSocketConnection connection, WebSocketEndpoint endpoint, ServerWebSocket ws,
-            Context context, Consumer<Buffer> binaryAction, boolean newDuplicatedContext) {
-        ws.binaryMessageHandler(new Handler<Buffer>() {
-            @Override
-            public void handle(Buffer message) {
-                Context duplicatedContext = newDuplicatedContext
-                        ? ContextSupport.createNewDuplicatedContext(context, connection)
-                        : context;
-                duplicatedContext.runOnContext(new Handler<Void>() {
-                    @Override
-                    public void handle(Void event) {
-                        binaryAction.accept(message);
-                    }
-                });
-            }
-        });
-    }
-
-    private void pongMessageHandler(WebSocketConnection connection, WebSocketEndpoint endpoint, ServerWebSocket ws,
-            Context context, Consumer<Buffer> pongAction) {
-        ws.pongHandler(new Handler<Buffer>() {
-            @Override
-            public void handle(Buffer message) {
-                Context duplicatedContext = ContextSupport.createNewDuplicatedContext(context, connection);
-                duplicatedContext.runOnContext(new Handler<Void>() {
-                    @Override
-                    public void handle(Void event) {
-                        pongAction.accept(message);
-                    }
-                });
-            }
-        });
-    }
-
-    private WebSocketEndpoint createEndpoint(String endpointClassName, Context context, WebSocketConnection connection,
-            Codecs codecs, WebSocketsServerRuntimeConfig config, ContextSupport contextSupport) {
-        try {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            if (cl == null) {
-                cl = WebSocketServerRecorder.class.getClassLoader();
-            }
-            @SuppressWarnings("unchecked")
-            Class<? extends WebSocketEndpoint> endpointClazz = (Class<? extends WebSocketEndpoint>) cl
-                    .loadClass(endpointClassName);
-            WebSocketEndpoint endpoint = (WebSocketEndpoint) endpointClazz
-                    .getDeclaredConstructor(WebSocketConnection.class, Codecs.class,
-                            WebSocketsServerRuntimeConfig.class, ContextSupport.class)
-                    .newInstance(connection, codecs, config, contextSupport);
-            return endpoint;
-        } catch (Exception e) {
-            throw new WebSocketServerException("Unable to create endpoint instance: " + endpointClassName, e);
-        }
-    }
-
-    private static WebSocketSessionContext sessionContext(ArcContainer container) {
-        for (InjectableContext injectableContext : container.getContexts(SessionScoped.class)) {
-            if (WebSocketSessionContext.class.equals(injectableContext.getClass())) {
-                return (WebSocketSessionContext) injectableContext;
-            }
-        }
-        throw new WebSocketServerException("CDI session context not registered");
     }
 
 }


### PR DESCRIPTION
- includes refactoring of the server part so that we can reuse as much as possible

We introduce 2 new concepts for the client part:

- client endpoints; using the same programming model as server endpoints, except that annotated with `@WebSocketConnection` and built around the `WebSocketClientConnection` (unlike `@WebSocket` and `WebSocketConnection` on the server)
- WebSocket connector API - this API is used to configure and create new connections

```java
@WebSocket(path = "/end/{name}")
public class ServerEndpoint {
    @OnTextMessage
    String echo(String message, WebSocketConnection connection, @PathParam String name) {
       // do something with connection and name
       return message;
    }
}

@WebSocketClient(path = "/end/{name}")
public class ClientEndpoint {
   @OnTextMessage
   String echo(String message, WebSocketClientConnection connection, @PathParam String name) {
      // do something with connection and name
      return message;
    }
}
```

The `WebSocketConnector` can be injected in any bean:

```java
@Singleton
public class Service {

   @Inject
   WebSocketConnector<ClientEndpoint> connector;

   void connectToClientEndpoint() {
      connector.
         .baseUri(uri) // base URI is configurable per endpoint
         .pathParam("name", "Lu")
         .addHeader("X-Test", "foo")
         .connectAndAwait();
     }
}
```

## TODO

- [x] add more tests
- [x] fail the build if `@OnTextMessage.broadcast()=true`/ `@OnBinaryMessage.broadcast()=true` on a client endpoint
- [x] Dev UI update (just make sure the server part works fine)

~~-`@WebSocketClient#autoConnect()` - connect the client automatically when the app starts~~ removed from the list, not a high priority, maybe later...


NOTE: We decided to include the client part in the same extension as the server part. Therefore, we will get rid of `extensions/websockets-next/server` in a follow-up PR; i.e. the deployment module will be moved from `extensions/websockets-next/server/deployment` to `extensions/websockets-next/deployment` and the runtime module will be moved from `extensions/websockets-next/server/runtime` to `extensions/websockets-next/runtime`.