### PR TITLE
Correct JavaDoc example

### DIFF
--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupIfProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupIfProperty.java
@@ -30,7 +30,7 @@ import jakarta.enterprise.inject.Instance;
  *  }
  *
  *  {@literal @ApplicationScoped}
- *  class ServiceBar {
+ *  class ServiceBar implements Service {
  *
  *     public String name() {
  *        return "bar";

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupUnlessProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupUnlessProperty.java
@@ -30,7 +30,7 @@ import jakarta.enterprise.inject.Instance;
  *  }
  *
  *  {@literal @ApplicationScoped}
- *  class ServiceBar {
+ *  class ServiceBar implements Service {
  *
  *     public String name() {
  *        return "bar";


### PR DESCRIPTION
The example in the JavaDoc for `@LookupIfProperty` does not make sense unless both classes implement the `Service` interface.