### PR TITLE
QuarkusUnitTest: clear test method invokers to avoid QuarkusCL leaks

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -734,6 +734,9 @@ public class QuarkusUnitTest
         rootLogger.setHandlers(originalHandlers);
         inMemoryLogHandler.clearRecords();
         inMemoryLogHandler.setFilter(null);
+        if (testMethodInvokers != null) {
+            testMethodInvokers.clear();
+        }
 
         try {
             if (runningQuarkusApplication != null) {


### PR DESCRIPTION
- can cause OOM: Metaspace when running tests in a deployment module of an extension
- the leak only demonstrates if a TestMethodInvoker is registered