### PR TITLE
Reinitialize shaded `com.google.protobuf.UnsafeUtil` class

### DIFF
--- a/extensions/kafka-client/runtime/src/main/java/io/smallrye/reactive/kafka/graal/KafkaSubstitutions.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/smallrye/reactive/kafka/graal/KafkaSubstitutions.java
@@ -1,9 +1,12 @@
 package io.smallrye.reactive.kafka.graal;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+
+import sun.misc.Unsafe;
 
 @TargetClass(className = "org.apache.kafka.common.network.SaslChannelBuilder")
 final class Target_org_apache_kafka_common_network_SaslChannelBuilder {
@@ -15,6 +18,20 @@ final class Target_org_apache_kafka_common_network_SaslChannelBuilder {
         throw new RuntimeException("Not implemented on native");
     }
 
+}
+
+@TargetClass(className = "org.apache.kafka.shaded.com.google.protobuf.UnsafeUtil")
+final class Target_org_apache_kafka_shaded_com_google_protobuf_UnsafeUtil {
+    @Substitute
+    static sun.misc.Unsafe getUnsafe() {
+        try {
+            Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+            theUnsafe.setAccessible(true);
+            return (Unsafe) theUnsafe.get(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }
 
 class KafkaSubstitutions {


### PR DESCRIPTION
Adaptation of https://github.com/quarkusio/quarkus/pull/36642 for the
shaded `com.google.protobuf.UnsafeUtil` class in kafka-clients.

Fixes: https://github.com/quarkusio/quarkus/issues/40100
