### PR TITLE
[3.10] Update Hibernate ORM to 6.4.8.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -101,7 +101,7 @@
              bytebuddy.version (just below), hibernate-orm.version-for-documentation (in docs/pom.xml)
              and both hibernate-orm.version and antlr.version in build-parent/pom.xml
              WARNING again for diffs that don't provide enough context: when updating, see above -->
-        <hibernate-orm.version>6.4.7.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.4.8.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.11</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.2.2.Final</hibernate-reactive.version>


### PR DESCRIPTION
Given we update to 6.4.8.Final in 3.8, we might as well be consistent here.