### PR TITLE
WebSockets Next: initial version of security integration

### DIFF
--- a/docs/src/main/asciidoc/security-overview.adoc
+++ b/docs/src/main/asciidoc/security-overview.adoc
@@ -53,6 +53,12 @@ For guidance on testing Quarkus Security features and ensuring that your Quarkus
 
 == More about security features in Quarkus
 
+=== WebSockets Next security
+
+The `quarkus-websockets-next` extension provides a modern, efficient implementation of the WebSocket API.
+It also provides an integration with Quarkus security.
+For more information, see the xref:websockets-next-reference.adoc#websocket-next-security[Security] section of the Quarkus "WebSockets Next reference" guide.
+
 [[cross-origin-resource-sharing]]
 === Cross-origin resource sharing
 

--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -574,6 +574,67 @@ void pong(Buffer data) {
 }
 ----
 
+[[websocket-next-security]]
+== Security
+
+WebSocket endpoint callback methods can be secured with security annotations such as `io.quarkus.security.Authenticated`,
+`jakarta.annotation.security.RolesAllowed` and other annotations listed in the xref:security-authorize-web-endpoints-reference.adoc#standard-security-annotations[Supported security annotations] documentation.
+
+For example:
+
+[source, java]
+----
+package io.quarkus.websockets.next.test.security;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/end")
+public class Endpoint {
+
+    @Inject
+    SecurityIdentity currentIdentity;
+
+    @OnOpen
+    String open() {
+        return "ready";
+    }
+
+    @RolesAllowed("admin")
+    @OnTextMessage
+    String echo(String message) { <1>
+        return message;
+    }
+
+    @OnError
+    String error(ForbiddenException t) { <2>
+        return "forbidden:" + currentIdentity.getPrincipal().getName();
+    }
+}
+----
+<1> The echo callback method can only be invoked if the current security identity has an `admin` role.
+<2> The error handler is invoked in case of the authorization failure.
+
+`SecurityIdentity` is initially created during a secure HTTP upgrade and associated with the websocket connection.
+
+Currently, for an HTTP upgrade be secured, users must configure an HTTP policy protecting the HTTP upgrade path.
+For example, to secure the `open()` method in the above websocket endpoint, one can add the following authentication policy:
+
+[source,properties]
+----
+quarkus.http.auth.permission.secured.paths=/end
+quarkus.http.auth.permission.secured.policy=authenticated
+----
+
+Other options for securing HTTP upgrade requests, such as using the security annotations, will be explored in the future.
+
 [[websocket-next-configuration-reference]]
 == Configuration reference
 

--- a/extensions/websockets-next/deployment/pom.xml
+++ b/extensions/websockets-next/deployment/pom.xml
@@ -38,6 +38,16 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/RuntimeErrorTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/RuntimeErrorTest.java
@@ -80,8 +80,8 @@ public class RuntimeErrorTest {
         Uni<Void> runtimeProblem(RuntimeException e, WebSocketConnection connection) {
             assertTrue(Context.isOnEventLoopThread());
             assertEquals(connection.id(), this.connection.id());
-            // The request context from @OnBinaryMessage is reused
-            assertEquals("ok", requestBean.getState());
+            // A new request context is used
+            assertEquals("nok", requestBean.getState());
             return connection.sendText(e.getMessage());
         }
 

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UniFailureErrorTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UniFailureErrorTest.java
@@ -80,8 +80,8 @@ public class UniFailureErrorTest {
         String runtimeProblem(RuntimeException e, WebSocketConnection connection) {
             assertTrue(Context.isOnWorkerThread());
             assertEquals(connection.id(), this.connection.id());
-            // The request context from @OnBinaryMessage is reused
-            assertEquals("ok", requestBean.getState());
+            // A new request context is used
+            assertEquals("nok", requestBean.getState());
             return e.getMessage();
         }
 

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/AdminService.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/AdminService.java
@@ -1,0 +1,14 @@
+package io.quarkus.websockets.next.test.security;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@RolesAllowed("admin")
+@ApplicationScoped
+public class AdminService {
+
+    public String ping() {
+        return "" + 24;
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/EagerSecurityTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/EagerSecurityTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.websockets.next.test.security;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.utils.WSClient;
+
+public class EagerSecurityTest extends SecurityTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=true\n" +
+                            "quarkus.http.auth.permission.secured.paths=/end\n" +
+                            "quarkus.http.auth.permission.secured.policy=authenticated\n"), "application.properties")
+                    .addClasses(Endpoint.class, WSClient.class, TestIdentityProvider.class, TestIdentityController.class));
+
+    @Authenticated
+    @WebSocket(path = "/end")
+    public static class Endpoint {
+
+        @Inject
+        CurrentIdentityAssociation currentIdentity;
+
+        @OnOpen
+        String open() {
+            return "ready";
+        }
+
+        @RolesAllowed("admin")
+        @OnTextMessage
+        String echo(String message) {
+            if (!currentIdentity.getIdentity().hasRole("admin")) {
+                throw new IllegalStateException();
+            }
+            return message;
+        }
+
+        @OnError
+        String error(ForbiddenException t) {
+            return "forbidden:" + currentIdentity.getIdentity().getPrincipal().getName();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/EagerSecurityUniTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/EagerSecurityUniTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.websockets.next.test.security;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.smallrye.mutiny.Uni;
+
+public class EagerSecurityUniTest extends SecurityTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=true\n" +
+                            "quarkus.http.auth.permission.secured.paths=/end\n" +
+                            "quarkus.http.auth.permission.secured.policy=authenticated\n"), "application.properties")
+                    .addClasses(Endpoint.class, WSClient.class, TestIdentityProvider.class, TestIdentityController.class));
+
+    @Authenticated
+    @WebSocket(path = "/end")
+    public static class Endpoint {
+
+        @Inject
+        CurrentIdentityAssociation currentIdentity;
+
+        @OnOpen
+        String open() {
+            return "ready";
+        }
+
+        @RolesAllowed("admin")
+        @OnTextMessage
+        Uni<String> echo(String message) {
+            if (!currentIdentity.getIdentity().hasRole("admin")) {
+                throw new IllegalStateException();
+            }
+            return Uni.createFrom().item(message);
+        }
+
+        @OnError
+        String error(ForbiddenException t) {
+            return "forbidden:" + currentIdentity.getIdentity().getPrincipal().getName();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/LazySecurityTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/LazySecurityTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.websockets.next.test.security;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.security.EagerSecurityTest.Endpoint;
+import io.quarkus.websockets.next.test.utils.WSClient;
+
+public class LazySecurityTest extends SecurityTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n" +
+                            "quarkus.http.auth.permission.secured.paths=/end\n" +
+                            "quarkus.http.auth.permission.secured.policy=authenticated\n"), "application.properties")
+                    .addClasses(Endpoint.class, WSClient.class, TestIdentityProvider.class, TestIdentityController.class));
+
+    @Authenticated
+    @WebSocket(path = "/end")
+    public static class Endpoint {
+
+        @Inject
+        CurrentIdentityAssociation currentIdentity;
+
+        @OnOpen
+        String open() {
+            return "ready";
+        }
+
+        @RolesAllowed("admin")
+        @OnTextMessage
+        String echo(String message) {
+            if (!currentIdentity.getIdentity().hasRole("admin")) {
+                throw new IllegalStateException();
+            }
+            return message;
+        }
+
+        @OnError
+        String error(ForbiddenException t) {
+            return "forbidden:" + currentIdentity.getIdentity().getPrincipal().getName();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/LazySecurityUniTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/LazySecurityUniTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.websockets.next.test.security;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.smallrye.mutiny.Uni;
+
+public class LazySecurityUniTest extends SecurityTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n" +
+                            "quarkus.http.auth.permission.secured.paths=/end\n" +
+                            "quarkus.http.auth.permission.secured.policy=authenticated\n"), "application.properties")
+                    .addClasses(Endpoint.class, WSClient.class, TestIdentityProvider.class, TestIdentityController.class));
+
+    @Authenticated
+    @WebSocket(path = "/end")
+    public static class Endpoint {
+
+        @Inject
+        CurrentIdentityAssociation currentIdentity;
+
+        @OnOpen
+        String open() {
+            return "ready";
+        }
+
+        @RolesAllowed("admin")
+        @OnTextMessage
+        Uni<String> echo(String message) {
+            if (!currentIdentity.getIdentity().hasRole("admin")) {
+                throw new IllegalStateException();
+            }
+            return Uni.createFrom().item(message);
+        }
+
+        @OnError
+        String error(ForbiddenException t) {
+            return "forbidden:" + currentIdentity.getIdentity().getPrincipal().getName();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/RbacServiceSecurityTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/RbacServiceSecurityTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.websockets.next.test.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+
+public class RbacServiceSecurityTest extends SecurityTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(Endpoint.class, AdminService.class, UserService.class,
+                    TestIdentityProvider.class, TestIdentityController.class, WSClient.class));
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("end")
+    URI endUri;
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void testEndpoint() {
+        try (WSClient client = new WSClient(vertx)) {
+            client.connect(basicAuth("admin", "admin"), endUri);
+            client.sendAndAwait("hello"); // admin service
+            client.sendAndAwait("hi"); // forbidden
+            client.waitForMessages(2);
+            assertEquals(Set.of("24", "forbidden"), Set.copyOf(client.getMessages().stream().map(Object::toString).toList()));
+        }
+        try (WSClient client = new WSClient(vertx)) {
+            client.connect(basicAuth("user", "user"), endUri);
+            client.sendAndAwait("hello"); // forbidden
+            client.sendAndAwait("hi"); // user service
+            client.waitForMessages(2);
+            assertEquals(Set.of("42", "forbidden"), Set.copyOf(client.getMessages().stream().map(Object::toString).toList()));
+        }
+    }
+
+    @WebSocket(path = "/end")
+    public static class Endpoint {
+
+        @Inject
+        UserService userService;
+
+        @Inject
+        AdminService adminService;
+
+        @OnTextMessage
+        String echo(String message) {
+            return message.equals("hello") ? adminService.ping() : userService.ping();
+        }
+
+        @OnError
+        String error(ForbiddenException t) {
+            return "forbidden";
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/SecurityTestBase.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/SecurityTestBase.java
@@ -1,0 +1,71 @@
+package io.quarkus.websockets.next.test.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.CompletionException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.UpgradeRejectedException;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
+
+public abstract class SecurityTestBase {
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("end")
+    URI endUri;
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void testEndpoint() {
+        try (WSClient client = new WSClient(vertx)) {
+            CompletionException ce = assertThrows(CompletionException.class, () -> client.connect(endUri));
+            Throwable root = ExceptionUtil.getRootCause(ce);
+            assertTrue(root instanceof UpgradeRejectedException);
+            assertTrue(root.getMessage().contains("401"));
+        }
+        try (WSClient client = new WSClient(vertx)) {
+            client.connect(basicAuth("admin", "admin"), endUri);
+            client.waitForMessages(1);
+            assertEquals("ready", client.getMessages().get(0).toString());
+            client.sendAndAwait("hello");
+            client.waitForMessages(2);
+            assertEquals("hello", client.getMessages().get(1).toString());
+        }
+        try (WSClient client = new WSClient(vertx)) {
+            client.connect(basicAuth("user", "user"), endUri);
+            client.waitForMessages(1);
+            assertEquals("ready", client.getMessages().get(0).toString());
+            client.sendAndAwait("hello");
+            client.waitForMessages(2);
+            assertEquals("forbidden:user", client.getMessages().get(1).toString());
+        }
+    }
+
+    static WebSocketConnectOptions basicAuth(String username, String password) {
+        return new WebSocketConnectOptions().addHeader(HttpHeaders.AUTHORIZATION.toString(),
+                new UsernamePasswordCredentials(username, password).applyHttpChallenge(null).toHttpAuthorization());
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/UserService.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/security/UserService.java
@@ -1,0 +1,14 @@
+package io.quarkus.websockets.next.test.security;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@RolesAllowed("user")
+@ApplicationScoped
+public class UserService {
+
+    public String ping() {
+        return "" + 42;
+    }
+
+}

--- a/extensions/websockets-next/runtime/pom.xml
+++ b/extensions/websockets-next/runtime/pom.xml
@@ -26,6 +26,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
+        <!-- Quarkus Security API -->
+        <dependency>
+            <groupId>io.quarkus.security</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/ContextSupport.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/ContextSupport.java
@@ -36,7 +36,6 @@ public class ContextSupport {
     void start(ContextState requestContextState) {
         LOG.debugf("Start contexts: %s", connection);
         startSession();
-        // Activate a new request context
         requestContext.activate(requestContextState);
     }
 

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/SecuritySupport.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/SecuritySupport.java
@@ -1,0 +1,32 @@
+package io.quarkus.websockets.next.runtime;
+
+import java.util.Objects;
+
+import jakarta.enterprise.inject.Instance;
+
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
+
+public class SecuritySupport {
+
+    static final SecuritySupport NOOP = new SecuritySupport(null, null);
+
+    private final Instance<CurrentIdentityAssociation> currentIdentity;
+    private final SecurityIdentity identity;
+
+    SecuritySupport(Instance<CurrentIdentityAssociation> currentIdentity, SecurityIdentity identity) {
+        this.currentIdentity = currentIdentity;
+        this.identity = currentIdentity != null ? Objects.requireNonNull(identity) : identity;
+    }
+
+    /**
+     * This method is called before an endpoint callback is invoked.
+     */
+    void start() {
+        if (currentIdentity != null) {
+            CurrentIdentityAssociation current = currentIdentity.get();
+            current.setIdentity(identity);
+        }
+    }
+
+}

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
@@ -115,7 +115,7 @@ public class WebSocketConnectorImpl<CLIENT> extends WebSocketConnectorBase<WebSo
                     connectionManager.add(clientEndpoint.generatedEndpointClass, connection);
 
                     Endpoints.initialize(vertx, Arc.container(), codecs, connection, ws,
-                            clientEndpoint.generatedEndpointClass, config.autoPingInterval(),
+                            clientEndpoint.generatedEndpointClass, config.autoPingInterval(), SecuritySupport.NOOP,
                             () -> {
                                 connectionManager.remove(clientEndpoint.generatedEndpointClass, connection);
                                 client.close();

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
@@ -1,21 +1,29 @@
 package io.quarkus.websockets.next.runtime;
 
+import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import jakarta.enterprise.inject.Instance;
 
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.quarkus.websockets.next.WebSocketServerException;
 import io.quarkus.websockets.next.WebSocketsServerRuntimeConfig;
 import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.ServerWebSocket;
+import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 
 @Recorder
@@ -46,6 +54,34 @@ public class WebSocketServerRecorder {
         };
     }
 
+    public Consumer<Route> initializeSecurityHandler() {
+        return new Consumer<Route>() {
+
+            @Override
+            public void accept(Route route) {
+                // Force authentication so that it's possible to capture the SecurityIdentity before the HTTP upgrade
+                route.handler(new Handler<RoutingContext>() {
+
+                    @Override
+                    public void handle(RoutingContext ctx) {
+                        if (ctx.user() == null) {
+                            Uni<SecurityIdentity> deferredIdentity = ctx
+                                    .<Uni<SecurityIdentity>> get(QuarkusHttpUser.DEFERRED_IDENTITY_KEY);
+                            deferredIdentity.subscribe().with(i -> {
+                                if (ctx.response().ended()) {
+                                    return;
+                                }
+                                ctx.next();
+                            }, ctx::fail);
+                        } else {
+                            ctx.next();
+                        }
+                    }
+                });
+            }
+        };
+    }
+
     public Handler<RoutingContext> createEndpointHandler(String generatedEndpointClass, String endpointId) {
         ArcContainer container = Arc.container();
         ConnectionManager connectionManager = container.instance(ConnectionManager.class).get();
@@ -54,6 +90,8 @@ public class WebSocketServerRecorder {
 
             @Override
             public void handle(RoutingContext ctx) {
+                SecuritySupport securitySupport = initializeSecuritySupport(container, ctx);
+
                 Future<ServerWebSocket> future = ctx.request().toWebSocket();
                 future.onSuccess(ws -> {
                     Vertx vertx = VertxCoreRecorder.getVertx().get();
@@ -64,10 +102,24 @@ public class WebSocketServerRecorder {
                     LOG.debugf("Connection created: %s", connection);
 
                     Endpoints.initialize(vertx, container, codecs, connection, ws, generatedEndpointClass,
-                            config.autoPingInterval(), () -> connectionManager.remove(generatedEndpointClass, connection));
+                            config.autoPingInterval(), securitySupport,
+                            () -> connectionManager.remove(generatedEndpointClass, connection));
                 });
             }
         };
+    }
+
+    SecuritySupport initializeSecuritySupport(ArcContainer container, RoutingContext ctx) {
+        Instance<CurrentIdentityAssociation> currentIdentityAssociation = container.select(CurrentIdentityAssociation.class);
+        if (currentIdentityAssociation.isResolvable()) {
+            // Security extension is present
+            // Obtain the current security identity from the handshake request
+            QuarkusHttpUser user = (QuarkusHttpUser) ctx.user();
+            if (user != null) {
+                return new SecuritySupport(currentIdentityAssociation, user.getSecurityIdentity());
+            }
+        }
+        return SecuritySupport.NOOP;
     }
 
 }


### PR DESCRIPTION
- also create a new Vertx duplicated context for error handler invocation

This is the initial POC for security integration. When `quarkus-security` is present and `quarkus.http.auth.proactive=false`, then we force the authentication before the HTTP upgrade so that it's possible to capture the `SecurityIdentity` and set it afterwards for all endpoint callbacks.

- Fixes: #40312

CC @sberyozkin @michalvavrik 