### PR TITLE
Multiple Hibernate ORM multitenancy fixes

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1132,7 +1132,7 @@ quarkus.hibernate-orm.database.generation=none
 # Enable SCHEMA approach and use default datasource
 quarkus.hibernate-orm.multitenant=SCHEMA
 # You could use a non-default datasource by using the following setting
-# quarkus.hibernate-orm.multitenant-schema-datasource=other
+# quarkus.hibernate-orm.datasource=other
 
 # The default data source used for all tenant schemas
 quarkus.datasource.db-kind=postgresql

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -229,7 +229,10 @@ public interface HibernateOrmConfigPersistenceUnit {
     /**
      * Defines the name of the datasource to use in case of SCHEMA approach. The datasource of the persistence unit will be used
      * if not set.
+     *
+     * @deprecated Use {@link #datasource()} instead.
      */
+    @Deprecated
     @WithConverter(TrimmedStringConverter.class)
     Optional<String> multitenantSchemaDatasource();
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
@@ -83,12 +83,11 @@ public class HibernateOrmRecorder {
 
     public Supplier<DataSourceTenantConnectionResolver> dataSourceTenantConnectionResolver(String persistenceUnitName,
             Optional<String> dataSourceName,
-            MultiTenancyStrategy multiTenancyStrategy, String multiTenancySchemaDataSourceName) {
+            MultiTenancyStrategy multiTenancyStrategy) {
         return new Supplier<DataSourceTenantConnectionResolver>() {
             @Override
             public DataSourceTenantConnectionResolver get() {
-                return new DataSourceTenantConnectionResolver(persistenceUnitName, dataSourceName, multiTenancyStrategy,
-                        multiTenancySchemaDataSourceName);
+                return new DataSourceTenantConnectionResolver(persistenceUnitName, dataSourceName, multiTenancyStrategy);
             }
         };
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/DataSourceTenantConnectionResolver.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/DataSourceTenantConnectionResolver.java
@@ -11,7 +11,6 @@ import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.jboss.logging.Logger;
 
 import io.agroal.api.AgroalDataSource;
-import io.agroal.api.configuration.AgroalDataSourceConfiguration;
 import io.quarkus.agroal.DataSource;
 import io.quarkus.arc.Arc;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
@@ -66,22 +65,6 @@ public class DataSourceTenantConnectionResolver implements TenantConnectionResol
         return new QuarkusConnectionProvider(dataSource);
     }
 
-    /**
-     * Create a new data source from the given configuration.
-     *
-     * @param config Configuration to use.
-     *
-     * @return New data source instance.
-     */
-    private static AgroalDataSource createFrom(AgroalDataSourceConfiguration config) {
-        try {
-            return AgroalDataSource.from(config);
-        } catch (SQLException ex) {
-            throw new IllegalStateException("Failed to create a new data source based on the existing datasource configuration",
-                    ex);
-        }
-    }
-
     private static AgroalDataSource tenantDataSource(Optional<String> dataSourceName, String tenantId,
             MultiTenancyStrategy strategy, String multiTenancySchemaDataSourceName) {
         if (strategy != MultiTenancyStrategy.SCHEMA) {
@@ -89,10 +72,9 @@ public class DataSourceTenantConnectionResolver implements TenantConnectionResol
         }
 
         if (multiTenancySchemaDataSourceName == null) {
-            // The datasource name should always be present when using SCHEMA multi-tenancy;
+            // The datasource name should always be present when using a multi-tenancy other than DATABASE;
             // we perform checks in HibernateOrmProcessor during the build.
-            AgroalDataSource dataSource = getDataSource(dataSourceName.get());
-            return createFrom(dataSource.getConfiguration());
+            return getDataSource(dataSourceName.get());
         }
 
         return getDataSource(multiTenancySchemaDataSourceName);


### PR DESCRIPTION
Fixes #18564 and then some.

See commits for details:

1.  Avoid unnecessary copying of datasources for `SCHEMA` multi-tenancy
This is undocumented behavior and I have no idea what the point would be.
2.  Avoid unnecessary definition of a `DataSourceTenantConnectionResolver` bean for discriminator multi-tenancy
The only consumer of this bean is `HibernateMultiTenantConnectionProvider` and that consumer is not enabled with discriminator multi-tenancy.
See https://github.com/quarkusio/quarkus/blob/78952bcd4193042c2f569c3cf3b13d95be618b9a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java#L253-L263
3.  Deprecate `quarkus.hibernate-orm.multitenant-schema-datasource`
There are no tests involving this configuration property.
`quarkus.hibernate-orm.datasource` serves the exact same purpose and is more standardized and better handled (e.g. in Dev UI).