### PR TITLE
Allow extension to define CLI plugins with aliases

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/Plugin.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/Plugin.java
@@ -80,6 +80,10 @@ public class Plugin {
         return catalogLocation;
     }
 
+    public Plugin withName(String name) {
+        return new Plugin(name, type, location, description, catalogLocation, inUserCatalog);
+    }
+
     public Plugin withDescription(Optional<String> description) {
         return new Plugin(name, type, location, description, catalogLocation, inUserCatalog);
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerUtil.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerUtil.java
@@ -10,6 +10,7 @@ import io.quarkus.maven.dependency.GACTV;
 
 public class PluginManagerUtil {
 
+    static final String ALIAS_SEPARATOR = ": ";
     private static final Pattern CLI_SUFFIX = Pattern.compile("(\\-cli)(@\\w+)?$");
 
     private final PluginManagerSettings settings;
@@ -32,13 +33,29 @@ public class PluginManagerUtil {
      * @param the location
      * @return the {@link Plugin} that corresponds to the location.
      */
-    public Plugin from(String location) {
+    public Plugin fromLocation(String location) {
         Optional<URL> url = PluginUtil.checkUrl(location);
         Optional<Path> path = PluginUtil.checkPath(location);
         Optional<GACTV> gactv = PluginUtil.checkGACTV(location);
         String name = getName(gactv, url, path);
         PluginType type = PluginUtil.getType(gactv, url, path);
         return new Plugin(name, type, Optional.of(location), Optional.empty());
+    }
+
+    /**
+     * Create a {@link Plugin} from the specified alias.
+     *
+     * @param alias (e.g. name: location)
+     * @return the {@link Plugin} that corresponds to the alias.
+     */
+    public Plugin fromAlias(String alias) {
+        String name = null;
+        String location = alias;
+        if (alias.contains(ALIAS_SEPARATOR)) {
+            name = alias.substring(0, alias.indexOf(ALIAS_SEPARATOR)).trim();
+            location = alias.substring(alias.indexOf(ALIAS_SEPARATOR) + 1).trim();
+        }
+        return fromLocation(location).withName(name);
     }
 
     /**

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginUtil.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginUtil.java
@@ -5,6 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -136,7 +137,7 @@ public final class PluginUtil {
      */
     public static Optional<Path> checkPath(String location) {
         try {
-            return Optional.of(Path.of(location));
+            return Optional.of(Paths.get(location));
         } catch (InvalidPathException | NullPointerException e) {
             return Optional.empty();
         }

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/cli/plugin/PluginManagerUtilTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/cli/plugin/PluginManagerUtilTest.java
@@ -49,20 +49,41 @@ public class PluginManagerUtilTest {
     public void shouldGetPluginFromLocation() {
         PluginManagerUtil util = PluginManagerUtil.getUtil();
 
-        Plugin p = util.from("http://shomehost/some/path/my.jar");
+        Plugin p = util.fromLocation("http://shomehost/some/path/my.jar");
         assertEquals("my", p.getName());
         assertEquals(PluginType.jar, p.getType());
 
-        p = util.from("/some/path/my.jar");
+        p = util.fromLocation("/some/path/my.jar");
         assertEquals("my", p.getName());
         assertEquals(PluginType.jar, p.getType());
 
-        p = util.from("my.group:my-artifact-cli:my.version");
+        p = util.fromLocation("my.group:my-artifact-cli:my.version");
         assertEquals("my-artifact", p.getName());
         assertEquals(PluginType.maven, p.getType());
 
-        p = util.from("quarkus-alias");
+        p = util.fromLocation("quarkus-alias");
         assertEquals("alias", p.getName());
+        assertEquals(PluginType.jbang, p.getType());
+    }
+
+    @Test
+    public void shouldGetPluginFromAliasedLocation() {
+        PluginManagerUtil util = PluginManagerUtil.getUtil();
+
+        Plugin p = util.fromAlias("my-alias: http://shomehost/some/path/my.jar");
+        assertEquals("my-alias", p.getName());
+        assertEquals(PluginType.jar, p.getType());
+
+        p = util.fromAlias("my-alias: /some/path/my.jar");
+        assertEquals("my-alias", p.getName());
+        assertEquals(PluginType.jar, p.getType());
+
+        p = util.fromAlias("my-alias: my.group:my-artifact-cli:my.version");
+        assertEquals("my-alias", p.getName());
+        assertEquals(PluginType.maven, p.getType());
+
+        p = util.fromAlias("my-alias: quarkus-alias");
+        assertEquals("my-alias", p.getName());
         assertEquals(PluginType.jbang, p.getType());
     }
 }


### PR DESCRIPTION
Currently, when an extension defines a plugin, the name is inferred by the artifact id. In some cases that can be annoying and this pull request addresses that, by optionally allowing user to specify the `alias` they need.