### PR TITLE
Bump Keycloak version to 24.0.4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -187,7 +187,7 @@
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.13.0</antlr.version><!-- needs to align with same property in build-parent/pom.xml -->
         <quarkus-security.version>2.0.3.Final</quarkus-security.version>
-        <keycloak.version>23.0.7</keycloak.version>
+        <keycloak.version>24.0.4</keycloak.version>
         <logstash-gelf.version>1.15.1</logstash-gelf.version>
         <checker-qual.version>3.43.0</checker-qual.version>
         <error-prone-annotations.version>2.27.1</error-prone-annotations.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -107,7 +107,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update bom/application/pom.xml and KeycloakBuildTimeConfig/DevServicesConfig in quarkus-oidc/deployment to match the version -->
-        <keycloak.version>23.0.7</keycloak.version>
+        <keycloak.version>24.0.4</keycloak.version>
         <keycloak.wildfly.version>19.0.3</keycloak.wildfly.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.version}</keycloak.docker.image>
         <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.wildfly.version}-legacy</keycloak.docker.legacy.image>

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -258,7 +258,7 @@ For more information, see xref:security-oidc-bearer-token-authentication.adoc#in
 [[keycloak-initialization]]
 === Keycloak initialization
 
-The `quay.io/keycloak/keycloak:23.0.7` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
+The `quay.io/keycloak/keycloak:24.0.4` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
 `quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name.
 For example, set it to `quay.io/keycloak/keycloak:19.0.3-legacy` to use a Keycloak distribution powered by WildFly.
 Be aware that a Quarkus-based Keycloak distribution is only available starting from Keycloak `20.0.0`.

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -34,7 +34,7 @@ public class DevServicesConfig {
      * ends with `-legacy`.
      * Override with `quarkus.keycloak.devservices.keycloak-x-image`.
      */
-    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:23.0.7")
+    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:24.0.4")
     public String imageName;
 
     /**

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -109,7 +109,8 @@ public class KeycloakDevServicesProcessor {
     private static final String KEYCLOAK_QUARKUS_HOSTNAME = "KC_HOSTNAME";
     private static final String KEYCLOAK_QUARKUS_ADMIN_PROP = "KEYCLOAK_ADMIN";
     private static final String KEYCLOAK_QUARKUS_ADMIN_PASSWORD_PROP = "KEYCLOAK_ADMIN_PASSWORD";
-    private static final String KEYCLOAK_QUARKUS_START_CMD = "start --http-enabled=true --hostname-strict=false --hostname-strict-https=false";
+    private static final String KEYCLOAK_QUARKUS_START_CMD = "start --http-enabled=true --hostname-strict=false --hostname-strict-https=false "
+            + "--spi-user-profile-declarative-user-profile-config-file=/opt/keycloak/upconfig.json";
 
     private static final String JAVA_OPTS = "JAVA_OPTS";
     private static final String OIDC_USERS = "oidc.users";
@@ -509,6 +510,7 @@ public class KeycloakDevServicesProcessor {
                 addEnv(KEYCLOAK_QUARKUS_ADMIN_PASSWORD_PROP, KEYCLOAK_ADMIN_PASSWORD);
                 withCommand(startCommand.orElse(KEYCLOAK_QUARKUS_START_CMD)
                         + (useSharedNetwork ? " --hostname-port=" + fixedExposedPort.getAsInt() : ""));
+                addUpConfigResource();
             } else {
                 addEnv(KEYCLOAK_WILDFLY_USER_PROP, KEYCLOAK_ADMIN_USER);
                 addEnv(KEYCLOAK_WILDFLY_PASSWORD_PROP, KEYCLOAK_ADMIN_PASSWORD);
@@ -557,6 +559,13 @@ public class KeycloakDevServicesProcessor {
                                 resourcePath, mappedResource));
                 LOG.errorf("%s resource can not be mapped to %s because it is not available on the classpath and file system",
                         resourcePath, mappedResource);
+            }
+        }
+
+        private void addUpConfigResource() {
+            if (Thread.currentThread().getContextClassLoader().getResource("/dev-service/upconfig.json") != null) {
+                LOG.debug("Mapping the classpath /dev-service/upconfig.json resource to /opt/keycloak/upconfig.json");
+                withClasspathResourceMapping("/dev-service/upconfig.json", "/opt/keycloak/upconfig.json", BindMode.READ_ONLY);
             }
         }
 

--- a/extensions/oidc/deployment/src/main/resources/dev-service/upconfig.json
+++ b/extensions/oidc/deployment/src/main/resources/dev-service/upconfig.json
@@ -1,0 +1,60 @@
+{
+	"attributes": [
+		{
+			"name": "username",
+			"displayName": "${username}",
+			"permissions": {
+				"view": ["admin", "user"],
+				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"length": { "min": 3, "max": 255 },
+				"username-prohibited-characters": {},
+				"up-username-not-idn-homograph": {}
+			}
+		},
+		{
+			"name": "email",
+			"displayName": "${email}",
+			"permissions": {
+				"view": ["admin", "user"],
+				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"email" : {},
+				"length": { "max": 255 }
+			}
+		},
+		{
+			"name": "firstName",
+			"displayName": "${firstName}",
+			"permissions": {
+				"view": ["admin", "user"],
+				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"length": { "max": 255 },
+				"person-name-prohibited-characters": {}
+			}
+		},
+		{
+			"name": "lastName",
+			"displayName": "${lastName}",
+			"permissions": {
+				"view": ["admin", "user"],
+				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"length": { "max": 255 },
+				"person-name-prohibited-characters": {}
+			}
+		}
+	],
+	"groups": [
+		{
+			"name": "user-metadata",
+			"displayHeader": "User metadata",
+			"displayDescription": "Attributes, which refer to user metadata"
+		}
+	]
+}

--- a/integration-tests/keycloak-authorization/src/main/resources/application.properties
+++ b/integration-tests/keycloak-authorization/src/main/resources/application.properties
@@ -92,3 +92,5 @@ admin-url=${keycloak.url}
 
 # Configure Keycloak Admin Client
 quarkus.keycloak.admin-client.server-url=${admin-url}
+
+quarkus.log.category."com.gargoylesoftware.htmlunit".level=ERROR

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.keycloak.devservices.create-realm=false
+quarkus.keycloak.devservices.show-logs=true
 # Default tenant configurationf
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -135,7 +135,7 @@ quarkus.http.auth.permission.authenticated.policy=authenticated
 smallrye.jwt.sign.key.location=/privateKey.pem
 smallrye.jwt.new-token.lifespan=5
 
-quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
+quarkus.log.category."com.gargoylesoftware.htmlunit".level=ERROR
 quarkus.http.auth.proactive=false
 
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.pem

--- a/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
+++ b/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
@@ -53,7 +53,7 @@ public class OidcTokenPropagationTest {
                 //.statusCode(200)
                 //.body(equalTo("alice"));
                 .statusCode(500)
-                .body(containsString("Feature not enabled"));
+                .body(containsString("Client not allowed to exchange"));
     }
 
     @Test

--- a/integration-tests/oidc/src/main/resources/upconfig.json
+++ b/integration-tests/oidc/src/main/resources/upconfig.json
@@ -1,0 +1,60 @@
+{
+	"attributes": [
+		{
+			"name": "username",
+			"displayName": "${username}",
+			"permissions": {
+				"view": ["admin", "user"],
+				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"length": { "min": 3, "max": 255 },
+				"username-prohibited-characters": {},
+				"up-username-not-idn-homograph": {}
+			}
+		},
+		{
+			"name": "email",
+			"displayName": "${email}",
+			"permissions": {
+				"view": ["admin", "user"],
+				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"email" : {},
+				"length": { "max": 255 }
+			}
+		},
+		{
+			"name": "firstName",
+			"displayName": "${firstName}",
+			"permissions": {
+				"view": ["admin", "user"],
+				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"length": { "max": 255 },
+				"person-name-prohibited-characters": {}
+			}
+		},
+		{
+			"name": "lastName",
+			"displayName": "${lastName}",
+			"permissions": {
+				"view": ["admin", "user"],
+				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"length": { "max": 255 },
+				"person-name-prohibited-characters": {}
+			}
+		}
+	],
+	"groups": [
+		{
+			"name": "user-metadata",
+			"displayHeader": "User metadata",
+			"displayDescription": "Attributes, which refer to user metadata"
+		}
+	]
+}

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakXTestResourceLifecycleManager.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakXTestResourceLifecycleManager.java
@@ -51,10 +51,12 @@ public class KeycloakXTestResourceLifecycleManager implements QuarkusTestResourc
         keycloak = keycloak
                 .withClasspathResourceMapping(SERVER_KEYSTORE, SERVER_KEYSTORE_MOUNTED_PATH, BindMode.READ_ONLY)
                 .withClasspathResourceMapping(SERVER_TRUSTSTORE, SERVER_TRUSTSTORE_MOUNTED_PATH, BindMode.READ_ONLY)
+                .withClasspathResourceMapping("/upconfig.json", "/opt/keycloak/upconfig.json", BindMode.READ_ONLY)
                 .withCommand("build --https-client-auth=required")
                 .withCommand(String.format(
                         "start --https-client-auth=required --hostname-strict=false --hostname-strict-https=false"
-                                + " --https-key-store-file=%s --https-trust-store-file=%s --https-trust-store-password=password",
+                                + " --https-key-store-file=%s --https-trust-store-file=%s --https-trust-store-password=password"
+                                + " --spi-user-profile-declarative-user-profile-config-file=/opt/keycloak/upconfig.json",
                         SERVER_KEYSTORE_MOUNTED_PATH, SERVER_TRUSTSTORE_MOUNTED_PATH));
         keycloak.start();
         LOGGER.info(keycloak.getLogs());


### PR DESCRIPTION
This upgrade is possible with thanks to @pedroigor suggesting to use a JSON file at the startup which allows Keycloak to avoid enforcing that an attribute like `email` is required during the new user registration or authentication.