### PR TITLE
Bump Agroal from 2.3 to 2.4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -109,7 +109,7 @@
         <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
         <hibernate-search.version>7.1.1.Final</hibernate-search.version>
         <narayana.version>7.0.1.Final</narayana.version>
-        <agroal.version>2.3</agroal.version>
+        <agroal.version>2.4</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
         <elasticsearch-opensource-components.version>8.13.4</elasticsearch-opensource-components.version>
         <rxjava.version>2.2.21</rxjava.version>


### PR DESCRIPTION
This fixes QUARKUS-4185:

"Every two minutes, the "periodic recovery" thread runs for each XA data source. It opens a connection to the database (Microsoft SQL Server), performs some queries, and then closes the connection.

Over time, the difference between "Start create new connection for pool" and "Closing physical connection" log entries shows that database connections are left open, which is confirmed on the SQL Server end in the dm_exec_connections table."

