### PR TITLE
Add Redirect annotation for OidcRedirectFilter

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -475,6 +475,7 @@ import org.eclipse.microprofile.jwt.Claims;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.oidc.AuthorizationCodeTokens;
 import io.quarkus.oidc.OidcRedirectFilter;
+import io.quarkus.oidc.Redirect;
 import io.quarkus.oidc.TenantFeature;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.smallrye.jwt.build.Jwt;
@@ -482,27 +483,29 @@ import io.smallrye.jwt.build.Jwt;
 @ApplicationScoped
 @Unremovable
 @TenantFeature("tenant-refresh")
+@Redirect(Location.SESSION_EXPIRED_PAGE) <1>
 public class SessionExpiredOidcRedirectFilter implements OidcRedirectFilter {
 
     @Override
     public void filter(OidcRedirectContext context) {
 
         if (context.redirectUri().contains("/session-expired-page")) {
-            AuthorizationCodeTokens tokens = context.routingContext().get(AuthorizationCodeTokens.class.getName()); <1>
-            String userName = OidcUtils.decodeJwtContent(tokens.getIdToken()).getString(Claims.preferred_username.name()); <2>
-            String jwe = Jwt.preferredUserName(userName).jwe()
-                    .encryptWithSecret(context.oidcTenantConfig().credentials.secret.get()); <3>
-            OidcUtils.createCookie(context.routingContext(), context.oidcTenantConfig(), "session_expired",
-                    jwe + "|" + context.oidcTenantConfig().tenantId.get(), 10); <4>
+        AuthorizationCodeTokens tokens = context.routingContext().get(AuthorizationCodeTokens.class.getName()); <2>
+        String userName = OidcUtils.decodeJwtContent(tokens.getIdToken()).getString(Claims.preferred_username.name()); <3>
+        String jwe = Jwt.preferredUserName(userName).jwe()
+                .encryptWithSecret(context.oidcTenantConfig().credentials.secret.get()); <4>
+        OidcUtils.createCookie(context.routingContext(), context.oidcTenantConfig(), "session_expired",
+                jwe + "|" + context.oidcTenantConfig().tenantId.get(), 10); <5>
      }
     }
 }
 
 ----
-<1> Access `AuthorizationCodeTokens` tokens associated with the now expired session as a `RoutingContext`  attribute.
-<2> Decode ID token claims and get a user name.
-<3> Save the user name in a JWT token encrypted with the current OIDC tenant's client secret.
-<4> Create a custom `session_expired` cookie valid for 5 seconds which joins the encrypted token and a tenant id using a "|" separator. Recording a tenant id in a custom cookie can help to generate correct session expired pages in a multi-tenant OIDC setup.
+<1> Make sure this redirect filter is only called during a redirect to the session expired page.
+<2> Access `AuthorizationCodeTokens` tokens associated with the now expired session as a `RoutingContext`  attribute.
+<3> Decode ID token claims and get a user name.
+<4> Save the user name in a JWT token encrypted with the current OIDC tenant's client secret.
+<5> Create a custom `session_expired` cookie valid for 5 seconds which joins the encrypted token and a tenant id using a "|" separator. Recording a tenant id in a custom cookie can help to generate correct session expired pages in a multi-tenant OIDC setup.
 
 Next, a public JAX-RS resource which generates session expired pages can use this cookie to create a page tailored for this user and the corresponding OIDC tenant, for example:
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -546,7 +546,6 @@ public class OidcCommonUtils {
             combined.addAll(all);
             return combined;
         }
-
     }
 
     public static Uni<HttpResponse<Buffer>> sendRequest(io.vertx.core.Vertx vertx, HttpRequest<Buffer> request,

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/Redirect.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/Redirect.java
@@ -1,0 +1,52 @@
+package io.quarkus.oidc;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that can be used to restrict {@link OidcRedirectFilter} to specific redirect locations
+ */
+@Target({ TYPE })
+@Retention(RUNTIME)
+public @interface Redirect {
+
+    enum Location {
+        ALL,
+
+        /**
+         * Applies to OIDC authorization endpoint
+         */
+        OIDC_AUTHORIZATION,
+
+        /**
+         * Applies to OIDC logout endpoint
+         */
+        OIDC_LOGOUT,
+
+        /**
+         * Applies to the local redirect to a custom error page resource when an authorization code flow
+         * redirect from OIDC provider to Quarkus returns an error instead of an authorization code
+         */
+        ERROR_PAGE,
+
+        /**
+         * Applies to the local redirect to a custom session expired page resource when
+         * the current user's session has expired and no longer can be refreshed.
+         */
+        SESSION_EXPIRED_PAGE,
+
+        /**
+         * Applies to the local redirect to the callback resource which is done after successful authorization
+         * code flow completion in order to drop the code and state parameters from the callback URL.
+         */
+        LOCAL_ENDPOINT_CALLBACK
+    }
+
+    /**
+     * Identifies one or more redirect locations.
+     */
+    Location[] value() default Location.ALL;
+}


### PR DESCRIPTION
This is a follow up to #40600, the idea of this PR was briefly mentioned during the #40600 review, and is about letting users bind `OidcRedirectFilter` to specific redirect locations only, which can help to simplify the filter code, where the code is focusing on a specific redirect only, instead of filtering the redirect URI for a specific location value which the filter must also be made aware of somehow.

The code is done similarly to how it is done for `OidcRequestFilter` which can be bound to specific OIDC endpoints only.

Updated one of the test filters (a 2nd test filter remains global), and the docs