### PR TITLE
Make error message thrown when Quarkus REST and RESTEasy Classic are combined user-friendly again

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/UserFriendlyQuarkusRESTCapabilityCombinationTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/UserFriendlyQuarkusRESTCapabilityCombinationTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.deployment.Capability;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+class UserFriendlyQuarkusRESTCapabilityCombinationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-rest-deployment", Version.getVersion())))
+            .assertException(t -> {
+                assertTrue(t.getMessage().contains("only one provider of the following capabilities"), t.getMessage());
+                assertTrue(t.getMessage().contains("capability %s is provided by".formatted(Capability.REST)), t.getMessage());
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+}

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -55,6 +55,7 @@ import io.quarkus.arc.processor.AnnotationStore;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.ObserverInfo;
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -519,6 +520,7 @@ public class SecurityProcessor {
         }
     }
 
+    @Consume(Capabilities.class) // make sure extension combinations are validated before default security check
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void gatherSecurityChecks(BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -529,7 +531,7 @@ public class SecurityProcessor {
             BuildProducer<RunTimeConfigBuilderBuildItem> configBuilderProducer,
             List<AdditionalSecuredMethodsBuildItem> additionalSecuredMethods,
             SecurityCheckRecorder recorder,
-            Optional<DefaultSecurityCheckBuildItem> defaultSecurityCheckBuildItem,
+            List<DefaultSecurityCheckBuildItem> defaultSecurityCheckBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer,
             List<AdditionalSecurityCheckBuildItem> additionalSecurityChecks, SecurityBuildTimeConfig config) {
         classPredicate.produce(new ApplicationClassPredicateBuildItem(new SecurityCheckStorageAppPredicate()));
@@ -563,8 +565,14 @@ public class SecurityProcessor {
                     methodEntry.getValue());
         }
 
-        if (defaultSecurityCheckBuildItem.isPresent()) {
-            var roles = defaultSecurityCheckBuildItem.get().getRolesAllowed();
+        if (!defaultSecurityCheckBuildItem.isEmpty()) {
+            if (defaultSecurityCheckBuildItem.size() > 1) {
+                int itemCount = defaultSecurityCheckBuildItem.size();
+                throw new IllegalStateException("Found %d DefaultSecurityCheckBuildItem items, ".formatted(itemCount)
+                        + "please make sure the item is produced exactly once");
+            }
+
+            var roles = defaultSecurityCheckBuildItem.get(0).getRolesAllowed();
             if (roles == null) {
                 recorder.registerDefaultSecurityCheck(builder, recorder.denyAll());
             } else {

--- a/extensions/security/spi/src/main/java/io/quarkus/security/spi/DefaultSecurityCheckBuildItem.java
+++ b/extensions/security/spi/src/main/java/io/quarkus/security/spi/DefaultSecurityCheckBuildItem.java
@@ -3,9 +3,16 @@ package io.quarkus.security.spi;
 import java.util.List;
 import java.util.Objects;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.builder.item.MultiBuildItem;
 
-public final class DefaultSecurityCheckBuildItem extends SimpleBuildItem {
+/**
+ * Registers default SecurityCheck with the SecurityCheckStorage.
+ * Please make sure this build item is produced exactly once or validation will fail and exception will be thrown.
+ */
+public final class DefaultSecurityCheckBuildItem
+        // we make this Multi to run CapabilityAggregationStep#aggregateCapabilities first
+        // so that user-friendly error message is logged when Quarkus REST and RESTEasy are used together
+        extends MultiBuildItem {
 
     public final List<String> rolesAllowed;
 


### PR DESCRIPTION
fixes: #40410

Due to the RESTEasy Reactive to Quarkus REST renaming, the test added in this PR is not backportable.