### PR TITLE
Bump smallrye-jwt version to 4.5.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -57,7 +57,7 @@
         <smallrye-open-api.version>3.10.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.8.3</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.3.0</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>4.5.1</smallrye-jwt.version>
+        <smallrye-jwt.version>4.5.2</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -1106,6 +1106,7 @@ SmallRye JWT provides more properties which can be used to customize the token p
 |smallrye.jwt.keystore.verify.key.alias||This property has to be set to identify a public verification key which will be extracted from `KeyStore` from a matching certificate if `mp.jwt.verify.publickey.location` points to a `KeyStore` file.
 |smallrye.jwt.keystore.decrypt.key.alias||This property has to be set to identify a private decryption key if `mp.jwt.decrypt.key.location` points to a `KeyStore` file.
 |smallrye.jwt.keystore.decrypt.key.password||This property may be set if a private decryption key's password in `KeyStore` is different to `smallrye.jwt.keystore.password` when `mp.jwt.decrypt.key.location` points to a `KeyStore` file.
+|smallrye.jwt.resolve-remote-keys-at-startup|false|Set this property to true to resolve the remote keys at the application startup.
 |===
 
 == References


### PR DESCRIPTION
This version has the following improvements and bug fixes:
* Controlling the time at which remote keys can be fetched, done by @laDok8
* Two bug fixes related to the way Elliptic EdDsa algorithm is handled, done by @Eng-Fouad 