### PR TITLE
[3.10] Mention Bootstrap instead of jQuery in doc

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -35,7 +35,7 @@ location to function correctly.
 [[from-mvnpm]]
 === From mvnpm
 
-If you are using https://mvnpm.org/[mvnpm], as for the following JQuery dependency:
+If you are using https://mvnpm.org/[mvnpm], as for the following Bootstrap dependency:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml


### PR DESCRIPTION
We are talking about a Boostrap artifact and I think it was a copypasto.

Pushing only to 3.10 as this doc has been rewritten for 3.11.
Also 3.8 doesn't have the issue.

Not much value in fixing 3.10 given we will release 3.11 soon but I was tracking the issue given I saw it in our currently published doc so I might as well fix it.