### PR TITLE
Arc - copy over annotations when transforming intercepted static methods

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
@@ -454,6 +454,10 @@ public class InterceptedStaticMethodsProcessor {
                 MethodCreator newMethod = transformer.addMethod(originalDescriptor)
                         .setModifiers(interceptedMethod.flags())
                         .setSignature(interceptedMethod.genericSignatureIfRequired());
+                // Copy over all annotations
+                for (AnnotationInstance annotationInstance : interceptedMethod.annotations()) {
+                    newMethod.addAnnotation(annotationInstance);
+                }
                 for (Type exceptionType : interceptedMethod.exceptions()) {
                     newMethod.addException(exceptionType.name().toString());
                 }

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/staticmethods/InterceptedStaticMethodTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/staticmethods/InterceptedStaticMethodTest.java
@@ -4,6 +4,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.annotation.Retention;
@@ -120,6 +121,11 @@ public class InterceptedStaticMethodTest {
                 throw new AssertionFailedError("Not a static method!");
             }
             assertNull(ctx.getTarget());
+            // verify annotations can be inspected
+            if (ctx.getMethod().getDeclaringClass().getName().equals(Simple.class.getName())) {
+                assertEquals(1, ctx.getMethod().getAnnotations().length);
+                assertNotNull(ctx.getMethod().getAnnotation(InterceptMe.class));
+            }
             Object ret = ctx.proceed();
             if (ret != null) {
                 if (ret instanceof String) {


### PR DESCRIPTION
Fixes #40399