### PR TITLE
Fix collapsing when there are several keys

### DIFF
--- a/docs/src/main/asciidoc/javascript/config.js
+++ b/docs/src/main/asciidoc/javascript/config.js
@@ -24,7 +24,7 @@ if(tables){
                 const decoration = td.firstElementChild.lastElementChild.firstElementChild;
                 const iconDecoration = decoration.children.item(0);
                 const collapsibleSpan = decoration.children.item(1);
-                const descDiv = td.firstElementChild.children.item(1);
+                const descDiv = td.firstElementChild.querySelector(".description");
                 const collapsibleHandler = makeCollapsibleHandler(descDiv, td, row, collapsibleSpan, iconDecoration);
                 row.addEventListener('click', collapsibleHandler);
             }


### PR DESCRIPTION
@yrodiere this is related to your patch that handles named keys differently. When having two keys, things went berserk.