### PR TITLE
Quarkus REST - reuse CDI request context if it exists

### DIFF
--- a/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ArcThreadSetupAction.java
+++ b/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ArcThreadSetupAction.java
@@ -41,4 +41,9 @@ public class ArcThreadSetupAction implements ThreadSetupAction {
     public ThreadState currentState() {
         return toThreadState(managedContext.getState());
     }
+
+    @Override
+    public boolean isRequestContextActive() {
+        return managedContext.isActive();
+    }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -246,12 +246,17 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
         if (requestScopeActivated) {
             return;
         }
-        requestScopeActivated = true;
         if (isRequestScopeManagementRequired()) {
-            if (currentRequestScope == null) {
-                currentRequestScope = requestContext.activateInitial();
+            if (requestContext.isRequestContextActive()) {
+                // req. context is already active, just reuse existing one
+                currentRequestScope = requestContext.currentState();
             } else {
-                currentRequestScope.activate();
+                requestScopeActivated = true;
+                if (currentRequestScope == null) {
+                    currentRequestScope = requestContext.activateInitial();
+                } else {
+                    currentRequestScope.activate();
+                }
             }
         } else {
             currentRequestScope = requestContext.currentState();

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/spi/ThreadSetupAction.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/spi/ThreadSetupAction.java
@@ -6,6 +6,8 @@ public interface ThreadSetupAction {
 
     ThreadState currentState();
 
+    boolean isRequestContextActive();
+
     interface ThreadState {
         void close();
 
@@ -38,6 +40,11 @@ public interface ThreadSetupAction {
         @Override
         public ThreadState currentState() {
             return activateInitial();
+        }
+
+        @Override
+        public boolean isRequestContextActive() {
+            return false;
         }
     };
 }

--- a/integration-tests/openapi/pom.xml
+++ b/integration-tests/openapi/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security</artifactId>
+            <scope>test</scope>
+        </dependency>
         
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/openapi/src/main/java/io/quarkus/it/openapi/security/TestSecurityResource.java
+++ b/integration-tests/openapi/src/main/java/io/quarkus/it/openapi/security/TestSecurityResource.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.openapi.security;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+
+import io.quarkus.vertx.web.RouteFilter;
+import io.vertx.ext.web.RoutingContext;
+
+@Path("/security")
+public class TestSecurityResource {
+
+    @RolesAllowed("admin")
+    @GET
+    @Path("reactive-routes")
+    public String reactiveRoutes(@Context SecurityContext securityContext) {
+        return securityContext.getUserPrincipal().getName();
+    }
+
+    @RouteFilter(401)
+    public void doNothing(RoutingContext routingContext) {
+        // here so that the Reactive Routes extension activates CDI request context
+        routingContext.response().putHeader("reactive-routes-filter", "true");
+        routingContext.next();
+    }
+
+}

--- a/integration-tests/openapi/src/test/java/io/quarkus/it/openapi/security/TestSecurityReactiveRoutesTest.java
+++ b/integration-tests/openapi/src/test/java/io/quarkus/it/openapi/security/TestSecurityReactiveRoutesTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.openapi.security;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@TestHTTPEndpoint(TestSecurityResource.class)
+public class TestSecurityReactiveRoutesTest {
+
+    @TestSecurity(user = "Martin", roles = "admin")
+    @Test
+    public void testSecurityWithReactiveRoutesAndQuarkusRest() {
+        RestAssured.get("reactive-routes")
+                .then()
+                .statusCode(200)
+                .header("reactive-routes-filter", is("true"))
+                .body(is("Martin"));
+    }
+
+}


### PR DESCRIPTION
Related to: #40307

Allows reuse of existing CDI req. context if present and monitors if req. context was activated from within `AbstractResteasyReactiveContext`. Only performs cleanup if the context was initialized here.