### PR TITLE
Allow ClassLoader to return multiple resources

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/CachingPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/CachingPathTree.java
@@ -88,6 +88,11 @@ public class CachingPathTree implements OpenPathTree {
     }
 
     @Override
+    public void acceptAll(String relativePath, Consumer<PathVisit> func) {
+        delegate.acceptAll(relativePath, func);
+    }
+
+    @Override
     public boolean contains(String relativePath) {
         final LinkedHashMap<String, PathVisitSnapshot> snapshot = walkSnapshot;
         if (snapshot != null) {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
@@ -55,6 +55,15 @@ public class FilteredPathTree implements PathTree {
     }
 
     @Override
+    public void acceptAll(String relativePath, Consumer<PathVisit> consumer) {
+        if (!PathFilter.isVisible(filter, relativePath)) {
+            consumer.accept(null);
+        } else {
+            original.acceptAll(relativePath, consumer);
+        }
+    }
+
+    @Override
     public boolean contains(String relativePath) {
         return PathFilter.isVisible(filter, relativePath) && original.contains(relativePath);
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
@@ -87,6 +87,26 @@ public class MultiRootPathTree implements OpenPathTree {
     }
 
     @Override
+    public void acceptAll(String relativePath, Consumer<PathVisit> func) {
+        final AtomicBoolean consumed = new AtomicBoolean();
+        final Consumer<PathVisit> wrapper = new Consumer<>() {
+            @Override
+            public void accept(PathVisit t) {
+                if (t != null) {
+                    func.accept(t);
+                    consumed.set(true);
+                }
+            }
+        };
+        for (PathTree tree : trees) {
+            tree.accept(relativePath, wrapper);
+        }
+        if (!consumed.get()) {
+            func.accept(null);
+        }
+    }
+
+    @Override
     public boolean contains(String relativePath) {
         for (PathTree tree : trees) {
             if (tree.contains(relativePath)) {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
@@ -135,6 +135,20 @@ public interface PathTree {
     void accept(String relativePath, Consumer<PathVisit> consumer);
 
     /**
+     * Consumes a given path relative to the root of the tree.
+     * If the path isn't found in the tree, the {@link PathVisit} argument
+     * passed to the consumer will be {@code null}.
+     *
+     * If multiple items match then the consumer will be called multiple times.
+     *
+     * @param relativePath relative path to consume
+     * @param consumer path consumer
+     */
+    default void acceptAll(String relativePath, Consumer<PathVisit> consumer) {
+        accept(relativePath, consumer);
+    }
+
+    /**
      * Checks whether the tree contains a relative path.
      *
      * @param relativePath path relative to the root of the tree

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
@@ -159,6 +159,11 @@ class SharedArchivePathTree extends ArchivePathTree {
         }
 
         @Override
+        public void acceptAll(String relativePath, Consumer<PathVisit> consumer) {
+            delegate.acceptAll(relativePath, consumer);
+        }
+
+        @Override
         public boolean contains(String relativePath) {
             return delegate.contains(relativePath);
         }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
@@ -4,6 +4,7 @@ import java.io.Closeable;
 import java.nio.file.Path;
 import java.security.ProtectionDomain;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.jar.Manifest;
@@ -141,4 +142,8 @@ public interface ClassPathElement extends Closeable {
 
         }
     };
+
+    default List<ClassPathResource> getResources(String name) {
+        return List.of(getResource(name));
+    }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
@@ -12,8 +12,10 @@ import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -104,6 +106,26 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
             return null;
         }
         return apply(tree -> tree.apply(sanitized, visit -> visit == null ? null : new Resource(visit)));
+    }
+
+    @Override
+    public List<ClassPathResource> getResources(String name) {
+        final String sanitized = sanitize(name);
+        final Set<String> resources = this.resources;
+        if (resources != null && !resources.contains(sanitized)) {
+            return null;
+        }
+        List<ClassPathResource> ret = new ArrayList<>();
+        apply(tree -> {
+            tree.acceptAll(sanitized, visit -> {
+                if (visit != null) {
+                    ret.add(new Resource(visit));
+
+                }
+            });
+            return null;
+        });
+        return ret;
     }
 
     @Override

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ClassLoaderTest.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ClassLoaderTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.extension;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ClassLoaderTest {
+
+    @Test
+    void testClassLoaderResources() throws IOException {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ArrayList<URL> resources = Collections.list(contextClassLoader.getResources("io/quarkus/it/extension"));
+        Assertions.assertEquals(2, resources.size());
+    }
+
+    @Test
+    void testClassLoaderSingleResource() throws IOException {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        URL resource = contextClassLoader.getResource("io/quarkus/it/extension/my_resource.txt");
+        Assertions.assertNotNull(resource);
+    }
+}


### PR DESCRIPTION
Previously if the resources were in the same PathTree only one would be returned.

- Fixes #40371