### PR TITLE
Workaround unknown SecureRandom strong algorithm with OpenJDK17 & RHEL & BCFIPS provider when run in FIPS-enabled environment

### DIFF
--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderRecorder.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderRecorder.java
@@ -6,16 +6,27 @@ import static io.quarkus.security.runtime.SecurityProviderUtils.insertProvider;
 import static io.quarkus.security.runtime.SecurityProviderUtils.loadProvider;
 import static io.quarkus.security.runtime.SecurityProviderUtils.loadProviderWithParams;
 
+import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.Security;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class SecurityProviderRecorder {
+
+    private static final Logger LOG = Logger.getLogger(SecurityProviderRecorder.class);
+
     public void addBouncyCastleProvider(boolean inFipsMode) {
         final String providerName = inFipsMode ? SecurityProviderUtils.BOUNCYCASTLE_FIPS_PROVIDER_CLASS_NAME
                 : SecurityProviderUtils.BOUNCYCASTLE_PROVIDER_CLASS_NAME;
         addProvider(loadProvider(providerName));
+        if (inFipsMode) {
+            setSecureRandomStrongAlgorithmIfNecessary();
+        }
     }
 
     public void addBouncyCastleJsseProvider() {
@@ -33,5 +44,23 @@ public class SecurityProviderRecorder {
         Provider bcJsse = loadProviderWithParams(SecurityProviderUtils.BOUNCYCASTLE_JSSE_PROVIDER_CLASS_NAME,
                 new Class[] { boolean.class, Provider.class }, new Object[] { true, bc });
         insertProvider(bcJsse, sunIndex + 1);
+        setSecureRandomStrongAlgorithmIfNecessary();
+    }
+
+    private void setSecureRandomStrongAlgorithmIfNecessary() {
+        try {
+            // workaround for the issue on OpenJDK 17 & RHEL8 & FIPS
+            // see https://github.com/bcgit/bc-java/issues/1285#issuecomment-2068958587
+            // we can remove this when OpenJDK 17 support is dropped or if it starts working on newer versions of RHEL8+
+            SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException e) {
+            SecureRandom secRandom = new SecureRandom();
+            String origStrongAlgorithms = Security.getProperty("securerandom.strongAlgorithms");
+            String usedAlgorithm = secRandom.getAlgorithm() + ":" + secRandom.getProvider().getName();
+            String strongAlgorithms = origStrongAlgorithms == null ? usedAlgorithm : usedAlgorithm + "," + origStrongAlgorithms;
+            LOG.debugf("Strong SecureRandom algorithm '%s' is not available. "
+                    + "Using fallback algorithm '%s'.", origStrongAlgorithms, usedAlgorithm);
+            Security.setProperty("securerandom.strongAlgorithms", strongAlgorithms);
+        }
     }
 }


### PR DESCRIPTION
fixes: #40659

When run on RHEL8 with Open JDK 17 with BCFIPS provider the SecureRandom strong algorithm is `NativePRNGBlocking:SUN,DRBG:SUN`, algorithms that are not available.
Keycloak works around that by just initializing default SecureRandom with known strong algorithms (PKCS11:SunPKCS11-NSS-FIPS) and removing them, but that means that when Vert.x loads keystores during the HTTP Server startup (when users can't provide their fixes, before app starts) and `org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider#getCoreSecureRandom` is invoked while `getInstanceStrong` throws exception, it leads to initializing `org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.CoreSecureRandom#CoreSecureRandom` with `sun.security.provider.SecureRandom()` and following exception is thrown `BouncyCastleFipsProvider$CoreSecureRandom (in unnamed module @0x621a387f) cannot access class sun.security.provider.SecureRandom`.

I've tried both using reflection to invoke `org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider#getDefaultSecureRandom` and initialize initialize SecureRandom instance via Java API, but BCFIPS require this strong algorithm later as well. I think we need to keep it in place.

My thinking (AKA selected code lines from KC) is that if `NoSuchAlgorithmException` is thrown, that won't change until user code is run on app startup (extensions could do something sooner). Which is too late, and if they want to change the strong algorithm, they can change what we set as well.

Tested only in JVM as native mode is not working https://github.com/quarkusio/quarkus/issues/37500.