### PR TITLE
Make LRA proxy endpoints optional in OpenAPI

### DIFF
--- a/extensions/narayana-lra/deployment/pom.xml
+++ b/extensions/narayana-lra/deployment/pom.xml
@@ -21,6 +21,35 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/LRABuildTimeConfiguration.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/LRABuildTimeConfiguration.java
@@ -1,0 +1,18 @@
+package io.quarkus.narayana.lra.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * LRA build time configuration properties
+ */
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public final class LRABuildTimeConfiguration {
+
+    /**
+     * Whether to include LRA proxy endpoints in the generated OpenAPI document
+     */
+    @ConfigItem(name = "openapi.included", defaultValue = "false")
+    public boolean openapiIncluded;
+}

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/NarayanaLRAOpenAPIFilter.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/NarayanaLRAOpenAPIFilter.java
@@ -1,0 +1,48 @@
+package io.quarkus.narayana.lra.deployment;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Paths;
+
+public class NarayanaLRAOpenAPIFilter implements OASFilter {
+
+    final static String LRA_PROXY_PATH = "/lraproxy";
+    final static String LRA_PARTICIAPANT_PROXY_PATH = "/lra-participant-proxy";
+    final static String LRA_STATUS_SCHEMA = "LRAStatus";
+
+    boolean openapiIncluded;
+
+    public NarayanaLRAOpenAPIFilter(boolean openapiIncluded) {
+        this.openapiIncluded = openapiIncluded;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+
+        Paths paths = openAPI.getPaths();
+
+        if (!openapiIncluded) {
+
+            Set<String> lraProxyPaths = new HashSet<>();
+
+            for (String path : paths.getPathItems().keySet()) {
+                if (path.startsWith(LRA_PROXY_PATH) || path.startsWith(LRA_PARTICIAPANT_PROXY_PATH)) {
+                    lraProxyPaths.add(path);
+                }
+            }
+
+            // remove LRA proxy paths from OpenAPI
+            for (String path : lraProxyPaths) {
+                paths.removePathItem(path);
+            }
+
+            // remove LRA schema from OpenAPI
+            openAPI.getComponents().removeSchema(LRA_STATUS_SCHEMA);
+        }
+
+    }
+
+}

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/NarayanaLRAProcessor.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/NarayanaLRAProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.narayana.lra.runtime.LRAConfiguration;
 import io.quarkus.narayana.lra.runtime.NarayanaLRAProducers;
 import io.quarkus.narayana.lra.runtime.NarayanaLRARecorder;
+import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
 
 class NarayanaLRAProcessor {
 
@@ -152,5 +153,15 @@ class NarayanaLRAProcessor {
                 .addBeanClass(ParticipantProxyResource.class)
                 .build());
         additionalBeans.produce(new AdditionalBeanBuildItem(NarayanaLRAProducers.class));
+    }
+
+    @BuildStep
+    public void filterOpenAPIEndpoint(BuildProducer<AddToOpenAPIDefinitionBuildItem> openAPIProducer,
+            Capabilities capabilities, LRABuildTimeConfiguration lraBuildTimeConfig) {
+
+        if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI)) {
+            NarayanaLRAOpenAPIFilter lraOpenAPIFilter = new NarayanaLRAOpenAPIFilter(lraBuildTimeConfig.openapiIncluded);
+            openAPIProducer.produce(new AddToOpenAPIDefinitionBuildItem(lraOpenAPIFilter));
+        }
     }
 }

--- a/extensions/narayana-lra/deployment/src/test/java/io/quarkus/narayana/lra/test/LRAOpenAPIExcludedTest.java
+++ b/extensions/narayana-lra/deployment/src/test/java/io/quarkus/narayana/lra/test/LRAOpenAPIExcludedTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.narayana.lra.test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class LRAOpenAPIExcludedTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().withApplicationRoot((jar) -> jar
+            .addAsResource(new StringAsset("quarkus.lra.openapi.included=false"),
+                    "application.properties"));
+
+    @Test
+    public void testLRAExcluded() {
+        RestAssured.when().get("/q/openapi").then()
+                .body(not(containsString("lraproxy")), not(containsString("lra-participant-proxy")),
+                        not(containsString("LRAStatus")));
+    }
+}

--- a/extensions/narayana-lra/deployment/src/test/java/io/quarkus/narayana/lra/test/LRAOpenAPIIncludedTest.java
+++ b/extensions/narayana-lra/deployment/src/test/java/io/quarkus/narayana/lra/test/LRAOpenAPIIncludedTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.narayana.lra.test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class LRAOpenAPIIncludedTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().withApplicationRoot((jar) -> jar
+            .addAsResource(new StringAsset("quarkus.lra.openapi.included=true"),
+                    "application.properties"));
+
+    @Test
+    public void testLRAIncluded() {
+        RestAssured.when().get("/q/openapi").then()
+                .body(containsString("lraproxy"), containsString("lra-participant-proxy"), containsString("LRAStatus"));
+    }
+}


### PR DESCRIPTION
PR to resolve https://github.com/quarkusio/quarkus/issues/23586.
Add a flag to enable/disable LRA endpoints in OpenAPI/Swagger.
LRA endpoints are disabled by default.

I propose to update the LRA guide it in a separate PR. 