### PR TITLE
Fix doc structure

### DIFF
--- a/docs/src/main/asciidoc/telemetry-opentracing-to-otel-tutorial.adoc
+++ b/docs/src/main/asciidoc/telemetry-opentracing-to-otel-tutorial.adoc
@@ -302,7 +302,7 @@ innerSpan.setTag("error.message", e.getMessage());```
 innerSpan.recordException(e);```
 
 |-
-|Baggage carried by SpanContext in the Span    | Baggage is an independent signal propagated in parallel with the OTel Context
+|Baggage carried by SpanContext in the Span
 |Baggage is an independent signal propagated in parallel with the OTel Context, it's not part of it.
 |===
 


### PR DESCRIPTION
- This fixes the build broken by https://github.com/quarkusio/quarkus/pull/40758

```
[INFO] Converted /home/runner/work/quarkus/quarkus/docs/target/asciidoc/sources/telemetry-opentracing-to-otel-tutorial.adoc
Error:  asciidoctor: ERROR: telemetry-opentracing-to-otel-tutorial.adoc: line 306: dropping cells from incomplete row detected end of table
```