### PR TITLE
Update panache documentation: zero-based page index fix

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -639,7 +639,7 @@ List<Person> firstPage = livingPersons.list();
 List<Person> secondPage = livingPersons.nextPage().list();
 
 // get page 7
-List<Person> page7 = livingPersons.page(Page.of(7, 25)).list();
+List<Person> page7 = livingPersons.page(Page.of(6, 25)).list();
 
 // get the number of pages
 int numberOfPages = livingPersons.pageCount();


### PR DESCRIPTION
To fetch page 7, Page with index 6 needs to be provided as index is zero-based
![image](https://github.com/quarkusio/quarkus/assets/19426823/74211f29-95d9-4564-b5f0-306895cbfa1b)
