### PR TITLE
Change io.quarkus.security:quarkus-security dependency to io.quarkus.security:quarkus-security-api

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -186,7 +186,7 @@
         <mockito.version>5.11.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.13.0</antlr.version><!-- needs to align with same property in build-parent/pom.xml -->
-        <quarkus-security.version>2.0.3.Final</quarkus-security.version>
+        <quarkus-security.version>2.0.4.Final</quarkus-security.version>
         <keycloak.version>23.0.7</keycloak.version>
         <logstash-gelf.version>1.15.1</logstash-gelf.version>
         <checker-qual.version>3.42.0</checker-qual.version>
@@ -3754,7 +3754,7 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus.security</groupId>
-                <artifactId>quarkus-security</artifactId>
+                <artifactId>quarkus-security-api</artifactId>
                 <version>${quarkus-security.version}</version>
                 <exclusions>
                     <exclusion>

--- a/extensions/elytron-security-properties-file/runtime/pom.xml
+++ b/extensions/elytron-security-properties-file/runtime/pom.xml
@@ -38,16 +38,6 @@
             <artifactId>quarkus-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.enterprise</groupId>
-                    <artifactId>cdi-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>

--- a/extensions/elytron-security/runtime/pom.xml
+++ b/extensions/elytron-security/runtime/pom.xml
@@ -47,16 +47,6 @@
             <artifactId>quarkus-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.enterprise</groupId>
-                    <artifactId>cdi-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>

--- a/extensions/grpc/runtime/pom.xml
+++ b/extensions/grpc/runtime/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
+            <artifactId>quarkus-security-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/reactive-routes/runtime/pom.xml
+++ b/extensions/reactive-routes/runtime/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
+            <artifactId>quarkus-security-api</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>javax.enterprise</groupId>

--- a/extensions/security/runtime-spi/pom.xml
+++ b/extensions/security/runtime-spi/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
+            <artifactId>quarkus-security-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/security/runtime/pom.xml
+++ b/extensions/security/runtime/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
+            <artifactId>quarkus-security-api</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>javax.enterprise</groupId>

--- a/extensions/security/spi/pom.xml
+++ b/extensions/security/spi/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
+            <artifactId>quarkus-security-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/security/test-utils/pom.xml
+++ b/extensions/security/test-utils/pom.xml
@@ -22,16 +22,6 @@
             <artifactId>quarkus-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.enterprise</groupId>
-                    <artifactId>cdi-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>

--- a/extensions/spring-security/deployment/pom.xml
+++ b/extensions/spring-security/deployment/pom.xml
@@ -35,16 +35,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.enterprise</groupId>
-                    <artifactId>cdi-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-test-utils</artifactId>
             <scope>test</scope>

--- a/extensions/undertow/runtime/pom.xml
+++ b/extensions/undertow/runtime/pom.xml
@@ -23,16 +23,6 @@
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.enterprise</groupId>
-                    <artifactId>cdi-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -34,16 +34,6 @@
             <artifactId>smallrye-common-vertx-context</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.enterprise</groupId>
-                    <artifactId>cdi-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>

--- a/extensions/websockets/client/runtime/pom.xml
+++ b/extensions/websockets/client/runtime/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.security</groupId>
-            <artifactId>quarkus-security</artifactId>
+            <artifactId>quarkus-security-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.websocket</groupId>


### PR DESCRIPTION
Fixes #40417.
Depends on https://github.com/quarkusio/quarkus-security/pull/41.

This PR changes `io.quarkus.security:quarkus-security` dependency to `io.quarkus.security:quarkus-security-api`.
I've removed the old `io.quarkus.security:quarkus-security` dependency from some extensions where `io.quarkus:quarkus-security`, or `io.quarkus:quarkus-security-api` or `io.quarkus:quarkus-security-runtime-spi` already exist.

As far as relocations are concerned, Quarkus core extensions are most likely the only consumers of the old `io.quarkus.security:quarkus-security` dependency.  Any extension in Quarkus or Quarkiverse or elsewhere, if it needs it, shoud get it indirectly from `io.quarkus:quarkus-security`, or `io.quarkus:quarkus-security-api` or `io.quarkus:quarkus-security-runtime-spi` or other security and vert.x extensions which depend on it.
 
The `relocations` in the core repository manages the relocation from the `io.quarkus` group. If it is really needed then it would have to be added as part of https://github.com/quarkusio/quarkus-security/pull/41.