### PR TITLE
Handling deserialization failures for Kafka documentation updated

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -472,6 +472,12 @@ To use this failure handler, the bean must be exposed with the `@Identifier` qua
 The handler is called with details of the deserialization, including the action represented as `Uni<T>`.
 On the deserialization `Uni` failure strategies like retry, providing a fallback value or applying timeout can be implemented.
 
+If you don’t configure a deserialization failure handler and a deserialization failure happens, the application is marked unhealthy.
+You can also ignore the failure, which will log the exception and produce a `null` value.
+To enable this behavior, set the `mp.messaging.incoming.$channel.fail-on-deserialization-failure` attribute to `false`.
+
+If the `fail-on-deserialization-failure` attribute is set to `false` and the `failure-strategy` attribute is `dead-letter-queue` the failed record will be sent to the corresponding *dead letter queue* topic.
+
 === Consumer Groups
 
 In Kafka, a consumer group is a set of consumers which cooperate to consume data from a topic.


### PR DESCRIPTION
Post smallrye reactive messaging release 4.10.0, the deserialization failure handling has been upgraded to align with the failure strategy. The smallrye reactive documentation was updated, but the related quarkus documentation is still not yet updated.

This documentation change MR should also be back ported to 3.8 version.

Smallrye MR : https://github.com/smallrye/smallrye-reactive-messaging/pull/2256/files#diff-7bbf3222942af87ef0b2fdde53936b4a9e371b3968c8b09159430296cbefd042

Smallrye documentation: https://smallrye.io/smallrye-reactive-messaging/4.21.0/kafka/receiving-kafka-records/#handling-deserialization-failures

If fail-on-deserialization-failure attribute is set to false and the failure-strategy attribute is dead-letter-queue.
With Quarkus 3.2, the failed message won't be posted to DLQ
But starting from Quarkus 3.8, the failed message will be pushed to DLQ based on failure strategy

Documentation should mention that the message would be pushed to DLQ if the failure strategy is DLQ.
Otherwise unaware developers might end up implementing a custom failure handler to push it to DLQ.