### PR TITLE
Move standard `ObjectMapper` customization to dedicated Customizer

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -63,6 +63,7 @@ import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.jackson.JacksonMixin;
 import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.jackson.runtime.ConfigurationCustomizer;
 import io.quarkus.jackson.runtime.JacksonBuildTimeConfig;
 import io.quarkus.jackson.runtime.JacksonSupport;
 import io.quarkus.jackson.runtime.JacksonSupportRecorder;
@@ -111,6 +112,8 @@ public class JacksonProcessor {
     @BuildStep
     void unremovable(Capabilities capabilities, BuildProducer<UnremovableBeanBuildItem> producer,
             BuildProducer<AdditionalBeanBuildItem> additionalProducer) {
+        additionalProducer.produce(AdditionalBeanBuildItem.unremovableOf(ConfigurationCustomizer.class));
+
         if (capabilities.isPresent(Capability.VERTX_CORE)) {
             producer.produce(UnremovableBeanBuildItem.beanTypes(ObjectMapper.class));
             additionalProducer.produce(AdditionalBeanBuildItem.unremovableOf(VertxHybridPoolObjectMapperCustomizer.class));

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/ObjectMapperCustomizer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/ObjectMapperCustomizer.java
@@ -15,6 +15,7 @@ import io.quarkus.jackson.runtime.ObjectMapperProducer;
 public interface ObjectMapperCustomizer extends Comparable<ObjectMapperCustomizer> {
 
     int MINIMUM_PRIORITY = Integer.MIN_VALUE;
+    int MAXIMUM_PRIORITY = Integer.MAX_VALUE;
     // we use this priority to give a chance to other customizers to override serializers / deserializers
     // that might have been added by the modules that Quarkus registers automatically
     // (Jackson will keep the last registered serializer / deserializer for a given type

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ConfigurationCustomizer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ConfigurationCustomizer.java
@@ -1,0 +1,65 @@
+package io.quarkus.jackson.runtime;
+
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class ConfigurationCustomizer implements ObjectMapperCustomizer {
+    @Inject
+    JacksonBuildTimeConfig jacksonBuildTimeConfig;
+
+    @Inject
+    JacksonSupport jacksonSupport;
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        if (!jacksonBuildTimeConfig.failOnUnknownProperties) {
+            // this feature is enabled by default, so we disable it
+            objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        }
+        if (!jacksonBuildTimeConfig.failOnEmptyBeans) {
+            // this feature is enabled by default, so we disable it
+            objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        }
+        if (!jacksonBuildTimeConfig.writeDatesAsTimestamps) {
+            // this feature is enabled by default, so we disable it
+            objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        }
+        if (!jacksonBuildTimeConfig.writeDurationsAsTimestamps) {
+            // this feature is enabled by default, so we disable it
+            objectMapper.disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS);
+        }
+        if (jacksonBuildTimeConfig.acceptCaseInsensitiveEnums) {
+            objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+        }
+        JsonInclude.Include serializationInclusion = jacksonBuildTimeConfig.serializationInclusion.orElse(null);
+        if (serializationInclusion != null) {
+            objectMapper.setSerializationInclusion(serializationInclusion);
+        }
+        ZoneId zoneId = jacksonBuildTimeConfig.timezone.orElse(null);
+        if ((zoneId != null) && !zoneId.getId().equals("UTC")) { // Jackson uses UTC as the default, so let's not reset it
+            objectMapper.setTimeZone(TimeZone.getTimeZone(zoneId));
+        }
+        if (jacksonSupport.configuredNamingStrategy().isPresent()) {
+            objectMapper.setPropertyNamingStrategy(jacksonSupport.configuredNamingStrategy().get());
+        }
+    }
+
+    @Override
+    public int priority() {
+        // we return the maximum possible priority to make sure these
+        // settings are always applied first, before any other customizers.
+        return ObjectMapperCustomizer.MAXIMUM_PRIORITY;
+    }
+}

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
@@ -1,20 +1,14 @@
 package io.quarkus.jackson.runtime;
 
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.TimeZone;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
 import io.quarkus.arc.All;
 import io.quarkus.arc.DefaultBean;
@@ -22,43 +16,12 @@ import io.quarkus.jackson.ObjectMapperCustomizer;
 
 @ApplicationScoped
 public class ObjectMapperProducer {
-
     @DefaultBean
     @Singleton
     @Produces
     public ObjectMapper objectMapper(@All List<ObjectMapperCustomizer> customizers,
             JacksonBuildTimeConfig jacksonBuildTimeConfig, JacksonSupport jacksonSupport) {
         ObjectMapper objectMapper = new ObjectMapper();
-        if (!jacksonBuildTimeConfig.failOnUnknownProperties) {
-            // this feature is enabled by default, so we disable it
-            objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        }
-        if (!jacksonBuildTimeConfig.failOnEmptyBeans) {
-            // this feature is enabled by default, so we disable it
-            objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-        }
-        if (!jacksonBuildTimeConfig.writeDatesAsTimestamps) {
-            // this feature is enabled by default, so we disable it
-            objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        }
-        if (!jacksonBuildTimeConfig.writeDurationsAsTimestamps) {
-            // this feature is enabled by default, so we disable it
-            objectMapper.disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS);
-        }
-        if (jacksonBuildTimeConfig.acceptCaseInsensitiveEnums) {
-            objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
-        }
-        JsonInclude.Include serializationInclusion = jacksonBuildTimeConfig.serializationInclusion.orElse(null);
-        if (serializationInclusion != null) {
-            objectMapper.setSerializationInclusion(serializationInclusion);
-        }
-        ZoneId zoneId = jacksonBuildTimeConfig.timezone.orElse(null);
-        if ((zoneId != null) && !zoneId.getId().equals("UTC")) { // Jackson uses UTC as the default, so let's not reset it
-            objectMapper.setTimeZone(TimeZone.getTimeZone(zoneId));
-        }
-        if (jacksonSupport.configuredNamingStrategy().isPresent()) {
-            objectMapper.setPropertyNamingStrategy(jacksonSupport.configuredNamingStrategy().get());
-        }
         List<ObjectMapperCustomizer> sortedCustomizers = sortCustomizersInDescendingPriorityOrder(customizers);
         for (ObjectMapperCustomizer customizer : sortedCustomizers) {
             customizer.customize(objectMapper);


### PR DESCRIPTION
This change moved the standard `ObjectMapper` customization behaviour to its own dedicated `ObjectMapperCustomizer` with maximum priority. This way, these default (config-driven) customizations are available to anyone injecting all Customizers in their own code when creating custom `ObjectMapper` instances - such as ones based on YAML or other formats.

The current code has these customizations tied to the instantiation of a default `ObjectMapper` - thus unavailable to anyone constructing a `YAMLMapper`, `CsvMapper`, or any of the other custom data formats. Other customizations of the `ObjectMapper` offered by Quarkus (such as OTel-specific ones) are offered through the `ObjectMapperCustomizer` interface. This MR makes the situation more consistent, allowing users to inherit all Quarkus customizations.

The new customizer has the highest priority to ensure that the customizations remain applied in the same order.