### PR TITLE
Classloader improvements: introducing quarkus-classloader-commons and benchmarking infrastructure

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -15,6 +15,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-classloader-commons</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.aesh</groupId>
             <artifactId>readline</artifactId>
         </dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -381,7 +383,7 @@ public class CodeGenerator {
                                 .map(String::trim)
                                 // skip comments and empty lines
                                 .filter(line -> !line.startsWith("#") && !line.isEmpty())
-                                .filter(className -> classLoader.getResource(className.replace('.', '/') + ".class") == null)
+                                .filter(className -> classLoader.getResource(fromClassNameToResourceName(className)) == null)
                                 .forEach(unavailableList::add);
                     } catch (IOException e) {
                         throw new UncheckedIOException("Failed to read " + serviceFile, e);

--- a/core/deployment/src/main/java/io/quarkus/deployment/GeneratedClassGizmoAdaptor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/GeneratedClassGizmoAdaptor.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.List;
@@ -77,7 +79,7 @@ public class GeneratedClassGizmoAdaptor implements ClassOutput {
                 .getContextClassLoader();
         //if the class file is present in this (and not the parent) CL then it is an application class
         List<ClassPathElement> res = cl
-                .getElementsWithResource(className.replace('.', '/') + ".class", true);
+                .getElementsWithResource(fromClassNameToResourceName(className), true);
         return !res.isEmpty();
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -36,6 +36,7 @@ import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildStep;
+import io.quarkus.commons.classloading.ClassloadHelper;
 import io.quarkus.deployment.builditem.ApplicationClassPredicateBuildItem;
 import io.quarkus.deployment.console.ConsoleCommand;
 import io.quarkus.deployment.console.ConsoleStateManager;
@@ -408,9 +409,10 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                                         public boolean test(String s) {
                                             QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread()
                                                     .getContextClassLoader();
+                                            String resourceName = ClassloadHelper.fromClassNameToResourceName(s);
                                             //if the class file is present in this (and not the parent) CL then it is an application class
                                             List<ClassPathElement> res = cl
-                                                    .getElementsWithResource(s.replace('.', '/') + ".class", true);
+                                                    .getElementsWithResource(resourceName, true);
                                             return !res.isEmpty();
                                         }
                                     }));

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filesystem/ReloadableFileManager.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filesystem/ReloadableFileManager.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.dev.filesystem;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -296,7 +298,7 @@ public class ReloadableFileManager extends QuarkusFileManager {
             // It would be easier to call the loadClass() methods of the delegateClassLoaders
             // here, but we have to load the class from the bytecode ourselves, because we
             // need it to be associated with our class loader.
-            String path = name.replace('.', '/') + ".class";
+            String path = fromClassNameToResourceName(name);
             URL url = findResource(path);
             if (url == null) {
                 throw new ClassNotFoundException(name);

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.dev.testing;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
@@ -654,13 +656,14 @@ public class JunitTestRunner {
             Map<String, byte[]> transformedClasses = new HashMap<>();
             for (String i : classesToTransform) {
                 try {
+                    String resourceName = fromClassNameToResourceName(i);
                     byte[] classData = IoUtil
-                            .readBytes(deploymentClassLoader.getResourceAsStream(i.replace('.', '/') + ".class"));
+                            .readBytes(deploymentClassLoader.getResourceAsStream(resourceName));
                     ClassReader cr = new ClassReader(classData);
                     ClassWriter writer = new QuarkusClassWriter(cr,
                             ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
                     cr.accept(new TestTracingProcessor.TracingClassVisitor(writer, i), 0);
-                    transformedClasses.put(i.replace('.', '/') + ".class", writer.toByteArray());
+                    transformedClasses.put(resourceName, writer.toByteArray());
                 } catch (Exception e) {
                     log.error("Failed to instrument " + i + " for usage tracking", e);
                 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexWrapper.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexWrapper.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.index;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
@@ -313,7 +315,7 @@ public class IndexWrapper implements IndexView {
             return false;
         }
         try (InputStream stream = classLoader
-                .getResourceAsStream(className.replace('.', '/') + ".class")) {
+                .getResourceAsStream(fromClassNameToResourceName(className))) {
             if (stream != null) {
                 indexer.index(stream);
                 result = true;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.pkg.steps;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
 import static io.quarkus.deployment.pkg.PackageConfig.JarConfig.JarType.*;
 
 import java.io.BufferedInputStream;
@@ -649,7 +650,7 @@ public class JarResultBuildStep {
         fastJarJarsBuilder.setGenerated(generatedZip);
         try (FileSystem out = createNewZip(generatedZip, packageConfig)) {
             for (GeneratedClassBuildItem i : generatedClasses) {
-                String fileName = i.getName().replace('.', '/') + ".class";
+                String fileName = fromClassNameToResourceName(i.getName());
                 Path target = out.getPath(fileName);
                 if (target.getParent() != null) {
                     Files.createDirectories(target.getParent());
@@ -1181,7 +1182,7 @@ public class JarResultBuildStep {
             }
         }
         for (GeneratedClassBuildItem i : generatedClasses) {
-            String fileName = i.getName().replace('.', '/') + ".class";
+            String fileName = fromClassNameToResourceName(i.getName());
             seen.put(fileName, "Current Application");
             Path target = runnerZipFs.getPath(fileName);
             handleParent(runnerZipFs, fileName, seen);

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/AdditionalClassLoaderResourcesBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/AdditionalClassLoaderResourcesBuildStep.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.steps;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -31,7 +33,7 @@ public class AdditionalClassLoaderResourcesBuildStep {
 
                     collected.put(entry.getKey(), entry.getValue());
                     // add it also as resources to allow index to work properly
-                    collected.put(entry.getKey().replace('.', '/') + ".class", entry.getValue());
+                    collected.put(fromClassNameToResourceName(entry.getKey()), entry.getValue());
 
                 }
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/BannerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/BannerProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.steps;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URL;
@@ -113,7 +115,7 @@ public class BannerProcessor {
                 // We determine whether the banner is the default by checking to see if the jar that contains it also
                 // contains this class. This way although somewhat complicated guarantees that any rename of artifacts
                 // won't affect the check
-                Path resolved = p.resolve("/" + thisClassName.replace('.', '/') + ".class");
+                Path resolved = p.resolve("/" + fromClassNameToResourceName(thisClassName));
                 return Files.exists(resolved);
             });
         } catch (UncheckedIOException ex) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.steps;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -145,7 +147,7 @@ public class ClassTransformingBuildStep {
                 ClassLoader old = Thread.currentThread().getContextClassLoader();
                 try {
                     Thread.currentThread().setContextClassLoader(transformCl);
-                    String classFileName = className.replace('.', '/') + ".class";
+                    String classFileName = fromClassNameToResourceName(className);
                     List<ClassPathElement> archives = cl.getElementsWithResource(classFileName);
                     if (!archives.isEmpty()) {
                         ClassPathElement classPathElement = archives.get(0);
@@ -195,7 +197,7 @@ public class ClassTransformingBuildStep {
                     }
                 }
             }
-            String classFileName = className.replace('.', '/') + ".class";
+            String classFileName = fromClassNameToResourceName(className);
             List<ClassPathElement> archives = cl.getElementsWithResource(classFileName);
             if (!archives.isEmpty()) {
                 ClassPathElement classPathElement = archives.get(0);
@@ -372,7 +374,7 @@ public class ClassTransformingBuildStep {
             if (!debugPath.exists()) {
                 debugPath.mkdir();
             }
-            File classFile = new File(debugPath, className.replace('.', '/') + ".class");
+            File classFile = new File(debugPath, fromClassNameToResourceName(className));
             classFile.getParentFile().mkdirs();
             try (FileOutputStream classWriter = new FileOutputStream(classFile)) {
                 classWriter.write(data);

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/IoUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/IoUtil.java
@@ -1,11 +1,13 @@
 package io.quarkus.deployment.util;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.IOException;
 import java.io.InputStream;
 
 public class IoUtil {
     public static InputStream readClass(ClassLoader classLoader, String className) {
-        return classLoader.getResourceAsStream(className.replace('.', '/') + ".class");
+        return classLoader.getResourceAsStream(fromClassNameToResourceName(className));
     }
 
     public static byte[] readClassAsBytes(ClassLoader classLoader, String className) throws IOException {

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -1,5 +1,7 @@
 package io.quarkus.runner.bootstrap;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -362,7 +364,7 @@ public class StartupActionImpl implements StartupAction {
         Map<String, byte[]> data = new HashMap<>();
         for (GeneratedClassBuildItem i : buildResult.consumeMulti(GeneratedClassBuildItem.class)) {
             if (i.isApplicationClass() == applicationClasses) {
-                data.put(i.getName().replace('.', '/') + ".class", i.getClassData());
+                data.put(fromClassNameToResourceName(i.getName()), i.getClassData());
                 if (BootstrapDebug.DEBUG_CLASSES_DIR != null) {
                     try {
                         File debugPath = new File(BootstrapDebug.DEBUG_CLASSES_DIR);

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/BannerProcessorTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/BannerProcessorTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.pkg.steps;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,7 +41,7 @@ public class BannerProcessorTest {
             }
 
             try (final FileSystem fs = ZipUtils.newFileSystem(zipPath)) {
-                Path classFile = fs.getPath(MyBannerProcessor.class.getName().replace('.', '/') + ".class");
+                Path classFile = fs.getPath(fromClassNameToResourceName(MyBannerProcessor.class.getName()));
                 Files.createDirectories(classFile.getParent());
                 Files.write(classFile, "".getBytes(StandardCharsets.UTF_8));
             }

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
@@ -16,6 +16,8 @@ import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.commons.classloading.ClassloadHelper;
+
 public class JandexUtilTest {
 
     private static final DotName SIMPLE = DotName.createSimple(Single.class.getName());
@@ -307,7 +309,7 @@ public class JandexUtilTest {
         for (Class<?> clazz : classes) {
             try {
                 try (InputStream stream = JandexUtilTest.class.getClassLoader()
-                        .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                        .getResourceAsStream(ClassloadHelper.fromClassNameToResourceName(clazz.getName()))) {
                     indexer.index(stream);
                 }
             } catch (IOException e) {

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -148,6 +148,7 @@
                     </lesserPriorityArtifacts>
                     <parentFirstArtifacts>
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-runner</parentFirstArtifact>
+                        <parentFirstArtifact>io.quarkus:quarkus-classloader-commons</parentFirstArtifact>
                         <parentFirstArtifact>io.smallrye.common:smallrye-common-constraint</parentFirstArtifact>
                         <parentFirstArtifact>io.smallrye.common:smallrye-common-cpu</parentFirstArtifact>
                         <parentFirstArtifact>io.smallrye.common:smallrye-common-expression</parentFirstArtifact>
@@ -237,6 +238,7 @@
                         <runnerParentFirstArtifact>org.graalvm.sdk:native-bridge</runnerParentFirstArtifact>
                         <!-- /support for GraalVM js -->
                         <runnerParentFirstArtifact>io.quarkus:quarkus-bootstrap-runner</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>io.quarkus:quarkus-classloader-commons</runnerParentFirstArtifact>
                         <runnerParentFirstArtifact>io.quarkus:quarkus-development-mode-spi</runnerParentFirstArtifact>
                         <!-- logging dependencies always need to be loaded by the JDK ClassLoader -->
                         <runnerParentFirstArtifact>org.jboss.logging:jboss-logging</runnerParentFirstArtifact>

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/scan/QuarkusScanner.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/scan/QuarkusScanner.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.orm.runtime.boot.scan;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -149,8 +151,9 @@ public class QuarkusScanner implements Scanner {
 
         @Override
         public InputStreamAccess getStreamAccess() {
+            final String resourceName = fromClassNameToResourceName(name);
             return new UrlInputStreamAccess(
-                    Thread.currentThread().getContextClassLoader().getResource(name.replace('.', '/') + ".class"));
+                    Thread.currentThread().getContextClassLoader().getResource(resourceName));
         }
     }
 }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TypeInfosTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TypeInfosTest.java
@@ -19,6 +19,7 @@ import org.jboss.jandex.Indexer;
 import org.jboss.jandex.ParameterizedType;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.commons.classloading.ClassloadHelper;
 import io.quarkus.qute.Engine;
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.deployment.TypeInfos.Info;
@@ -94,8 +95,9 @@ public class TypeInfosTest {
     private static Index index(Class<?>... classes) throws IOException {
         Indexer indexer = new Indexer();
         for (Class<?> clazz : classes) {
+            final String resourceName = ClassloadHelper.fromClassNameToResourceName(clazz.getName());
             try (InputStream stream = TypeInfosTest.class.getClassLoader()
-                    .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                    .getResourceAsStream(resourceName)) {
                 indexer.index(stream);
             }
         }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TypesTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TypesTest.java
@@ -19,6 +19,7 @@ import org.jboss.jandex.PrimitiveType.Primitive;
 import org.jboss.jandex.Type;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.commons.classloading.ClassloadHelper;
 import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.ValueResolver;
 import io.quarkus.qute.deployment.Types.AssignabilityCheck;
@@ -78,8 +79,9 @@ public class TypesTest {
     private static Index index(Class<?>... classes) throws IOException {
         Indexer indexer = new Indexer();
         for (Class<?> clazz : classes) {
+            final String resourceName = ClassloadHelper.fromClassNameToResourceName(clazz.getName());
             try (InputStream stream = TypesTest.class.getClassLoader()
-                    .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                    .getResourceAsStream(resourceName)) {
                 indexer.index(stream);
             }
         }

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/FilterClassIntrospector.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/FilterClassIntrospector.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.deployment;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -24,7 +26,8 @@ public class FilterClassIntrospector {
 
     public boolean usesGetResourceMethod(MethodInfo methodInfo) {
         String className = methodInfo.declaringClass().name().toString();
-        try (InputStream is = classLoader.getResourceAsStream(className.replace('.', '/') + ".class")) {
+        final String resourceName = fromClassNameToResourceName(className);
+        try (InputStream is = classLoader.getResourceAsStream(resourceName)) {
             ClassReader configClassReader = new ClassReader(is);
             FilterClassVisitor classVisitor = new FilterClassVisitor(methodInfo.descriptor());
             configClassReader.accept(classVisitor, 0);

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MessageBodyWriterTransformerUtils.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/MessageBodyWriterTransformerUtils.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.deployment;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
@@ -24,7 +26,8 @@ final class MessageBodyWriterTransformerUtils {
     }
 
     public static boolean shouldAddAllWriteableMarker(String messageBodyWriterClassName, ClassLoader classLoader) {
-        try (InputStream is = classLoader.getResourceAsStream(messageBodyWriterClassName.replace('.', '/') + ".class")) {
+        final String resourceName = fromClassNameToResourceName(messageBodyWriterClassName);
+        try (InputStream is = classLoader.getResourceAsStream(resourceName)) {
             if (is != null) {
                 AtomicBoolean result = new AtomicBoolean(false);
                 ClassReader configClassReader = new ClassReader(is);

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/IllegalClassExceptionMapper.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/IllegalClassExceptionMapper.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.test.simple;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -78,7 +80,7 @@ public class IllegalClassExceptionMapper implements ExceptionMapper<Incompatible
 
     private void dumpClass(String classname, String method) {
         InputStream bytes = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream(classname.replace('.', '/') + ".class");
+                .getResourceAsStream(fromClassNameToResourceName(classname));
         try {
             ClassReader cr = new ClassReader(bytes);
             PrintWriter writer = new PrintWriter(System.err);

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/rolesallowed/ConfigExpressionDetectionTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/rolesallowed/ConfigExpressionDetectionTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.security.test.rolesallowed;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -24,8 +26,9 @@ public class ConfigExpressionDetectionTest {
         // point here is to verify expected values gathered from @RolesAllowed annotation are detected correctly
         var indexer = new Indexer();
         for (Class<?> aClass : new Class<?>[] { ConfigExpressionDetectionTest.class, ValidValues.class }) {
+            final String resourceName = fromClassNameToResourceName(aClass.getName());
             try (InputStream stream = ConfigExpressionDetectionTest.class.getClassLoader()
-                    .getResourceAsStream(aClass.getName().replace('.', '/') + ".class")) {
+                    .getResourceAsStream(resourceName)) {
                 assert stream != null;
                 indexer.index(stream);
             } catch (IOException e) {

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
@@ -41,6 +41,7 @@ import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
+import io.quarkus.commons.classloading.ClassloadHelper;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -146,9 +147,10 @@ public class DefaultSerdeConfigTest {
     private static IndexView index(List<Class<?>> classes) {
         Indexer indexer = new Indexer();
         for (Class<?> clazz : classes) {
+            final String resourceName = ClassloadHelper.fromClassNameToResourceName(clazz.getName());
             try {
                 try (InputStream stream = DefaultSerdeConfigTest.class.getClassLoader()
-                        .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                        .getResourceAsStream(resourceName)) {
                     indexer.index(stream);
                 }
             } catch (IOException e) {

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/ReflectiveClassForValueSerializerPayloadTest.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/ReflectiveClassForValueSerializerPayloadTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.reactivemessaging.kafka.deployment;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
@@ -332,9 +333,10 @@ class ReflectiveClassForValueSerializerPayloadTest {
     private static IndexView index(Class<?>... classes) {
         Indexer indexer = new Indexer();
         for (Class<?> clazz : classes) {
+            final String resourceName = fromClassNameToResourceName(clazz.getName());
             try {
                 try (InputStream stream = DefaultSerdeConfigTest.class.getClassLoader()
-                        .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                        .getResourceAsStream(resourceName)) {
                     indexer.index(stream);
                 }
             } catch (IOException e) {

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/DefaultSchemaConfigTest.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/DefaultSchemaConfigTest.java
@@ -41,6 +41,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.commons.classloading.ClassloadHelper;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
@@ -136,9 +137,10 @@ public class DefaultSchemaConfigTest {
     private static IndexView index(List<Class<?>> classes) {
         Indexer indexer = new Indexer();
         for (Class<?> clazz : classes) {
+            final String resourceName = ClassloadHelper.fromClassNameToResourceName(clazz.getName());
             try {
                 try (InputStream stream = DefaultSchemaConfigTest.class.getClassLoader()
-                        .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                        .getResourceAsStream(resourceName)) {
                     indexer.index(stream);
                 }
             } catch (IOException e) {

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigPropertyBuildItemCandidateUtil.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigPropertyBuildItemCandidateUtil.java
@@ -1,5 +1,7 @@
 package io.quarkus.spring.boot.properties.deployment;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -26,7 +28,8 @@ public class ConfigPropertyBuildItemCandidateUtil {
      */
     public static void removePropertiesWithDefaultValue(ClassLoader classLoader, String configClass,
             List<ConfigPropertyBuildItemCandidate> candidates) {
-        try (InputStream is = classLoader.getResourceAsStream(configClass.replace('.', '/') + ".class")) {
+        final String resourceName = fromClassNameToResourceName(configClass);
+        try (InputStream is = classLoader.getResourceAsStream(resourceName)) {
             ClassReader configClassReader = new ClassReader(is);
             configClassReader.accept(new ConfigClassVisitor(candidates, configClass), 0);
         } catch (IOException e) {

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/MethodNameParserTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/MethodNameParserTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.spring.data.deployment;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -115,7 +116,7 @@ public class MethodNameParserTest {
         Indexer indexer = new Indexer();
         for (Class<?> clazz : classes) {
             try (InputStream stream = MethodNameParserTest.class.getClassLoader()
-                    .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
+                    .getResourceAsStream(fromClassNameToResourceName(clazz.getName()))) {
                 indexer.index(stream);
             }
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionInvoker.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionInvoker.java
@@ -38,7 +38,7 @@ class ExtensionInvoker {
             extensionClasses.put(extensionClass.getName(), extensionClass);
             extensionClassInstances.put(extensionClass, extension);
             try (InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(
-                    extensionClass.getName().replace('.', '/') + ".class")) {
+                    extensionClass.getName().replace('.', '/').concat(".class"))) {
                 extensionsIndexer.index(stream);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/independent-projects/bootstrap/benchmarks/pom.xml
+++ b/independent-projects/bootstrap/benchmarks/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quarkus-bootstrap-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>benchmarks</artifactId>
+    <name>Quarkus - Bootstrap - JMH Benchmarks</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-classloader-commons</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmark</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/independent-projects/bootstrap/benchmarks/src/main/java/io/quarkus/commons/benchmarks/BenchmarkClassnameToResourceName.java
+++ b/independent-projects/bootstrap/benchmarks/src/main/java/io/quarkus/commons/benchmarks/BenchmarkClassnameToResourceName.java
@@ -1,6 +1,8 @@
 package io.quarkus.commons.benchmarks;
 
-import io.quarkus.commons.classloading.ClassloadHelper;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -12,8 +14,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import io.quarkus.commons.classloading.ClassloadHelper;
 
 /**
  * We benchmark this strategy with CompilerControl.Mode.EXCLUDE as this code

--- a/independent-projects/bootstrap/benchmarks/src/main/java/io/quarkus/commons/benchmarks/BenchmarkClassnameToResourceName.java
+++ b/independent-projects/bootstrap/benchmarks/src/main/java/io/quarkus/commons/benchmarks/BenchmarkClassnameToResourceName.java
@@ -1,0 +1,63 @@
+package io.quarkus.commons.benchmarks;
+
+import io.quarkus.commons.classloading.ClassloadHelper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * We benchmark this strategy with CompilerControl.Mode.EXCLUDE as this code
+ * is primarily useful during bootstrap. We already know JIT will do a fantastic
+ * job when compiling it even if it's written in less efficient ways, so there's
+ * no much point in optimising such for compiled code: let's choose a strategy
+ * that doesn't cost excessively even before JIT kicks in.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SingleShotTime) //!
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 10, time = 20, timeUnit = TimeUnit.MILLISECONDS) //ignored in single shot mode
+@Measurement(iterations = 20, time = 50, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+public class BenchmarkClassnameToResourceName {
+
+    @Param({ "io.quarkus.commons.benchmarks.BenchmarkClassnameToResourceName" })
+    public String arg;
+
+    @Benchmark
+    public String checkNewMethod() {
+        return ClassloadHelper.fromClassNameToResourceName(arg);
+    }
+
+    @Benchmark
+    public String oldMethod() {
+        return oldMethod(arg);
+    }
+
+    private static String oldMethod(String name) {
+        return name.replace(".", "/") + ".class";
+    }
+
+    @Benchmark
+    public String oldAltMethod() {
+        return oldAltMethod(arg);
+    }
+
+    private static String oldAltMethod(String name) {
+        return name.replace('.', '/') + ".class";
+    }
+
+    public static void main(String[] args) throws IOException {
+        org.openjdk.jmh.Main.main(new String[] { "-prof", "gc", "-prof", "perfnorm" });
+    }
+
+}

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -49,6 +49,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-classloader-commons</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-core</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/independent-projects/bootstrap/classloader-commons/pom.xml
+++ b/independent-projects/bootstrap/classloader-commons/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quarkus-bootstrap-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-classloader-commons</artifactId>
+    <name>Quarkus - Bootstrap - Classloader common utilities</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/independent-projects/bootstrap/classloader-commons/src/main/java/io/quarkus/commons/classloading/ClassloadHelper.java
+++ b/independent-projects/bootstrap/classloader-commons/src/main/java/io/quarkus/commons/classloading/ClassloadHelper.java
@@ -1,0 +1,21 @@
+package io.quarkus.commons.classloading;
+
+public final class ClassloadHelper {
+
+    private ClassloadHelper() {
+        //Not meant to be instantiated
+    }
+
+    /**
+     * Helper method to convert a classname into its typical resource name:
+     * replace all "." with "/" and append the ".class" postfix.
+     *
+     * @param className
+     * @return the name of the respective resource
+     */
+    public static String fromClassNameToResourceName(final String className) {
+        //Important: avoid indy!
+        return className.replace('.', '/').concat(".class");
+    }
+
+}

--- a/independent-projects/bootstrap/classloader-commons/src/test/java/io/quarkus/commons/classloading/ClassloadHelperTest.java
+++ b/independent-projects/bootstrap/classloader-commons/src/test/java/io/quarkus/commons/classloading/ClassloadHelperTest.java
@@ -1,0 +1,14 @@
+package io.quarkus.commons.classloading;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ClassloadHelperTest {
+
+    @Test
+    public void testFromClassToResourceName() {
+        Assertions.assertEquals("java/lang/String.class", ClassloadHelper.fromClassNameToResourceName("java.lang.String"));
+        Assertions.assertEquals(".class", ClassloadHelper.fromClassNameToResourceName(""));
+    }
+
+}

--- a/independent-projects/bootstrap/core/pom.xml
+++ b/independent-projects/bootstrap/core/pom.xml
@@ -35,6 +35,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-classloader-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-app-model</artifactId>
         </dependency>
         <dependency>

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -1,5 +1,7 @@
 package io.quarkus.bootstrap.classloading;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -64,7 +66,8 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
      * @param className the name of the class.
      */
     public static boolean isClassPresentAtRuntime(String className) {
-        return isResourcePresentAtRuntime(className.replace('.', '/') + ".class");
+        String resourceName = fromClassNameToResourceName(className);
+        return isResourcePresentAtRuntime(resourceName);
     }
 
     /**
@@ -178,7 +181,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         try {
             ClassLoaderState state = getState();
             synchronized (getClassLoadingLock(name)) {
-                String resourceName = sanitizeName(name).replace('.', '/') + ".class";
+                String resourceName = fromClassNameToResourceName(name);
                 return parentFirst(resourceName, state);
             }
 
@@ -491,7 +494,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
                 if (c != null) {
                     return c;
                 }
-                String resourceName = sanitizeName(name).replace('.', '/') + ".class";
+                String resourceName = fromClassNameToResourceName(name);
                 if (state.bannedResources.contains(resourceName)) {
                     throw new ClassNotFoundException(name);
                 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -594,6 +594,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         List<String> ret = new ArrayList<>();
         for (String name : getState().loadableResources.keySet()) {
             if (name.endsWith(".class")) {
+                //TODO: clients of this method actually need the non-transformed variant and are transforming it back !?
                 ret.add(name.substring(0, name.length() - 6).replace('/', '.'));
             }
         }

--- a/independent-projects/bootstrap/maven-resolver/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/pom.xml
@@ -34,6 +34,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-classloader-commons</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.beanbag</groupId>
             <artifactId>smallrye-beanbag-maven</artifactId>
             <exclusions>

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptions.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptions.java
@@ -22,6 +22,7 @@ import org.apache.maven.shared.utils.cli.CommandLineException;
 import org.apache.maven.shared.utils.cli.CommandLineUtils;
 
 import io.quarkus.bootstrap.util.PropertyUtils;
+import io.quarkus.commons.classloading.ClassloadHelper;
 
 /**
  * This class resolves relevant Maven command line options in case it's called
@@ -256,7 +257,7 @@ public class BootstrapMavenOptions {
      * classpath of the context classloader
      */
     public static Path getClassOrigin(Class<?> cls) throws IOException {
-        return getResourceOrigin(cls.getClassLoader(), cls.getName().replace('.', '/') + ".class");
+        return getResourceOrigin(cls.getClassLoader(), ClassloadHelper.fromClassNameToResourceName(cls.getName()));
     }
 
     public static Path getResourceOrigin(ClassLoader cl, final String name) throws IOException {

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -38,6 +38,7 @@
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <jandex.version>3.1.7</jandex.version>
+        <jmh.version>1.37</jmh.version>
 
         <!-- Dependency versions -->
         <assertj.version>3.25.3</assertj.version>
@@ -89,6 +90,8 @@
         <module>core</module>
         <module>runner</module>
         <module>gradle-resolver</module>
+        <module>classloader-commons</module>
+        <module>benchmarks</module>
     </modules>
     <build>
         <pluginManagement>

--- a/independent-projects/bootstrap/runner/pom.xml
+++ b/independent-projects/bootstrap/runner/pom.xml
@@ -39,6 +39,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-classloader-commons</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-io</artifactId>
         </dependency>

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -1,5 +1,7 @@
 package io.quarkus.bootstrap.runner;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -97,7 +99,7 @@ public final class RunnerClassLoader extends ClassLoader {
             resources = resourceDirectoryMap.get(dirName);
         }
         if (resources != null) {
-            String classResource = name.replace('.', '/') + ".class";
+            String classResource = fromClassNameToResourceName(name);
             for (ClassLoadingResource resource : resources) {
                 accessingResource(resource);
                 byte[] data = resource.getResourceData(classResource);

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/maven/utilities/MojoUtils.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/maven/utilities/MojoUtils.java
@@ -28,6 +28,7 @@ import org.eclipse.aether.RepositorySystemSession;
 
 import io.fabric8.maven.Maven;
 import io.fabric8.maven.XMLFormat;
+import io.quarkus.commons.classloading.ClassloadHelper;
 
 /**
  * @author kameshs
@@ -319,7 +320,7 @@ public class MojoUtils {
      * classpath of the context classloader
      */
     public static Path getClassOrigin(Class<?> cls) throws IOException {
-        return getResourceOrigin(cls.getClassLoader(), cls.getName().replace('.', '/') + ".class");
+        return getResourceOrigin(cls.getClassLoader(), ClassloadHelper.fromClassNameToResourceName(cls.getName()));
     }
 
     public static Path getResourceOrigin(ClassLoader cl, final String name) throws IOException {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.common;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -133,7 +135,7 @@ public final class PathTestHelper {
      */
     public static Path getTestClassesLocation(Class<?> testClass) {
         String classFileName = testClass.getName().replace('.', File.separatorChar) + ".class";
-        URL resource = testClass.getClassLoader().getResource(testClass.getName().replace('.', '/') + ".class");
+        URL resource = testClass.getClassLoader().getResource(fromClassNameToResourceName(testClass.getName()));
 
         if (resource.getProtocol().equals("jar")) {
             try {
@@ -254,7 +256,7 @@ public final class PathTestHelper {
     }
 
     public static boolean isTestClass(String className, ClassLoader classLoader, Path testLocation) {
-        URL resource = classLoader.getResource(className.replace('.', '/') + ".class");
+        URL resource = classLoader.getResource(fromClassNameToResourceName(className));
         if (resource == null) {
             return false;
         }

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.component;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -1196,7 +1198,7 @@ public class QuarkusComponentTestExtension
             testOutputDirectory = new File(outputDirectory);
         } else {
             // org.acme.Foo -> org/acme/Foo.class
-            String testClassResourceName = testClass.getName().replace('.', '/') + ".class";
+            String testClassResourceName = fromClassNameToResourceName(testClass.getName());
             // org/acme/Foo.class -> /some/path/to/project/target/test-classes/org/acme/Foo.class
             String testPath = testClass.getClassLoader().getResource(testClassResourceName).getFile();
             // /some/path/to/project/target/test-classes/org/acme/Foo.class -> /some/path/to/project/target/test-classes

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.junit;
 
+import static io.quarkus.commons.classloading.ClassloadHelper.fromClassNameToResourceName;
 import static io.quarkus.test.common.PathTestHelper.getAppClassLocationForTestLocation;
 import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
 
@@ -77,7 +78,7 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
         // If gradle project running directly with IDE
         if (gradleAppModel != null && gradleAppModel.getApplicationModule() != null) {
             final WorkspaceModule module = gradleAppModel.getApplicationModule();
-            final String testClassFileName = requiredTestClass.getName().replace('.', '/') + ".class";
+            final String testClassFileName = fromClassNameToResourceName(requiredTestClass.getName());
             Path testClassesDir = null;
             for (String classifier : module.getSourceClassifiers()) {
                 final ArtifactSources sources = module.getSources(classifier);


### PR DESCRIPTION
This is moslty and "empty shell" now but it provides a reasonable place for working together on various ClassLoader related improvements, as we didn't have a module which could be shared among various ClassLoader implementations that we have.

Extracted also one method which we seem to be re-implementing everywhere, and added a JMH benchmark to it to setup the infrastructure, and se the example, for hopefully for more of these.

For example, a next-step optimisation could be to provide a better helper for

```
sanitizeName(name).replace('.', '/') + ".class"
```

which is incredibly common code across the entire codebase.