### PR TITLE
Add a temporary config property to allow multiple resources

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -572,12 +572,16 @@ or xref:transaction.adoc#legacy-api-approach[`UserTransaction`] (for more comple
 ====
 As a last resort, and for compatibility with Quarkus 3.8 and earlier,
 you may allow unsafe transaction handling across multiple non-XA datasources
-by setting `quarkus.transaction-manager.allow-unsafe-multiple-last-resources` to `true`.
+by setting `quarkus.transaction-manager.unsafe-multiple-last-resources` to `allow`.
 
-With this property set to `true`, a transaction rollback
+With this property set to `allow`, a transaction rollback
 could possibly be applied to only some of the non-XA datasources,
 with other non-XA datasources having already committed their changes,
 leaving your overall system in an inconsistent state.
+
+Setting this property to `warn` leads to the same unsafe behavior,
+but with a warning being logged on each offending transaction,
+instead of a single one on startup.
 
 We do not recommend using this configuration property,
 and we plan to remove it in the future,

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -517,6 +517,76 @@ public class MyProducer {
 ----
 ====
 
+[[datasource-multiple-single-transaction]]
+=== Use multiple datasources in a single transaction
+
+By default, XA support on datasources is disabled,
+and thus a transaction may include at most one datasource.
+Attempting to access multiple non-XA datasources in the same transaction
+would result in an exception similar to this:
+
+[source]
+----
+...
+Caused by: java.sql.SQLException: Exception in association of connection to existing transaction
+        at io.agroal.narayana.NarayanaTransactionIntegration.associate(NarayanaTransactionIntegration.java:130)
+        ...
+Caused by: java.sql.SQLException: Unable to enlist connection to existing transaction
+        at io.agroal.narayana.NarayanaTransactionIntegration.associate(NarayanaTransactionIntegration.java:121)
+        ...
+----
+
+To allow using multiple JDBC datasources in the same transaction:
+
+. Make sure your JDBC driver supports XA.
+All <<extensions-and-database-drivers-reference,supported JDBC drivers do>>,
+but <<other-databases,other JDBC drivers>> might not.
+. Make sure your database server is configured to enable XA.
+. Enable XA support explicitly for each relevant datasource by setting
+<<quarkus-agroal_quarkus-datasource-jdbc-transactions,`quarkus.datasource[.optional name].transactions`>> to `xa`.
+
+Using XA, a rollback in one datasource will trigger a rollback in every other datasource enrolled in the transaction.
+
+[NOTE]
+====
+XA transactions on reactive datasources are not supported at the moment.
+====
+
+[NOTE]
+====
+If your transaction involves other, non-datasource resources,
+keep in mind *those* resources might not support XA transactions,
+or might require additional configuration.
+====
+
+If XA cannot be enabled for one of your datasources:
+
+* Be aware that enabling XA for all datasources _except one_ (and only one) is still supported
+through https://www.narayana.io/docs/project/index.html#d5e857[Last Resource Commit Optimization (LRCO)].
+* If you do not need a rollback for one datasource to trigger a rollback for other datasources,
+consider splitting your code into multiple transactions.
+To that end, use xref:transaction.adoc#programmatic-approach[`QuarkusTransaction.requiringNew()`]/xref:transaction.adoc#declarative-approach[`@Transactional(REQUIRES_NEW)`] (preferably)
+or xref:transaction.adoc#legacy-api-approach[`UserTransaction`] (for more complex use cases).
+
+[CAUTION]
+====
+As a last resort, and for compatibility with Quarkus 3.8 and earlier,
+you may allow unsafe transaction handling across multiple non-XA datasources
+by setting `quarkus.transaction-manager.allow-unsafe-multiple-last-resources` to `true`.
+
+With this property set to `true`, a transaction rollback
+could possibly be applied to only some of the non-XA datasources,
+with other non-XA datasources having already committed their changes,
+leaving your overall system in an inconsistent state.
+
+We do not recommend using this configuration property,
+and we plan to remove it in the future,
+so you should plan fixing your application accordingly.
+If you think your use case of this feature is valid and this option should be kept around,
+open an issue in the https://github.com/quarkusio/quarkus/issues/new?assignees=&labels=kind%2Fenhancement&projects=&template=feature_request.yml[Quarkus tracker]
+explaining why.
+====
+
 == Datasource integrations
 
 === Datasource health check

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -579,9 +579,13 @@ could possibly be applied to only some of the non-XA datasources,
 with other non-XA datasources having already committed their changes,
 leaving your overall system in an inconsistent state.
 
-Setting this property to `warn` leads to the same unsafe behavior,
-but with a warning being logged on each offending transaction,
-instead of a single one on startup.
+Alternatively, you can allow the same unsafe behavior,
+but with warnings when it is taken advantage of:
+
+* setting the property to `warn-each`
+would result in logging a warning on *each* offending transaction.
+* setting the property to `warn-first`
+would result in logging a warning on the *first* offending transaction.
 
 We do not recommend using this configuration property,
 and we plan to remove it in the future,

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -182,7 +182,14 @@ class NarayanaJtaProcessor {
                 logCleanupFilters.produce(
                         new LogCleanupFilterBuildItem("com.arjuna.ats.arjuna", "ARJUNA012139", "ARJUNA012141", "ARJUNA012142"));
             }
-            case WARN -> {
+            case WARN_FIRST -> {
+                recorder.allowUnsafeMultipleLastResources(capabilities.isPresent(Capability.AGROAL), true);
+                // we will handle the warnings ourselves at runtime init when the option is set explicitly
+                // but we still want Narayana to produce a warning on the first offending transaction
+                logCleanupFilters.produce(
+                        new LogCleanupFilterBuildItem("com.arjuna.ats.arjuna", "ARJUNA012139", "ARJUNA012142"));
+            }
+            case WARN_EACH -> {
                 recorder.allowUnsafeMultipleLastResources(capabilities.isPresent(Capability.AGROAL), false);
                 // we will handle the warnings ourselves at runtime init when the option is set explicitly
                 // but we still want Narayana to produce one warning per offending transaction
@@ -199,7 +206,7 @@ class NarayanaJtaProcessor {
             BuildProducer<NativeImageFeatureBuildItem> nativeImageFeatures) {
         switch (transactionManagerBuildTimeConfig.unsafeMultipleLastResources
                 .orElse(UnsafeMultipleLastResourcesMode.DEFAULT)) {
-            case ALLOW, WARN -> {
+            case ALLOW, WARN_FIRST, WARN_EACH -> {
                 nativeImageFeatures.produce(new NativeImageFeatureBuildItem(DisableLoggingFeature.class));
             }
         }

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.narayana.jta.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,8 @@ import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsTest;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -64,6 +67,7 @@ import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.narayana.jta.runtime.NarayanaJtaProducers;
 import io.quarkus.narayana.jta.runtime.NarayanaJtaRecorder;
+import io.quarkus.narayana.jta.runtime.TransactionManagerBuildTimeConfig;
 import io.quarkus.narayana.jta.runtime.TransactionManagerConfiguration;
 import io.quarkus.narayana.jta.runtime.context.TransactionContext;
 import io.quarkus.narayana.jta.runtime.interceptor.TestTransactionInterceptor;
@@ -150,6 +154,16 @@ class NarayanaJtaProcessor {
         recorder.setNodeName(transactions);
         recorder.setDefaultTimeout(transactions);
         recorder.setConfig(transactions);
+    }
+
+    @BuildStep
+    @Record(STATIC_INIT)
+    public void allowUnsafeMultipleLastResources(NarayanaJtaRecorder recorder,
+            TransactionManagerBuildTimeConfig transactionManagerBuildTimeConfig,
+            Capabilities capabilities) {
+        if (transactionManagerBuildTimeConfig.allowUnsafeMultipleLastResources) {
+            recorder.allowUnsafeMultipleLastResources(capabilities.isPresent(Capability.AGROAL));
+        }
     }
 
     @BuildStep

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
@@ -7,6 +7,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -114,9 +115,9 @@ public class NarayanaJtaRecorder {
      * This should be removed in the future.
      */
     @Deprecated(forRemoval = true)
-    public void allowUnsafeMultipleLastResources(boolean agroalPresent) {
+    public void allowUnsafeMultipleLastResources(boolean agroalPresent, boolean disableMultipleLastResourcesWarning) {
         arjPropertyManager.getCoreEnvironmentBean().setAllowMultipleLastResources(true);
-        arjPropertyManager.getCoreEnvironmentBean().setDisableMultipleLastResourcesWarning(true);
+        arjPropertyManager.getCoreEnvironmentBean().setDisableMultipleLastResourcesWarning(disableMultipleLastResourcesWarning);
         if (agroalPresent) {
             jtaPropertyManager.getJTAEnvironmentBean()
                     .setLastResourceOptimisationInterfaceClassName("io.agroal.narayana.LocalXAResource");
@@ -127,9 +128,11 @@ public class NarayanaJtaRecorder {
      * This should be removed in the future.
      */
     @Deprecated(forRemoval = true)
-    public void logAllowUnsafeMultipleLastResources() {
-        log.warn(
-                "Setting quarkus.transaction-manager.allow-unsafe-multiple-last-resources to true makes adding multiple resources to the same transaction unsafe.");
+    public void logUnsafeMultipleLastResourcesOnStartup(
+            TransactionManagerBuildTimeConfig.UnsafeMultipleLastResourcesMode mode) {
+        log.warnf(
+                "Setting quarkus.transaction-manager.unsafe-multiple-last-resources to '%s' makes adding multiple resources to the same transaction unsafe.",
+                mode.name().toLowerCase(Locale.ROOT));
     }
 
     private void setObjectStoreDir(String name, TransactionManagerConfiguration config) {

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
@@ -111,15 +111,25 @@ public class NarayanaJtaRecorder {
     }
 
     /**
-     * This should be removed in 3.11.
+     * This should be removed in the future.
      */
     @Deprecated(forRemoval = true)
     public void allowUnsafeMultipleLastResources(boolean agroalPresent) {
         arjPropertyManager.getCoreEnvironmentBean().setAllowMultipleLastResources(true);
+        arjPropertyManager.getCoreEnvironmentBean().setDisableMultipleLastResourcesWarning(true);
         if (agroalPresent) {
             jtaPropertyManager.getJTAEnvironmentBean()
                     .setLastResourceOptimisationInterfaceClassName("io.agroal.narayana.LocalXAResource");
         }
+    }
+
+    /**
+     * This should be removed in the future.
+     */
+    @Deprecated(forRemoval = true)
+    public void logAllowUnsafeMultipleLastResources() {
+        log.warn(
+                "Setting quarkus.transaction-manager.allow-unsafe-multiple-last-resources to true makes adding multiple resources to the same transaction unsafe.");
     }
 
     private void setObjectStoreDir(String name, TransactionManagerConfiguration config) {

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
@@ -110,6 +110,18 @@ public class NarayanaJtaRecorder {
                 .setXaResourceOrphanFilterClassNames(transactions.xaResourceOrphanFilters);
     }
 
+    /**
+     * This should be removed in 3.11.
+     */
+    @Deprecated(forRemoval = true)
+    public void allowUnsafeMultipleLastResources(boolean agroalPresent) {
+        arjPropertyManager.getCoreEnvironmentBean().setAllowMultipleLastResources(true);
+        if (agroalPresent) {
+            jtaPropertyManager.getJTAEnvironmentBean()
+                    .setLastResourceOptimisationInterfaceClassName("io.agroal.narayana.LocalXAResource");
+        }
+    }
+
     private void setObjectStoreDir(String name, TransactionManagerConfiguration config) {
         BeanPopulator.getNamedInstance(ObjectStoreEnvironmentBean.class, name).setObjectStoreDir(config.objectStore.directory);
     }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
@@ -7,7 +7,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -30,6 +29,7 @@ import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.runtime.util.StringUtil;
 
 @Recorder
 public class NarayanaJtaRecorder {
@@ -132,7 +132,7 @@ public class NarayanaJtaRecorder {
             TransactionManagerBuildTimeConfig.UnsafeMultipleLastResourcesMode mode) {
         log.warnf(
                 "Setting quarkus.transaction-manager.unsafe-multiple-last-resources to '%s' makes adding multiple resources to the same transaction unsafe.",
-                mode.name().toLowerCase(Locale.ROOT));
+                StringUtil.hyphenate(mode.name()).replace('_', '-'));
     }
 
     private void setObjectStoreDir(String name, TransactionManagerConfiguration config) {

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerBuildTimeConfig.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerBuildTimeConfig.java
@@ -44,9 +44,14 @@ public final class TransactionManagerBuildTimeConfig {
         ALLOW,
         /**
          * Allow using multiple XA unaware resources in the same transactional demarcation,
+         * but log a warning on the first occurrence.
+         */
+        WARN_FIRST,
+        /**
+         * Allow using multiple XA unaware resources in the same transactional demarcation,
          * but log a warning on each occurrence.
          */
-        WARN,
+        WARN_EACH,
         /**
          * Allow using multiple XA unaware resources in the same transactional demarcation,
          * but log a warning on each occurrence.

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerBuildTimeConfig.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerBuildTimeConfig.java
@@ -20,8 +20,8 @@ public final class TransactionManagerBuildTimeConfig {
      * recommended since the probability of inconsistent outcomes is significantly higher and
      * much harder to recover from than LRCO. For this reason, use LRCO as a last resort.
      * <p>
-     * We plan to remove this property in the future so you should plan fixing your application
-     * accordingly.
+     * We do not recommend using this configuration property, and we plan to remove it in the future,
+     * so you should plan fixing your application accordingly.
      * If you think your use case of this feature is valid and this option should be kept around,
      * open an issue in our tracker explaining why.
      *

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerBuildTimeConfig.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerBuildTimeConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.narayana.jta.runtime;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -7,9 +9,10 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public final class TransactionManagerBuildTimeConfig {
     /**
-     * Allow using multiple XA unaware resources in the same transactional demarcation.
-     * This is UNSAFE and may only be used for compatibility.
+     * Define the behavior when using multiple XA unaware resources in the same transactional demarcation.
      * <p>
+     * Defaults to {@code fail}.
+     * {@code warn} and {@code allow} are UNSAFE and should only be used for compatibility.
      * Either use XA for all resources if you want consistency, or split the code into separate
      * methods with separate transactions.
      * <p>
@@ -28,7 +31,31 @@ public final class TransactionManagerBuildTimeConfig {
      * @deprecated This property is planned for removal in a future version.
      */
     @Deprecated(forRemoval = true)
-    @ConfigItem(defaultValue = "false")
-    public boolean allowUnsafeMultipleLastResources;
+    @ConfigItem(defaultValueDocumentation = "fail")
+    public Optional<UnsafeMultipleLastResourcesMode> unsafeMultipleLastResources;
+
+    public enum UnsafeMultipleLastResourcesMode {
+        /**
+         * Allow using multiple XA unaware resources in the same transactional demarcation.
+         * <p>
+         * This will log a warning once on application startup,
+         * but not on each use of multiple XA unaware resources in the same transactional demarcation.
+         */
+        ALLOW,
+        /**
+         * Allow using multiple XA unaware resources in the same transactional demarcation,
+         * but log a warning on each occurrence.
+         */
+        WARN,
+        /**
+         * Allow using multiple XA unaware resources in the same transactional demarcation,
+         * but log a warning on each occurrence.
+         */
+        FAIL;
+
+        // The default is WARN in Quarkus 3.8, FAIL in Quarkus 3.9+
+        // Make sure to update defaultValueDocumentation on unsafeMultipleLastResources when changing this.
+        public static final UnsafeMultipleLastResourcesMode DEFAULT = FAIL;
+    }
 
 }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerBuildTimeConfig.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerBuildTimeConfig.java
@@ -1,0 +1,34 @@
+package io.quarkus.narayana.jta.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public final class TransactionManagerBuildTimeConfig {
+    /**
+     * Allow using multiple XA unaware resources in the same transactional demarcation.
+     * This is UNSAFE and may only be used for compatibility.
+     * <p>
+     * Either use XA for all resources if you want consistency, or split the code into separate
+     * methods with separate transactions.
+     * <p>
+     * Note that using a single XA unaware resource together with XA aware resources, known as
+     * the Last Resource Commit Optimization (LRCO), is different from using multiple XA unaware
+     * resources. Although LRCO allows most transactions to complete normally, some errors can
+     * cause an inconsistent transaction outcome. Using multiple XA unaware resources is not
+     * recommended since the probability of inconsistent outcomes is significantly higher and
+     * much harder to recover from than LRCO. For this reason, use LRCO as a last resort.
+     * <p>
+     * We plan to remove this property in the future so you should plan fixing your application
+     * accordingly.
+     * If you think your use case of this feature is valid and this option should be kept around,
+     * open an issue in our tracker explaining why.
+     *
+     * @deprecated This property is planned for removal in a future version.
+     */
+    @Deprecated(forRemoval = true)
+    @ConfigItem(defaultValue = "false")
+    public boolean allowUnsafeMultipleLastResources;
+
+}

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/graal/DisableLoggingFeature.java
@@ -31,10 +31,8 @@ public class DisableLoggingFeature implements Feature {
     public void afterAnalysis(AfterAnalysisAccess access) {
         for (String category : CATEGORIES) {
             Level level = categoryMap.remove(category);
-            if (level != null) {
-                Logger logger = Logger.getLogger(category);
-                logger.setLevel(level);
-            }
+            Logger logger = Logger.getLogger(category);
+            logger.setLevel(level);
         }
     }
 

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/graal/DisableLoggingFeature.java
@@ -1,0 +1,45 @@
+package io.quarkus.narayana.jta.runtime.graal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.graalvm.nativeimage.hosted.Feature;
+
+/**
+ * Disables logging during the analysis phase
+ */
+public class DisableLoggingFeature implements Feature {
+
+    private static final String[] CATEGORIES = {
+            "com.arjuna.ats.arjuna"
+    };
+
+    private final Map<String, Level> categoryMap = new HashMap<>(CATEGORIES.length);
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        for (String category : CATEGORIES) {
+            Logger logger = Logger.getLogger(category);
+            categoryMap.put(category, logger.getLevel());
+            logger.setLevel(Level.SEVERE);
+        }
+    }
+
+    @Override
+    public void afterAnalysis(AfterAnalysisAccess access) {
+        for (String category : CATEGORIES) {
+            Level level = categoryMap.remove(category);
+            if (level != null) {
+                Logger logger = Logger.getLogger(category);
+                logger.setLevel(level);
+            }
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return "Disables INFO and WARN logging during the analysis phase";
+    }
+}


### PR DESCRIPTION
The plan is to remove this property in the future but we need to provide a way for people to update to latest security fixes without having to significantly adjust their applications.

When we remove it, we need to document this breaking change properly and also provide guidance on how to fix the most common issues that could be encountered due to this breaking change.

TODO:
- [ ] Document in the 3.8 migration guide (and maybe the other versions too) - the migration guide should clearly state the error message so that people can find it with the error message
- [x] I wonder if we should have a paragraph in the documentation too, again with the explicit error message and strategies on how to fix the apps (part of this section should stay in 3.11 as the plan is to drop the property).

Fixes https://github.com/quarkusio/quarkus/issues/39283