### PR TITLE
Podman on linux doc: prefix the remote socket path with unix://

### DIFF
--- a/docs/src/main/asciidoc/podman.adoc
+++ b/docs/src/main/asciidoc/podman.adoc
@@ -73,7 +73,7 @@ With the above rootless setup on Linux, you will need to configure clients, such
 
 [source,bash]
 ----
-export DOCKER_HOST=$(podman info --format '{{.Host.RemoteSocket.Path}}')
+export DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')
 ----
 
 == Other Linux settings


### PR DESCRIPTION
As in the Podman doc : https://podman-desktop.io/docs/migrating-from-docker/using-the-docker_host-environment-variable