### PR TITLE
[3.8] Upgrade to Hibernate ORM 6.4.8.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -101,7 +101,7 @@
              bytebuddy.version (just below), hibernate-orm.version-for-documentation (in docs/pom.xml)
              and both hibernate-orm.version and antlr.version in build-parent/pom.xml
              WARNING again for diffs that don't provide enough context: when updating, see above -->
-        <hibernate-orm.version>6.4.4.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.4.8.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.11</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.2.2.Final</hibernate-reactive.version>


### PR DESCRIPTION
See https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HHH%20AND%20fixVersion%20in%20(6.4.5,6.4.6,6.4.7,6.4.8)%20ORDER%20BY%20updated

It seems we've been missing quite a few updates... Should we enable dependabot on LTS branches, @gsmet? Apparently that's possible, but requires duplicating config for each maintenance branch and setting `target-branch`: https://github.com/dependabot/dependabot-core/issues/569#issuecomment-402619051 That's probably reasonable anyway, since on LTS branches we likely only want dependabot PRs for a few of our dependencies only.