### PR TITLE
Trivial: Update matcher in component test test to catch single test case

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildStep.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ProdModeTestBuildStep.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 import io.quarkus.builder.BuildStep;
 
-// needs to be in a class of it's own in order to avoid java.lang.IncompatibleClassChangeError
+// needs to be in a class of its own in order to avoid java.lang.IncompatibleClassChangeError
 public abstract class ProdModeTestBuildStep implements BuildStep {
 
     private final Map<String, Object> testContext;

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/continuoustesting/TestModeContinuousTestingMavenTestUtils.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/continuoustesting/TestModeContinuousTestingMavenTestUtils.java
@@ -22,10 +22,11 @@ public class TestModeContinuousTestingMavenTestUtils extends ContinuousTestingMa
     // Example output we look for
     // 1 test failed (1 passing, 0 skipped), 1 test was run in 217ms. Tests completed at 21:22:34 due to changes to HelloResource$Blah.class and 1 other files.
     // All 2 tests are passing (0 skipped), 2 tests were run in 1413ms. Tests completed at 21:22:33.
+    // All 1 test is passing (0 skipped), ...
     // Windows log, despite `quarkus.console.basic=true', might contain terminal control symbols, colour decorations.
     // e.g. the matcher is then fighting: [39m[91m1 test failed[39m ([32m1 passing[39m, [94m0 skipped[39m)
     private static final Pattern ALL_PASSING = Pattern.compile(
-            "(?:\\e\\[[\\d;]+m)*All (\\d+) tests are passing \\((\\d+) skipped\\)",
+            "(?:\\e\\[[\\d;]+m)*All (\\d+) tests? (?:are|is) passing \\((\\d+) skipped\\)",
             Pattern.MULTILINE);
     private static final Pattern SOME_PASSING = Pattern
             .compile(


### PR DESCRIPTION
I found this in a monster changeset of mine, so pulling it out into its own safe little change. I assume something else in my changeset exposed the incomplete matcher. Reading https://github.com/quarkusio/quarkus/blob/adee1a6e74e8a85b4f08c95342990c6f7966bce6/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java#L207, we would expect "all 1 test is passing" not "all 1 tests are passing". 

I also fixed a typo in a comment. I dunno, should we update the release notes for that? :)