### PR TITLE
Fix SharedOpenArchivePathTree.open() to go through acquiring process

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
@@ -85,6 +85,11 @@ class SharedArchivePathTree extends ArchivePathTree {
         }
 
         @Override
+        public OpenPathTree open() {
+            return SharedArchivePathTree.this.open();
+        }
+
+        @Override
         public void close() throws IOException {
             writeLock().lock();
             final boolean close = users.decrementAndGet() == 0;


### PR DESCRIPTION
This change fixes `SharedOpenArchivePathTree.open()`, instead of delegating it to `OpenArchivePathTree.open()` it should go through the "acquiring process", otherwise the `users` counter isn't properly updated and the `FileSystem` instance managed by this instance may get closed before all its users have been done using it.