### PR TITLE
Add Warning Log for 503 Responses Due to Thread Pool Exhaustion

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -96,7 +96,8 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
             }
 
             if (event.failure() instanceof RejectedExecutionException) {
-                // No more worker threads - return a 503
+                log.warn(
+                        "Worker thread pool exhaustion, no more worker threads available - returning a `503 - SERVICE UNAVAILABLE` response.");
                 event.response().setStatusCode(HttpResponseStatus.SERVICE_UNAVAILABLE.code()).end();
                 return;
             }


### PR DESCRIPTION
This commit introduces a warning log message when a 503 response is returned due to thread pool exhaustion. Previously, no server-side log was generated in such scenarios.

The log message is categorized as a warning, as this is not an exceptional situation. Despite the thread pool exhaustion, reactive endpoints and virtual threads can still operate successfully.

@maxandersen @franz1981 As discussed yesterday. 
