### PR TITLE
Update Pulsar's artifactId dependency

### DIFF
--- a/docs/src/main/asciidoc/pulsar.adoc
+++ b/docs/src/main/asciidoc/pulsar.adoc
@@ -56,14 +56,14 @@ This will add the following to your build file:
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-messaging-pulsar</artifactId>
+    <artifactId>quarkus-smallrye-reactive-messaging-pulsar</artifactId>
 </dependency>
 ----
 
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-implementation("io.quarkus:quarkus-messaging-pulsar")
+implementation("io.quarkus:quarkus-smallrye-reactive-messaging-pulsar")
 ----
 
 [NOTE]


### PR DESCRIPTION
Hi everyone ! 

I saw an incoherence in the  the Pulsar [documentation](https://quarkus.io/guides/pulsar) 

in fact, it is proposed as Maven dependency :  `<artifactId>quarkus-messaging-pulsar</artifactId>` 
Or when I execute `quarkus extension add messaging-pulsar` I get `<artifactId>quarkus-smallrye-reactive-messaging-pulsar</artifactId>`

I therefore suggest a small documentation update :) 