### PR TITLE
More classloaders cleanup

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/IoUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/IoUtil.java
@@ -6,17 +6,40 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class IoUtil {
+
+    /**
+     * Returns an input stream for reading the specified resource from the specified ClassLoader.
+     * This might return {@code null}, in the case there is no matching resource.
+     *
+     * @param classLoader
+     * @param className
+     * @return
+     */
     public static InputStream readClass(ClassLoader classLoader, String className) {
         return classLoader.getResourceAsStream(fromClassNameToResourceName(className));
     }
 
+    /**
+     * Returns an byte array representing the content of the specified resource as loaded
+     * from the specified ClassLoader.
+     * This might return {@code null}, in the case there is no matching resource.
+     *
+     * @param classLoader
+     * @param className
+     * @return
+     */
     public static byte[] readClassAsBytes(ClassLoader classLoader, String className) throws IOException {
         try (InputStream stream = readClass(classLoader, className)) {
-            return readBytes(stream);
+            if (stream == null) {
+                return null;
+            } else {
+                return readBytes(stream);
+            }
         }
     }
 
     public static byte[] readBytes(InputStream is) throws IOException {
         return is.readAllBytes();
     }
+
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
@@ -150,10 +150,10 @@ public class JarClassPathElement implements ClassPathElement {
                                     public byte[] apply(JarFile jarFile) {
                                         try {
                                             try {
-                                                return readStreamContents(jarFile.getInputStream(res));
+                                                return jarFile.getInputStream(res).readAllBytes();
                                             } catch (InterruptedIOException e) {
                                                 //if we are interrupted reading data we finish the op, then just re-interrupt the thread state
-                                                byte[] bytes = readStreamContents(jarFile.getInputStream(res));
+                                                byte[] bytes = jarFile.getInputStream(res).readAllBytes();
                                                 Thread.currentThread().interrupt();
                                                 return bytes;
                                             }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -634,7 +634,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
             //DriverManager only lets you remove drivers with the same CL as the caller
             //so we need do define the cleaner in this class loader
             try (InputStream is = getClass().getResourceAsStream("DriverRemover.class")) {
-                byte[] data = JarClassPathElement.readStreamContents(is);
+                byte[] data = is.readAllBytes();
                 Runnable r = (Runnable) defineClass(DriverRemover.class.getName(), data, 0, data.length)
                         .getConstructor(ClassLoader.class).newInstance(this);
                 r.run();


### PR DESCRIPTION
A very minor cleanup, but paving the road for other PRs which would otherwise depend on this.

 - Stop using `JarClassPathElement`.`readStreamContents(InputStream)` which has been deprecated for years
 - actually resolves a performance issue as this method is far less efficient in loading resources than the newly available alternatives
 - prepare `IoUtil` to be reused more by upcoming improvements in the Hibernate extension

I haven't deleted `readStreamContents` yet as there are some tests using it still.