### PR TITLE
Fix potential NPE in ClassPathElement.getResources

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
@@ -144,6 +144,10 @@ public interface ClassPathElement extends Closeable {
     };
 
     default List<ClassPathResource> getResources(String name) {
-        return List.of(getResource(name));
+        ClassPathResource resource = getResource(name);
+        if (resource != null) {
+            return List.of(resource);
+        }
+        return Collections.emptyList();
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -268,9 +268,11 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         } else if (name.isEmpty()) {
             for (ClassPathElement i : elements) {
                 List<ClassPathResource> resList = i.getResources("");
-                for (var res : resList) {
-                    if (res != null) {
-                        resources.add(res.getUrl());
+                if (resList != null) {
+                    for (var res : resList) {
+                        if (res != null) {
+                            resources.add(res.getUrl());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes an issue observed on the Camel Quarkus nightly build with Quarkus 999-SNAPSHOT.

The following change causes the camel-quarkus-kotlin-dsl tests to fail:

https://github.com/quarkusio/quarkus/commit/9daa467417b84c812ee04da5d909c79d5a729580

```
Caused by: java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/java.util.ImmutableCollections$List12.<init>(ImmutableCollections.java:563)
	at java.base/java.util.List.of(List.java:937)
	at io.quarkus.bootstrap.classloading.ClassPathElement.getResources(ClassPathElement.java:147)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.getResources(QuarkusClassLoader.java:270)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.getResources(QuarkusClassLoader.java:210)
	at kotlin.script.experimental.jvm.util.JvmClasspathUtilKt.rawClassPathFromKeyResourcePath(jvmClasspathUtil.kt:139)
	at kotlin.script.experimental.jvm.util.JvmClasspathUtilKt.classPathFromTypicalResourceUrls(jvmClasspathUtil.kt:152)
	at kotlin.script.experimental.jvm.util.JvmClasspathUtilKt$classpathFromClassloader$1.invoke(jvmClasspathUtil.kt:96)
	at kotlin.script.experimental.jvm.util.JvmClasspathUtilKt$classpathFromClassloader$1.invoke(jvmClasspathUtil.kt:77)
```

I'm no expert in this area but the change was enough to get the tests passing again.