### PR TITLE
Avoid using the same directory twice in Maven ITs

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateJBangProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateJBangProjectMojoIT.java
@@ -27,7 +27,7 @@ public class CreateJBangProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
 
     @Test
     public void testProjectGeneration() throws MavenInvocationException, IOException {
-        testDir = initEmptyProject("projects/project-generation");
+        testDir = initEmptyProject("projects/jbang-project-generation");
         assertThat(testDir).isDirectory();
         invoker = initInvoker(testDir);
 


### PR DESCRIPTION
Doesn't work very well on Windows CI as deleting files can be problematic.
See:
https://github.com/quarkusio/quarkus/pull/40537#issuecomment-2103146744