### PR TITLE
Funqy Amazon Lambda should support more Amazon events

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -149,6 +149,7 @@
         <aws-lambda-java.version>1.2.3</aws-lambda-java.version>
         <aws-lambda-java-events.version>3.11.6</aws-lambda-java-events.version>
         <aws-xray.version>2.17.0</aws-xray.version>
+        <cloudevents-api.version>3.0.0</cloudevents-api.version>
         <azure-functions-java-library.version>3.1.0</azure-functions-java-library.version>
         <azure-functions-java-spi.version>1.0.0</azure-functions-java-spi.version>
         <kotlin.version>2.0.0</kotlin.version>
@@ -5815,6 +5816,12 @@
                         <artifactId>joda-time</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.cloudevents</groupId>
+                <artifactId>cloudevents-api</artifactId>
+                <version>${cloudevents-api.version}</version>
             </dependency>
 
             <dependency>

--- a/extensions/funqy/funqy-amazon-lambda/deployment/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/pom.xml
@@ -29,6 +29,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyAmazonLambdaProcessor.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyAmazonLambdaProcessor.java
@@ -1,0 +1,46 @@
+package io.quarkus.funqy.deployment.bindings;
+
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+import com.amazonaws.services.lambda.runtime.events.models.kinesis.Record;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeBuild;
+import io.quarkus.funqy.lambda.model.cloudevents.CloudEventDataV1;
+import io.quarkus.funqy.lambda.model.cloudevents.CloudEventV1;
+
+public class FunqyAmazonLambdaProcessor {
+
+    @BuildStep(onlyIf = NativeBuild.class)
+    public void process(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(
+                // io CloudEvents
+                CloudEventV1.class.getName(),
+                CloudEventDataV1.class.getName(),
+                // SQS
+                SQSEvent.class.getName(),
+                SQSEvent.SQSMessage.class.getName(),
+                SQSEvent.MessageAttribute.class.getName(),
+                SQSBatchResponse.class.getName(),
+                SQSBatchResponse.BatchItemFailure.class.getName(),
+                // SNS
+                SNSEvent.class.getName(),
+                SNSEvent.SNSRecord.class.getName(),
+                SNSEvent.SNS.class.getName(),
+                // Kinesis
+                KinesisEvent.class.getName(),
+                KinesisEvent.KinesisEventRecord.class.getName(),
+                Record.class.getName(),
+                StreamsEventResponse.class.getName(),
+                StreamsEventResponse.BatchItemFailure.class.getName(),
+                // DynamoDB
+                DynamodbEvent.class.getName(),
+                DynamodbEvent.DynamodbStreamRecord.class.getName()).constructors().methods().fields().build());
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyLambdaBuildStep.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyLambdaBuildStep.java
@@ -20,6 +20,8 @@ import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.funqy.deployment.FunctionBuildItem;
 import io.quarkus.funqy.deployment.FunctionInitializedBuildItem;
 import io.quarkus.funqy.lambda.FunqyLambdaBindingRecorder;
+import io.quarkus.funqy.lambda.config.FunqyAmazonBuildTimeConfig;
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
 import io.quarkus.funqy.runtime.FunqyConfig;
 import io.quarkus.runtime.LaunchMode;
 
@@ -37,17 +39,20 @@ public class FunqyLambdaBuildStep {
             BuildProducer<FeatureBuildItem> feature,
             Optional<FunctionInitializedBuildItem> hasFunctions,
             LambdaObjectMapperInitializedBuildItem mapperDependency,
-            BeanContainerBuildItem beanContainer) throws Exception {
+            BeanContainerBuildItem beanContainer,
+            FunqyAmazonBuildTimeConfig buildTimeConfig) throws Exception {
         if (!hasFunctions.isPresent() || hasFunctions.get() == null)
             return;
         feature.produce(new FeatureBuildItem(FUNQY_AMAZON_LAMBDA));
-        recorder.init(beanContainer.getValue());
+        recorder.init(beanContainer.getValue(), buildTimeConfig);
     }
 
     @BuildStep
     @Record(RUNTIME_INIT)
-    public RuntimeComplete choose(FunqyConfig config, FunqyLambdaBindingRecorder recorder) {
-        recorder.chooseInvoker(config);
+    public RuntimeComplete choose(FunqyConfig config,
+            FunqyAmazonConfig amazonConfig,
+            FunqyLambdaBindingRecorder recorder) {
+        recorder.chooseInvoker(config, amazonConfig);
         return new RuntimeComplete();
     }
 

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/AnyFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/AnyFunctionTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the item-function can handle an event, which just represents the item itself. So no special aws event
+ * is used as envelope
+ */
+public class AnyFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("any-function.properties", "application.properties")
+                    .addAsResource("events/any", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            EventDataProvider.class));
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        response.then().statusCode(204);
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        response.then().statusCode(500);
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/CloudEventsEventFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/CloudEventsEventFunctionTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.model.BatchItemFailures;
+import io.quarkus.funqy.test.model.ItemFailure;
+import io.quarkus.funqy.test.util.BodyDeserializer;
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the cloudevents-function with a cloud events specific model can handle events.
+ */
+public class CloudEventsEventFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.funqy.export", "cloudevents-function")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/cloudevents", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            BatchItemFailures.class, ItemFailure.class,
+                            EventDataProvider.class, BodyDeserializer.class));
+
+    @Inject
+    BodyDeserializer deserializer;
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/CloudEventsFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/CloudEventsFunctionTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.model.BatchItemFailures;
+import io.quarkus.funqy.test.model.ItemFailure;
+import io.quarkus.funqy.test.util.BodyDeserializer;
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the item-function with a customer model can handle cloud events.
+ */
+public class CloudEventsFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/cloudevents", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            BatchItemFailures.class, ItemFailure.class,
+                            EventDataProvider.class, BodyDeserializer.class));
+
+    @Inject
+    BodyDeserializer deserializer;
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/DynamoDbEventFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/DynamoDbEventFunctionTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.model.BatchItemFailures;
+import io.quarkus.funqy.test.model.ItemFailure;
+import io.quarkus.funqy.test.util.BodyDeserializer;
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the dynamodb-function with a customer model can handle cloud events.
+ */
+public class DynamoDbEventFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.funqy.export", "dynamodb-function")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/dynamodb", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            BatchItemFailures.class, ItemFailure.class,
+                            EventDataProvider.class, BodyDeserializer.class));
+
+    @Inject
+    BodyDeserializer deserializer;
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+
+    @Test
+    public void should_return_no_failures_if_processing_pipes_is_ok() {
+        // given
+        var body = getData("pipes-ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_pipes_fails() {
+        // given
+        var body = getData("pipes-fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/DynamoDbFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/DynamoDbFunctionTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.model.BatchItemFailures;
+import io.quarkus.funqy.test.model.ItemFailure;
+import io.quarkus.funqy.test.util.BodyDeserializer;
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the item-function with a customer model cannot handle dynamodb events. Due to the structure we cannot
+ * really guess which data is relevant for the customer. But the impl will allow to use batching.
+ */
+public class DynamoDbFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/dynamodb", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            BatchItemFailures.class, ItemFailure.class,
+                            EventDataProvider.class, BodyDeserializer.class));
+
+    @Inject
+    BodyDeserializer deserializer;
+
+    @Test
+    public void should_fail_on_dynamodb_event_without_dynamodb_event_type() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        // It is not supported to transform the DynamoDB event record to an internal model. Therefore, if somebody
+        // would try this, the lambda would return every message as failure in batch item failures and log an error.
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(2));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItems("1", "2"));
+    }
+
+    @Test
+    public void should_fail_on_dynamodb_event_via_pipes_without_dynamodb_event_type() {
+        // given
+        var body = getData("pipes-ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        // It is not supported to transform the DynamoDB event record to an internal model. Therefore, if somebody
+        // would try this, the lambda would return every message as failure in batch item failures and log an error.
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(2));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItems("1", "2"));
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/Item.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/Item.java
@@ -1,0 +1,24 @@
+package io.quarkus.funqy.test;
+
+public class Item {
+
+    String message;
+
+    boolean throwError;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(final String message) {
+        this.message = message;
+    }
+
+    public boolean isThrowError() {
+        return throwError;
+    }
+
+    public void setThrowError(final boolean throwError) {
+        this.throwError = throwError;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/KinesisEventFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/KinesisEventFunctionTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.model.BatchItemFailures;
+import io.quarkus.funqy.test.model.ItemFailure;
+import io.quarkus.funqy.test.util.BodyDeserializer;
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the kinesis-function with a kinesis specific model can handle events.
+ */
+public class KinesisEventFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.funqy.export", "kinesis-function")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/kinesis", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            BatchItemFailures.class, ItemFailure.class,
+                            EventDataProvider.class, BodyDeserializer.class));
+
+    @Inject
+    BodyDeserializer deserializer;
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+
+    @Test
+    public void should_return_no_failures_if_processing_pipes_is_ok() {
+        // given
+        var body = getData("pipes-ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_pipes_fails() {
+        // given
+        var body = getData("pipes-fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/KinesisFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/KinesisFunctionTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.model.BatchItemFailures;
+import io.quarkus.funqy.test.model.ItemFailure;
+import io.quarkus.funqy.test.util.BodyDeserializer;
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the item-function with a customer model can handle kinesis events.
+ */
+public class KinesisFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/kinesis", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            BatchItemFailures.class, ItemFailure.class,
+                            EventDataProvider.class, BodyDeserializer.class));
+
+    @Inject
+    BodyDeserializer deserializer;
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+
+    @Test
+    public void should_return_no_failures_if_processing_pipes_is_ok() {
+        // given
+        var body = getData("pipes-ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_pipes_fails() {
+        // given
+        var body = getData("pipes-fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SnsEventFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SnsEventFunctionTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the sns-function with an sns specific model can handle events.
+ */
+public class SnsEventFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.funqy.export", "sns-function")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/sns", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            EventDataProvider.class));
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        response.then().statusCode(204);
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        // SNS triggers have no error handling.
+        response.then().statusCode(204);
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SnsFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SnsFunctionTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the item-function with a customer model can handle sns events.
+ */
+public class SnsFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/sns", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            EventDataProvider.class));
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        response.then().statusCode(204);
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        // SNS triggers have no error handling.
+        response.then().statusCode(204);
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SqsEventFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SqsEventFunctionTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.model.BatchItemFailures;
+import io.quarkus.funqy.test.model.ItemFailure;
+import io.quarkus.funqy.test.util.BodyDeserializer;
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the sqs-function with an sqs specific model can handle events.
+ */
+public class SqsEventFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.funqy.export", "sqs-function")
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/sqs", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            BatchItemFailures.class, ItemFailure.class,
+                            EventDataProvider.class, BodyDeserializer.class));
+
+    @Inject
+    BodyDeserializer deserializer;
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+
+    @Test
+    public void should_return_no_failures_if_processing_pipes_is_ok() {
+        // given
+        var body = getData("pipes-ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_pipes_fails() {
+        // given
+        var body = getData("pipes-fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SqsFunctionNoBatchItemFailuresTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SqsFunctionNoBatchItemFailuresTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class SqsFunctionNoBatchItemFailuresTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("no-batch-function.properties", "application.properties")
+                    .addAsResource("events/sqs", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            EventDataProvider.class));
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        response.then().statusCode(204);
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        response.then().statusCode(204);
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SqsFunctionTest.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/SqsFunctionTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.funqy.test;
+
+import static io.quarkus.funqy.test.util.EventDataProvider.getData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.test.model.BatchItemFailures;
+import io.quarkus.funqy.test.model.ItemFailure;
+import io.quarkus.funqy.test.util.BodyDeserializer;
+import io.quarkus.funqy.test.util.EventDataProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Testing that the item-function with a customer model can handle sqs events.
+ */
+public class SqsFunctionTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("item-function.properties", "application.properties")
+                    .addAsResource("events/sqs", "events")
+                    .addClasses(TestFunctions.class, Item.class,
+                            BatchItemFailures.class, ItemFailure.class,
+                            EventDataProvider.class, BodyDeserializer.class));
+
+    @Inject
+    BodyDeserializer deserializer;
+
+    @Test
+    public void should_return_no_failures_if_processing_is_ok() {
+        // given
+        var body = getData("ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_fails() {
+        // given
+        var body = getData("fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+
+    @Test
+    public void should_return_no_failures_if_processing_pipes_is_ok() {
+        // given
+        var body = getData("pipes-ok.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), is(empty()));
+    }
+
+    @Test
+    public void should_return_one_failure_if_processing_pipes_fails() {
+        // given
+        var body = getData("pipes-fail.json");
+
+        // when
+        var response = RestAssured.given().contentType("application/json")
+                .body(body)
+                .post("/");
+
+        // then
+        var respBody = deserializer.getBodyAs(response.then().statusCode(200), BatchItemFailures.class);
+        assertThat(respBody.batchItemFailures(), hasSize(1));
+        assertThat(respBody.batchItemFailures().stream().map(ItemFailure::itemIdentifier).toList(), hasItem("1"));
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/TestFunctions.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/TestFunctions.java
@@ -1,0 +1,65 @@
+package io.quarkus.funqy.test;
+
+import java.nio.charset.StandardCharsets;
+
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+
+import io.cloudevents.CloudEvent;
+import io.quarkus.funqy.Funq;
+import io.smallrye.mutiny.Uni;
+
+public class TestFunctions {
+
+    @Funq("item-function")
+    public Uni<Void> itemFunction(Item item) {
+        if (item.isThrowError()) {
+            return Uni.createFrom().failure(new IllegalArgumentException("This is an expected error."));
+        }
+        return Uni.createFrom().voidItem();
+    }
+
+    @Funq("sqs-function")
+    public Uni<Void> sqsFunction(SQSEvent.SQSMessage msg) {
+        if (msg.getBody().contains("true")) {
+            return Uni.createFrom().failure(new IllegalArgumentException("This is an expected error."));
+        }
+        return Uni.createFrom().voidItem();
+    }
+
+    @Funq("sns-function")
+    public Uni<Void> snsFunction(SNSEvent.SNSRecord msg) {
+        if (msg.getSNS().getMessage().contains("true")) {
+            return Uni.createFrom().failure(new IllegalArgumentException("This is an expected error."));
+        }
+        return Uni.createFrom().voidItem();
+    }
+
+    @Funq("cloudevents-function")
+    public Uni<Void> cloudEventsFunction(CloudEvent msg) {
+        // Due to jackson deserialization the base64 decoding already happened.
+        if (new String(msg.getData().toBytes(), StandardCharsets.UTF_8).contains("true")) {
+            return Uni.createFrom().failure(new IllegalArgumentException("This is an expected error."));
+        }
+        return Uni.createFrom().voidItem();
+    }
+
+    @Funq("kinesis-function")
+    public Uni<Void> kinesisFunction(KinesisEvent.Record msg) {
+        // Due to jackson deserialization the base64 decoding already happened.
+        if (StandardCharsets.UTF_8.decode(msg.getData()).toString().contains("true")) {
+            return Uni.createFrom().failure(new IllegalArgumentException("This is an expected error."));
+        }
+        return Uni.createFrom().voidItem();
+    }
+
+    @Funq("dynamodb-function")
+    public Uni<Void> dynamodbFunction(DynamodbEvent.DynamodbStreamRecord msg) {
+        if (msg.getDynamodb().getNewImage().get("ThrowError").getBOOL()) {
+            return Uni.createFrom().failure(new IllegalArgumentException("This is an expected error."));
+        }
+        return Uni.createFrom().voidItem();
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/model/BatchItemFailures.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/model/BatchItemFailures.java
@@ -1,0 +1,6 @@
+package io.quarkus.funqy.test.model;
+
+import java.util.List;
+
+public record BatchItemFailures(List<ItemFailure> batchItemFailures) {
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/model/ItemFailure.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/model/ItemFailure.java
@@ -1,0 +1,4 @@
+package io.quarkus.funqy.test.model;
+
+public record ItemFailure(String itemIdentifier) {
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/util/BodyDeserializer.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/util/BodyDeserializer.java
@@ -1,0 +1,32 @@
+package io.quarkus.funqy.test.util;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.restassured.response.ValidatableResponse;
+
+@ApplicationScoped
+public class BodyDeserializer {
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    /**
+     * Allows to deserialize the response provided by RestAssured to the specified class.
+     *
+     * @param response RestAssured response
+     * @param clazz class to deserialize to
+     * @return the deserialized class
+     * @param <T> type of the class to deserialize to
+     */
+    public <T> T getBodyAs(ValidatableResponse response, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(response.extract().body().asString(), clazz);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/util/EventDataProvider.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/java/io/quarkus/funqy/test/util/EventDataProvider.java
@@ -1,0 +1,19 @@
+package io.quarkus.funqy.test.util;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.apache.commons.io.IOUtils;
+
+public class EventDataProvider {
+
+    public static String getData(String path) {
+        try {
+            return IOUtils.toString(
+                    EventDataProvider.class.getClassLoader().getResourceAsStream("events/" + path),
+                    Charset.defaultCharset());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/any-function.properties
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/any-function.properties
@@ -1,0 +1,1 @@
+quarkus.funqy.export=item-function

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/any/fail.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/any/fail.json
@@ -1,0 +1,4 @@
+{
+  "message": "hello",
+  "throwError": true
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/any/ok.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/any/ok.json
@@ -1,0 +1,4 @@
+{
+  "message": "hello",
+  "throwError": false
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/cloudevents/fail.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/cloudevents/fail.json
@@ -1,0 +1,26 @@
+[
+  {
+    "specversion" : "1.0",
+    "type" : "com.github.pull_request.opened",
+    "source" : "https://github.com/cloudevents/spec/pull",
+    "subject" : "123",
+    "id" : "1",
+    "time" : "2018-04-05T17:31:00Z",
+    "comexampleextension1" : "value",
+    "comexampleothervalue" : 5,
+    "datacontenttype" : "text/plain",
+    "data" : "{\"message\":\"hello\",\"throwError\":true}"
+  },
+  {
+    "specversion" : "1.0",
+    "type" : "com.github.pull_request.opened",
+    "source" : "https://github.com/cloudevents/spec/pull",
+    "subject" : "123",
+    "id" : "2",
+    "time" : "2018-04-05T17:31:00Z",
+    "comexampleextension1" : "value",
+    "comexampleothervalue" : 5,
+    "datacontenttype" : "text/plain",
+    "data" : "{\"message\":\"fail\",\"throwError\":false}"
+  }
+]

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/cloudevents/ok.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/cloudevents/ok.json
@@ -1,0 +1,41 @@
+[
+  {
+    "specversion" : "1.0",
+    "type" : "com.github.pull_request.opened",
+    "source" : "https://github.com/cloudevents/spec/pull",
+    "subject" : "123",
+    "id" : "1",
+    "time" : "2018-04-05T17:31:00Z",
+    "comexampleextension1" : "value",
+    "comexampleothervalue" : 5,
+    "datacontenttype" : "text/plain",
+    "data" : "{\"message\":\"hello\",\"throwError\":false}"
+  },
+  {
+    "specversion" : "1.0",
+    "type" : "com.github.pull_request.opened",
+    "source" : "https://github.com/cloudevents/spec/pull",
+    "subject" : "123",
+    "id" : "2",
+    "time" : "2018-04-05T17:31:00Z",
+    "comexampleextension1" : "value",
+    "comexampleothervalue" : 5,
+    "datacontenttype" : "application/json",
+    "data" : {
+      "message": "ok",
+      "throwError": false
+    }
+  },
+  {
+    "specversion" : "1.0",
+    "type" : "com.github.pull_request.opened",
+    "source" : "https://github.com/cloudevents/spec/pull",
+    "subject" : "123",
+    "id" : "3",
+    "time" : "2018-04-05T17:31:00Z",
+    "comexampleextension1" : "value",
+    "comexampleothervalue" : 5,
+    "datacontenttype" : "text/xml",
+    "data_base64" : "eyJtZXNzYWdlIjoiZmFpbCIsInRocm93RXJyb3IiOmZhbHNlfQ=="
+  }
+]

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/dynamodb/fail.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/dynamodb/fail.json
@@ -1,0 +1,62 @@
+{
+  "Records": [
+    {
+      "eventID": "1",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "Keys": {
+          "Id": {
+            "N": "1"
+          }
+        },
+        "NewImage": {
+          "Message": {
+            "S": "hello"
+          },
+          "ThrowError": {
+            "BOOL": true
+          },
+          "Id": {
+            "N": "1"
+          }
+        },
+        "StreamViewType": "NEW_AND_OLD_IMAGES",
+        "SequenceNumber": "1",
+        "SizeBytes": 26
+      },
+      "awsRegion": "us-west-2",
+      "eventName": "INSERT",
+      "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+      "eventSource": "aws:dynamodb"
+    },
+    {
+      "eventID": "2",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "NewImage": {
+          "Message": {
+            "S": "fail"
+          },
+          "ThrowError": {
+            "BOOL": false
+          },
+          "Id": {
+            "N": "2"
+          }
+        },
+        "SequenceNumber": "2",
+        "Keys": {
+          "Id": {
+            "N": "101"
+          }
+        },
+        "SizeBytes": 59,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "awsRegion": "us-west-2",
+      "eventName": "INSERT",
+      "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+      "eventSource": "aws:dynamodb"
+    }
+  ]
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/dynamodb/ok.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/dynamodb/ok.json
@@ -1,0 +1,64 @@
+{
+  "Records": [
+    {
+      "eventID": "1",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1719318377.0,
+        "Keys": {
+          "Id": {
+            "N": "1"
+          }
+        },
+        "NewImage": {
+          "Message": {
+            "S": "hello"
+          },
+          "ThrowError": {
+            "BOOL": false
+          },
+          "Id": {
+            "N": "1"
+          }
+        },
+        "StreamViewType": "NEW_AND_OLD_IMAGES",
+        "SequenceNumber": "1",
+        "SizeBytes": 26
+      },
+      "awsRegion": "us-west-2",
+      "eventName": "INSERT",
+      "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+      "eventSource": "aws:dynamodb"
+    },
+    {
+      "eventID": "2",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1719318377.0,
+        "NewImage": {
+          "Message": {
+            "S": "fail"
+          },
+          "ThrowError": {
+            "BOOL": false
+          },
+          "Id": {
+            "N": "2"
+          }
+        },
+        "SequenceNumber": "2",
+        "Keys": {
+          "Id": {
+            "N": "101"
+          }
+        },
+        "SizeBytes": 59,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "awsRegion": "us-west-2",
+      "eventName": "INSERT",
+      "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+      "eventSource": "aws:dynamodb"
+    }
+  ]
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/dynamodb/pipes-fail.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/dynamodb/pipes-fail.json
@@ -1,0 +1,60 @@
+[
+  {
+    "eventID": "1",
+    "eventVersion": "1.0",
+    "dynamodb": {
+      "Keys": {
+        "Id": {
+          "N": "1"
+        }
+      },
+      "NewImage": {
+        "Message": {
+          "S": "hello"
+        },
+        "ThrowError": {
+          "BOOL": true
+        },
+        "Id": {
+          "N": "1"
+        }
+      },
+      "StreamViewType": "NEW_AND_OLD_IMAGES",
+      "SequenceNumber": "1",
+      "SizeBytes": 26
+    },
+    "awsRegion": "us-west-2",
+    "eventName": "INSERT",
+    "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+    "eventSource": "aws:dynamodb"
+  },
+  {
+    "eventID": "2",
+    "eventVersion": "1.0",
+    "dynamodb": {
+      "NewImage": {
+        "Message": {
+          "S": "fail"
+        },
+        "ThrowError": {
+          "BOOL": false
+        },
+        "Id": {
+          "N": "2"
+        }
+      },
+      "SequenceNumber": "2",
+      "Keys": {
+        "Id": {
+          "N": "101"
+        }
+      },
+      "SizeBytes": 59,
+      "StreamViewType": "NEW_AND_OLD_IMAGES"
+    },
+    "awsRegion": "us-west-2",
+    "eventName": "INSERT",
+    "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+    "eventSource": "aws:dynamodb"
+  }
+]

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/dynamodb/pipes-ok.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/dynamodb/pipes-ok.json
@@ -1,0 +1,60 @@
+[
+  {
+    "eventID": "1",
+    "eventVersion": "1.0",
+    "dynamodb": {
+      "Keys": {
+        "Id": {
+          "N": "1"
+        }
+      },
+      "NewImage": {
+        "Message": {
+          "S": "hello"
+        },
+        "ThrowError": {
+          "BOOL": false
+        },
+        "Id": {
+          "N": "1"
+        }
+      },
+      "StreamViewType": "NEW_AND_OLD_IMAGES",
+      "SequenceNumber": "1",
+      "SizeBytes": 26
+    },
+    "awsRegion": "us-west-2",
+    "eventName": "INSERT",
+    "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+    "eventSource": "aws:dynamodb"
+  },
+  {
+    "eventID": "2",
+    "eventVersion": "1.0",
+    "dynamodb": {
+      "NewImage": {
+        "Message": {
+          "S": "fail"
+        },
+        "ThrowError": {
+          "BOOL": false
+        },
+        "Id": {
+          "N": "2"
+        }
+      },
+      "SequenceNumber": "2",
+      "Keys": {
+        "Id": {
+          "N": "101"
+        }
+      },
+      "SizeBytes": 59,
+      "StreamViewType": "NEW_AND_OLD_IMAGES"
+    },
+    "awsRegion": "us-west-2",
+    "eventName": "INSERT",
+    "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+    "eventSource": "aws:dynamodb"
+  }
+]

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/kinesis/fail.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/kinesis/fail.json
@@ -1,0 +1,36 @@
+{
+  "Records": [
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "1",
+        "sequenceNumber": "1",
+        "data": "eyJtZXNzYWdlIjoiaGVsbG8iLCJ0aHJvd0Vycm9yIjp0cnVlfQ==",
+        "approximateArrivalTimestamp": 1545084650.987
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000006:49590338271490256608559692538361571095921575989136588898",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+      "awsRegion": "us-east-2",
+      "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+    },
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "1",
+        "sequenceNumber": "2",
+        "data": "eyJtZXNzYWdlIjoiZmFpbCIsInRocm93RXJyb3IiOmZhbHNlfQ==",
+        "approximateArrivalTimestamp": 1545084711.166
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000006:49590338271490256608559692540925702759324208523137515618",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+      "awsRegion": "us-east-2",
+      "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+    }
+  ]
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/kinesis/ok.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/kinesis/ok.json
@@ -1,0 +1,36 @@
+{
+  "Records": [
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "1",
+        "sequenceNumber": "1",
+        "data": "eyJtZXNzYWdlIjoiaGVsbG8iLCJ0aHJvd0Vycm9yIjpmYWxzZX0=",
+        "approximateArrivalTimestamp": 1545084650.987
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000006:49590338271490256608559692538361571095921575989136588898",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+      "awsRegion": "us-east-2",
+      "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+    },
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "1",
+        "sequenceNumber": "2",
+        "data": "eyJtZXNzYWdlIjoiZmFpbCIsInRocm93RXJyb3IiOmZhbHNlfQ==",
+        "approximateArrivalTimestamp": 1545084711.166
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000006:49590338271490256608559692540925702759324208523137515618",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+      "awsRegion": "us-east-2",
+      "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+    }
+  ]
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/kinesis/pipes-fail.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/kinesis/pipes-fail.json
@@ -1,0 +1,30 @@
+[
+  {
+    "kinesisSchemaVersion": "1.0",
+    "partitionKey": "1",
+    "sequenceNumber": "1",
+    "data": "eyJtZXNzYWdlIjoiaGVsbG8iLCJ0aHJvd0Vycm9yIjp0cnVlfQ==",
+    "approximateArrivalTimestamp": 1545084650.987,
+    "eventSource": "aws:kinesis",
+    "eventVersion": "1.0",
+    "eventID": "shardId-000000000006:49590338271490256608559692538361571095921575989136588898",
+    "eventName": "aws:kinesis:record",
+    "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+    "awsRegion": "us-east-2",
+    "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+  },
+  {
+    "kinesisSchemaVersion": "1.0",
+    "partitionKey": "1",
+    "sequenceNumber": "2",
+    "data": "eyJtZXNzYWdlIjoiZmFpbCIsInRocm93RXJyb3IiOmZhbHNlfQ==",
+    "approximateArrivalTimestamp": 1545084711.166,
+    "eventSource": "aws:kinesis",
+    "eventVersion": "1.0",
+    "eventID": "shardId-000000000006:49590338271490256608559692540925702759324208523137515618",
+    "eventName": "aws:kinesis:record",
+    "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+    "awsRegion": "us-east-2",
+    "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+  }
+]

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/kinesis/pipes-ok.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/kinesis/pipes-ok.json
@@ -1,0 +1,30 @@
+[
+  {
+    "kinesisSchemaVersion": "1.0",
+    "partitionKey": "1",
+    "sequenceNumber": "1",
+    "data": "eyJtZXNzYWdlIjoiaGVsbG8iLCJ0aHJvd0Vycm9yIjpmYWxzZX0=",
+    "approximateArrivalTimestamp": 1545084650.987,
+    "eventSource": "aws:kinesis",
+    "eventVersion": "1.0",
+    "eventID": "shardId-000000000006:49590338271490256608559692538361571095921575989136588898",
+    "eventName": "aws:kinesis:record",
+    "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+    "awsRegion": "us-east-2",
+    "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+  },
+  {
+    "kinesisSchemaVersion": "1.0",
+    "partitionKey": "1",
+    "sequenceNumber": "2",
+    "data": "eyJtZXNzYWdlIjoiZmFpbCIsInRocm93RXJyb3IiOmZhbHNlfQ==",
+    "approximateArrivalTimestamp": 1545084711.166,
+    "eventSource": "aws:kinesis",
+    "eventVersion": "1.0",
+    "eventID": "shardId-000000000006:49590338271490256608559692540925702759324208523137515618",
+    "eventName": "aws:kinesis:record",
+    "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+    "awsRegion": "us-east-2",
+    "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+  }
+]

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sns/fail.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sns/fail.json
@@ -1,0 +1,31 @@
+{
+  "Records": [
+    {
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+      "EventSource": "aws:sns",
+      "Sns": {
+        "SignatureVersion": "1",
+        "Timestamp": "2019-01-02T12:45:07.000Z",
+        "Signature": "tcc6faL2yUC6dgZdmrwh1Y4cGa/ebXEkAi6RibDsvpi+tE/1+82j...65r==",
+        "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+        "MessageId": "1",
+        "Message": "{\"message\":\"hello\",\"throwError\":true}",
+        "MessageAttributes": {
+          "Test": {
+            "Type": "String",
+            "Value": "TestString"
+          },
+          "TestBinary": {
+            "Type": "Binary",
+            "Value": "TestBinary"
+          }
+        },
+        "Type": "Notification",
+        "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:us-east-1:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+        "TopicArn":"arn:aws:sns:us-east-1:123456789012:sns-lambda",
+        "Subject": "TestInvoke"
+      }
+    }
+  ]
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sns/ok.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sns/ok.json
@@ -1,0 +1,31 @@
+{
+  "Records": [
+    {
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+      "EventSource": "aws:sns",
+      "Sns": {
+        "SignatureVersion": "1",
+        "Timestamp": "2019-01-02T12:45:07.000Z",
+        "Signature": "tcc6faL2yUC6dgZdmrwh1Y4cGa/ebXEkAi6RibDsvpi+tE/1+82j...65r==",
+        "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+        "MessageId": "1",
+        "Message": "{\"message\":\"hello\",\"throwError\":false}",
+        "MessageAttributes": {
+          "Test": {
+            "Type": "String",
+            "Value": "TestString"
+          },
+          "TestBinary": {
+            "Type": "Binary",
+            "Value": "TestBinary"
+          }
+        },
+        "Type": "Notification",
+        "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:us-east-1:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+        "TopicArn":"arn:aws:sns:us-east-1:123456789012:sns-lambda",
+        "Subject": "TestInvoke"
+      }
+    }
+  ]
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sqs/fail.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sqs/fail.json
@@ -1,0 +1,36 @@
+{
+  "Records": [
+    {
+      "messageId": "1",
+      "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+      "body": "{\"message\":\"hello\",\"throwError\":true}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1545082649183",
+        "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+        "ApproximateFirstReceiveTimestamp": "1545082649185"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+      "awsRegion": "us-east-2"
+    },
+    {
+      "messageId": "2",
+      "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+      "body": "{\"message\":\"fail\",\"throwError\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1545082650636",
+        "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+        "ApproximateFirstReceiveTimestamp": "1545082650649"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+      "awsRegion": "us-east-2"
+    }
+  ]
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sqs/ok.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sqs/ok.json
@@ -1,0 +1,36 @@
+{
+  "Records": [
+    {
+      "messageId": "1",
+      "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+      "body": "{\"message\":\"hello\",\"throwError\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1545082649183",
+        "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+        "ApproximateFirstReceiveTimestamp": "1545082649185"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+      "awsRegion": "us-east-2"
+    },
+    {
+      "messageId": "2",
+      "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+      "body": "{\"message\":\"fail\",\"throwError\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1545082650636",
+        "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+        "ApproximateFirstReceiveTimestamp": "1545082650649"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+      "awsRegion": "us-east-2"
+    }
+  ]
+}

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sqs/pipes-fail.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sqs/pipes-fail.json
@@ -1,0 +1,34 @@
+[
+  {
+    "messageId": "1",
+    "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+    "body": "{\"message\":\"hello\",\"throwError\":true}",
+    "attributes": {
+      "ApproximateReceiveCount": "1",
+      "SentTimestamp": "1545082649183",
+      "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+      "ApproximateFirstReceiveTimestamp": "1545082649185"
+    },
+    "messageAttributes": {},
+    "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+    "eventSource": "aws:sqs",
+    "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+    "awsRegion": "us-east-2"
+  },
+  {
+    "messageId": "2",
+    "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+    "body": "{\"message\":\"fail\",\"throwError\":false}",
+    "attributes": {
+      "ApproximateReceiveCount": "1",
+      "SentTimestamp": "1545082650636",
+      "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+      "ApproximateFirstReceiveTimestamp": "1545082650649"
+    },
+    "messageAttributes": {},
+    "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+    "eventSource": "aws:sqs",
+    "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+    "awsRegion": "us-east-2"
+  }
+]

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sqs/pipes-ok.json
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/events/sqs/pipes-ok.json
@@ -1,0 +1,34 @@
+[
+  {
+    "messageId": "1",
+    "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+    "body": "{\"message\":\"hello\",\"throwError\":false}",
+    "attributes": {
+      "ApproximateReceiveCount": "1",
+      "SentTimestamp": "1545082649183",
+      "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+      "ApproximateFirstReceiveTimestamp": "1545082649185"
+    },
+    "messageAttributes": {},
+    "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+    "eventSource": "aws:sqs",
+    "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+    "awsRegion": "us-east-2"
+  },
+  {
+    "messageId": "2",
+    "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+    "body": "{\"message\":\"fail\",\"throwError\":false}",
+    "attributes": {
+      "ApproximateReceiveCount": "1",
+      "SentTimestamp": "1545082650636",
+      "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+      "ApproximateFirstReceiveTimestamp": "1545082650649"
+    },
+    "messageAttributes": {},
+    "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+    "eventSource": "aws:sqs",
+    "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+    "awsRegion": "us-east-2"
+  }
+]

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/item-function.properties
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/item-function.properties
@@ -1,0 +1,2 @@
+quarkus.funqy.export=item-function
+quarkus.funqy.amazon-lambda.advanced-event-handling.enabled=true

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/no-batch-function.properties
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/test/resources/no-batch-function.properties
@@ -1,0 +1,3 @@
+quarkus.funqy.export=item-function
+quarkus.funqy.amazon-lambda.advanced-event-handling.enabled=true
+quarkus.funqy.amazon-lambda.advanced-event-handling.sqs.report-batch-item-failures=false

--- a/extensions/funqy/funqy-amazon-lambda/runtime/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/pom.xml
@@ -26,6 +26,20 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-events</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/FunqyLambdaBindingRecorder.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/FunqyLambdaBindingRecorder.java
@@ -21,6 +21,11 @@ import io.quarkus.amazon.lambda.runtime.LambdaInputReader;
 import io.quarkus.amazon.lambda.runtime.LambdaOutputWriter;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.funqy.lambda.config.FunqyAmazonBuildTimeConfig;
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.AwsEventInputReader;
+import io.quarkus.funqy.lambda.event.AwsEventOutputWriter;
+import io.quarkus.funqy.lambda.event.EventProcessor;
 import io.quarkus.funqy.runtime.FunctionConstructor;
 import io.quarkus.funqy.runtime.FunctionInvoker;
 import io.quarkus.funqy.runtime.FunctionRecorder;
@@ -42,11 +47,15 @@ public class FunqyLambdaBindingRecorder {
     private static BeanContainer beanContainer;
     private static LambdaInputReader reader;
     private static LambdaOutputWriter writer;
+    private static EventProcessor eventProcessor;
+    private static FunqyAmazonBuildTimeConfig amazonBuildTimeConfig;
 
-    public void init(BeanContainer bc) {
+    public void init(BeanContainer bc, FunqyAmazonBuildTimeConfig buildTimeConfig) {
         beanContainer = bc;
         FunctionConstructor.CONTAINER = bc;
+        amazonBuildTimeConfig = buildTimeConfig;
         ObjectMapper objectMapper = AmazonLambdaMapperRecorder.objectMapper;
+
         for (FunctionInvoker invoker : FunctionRecorder.registry.invokers()) {
             if (invoker.hasInput()) {
                 JavaType javaInputType = objectMapper.constructType(invoker.getInputType());
@@ -61,7 +70,7 @@ public class FunqyLambdaBindingRecorder {
         }
     }
 
-    public void chooseInvoker(FunqyConfig config) {
+    public void chooseInvoker(FunqyConfig config, FunqyAmazonConfig amazonConfig) {
         // this is done at Runtime so that we can change it with an environment variable.
         if (config.export.isPresent()) {
             invoker = FunctionRecorder.registry.matchInvoker(config.export.get());
@@ -76,35 +85,59 @@ public class FunqyLambdaBindingRecorder {
         } else {
             invoker = FunctionRecorder.registry.invokers().iterator().next();
         }
+
+        ObjectReader objectReader = null;
         if (invoker.hasInput()) {
-            reader = new JacksonInputReader((ObjectReader) invoker.getBindingContext().get(ObjectReader.class.getName()));
+            objectReader = (ObjectReader) invoker.getBindingContext().get(ObjectReader.class.getName());
+
+            if (amazonBuildTimeConfig.advancedEventHandling().enabled()) {
+                // We create a copy, because the mapper will be reconfigured for the advanced event handling,
+                // and we do not want to adjust the ObjectMapper, which is available in arc context.
+                ObjectMapper objectMapper = AmazonLambdaMapperRecorder.objectMapper.copy();
+                reader = new AwsEventInputReader(objectMapper, objectReader, amazonBuildTimeConfig);
+            } else {
+                reader = new JacksonInputReader(objectReader);
+            }
+
         }
         if (invoker.hasOutput()) {
-            writer = new JacksonOutputWriter((ObjectWriter) invoker.getBindingContext().get(ObjectWriter.class.getName()));
-        }
+            ObjectWriter objectWriter = (ObjectWriter) invoker.getBindingContext().get(ObjectWriter.class.getName());
 
+            if (!amazonBuildTimeConfig.advancedEventHandling().enabled()) {
+                writer = new JacksonOutputWriter(objectWriter);
+            }
+        }
+        if (amazonBuildTimeConfig.advancedEventHandling().enabled()) {
+            ObjectMapper objectMapper = AmazonLambdaMapperRecorder.objectMapper.copy();
+            writer = new AwsEventOutputWriter(objectMapper);
+
+            eventProcessor = new EventProcessor(objectReader, amazonBuildTimeConfig, amazonConfig);
+        }
     }
 
     /**
      * Called by JVM handler wrapper
      *
      * @param inputStream
+     *        {@link InputStream} of the AWS SDK {@link com.amazonaws.services.lambda.runtime.RequestStreamHandler}
      * @param outputStream
+     *        {@link OutputStream} of the AWS SDK {@link com.amazonaws.services.lambda.runtime.RequestStreamHandler}
      * @param context
+     *        AWS context information provided to the Lambda
      * @throws IOException
+     *         Is thrown in case the (de)serialization fails
      */
     public static void handle(InputStream inputStream, OutputStream outputStream, Context context) throws IOException {
         Object input = null;
         if (invoker.hasInput()) {
             input = reader.readValue(inputStream);
         }
-        FunqyServerResponse response = dispatch(input);
+        FunqyServerResponse response = dispatch(input, context);
 
         Object value = response.getOutput().await().indefinitely();
         if (value != null) {
             writer.writeValue(outputStream, value);
         }
-
     }
 
     @SuppressWarnings("rawtypes")
@@ -114,7 +147,7 @@ public class FunqyLambdaBindingRecorder {
 
             @Override
             protected Object processRequest(Object input, AmazonLambdaContext context) throws Exception {
-                FunqyServerResponse response = dispatch(input);
+                FunqyServerResponse response = dispatch(input, context);
                 return response.getOutput().await().indefinitely();
             }
 
@@ -141,6 +174,14 @@ public class FunqyLambdaBindingRecorder {
         };
         loop.startPollLoop(context);
 
+    }
+
+    private static FunqyServerResponse dispatch(Object input, Context context) throws IOException {
+        if (eventProcessor != null) {
+            return eventProcessor.handle(input, FunqyLambdaBindingRecorder::dispatch, context);
+        } else {
+            return dispatch(input);
+        }
     }
 
     private static FunqyServerResponse dispatch(Object input) {

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/AdvancedEventHandlingBuildTimeConfig.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/AdvancedEventHandlingBuildTimeConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.funqy.lambda.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Advanced event handling build time configuration
+ */
+@ConfigGroup
+public interface AdvancedEventHandlingBuildTimeConfig {
+
+    /**
+     * If advanced event handling should be enabled
+     */
+    @WithDefault("true")
+    boolean enabled();
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/AdvancedEventHandlingConfig.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/AdvancedEventHandlingConfig.java
@@ -1,0 +1,30 @@
+package io.quarkus.funqy.lambda.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+/**
+ * Advanced event handling configuration
+ */
+@ConfigGroup
+public interface AdvancedEventHandlingConfig {
+
+    /**
+     * Sqs related config.
+     */
+    Sqs sqs();
+
+    /**
+     * Sns related config.
+     */
+    Sns sns();
+
+    /**
+     * Kinesis related config.
+     */
+    Kinesis kinesis();
+
+    /**
+     * DynamoDb related config.
+     */
+    DynamoDb dynamoDb();
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/DynamoDb.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/DynamoDb.java
@@ -1,0 +1,17 @@
+package io.quarkus.funqy.lambda.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Kinesis event config
+ */
+@ConfigGroup
+public interface DynamoDb {
+
+    /**
+     * Allows functions to return partially successful responses for a batch of event records.
+     */
+    @WithDefault("true")
+    boolean reportBatchItemFailures();
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/FunqyAmazonBuildTimeConfig.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/FunqyAmazonBuildTimeConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.funqy.lambda.config;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
+
+@ConfigMapping(prefix = "quarkus.funqy.amazon-lambda")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface FunqyAmazonBuildTimeConfig {
+
+    /**
+     * The advanced event handling config
+     */
+    @WithName("advanced-event-handling")
+    AdvancedEventHandlingBuildTimeConfig advancedEventHandling();
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/FunqyAmazonConfig.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/FunqyAmazonConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.funqy.lambda.config;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
+
+@ConfigMapping(prefix = "quarkus.funqy.amazon-lambda")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface FunqyAmazonConfig {
+
+    /**
+     * The advanced event handling config
+     */
+    @WithName("advanced-event-handling")
+    AdvancedEventHandlingConfig advancedEventHandling();
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/Kinesis.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/Kinesis.java
@@ -1,0 +1,17 @@
+package io.quarkus.funqy.lambda.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Kinesis event config
+ */
+@ConfigGroup
+public interface Kinesis {
+
+    /**
+     * Allows functions to return partially successful responses for a batch of event records.
+     */
+    @WithDefault("true")
+    boolean reportBatchItemFailures();
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/Sns.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/Sns.java
@@ -1,0 +1,11 @@
+package io.quarkus.funqy.lambda.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+/**
+ * Sns event config
+ */
+@ConfigGroup
+public interface Sns {
+
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/Sqs.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/config/Sqs.java
@@ -1,0 +1,17 @@
+package io.quarkus.funqy.lambda.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Sqs event config
+ */
+@ConfigGroup
+public interface Sqs {
+
+    /**
+     * Allows functions to return partially successful responses for a batch of event records.
+     */
+    @WithDefault("true")
+    boolean reportBatchItemFailures();
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/AwsEventInputReader.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/AwsEventInputReader.java
@@ -1,0 +1,201 @@
+package io.quarkus.funqy.lambda.event;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.cloudevents.SpecVersion;
+import io.quarkus.amazon.lambda.runtime.LambdaInputReader;
+import io.quarkus.funqy.lambda.config.FunqyAmazonBuildTimeConfig;
+import io.quarkus.funqy.lambda.model.cloudevents.CloudEventV1;
+import io.quarkus.funqy.lambda.model.kinesis.PipesKinesisEvent;
+
+public class AwsEventInputReader implements LambdaInputReader<Object> {
+
+    private static final Logger log = Logger.getLogger(AwsEventInputReader.class);
+
+    private static final String SQS_EVENT_SOURCE = "aws:sqs";
+    private static final String SNS_EVENT_SOURCE = "aws:sns";
+    private static final String KINESIS_EVENT_SOURCE = "aws:kinesis";
+    private static final String DYNAMODB_EVENT_SOURCE = "aws:dynamodb";
+
+    final ObjectMapper mapper;
+    final FunqyAmazonBuildTimeConfig amazonBuildTimeConfig;
+    final ObjectReader reader;
+
+    public AwsEventInputReader(ObjectMapper mapper, ObjectReader reader,
+            FunqyAmazonBuildTimeConfig amazonBuildTimeConfig) {
+        // configure the mapper for advanced event handling
+        final SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addDeserializer(Date.class, new DateDeserializer());
+        mapper.registerModule(simpleModule);
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        this.mapper = mapper;
+        this.amazonBuildTimeConfig = amazonBuildTimeConfig;
+        this.reader = reader;
+    }
+
+    @Override
+    public Object readValue(InputStream is) throws IOException {
+        try {
+            return safelyReadValue(is);
+        } catch (JacksonException e) {
+            // to make sure that we do not expose too many details about the issue in the lambda response
+            // we have some special treatment for jackson related issues
+            throw new IllegalArgumentException("Could not deserialize the provided message.", e);
+        }
+    }
+
+    private Object safelyReadValue(final InputStream is) throws IOException {
+        final JsonNode rootNode = mapper.readTree(is);
+
+        if (amazonBuildTimeConfig.advancedEventHandling().enabled()) {
+            if (rootNode.isObject() || rootNode.isArray()) {
+                if (rootNode.isObject()) {
+                    // object
+                    ObjectNode object = (ObjectNode) rootNode;
+
+                    if (object.has("Records") && object.get("Records").isArray()) {
+                        // We need to look into the first record entry, to distinguish the different types.
+                        for (JsonNode record : object.get("Records")) {
+                            return deserializeEvent(record, object);
+                        }
+                    }
+                } else {
+                    // array. This happens in case of AWS EventBridge usage, and is also the only way to enable
+                    // CloudEvents usage
+                    ArrayNode array = (ArrayNode) rootNode;
+                    for (JsonNode record : array) {
+                        return deserializeEvent(record, array);
+                    }
+                }
+            }
+            log.debug("Could not detect event type. Try to deserialize to funqy method type");
+        } else {
+            log.debug("Advanced event handling disabled. Try to deserialize to funqy method type");
+        }
+        // We could not identify the event based on the content. Fallback to deserializing the funq method input type.
+        return deserializeFunqReturnType(rootNode);
+    }
+
+    public Object deserializeEvent(JsonNode record, JsonNode rootNode) throws IOException {
+        Object eventClass = getEventType(record, rootNode);
+
+        log.debugv("Detected event class: {0}", eventClass);
+
+        if (eventClass != null) {
+            if (eventClass instanceof Class<?> clazz) {
+                return mapper.convertValue(rootNode, clazz);
+            } else if (eventClass instanceof TypeReference<?> typeReference) {
+                return mapper.convertValue(rootNode, typeReference);
+            }
+        }
+
+        log.debug("Could not detect event type. Try to deserialize to funqy method type");
+
+        // We could not identify the event based on the content. Fallback to deserializing the funq method input type.
+        return deserializeFunqReturnType(rootNode);
+    }
+
+    private Object getEventType(JsonNode record, JsonNode object) {
+        String eventSource = getEventSource(record);
+
+        if (eventSource == null) {
+            eventSource = "default";
+        }
+
+        // See: https://docs.aws.amazon.com/lambda/latest/dg/lambda-services.html
+        // and for Pipes: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-event-source.html
+        Class<?> eventType = null;
+        switch (eventSource) {
+            case SQS_EVENT_SOURCE:
+                if (object.isObject()) {
+                    eventType = SQSEvent.class;
+                } else if (object.isArray()) {
+                    // EventBridge Pipes
+                    return new TypeReference<List<SQSEvent.SQSMessage>>() {
+                    };
+                }
+                break;
+            case SNS_EVENT_SOURCE:
+                eventType = SNSEvent.class;
+                break;
+            case KINESIS_EVENT_SOURCE:
+                // Exclude Kinesis time window events. This would require to send a responsible with a state.
+                // This is very specific to AWS and maybe not the way funqy wants to handle things.
+                if (object.isObject() && !object.has("window")) {
+                    eventType = KinesisEvent.class;
+                } else if (object.isArray()) {
+                    // EventBridge Pipes
+                    return new TypeReference<List<PipesKinesisEvent>>() {
+                    };
+                }
+                break;
+            case DYNAMODB_EVENT_SOURCE:
+                if (object.isObject()) {
+                    eventType = DynamodbEvent.class;
+                } else if (object.isArray()) {
+                    // EventBridge Pipes
+                    return new TypeReference<List<DynamodbEvent.DynamodbStreamRecord>>() {
+                    };
+                }
+                break;
+            default:
+                break;
+        }
+        if (eventType == null && isCloudEvent(record)) {
+            return new TypeReference<List<CloudEventV1>>() {
+            };
+        }
+        return eventType;
+    }
+
+    private boolean isCloudEvent(final JsonNode record) {
+        // this is the best guess we can do. We check for required attributes:
+        // https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#required-attributes
+        // A more tolerant way to check the type. We do not want the process to fail. We can fall back to
+        // the best guess logic.
+        return record.has("specversion") && record.get("specversion").isTextual() &&
+                SpecVersion.V1.toString().equals(record.get("specversion").asText()) &&
+                record.has("type");
+    }
+
+    private String getEventSource(JsonNode record) {
+        if (record.has("eventSource") && record.get("eventSource").isTextual()) {
+            return record.get("eventSource").asText();
+        }
+
+        // Unsure. In the AWS SNS documentation the key starts with a capital letter. I assume this is a mistake,
+        // but it should not hurt to be that tolerant as well.
+        if (record.has("EventSource") && record.get("EventSource").isTextual()) {
+            return record.get("EventSource").asText();
+        }
+        return null;
+    }
+
+    private Object deserializeFunqReturnType(TreeNode node) throws IOException {
+        if (reader != null) {
+            return reader.readValue(node.traverse());
+        }
+        return null;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/AwsEventOutputWriter.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/AwsEventOutputWriter.java
@@ -1,0 +1,39 @@
+package io.quarkus.funqy.lambda.event;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.amazon.lambda.runtime.LambdaOutputWriter;
+
+/**
+ * Responsible for serializing the different data models of the events
+ */
+public class AwsEventOutputWriter implements LambdaOutputWriter {
+
+    final ObjectMapper mapper;
+
+    public AwsEventOutputWriter(ObjectMapper mapper) {
+        // At the moment no special configuration is needed. But we need an ObjectMapper due to different models.
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void writeValue(OutputStream os, Object obj) throws IOException {
+        try {
+            mapper.writeValue(os, obj);
+        } catch (JacksonException e) {
+            // to make sure that we do not expose too many details about the issue in the lambda response
+            // we have some special treatment for jackson related issues
+            throw new IllegalArgumentException("Could not serialize the provided output.", e);
+        }
+    }
+
+    @Override
+    public void writeHeaders(HttpURLConnection conn) {
+        conn.setRequestProperty("Content-Type", "application/json");
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/DateDeserializer.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/DateDeserializer.java
@@ -1,0 +1,22 @@
+package io.quarkus.funqy.lambda.event;
+
+import java.io.IOException;
+import java.util.Date;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+/**
+ * AWS uses double values. E.g. 1719318377.0
+ * Therefore, a dedicated deserializer is needed
+ */
+public class DateDeserializer extends JsonDeserializer<Date> {
+
+    @Override
+    public Date deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+        double timestamp = jsonParser.getDoubleValue();
+        long milliseconds = (long) (timestamp * 1000);
+        return new Date(milliseconds);
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/EventErrorHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/EventErrorHandler.java
@@ -1,0 +1,29 @@
+package io.quarkus.funqy.lambda.event;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.smallrye.mutiny.Uni;
+
+public class EventErrorHandler {
+
+    private final List<String> failures = new ArrayList<>();
+
+    public Uni<?> collectFailures(Uni<?> uni, String id) {
+        return uni.onTermination().invoke((item, failure, cancellation) -> {
+            Throwable actualFailure = null;
+            if (failure != null) {
+                actualFailure = failure;
+            } else if (cancellation) {
+                actualFailure = new RuntimeException("Stream cancelled");
+            }
+            if (actualFailure != null) {
+                failures.add(id);
+            }
+        }).onFailure().recoverWithNull();
+    }
+
+    public List<String> getFailures() {
+        return failures;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/EventHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/EventHandler.java
@@ -1,0 +1,61 @@
+package io.quarkus.funqy.lambda.event;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+
+/**
+ * This interface described how events should be handled
+ *
+ * @param <E> type of the event
+ * @param <M> type of the message
+ * @param <R> type of the response
+ */
+public interface EventHandler<E, M, R> {
+
+    /**
+     * Provides all messages from the event. Specially for events with multiple messages from a batch.
+     *
+     * @param event event to provide messages from
+     * @param amazonConfig config
+     * @return a stream of messages
+     */
+    Stream<M> streamEvent(E event, FunqyAmazonConfig amazonConfig);
+
+    /**
+     * Get the identifier of a message.
+     *
+     * @param message message to extract the identifier from
+     * @param amazonConfig config
+     * @return the identifier
+     */
+    String getIdentifier(M message, FunqyAmazonConfig amazonConfig);
+
+    /**
+     * Get the body of a message as an {@link InputStream}
+     *
+     * @param message message to extract the body from
+     * @param amazonConfig config
+     * @return the body input stream
+     */
+    Supplier<InputStream> getBody(M message, FunqyAmazonConfig amazonConfig);
+
+    /**
+     * Create the response based on the collected failures.
+     *
+     * @param failures a list of message identifier, which failed
+     * @param amazonConfig config
+     * @return the created response
+     */
+    R createResponse(List<String> failures, FunqyAmazonConfig amazonConfig);
+
+    /**
+     * The class of the message
+     *
+     * @return the class of the message
+     */
+    Class<M> getMessageClass();
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/EventProcessor.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/EventProcessor.java
@@ -1,0 +1,153 @@
+package io.quarkus.funqy.lambda.event;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import io.quarkus.funqy.lambda.FunqyResponseImpl;
+import io.quarkus.funqy.lambda.config.FunqyAmazonBuildTimeConfig;
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.cloudevents.CloudEventsHandler;
+import io.quarkus.funqy.lambda.event.dynamodb.DynamoDbEventHandler;
+import io.quarkus.funqy.lambda.event.dynamodb.PipesDynamoDbEventHandler;
+import io.quarkus.funqy.lambda.event.kinesis.KinesisEventHandler;
+import io.quarkus.funqy.lambda.event.kinesis.PipesKinesisEventHandler;
+import io.quarkus.funqy.lambda.event.sns.SnsEventHandler;
+import io.quarkus.funqy.lambda.event.sqs.PipesSqsEventHandler;
+import io.quarkus.funqy.lambda.event.sqs.SqsEventHandler;
+import io.quarkus.funqy.lambda.model.cloudevents.CloudEventV1;
+import io.quarkus.funqy.lambda.model.kinesis.PipesKinesisEvent;
+import io.quarkus.funqy.runtime.FunqyServerResponse;
+import io.smallrye.mutiny.Uni;
+
+public class EventProcessor {
+
+    private static final Logger log = Logger.getLogger(EventProcessor.class);
+
+    private final ObjectReader objectReader;
+    private final FunqyAmazonConfig config;
+    private final Map<Class<?>, EventHandler<?, ?, ?>> eventHandlers;
+
+    public EventProcessor(final ObjectReader objectReader,
+            final FunqyAmazonBuildTimeConfig buildTimeConfig, final FunqyAmazonConfig config) {
+        this.objectReader = objectReader;
+        this.config = config;
+
+        this.eventHandlers = new HashMap<>();
+        if (buildTimeConfig.advancedEventHandling().enabled()) {
+            this.eventHandlers.put(SQSEvent.class, new SqsEventHandler());
+            this.eventHandlers.put(SQSEvent.SQSMessage.class, new PipesSqsEventHandler());
+            this.eventHandlers.put(SNSEvent.class, new SnsEventHandler());
+            this.eventHandlers.put(KinesisEvent.class, new KinesisEventHandler());
+            this.eventHandlers.put(PipesKinesisEvent.class, new PipesKinesisEventHandler());
+            this.eventHandlers.put(DynamodbEvent.class, new DynamoDbEventHandler());
+            this.eventHandlers.put(DynamodbEvent.DynamodbStreamRecord.class, new PipesDynamoDbEventHandler());
+            this.eventHandlers.put(CloudEventV1.class, new CloudEventsHandler());
+        }
+    }
+
+    public FunqyServerResponse handle(Object event,
+            Function<Object, FunqyServerResponse> dispatcher, Context context) throws IOException {
+
+        EventHandler<?, ?, ?> handler = getHandler(event);
+
+        if (handler != null) {
+            EventErrorHandler eventErrorHandler = new EventErrorHandler();
+
+            FunqyResponseImpl funqyResponse = new FunqyResponseImpl();
+            funqyResponse.setOutput(handleEvent(handler, event, eventErrorHandler, dispatcher));
+            return funqyResponse;
+
+        } else {
+            // Unknown event type. We do what Funqy normally did in the past.
+            return dispatcher.apply(event);
+        }
+    }
+
+    private EventHandler<?, ?, ?> getHandler(Object event) {
+        if (event == null) {
+            return null;
+        }
+        if (event instanceof List<?> list && !list.isEmpty()) {
+            // we need some special handling for lists
+            return eventHandlers.get(list.get(0).getClass());
+        }
+
+        return eventHandlers.get(event.getClass());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E, M, R> Uni<?> handleEvent(EventHandler<E, M, R> handler, Object event,
+            EventErrorHandler eventErrorHandler, Function<Object, FunqyServerResponse> dispatcher) {
+
+        // We collect all messages in a list first, so that we can execute them in parallel.
+        List<? extends Uni<?>> unis = handler.streamEvent((E) event, config)
+                .map(msg -> handleMessage(handler, eventErrorHandler, dispatcher, msg)).toList();
+
+        log.debugv("Received {0} messages in a batch.", unis.size());
+
+        return Uni.combine().all().unis(unis)
+                .collectFailures().discardItems()
+                .onFailure().invoke(err -> log.errorv(err, "An exception occurred during message handling."))
+                .onFailure().recoverWithNull()
+                .replaceWith(() -> {
+                    log.debugv("Detected {0} errors during message handling.", unis.size());
+                    return handler.createResponse(eventErrorHandler.getFailures(), config);
+                });
+    }
+
+    private <E, M, R> Uni<?> handleMessage(final EventHandler<E, M, R> handler, final EventErrorHandler eventErrorHandler,
+            final Function<Object, FunqyServerResponse> dispatcher, final M msg) {
+        try {
+            // We check if the funqy method already uses the event model
+            final boolean isUsingEventModel = Optional.ofNullable(objectReader).map(ObjectReader::getValueType)
+                    .map(type -> type.hasRawClass(handler.getMessageClass()))
+                    .orElse(false);
+
+            Object input;
+            if (isUsingEventModel) {
+                // If the funqy method is using the event model we do not need to deserialize the content
+                log.debug("Funqy method is using the event model. No further deserialization necessary.");
+                input = msg;
+            } else {
+                // The funqy method uses a custom model. We need to ask the handle to provide the content and then
+                // we deserialize it.
+                log.debug("Funqy method is using a custom model. Try to deserialize message.");
+                input = readMessageBody(handler.getBody(msg, config));
+            }
+
+            FunqyServerResponse response = dispatcher.apply(input);
+
+            return eventErrorHandler.collectFailures(response.getOutput(), handler.getIdentifier(msg, config));
+        } catch (Throwable e) {
+            log.errorv(e, """
+                    Event could not be handled. This can have multiple reasons:
+                    1. Message body could not be deserialized
+                    2. Using a not supported AWS event
+                    """);
+            return eventErrorHandler.collectFailures(Uni.createFrom().failure(e),
+                    handler.getIdentifier(msg, config));
+        }
+    }
+
+    private Object readMessageBody(Supplier<InputStream> is) throws IOException {
+        if (objectReader == null) {
+            return null;
+        }
+        return objectReader.readValue(is.get());
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/cloudevents/CloudEventsHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/cloudevents/CloudEventsHandler.java
@@ -1,0 +1,46 @@
+package io.quarkus.funqy.lambda.event.cloudevents;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import io.cloudevents.CloudEvent;
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.EventHandler;
+import io.quarkus.funqy.lambda.model.pipes.BatchItemFailures;
+import io.quarkus.funqy.lambda.model.pipes.Response;
+
+public class CloudEventsHandler implements EventHandler<List<CloudEvent>, CloudEvent, Response> {
+    @Override
+    public Stream<CloudEvent> streamEvent(final List<CloudEvent> event, final FunqyAmazonConfig amazonConfig) {
+        if (event == null) {
+            return Stream.empty();
+        }
+        return event.stream();
+    }
+
+    @Override
+    public String getIdentifier(final CloudEvent message, final FunqyAmazonConfig amazonConfig) {
+        return message.getId();
+    }
+
+    @Override
+    public Supplier<InputStream> getBody(final CloudEvent message, final FunqyAmazonConfig amazonConfig) {
+        return () -> new ByteArrayInputStream(message.getData().toBytes());
+    }
+
+    @Override
+    public Response createResponse(final List<String> failures, final FunqyAmazonConfig amazonConfig) {
+        if (!amazonConfig.advancedEventHandling().sqs().reportBatchItemFailures()) {
+            return null;
+        }
+        return new Response(failures.stream().map(BatchItemFailures::new).toList());
+    }
+
+    @Override
+    public Class<CloudEvent> getMessageClass() {
+        return CloudEvent.class;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/dynamodb/DynamoDbEventHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/dynamodb/DynamoDbEventHandler.java
@@ -1,0 +1,53 @@
+package io.quarkus.funqy.lambda.event.dynamodb;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.EventHandler;
+
+public class DynamoDbEventHandler implements EventHandler<DynamodbEvent, DynamodbStreamRecord, StreamsEventResponse> {
+
+    @Override
+    public Stream<DynamodbStreamRecord> streamEvent(DynamodbEvent event, FunqyAmazonConfig amazonConfig) {
+        if (event == null) {
+            return Stream.empty();
+        }
+        return event.getRecords().stream();
+    }
+
+    @Override
+    public String getIdentifier(DynamodbStreamRecord message, FunqyAmazonConfig amazonConfig) {
+        return message.getDynamodb().getSequenceNumber();
+    }
+
+    @Override
+    public Supplier<InputStream> getBody(DynamodbStreamRecord message, FunqyAmazonConfig amazonConfig) {
+        throw new IllegalStateException("""
+                DynamoDB records are too specific. It is not supported to extract a message from them. \
+                Use the DynamodbStreamRecord in your funq method, or use EventBridge Pipes with CloudEvents.
+                """);
+    }
+
+    @Override
+    public StreamsEventResponse createResponse(List<String> failures, FunqyAmazonConfig amazonConfig) {
+        if (!amazonConfig.advancedEventHandling().dynamoDb().reportBatchItemFailures()) {
+            return null;
+        }
+        return StreamsEventResponse.builder().withBatchItemFailures(
+                failures.stream().map(id -> StreamsEventResponse.BatchItemFailure.builder()
+                        .withItemIdentifier(id).build()).toList())
+                .build();
+    }
+
+    @Override
+    public Class<DynamodbStreamRecord> getMessageClass() {
+        return DynamodbStreamRecord.class;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/dynamodb/PipesDynamoDbEventHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/dynamodb/PipesDynamoDbEventHandler.java
@@ -1,0 +1,53 @@
+package io.quarkus.funqy.lambda.event.dynamodb;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.EventHandler;
+
+public class PipesDynamoDbEventHandler
+        implements EventHandler<List<DynamodbStreamRecord>, DynamodbStreamRecord, StreamsEventResponse> {
+
+    @Override
+    public Stream<DynamodbStreamRecord> streamEvent(List<DynamodbStreamRecord> event, FunqyAmazonConfig amazonConfig) {
+        if (event == null) {
+            return Stream.empty();
+        }
+        return event.stream();
+    }
+
+    @Override
+    public String getIdentifier(DynamodbStreamRecord message, FunqyAmazonConfig amazonConfig) {
+        return message.getDynamodb().getSequenceNumber();
+    }
+
+    @Override
+    public Supplier<InputStream> getBody(DynamodbStreamRecord message, FunqyAmazonConfig amazonConfig) {
+        throw new IllegalStateException("""
+                DynamoDB records are too specific. It is not supported to extract a message from them. \
+                Use the DynamodbStreamRecord in your funq method, or use EventBridge Pipes with CloudEvents.
+                """);
+    }
+
+    @Override
+    public StreamsEventResponse createResponse(List<String> failures, FunqyAmazonConfig amazonConfig) {
+        if (!amazonConfig.advancedEventHandling().dynamoDb().reportBatchItemFailures()) {
+            return null;
+        }
+        return StreamsEventResponse.builder().withBatchItemFailures(
+                failures.stream().map(id -> StreamsEventResponse.BatchItemFailure.builder()
+                        .withItemIdentifier(id).build()).toList())
+                .build();
+    }
+
+    @Override
+    public Class<DynamodbStreamRecord> getMessageClass() {
+        return DynamodbStreamRecord.class;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/kinesis/KinesisEventHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/kinesis/KinesisEventHandler.java
@@ -1,0 +1,54 @@
+package io.quarkus.funqy.lambda.event.kinesis;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent.KinesisEventRecord;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse.BatchItemFailure;
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.EventHandler;
+
+public class KinesisEventHandler implements EventHandler<KinesisEvent, KinesisEvent.Record, StreamsEventResponse> {
+
+    @Override
+    public Stream<KinesisEvent.Record> streamEvent(KinesisEvent event, FunqyAmazonConfig amazonConfig) {
+        if (event == null) {
+            return Stream.empty();
+        }
+        return event.getRecords().stream().map(KinesisEventRecord::getKinesis);
+    }
+
+    @Override
+    public String getIdentifier(KinesisEvent.Record message, FunqyAmazonConfig amazonConfig) {
+        return message.getSequenceNumber();
+    }
+
+    @Override
+    public Supplier<InputStream> getBody(KinesisEvent.Record message, FunqyAmazonConfig amazonConfig) {
+        if (message.getData() == null) {
+            return ByteArrayInputStream::nullInputStream;
+        }
+        return () -> new ByteBufferBackedInputStream(message.getData());
+    }
+
+    @Override
+    public StreamsEventResponse createResponse(List<String> failures, FunqyAmazonConfig amazonConfig) {
+        if (!amazonConfig.advancedEventHandling().kinesis().reportBatchItemFailures()) {
+            return null;
+        }
+        return StreamsEventResponse.builder().withBatchItemFailures(
+                failures.stream().map(id -> BatchItemFailure.builder().withItemIdentifier(id).build()).toList()).build();
+    }
+
+    @Override
+    public Class<KinesisEvent.Record> getMessageClass() {
+        return KinesisEvent.Record.class;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/kinesis/PipesKinesisEventHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/kinesis/PipesKinesisEventHandler.java
@@ -1,0 +1,57 @@
+package io.quarkus.funqy.lambda.event.kinesis;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse.BatchItemFailure;
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.EventHandler;
+import io.quarkus.funqy.lambda.model.kinesis.PipesKinesisEvent;
+
+public class PipesKinesisEventHandler
+        implements EventHandler<List<PipesKinesisEvent>, KinesisEvent.Record, StreamsEventResponse> {
+
+    @Override
+    public Stream<KinesisEvent.Record> streamEvent(List<PipesKinesisEvent> event, FunqyAmazonConfig amazonConfig) {
+        if (event == null) {
+            return Stream.empty();
+        }
+        return event.stream().map(Function.identity());
+    }
+
+    @Override
+    public String getIdentifier(KinesisEvent.Record message, FunqyAmazonConfig amazonConfig) {
+        return message.getSequenceNumber();
+    }
+
+    @Override
+    public Supplier<InputStream> getBody(KinesisEvent.Record message, FunqyAmazonConfig amazonConfig) {
+        if (message.getData() == null) {
+            return ByteArrayInputStream::nullInputStream;
+        }
+
+        return () -> new ByteBufferBackedInputStream(message.getData());
+    }
+
+    @Override
+    public StreamsEventResponse createResponse(List<String> failures, FunqyAmazonConfig amazonConfig) {
+        if (!amazonConfig.advancedEventHandling().kinesis().reportBatchItemFailures()) {
+            return null;
+        }
+        return StreamsEventResponse.builder().withBatchItemFailures(
+                failures.stream().map(id -> BatchItemFailure.builder().withItemIdentifier(id).build()).toList()).build();
+    }
+
+    @Override
+    public Class<KinesisEvent.Record> getMessageClass() {
+        return KinesisEvent.Record.class;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/sns/SnsEventHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/sns/SnsEventHandler.java
@@ -1,0 +1,49 @@
+package io.quarkus.funqy.lambda.event.sns;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent.SNSRecord;
+
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.EventHandler;
+
+public class SnsEventHandler implements EventHandler<SNSEvent, SNSRecord, Void> {
+
+    @Override
+    public Stream<SNSRecord> streamEvent(SNSEvent event, FunqyAmazonConfig amazonConfig) {
+        if (event == null) {
+            return Stream.empty();
+        }
+        return event.getRecords().stream();
+    }
+
+    @Override
+    public String getIdentifier(SNSRecord message, FunqyAmazonConfig amazonConfig) {
+        return message.getSNS().getMessageId();
+    }
+
+    @Override
+    public Supplier<InputStream> getBody(SNSRecord message, FunqyAmazonConfig amazonConfig) {
+        if (message.getSNS() == null) {
+            return ByteArrayInputStream::nullInputStream;
+        }
+        return () -> new ByteArrayInputStream(message.getSNS().getMessage().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public Void createResponse(List<String> failures, FunqyAmazonConfig amazonConfig) {
+        // SNS does not support batch item failures. We return nothing, which results in no response
+        return null;
+    }
+
+    @Override
+    public Class<SNSRecord> getMessageClass() {
+        return SNSRecord.class;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/sqs/PipesSqsEventHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/sqs/PipesSqsEventHandler.java
@@ -1,0 +1,49 @@
+package io.quarkus.funqy.lambda.event.sqs;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.EventHandler;
+import io.quarkus.funqy.lambda.model.pipes.BatchItemFailures;
+import io.quarkus.funqy.lambda.model.pipes.Response;
+
+public class PipesSqsEventHandler implements EventHandler<List<SQSMessage>, SQSMessage, Response> {
+
+    @Override
+    public Stream<SQSMessage> streamEvent(final List<SQSMessage> event, final FunqyAmazonConfig amazonConfig) {
+        return event.stream();
+    }
+
+    @Override
+    public String getIdentifier(SQSMessage message, FunqyAmazonConfig amazonConfig) {
+        return message.getMessageId();
+    }
+
+    @Override
+    public Supplier<InputStream> getBody(SQSMessage message, FunqyAmazonConfig amazonConfig) {
+        if (message.getBody() == null) {
+            return ByteArrayInputStream::nullInputStream;
+        }
+        return () -> new ByteArrayInputStream(message.getBody().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public Response createResponse(List<String> failures, FunqyAmazonConfig amazonConfig) {
+        if (!amazonConfig.advancedEventHandling().sqs().reportBatchItemFailures()) {
+            return null;
+        }
+        return new Response(failures.stream().map(BatchItemFailures::new).toList());
+    }
+
+    @Override
+    public Class<SQSMessage> getMessageClass() {
+        return SQSMessage.class;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/sqs/SqsEventHandler.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/event/sqs/SqsEventHandler.java
@@ -1,0 +1,54 @@
+package io.quarkus.funqy.lambda.event.sqs;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse.BatchItemFailure;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+
+import io.quarkus.funqy.lambda.config.FunqyAmazonConfig;
+import io.quarkus.funqy.lambda.event.EventHandler;
+
+public class SqsEventHandler implements EventHandler<SQSEvent, SQSMessage, SQSBatchResponse> {
+
+    @Override
+    public Stream<SQSMessage> streamEvent(SQSEvent event, FunqyAmazonConfig amazonConfig) {
+        if (event == null) {
+            return Stream.empty();
+        }
+        return event.getRecords().stream();
+    }
+
+    @Override
+    public String getIdentifier(SQSMessage message, FunqyAmazonConfig amazonConfig) {
+        return message.getMessageId();
+    }
+
+    @Override
+    public Supplier<InputStream> getBody(SQSMessage message, FunqyAmazonConfig amazonConfig) {
+        if (message.getBody() == null) {
+            return ByteArrayInputStream::nullInputStream;
+        }
+        return () -> new ByteArrayInputStream(message.getBody().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public SQSBatchResponse createResponse(List<String> failures, FunqyAmazonConfig amazonConfig) {
+        if (!amazonConfig.advancedEventHandling().sqs().reportBatchItemFailures()) {
+            return null;
+        }
+        return SQSBatchResponse.builder().withBatchItemFailures(
+                failures.stream().map(id -> BatchItemFailure.builder().withItemIdentifier(id).build()).toList()).build();
+    }
+
+    @Override
+    public Class<SQSMessage> getMessageClass() {
+        return SQSMessage.class;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/FunqyMethod.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/FunqyMethod.java
@@ -1,0 +1,51 @@
+package io.quarkus.funqy.lambda.model;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+public class FunqyMethod {
+
+    private ObjectReader reader;
+    private ObjectWriter writer;
+    private JavaType inputType;
+    private JavaType outputType;
+
+    public FunqyMethod setReader(final ObjectReader reader) {
+        this.reader = reader;
+        return this;
+    }
+
+    public FunqyMethod setWriter(final ObjectWriter writer) {
+        this.writer = writer;
+        return this;
+    }
+
+    public FunqyMethod setInputType(final JavaType inputType) {
+        this.inputType = inputType;
+        return this;
+    }
+
+    public FunqyMethod setOutputType(final JavaType outputType) {
+        this.outputType = outputType;
+        return this;
+    }
+
+    public Optional<ObjectReader> getReader() {
+        return Optional.ofNullable(reader);
+    }
+
+    public Optional<ObjectWriter> getWriter() {
+        return Optional.ofNullable(writer);
+    }
+
+    public Optional<JavaType> getInputType() {
+        return Optional.ofNullable(inputType);
+    }
+
+    public Optional<JavaType> getOutputType() {
+        return Optional.ofNullable(outputType);
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/cloudevents/CloudEventDataV1.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/cloudevents/CloudEventDataV1.java
@@ -1,0 +1,27 @@
+package io.quarkus.funqy.lambda.model.cloudevents;
+
+import java.nio.charset.StandardCharsets;
+
+import io.cloudevents.CloudEventData;
+
+public class CloudEventDataV1 implements CloudEventData {
+
+    private final byte[] data;
+
+    public CloudEventDataV1(final String data) {
+        if (data == null) {
+            this.data = null;
+        } else {
+            this.data = data.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    public CloudEventDataV1(final byte[] data) {
+        this.data = data;
+    }
+
+    @Override
+    public byte[] toBytes() {
+        return this.data;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/cloudevents/CloudEventV1.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/cloudevents/CloudEventV1.java
@@ -1,0 +1,172 @@
+package io.quarkus.funqy.lambda.model.cloudevents;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.SpecVersion;
+
+/**
+ * This class represents a {@link CloudEvent} in version 1.0 and is Jackson friendly
+ */
+public class CloudEventV1 implements CloudEvent {
+
+    //private static final Pattern JSON_TYPE_PATTERN = Pattern.compile("^(application|text)/([a-zA-Z]+\\+)?json;?.*$");
+
+    private final CloudEventDataV1 data;
+    private final SpecVersion specVersion;
+    private final String id;
+    private final String type;
+    private final URI source;
+    private final String dataContentType;
+    private final URI dataSchema;
+    private final String subject;
+    private final OffsetDateTime time;
+    private final Map<String, Object> extensions;
+
+    public CloudEventV1(
+            @JsonProperty("specversion") String specVersion,
+            @JsonProperty("id") String id,
+            @JsonProperty("type") String type,
+            @JsonProperty("source") URI source,
+            @JsonProperty("datacontenttype") String dataContentType,
+            @JsonProperty("dataschema") URI dataSchema,
+            @JsonProperty("subject") String subject,
+            @JsonProperty("time") OffsetDateTime time,
+            @JsonProperty("data") JsonNode data,
+            @JsonProperty("data_base64") JsonNode dataBase64) {
+        this.specVersion = SpecVersion.parse(specVersion);
+        this.id = id;
+        this.type = type;
+        this.source = source;
+        this.dataContentType = dataContentType;
+        this.dataSchema = dataSchema;
+        this.subject = subject;
+        this.time = time;
+        this.extensions = new HashMap<>();
+        this.data = deserializeData(data, dataBase64, dataContentType);
+    }
+
+    @JsonAnySetter
+    public void add(String property, String value) {
+        switch (property) {
+            case "specversion":
+            case "id":
+            case "source":
+            case "type":
+            case "datacontenttype":
+            case "dataschema":
+            case "data":
+            case "data_base64":
+            case "subject":
+            case "time":
+                // Those names are reserved
+                return;
+        }
+        extensions.put(property, value);
+    }
+
+    private CloudEventDataV1 deserializeData(final JsonNode data, final JsonNode dataBase64,
+            final String dataContentType) {
+        if (dataBase64 != null) {
+            try {
+                return new CloudEventDataV1(dataBase64.binaryValue());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else if (data == null) {
+            return null;
+        }
+
+        if (data.isTextual()) {
+            return new CloudEventDataV1(data.asText());
+        } else {
+            // This should work for every other type. Even for application/json, because we need to serialize
+            // the data anyway for the interface.
+            return new CloudEventDataV1(data.toString());
+        }
+    }
+
+    @Override
+    public CloudEventData getData() {
+        return this.data;
+    }
+
+    @Override
+    public SpecVersion getSpecVersion() {
+        return this.specVersion;
+    }
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getType() {
+        return this.type;
+    }
+
+    @Override
+    public URI getSource() {
+        return this.source;
+    }
+
+    @Override
+    public String getDataContentType() {
+        return this.dataContentType;
+    }
+
+    @Override
+    public URI getDataSchema() {
+        return this.dataSchema;
+    }
+
+    @Override
+    public String getSubject() {
+        return this.subject;
+    }
+
+    @Override
+    public OffsetDateTime getTime() {
+        return this.time;
+    }
+
+    @Override
+    public Object getAttribute(final String attributeName) throws IllegalArgumentException {
+        return switch (attributeName) {
+            case "specversion" -> getSpecVersion();
+            case "id" -> getId();
+            case "source" -> getSource();
+            case "type" -> getType();
+            case "datacontenttype" -> getDataContentType();
+            case "dataschema" -> getDataSchema();
+            case "subject" -> getSubject();
+            case "time" -> getTime();
+            default -> throw new IllegalArgumentException(
+                    "The specified attribute name \"" + attributeName + "\" is not specified in version v1.");
+        };
+    }
+
+    @Override
+    public Object getExtension(final String s) {
+        if (s == null) {
+            throw new IllegalArgumentException("Extension name cannot be null");
+        }
+        return this.extensions.get(s);
+    }
+
+    @Override
+    public Set<String> getExtensionNames() {
+        return this.extensions.keySet();
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/kinesis/PipesKinesisEvent.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/kinesis/PipesKinesisEvent.java
@@ -1,0 +1,63 @@
+package io.quarkus.funqy.lambda.model.kinesis;
+
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+
+/**
+ * For some reason AWS decided to flatten the model in EventBridge pipes for Kinesis. So there is no additional
+ * property called kinesis. We use the Record model and add the missing properties. Sadly I could not find a
+ * dedicated model for Kinesis in Pipes. So it is a combination of
+ * {@link com.amazonaws.services.lambda.runtime.events.KinesisEvent.KinesisEventRecord} and {@link KinesisEvent.Record}
+ */
+public class PipesKinesisEvent extends KinesisEvent.Record {
+
+    private static final long serialVersionUID = 4365865918351932405L;
+
+    private String eventSource;
+
+    private String eventID;
+
+    private String invokeIdentityArn;
+
+    private String eventName;
+
+    private String eventVersion;
+
+    private String eventSourceARN;
+
+    private String awsRegion;
+
+    public PipesKinesisEvent setEventSource(final String eventSource) {
+        this.eventSource = eventSource;
+        return this;
+    }
+
+    public PipesKinesisEvent setEventID(final String eventID) {
+        this.eventID = eventID;
+        return this;
+    }
+
+    public PipesKinesisEvent setInvokeIdentityArn(final String invokeIdentityArn) {
+        this.invokeIdentityArn = invokeIdentityArn;
+        return this;
+    }
+
+    public PipesKinesisEvent setEventName(final String eventName) {
+        this.eventName = eventName;
+        return this;
+    }
+
+    public PipesKinesisEvent setEventVersion(final String eventVersion) {
+        this.eventVersion = eventVersion;
+        return this;
+    }
+
+    public PipesKinesisEvent setEventSourceARN(final String eventSourceARN) {
+        this.eventSourceARN = eventSourceARN;
+        return this;
+    }
+
+    public PipesKinesisEvent setAwsRegion(final String awsRegion) {
+        this.awsRegion = awsRegion;
+        return this;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/pipes/BatchItemFailures.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/pipes/BatchItemFailures.java
@@ -1,0 +1,14 @@
+package io.quarkus.funqy.lambda.model.pipes;
+
+public class BatchItemFailures {
+
+    private final String itemIdentifier;
+
+    public BatchItemFailures(final String itemIdentifier) {
+        this.itemIdentifier = itemIdentifier;
+    }
+
+    public String getItemIdentifier() {
+        return itemIdentifier;
+    }
+}

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/pipes/Response.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/model/pipes/Response.java
@@ -1,0 +1,16 @@
+package io.quarkus.funqy.lambda.model.pipes;
+
+import java.util.List;
+
+public class Response {
+
+    private final List<BatchItemFailures> batchItemFailures;
+
+    public Response(final List<BatchItemFailures> batchItemFailures) {
+        this.batchItemFailures = batchItemFailures;
+    }
+
+    public List<BatchItemFailures> getBatchItemFailures() {
+        return batchItemFailures;
+    }
+}

--- a/integration-tests/funqy-amazon-lambda/src/test/java/io/quarkus/funqy/test/GreetTestBase.java
+++ b/integration-tests/funqy-amazon-lambda/src/test/java/io/quarkus/funqy/test/GreetTestBase.java
@@ -30,7 +30,7 @@ public abstract class GreetTestBase {
                 .post()
                 .then()
                 .statusCode(500)
-                .body("errorMessage", containsString("end-of-input"));
+                .body("errorMessage", containsString("Could not deserialize the provided message"));
     }
 
 }


### PR DESCRIPTION
Why this feature. We like the Funqy extension. Sadly it makes the usage in AWS a bit difficult at the moment, because although Funqy seems to be cloud agnostic this is not really the case when Event driven sources are used as trigger for a lambda function. E.g. SQS. When using SQS it was necessary to use the SQS model in the funq method, which reduces the benefit of a cloud agnostic solution. Furthermore, it prevents the usage of features of AWS batching.

# Requirements
To solve that I thought about the following requirements:
- Check which trigger exists in AWS Lambda and select at least a sub set. I decided for SQS, SNS, DynamoDB and Kinesis.
- Realized that multiple triggers can be used for a Lambda at the same time
- Support the batching in case this is possible
- Support for CloudEvents
- configurable so that the new "advanced" features can be enabled or disabled

So I checked the following documentation of AWS:
AWS Lambda: https://docs.aws.amazon.com/lambda/latest/dg/lambda-services.html
AWS EventBridge Pipes: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-event-source.html

I checked AWS EventBridge Pipes, because this allows to use CloudEvents in AWS. E.g.:
![image](https://github.com/quarkusio/quarkus/assets/30546982/302ff1c5-1975-4f9d-b973-f1db1ad74ad5)
With an input transformer similar to this:
![image](https://github.com/quarkusio/quarkus/assets/30546982/80217c9c-fc83-4db6-9e19-6a143b6c8f17)

# So what did I do
- Add CloudEvents dependency
- Adjust the deserialization of messages for AWS. Due to the fact that it is not clear which event the logic receives it is a custom deserializer. It checks the content of the records to identify the type and then deserializes it by type.
- If the type is determined try to deserialize the content of the event to the type of the Funqy method parameter.
- Wrap the invocation so that I can catch failures and create the batch item failures response
- Deserialization of CloudEvents

# What is tricky and I could need feedback for
1. Native build. I am not sure how I can see which classes I need to add for reflection. I added the one for the different Events, but I am unsure how to see that. When we tested funqy so far we also received an error, because of io.quarkus.amazon.lambda.runtime.FunctionError, which was missing. But, the code seems to add it for reflection. We were forced to add it manually to reflection, so this made me more unsure how to handle this topic.
2. The deserialization. I created a copy of the ObjectMapper, which was retrieved via ARC as it seems. It felt wrong to register a deserializer for Object, which might influence more logic. It was strange though, because the amazon-lambda (not funqy) already reconfigures the ObjectMapper. I tried to reuse the ObjectReader and ObjectWriter for the funqy method, which seems like a good idea, but I was not sure, if it was worth it to create a dedicated reader and writer for all the AWS events.
3. I am unsure about the processing of the messages. E.g. in SQS I receive 10 messages in one event and the funq method is called for all of them. I used parallel execution. I guess this should be configurable what do you think?
4. I tried to understand why some variables are staticly defined. I think it is because of the different executions. Some static (build time?) and some for run time. This created a bit of a strange approach, where I needed to update the EventProcessor, which was created during build time? I hope this is ok. Maybe you have a better idea

# Last words
I know this PR looks huge. There are a lot of json test files though. I would love if you could take a look and tell me what you think. Help would be appreciated.