### PR TITLE
Experimental Loomania blocking pool

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -229,6 +229,7 @@
         <prometheus.version>0.16.0</prometheus.version>
         <!-- Dev UI -->
         <importmap.version>1.0.10</importmap.version>
+        <loomania.version>2.0</loomania.version>
     </properties>
 
     <dependencyManagement>
@@ -6266,6 +6267,11 @@
                 <groupId>io.github.crac</groupId>
                 <artifactId>org-crac</artifactId>
                 <version>${org-crac.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.dmlloyd</groupId>
+                <artifactId>loomania</artifactId>
+                <version>${loomania.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.dajudge.kindcontainer</groupId>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -28,6 +28,10 @@
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.dmlloyd</groupId>
+            <artifactId>loomania</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-os</artifactId>
         </dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -100,7 +100,9 @@
                             <junit.quarkus.orderer.secondary-orderer>
                                 org.junit.jupiter.api.ClassOrderer$OrderAnnotation
                             </junit.quarkus.orderer.secondary-orderer>
+                            <exp.quarkus.virtual-blocking-pool>true</exp.quarkus.virtual-blocking-pool>
                         </systemPropertyVariables>
+                        <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED</argLine>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
This implements a global switch which turns on Loomania for the normal blocking thread pool executor.  Possibly useful for playing around and getting benchmark data (apples-to-apples versus a "plain" blocking pool).

* Uses our `EnhancedQueueExecutor` as the backing pool (instead of the JDK-default `ForkJoinPool`)
* Global, all-or-nothing switch
* Unknown performance impact
* Unknown memory impact
* Should improve thread density
* All integration tests run with the virtual thread facade, for the purposes of testing

/cc @franz1981, @cescoffier