### PR TITLE
 Arc - improve injection point transformation API

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -346,21 +346,17 @@ public class GrpcClientProcessor {
                 AnnotationInstance clientAnnotation = Annotations.find(ctx.getQualifiers(), GrpcDotNames.GRPC_CLIENT);
                 if (clientAnnotation != null && clientAnnotation.value() == null) {
                     String clientName = null;
-                    AnnotationTarget annotationTarget = ctx.getTarget();
-                    if (ctx.getTarget().kind() == Kind.FIELD) {
+                    AnnotationTarget annotationTarget = ctx.getAnnotationTarget();
+                    if (ctx.getAnnotationTarget().kind() == Kind.FIELD) {
                         clientName = clientAnnotation.target().asField().name();
-                    } else if (ctx.getTarget().kind() == Kind.METHOD
-                            && clientAnnotation.target().kind().equals(Kind.METHOD_PARAMETER)) {
+                    } else if (annotationTarget.kind() == Kind.METHOD_PARAMETER) {
                         MethodParameterInfo param = clientAnnotation.target().asMethodParameter();
-                        annotationTarget = param;
                         // We don't need to check if parameter names are recorded - that's validated elsewhere
                         clientName = param.method().parameterName(param.position());
                     }
                     if (clientName != null) {
                         ctx.transform().remove(GrpcDotNames::isGrpcClient)
-                                .add(AnnotationInstance.builder(GrpcDotNames.GRPC_CLIENT)
-                                        .value(clientName)
-                                        .buildWithTarget(annotationTarget))
+                                .add(AnnotationInstance.builder(GrpcDotNames.GRPC_CLIENT).value(clientName).build())
                                 .done();
                     }
                 }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -3341,10 +3341,10 @@ public class QuteProcessor {
 
     public static String getName(InjectionPointInfo injectionPoint) {
         if (injectionPoint.isField()) {
-            return injectionPoint.getTarget().asField().name();
+            return injectionPoint.getAnnotationTarget().asField().name();
         } else if (injectionPoint.isParam()) {
-            String name = injectionPoint.getTarget().asMethod().parameterName(injectionPoint.getPosition());
-            return name == null ? injectionPoint.getTarget().asMethod().name() : name;
+            String name = injectionPoint.getAnnotationTarget().asMethodParameter().name();
+            return name == null ? injectionPoint.getAnnotationTarget().asMethodParameter().method().name() : name;
         }
         throw new IllegalArgumentException();
     }

--- a/extensions/security-jpa/deployment/src/main/java/io/quarkus/security/jpa/deployment/QuarkusSecurityJpaProcessor.java
+++ b/extensions/security-jpa/deployment/src/main/java/io/quarkus/security/jpa/deployment/QuarkusSecurityJpaProcessor.java
@@ -99,8 +99,8 @@ class QuarkusSecurityJpaProcessor {
             }
 
             public void transform(TransformationContext context) {
-                if (context.getTarget().kind() == AnnotationTarget.Kind.FIELD) {
-                    var declaringClassName = context.getTarget().asField().declaringClass().name();
+                if (context.getAnnotationTarget().kind() == AnnotationTarget.Kind.FIELD) {
+                    var declaringClassName = context.getAnnotationTarget().asField().declaringClass().name();
                     if (JPA_IDENTITY_PROVIDER_NAME.equals(declaringClassName)
                             || JPA_TRUSTED_IDENTITY_PROVIDER_NAME.equals(declaringClassName)) {
                         context.transform()

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/ConfiguredAndSharedBeansTest.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/ConfiguredAndSharedBeansTest.java
@@ -99,14 +99,17 @@ public class ConfiguredAndSharedBeansTest {
         final ManagedExecutor ctorExecutor1;
         final ManagedExecutor ctorExecutor2;
         final ThreadContext ctorThreadContext;
+        final ManagedExecutor ctorExecutor3;
 
-        // c-tor injection, three out of four params should be configured
+        // c-tor injection, three out of five params should be configured
         public SomeBean(@ManagedExecutorConfig(maxAsync = 8, maxQueued = 8) ManagedExecutor ctorExecutor1,
                 @ManagedExecutorConfig(maxAsync = 3, maxQueued = 3) ManagedExecutor ctorExecutor2, Foo foo,
-                @ThreadContextConfig(cleared = "CDI") ThreadContext ctorTc) {
+                @ThreadContextConfig(cleared = "CDI") ThreadContext ctorTc,
+                @MyQualifier ManagedExecutor ctorExecutor3) { // this one has custom qualifier, we shouldn't modify it
             this.ctorExecutor1 = ctorExecutor1;
             this.ctorExecutor2 = ctorExecutor2;
             this.ctorThreadContext = ctorTc;
+            this.ctorExecutor3 = ctorExecutor3;
         }
 
         @Inject
@@ -264,6 +267,10 @@ public class ConfiguredAndSharedBeansTest {
             Set<String> cleared = providersToStringSet(plan.clearedProviders);
             assertTrue(propagated.isEmpty());
             assertTrue(cleared.contains(ThreadContext.CDI));
+
+            exec = unwrapExecutor(ctorExecutor3);
+            assertEquals(2, exec.getMaxAsync());
+            assertEquals(-1, exec.getMaxQueued()); // default value
         }
     }
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -264,21 +263,13 @@ public class WiringHelper {
     static Optional<AnnotationInstance> getAnnotation(TransformedAnnotationsBuildItem transformedAnnotations,
             InjectionPointInfo injectionPoint,
             DotName annotationName) {
-        // Query annotations for either field, or whole method
-        AnnotationTarget annotationTarget = injectionPoint.isField() ? injectionPoint.getAnnotationTarget()
-                : injectionPoint.getAnnotationTarget().asMethodParameter().method();
-        Collection<AnnotationInstance> annotations = transformedAnnotations.getAnnotations(annotationTarget);
+        // For field IP -> set of field annotations
+        // For method param IP -> set of param annotations
+        Collection<AnnotationInstance> annotations = transformedAnnotations
+                .getAnnotations(injectionPoint.getAnnotationTarget());
         for (AnnotationInstance annotation : annotations) {
             if (annotationName.equals(annotation.name())) {
-                // For method parameter we must check the position
-                if (annotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER
-                        && injectionPoint.isParam()
-                        && annotation.target().asMethodParameter().position() == injectionPoint.getPosition()) {
-                    return Optional.of(annotation);
-                } else if (annotation.target().kind() != AnnotationTarget.Kind.METHOD_PARAMETER) {
-                    // For other kind, no need to check anything else
-                    return Optional.of(annotation);
-                }
+                return Optional.of(annotation);
             }
         }
         return Optional.empty();

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringHelper.java
@@ -264,7 +264,10 @@ public class WiringHelper {
     static Optional<AnnotationInstance> getAnnotation(TransformedAnnotationsBuildItem transformedAnnotations,
             InjectionPointInfo injectionPoint,
             DotName annotationName) {
-        Collection<AnnotationInstance> annotations = transformedAnnotations.getAnnotations(injectionPoint.getTarget());
+        // Query annotations for either field, or whole method
+        AnnotationTarget annotationTarget = injectionPoint.isField() ? injectionPoint.getAnnotationTarget()
+                : injectionPoint.getAnnotationTarget().asMethodParameter().method();
+        Collection<AnnotationInstance> annotations = transformedAnnotations.getAnnotations(annotationTarget);
         for (AnnotationInstance annotation : annotations) {
             if (annotationName.equals(annotation.name())) {
                 // For method parameter we must check the position

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationsTransformation.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationsTransformation.java
@@ -36,9 +36,13 @@ public interface AnnotationsTransformation<T extends AnnotationsTransformation<T
     T addAll(AnnotationInstance... annotations);
 
     /**
-     * NOTE: The annotation target is derived from the transformation context. If you need to add an annotation instance
-     * to a method parameter use methods consuming {@link AnnotationInstance} directly and supply the correct
-     * {@link MethodParameterInfo}.
+     * NOTE: The annotation will belong to an annotation target which is derived from the transformation context.
+     * Each transformation context has means to obtain its annotation target such as
+     * {@link AnnotationsTransformer.TransformationContext#getTarget()} or
+     * {@link InjectionPointsTransformer.TransformationContext#getAnnotationTarget()}.
+     * <p>
+     * If you need to add an annotation instance to a method parameter and the annotation target is the whole method, use
+     * methods consuming {@link AnnotationInstance} directly and supply the correct {@link MethodParameterInfo}.
      *
      * @param annotationType
      * @param values
@@ -47,9 +51,13 @@ public interface AnnotationsTransformation<T extends AnnotationsTransformation<T
     T add(Class<? extends Annotation> annotationType, AnnotationValue... values);
 
     /**
-     * NOTE: The annotation target is derived from the transformation context.. If you need to add an annotation instance
-     * to a method parameter use methods consuming {@link AnnotationInstance} directly and supply the correct
-     * {@link MethodParameterInfo}.
+     * NOTE: The annotation will belong to an annotation target which is derived from the transformation context.
+     * Each transformation context has means to obtain its annotation target such as
+     * {@link AnnotationsTransformer.TransformationContext#getTarget()} or
+     * {@link InjectionPointsTransformer.TransformationContext#getAnnotationTarget()}.
+     * <p>
+     * If you need to add an annotation instance to a method parameter and the annotation target is the whole method, use
+     * methods consuming {@link AnnotationInstance} directly and supply the correct {@link MethodParameterInfo}.
      *
      * @param name
      * @param values

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationsTransformationContext.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationsTransformationContext.java
@@ -18,6 +18,7 @@ abstract class AnnotationsTransformationContext<C extends Collection<AnnotationI
 
     protected final BuildContext buildContext;
     protected final AnnotationTarget target;
+    protected final AnnotationTarget methodParameterTarget;
     private C annotations;
 
     /**
@@ -27,9 +28,13 @@ abstract class AnnotationsTransformationContext<C extends Collection<AnnotationI
      * @param annotations Mutable collection of annotations
      */
     public AnnotationsTransformationContext(BuildContext buildContext, AnnotationTarget target,
+            AnnotationTarget methodParameterTarget,
             C annotations) {
         this.buildContext = buildContext;
         this.target = target;
+        // once we remove #getTarget(), 'target' field should contain method parameter AnnotationTarget for method parameter injection
+        // can be null for field injection as well as synth injection point
+        this.methodParameterTarget = methodParameterTarget;
         this.annotations = annotations;
     }
 
@@ -47,6 +52,10 @@ abstract class AnnotationsTransformationContext<C extends Collection<AnnotationI
         return target;
     }
 
+    public AnnotationTarget getAnnotationTarget() {
+        return methodParameterTarget == null ? target : methodParameterTarget;
+    }
+
     public C getAnnotations() {
         return annotations;
     }
@@ -57,12 +66,27 @@ abstract class AnnotationsTransformationContext<C extends Collection<AnnotationI
     }
 
     public Collection<AnnotationInstance> getAllAnnotations() {
+        return getAllAnnotationForTarget(getTarget());
+    }
+
+    public Collection<AnnotationInstance> getAllTargetAnnotations() {
+        return getAllAnnotationForTarget(getAnnotationTarget());
+    }
+
+    private Collection<AnnotationInstance> getAllAnnotationForTarget(AnnotationTarget target) {
         AnnotationStore annotationStore = get(BuildExtension.Key.ANNOTATION_STORE);
         if (annotationStore == null) {
             throw new IllegalStateException(
                     "Attempted to use the getAllAnnotations() method but AnnotationStore wasn't initialized.");
         }
-        return annotationStore.getAnnotations(getTarget());
+        // Jandex overlay in compatible mode won't allow us to query for METHOD_PARAMETER
+        // hence if the "target" is method param, we query whole method and filter it
+        if (AnnotationTarget.Kind.METHOD_PARAMETER.equals(target.kind())) {
+            return Annotations.getParameterAnnotations(at -> annotationStore.getAnnotations(at),
+                    target.asMethodParameter().method(), target.asMethodParameter().position());
+        } else {
+            return annotationStore.getAnnotations(target);
+        }
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1795,7 +1795,7 @@ public class BeanGenerator extends AbstractGenerator {
                     // We cannot use injectionPoint.getRequiredType() because it might be a resolved parameterize type and we could get NoSuchFieldError
                     tryBlock.writeInstanceField(
                             FieldDescriptor.of(injectedField.declaringClass().name().toString(), injectedField.name(),
-                                    DescriptorUtils.typeToString(injectionPoint.getTarget().asField().type())),
+                                    DescriptorUtils.typeToString(injectionPoint.getAnnotationTarget().asField().type())),
                             instanceHandle, referenceHandle);
                 }
                 CatchBlockCreator catchBlock = tryBlock.addCatch(RuntimeException.class);
@@ -2288,13 +2288,13 @@ public class BeanGenerator extends AbstractGenerator {
         if (injectionPoint.isSynthetic()) {
             javaMemberHandle = bytecode.loadNull();
         } else if (injectionPoint.isField()) {
-            FieldInfo field = injectionPoint.getTarget().asField();
+            FieldInfo field = injectionPoint.getAnnotationTarget().asField();
             javaMemberHandle = bytecode.invokeStaticMethod(MethodDescriptors.REFLECTIONS_FIND_FIELD,
                     bytecode.loadClass(field.declaringClass().name().toString()),
                     bytecode.load(field.name()));
             reflectionRegistration.registerField(field);
         } else {
-            MethodInfo method = injectionPoint.getTarget().asMethod();
+            MethodInfo method = injectionPoint.getAnnotationTarget().asMethodParameter().method();
             reflectionRegistration.registerMethod(method);
             if (method.name().equals(Methods.INIT)) {
                 // Reflections.findConstructor(org.foo.SimpleBean.class,java.lang.String.class)
@@ -2333,11 +2333,11 @@ public class BeanGenerator extends AbstractGenerator {
         }
         ResultHandle annotationsHandle = bytecode.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
         Collection<AnnotationInstance> annotations;
-        if (Kind.FIELD.equals(injectionPoint.getTarget().kind())) {
-            FieldInfo field = injectionPoint.getTarget().asField();
+        if (Kind.FIELD.equals(injectionPoint.getAnnotationTarget().kind())) {
+            FieldInfo field = injectionPoint.getAnnotationTarget().asField();
             annotations = beanDeployment.getAnnotations(field);
         } else {
-            MethodInfo method = injectionPoint.getTarget().asMethod();
+            MethodInfo method = injectionPoint.getAnnotationTarget().asMethodParameter().method();
             annotations = Annotations.getParameterAnnotations(beanDeployment,
                     method, injectionPoint.getPosition());
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -371,9 +371,9 @@ public enum BuiltinBean {
         // Register injection point for reflection
         InjectionPointInfo injectionPoint = ctx.injectionPoint;
         if (injectionPoint.isField()) {
-            ctx.reflectionRegistration.registerField(injectionPoint.getTarget().asField());
+            ctx.reflectionRegistration.registerField(injectionPoint.getAnnotationTarget().asField());
         } else {
-            ctx.reflectionRegistration.registerMethod(injectionPoint.getTarget().asMethod());
+            ctx.reflectionRegistration.registerMethod(injectionPoint.getAnnotationTarget().asMethodParameter().method());
         }
 
         MethodCreator mc = ctx.constructor;
@@ -464,9 +464,9 @@ public enum BuiltinBean {
             if (typeParam.kind() == Type.Kind.WILDCARD_TYPE) {
                 ClassInfo declaringClass;
                 if (injectionPoint.isField()) {
-                    declaringClass = injectionPoint.getTarget().asField().declaringClass();
+                    declaringClass = injectionPoint.getAnnotationTarget().asField().declaringClass();
                 } else {
-                    declaringClass = injectionPoint.getTarget().asMethod().declaringClass();
+                    declaringClass = injectionPoint.getAnnotationTarget().asMethodParameter().method().declaringClass();
                 }
                 if (isKotlinClass(declaringClass)) {
                     errors.accept(

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
@@ -90,18 +90,18 @@ public class Injection {
                     && injectionPointInfo.getRequiredType().asParameterizedType().arguments().size() == 1
                     && injectionPointInfo.hasDefaultedQualifier()) {
                 Type actualType = injectionPointInfo.getRequiredType().asParameterizedType().arguments().get(0);
-                AnnotationTarget ipTarget = injectionPointInfo.getTarget();
+                AnnotationTarget ipTarget = injectionPointInfo.getAnnotationTarget();
                 DotName expectedType = null;
                 if (ipTarget.kind() == Kind.FIELD) {
                     // field injection derives this from the class
                     expectedType = ipTarget.asField().declaringClass().name();
-                } else if (ipTarget.kind() == Kind.METHOD) {
+                } else if (ipTarget.kind() == Kind.METHOD_PARAMETER) {
                     // the injection point is a producer method parameter then the type parameter of the injected Bean
                     // must be the same as the producer method return type
                     if (beanType == BeanType.PRODUCER_METHOD) {
-                        expectedType = ipTarget.asMethod().returnType().name();
+                        expectedType = ipTarget.asMethodParameter().method().returnType().name();
                     } else {
-                        expectedType = ipTarget.asMethod().declaringClass().name();
+                        expectedType = ipTarget.asMethodParameter().method().declaringClass().name();
                     }
                 }
                 if (expectedType != null
@@ -137,12 +137,12 @@ public class Injection {
                     && injectionPointInfo.getRequiredType().kind() == Type.Kind.PARAMETERIZED_TYPE
                     && injectionPointInfo.getRequiredType().asParameterizedType().arguments().size() == 1) {
                 Type actualType = injectionPointInfo.getRequiredType().asParameterizedType().arguments().get(0);
-                AnnotationTarget ipTarget = injectionPointInfo.getTarget();
+                AnnotationTarget ipTarget = injectionPointInfo.getAnnotationTarget();
                 DotName expectedType = null;
                 if (ipTarget.kind() == Kind.FIELD) {
                     expectedType = ipTarget.asField().declaringClass().name();
-                } else if (ipTarget.kind() == Kind.METHOD) {
-                    expectedType = ipTarget.asMethod().declaringClass().name();
+                } else if (ipTarget.kind() == Kind.METHOD_PARAMETER) {
+                    expectedType = ipTarget.asMethodParameter().method().declaringClass().name();
                 }
                 if (expectedType != null
                         // This is very rudimentary check, might need to be expanded?

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointModifier.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointModifier.java
@@ -29,28 +29,30 @@ public class InjectionPointModifier {
         this.transformers = transformers;
     }
 
-    public Set<AnnotationInstance> applyTransformers(Type type, AnnotationTarget target, Integer paramPosition,
+    public Set<AnnotationInstance> applyTransformers(Type type, AnnotationTarget target, AnnotationTarget methodParameterTarget,
             Set<AnnotationInstance> qualifiers) {
         // with no transformers, we just immediately return original set of qualifiers
         if (transformers.isEmpty()) {
             return qualifiers;
         }
-        TransformationContextImpl transformationContext = new TransformationContextImpl(buildContext, target, qualifiers);
+        TransformationContextImpl transformationContext = new TransformationContextImpl(buildContext, target,
+                methodParameterTarget, qualifiers);
         for (InjectionPointsTransformer transformer : transformers) {
             if (transformer.appliesTo(type)) {
                 transformer.transform(transformationContext);
             }
         }
-        if (paramPosition != null && AnnotationTarget.Kind.METHOD.equals(target.kind())) {
+        if (methodParameterTarget != null && AnnotationTarget.Kind.METHOD_PARAMETER.equals(methodParameterTarget.kind())) {
             // only return set of qualifiers related to the given method parameter
             return transformationContext.getQualifiers().stream().filter(
-                    annotationInstance -> target.asMethod().parameters().get(paramPosition).equals(annotationInstance.target()))
+                    annotationInstance -> methodParameterTarget.equals(annotationInstance.target()))
                     .collect(Collectors.toSet());
         } else {
             return transformationContext.getQualifiers();
         }
     }
 
+    // method variant used for field and resource field injection; a case where we don't need to deal with method. params
     public Set<AnnotationInstance> applyTransformers(Type type, AnnotationTarget target, Set<AnnotationInstance> qualifiers) {
         return applyTransformers(type, target, null, qualifiers);
     }
@@ -59,13 +61,14 @@ public class InjectionPointModifier {
             implements InjectionPointsTransformer.TransformationContext {
 
         public TransformationContextImpl(BuildContext buildContext, AnnotationTarget target,
+                AnnotationTarget methodParameterTarget,
                 Set<AnnotationInstance> annotations) {
-            super(buildContext, target, annotations);
+            super(buildContext, target, methodParameterTarget, annotations);
         }
 
         @Override
         public InjectionPointsTransformer.Transformation transform() {
-            return new InjectionPointsTransformer.Transformation(new HashSet<>(getAnnotations()), getTarget(),
+            return new InjectionPointsTransformer.Transformation(new HashSet<>(getAnnotations()), getAnnotationTarget(),
                     this::setAnnotations);
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointsTransformer.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointsTransformer.java
@@ -35,11 +35,24 @@ public interface InjectionPointsTransformer extends BuildExtension {
     interface TransformationContext extends BuildExtension.BuildContext {
 
         /**
+         * This method is deprecated and will be removed at some point after Quarkus 3.15.
+         * Use {@link #getAnnotationTarget()} instead.
+         * <p>
          * Returns {@link AnnotationTarget} representing this injection point.
+         * For injected parameters, this method returns the {@link AnnotationTarget} of the whole method.
          *
          * @return the annotation target of this injection point
          */
+        @Deprecated(forRemoval = true, since = "3.12")
         AnnotationTarget getTarget();
+
+        /**
+         * Returns {@link AnnotationTarget} representing this injection point.
+         * Unlike {@link #getTarget()}, for injected parameters, this method returns the method parameter.
+         *
+         * @return the annotation target of this injection point
+         */
+        AnnotationTarget getAnnotationTarget();
 
         /**
          * Returns current set of annotations instances - qualifiers.
@@ -49,9 +62,15 @@ public interface InjectionPointsTransformer extends BuildExtension {
         Set<AnnotationInstance> getQualifiers();
 
         /**
-         * Retrieves all annotations attached to the {@link AnnotationTarget} that this transformer operates on
-         * even if they were altered by {@code AnnotationsTransformer}. This method is preferred to manual inspection
-         * of {@link AnnotationTarget} which may, in some corner cases, hold outdated information.
+         * This method is deprecated and will be removed at some point after Quarkus 3.15.
+         * Use {@link #getAllTargetAnnotations()} instead.
+         * <p>
+         * Retrieves all annotations attached to the {@link AnnotationTarget} that this transformer operates on.
+         * This {@link AnnotationTarget} is equal to what the {@link #getTarget()} ()} method returns.
+         *
+         * The result includes annotations that were altered by {@code AnnotationsTransformer}.
+         * This method is preferred to manual inspection of {@link AnnotationTarget} which may, in some corner cases,
+         * hold outdated information.
          *
          * The resulting set of annotations contains all annotations, not just CDI qualifiers.
          * If the annotation target is a method, then this set contains annotations that belong to the method itself
@@ -59,7 +78,22 @@ public interface InjectionPointsTransformer extends BuildExtension {
          *
          * @return collection of all annotations related to given {@link AnnotationTarget}
          */
+        @Deprecated(forRemoval = true, since = "3.12")
         Collection<AnnotationInstance> getAllAnnotations();
+
+        /**
+         * Retrieves all annotations attached to the {@link AnnotationTarget} that this transformer operates on.
+         * This {@link AnnotationTarget} is equal to what the {@link #getAnnotationTarget()} method returns.
+         *
+         * The result includes annotations that were altered by {@code AnnotationsTransformer}.
+         * This method is preferred to manual inspection of {@link AnnotationTarget} which may, in some corner cases,
+         * hold outdated information.
+         *
+         * The resulting set of annotations contains all annotations, not just CDI qualifiers.
+         *
+         * @return collection of all annotations related to given {@link AnnotationTarget}
+         */
+        Collection<AnnotationInstance> getAllTargetAnnotations();
 
         /**
          * The transformation is not applied until the {@link Transformation#done()} method is invoked.

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
@@ -400,7 +400,7 @@ public class ObserverInfo implements InjectionTargetInfo {
         public ObserverTransformationContext(BuildContext buildContext, AnnotationTarget target,
                 Type observedType, Set<AnnotationInstance> qualifiers, Reception reception, TransactionPhase transactionPhase,
                 Integer priority, boolean async) {
-            super(buildContext, target, qualifiers);
+            super(buildContext, target, null, qualifiers);
             this.observedType = observedType;
             this.reception = reception;
             this.transactionPhase = transactionPhase;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverTransformer.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverTransformer.java
@@ -78,7 +78,7 @@ public interface ObserverTransformer extends BuildExtension {
          * Retrieves all annotations declared on the observer method. This method is preferred to manual inspection
          * of {@link #getMethod()} which may, in some corner cases, hold outdated information.
          * <p>
-         * The resulting set of annotations contains contains annotations that belong to the method itself
+         * The resulting set of annotations contains annotations that belong to the method itself
          * as well as to its parameters.
          *
          * @return collection of all annotations or an empty list in case of synthetic observer
@@ -119,7 +119,7 @@ public interface ObserverTransformer extends BuildExtension {
 
         /**
          *
-         * @param reception
+         * @param transactionPhase
          * @return self
          */
         ObserverTransformation transactionPhase(TransactionPhase transactionPhase);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -713,10 +713,10 @@ public final class Types {
             throw new IllegalArgumentException("Delegate type not found in index: " + delegateType);
         }
         if (Kind.CLASS.equals(delegateType.kind())) {
-            types = getTypeClosure(delegateTypeClass, delegateInjectionPoint.getTarget(), Collections.emptyMap(),
+            types = getTypeClosure(delegateTypeClass, delegateInjectionPoint.getAnnotationTarget(), Collections.emptyMap(),
                     beanDeployment, null, unrestrictedBeanTypes);
         } else if (Kind.PARAMETERIZED_TYPE.equals(delegateType.kind())) {
-            types = getTypeClosure(delegateTypeClass, delegateInjectionPoint.getTarget(),
+            types = getTypeClosure(delegateTypeClass, delegateInjectionPoint.getAnnotationTarget(),
                     buildResolvedMap(delegateType.asParameterizedType().arguments(), delegateTypeClass.typeParameters(),
                             Collections.emptyMap(), beanDeployment.getBeanArchiveIndex()),
                     beanDeployment, null, unrestrictedBeanTypes);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/InjectionPointInfoImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/InjectionPointInfoImpl.java
@@ -35,14 +35,11 @@ class InjectionPointInfoImpl implements InjectionPointInfo {
     @Override
     public DeclarationInfo declaration() {
         if (arcInjectionPointInfo.isField()) {
-            org.jboss.jandex.FieldInfo jandexField = arcInjectionPointInfo.getTarget().asField();
+            org.jboss.jandex.FieldInfo jandexField = arcInjectionPointInfo.getAnnotationTarget().asField();
             return new FieldInfoImpl(jandexIndex, annotationOverlay, jandexField);
         } else if (arcInjectionPointInfo.isParam()) {
-            org.jboss.jandex.MethodInfo jandexMethod = arcInjectionPointInfo.getTarget().asMethod();
-            int parameterPosition = arcInjectionPointInfo.getPosition();
-            org.jboss.jandex.MethodParameterInfo jandexParameter = org.jboss.jandex.MethodParameterInfo.create(
-                    jandexMethod, (short) parameterPosition);
-            return new ParameterInfoImpl(jandexIndex, annotationOverlay, jandexParameter);
+            return new ParameterInfoImpl(jandexIndex, annotationOverlay,
+                    arcInjectionPointInfo.getAnnotationTarget().asMethodParameter());
         } else {
             throw new IllegalStateException("Unknown injection point: " + arcInjectionPointInfo);
         }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/validator/BeanDeploymentValidatorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/validator/BeanDeploymentValidatorTest.java
@@ -62,8 +62,8 @@ public class BeanDeploymentValidatorTest {
         @Override
         public void validate(ValidationContext context) {
             assertTrue(context.getInjectionPoints().stream().filter(InjectionPointInfo::isProgrammaticLookup)
-                    .filter(ip -> ip.getTarget().kind() == org.jboss.jandex.AnnotationTarget.Kind.FIELD
-                            && ip.getTarget().asField().name().equals("foo"))
+                    .filter(ip -> ip.getAnnotationTarget().kind() == org.jboss.jandex.AnnotationTarget.Kind.FIELD
+                            && ip.getAnnotationTarget().asField().name().equals("foo"))
                     .findFirst().isPresent());
 
             assertFalse(context.removedBeans().withBeanClass(UselessBean.class).isEmpty());

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/resource/ResourceInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/resource/ResourceInjectionTest.java
@@ -62,7 +62,7 @@ public class ResourceInjectionTest {
 
                 @Override
                 public void transform(TransformationContext transformationContext) {
-                    if (transformationContext.getAllAnnotations()
+                    if (transformationContext.getAllTargetAnnotations()
                             .stream()
                             .anyMatch(it -> it.name().toString().equals(Dummy.class.getName()))) {
                         // pretend that the injection point has an annotation whose class is missing


### PR DESCRIPTION
Fixes #38856 

First commit changes Arc's injection point transformation API. ATM the injection point `AnnotationTarget` is either `FIELD` or `METHOD`, making it difficult to alter any annotation for single or multiple `METHOD_PARAMETER` targets underneath.
Changes I introduce allow to operate directly on method parameters but in order to stay backward compatible, this requires new methods. The old ones are still in place, but I marked them as `@Deprecated(forRemoval=true)`

Second commit changes all internal usages of the newly deprecated methods to their new variants.