### PR TITLE
Upgrade to Hibernate ORM 6.5.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -101,7 +101,7 @@
              bytebuddy.version (just below), hibernate-orm.version-for-documentation (in docs/pom.xml)
              and both hibernate-orm.version and antlr.version in build-parent/pom.xml
              WARNING again for diffs that don't provide enough context: when updating, see above -->
-        <hibernate-orm.version>6.5.1.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.5.2.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.15</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.3.0.Final</hibernate-reactive.version>

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/HibernateOrmNoWarningsTest.java
@@ -2,7 +2,6 @@ package io.quarkus.it.jpa.postgresql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
@@ -20,11 +19,6 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-// Temporarily ignore this test:
-// See https://hibernate.atlassian.net/browse/HHH-18112
-// See https://hibernate.zulipchat.com/#narrow/stream/132094-hibernate-orm-dev/topic/6.2E5.2E1.20in.20Quarkus
-// TODO remove this once we upgrade to ORM 6.5.2
-@Disabled
 @QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),


### PR DESCRIPTION
Creating now as draft, but the ORM 6.5.2 release hasn't happened yet.

Follows up on #40474

Content:

https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HHH%20AND%20fixVersion%20in%20(6.5.2)%20ORDER%20BY%20updated

Includes the following fixes:

[HHH-18112](https://hibernate.atlassian.net/browse/HHH-18112) Some dialects use the wrong default version
[HHH-18026](https://hibernate.atlassian.net/browse/HHH-18026) Prevent dialects not supporting arbitrary values retrieval in `getGeneratedKeys()` from logging a SQL exception