### PR TITLE
Panache: allow caching of extended enhancement of entities

### DIFF
--- a/extensions/panache/panache-hibernate-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheHibernateCommonResourceProcessor.java
+++ b/extensions/panache/panache-hibernate-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheHibernateCommonResourceProcessor.java
@@ -125,6 +125,7 @@ public final class PanacheHibernateCommonResourceProcessor {
         // transform all users of those classes
         for (String entityClassName : entitiesWithExternallyAccessibleFields) {
             for (ClassInfo userClass : index.getIndex().getKnownUsers(entityClassName)) {
+                //N.B. getKnownUsers(entityClassName) will include also the entityClassName
                 String cn = userClass.name().toString('.');
                 if (produced.contains(cn)) {
                     continue;
@@ -134,9 +135,10 @@ public final class PanacheHibernateCommonResourceProcessor {
                 //It shouldn't be too hard to improve on this by checking the related entities haven't been changed
                 //via LiveReloadBuildItem (#isLiveReload() && #getChangeInformation()) but I'm not comfortable in making this
                 //change without having solid integration tests.
+                final boolean cacheAble = entityClassName.equals(cn);//This case is always safe as the transformation would only depend on itself
                 final BytecodeTransformerBuildItem transformation = new BytecodeTransformerBuildItem.Builder()
                         .setClassToTransform(cn)
-                        .setCacheable(false)//TODO this would be nice to improve on: see note above.
+                        .setCacheable(cacheAble)
                         .setVisitorFunction(panacheFieldAccessEnhancer)
                         .setRequireConstPoolEntry(entityClassNamesInternal)
                         .build();


### PR DESCRIPTION
The bytecode transformers applied on Hibernate entities can't use caching on the client side, as discussed previously in #40192, however it turns out that any entity A is also classed as a client of entity A, therefore invalidating the cache of all regular transformations on itself as well.

This invalidation is not necessary, as the cache of A is invalidated alread if A has changed. So when A is not changed, it's safe to reuse the cache of it as it depends only on itself.