### PR TITLE
Use the new Vertx local context storage

### DIFF
--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusAccessModes.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusAccessModes.java
@@ -1,0 +1,42 @@
+package io.quarkus.vertx.core.runtime;
+
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Supplier;
+
+import io.vertx.core.Context;
+import io.vertx.core.spi.context.storage.AccessMode;
+
+final class QuarkusAccessModes {
+
+    /**
+     * Beware this {@link AccessMode#getOrCreate(AtomicReferenceArray, int, Supplier)} because, differently from
+     * {@link io.vertx.core.spi.context.storage.ContextLocal#get(Context, Supplier)},
+     * is not suitable to be used with {@link io.vertx.core.spi.context.storage.ContextLocal#get(Context, AccessMode, Supplier)}
+     * with the same guarantees of atomicity i.e. the supplier can get called more than once by different racing threads!
+     */
+    public static final AccessMode ACQUIRE_RELEASE = new AccessMode() {
+        @Override
+        public Object get(AtomicReferenceArray<Object> locals, int idx) {
+            return locals.getAcquire(idx);
+        }
+
+        @Override
+        public void put(AtomicReferenceArray<Object> locals, int idx, Object value) {
+            // This is still ensuring visibility across threads and happens-before,
+            // but won't impose setVolatile total ordering i.e. StoreLoad barriers after write
+            // to make it faster
+            locals.setRelease(idx, value);
+        }
+
+        @Override
+        public Object getOrCreate(AtomicReferenceArray<Object> locals, int idx, Supplier<Object> initialValueSupplier) {
+            Object value = locals.getAcquire(idx);
+            if (value == null) {
+                value = initialValueSupplier.get();
+                locals.setRelease(idx, value);
+            }
+            return value;
+        }
+    };
+
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxLocalsHelper.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxLocalsHelper.java
@@ -2,6 +2,8 @@ package io.quarkus.vertx.core.runtime;
 
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.ContextLocalImpl;
+import io.vertx.core.spi.context.storage.ContextLocal;
 
 public class VertxLocalsHelper {
 
@@ -22,6 +24,11 @@ public class VertxLocalsHelper {
     public static <T> T getLocal(ContextInternal context, Object key) {
         if (VertxContext.isDuplicatedContext(context)) {
             // We are on a duplicated context, allow accessing the locals
+            if (key instanceof ContextLocalImpl<?>) {
+                var localKey = (ContextLocal<T>) key;
+                return (T) context.getLocal(localKey, QuarkusAccessModes.ACQUIRE_RELEASE);
+            }
+            assert !(key instanceof ContextLocal<?>);
             return (T) context.localContextData().get(key);
         } else {
             throw new UnsupportedOperationException(ILLEGAL_ACCESS_TO_LOCAL_CONTEXT);
@@ -31,7 +38,13 @@ public class VertxLocalsHelper {
     public static void putLocal(ContextInternal context, Object key, Object value) {
         if (VertxContext.isDuplicatedContext(context)) {
             // We are on a duplicated context, allow accessing the locals
-            context.localContextData().put(key, value);
+            if (key instanceof ContextLocalImpl<?>) {
+                var localKey = (ContextLocal<Object>) key;
+                context.putLocal(localKey, QuarkusAccessModes.ACQUIRE_RELEASE, value);
+            } else {
+                assert !(key instanceof ContextLocal<?>);
+                context.localContextData().put(key, value);
+            }
         } else {
             throw new UnsupportedOperationException(ILLEGAL_ACCESS_TO_LOCAL_CONTEXT);
         }
@@ -40,6 +53,15 @@ public class VertxLocalsHelper {
     public static boolean removeLocal(ContextInternal context, Object key) {
         if (VertxContext.isDuplicatedContext(context)) {
             // We are on a duplicated context, allow accessing the locals
+            if (key instanceof ContextLocalImpl<?>) {
+                var localKey = (ContextLocal<Object>) key;
+                if (localKey == null) {
+                    return false;
+                }
+                context.removeLocal(localKey, QuarkusAccessModes.ACQUIRE_RELEASE);
+                return true;
+            }
+            assert !(key instanceof ContextLocal<?>);
             return context.localContextData().remove(key) != null;
         } else {
             throw new UnsupportedOperationException(ILLEGAL_ACCESS_TO_LOCAL_CONTEXT);

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/VertxContextSafetyToggle.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/VertxContextSafetyToggle.java
@@ -1,8 +1,11 @@
 package io.quarkus.vertx.core.runtime.context;
 
+import static io.quarkus.vertx.runtime.storage.QuarkusLocalStorageKeyVertxServiceProvider.ACCESS_TOGGLE_KEY;
+
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.core.spi.context.storage.ContextLocal;
 
 /**
  * This is meant for other extensions to integrate with, to help
@@ -39,7 +42,6 @@ import io.vertx.core.Vertx;
  */
 public final class VertxContextSafetyToggle {
 
-    private static final Object ACCESS_TOGGLE_KEY = new Object();
     public static final String UNRESTRICTED_BY_DEFAULT_PROPERTY = "io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.UNRESTRICTED_BY_DEFAULT";
 
     /**
@@ -49,6 +51,12 @@ public final class VertxContextSafetyToggle {
     public static final String FULLY_DISABLE_PROPERTY = "io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.I_HAVE_CHECKED_EVERYTHING";
     private static final boolean UNRESTRICTED_BY_DEFAULT = Boolean.getBoolean(UNRESTRICTED_BY_DEFAULT_PROPERTY);
     private static final boolean FULLY_DISABLED = Boolean.getBoolean(FULLY_DISABLE_PROPERTY);
+
+    public static ContextLocal<Boolean> registerAccessToggleKey() {
+        if (FULLY_DISABLED)
+            return null;
+        return ContextLocal.registerLocal(Boolean.class);
+    }
 
     /**
      * Verifies if the current Vert.x context was flagged as safe

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/storage/QuarkusLocalStorageKeyVertxServiceProvider.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/storage/QuarkusLocalStorageKeyVertxServiceProvider.java
@@ -1,0 +1,23 @@
+package io.quarkus.vertx.runtime.storage;
+
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.vertx.core.impl.VertxBuilder;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+/**
+ * This provider exists with the sole purpose of reliably get the optimized local keys created before
+ * the Vertx instance is created.
+ */
+public class QuarkusLocalStorageKeyVertxServiceProvider implements VertxServiceProvider {
+
+    public static final ContextLocal<Boolean> ACCESS_TOGGLE_KEY = VertxContextSafetyToggle.registerAccessToggleKey();
+    public static final ContextLocal<InjectableContext.ContextState> REQUEST_SCOPED_LOCAL_KEY = ContextLocal
+            .registerLocal(InjectableContext.ContextState.class);
+
+    @Override
+    public void init(VertxBuilder builder) {
+
+    }
+}

--- a/extensions/vertx/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.quarkus.vertx.runtime.storage.QuarkusLocalStorageKeyVertxServiceProvider


### PR DESCRIPTION
This is to keep up with the Vertx API changes for https://github.com/eclipse-vertx/vert.x/commit/88cf77bfe4f44c3dc5ee89d65b8891674088de46, although I'm not very happy with the current state (that's why is in draft):
1. `VertxLocalsHelper.` is "stealthy" using the new API by intercepting when users are passing `ContextLocal`-like keys, which means performing 2 instanceof checks (one being an interface check too, which is not yet safe with JDK till 21...)
2. As written in the `TODO` parts, we have some ordering issue: we need the keys statically defined as `ACCESS_TOGGLE_KEY` to be initialized before instantiating the `Vertx` instance has to use them, due to https://github.com/eclipse-vertx/vert.x/blob/4.5.7/src/main/java/io/vertx/core/impl/VertxImpl.java#L194 which is forcing every new context creation to dedicate the fixed amount of "optimized" keys in the context's local storage
3. The new `AccessMode` I've defined is good enough that having a new method in `AccessMode::putRelease`, would have been better IMO (@vietj )

For @mkouba and @Ladicek : the new "optimized" API for local storage is double edge sword because it needs some care on init ordering, need some care in dev mode (I think, @geoand ? @sanne ?) and requires to create local "permanent" keys only for the ones we're 100% are going to be stored on each context (and I need some help from @Ladicek and @mkouba for such, I have no IDEA!)

Additionally there are some weird things in the original API (but is ok, the purpose of dog fooding is indeed to try things and found how to use them!): @vietj see https://github.com/quarkusio/quarkus/compare/main...franz1981:quarkus:local_ctx?expand=1#diff-af571e338cf42e877b9b99b70840f0842b293365f18c24d5fb24c930e5b0b064R64: this one is just wrong, because we cannot query all the local storage `ContextLocal`'s values stored in the source context...we cannot do it unless we have a new method as `ContextInternal::addLocals(ContextInternal from, AccessMode accessMode)` 