### PR TITLE
Label WebSocket Next as Experimental in Documentation

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -12,9 +12,9 @@ include::_attributes.adoc[]
 :categories: web
 :topics: web,websockets
 :extensions: io.quarkus:quarkus-websockets-next
+:extension-status: experimental
 
-The `websockets-next` extension provides an experimental API to define  _WebSocket_ endpoints declaratively.
-The proposed API may change in future releases.
+include::{includes}/extension-status.adoc[]
 
 == The WebSocket protocol
 

--- a/docs/src/main/asciidoc/websockets-next-tutorial.adoc
+++ b/docs/src/main/asciidoc/websockets-next-tutorial.adoc
@@ -10,11 +10,13 @@ include::_attributes.adoc[]
 :summary: This guide explains how your Quarkus application can utilize web sockets to create interactive web applications. This guide uses the WebSockets Next extension
 :topics: web,websockets
 :extensions: io.quarkus:quarkus-websockets-next
+:extension-status: experimental
 
 This guide explains how your Quarkus application can utilize web sockets to create interactive web applications.
 In this guide, we will develop a very simple chat application using web sockets to receive and send messages to the other connected users.
 
-IMPORTANT: The `websockets-next` extension is experimental. The proposal API may change in future releases.
+include::{includes}/extension-status.adoc[]
+
 
 == Prerequisites
 


### PR DESCRIPTION
This commit updates the quickstart and reference guides for the websocket-next extension to reflect its experimental status correctly. Previously, these guides lacked the appropriate header and warning/information admonition; they were only written in the guides' text.


@mkouba @maxandersen As discussed during the insights yesterday.