### PR TITLE
Update kafka strimzi and redpanda images

### DIFF
--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -82,7 +82,7 @@ For Strimzi, you can select any image with a Kafka version which has Kraft suppo
 
 [source, properties]
 ----
-quarkus.kafka.devservices.image-name=quay.io/strimzi-test-container/test-container:0.105.0-kafka-3.6.0
+quarkus.kafka.devservices.image-name=quay.io/strimzi-test-container/test-container:0.106.0-kafka-3.7.0
 ----
 
 == Configuring Kafka topics

--- a/docs/src/main/asciidoc/kafka-getting-started.adoc
+++ b/docs/src/main/asciidoc/kafka-getting-started.adoc
@@ -408,7 +408,7 @@ version: '3.5'
 services:
 
   zookeeper:
-    image: quay.io/strimzi/kafka:0.39.0-kafka-3.6.1
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
     command: [
       "sh", "-c",
       "bin/zookeeper-server-start.sh config/zookeeper.properties"
@@ -421,7 +421,7 @@ services:
       - kafka-quickstart-network
 
   kafka:
-    image: quay.io/strimzi/kafka:0.39.0-kafka-3.6.1
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
     command: [
       "sh", "-c",
       "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -324,7 +324,7 @@ version: '2'
 services:
 
   zookeeper:
-    image: quay.io/strimzi/kafka:0.39.0-kafka-3.6.1
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
     command: [
         "sh", "-c",
         "bin/zookeeper-server-start.sh config/zookeeper.properties"
@@ -335,7 +335,7 @@ services:
       LOG_DIR: /tmp/logs
 
   kafka:
-    image: quay.io/strimzi/kafka:0.39.0-kafka-3.6.1
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
     command: [
         "sh", "-c",
         "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"

--- a/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
@@ -352,7 +352,7 @@ version: '2'
 services:
 
   zookeeper:
-    image: quay.io/strimzi/kafka:0.39.0-kafka-3.6.1
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
     command: [
         "sh", "-c",
         "bin/zookeeper-server-start.sh config/zookeeper.properties"
@@ -363,7 +363,7 @@ services:
       LOG_DIR: /tmp/logs
 
   kafka:
-    image: quay.io/strimzi/kafka:0.39.0-kafka-3.6.1
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
     command: [
         "sh", "-c",
         "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -499,7 +499,7 @@ version: '3.5'
 
 services:
   zookeeper:
-    image: quay.io/strimzi/kafka:0.39.0-kafka-3.6.1
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
     command: [
       "sh", "-c",
       "bin/zookeeper-server-start.sh config/zookeeper.properties"
@@ -511,7 +511,7 @@ services:
     networks:
       - kafkastreams-network
   kafka:
-    image: quay.io/strimzi/kafka:0.39.0-kafka-3.6.1
+    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
     command: [
       "sh", "-c",
       "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT} --override num.partitions=$${KAFKA_NUM_PARTITIONS}"

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -2423,7 +2423,7 @@ The configuration of the created Kafka broker can be customized using `@Resource
 [source,java]
 ----
 @QuarkusTestResource(value = KafkaCompanionResource.class, initArgs = {
-        @ResourceArg(name = "strimzi.kafka.image", value = "quay.io/strimzi-test-container/test-container:0.105.0-kafka-3.6.0"), // Image name
+        @ResourceArg(name = "strimzi.kafka.image", value = "quay.io/strimzi-test-container/test-container:0.106.0-kafka-3.7.0"), // Image name
         @ResourceArg(name = "kafka.port", value = "9092"), // Fixed port for kafka, by default it will be exposed on a random port
         @ResourceArg(name = "kraft", value = "true"), // Enable Kraft mode
         @ResourceArg(name = "num.partitions", value = "3"), // Other custom broker configurations

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -48,7 +48,7 @@ public class KafkaDevServicesBuildTimeConfig {
     public Provider provider = Provider.REDPANDA;
 
     public enum Provider {
-        REDPANDA("docker.io/vectorized/redpanda:v22.3.4"),
+        REDPANDA("docker.io/vectorized/redpanda:v24.1.2"),
         STRIMZI("quay.io/strimzi-test-container/test-container:latest-kafka-3.7.0"),
         KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest");
 

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -49,7 +49,7 @@ public class KafkaDevServicesBuildTimeConfig {
 
     public enum Provider {
         REDPANDA("docker.io/vectorized/redpanda:v22.3.4"),
-        STRIMZI("quay.io/strimzi-test-container/test-container:latest-kafka-3.2.1"),
+        STRIMZI("quay.io/strimzi-test-container/test-container:latest-kafka-3.7.0"),
         KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest");
 
         private final String defaultImageName;

--- a/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaKeycloakTestResource.java
+++ b/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaKeycloakTestResource.java
@@ -29,7 +29,7 @@ public class KafkaKeycloakTestResource implements QuarkusTestResourceLifecycleMa
         client.createRealmFromPath(KEYCLOAK_REALM_JSON);
 
         //Start kafka container
-        this.kafka = new StrimziKafkaContainer("quay.io/strimzi/kafka:latest-kafka-3.0.0")
+        this.kafka = new StrimziKafkaContainer("quay.io/strimzi/kafka:latest-kafka-3.7.0")
                 .withBrokerId(1)
                 .withKafkaConfigurationMap(Map.of("listener.security.protocol.map",
                         "JWT:SASL_PLAINTEXT,BROKER1:PLAINTEXT",


### PR DESCRIPTION
Updating kafka ztrimzi and redpanda images as mainly kafka strimzi images for devmode and test are old. For redpanda I used latest image and try it on kafka quickstart. Didn't see any different behavioral.

For strimzi I teted it by 2 integration test and also try it with QE tests and dind't see any problem.