### PR TITLE
Add test security attribute type handling

### DIFF
--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -93,6 +93,24 @@ identity to be present.
 
 See xref:security-oidc-bearer-token-authentication.adoc#integration-testing-security-annotation[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication.adoc#integration-testing-security-annotation[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-security-annotation[SmallRye JWT Integration testing] for more details about testing the endpoint code which depends on the injected `JsonWebToken`.
 
+Additionally, you can specify attributes for the identity, perhaps custom items that were added with identity augmentation:
+
+[source,java]
+----
+@Inject
+SecurityIdentity identity;
+
+@Test
+@TestSecurity(user = "testUser", "roles = {"admin, "user"}, attributes = {
+            @SecurityAttribute(key = "answer", value = "42", type = AttributeType.LONG) }
+void someTestMethod() {
+    Long answer = identity.<Long>getAttribute("answer");
+...
+}
+----
+
+This will run the test with an identity with an attribute of type `Long` named `answer`.
+
 [WARNING]
 ====
 The feature is only available for `@QuarkusTest` and will **not** work on a `@QuarkusIntegrationTest`.

--- a/test-framework/security/pom.xml
+++ b/test-framework/security/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>        
     </dependencies>
 
     <build>

--- a/test-framework/security/src/main/java/io/quarkus/test/security/AttributeType.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/AttributeType.java
@@ -1,0 +1,69 @@
+package io.quarkus.test.security;
+
+import java.io.StringReader;
+import java.util.Set;
+
+import jakarta.json.Json;
+import jakarta.json.JsonReader;
+
+public enum AttributeType {
+    LONG {
+        @Override
+        Object convert(String value) {
+            return Long.valueOf(value);
+        }
+    },
+    INTEGER {
+        @Override
+        Object convert(String value) {
+            return Integer.valueOf(value);
+        }
+    },
+    BOOLEAN {
+        @Override
+        Object convert(String value) {
+            return Boolean.valueOf(value);
+        }
+    },
+    STRING {
+        @Override
+        Object convert(String value) {
+            return value;
+        }
+    },
+    STRING_SET {
+        /**
+         * Returns a Set of String values, parsed from the given value.
+         *
+         * @param value a comma separated list of values
+         */
+        @Override
+        Object convert(String value) {
+            return Set.of(value.split(","));
+        }
+    },
+    JSON_ARRAY {
+        @Override
+        Object convert(String value) {
+            try (JsonReader reader = Json.createReader(new StringReader(value))) {
+                return reader.readArray();
+            }
+        }
+    },
+    JSON_OBJECT {
+        @Override
+        Object convert(String value) {
+            try (JsonReader reader = Json.createReader(new StringReader(value))) {
+                return reader.readObject();
+            }
+        }
+    },
+    DEFAULT {
+        @Override
+        Object convert(String value) {
+            return value;
+        }
+    };
+
+    abstract Object convert(String value);
+}

--- a/test-framework/security/src/main/java/io/quarkus/test/security/QuarkusSecurityTestExtension.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/QuarkusSecurityTestExtension.java
@@ -60,7 +60,7 @@ public class QuarkusSecurityTestExtension implements QuarkusTestBeforeEachCallba
 
                 if (testSecurity.attributes() != null) {
                     user.addAttributes(Arrays.stream(testSecurity.attributes())
-                            .collect(Collectors.toMap(s -> s.key(), s -> s.value())));
+                            .collect(Collectors.toMap(s -> s.key(), s -> s.type().convert(s.value()))));
                 }
 
                 SecurityIdentity userIdentity = augment(user.build(), allAnnotations);

--- a/test-framework/security/src/main/java/io/quarkus/test/security/SecurityAttribute.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/SecurityAttribute.java
@@ -10,4 +10,6 @@ public @interface SecurityAttribute {
     String key();
 
     String value();
+
+    AttributeType type() default AttributeType.DEFAULT;
 }


### PR DESCRIPTION
* added an attribute type enum which converts the `String` `value` into various types of objects
* use the converter when setting up the security identity for tests
* added some documentation about how to use `@SecurityAttribute` inside the `@TestSecurity` annotation

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com> Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>