### PR TITLE
Fix configuration table filter and row collapse/expansion in guides

### DIFF
--- a/docs/src/main/asciidoc/javascript/config.js
+++ b/docs/src/main/asciidoc/javascript/config.js
@@ -13,7 +13,7 @@ if(tables){
             var input = caption.firstElementChild.lastElementChild;
             input.addEventListener("keyup", initiateSearch);
             input.addEventListener("input", initiateSearch);
-            input.attributes.removeNamedItem('disabled');
+            if (input.attributes.disabled) input.attributes.removeNamedItem('disabled');
             inputs[input.id] = {"table": table};
         }
 


### PR DESCRIPTION
This is a fix for the filter on top of the configuration reference tables in the guides.

The filter is currently failing because when the table is configured, it is attempted to remove a non-existing `disabled` attribute from the input field. The call fails (at least in my setup, FF 125 on Linux) which leaves the table and search fields in an inconsistent state; typing in the field does not filter and row collapse/expansion does not work.