### PR TITLE
Bump JUnit to 5.11.0-M2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -139,7 +139,7 @@
         <db2-jdbc.version>11.5.8.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.11.0-M2</junit.jupiter.version>
         <infinispan.version>15.0.3.Final</infinispan.version>
         <infinispan.protostream.version>5.0.3.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ plugin-publish = "1.2.1"
 kotlin = "1.9.24"
 smallrye-config = "3.7.1"
 
-junit5 = "5.10.2"
+junit5 = "5.11.0-M2"
 assertj = "3.25.3"
 
 [plugins]

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -51,7 +51,7 @@
         <version.bridger>1.6.Final</version.bridger>
         <!-- test versions -->
         <version.assertj>3.25.3</version.assertj>
-        <version.junit5>5.10.2</version.junit5>
+        <version.junit5>5.11.0-M2</version.junit5>
         <version.kotlin>1.9.23</version.kotlin>
         <version.kotlin-coroutines>1.8.1</version.kotlin-coroutines>
         <version.mockito>5.12.0</version.mockito>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -44,7 +44,7 @@
         <assertj.version>3.25.3</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.11.0-M2</junit.jupiter.version>
         <maven-core.version>3.9.6</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.9.0.M2</sisu.version><!-- Keep in sync with maven-core.version -->
         <maven-plugin-annotations.version>3.10.2</maven-plugin-annotations.version>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -43,7 +43,7 @@
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <jackson-bom.version>2.17.1</jackson-bom.version>
         <smallrye-beanbag.version>1.4.1</smallrye-beanbag.version>
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.11.0-M2</junit.jupiter.version>
     </properties>
     <build>
         <testResources>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -45,7 +45,7 @@
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
 
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.11.0-M2</junit.jupiter.version>
         <assertj.version>3.25.3</assertj.version>
     </properties>
 

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.junit>5.10.2</version.junit>
+        <version.junit>5.11.0-M2</version.junit>
         <version.assertj>3.25.3</version.assertj>
         <version.jandex>3.2.0</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -47,7 +47,7 @@
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <jandex.version>3.2.0</jandex.version>
         <bytebuddy.version>1.14.11</bytebuddy.version>
-        <junit5.version>5.10.2</junit5.version>
+        <junit5.version>5.11.0-M2</junit5.version>
         <maven.version>3.9.6</maven.version>
         <assertj.version>3.25.3</assertj.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -51,7 +51,7 @@
         <assertj.version>3.25.3</assertj.version>
         <jackson-bom.version>2.17.1</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
-        <junit.version>5.10.2</junit.version>
+        <junit.version>5.11.0-M2</junit.version>
         <commons-compress.version>1.26.1</commons-compress.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>
         <mockito.version>5.11.0</mockito.version>


### PR DESCRIPTION
Relates to #40601, #40749, #38991. No use waiting for Dependabot. Fixes problem where an NPE can occur in some tests.