### PR TITLE
Use Provider instead of Property in Quarkus Gradle Extension

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -270,10 +270,14 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
     }
 
     public void set(String name, @Nullable String value) {
-        quarkusBuildProperties.put(String.format("quarkus.%s", name), value);
+        quarkusBuildProperties.put(addQuarkusBuildPropertyPrefix(name), value);
     }
 
-    public void set(String name, Property<String> value) {
-        quarkusBuildProperties.put(String.format("quarkus.%s", name), value);
+    public void set(String name, Provider<String> value) {
+        quarkusBuildProperties.put(addQuarkusBuildPropertyPrefix(name), value);
+    }
+
+    private String addQuarkusBuildPropertyPrefix(String name) {
+        return String.format("quarkus.%s", name);
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/extension/QuarkusExtensionTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/extension/QuarkusExtensionTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.gradle.extension;
 
 import static io.quarkus.gradle.QuarkusPlugin.EXTENSION_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -14,5 +16,17 @@ public class QuarkusExtensionTest {
 
         QuarkusPluginExtension extension = project.getExtensions().create(EXTENSION_NAME, QuarkusPluginExtension.class,
                 project);
+    }
+
+    @Test
+    void prefixesBuildProperty() {
+        Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply("java");
+        QuarkusPluginExtension extension = project.getExtensions()
+                .create(EXTENSION_NAME, QuarkusPluginExtension.class, project);
+
+        extension.set("test.args", "value");
+
+        assertThat(extension.getQuarkusBuildProperties().get()).containsExactly(entry("quarkus.test.args", "value"));
     }
 }


### PR DESCRIPTION
The `MapProperty#put` method expects either an instance or a `Provider` of the value type `T` when adding new values to the underlying map. The `QuarkusPluginExtension#set` method uses a `Property` instead of a `Provider`, which requires a more verbose syntax.