### PR TITLE
Check whether outputDirectory is the root of the file system before using its parent

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -12,7 +12,6 @@ import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -939,14 +938,19 @@ public class SmallRyeOpenApiProcessor {
         Path outputDirectory = out.getOutputDirectory();
 
         if (!directory.isAbsolute() && outputDirectory != null) {
-            directory = Paths.get(outputDirectory.getParent().toString(), directory.toString());
+            var baseDir = outputDirectory.getParent();
+            // check if outputDirectory is the root of the filesystem
+            if (baseDir == null) {
+                baseDir = outputDirectory;
+            }
+            directory = baseDir.resolve(directory);
         }
 
         if (!Files.exists(directory)) {
             Files.createDirectories(directory);
         }
 
-        Path file = Paths.get(directory.toString(), "openapi." + format.toString().toLowerCase());
+        Path file = directory.resolve("openapi." + format.toString().toLowerCase());
         if (!Files.exists(file)) {
             Files.createFile(file);
         }


### PR DESCRIPTION
@phillip-kruger does it make sense to you?

It seems like this could happen in remote dev case.