### PR TITLE
Revert "Bump jakarta.authorization:jakarta.authorization-api from 2.1.0 to 3.0.0"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -67,7 +67,7 @@
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <jakarta.authentication-api>3.0.0</jakarta.authentication-api>
-        <jakarta.authorization-api.version>3.0.0</jakarta.authorization-api.version>
+        <jakarta.authorization-api.version>2.1.0</jakarta.authorization-api.version>
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>


### PR DESCRIPTION
This reverts commit 1c8d9f36c435344c8c13065ced57536929f61ce9.

As stated in https://github.com/quarkusio/quarkus/pull/40607, I think we should update all the Jakarta EE dependencies in one go when they are all ready.
Unfortunately, this will hit 3.11.0 but better fixing it for 3.11.1 anyway.