### PR TITLE
Azure Functions HTTP: use utf-8 instead of default charset decoding request

### DIFF
--- a/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
+++ b/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
@@ -3,6 +3,7 @@ package io.quarkus.azure.functions.resteasy.runtime;
 import java.io.ByteArrayOutputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -62,7 +63,7 @@ public class BaseFunction {
 
         HttpContent requestContent = LastHttpContent.EMPTY_LAST_CONTENT;
         if (request.getBody().isPresent()) {
-            ByteBuf body = Unpooled.wrappedBuffer(request.getBody().get().getBytes());
+            ByteBuf body = Unpooled.wrappedBuffer(request.getBody().get().getBytes(StandardCharsets.UTF_8));
             requestContent = new DefaultLastHttpContent(body);
         }
 


### PR DESCRIPTION
This change removes the implicit usage of the default charset when decoding the request from the incoming Azure Functions invocation. It now always decodes the payload as UTF-8, which should match the grpc passing which is used internally in Azure.
Fix #36973
