### PR TITLE
Fix priority of interceptors preventing repeated security checks so that interceptor activating CDI request context runs first

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/StandardSecurityCheckInterceptor.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/StandardSecurityCheckInterceptor.java
@@ -58,7 +58,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @RolesAllowed("")
-    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
     public static final class RolesAllowedInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -68,7 +68,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @PermissionsAllowed("")
-    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
     public static final class PermissionsAllowedInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -78,7 +78,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @PermitAll
-    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
     public static final class PermitAllInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -88,7 +88,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @Authenticated
-    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
     public static final class AuthenticatedInterceptor extends StandardSecurityCheckInterceptor {
 
     }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedService.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedService.java
@@ -1,14 +1,19 @@
 package io.quarkus.resteasy.reactive.server.test.security;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
 
 @ApplicationScoped
 public class RolesAllowedService {
 
     public static final String SERVICE_HELLO = "Hello from Service!";
     public static final String SERVICE_BYE = "Bye from Service!";
+    public static final List<String> EVENT_BUS_MESSAGES = new CopyOnWriteArrayList<>();
 
     @RolesAllowed("admin")
     public String hello() {
@@ -20,4 +25,15 @@ public class RolesAllowedService {
         return SERVICE_BYE;
     }
 
+    @PermitAll
+    @ActivateRequestContext
+    void receivePermitAllMessage(String m) {
+        EVENT_BUS_MESSAGES.add("permit all " + m);
+    }
+
+    @RolesAllowed("admin")
+    @ActivateRequestContext
+    void receiveRolesAllowedMessage(String m) {
+        EVENT_BUS_MESSAGES.add("roles allowed " + m);
+    }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedServiceResource.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedServiceResource.java
@@ -1,15 +1,29 @@
 package io.quarkus.resteasy.reactive.server.test.security;
 
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.core.Vertx;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import io.vertx.mutiny.core.eventbus.MessageConsumer;
 
 @Path("/roles-service")
 public class RolesAllowedServiceResource {
 
+    private MessageConsumer<String> permitAllConsumer;
+    private MessageConsumer<String> rolesAllowedConsumer;
+
     @Inject
     RolesAllowedService rolesAllowedService;
+
+    @Inject
+    EventBus bus;
 
     @Path("/hello")
     @RolesAllowed({ "user", "admin" })
@@ -22,5 +36,36 @@ public class RolesAllowedServiceResource {
     @GET
     public String getServiceBye() {
         return rolesAllowedService.bye();
+    }
+
+    @Path("/secured-event-bus")
+    @POST
+    public void sendMessage(String message) {
+        bus.send("roles-allowed-message", message);
+        bus.send("permit-all-message", message);
+    }
+
+    void observeStartup(@Observes StartupEvent startupEvent, EventBus eventBus, Vertx vertx) {
+        permitAllConsumer = eventBus
+                .<String> consumer("permit-all-message")
+                .handler(msg -> rolesAllowedService.receivePermitAllMessage(msg.body()));
+
+        // this must always fail because the authorization is happening in a blank CDI request context
+        rolesAllowedConsumer = eventBus
+                .<String> consumer("roles-allowed-message")
+                .handler(msg -> vertx.executeBlocking(() -> {
+                    // make sure authentication is attempted on a worker thread to prevent blocking event loop
+                    rolesAllowedService.receiveRolesAllowedMessage(msg.body());
+                    return null;
+                }));
+    }
+
+    void observerShutdown(@Observes ShutdownEvent shutdownEvent) {
+        if (permitAllConsumer != null) {
+            permitAllConsumer.unregister().await().indefinitely();
+        }
+        if (rolesAllowedConsumer != null) {
+            rolesAllowedConsumer.unregister().await().indefinitely();
+        }
     }
 }

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/StandardSecurityCheckInterceptor.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/StandardSecurityCheckInterceptor.java
@@ -54,7 +54,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @RolesAllowed("")
-    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
     public static final class RolesAllowedInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -64,7 +64,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @PermissionsAllowed("")
-    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
     public static final class PermissionsAllowedInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -74,7 +74,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @PermitAll
-    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
     public static final class PermitAllInterceptor extends StandardSecurityCheckInterceptor {
 
     }
@@ -84,7 +84,7 @@ public abstract class StandardSecurityCheckInterceptor {
      */
     @Interceptor
     @Authenticated
-    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    @Priority(Interceptor.Priority.LIBRARY_BEFORE - 100)
     public static final class AuthenticatedInterceptor extends StandardSecurityCheckInterceptor {
 
     }


### PR DESCRIPTION
Makes sure that `ActivateRequestContextInterceptor` runs before interceptors that prevent repeated checks which already happened eagerly.

Motivation for this change: https://github.com/quarkiverse/quarkus-langchain4j/pull/539#issuecomment-2123520926

When HTTP request has completed, the interceptors preventing repeated checks must applied without internal error. See linked issue for more information.

New order:

- `ActivateRequestContextInterceptor` priority 100 (activate request context)
- `StandardSecurityCheckInterceptor`s priority 900 (prevent repeated checks if the security check had been performed eagerly)
- standard security interceptors 1000 (secure CDI beans and play fallback security role for the resources)

It is fairly edge case because it's hard to avoid active CDI request context at that point and if you activate it, you don't have the identity unless you do custom security yourself. Still, it's right thing to fix it.