### PR TITLE
Fix DisableLoggingFeature for JBoss Threads/Hibernate/Infinispan/Websocket-client

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/DisableLoggingFeature.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/DisableLoggingFeature.java
@@ -31,10 +31,8 @@ public class DisableLoggingFeature implements Feature {
     public void afterAnalysis(AfterAnalysisAccess access) {
         for (String category : CATEGORIES) {
             Level level = categoryMap.remove(category);
-            if (level != null) {
-                Logger logger = Logger.getLogger(category);
-                logger.setLevel(level);
-            }
+            Logger logger = Logger.getLogger(category);
+            logger.setLevel(level);
         }
     }
 

--- a/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/runtime/graal/DisableLoggingFeature.java
@@ -32,10 +32,8 @@ public class DisableLoggingFeature implements Feature {
     public void afterAnalysis(AfterAnalysisAccess access) {
         for (String category : CATEGORIES) {
             Level level = categoryMap.remove(category);
-            if (level != null) {
-                Logger logger = Logger.getLogger(category);
-                logger.setLevel(level);
-            }
+            Logger logger = Logger.getLogger(category);
+            logger.setLevel(level);
         }
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/DisableLoggingFeature.java
@@ -34,10 +34,8 @@ public class DisableLoggingFeature implements Feature {
     public void afterAnalysis(AfterAnalysisAccess access) {
         for (String category : CATEGORIES) {
             Level level = categoryMap.remove(category);
-            if (level != null) {
-                Logger logger = Logger.getLogger(category);
-                logger.setLevel(level);
-            }
+            Logger logger = Logger.getLogger(category);
+            logger.setLevel(level);
         }
     }
 

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/graal/DisableLoggingFeature.java
@@ -31,10 +31,8 @@ public class DisableLoggingFeature implements Feature {
     public void afterAnalysis(AfterAnalysisAccess access) {
         for (String category : CATEGORIES) {
             Level level = categoryMap.remove(category);
-            if (level != null) {
-                Logger logger = Logger.getLogger(category);
-                logger.setLevel(level);
-            }
+            Logger logger = Logger.getLogger(category);
+            logger.setLevel(level);
         }
     }
 

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/DisableLoggingFeature.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/DisableLoggingFeature.java
@@ -32,10 +32,8 @@ public class DisableLoggingFeature implements Feature {
     public void afterAnalysis(AfterAnalysisAccess access) {
         for (String category : CATEGORIES) {
             Level level = categoryMap.remove(category);
-            if (level != null) {
-                Logger logger = Logger.getLogger(category);
-                logger.setLevel(level);
-            }
+            Logger logger = Logger.getLogger(category);
+            logger.setLevel(level);
         }
     }
 

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/graal/DisableLoggingFeature.java
@@ -31,10 +31,8 @@ public class DisableLoggingFeature implements Feature {
     public void afterAnalysis(AfterAnalysisAccess access) {
         for (String category : CATEGORIES) {
             Level level = categoryMap.remove(category);
-            if (level != null) {
-                Logger logger = Logger.getLogger(category);
-                logger.setLevel(level);
-            }
+            Logger logger = Logger.getLogger(category);
+            logger.setLevel(level);
         }
     }
 

--- a/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/DisableLoggingFeature.java
+++ b/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/DisableLoggingFeature.java
@@ -31,10 +31,8 @@ public class DisableLoggingFeature implements Feature {
     public void afterAnalysis(AfterAnalysisAccess access) {
         for (String category : CATEGORIES) {
             Level level = categoryMap.remove(category);
-            if (level != null) {
-                Logger logger = Logger.getLogger(category);
-                logger.setLevel(level);
-            }
+            Logger logger = Logger.getLogger(category);
+            logger.setLevel(level);
         }
     }
 


### PR DESCRIPTION
The log level we get in `beforeAnalysis` may be null, in which case we still want to reset it after analysis.

From the javadoc of Logger#getLevel:

> Get the log Level that has been specified for this Logger.
> The result may be null, which means that this logger's effective level will be inherited from its parent.

Related: https://github.com/quarkusio/quarkus/pull/40365#issuecomment-2092997301 , where I noticed the bug.