### PR TITLE
Improve documentation of configuration properties with type Map<String, NotAConfigGroup>

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ClassLoadingConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ClassLoadingConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -71,6 +72,7 @@ public class ClassLoadingConfig {
      * Note that for technical reasons this is not supported when running with JBang.
      */
     @ConfigItem
+    @ConfigDocMapKey("group-id:artifact-id")
     public Map<String, Set<String>> removedResources;
 
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -186,6 +187,7 @@ public class TestConfig {
      * Additional environment variables to be set in the process that {@code @QuarkusIntegrationTest} launches.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     Map<String, String> env;
 
     /**
@@ -292,18 +294,21 @@ public class TestConfig {
          * Set additional ports to be exposed when @QuarkusIntegration needs to launch the application in a container.
          */
         @ConfigItem
+        @ConfigDocMapKey("host-port")
         Map<String, String> additionalExposedPorts;
 
         /**
          * A set of labels to add to the launched container
          */
         @ConfigItem
+        @ConfigDocMapKey("label-name")
         Map<String, String> labels;
 
         /**
          * A set of volume mounts to add to the launched container
          */
         @ConfigItem
+        @ConfigDocMapKey("host-path")
         Map<String, String> volumeMounts;
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.maven.dependency.GACT;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -246,6 +247,7 @@ public interface PackageConfig {
              * quarkus.package.jar.manifest.attributes."Entry-key1"=Value1
              * quarkus.package.jar.manifest.attributes."Entry-key2"=Value2
              */
+            @ConfigDocMapKey("attribute-name")
             Map<String, String> attributes();
 
             /**
@@ -254,6 +256,7 @@ public interface PackageConfig {
              * quarkus.package.jar.manifest.sections."Section-Name"."Entry-Key1"=Value1
              * quarkus.package.jar.manifest.sections."Section-Name"."Entry-Key2"=Value2
              */
+            @ConfigDocMapKey("section-name")
             Map<String, Map<String, String>> sections();
         }
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
@@ -24,7 +24,6 @@ import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getJ
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getKnownGenericType;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.hyphenate;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.hyphenateEnumValue;
-import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.stringifyType;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static javax.lang.model.element.Modifier.ABSTRACT;
@@ -292,23 +291,21 @@ class ConfigDocItemFinder {
                         // FIXME: this is super dodgy: we should check the type!!
                         if (typeArguments.size() == 2) {
                             type = getType(typeArguments.get(1));
+                            List<String> additionalNames;
+                            if (unnamedMapKey) {
+                                additionalNames = List
+                                        .of(name + String.format(NAMED_MAP_CONFIG_ITEM_FORMAT, configDocMapKey));
+                            } else {
+                                name += String.format(NAMED_MAP_CONFIG_ITEM_FORMAT, configDocMapKey);
+                                additionalNames = emptyList();
+                            }
                             if (isConfigGroup(type)) {
-                                List<String> additionalNames;
-                                if (unnamedMapKey) {
-                                    additionalNames = List
-                                            .of(name + String.format(NAMED_MAP_CONFIG_ITEM_FORMAT, configDocMapKey));
-                                } else {
-                                    name += String.format(NAMED_MAP_CONFIG_ITEM_FORMAT, configDocMapKey);
-                                    additionalNames = emptyList();
-                                }
                                 List<ConfigDocItem> groupConfigItems = readConfigGroupItems(configPhase, rootName, name,
                                         additionalNames, type, configSection, true, generateSeparateConfigGroupDocsFiles,
                                         configMapping);
                                 DocGeneratorUtil.appendConfigItemsIntoExistingOnes(configDocItems, groupConfigItems);
                                 continue;
                             } else {
-                                type = BACK_TICK + stringifyType(declaredType) + BACK_TICK;
-                                configDocKey.setPassThroughMap(true);
                                 configDocKey.setWithinAMap(true);
                             }
                         } else {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocKey.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocKey.java
@@ -22,7 +22,6 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
     private List<String> acceptedValues;
     private boolean optional;
     private boolean list;
-    private boolean passThroughMap;
     private boolean withinAConfigGroup;
     // if a key is "quarkus.kubernetes.part-of", then the value of this would be "kubernetes"
     private String topLevelGrouping;
@@ -167,14 +166,6 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
         this.docMapKey = docMapKey;
     }
 
-    public boolean isPassThroughMap() {
-        return passThroughMap;
-    }
-
-    public void setPassThroughMap(boolean passThroughMap) {
-        this.passThroughMap = passThroughMap;
-    }
-
     public boolean isWithinAConfigGroup() {
         return withinAConfigGroup;
     }
@@ -231,7 +222,6 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
         return withinAMap == that.withinAMap &&
                 optional == that.optional &&
                 list == that.list &&
-                passThroughMap == that.passThroughMap &&
                 withinAConfigGroup == that.withinAConfigGroup &&
                 Objects.equals(type, that.type) &&
                 Objects.equals(key, that.key) &&
@@ -247,7 +237,7 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
     @Override
     public int hashCode() {
         return Objects.hash(type, key, configDoc, withinAMap, defaultValue, javaDocSiteLink, docMapKey, configPhase,
-                acceptedValues, optional, list, passThroughMap, withinAConfigGroup, topLevelGrouping);
+                acceptedValues, optional, list, withinAConfigGroup, topLevelGrouping);
     }
 
     @Override
@@ -264,7 +254,6 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
                 ", acceptedValues=" + acceptedValues +
                 ", optional=" + optional +
                 ", list=" + list +
-                ", passThroughMap=" + passThroughMap +
                 ", withinAConfigGroup=" + withinAConfigGroup +
                 ", topLevelGrouping='" + topLevelGrouping + '\'' +
                 '}';

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -111,8 +111,7 @@ final class SummaryTableDocFormatter implements DocFormatter {
         String required = configDocKey.isOptional() || !defaultValue.isEmpty() ? ""
                 : "required icon:exclamation-circle[title=Configuration property is required]";
         String key = configDocKey.getKey();
-        String configKeyAnchor = configDocKey.isPassThroughMap() ? getAnchor(key + Constants.DASH + configDocKey.getDocMapKey())
-                : getAnchor(key);
+        String configKeyAnchor = getAnchor(key);
         String anchor = anchorPrefix + configKeyAnchor;
 
         StringBuilder keys = new StringBuilder();

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -8,6 +8,7 @@ import java.util.OptionalInt;
 import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
@@ -131,6 +132,7 @@ public interface DataSourceJdbcRuntimeConfig {
     /**
      * Other unspecified properties to be passed to the JDBC driver when creating new connections.
      */
+    @ConfigDocMapKey("property-key")
     Map<String, String> additionalJdbcProperties();
 
     /**

--- a/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsConfig.java
+++ b/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsConfig.java
@@ -26,6 +26,7 @@ import com.microsoft.azure.toolkit.lib.auth.AzureEnvironmentUtils;
 import com.microsoft.azure.toolkit.lib.common.exception.InvalidConfigurationException;
 import com.microsoft.azure.toolkit.lib.common.model.Region;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -117,6 +118,7 @@ public class AzureFunctionsConfig {
      * Specifies the application settings for your Azure Functions, which are defined in name-value pairs
      */
     @ConfigItem
+    @ConfigDocMapKey("setting-name")
     public Map<String, String> appSettings = Collections.emptyMap();
 
     @ConfigGroup

--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.container.image.buildpack.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -26,6 +27,7 @@ public class BuildpackConfig {
      * Environment key/values to pass to buildpacks.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> builderEnv;
 
     /**

--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerConfig.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -38,6 +39,7 @@ public class DockerConfig {
      * Build args passed to docker via {@code --build-arg}
      */
     @ConfigItem
+    @ConfigDocMapKey("arg-name")
     public Map<String, String> buildArgs;
 
     /**

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -99,6 +100,7 @@ public class ContainerImageJibConfig {
      * Environment variables to add to the container image
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> environmentVariables;
 
     /**
@@ -202,6 +204,7 @@ public class ContainerImageJibConfig {
      * when the container image is being built locally.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> dockerEnvironment;
 
     /**

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageConfig.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.annotations.ConvertWith;
@@ -42,6 +43,7 @@ public class ContainerImageConfig {
      * Custom labels to add to the generated image.
      */
     @ConfigItem
+    @ConfigDocMapKey("label-name")
     public Map<String, String> labels;
 
     /**

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.WithConverter;
@@ -33,6 +34,7 @@ public interface DevServicesBuildTimeConfig {
     /**
      * Environment variables that are passed to the container.
      */
+    @ConfigDocMapKey("environment-variable-name")
     Map<String, String> containerEnv();
 
     /**

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -43,11 +43,13 @@ public interface DevServicesBuildTimeConfig {
      * Properties defined here are database-specific
      * and are interpreted specifically in each database dev service implementation.
      */
+    @ConfigDocMapKey("property-key")
     Map<String, String> containerProperties();
 
     /**
      * Generic properties that are added to the database connection URL.
      */
+    @ConfigDocMapKey("property-key")
     Map<String, String> properties();
 
     /**
@@ -99,6 +101,7 @@ public interface DevServicesBuildTimeConfig {
      * <p>
      * This has no effect if the provider is not a container-based database, such as H2 or Derby.
      */
+    @ConfigDocMapKey("host-path")
     Map<String, String> volumes();
 
     /**

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -96,6 +97,7 @@ public class ElasticsearchDevServicesBuildTimeConfig {
      * Environment variables that are passed to the container.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 
     /**

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -218,6 +219,7 @@ public final class FlywayDataSourceRuntimeConfig {
      * Sets the placeholders to replace in SQL migration scripts.
      */
     @ConfigItem
+    @ConfigDocMapKey("placeholder-key")
     public Map<String, String> placeholders = Collections.emptyMap();
 
     /**

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanDevServicesConfig.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanDevServicesConfig.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -124,6 +125,7 @@ public class InfinispanDevServicesConfig {
      * Environment variables that are passed to the container.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 
     /**

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoBuildTimeConfig.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoBuildTimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.info.deployment;
 
 import java.util.Map;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -76,6 +77,7 @@ public interface InfoBuildTimeConfig {
          * Additional properties to be added to the build section
          */
         @WithParentName
+        @ConfigDocMapKey("property-key")
         Map<String, String> additionalProperties();
     }
 

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -107,6 +107,7 @@ public class KafkaDevServicesBuildTimeConfig {
      * The topic creation will not try to re-partition existing topics with different number of partitions.
      */
     @ConfigItem
+    @ConfigDocMapKey("topic-name")
     public Map<String, Integer> topicPartitions;
 
     /**

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -120,6 +121,7 @@ public class KafkaDevServicesBuildTimeConfig {
      * Environment variables that are passed to the container.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 
     /**

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesDevServicesBuildTimeConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesDevServicesBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.kubernetes.client.runtime;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.smallrye.config.WithDefault;
 
 public interface KubernetesDevServicesBuildTimeConfig {
@@ -67,6 +68,7 @@ public interface KubernetesDevServicesBuildTimeConfig {
     /**
      * Environment variables that are passed to the container.
      */
+    @ConfigDocMapKey("environment-variable-name")
     Map<String, String> containerEnv();
 
     enum Flavor {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ClusterRoleBindingConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ClusterRoleBindingConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.kubernetes.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -20,6 +21,7 @@ public class ClusterRoleBindingConfig {
      * Labels to add into the RoleBinding resource.
      */
     @ConfigItem
+    @ConfigDocMapKey("label-name")
     public Map<String, String> labels;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ClusterRoleConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ClusterRoleConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.kubernetes.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -19,6 +20,7 @@ public class ClusterRoleConfig {
      * Labels to add into the ClusterRole resource.
      */
     @ConfigItem
+    @ConfigDocMapKey("label-name")
     Map<String, String> labels;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarsConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarsConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -28,6 +29,7 @@ public class EnvVarsConfig {
      * The map associating environment variable names to their associated field references they take their value from.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     Map<String, String> fields;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/IngressConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/IngressConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.kubernetes.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -38,6 +39,7 @@ public class IngressConfig {
      * Custom annotations to add to exposition (route or ingress) resources
      */
     @ConfigItem
+    @ConfigDocMapKey("annotation-name")
     Map<String, String> annotations;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.annotation.ServiceType;
 import io.quarkus.kubernetes.spi.DeployStrategy;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
@@ -49,12 +50,14 @@ public class KnativeConfig implements PlatformConfiguration {
      * Custom labels to add to all resources
      */
     @ConfigItem
+    @ConfigDocMapKey("label-name")
     Map<String, String> labels;
 
     /**
      * Custom annotations to add to all resources
      */
     @ConfigItem
+    @ConfigDocMapKey("annotation-name")
     Map<String, String> annotations;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -14,6 +14,7 @@ import io.dekorate.kubernetes.config.DeploymentStrategy;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.kubernetes.spi.DeployStrategy;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
@@ -61,12 +62,14 @@ public class KubernetesConfig implements PlatformConfiguration {
      * Custom labels to add to all resources
      */
     @ConfigItem
+    @ConfigDocMapKey("label-name")
     Map<String, String> labels;
 
     /**
      * Custom annotations to add to all resources
      */
     @ConfigItem
+    @ConfigDocMapKey("annotation-name")
     Map<String, String> annotations;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -17,6 +17,7 @@ import io.quarkus.container.image.deployment.ContainerImageConfig;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.kubernetes.spi.DeployStrategy;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
@@ -80,12 +81,14 @@ public class OpenshiftConfig implements PlatformConfiguration {
      * Custom labels to add to all resources
      */
     @ConfigItem
+    @ConfigDocMapKey("label-name")
     Map<String, String> labels;
 
     /**
      * Custom annotations to add to all resources
      */
     @ConfigItem
+    @ConfigDocMapKey("annotation-name")
     Map<String, String> annotations;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RoleBindingConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RoleBindingConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.kubernetes.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -20,6 +21,7 @@ public class RoleBindingConfig {
      * Labels to add into the RoleBinding resource.
      */
     @ConfigItem
+    @ConfigDocMapKey("label-name")
     public Map<String, String> labels;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RoleConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RoleConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.kubernetes.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -25,6 +26,7 @@ public class RoleConfig {
      * Labels to add into the Role resource.
      */
     @ConfigItem
+    @ConfigDocMapKey("label-name")
     Map<String, String> labels;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RouteConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RouteConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.kubernetes.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -32,6 +33,7 @@ public class RouteConfig {
      * Custom annotations to add to exposition (route or ingress) resources
      */
     @ConfigItem
+    @ConfigDocMapKey("annotation-name")
     Map<String, String> annotations;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecurityContextConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecurityContextConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -55,6 +56,7 @@ public class SecurityContextConfig {
      * Sysctls hold a list of namespaced sysctls used for the pod.
      */
     @ConfigItem
+    @ConfigDocMapKey("sysctl-name")
     Optional<Map<String, String>> sysctls;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ServiceAccountConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ServiceAccountConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.kubernetes.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -25,6 +26,7 @@ public class ServiceAccountConfig {
      * Labels of the service account.
      */
     @ConfigItem
+    @ConfigDocMapKey("label-name")
     Map<String, String> labels;
 
     /**

--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseConfig.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseConfig.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+
 /**
  * The liquibase configuration
  */
@@ -48,6 +50,7 @@ public class LiquibaseConfig {
      */
     public List<String> labels = null;
 
+    @ConfigDocMapKey("parameter-name")
     public Map<String, String> changeLogParameters = null;
 
     /**

--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseDataSourceRuntimeConfig.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseDataSourceRuntimeConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -74,6 +75,7 @@ public final class LiquibaseDataSourceRuntimeConfig {
      * Map of parameters that can be used inside Liquibase changeLog files.
      */
     @ConfigItem
+    @ConfigDocMapKey("parameter-name")
     public Map<String, String> changeLogParameters = new HashMap<>();
 
     /**

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/PrometheusRuntimeConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/runtime/PrometheusRuntimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.micrometer.runtime.config.runtime;
 
 import java.util.Map;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -23,5 +24,6 @@ public class PrometheusRuntimeConfig {
      */
     // @formatter:on
     @ConfigItem(name = ConfigItem.PARENT)
+    @ConfigDocMapKey("configuration-property-name")
     public Map<String, String> prometheus;
 }

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesBuildTimeConfig.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesBuildTimeConfig.java
@@ -38,6 +38,7 @@ public class DevServicesBuildTimeConfig {
      * Generic properties that are added to the connection URL.
      */
     @ConfigItem
+    @ConfigDocMapKey("property-key")
     public Map<String, String> properties;
 
     /**

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesBuildTimeConfig.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.mongodb.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -43,6 +44,7 @@ public class DevServicesBuildTimeConfig {
      * Environment variables that are passed to the container.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/CredentialConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/CredentialConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.mongodb.runtime;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConvertWith;
@@ -50,6 +51,7 @@ public class CredentialConfig {
      * Allows passing authentication mechanism properties.
      */
     @ConfigItem
+    @ConfigDocMapKey("property-key")
     public Map<String, String> authMechanismProperties;
 
     /**

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -184,6 +185,7 @@ public class OidcClientConfig extends OidcCommonConfig {
      * Grant options
      */
     @ConfigItem
+    @ConfigDocMapKey("grant-name")
     public Map<String, Map<String, String>> grantOptions;
 
     /**

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -342,6 +343,7 @@ public class OidcCommonConfig {
              * Additional claims.
              */
             @ConfigItem
+            @ConfigDocMapKey("claim-name")
             public Map<String, String> claims = new HashMap<>();
 
             /**

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/DevUiConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/DevUiConfig.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -64,6 +65,7 @@ public class DevUiConfig {
      * Grant options
      */
     @ConfigItem
+    @ConfigDocMapKey("option-name")
     public Map<String, Map<String, String>> grantOptions;
 
     /**

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.oidc.deployment.DevUiConfig;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -223,6 +224,7 @@ public class DevServicesConfig {
      * Environment variables to be passed to the container.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 
     @Override

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -96,6 +96,7 @@ public class DevServicesConfig {
      * Each map entry represents a mapping between an alias and a class or file system resource path.
      */
     @ConfigItem
+    @ConfigDocMapKey("alias-name")
     public Map<String, String> resourceAliases;
     /**
      * Additional class or file system resources that are used to initialize Keycloak.
@@ -103,6 +104,7 @@ public class DevServicesConfig {
      * location.
      */
     @ConfigItem
+    @ConfigDocMapKey("resource-name")
     public Map<String, String> resourceMappings;
 
     /**
@@ -162,6 +164,7 @@ public class DevServicesConfig {
      * This map is used for role creation when no realm file is found at the `realm-path`.
      */
     @ConfigItem
+    @ConfigDocMapKey("role-name")
     public Map<String, List<String>> roles;
 
     /**

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -357,6 +357,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * Additional properties which is added as the query parameters to the logout redirect URI.
          */
         @ConfigItem
+        @ConfigDocMapKey("query-parameter-name")
         public Map<String, String> extraParams;
 
         /**
@@ -1037,6 +1038,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * Additional properties added as query parameters to the authentication redirect URI.
          */
         @ConfigItem
+        @ConfigDocMapKey("parameter-name")
         public Map<String, String> extraParams = new HashMap<>();
 
         /**
@@ -1472,12 +1474,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * which must be included to complete the authorization code grant request.
          */
         @ConfigItem
+        @ConfigDocMapKey("parameter-name")
         public Map<String, String> extraParams = new HashMap<>();
 
         /**
          * Custom HTTP headers which must be sent to complete the authorization code grant request.
          */
         @ConfigItem
+        @ConfigDocMapKey("header-name")
         public Map<String, String> headers = new HashMap<>();
 
         public Map<String, String> getExtraParams() {

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzExtensionPointConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzExtensionPointConfig.java
@@ -18,6 +18,6 @@ public class QuartzExtensionPointConfig {
      * The properties passed to the class.
      */
     @ConfigItem
-    @ConfigDocMapKey("property-name")
+    @ConfigDocMapKey("property-key")
     public Map<String, String> properties;
 }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteConfig.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteConfig.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -28,6 +29,7 @@ public class QuteConfig {
      * {@link java.net.URLConnection#getFileNameMap()} is used to determine the content type of a template file.
      */
     @ConfigItem
+    @ConfigDocMapKey("file-suffix")
     public Map<String, String> contentTypes;
 
     /**

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.vertx.core.runtime.config.JksConfiguration;
 import io.quarkus.vertx.core.runtime.config.PemKeyCertConfiguration;
@@ -147,5 +148,6 @@ public interface DataSourceReactiveRuntimeConfig {
      * Other unspecified properties to be passed through the Reactive SQL Client directly to the database when new connections
      * are initiated.
      */
+    @ConfigDocMapKey("property-key")
     Map<String, String> additionalProperties();
 }

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesConfig.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -64,5 +65,6 @@ public interface DevServicesConfig {
     /**
      * Environment variables that are passed to the container.
      */
+    @ConfigDocMapKey("environment-variable-name")
     Map<String, String> containerEnv();
 }

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.configuration.MemorySize;
@@ -233,6 +234,7 @@ public class RestClientConfig {
      * This property is not applicable to the RESTEasy Client.
      */
     @ConfigItem
+    @ConfigDocMapKey("header-name")
     public Map<String, String> headers;
 
     /**

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -12,6 +12,7 @@ import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -134,6 +135,7 @@ public class RestClientsConfig {
      * The HTTP headers that should be applied to all requests of the rest client.
      */
     @ConfigItem
+    @ConfigDocMapKey("header-name")
     public Map<String, String> headers;
 
     /**

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryDevServicesBuildTimeConfig.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryDevServicesBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.apicurio.registry.devservice;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -66,6 +67,7 @@ public class ApicurioRegistryDevServicesBuildTimeConfig {
      * Environment variables that are passed to the container.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 
 }

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
@@ -31,5 +32,6 @@ public interface SecurityConfig {
     /**
      * Security provider configuration
      */
+    @ConfigDocMapKey("provider-name")
     Map<String, String> securityProviderConfig();
 }

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -21,6 +22,7 @@ public class GraphQLClientConfig {
      * HTTP headers to add when communicating with the target GraphQL service.
      */
     @ConfigItem(name = "header")
+    @ConfigDocMapKey("header-name")
     public Map<String, String> headers;
 
     /**
@@ -118,6 +120,7 @@ public class GraphQLClientConfig {
      * Additional payload sent on websocket initialization.
      */
     @ConfigItem(name = "init-payload")
+    @ConfigDocMapKey("property-name")
     public Map<String, String> initPayload;
 
     /**

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthRuntimeConfig.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthRuntimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.smallrye.health.runtime;
 
 import java.util.Map;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -20,12 +21,14 @@ public class SmallRyeHealthRuntimeConfig {
      * Additional top-level properties to be included in the resulting JSON object.
      */
     @ConfigItem(name = "additional.property")
+    @ConfigDocMapKey("property-name")
     Map<String, String> additionalProperties;
 
     /**
      * Specifications of checks that can be disabled.
      */
     @ConfigItem
+    @ConfigDocMapKey("check-name")
     Map<String, Enabled> check;
 
     @ConfigGroup

--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
@@ -73,6 +74,7 @@ public final class SmallRyeOpenApiConfig {
      * Add one or more extensions to the security scheme
      */
     @ConfigItem
+    @ConfigDocMapKey("extension-name")
     public Map<String, String> securitySchemeExtensions = Collections.emptyMap();
 
     /**

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.reactivemessaging.amqp.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -77,6 +78,7 @@ public class AmqpDevServicesBuildTimeConfig {
      * Environment variables that are passed to the container.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 
 }

--- a/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesBuildTimeConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -66,5 +67,6 @@ public class MqttDevServicesBuildTimeConfig {
      * Environment variables that are passed to the container.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 }

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.reactivemessaging.pulsar.deployment;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -67,6 +68,7 @@ public class PulsarDevServicesBuildTimeConfig {
      * Broker config to set on the Pulsar instance
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> brokerConfig;
 
 }

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
@@ -36,6 +36,7 @@ public class RabbitMQDevServicesBuildTimeConfig {
          * Extra arguments for the exchange definition.
          */
         @ConfigItem
+        @ConfigDocMapKey("argument-name")
         public Map<String, String> arguments;
     }
 
@@ -58,6 +59,7 @@ public class RabbitMQDevServicesBuildTimeConfig {
          * Extra arguments for the queue definition.
          */
         @ConfigItem
+        @ConfigDocMapKey("argument-name")
         public Map<String, String> arguments;
     }
 
@@ -92,6 +94,7 @@ public class RabbitMQDevServicesBuildTimeConfig {
          * Extra arguments for the binding definition.
          */
         @ConfigItem
+        @ConfigDocMapKey("argument-name")
         public Map<String, String> arguments;
     }
 
@@ -160,18 +163,21 @@ public class RabbitMQDevServicesBuildTimeConfig {
      * Exchanges that should be predefined after starting the RabbitMQ broker.
      */
     @ConfigItem
+    @ConfigDocMapKey("exchange-name")
     public Map<String, Exchange> exchanges;
 
     /**
      * Queues that should be predefined after starting the RabbitMQ broker.
      */
     @ConfigItem
+    @ConfigDocMapKey("queue-name")
     public Map<String, Queue> queues;
 
     /**
      * Bindings that should be predefined after starting the RabbitMQ broker.
      */
     @ConfigItem
+    @ConfigDocMapKey("binding-name")
     public Map<String, Binding> bindings;
 
     /**

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -177,5 +178,6 @@ public class RabbitMQDevServicesBuildTimeConfig {
      * Environment variables that are passed to the container.
      */
     @ConfigItem
+    @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 }

--- a/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientConfig.java
+++ b/extensions/spring-cloud-config-client/runtime/src/main/java/io/quarkus/spring/cloud/config/client/runtime/SpringCloudConfigClientConfig.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.configuration.DurationConverter;
@@ -109,6 +110,7 @@ public interface SpringCloudConfigClientConfig {
     /**
      * Custom headers to pass the Spring Cloud Config Server when performing the HTTP request
      */
+    @ConfigDocMapKey("header-name")
     Map<String, String> headers();
 
     /**

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiConfig.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.openapi.ui.DocExpansion;
@@ -35,6 +36,7 @@ public class SwaggerUiConfig {
      * Here you can override that and supply multiple urls that will appear in the TopBar plugin.
      */
     @ConfigItem
+    @ConfigDocMapKey("name")
     Map<String, String> urls;
 
     /**

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
@@ -34,8 +34,8 @@ public class AuthRuntimeConfig {
      * use this property to map the `user` role to the `UserRole` role, and have `SecurityIdentity` to have
      * both `user` and `UserRole` roles.
      */
-    @ConfigDocMapKey("role1")
     @ConfigItem
+    @ConfigDocMapKey("role-name")
     public Map<String, List<String>> rolesMapping;
 
     /**

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FilterConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FilterConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -21,6 +22,7 @@ public class FilterConfig {
      * Additional HTTP Headers always sent in the response
      */
     @ConfigItem
+    @ConfigDocMapKey("header-name")
     public Map<String, String> header;
 
     /**

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyConfig.java
@@ -26,8 +26,8 @@ public class PolicyConfig {
      * For example, the Quarkus OIDC extension can map roles from the verified JWT access token, and you may want
      * to remap them to a deployment specific roles.
      */
-    @ConfigDocMapKey("role1")
     @ConfigItem
+    @ConfigDocMapKey("role-name")
     public Map<String, List<String>> roles;
 
     /**
@@ -37,8 +37,8 @@ public class PolicyConfig {
      * `quarkus.http.auth.policy.role-policy1.permissions.admin=perm1:action1,perm1:action2` configuration property.
      * Granted permissions are used for authorization with the `@PermissionsAllowed` annotation.
      */
-    @ConfigDocMapKey("role1")
     @ConfigItem
+    @ConfigDocMapKey("role-name")
     public Map<String, List<String>> permissions;
 
     /**

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementRuntimeAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementRuntimeAuthConfig.java
@@ -34,7 +34,7 @@ public class ManagementRuntimeAuthConfig {
      * use this property to map the `user` role to the `UserRole` role, and have `SecurityIdentity` to have
      * both `user` and `UserRole` roles.
      */
-    @ConfigDocMapKey("role1")
     @ConfigItem
+    @ConfigDocMapKey("role-name")
     public Map<String, List<String>> rolesMapping;
 }

--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorConfig.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.webdependency.locator.deployment;
 
 import java.util.Map;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
@@ -21,6 +22,7 @@ public class WebDependencyLocatorConfig {
      * User defined import mappings
      */
     @ConfigItem
+    @ConfigDocMapKey("module-specifier")
     public Map<String, String> importMappings;
 
     /**


### PR DESCRIPTION
Fixes #40332 

Before the patch:

![image](https://github.com/quarkusio/quarkus/assets/412878/888d5187-e48e-405e-9373-4c77bc942462)

After the patch (without CSS, since I tested locally...):

![image](https://github.com/quarkusio/quarkus/assets/412878/6b3b921d-a6f6-4681-89f9-ab4e4ef31799)


Unfortunately, this PR needs to set the name of the map keys, which will break direct links to the relevant configuration properties in the docs. That's because anchors are generated from the displayed key, including the `"some-name"` parts... which IMO is a dubious choice. We should probably change that to use anchors generated from some display-independent reference to the key. But that will result in breaking even more links, and anyway won't solve our problem here (since existing links will still be using the old anchor that includes the old `"some-name"`), so I won't do it in this PR.