### PR TITLE
WebSockets Next: provide strategies to process unhandled failures

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -16,6 +16,8 @@ include::_attributes.adoc[]
 
 include::{includes}/extension-status.adoc[]
 
+The `quarkus-websockets-next` extension provides a modern declarative API to define WebSocket server and client endpoints.
+
 == The WebSocket protocol
 
 The _WebSocket_ protocol, documented in the https://datatracker.ietf.org/doc/html/rfc6455[RFC6455], establishes a standardized method for creating a bidirectional communication channel between a client and a server through a single TCP connection.
@@ -456,6 +458,10 @@ However, each method must declare a different error parameter.
 The method that declares a most-specific supertype of the actual exception is selected.
 
 NOTE: The `@io.quarkus.websockets.next.OnError` annotation can be also used to declare a global error handler, i.e. a method that is not declared on a WebSocket endpoint. Such a method may not accept `@PathParam` paremeters. Error handlers declared on an endpoint take precedence over the global error handlers.
+
+When an error occurs but no error handler can handle the failure, Quarkus uses the strategy specified by `quarkus.websockets-next.server.unhandled-failure-strategy` and `quarkus.websockets-next.client.unhandled-failure-strategy`, respectively.
+By default, the connection is closed.
+Alternatively, an error message can be logged or no operation performed.
 
 == Access to the WebSocketConnection
 

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientMessageErrorEndpoint.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientMessageErrorEndpoint.java
@@ -1,0 +1,35 @@
+package io.quarkus.websockets.next.test.client;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocketClient;
+
+@WebSocketClient(path = "/endpoint")
+public class ClientMessageErrorEndpoint {
+
+    static final CountDownLatch MESSAGE_LATCH = new CountDownLatch(1);
+
+    static final List<String> MESSAGES = new CopyOnWriteArrayList<>();
+
+    static final CountDownLatch CLOSED_LATCH = new CountDownLatch(1);
+
+    @OnTextMessage
+    void message(String message) {
+        if ("foo".equals(message)) {
+            throw new IllegalStateException("I cannot do it!");
+        } else {
+            MESSAGES.add(message);
+        }
+        MESSAGE_LATCH.countDown();
+    }
+
+    @OnClose
+    void close() {
+        CLOSED_LATCH.countDown();
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientOpenErrorEndpoint.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientOpenErrorEndpoint.java
@@ -1,0 +1,37 @@
+package io.quarkus.websockets.next.test.client;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocketClient;
+
+@WebSocketClient(path = "/endpoint")
+public class ClientOpenErrorEndpoint {
+
+    static final CountDownLatch MESSAGE_LATCH = new CountDownLatch(1);
+
+    static final List<String> MESSAGES = new CopyOnWriteArrayList<>();
+
+    static final CountDownLatch CLOSED_LATCH = new CountDownLatch(1);
+
+    @OnOpen
+    void open() {
+        throw new IllegalStateException("I cannot do it!");
+    }
+
+    @OnTextMessage
+    void message(String message) {
+        MESSAGES.add(message);
+        MESSAGE_LATCH.countDown();
+    }
+
+    @OnClose
+    void close() {
+        CLOSED_LATCH.countDown();
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/ServerEndpoint.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/ServerEndpoint.java
@@ -1,0 +1,24 @@
+package io.quarkus.websockets.next.test.client;
+
+import java.util.concurrent.CountDownLatch;
+
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/endpoint")
+public class ServerEndpoint {
+
+    static final CountDownLatch CLOSED_LATCH = new CountDownLatch(1);
+
+    @OnTextMessage
+    String echo(String message) {
+        return message;
+    }
+
+    @OnClose
+    void close() {
+        CLOSED_LATCH.countDown();
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledMessageFailureDefaultStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledMessageFailureDefaultStrategyTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+public class UnhandledMessageFailureDefaultStrategyTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class, ClientMessageErrorEndpoint.class);
+            });
+
+    @Inject
+    WebSocketConnector<ClientMessageErrorEndpoint> connector;
+
+    @TestHTTPResource("/")
+    URI testUri;
+
+    @Test
+    void testError() throws InterruptedException {
+        WebSocketClientConnection connection = connector
+                .baseUri(testUri)
+                .connectAndAwait();
+        connection.sendTextAndAwait("foo");
+        assertTrue(ServerEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(ClientMessageErrorEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(connection.isClosed());
+        assertEquals(WebSocketCloseStatus.INTERNAL_SERVER_ERROR.code(), connection.closeReason().getCode());
+        assertTrue(ClientMessageErrorEndpoint.MESSAGES.isEmpty());
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledMessageFailureLogStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledMessageFailureLogStrategyTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+public class UnhandledMessageFailureLogStrategyTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class, ClientMessageErrorEndpoint.class);
+            }).overrideConfigKey("quarkus.websockets-next.client.unhandled-failure-strategy", "log");
+
+    @Inject
+    WebSocketConnector<ClientMessageErrorEndpoint> connector;
+
+    @TestHTTPResource("/")
+    URI testUri;
+
+    @Test
+    void testError() throws InterruptedException {
+        WebSocketClientConnection connection = connector
+                .baseUri(testUri)
+                .connectAndAwait();
+        connection.sendTextAndAwait("foo");
+        assertFalse(connection.isClosed());
+        connection.sendText("bar");
+        assertTrue(ClientMessageErrorEndpoint.MESSAGE_LATCH.await(5, TimeUnit.SECONDS));
+        assertEquals("bar", ClientMessageErrorEndpoint.MESSAGES.get(0));
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledOpenFailureDefaultStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledOpenFailureDefaultStrategyTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+public class UnhandledOpenFailureDefaultStrategyTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class, ClientOpenErrorEndpoint.class);
+            });
+
+    @Inject
+    WebSocketConnector<ClientOpenErrorEndpoint> connector;
+
+    @TestHTTPResource("/")
+    URI testUri;
+
+    @Test
+    void testError() throws InterruptedException {
+        WebSocketClientConnection connection = connector
+                .baseUri(testUri)
+                .connectAndAwait();
+        assertTrue(ServerEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(ClientOpenErrorEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(connection.isClosed());
+        assertEquals(WebSocketCloseStatus.INTERNAL_SERVER_ERROR.code(), connection.closeReason().getCode());
+        assertTrue(ClientOpenErrorEndpoint.MESSAGES.isEmpty());
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledOpenFailureLogStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledOpenFailureLogStrategyTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.websockets.next.test.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import io.quarkus.websockets.next.WebSocketConnector;
+
+public class UnhandledOpenFailureLogStrategyTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(ServerEndpoint.class, ClientOpenErrorEndpoint.class);
+            }).overrideConfigKey("quarkus.websockets-next.client.unhandled-failure-strategy", "log");
+
+    @Inject
+    WebSocketConnector<ClientOpenErrorEndpoint> connector;
+
+    @TestHTTPResource("/")
+    URI testUri;
+
+    @Test
+    void testError() throws InterruptedException {
+        WebSocketClientConnection connection = connector
+                .baseUri(testUri)
+                .connectAndAwait();
+        connection.sendTextAndAwait("foo");
+        assertFalse(connection.isClosed());
+        assertNull(connection.closeReason());
+        assertTrue(ClientOpenErrorEndpoint.MESSAGE_LATCH.await(5, TimeUnit.SECONDS));
+        assertEquals("foo", ClientOpenErrorEndpoint.MESSAGES.get(0));
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/EchoMessageError.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/EchoMessageError.java
@@ -1,0 +1,23 @@
+package io.quarkus.websockets.next.test.errors;
+
+import java.util.concurrent.CountDownLatch;
+
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/echo")
+public class EchoMessageError {
+
+    static final CountDownLatch MESSAGE_FAILURE_CALLED = new CountDownLatch(1);
+
+    @OnTextMessage
+    String echo(String message) {
+        if ("foo".equals(message)) {
+            MESSAGE_FAILURE_CALLED.countDown();
+            throw new IllegalStateException("I cannot do it!");
+        } else {
+            return message;
+        }
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/EchoOpenError.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/EchoOpenError.java
@@ -1,0 +1,25 @@
+package io.quarkus.websockets.next.test.errors;
+
+import java.util.concurrent.CountDownLatch;
+
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+
+@WebSocket(path = "/echo")
+public class EchoOpenError {
+
+    static final CountDownLatch OPEN_CALLED = new CountDownLatch(1);
+
+    @OnOpen
+    void open() {
+        OPEN_CALLED.countDown();
+        throw new IllegalStateException("I cannot do it!");
+    }
+
+    @OnTextMessage
+    String echo(String message) {
+        return message;
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UnhandledMessageFailureDefaultStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UnhandledMessageFailureDefaultStrategyTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.websockets.next.test.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+
+public class UnhandledMessageFailureDefaultStrategyTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(EchoMessageError.class, WSClient.class);
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("echo")
+    URI testUri;
+
+    @Test
+    void testError() throws InterruptedException {
+        try (WSClient client = WSClient.create(vertx).connect(testUri)) {
+            client.sendAndAwait("foo");
+            assertTrue(EchoMessageError.MESSAGE_FAILURE_CALLED.await(5, TimeUnit.SECONDS));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> client.isClosed());
+            assertEquals(WebSocketCloseStatus.INTERNAL_SERVER_ERROR.code(), client.closeStatusCode());
+        }
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UnhandledMessageFailureLogStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UnhandledMessageFailureLogStrategyTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.websockets.next.test.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+
+public class UnhandledMessageFailureLogStrategyTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(EchoMessageError.class, WSClient.class);
+            }).overrideConfigKey("quarkus.websockets-next.server.unhandled-failure-strategy", "log");
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("echo")
+    URI testUri;
+
+    @Test
+    void testErrorDoesNotCloseConnection() throws InterruptedException {
+        try (WSClient client = WSClient.create(vertx).connect(testUri)) {
+            client.sendAndAwait("foo");
+            assertTrue(EchoMessageError.MESSAGE_FAILURE_CALLED.await(5, TimeUnit.SECONDS));
+            client.sendAndAwait("bar");
+            client.waitForMessages(1);
+            assertEquals("bar", client.getLastMessage().toString());
+        }
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UnhandledOpenFailureDefaultStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UnhandledOpenFailureDefaultStrategyTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.websockets.next.test.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+
+public class UnhandledOpenFailureDefaultStrategyTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(EchoOpenError.class, WSClient.class);
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("echo")
+    URI testUri;
+
+    @Test
+    void testError() throws InterruptedException {
+        try (WSClient client = WSClient.create(vertx).connect(testUri)) {
+            assertTrue(EchoOpenError.OPEN_CALLED.await(5, TimeUnit.SECONDS));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> client.isClosed());
+            assertEquals(WebSocketCloseStatus.INTERNAL_SERVER_ERROR.code(), client.closeStatusCode());
+        }
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UnhandledOpenFailureLogStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/errors/UnhandledOpenFailureLogStrategyTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.websockets.next.test.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+
+public class UnhandledOpenFailureLogStrategyTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(EchoOpenError.class, WSClient.class);
+            }).overrideConfigKey("quarkus.websockets-next.server.unhandled-failure-strategy", "log");
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("echo")
+    URI testUri;
+
+    @Test
+    void testErrorDoesNotCloseConnection() throws InterruptedException {
+        try (WSClient client = WSClient.create(vertx).connect(testUri)) {
+            assertTrue(EchoOpenError.OPEN_CALLED.await(5, TimeUnit.SECONDS));
+            client.sendAndAwait("foo");
+            client.waitForMessages(1);
+            assertEquals("foo", client.getLastMessage().toString());
+        }
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/utils/WSClient.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/utils/WSClient.java
@@ -126,6 +126,10 @@ public class WSClient implements AutoCloseable {
         return socket.get().isClosed();
     }
 
+    public int closeStatusCode() {
+        return socket.get().closeStatusCode();
+    }
+
     @Override
     public void close() {
         disconnect();

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/CloseReason.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/CloseReason.java
@@ -15,6 +15,8 @@ public class CloseReason {
 
     public static final CloseReason NORMAL = new CloseReason(WebSocketCloseStatus.NORMAL_CLOSURE.code());
 
+    public static final CloseReason INTERNAL_SERVER_ERROR = new CloseReason(WebSocketCloseStatus.INTERNAL_SERVER_ERROR.code());
+
     private final int code;
 
     private final String message;

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/UnhandledFailureStrategy.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/UnhandledFailureStrategy.java
@@ -1,0 +1,20 @@
+package io.quarkus.websockets.next;
+
+/**
+ * The strategy used when an error occurs but no error handler can handle the failure.
+ */
+public enum UnhandledFailureStrategy {
+    /**
+     * Close the connection.
+     */
+    CLOSE,
+    /**
+     * Log an error message.
+     */
+    LOG,
+    /**
+     * No operation.
+     */
+    NOOP;
+
+}

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClientConnection.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClientConnection.java
@@ -27,7 +27,7 @@ public interface WebSocketClientConnection extends Sender, BlockingSender {
     /**
      *
      * @param name
-     * @return the actual value of the path parameter or null
+     * @return the actual value of the path parameter or {@code null}
      * @see WebSocketClient#path()
      */
     String pathParam(String name);
@@ -41,6 +41,12 @@ public interface WebSocketClientConnection extends Sender, BlockingSender {
      * @return {@code true} if the WebSocket is closed
      */
     boolean isClosed();
+
+    /**
+     *
+     * @return the close reason or {@code null} if the connection is not closed
+     */
+    CloseReason closeReason();
 
     /**
      *

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnection.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnection.java
@@ -37,7 +37,7 @@ public interface WebSocketConnection extends Sender, BlockingSender {
     /**
      *
      * @param name
-     * @return the actual value of the path parameter or null
+     * @return the actual value of the path parameter or {@code null}
      * @see WebSocket#path()
      */
     String pathParam(String name);
@@ -66,6 +66,12 @@ public interface WebSocketConnection extends Sender, BlockingSender {
      * @return {@code true} if the WebSocket is closed
      */
     boolean isClosed();
+
+    /**
+     *
+     * @return the close reason or {@code null} if the connection is not closed
+     */
+    CloseReason closeReason();
 
     /**
      *

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsClientRuntimeConfig.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsClientRuntimeConfig.java
@@ -40,4 +40,12 @@ public interface WebSocketsClientRuntimeConfig {
      */
     Optional<Duration> autoPingInterval();
 
+    /**
+     * The strategy used when an error occurs but no error handler can handle the failure.
+     * <p>
+     * By default, the connection is closed when an unhandled failure occurs.
+     */
+    @WithDefault("close")
+    UnhandledFailureStrategy unhandledFailureStrategy();
+
 }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsServerRuntimeConfig.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsServerRuntimeConfig.java
@@ -46,4 +46,12 @@ public interface WebSocketsServerRuntimeConfig {
      */
     Optional<Duration> autoPingInterval();
 
+    /**
+     * The strategy used when an error occurs but no error handler can handle the failure.
+     * <p>
+     * By default, the connection is closed when an unhandled failure occurs.
+     */
+    @WithDefault("close")
+    UnhandledFailureStrategy unhandledFailureStrategy();
+
 }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionBase.java
@@ -125,6 +125,6 @@ public abstract class WebSocketConnectionBase {
         if (ws.isClosed()) {
             return new CloseReason(ws.closeStatusCode(), ws.closeReason());
         }
-        throw new IllegalStateException("Connection is not closed");
+        return null;
     }
 }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorImpl.java
@@ -116,6 +116,7 @@ public class WebSocketConnectorImpl<CLIENT> extends WebSocketConnectorBase<WebSo
 
                     Endpoints.initialize(vertx, Arc.container(), codecs, connection, ws,
                             clientEndpoint.generatedEndpointClass, config.autoPingInterval(), SecuritySupport.NOOP,
+                            config.unhandledFailureStrategy(),
                             () -> {
                                 connectionManager.remove(clientEndpoint.generatedEndpointClass, connection);
                                 client.close();

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketServerRecorder.java
@@ -102,7 +102,7 @@ public class WebSocketServerRecorder {
                     LOG.debugf("Connection created: %s", connection);
 
                     Endpoints.initialize(vertx, container, codecs, connection, ws, generatedEndpointClass,
-                            config.autoPingInterval(), securitySupport,
+                            config.autoPingInterval(), securitySupport, config.unhandledFailureStrategy(),
                             () -> connectionManager.remove(generatedEndpointClass, connection));
                 });
             }


### PR DESCRIPTION
- resolves #40648

We provide the following strategies:

1. Close the connection (default)
2. Log an error message
3. NOOP