### PR TITLE
[3.8] Upgrade Infinispan to 14.0.27.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -142,7 +142,7 @@
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->
         <junit.jupiter.version>5.10.1</junit.jupiter.version>
         <junit-pioneer.version>1.5.0</junit-pioneer.version>
-        <infinispan.version>14.0.25.Final</infinispan.version>
+        <infinispan.version>14.0.27.Final</infinispan.version>
         <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
         <netty.version>4.1.107.Final</netty.version>


### PR DESCRIPTION
This version needs to be backported to branches/versions using 14.0 