### PR TITLE
Support for OIDC session expired page

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1105,6 +1105,16 @@ You can further optimize this process by having a simple JavaScript function pin
 
 [NOTE]
 ====
+When the session can not be refreshed, the currently authenticated user is redirected to the OIDC provider to re-authenticate. However, the user experience may not be ideal in such cases, if the user, after an earlier successful authentication, is suddently seeing an OIDC authentication challenge screen when trying to access an application page.
+
+Instead, you can request that the user is redirected to a public, application specific session expired page first. This page informs the user that the session has now expired and advise to re-authenticate by following a link to a secured application welcome page. The user clicks on the link and Quarkus OIDC enforces a redirect to the OIDC provider to re-authenticate. Use `quarkus.oidc.authentication.session-expired-page` relative path property, if you'd like to do it.
+
+For example, setting `quarkus.oidc.authentication.session-expired-page=/session-expired-page` will ensure that the user whose session has expired is redirected to  `http://localhost:8080/session-expired-page`, assuming the application is available at `http://localhost:8080`.
+====
+
+
+[NOTE]
+====
 You cannot extend the user session indefinitely.
 The returning user with the expired ID token will have to re-authenticate at the OIDC provider endpoint once the refresh token has expired.
 ====

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -981,6 +981,21 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<String> errorPath = Optional.empty();
 
         /**
+         * Relative path to the public endpoint which an authenticated user is redirected to when the session has expired.
+         * <p>
+         * When the OIDC session has expired and the session can not be refreshed, a user is redirected
+         * to the OIDC provider to re-authenticate. The user experience may not be ideal in this case
+         * as it may not be obvious to the authenticated user why an authentication challenge is returned.
+         * <p>
+         * Set this property if you would like the user whose session has expired be redirected to a public application specific
+         * page
+         * instead, which can inform that the session has expired and advise the user to re-authenticated by following
+         * a link to the secured initial entry page.
+         */
+        @ConfigItem
+        public Optional<String> sessionExpiredPath = Optional.empty();
+
+        /**
          * Both ID and access tokens are fetched from the OIDC provider as part of the authorization code flow.
          * <p>
          * ID token is always verified on every user request as the primary token which is used
@@ -1464,6 +1479,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setStateCookieAge(Duration stateCookieAge) {
             this.stateCookieAge = stateCookieAge;
+        }
+
+        public Optional<String> getSessionExpiredPath() {
+            return sessionExpiredPath;
+        }
+
+        public void setSessionExpiredPath(String sessionExpiredPath) {
+            this.sessionExpiredPath = Optional.of(sessionExpiredPath);
         }
     }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -89,6 +89,7 @@ quarkus.oidc.tenant-refresh.credentials.secret=secret
 quarkus.oidc.tenant-refresh.application-type=web-app
 quarkus.oidc.tenant-refresh.authentication.cookie-path=/tenant-refresh
 quarkus.oidc.tenant-refresh.authentication.session-age-extension=2M
+quarkus.oidc.tenant-refresh.authentication.session-expired-path=/session-expired-page
 quarkus.oidc.tenant-refresh.token.refresh-expired=true
 
 quarkus.oidc.tenant-autorefresh.auth-server-url=${quarkus.oidc.auth-server-url}
@@ -203,4 +204,4 @@ quarkus.log.category."io.quarkus.resteasy.runtime.UnauthorizedExceptionMapper".l
 quarkus.log.category."io.quarkus.vertx.http.runtime.security.HttpAuthenticator".level=DEBUG
 quarkus.log.category."io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder".level=DEBUG
 
-quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
+quarkus.log.category."com.gargoylesoftware.htmlunit".level=ERROR

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -751,6 +751,8 @@ public class CodeFlowTest {
 
                             if (statusCode == 302) {
                                 assertNull(getSessionCookie(webClient, "tenant-refresh"));
+                                assertEquals("http://localhost:8081/session-expired-page",
+                                        webResponse.getResponseHeaderValue("location"));
                                 return true;
                             }
 


### PR DESCRIPTION
Currently, a user whose session has expired or no longer can be refreshed (for example, RT itself is no longer valid) is redirected  to the OIDC provider to re-authenticate which can offer a poor UX. For example, imagine a user who has authenticated is accessing an application page after some idle time and is seeing an authentication challenge screen, instead of a friendly page which informs the user, your session has expired, follow this link to re-authenticate. 

This is exactly what this PR does, lets users configure a session expired page where a user whose session has expired or no longer can be refreshed is redirected to this page from where the user can again re-login, but in a normal interactive way.
One of the tests has been updated to confirm a redirect to such a page is initiated. Docs have been updated.  

- Fixes: #40289

CC @calvernaz

