### PR TITLE
Fix some markdownlint warnings on .md files

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -8,9 +8,11 @@ assignees: ''
 ---
 
 ### Description
+
 (A high level description of the work)
 
 ### Analysis
+
 (links to analysis docs containing architecture design work, requirements gathering, etc)
 
 <!-- task list will be automatically generated from below. 

--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -1,23 +1,22 @@
 # GitHub Actions setup
 
-Quarkus is built using GitHub Actions, with a mix of hosted and self-hosted runners. 
+Quarkus is built using GitHub Actions, with a mix of hosted and self-hosted runners.
 
-## Setting up a new self-hosted runner on Mac M1 
-
+## Setting up a new self-hosted runner on Mac M1
 
 ### Non-root user
 
-GitHub Actions should not run with administrator privileges, so will need to be run in a dedicated account. 
+GitHub Actions should not run with administrator privileges, so will need to be run in a dedicated account.
 Make an account for the actions runner. The steps below assume the account has the name `githubactions`.
-It's usually easiest to do account creation in the GUI, via a VNC connection. Users are managed in 
+It's usually easiest to do account creation in the GUI, via a VNC connection. Users are managed in
 the **Users and Groups** section of the Settings app.
 
 *Grant administrator privileges to the account* (we will remove them later).
 
-
 ### System utilities
 
-As administrator, install homebrew. 
+As administrator, install homebrew.
+
 ```shell
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
@@ -30,9 +29,9 @@ brew install gradle
 brew install podman
 ```
 
-### Podman setup 
+### Podman setup
 
-Podman needs some [extra configuration](https://quarkus.io/guides/podman) to work with test containers and dev services. 
+Podman needs some [extra configuration](https://quarkus.io/guides/podman) to work with test containers and dev services.
 
 Now log in to the account you created to run the actions.
 As the `githubactions` user (but with administrator privileges)
@@ -41,7 +40,8 @@ As the `githubactions` user (but with administrator privileges)
 PODMAN_VERSION=`podman -v | sed 's/[a-zA-Z ]*//'`
 sudo /opt/homebrew/Cellar/podman/$PODMAN_VERSION/bin/podman-mac-helper install
 ```
-The podman helper install seems to be per-user, but it needs to be done with administrator privileges. 
+
+The podman helper install seems to be per-user, but it needs to be done with administrator privileges.
 
 Again as the `githubactions` user, edit ~/.testcontainers.properties and add the following line: `ryuk.container.privileged=true`
 
@@ -63,8 +63,8 @@ rpm-ostree install qemu-user-static
 systemctl reboot
 ```
 
-Now remove administrator privileges from the `githubactions` user. 
-As with the user creation, it's usually easiest to do this in the GUI. 
+Now remove administrator privileges from the `githubactions` user.
+As with the user creation, it's usually easiest to do this in the GUI.
 
 ### Rosetta
 
@@ -73,22 +73,22 @@ A fresh install of macOS will not have Rosetta installed, so Intel binaries cann
 ```bash
 softwareupdate --install-rosetta --agree-to-license
 ```
+
 ### Stand up the actions runner
 
 #### Download the runner scripts
 
-GitHub provides an installation package of customized runner scripts for each repository. 
+GitHub provides an installation package of customized runner scripts for each repository.
 Follow [the instructions](https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners)
-to install the scripts for the repository to be built. 
+to install the scripts for the repository to be built.
 
 Choose the default group, a descriptive name, and the default work folder. Add a label `macos-arm64-latest`.
 If you forget the label, it will need to be added [through the UI](https://docs.github.com/en/actions/hosting-your-own-runners/using-labels-with-self-hosted-runners).
 
-
 #### Cleanup and setup logic
 
-Self-hosted runners do not run on ephemeral hardware, and so workflow runs may need to clean up. 
-We also need to start a podman machine before the job if one is not already running. 
+Self-hosted runners do not run on ephemeral hardware, and so workflow runs may need to clean up.
+We also need to start a podman machine before the job if one is not already running.
 
 To create cleanup and setup scripts and hooks, run:
 
@@ -100,24 +100,22 @@ echo ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/Users/githubactions/runner-cleanup.sh >>
 echo ACTIONS_RUNNER_HOOK_JOB_STARTED=/Users/githubactions/podman-start.sh >> .env
 ```
 
-
 In the same script, we also ensure that the podman machine is running before jobs execute.
 
-#### Start the runner 
+#### Start the runner
 
-To test the runner, run 
+To test the runner, run
 
 `run.sh`
 
-Once you're happy the runner is processing builds correctly, it's time to create it as a daemon. 
+Once you're happy the runner is processing builds correctly, it's time to create it as a daemon.
 
 ### Start the service on reboot
 
-Note that GitHub have scripts for this, but theirs run as LaunchAgents, not LaunchDaemons. 
+Note that GitHub have scripts for this, but theirs run as LaunchAgents, not LaunchDaemons.
 LaunchAgents run when a user logs in, and LaunchDaemons run on boot, so the daemon option seems preferable.
 
-
-As administrator, `sudo vi /Library/LaunchDaemons/actions.runner.quarkusio-quarkus.macstadium-m1.plist`. 
+As administrator, `sudo vi /Library/LaunchDaemons/actions.runner.quarkusio-quarkus.macstadium-m1.plist`.
 
 Then add the following:
 
@@ -164,7 +162,7 @@ Then add the following:
 </plist>
 ```
 
-Finally, run 
+Finally, run
 
 ```shell
 sudo launchctl load -w /Library/LaunchDaemons/actions.runner.quarkusio-quarkus.macstadium-m1.plist

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,31 +4,31 @@ ADOPTERS
 PUBLIC REFERENCES
 -----------------
 
-This document lists the organizations that use Quarkus based on public information available in blog posts and videos. 
+This document lists the organizations that use Quarkus based on public information available in blog posts and videos.
 If any organization would like get added or removed please make a pull request by following these guidelines:
 
 * Please don't include your organization's logo or other trademarked material
 * Add a reference (link to a public blog post, video, slides, etc) mentioning that Quarkus is used
 
-| Organization          | Reference                                                                         |
-|-----------------------|-----------------------------------------------------------------------------------|
-|Abraxas Informatik AG  | https://quarkus.io/blog/abraxas-customer-story/                                   |
-|Artes                  | https://horvie.github.io/adopt-quarkus/                                           |
-|B<>com                 | https://5g.labs.b-com.com/                                                        |
-|Carrefour              | https://horizons.carrefour.com/efficient-java-in-the-cloud-with-quarkus           |
-|Cytech                 | https://quarkus.io/blog/cytech-customer-story/                                    |
-|DataCater              | https://quarkus.io/blog/datacater-uses-quarkus-to-make-data-streaming-accessible/ |
-|Decathlon              | https://quarkus.io/blog/decathlon-user-story/                                     |
-|Ennovative Solutions   | https://quarkus.io/blog/ennovativesolutions-uses-quarkus-with-aws-lambda/         |
-|GoWithFlow             | https://quarkus.io/blog/gowithflow-chooses-quarkus-to-deliver-fast-to-production/ |
-|Lufthansa Technik      | https://quarkus.io/blog/aviatar-experiences-significant-savings/                  |
-|Logicdrop              | https://quarkus.io/blog/logicdrop-customer-story/                                 |
-|[Microcks](https://landscape.cncf.io/?selected=microcks)               | https://itnext.io/mocking-and-contract-testing-in-your-inner-loop-with-microcks-part-3-quarkus-devservice-ftw-a14b807737be            |
-|Payair                 | https://quarkus.io/blog/why-did-payair-technologies-switch-to-quarkus/            |
-|Sedona                 | https://quarkus.io/blog/sedona-rewrites-insurance-premium/                        |
-|Stargate               | https://quarkus.io/blog/stargate-selects-quarkus-for-its-v2-implementation/       |
-|Suomen Asiakastieto Oy | https://quarkus.io/blog/asiakastieto-chooses-quarkus-for-microservices/           |
-|Talkdesk               | https://quarkus.io/blog/talkdesk-chooses-quarkus-for-fast-innovation/             |
-|UTN Faculty Córdoba    | https://www.frc.utn.edu.ar/computos/tech/                                         |
-|Vodafone Greece        | https://quarkus.io/blog/vodafone-greece-replaces-spring-boot/                     |
-|Wipro                  | https://quarkus.io/blog/wipro-customer-story/                                     |
+| Organization          | Reference                                                                           |
+|-----------------------|-------------------------------------------------------------------------------------|
+|Abraxas Informatik AG  | <https://quarkus.io/blog/abraxas-customer-story/>                                   |
+|Artes                  | <https://horvie.github.io/adopt-quarkus/>                                           |
+|B<>com                 | <https://5g.labs.b-com.com/>                                                        |
+|Carrefour              | <https://horizons.carrefour.com/efficient-java-in-the-cloud-with-quarkus>           |
+|Cytech                 | <https://quarkus.io/blog/cytech-customer-story/>                                    |
+|DataCater              | <https://quarkus.io/blog/datacater-uses-quarkus-to-make-data-streaming-accessible/> |
+|Decathlon              | <https://quarkus.io/blog/decathlon-user-story/>                                     |
+|Ennovative Solutions   | <https://quarkus.io/blog/ennovativesolutions-uses-quarkus-with-aws-lambda/>         |
+|GoWithFlow             | <https://quarkus.io/blog/gowithflow-chooses-quarkus-to-deliver-fast-to-production/> |
+|Lufthansa Technik      | <https://quarkus.io/blog/aviatar-experiences-significant-savings/>                  |
+|Logicdrop              | <https://quarkus.io/blog/logicdrop-customer-story/>                                 |
+|[Microcks](https://landscape.cncf.io/?selected=microcks)               | <https://itnext.io/mocking-and-contract-testing-in-your-inner-loop-with-microcks-part-3-quarkus-devservice-ftw-a14b807737be>            |
+|Payair                 | <https://quarkus.io/blog/why-did-payair-technologies-switch-to-quarkus/>            |
+|Sedona                 | <https://quarkus.io/blog/sedona-rewrites-insurance-premium/>                        |
+|Stargate               | <https://quarkus.io/blog/stargate-selects-quarkus-for-its-v2-implementation/>       |
+|Suomen Asiakastieto Oy | <https://quarkus.io/blog/asiakastieto-chooses-quarkus-for-microservices/>           |
+|Talkdesk               | <https://quarkus.io/blog/talkdesk-chooses-quarkus-for-fast-innovation/>             |
+|UTN Faculty Córdoba    | <https://www.frc.utn.edu.ar/computos/tech/>                                         |
+|Vodafone Greece        | <https://quarkus.io/blog/vodafone-greece-replaces-spring-boot/>                     |
+|Wipro                  | <https://quarkus.io/blog/wipro-customer-story/>                                     |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ what you would expect to see. Don't forget to indicate your Quarkus, Java, Maven
 Sometimes a bug has been fixed in the `main` branch of Quarkus and you want to confirm it is fixed for your own
 application. There are two simple options for testing the `main` branch:
 
-* either use the snapshots we publish daily on https://s01.oss.sonatype.org/content/repositories/snapshots
+* either use the snapshots we publish daily on <https://s01.oss.sonatype.org/content/repositories/snapshots>
 * or build Quarkus locally
 
 The following is a quick summary aimed at allowing you to quickly test `main`. If you are interested in learning more details, refer to
@@ -86,7 +86,7 @@ the [Build section](#build) and the [Usage section](#usage).
 
 Snapshots are published daily with version `999-SNAPSHOT`, so you will have to wait for a snapshot containing the commits you are interested in.
 
-Then just add https://s01.oss.sonatype.org/content/repositories/snapshots as a Maven repository **and** a plugin
+Then just add <https://s01.oss.sonatype.org/content/repositories/snapshots> as a Maven repository **and** a plugin
 repository in your settings xml:
 
 ```xml
@@ -129,7 +129,7 @@ repository in your settings xml:
 </settings>
 ```
 
-You can check the last publication date here: https://s01.oss.sonatype.org/content/repositories/snapshots/io/quarkus/ .
+You can check the last publication date here: <https://s01.oss.sonatype.org/content/repositories/snapshots/io/quarkus/>.
 
 ### Building main
 
@@ -395,7 +395,7 @@ productive. The following Maven tips can vastly speed up development when workin
 Let's say you want to make changes to the `Jackson` extension. This extension contains the `deployment`, `runtime`
 and `spi` modules which can all be built by executing following command:
 
-```
+```shell
 ./mvnw install -f extensions/jackson/
 ```
 
@@ -407,13 +407,13 @@ all modules in that path recursively.
 Let's say you want to make changes to the `deployment` module of the Jackson extension. There are two ways to accomplish
 this task as shown by the following commands:
 
-```
+```shell
 ./mvnw install -f extensions/jackson/deployment
 ```
 
 or
 
-```
+```shell
 ./mvnw install --projects 'io.quarkus:quarkus-jackson-deployment'
 ```
 
@@ -427,7 +427,7 @@ Quarkus maintains compatibility as much as possible and for most renamed or move
 allowing the build to be redirected to the new artifact.
 However, relocations are not built by default, and to build and install them, you need to enable the `relocations` Maven profile as follows:
 
-```
+```shell
 ./mvnw -Dquickly -Prelocations
 ```
 
@@ -440,7 +440,7 @@ of the `resteasy-jackson` Quarkus integration test (which can be
 found [here](https://github.com/quarkusio/quarkus/blob/main/integration-tests/resteasy-jackson)). One way to accomplish
 this is by executing the following command:
 
-```
+```shell
 ./mvnw test -f integration-tests/resteasy-jackson/ -Dtest=GreetingResourceTest
 ```
 
@@ -452,7 +452,7 @@ directory which houses the test project.
 
 For example, in order to only run the MySQL test project of the container-image tests, the Maven command would be:
 
-```
+```shell
 ./mvnw verify -f integration-tests/container-image/maven-invoker-way -Dinvoker.test=container-build-jib-with-mysql
 ```
 
@@ -465,7 +465,7 @@ specific integration test mentioned above, `-Dstart-containers` and `-Dtest-cont
 The following standard Maven option can be used to build with multiple threads to speed things up (here 0.5 threads per
 CPU core):
 
-```
+```shell
 ./mvnw install -T0.5C
 ```
 
@@ -475,7 +475,7 @@ Please note that running tests in parallel is not supported at the moment!
 
 To omit building currently way over 100 pure test modules, run:
 
-```
+```shell
 ./mvnw install -Dno-test-modules
 ```
 
@@ -491,7 +491,7 @@ Instead of _manually_ specifying the modules to build as in the previous example
 tell [gitflow-incremental-builder (GIB)](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder) to
 only build the modules that have been changed or depend on modules that have been changed (downstream). E.g.:
 
-```
+```shell
 ./mvnw install -Dincremental
 ```
 
@@ -502,7 +502,7 @@ If you just want to build the changes since the last commit on the current branc
 comparison via `-Dgib.disableBranchComparison` (or short: `-Dgib.dbc`).
 
 There are many more configuration options in GIB you can use to customize its
-behaviour: https://github.com/gitflow-incremental-builder/gitflow-incremental-builder#configuration
+behaviour: <https://github.com/gitflow-incremental-builder/gitflow-incremental-builder#configuration>
 
 Parallel builds (`-T...`) should work without problems but parallel test execution is not yet supported (in general, not
 a GIB limitation).
@@ -534,16 +534,16 @@ For more details see the `Get GIB arguments` step in `.github/workflows/ci-actio
 
 ###### Getting set up
 
-Quarkus has a Develocity instance set up at https://ge.quarkus.io that can be used to analyze the build performance of the Quarkus project and also provides build cache services.
+Quarkus has a Develocity instance set up at <https://ge.quarkus.io> that can be used to analyze the build performance of the Quarkus project and also provides build cache services.
 
-If you have an account on https://ge.quarkus.io, this can speed up your local builds significantly.
+If you have an account on <https://ge.quarkus.io>, this can speed up your local builds significantly.
 
 If you have a need or interest to share your build scans and use the build cache, you will need to get an account for the Develocity instance.
 It is only relevant for members of the Quarkus team and you should contact either Guillaume Smet or Max Andersen to set up your account.
 
 When you have the account set up, from the root of your local Quarkus workspace, run:
 
-```
+```shell
 ./mvnw develocity:provision-access-key
 ```
 
@@ -553,7 +553,7 @@ From then your build scans will be sent to the Develocity instance and you will 
 
 You can alternatively also generate an API key from the Develocity UI and then use an environment variable like this:
 
-```
+```shell
 export DEVELOCITY_ACCESS_KEY=ge.quarkus.io=a_secret_key
 ```
 
@@ -640,7 +640,7 @@ When contributing a significant documentation change, it is highly recommended t
 
 First build the whole Quarkus repository with the documentation build enabled:
 
-```
+```shell
 ./mvnw -DquicklyDocs
 ```
 
@@ -649,7 +649,7 @@ directory and will avoid a lot of warnings when building the documentation modul
 
 Then you can build the `docs` module specifically:
 
-```
+```shell
 ./mvnw -f docs clean install
 ```
 
@@ -682,7 +682,7 @@ To include them into your project a few things have to be changed.
 
 *pom.xml*
 
-```
+```xml
 <properties>
     <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
@@ -698,7 +698,7 @@ To include them into your project a few things have to be changed.
 
 *gradle.properties*
 
-```
+```ini
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPluginVersion=999-SNAPSHOT
 quarkusPlatformVersion=999-SNAPSHOT
@@ -707,7 +707,7 @@ quarkusPlatformGroupId=io.quarkus
 
 *settings.gradle*
 
-```
+```gradle
 pluginManagement {
     repositories {
         mavenLocal() // add mavenLocal() to first position
@@ -722,7 +722,7 @@ pluginManagement {
 
 *build.gradle*
 
-```
+```gradle
 repositories {
     mavenLocal() // add mavenLocal() to first position
     mavenCentral()
@@ -762,7 +762,7 @@ with `-f ...`).
 ### Descriptions
 
 Extensions descriptions (in the `runtime/pom.xml` description or in the YAML `quarkus-extension.yaml`)
-are used to describe the extension and are visible in https://code.quarkus.io and https://extensions.quarkus.io. Try and pay attention to it. Here are a
+are used to describe the extension and are visible in <https://code.quarkus.io> and <https://extensions.quarkus.io>. Try and pay attention to it. Here are a
 few recommendation guidelines:
 
 - keep it relatively short so that no hover is required to read it
@@ -820,12 +820,14 @@ This project is an open source project, please act responsibly, be nice, polite 
   In the Maven pane, uncheck the `include-jdk-misc` and `compile-java8-release-flag` profiles
 
 * Build hangs with DevMojoIT running infinitely
-  ```
+
+  ```shell
   ./mvnw clean install
   # Wait...
   [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.192 s - in io.quarkus.maven.it.GenerateConfigIT
   [INFO] Running io.quarkus.maven.it.DevMojoIT
   ```
+
   DevMojoIT require a few minutes to run but anything more than that is not expected. Make sure that nothing is running
   on 8080.
 
@@ -849,10 +851,12 @@ This project is an open source project, please act responsibly, be nice, polite 
 
   Just scroll up, there should be an error or warning somewhere. Failing enforcer rules are known to cause such effects
   and in this case there'll be something like:
+
   ```
   [WARNING] Rule 0: ... failed with message:
   ...
   ```
+
 * Tests fail with `Caused by: io.quarkus.runtime.QuarkusBindException: Port(s) already bound: 8080: Address already in use`
 
     Check that you do not have other Quarkus dev environments, apps or other web servers running on this default 8080 port.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -8,7 +8,7 @@ you are more than welcome on our [mailing list](https://groups.google.com/d/foru
 
 To help us troubleshoot your issues, we will need some performance insights from your application.
 
-On Linux or macOS, one of the best way to gather performance insights would be to generate CPU and allocation [FlameGraphs](https://github.com/brendangregg/FlameGraph) 
+On Linux or macOS, one of the best way to gather performance insights would be to generate CPU and allocation [FlameGraphs](https://github.com/brendangregg/FlameGraph)
 via [Async Profiler](https://github.com/jvm-profiling-tools/async-profiler).
 
 If you want a deeper introduction to Async Profiler, do checkout [this article](https://hackernoon.com/profiling-java-applications-with-async-profiler-049s2790).
@@ -17,7 +17,7 @@ If you want a deeper introduction to Async Profiler, do checkout [this article](
 
 To install Async Profiler, go to the [release page](https://github.com/jvm-profiling-tools/async-profiler/releases) and download the latest release.
 
-Async Profiler depends on `perf_events`.    
+Async Profiler depends on `perf_events`.
 To allow capturing kernel call stacks using `perf_events` from a non-root process,
 you must first apply a couple OS configuration options.
 
@@ -49,6 +49,7 @@ apt install openjdk-8-dbg
 # On CentOS, RHEL and some other RPM-based distributions - Java 11
 debuginfo-install java-11-openjdk
 ```
+
 You can also use a __fastdebug__ build of OpenJdk, this kind of build is not for production use (JVM as assertions are enabled), but it includes debug symbols
 
 If needed, see [this](https://github.com/jvm-profiling-tools/async-profiler#allocation-profiling) section in the Async Profiler site for details.
@@ -57,13 +58,13 @@ If needed, see [this](https://github.com/jvm-profiling-tools/async-profiler#allo
 
 Async Profiler comes with a Java agent, and a command line.
 
-To profile application while it is running, it is recommended to use the command line as you can choose when to start the profiler and prevent your profile data from being bloated with startup events.    
-This can be important as any application performs a lot of bootstrapping operation upon startup that won't occur at any other during the application lifecycle.    
+To profile application while it is running, it is recommended to use the command line as you can choose when to start the profiler and prevent your profile data from being bloated with startup events.
+This can be important as any application performs a lot of bootstrapping operation upon startup that won't occur at any other during the application lifecycle.
 By starting the profiling on demand, you prevent these bootstrap instructions from being part of the profile data.
 
 When you use the command line, it is advised to use `-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints` JVM flags to have more accurate results.
 
-It is usually advised to profile an application under load, 
+It is usually advised to profile an application under load,
 and to start profiling only after some warmup time to allow Java's Just In Time compiler to optimize your application code (not to mention giving the opportunity for database caches to warmup, etc...).  
 Such load could be created by a load generator tool ([ab](https://httpd.apache.org/docs/2.4/programs/ab.html), [wrk2](https://github.com/giltene/wrk2), [Gatling](https://gatling.io/), [Apache JMeter](https://jmeter.apache.org/), ...).
 
@@ -77,7 +78,7 @@ To start CPU profiling, execute the following command:
 
 `-b 4000000` is used to increase the frame buffer size as the default is often too small.
 
-To end profiling and gather the results you can launch the same command with the `stop` subcommand, this will tell you if the buffer frame was too small.    
+To end profiling and gather the results you can launch the same command with the `stop` subcommand, this will tell you if the buffer frame was too small.
 The output is a text file that is not really usable, so let's use our preferred performance representation: the  flame graph.
 
 ```shell script
@@ -87,8 +88,8 @@ The output is a text file that is not really usable, so let's use our preferred 
 It will create an HTML flame graph (Async Profiler automatically detect that you ask for a  flame graph thanks to the `html` file extension)
 that you can open in your browser (and even zoom inside it by clicking on a frame).
 
-One very useful option is `-s` (or `--simple`) that results in simple class names being used instead of fully qualified class names, 
-thus making the  flame graph more readable (at cost of not showing the package names of classes).    
+One very useful option is `-s` (or `--simple`) that results in simple class names being used instead of fully qualified class names,
+thus making the  flame graph more readable (at cost of not showing the package names of classes).
 You can also limit the profiling duration by using `-d` (or `--duration`) followed by the duration in seconds.
 If you use the `--duration` option, the output file will be created automatically at the end of the duration period. You do not need to explicitly start and stop the profiler.
 
@@ -129,13 +130,13 @@ java -agentpath:/path/to/async-profiler/build/libasyncProfiler.so=start,event=al
 
 Note that short options are not supported inside the agent, you need to use their long versions.
 
-By default, Async Profiler sample events every 10ms. 
-When it comes to profiling / debugging a Quarkus startup issue, this value is often too high as Quarkus starts very fast.    
+By default, Async Profiler sample events every 10ms.
+When it comes to profiling / debugging a Quarkus startup issue, this value is often too high as Quarkus starts very fast.
 For that reason, it is not uncommon to configure the profiling interval to 1000000ns (i.e. 1ms).
 
 ## Profiling application dev mode with Async Profiler
 
-For profiling Quarkus dev mode, the Java agent is again necessary. 
+For profiling Quarkus dev mode, the Java agent is again necessary.
 It can be used in the same way as for the production application with the exception that `agentpath` option needs to be set via the `jvm.args` system property.
 
 ```shell script
@@ -150,13 +151,13 @@ You can also configure the `jvm.args` system property directly inside the `quark
 
 ## Analysing build steps execution time
 
-When trying to debug startup performance, it is convenient to log build steps execution time. 
+When trying to debug startup performance, it is convenient to log build steps execution time.
 This can be achieved by adding the following system property: `-Dquarkus.debug.print-startup-times=true` in dev mode or when launching the JAR.
 
-There is also a nice visualization of build steps available in the Dev UI located here: http://localhost:8080/q/dev/build-steps.
+There is also a nice visualization of build steps available in the Dev UI located here: <http://localhost:8080/q/dev/build-steps>.
 
-If you want to have the same visualization of build steps processing when building your application, you can use the `quarkus.debug.dump-build-metrics=true` property. 
-For example using `mvn package -Dquarkus.debug.dump-build-metrics=true`, will generate a `build-metrics.json` in your `target` repository that you can process via the quarkus-build-report application available here https://github.com/mkouba/quarkus-build-report. 
+If you want to have the same visualization of build steps processing when building your application, you can use the `quarkus.debug.dump-build-metrics=true` property.
+For example using `mvn package -Dquarkus.debug.dump-build-metrics=true`, will generate a `build-metrics.json` in your `target` repository that you can process via the quarkus-build-report application available here <https://github.com/mkouba/quarkus-build-report>.
 This application will generate a `report.html` that you can open in your browser.
 
 ## What about Windows?

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/funqy-google-cloud-functions-example/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/funqy-google-cloud-functions-example/base/README.tpl.qute.md
@@ -2,7 +2,5 @@
 
 > :warning: **INCOMPATIBLE WITH DEV MODE**: Funqy Google Cloud Functions is not compatible with dev mode yet!
 
-Two examples have been generated under `src/main/java/org/acme/funqygooglecloudfunctions`, you must remove them before deploying to 
-Google Cloud Functions or setup multi-functions support, see https://quarkus.io/guides/funqy-gcp-functions#choose.
-
-
+Two examples have been generated under `src/main/java/org/acme/funqygooglecloudfunctions`, you must remove them before deploying to
+Google Cloud Functions or setup multi-functions support, see <https://quarkus.io/guides/funqy-gcp-functions#choose>.

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/google-cloud-functions-example/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/google-cloud-functions-example/base/README.tpl.qute.md
@@ -1,6 +1,6 @@
 {#include readme-header /}
 
-Three examples have been generated under `src/main/java/org/acme/googlecloudfunctions`, you must remove them before deploying to 
-Google Cloud Functions or setup multi-functions support, see https://quarkus.io/guides/gcp-functions#choose-your-function.
+Three examples have been generated under `src/main/java/org/acme/googlecloudfunctions`, you must remove them before deploying to
+Google Cloud Functions or setup multi-functions support, see <https://quarkus.io/guides/gcp-functions#choose-your-function>.
 
 > :warning: **INCOMPATIBLE WITH DEV MODE**: Google Cloud Functions is not compatible with dev mode yet!

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-rest-data-codestart/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-rest-data-codestart/base/README.tpl.qute.md
@@ -1,2 +1,1 @@
 {#include readme-header /}
-

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/base/README.tpl.qute.md
@@ -3,6 +3,7 @@
 Also for picocli applications the dev mode is supported. When running dev mode, the picocli application is executed and on press of the Enter key, is restarted.
 
 As picocli applications will often require arguments to be passed on the commandline, this is also possible in dev mode via:
+
 ```shell script
 {buildtool.cli} {buildtool.cmd.dev} {#if input.base-codestart.buildtool == 'gradle' || input.base-codestart.buildtool == 'gradle-kotlin-dsl'}--quarkus-args{#else}-Dquarkus.args{/if}='Quarky'
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-## Quarkus Documentation
+# Quarkus Documentation
 
-This is the main folder for Quarkus documentation. 
+This is the main folder for Quarkus documentation.
 
 The contents of this folder are used to publish documentation to the quarkus.io website.
 The [main documentation README.adoc](src/main/asciidoc/README.adoc) is in the `src/main/asciidoc` folder that also contains the `.adoc` source files for the published documentation.

--- a/extensions/infinispan-client/README.MD
+++ b/extensions/infinispan-client/README.MD
@@ -90,7 +90,7 @@ DIGEST_MD5, PLAIN, EXTERNAL were all tested to work.
 
 Querying is also supported. To be able to do DSL based queries you need to add the infinispan-query-dsl artifact to your
 list of dependencies and then you can use it as normal. A simple example can be seen at
-https://infinispan.org/docs/stable/titles/query/query.html#ickle-query-language
+<https://infinispan.org/docs/stable/titles/query/query.html#ickle-query-language>
 
 ### Counters
 
@@ -111,10 +111,6 @@ must be generated at compile time and protostream, underlying library powering p
 runtime based class generation.
 
 ## Things to still verify work
-
-
-
-
 
 ### Multimap
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/README.tpl.qute.md
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/README.tpl.qute.md
@@ -24,4 +24,4 @@ The layout should follow the [Antora's Standard File and Directory Set](https://
 
 Once the docs are ready to be published, please open a PR including this repository in the [Quarkiverse Docs Antora playbook](https://github.com/quarkiverse/quarkiverse-docs/blob/main/antora-playbook.yml#L7). See an example [here](https://github.com/quarkiverse/quarkiverse-docs/pull/1)
 
-Your documentation will then be published to the https://docs.quarkiverse.io/ website.
+Your documentation will then be published to the <https://docs.quarkiverse.io/> website.

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/code/jbang-picocli-code/base/README.tpl.qute.md
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/code/jbang-picocli-code/base/README.tpl.qute.md
@@ -1,3 +1,5 @@
+# jbang-picocli-code
+
 ## Greet the world!
 
 ```shell script

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/code/jbang-resteasy-code/base/README.tpl.qute.md
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/code/jbang-resteasy-code/base/README.tpl.qute.md
@@ -1,3 +1,5 @@
+# jbang-resteasy-code
+
 ```shell script
 ./jbang src/main.java
 ```

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/project/quarkus-jbang/base/README.tpl.qute.md
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/project/quarkus-jbang/base/README.tpl.qute.md
@@ -1,2 +1,1 @@
 # JBang Quarkus Project
-

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/README.tpl.qute.md
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/README.tpl.qute.md
@@ -11,29 +11,33 @@
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
-If you want to learn more about Quarkus, please visit its website: https://quarkus.io/ .
+If you want to learn more about Quarkus, please visit its website: <https://quarkus.io/>.
 
 ## Running the application in dev mode
 
 You can run your application in dev mode that enables live coding using:
+
 ```shell script
 {buildtool.cli} {buildtool.cmd.dev}
 ```
 
-> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at http://localhost:8080/q/dev/.
+> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at <http://localhost:8080/q/dev/>.
 
 ## Packaging and running the application
 
 The application can be packaged using:
+
 ```shell script
 {buildtool.cli} {buildtool.cmd.package}
 ```
+
 It produces the `quarkus-run.jar` file in the `{buildtool.build-dir}/quarkus-app/` directory.
 Be aware that it’s not an _über-jar_ as the dependencies are copied into the `{buildtool.build-dir}/quarkus-app/lib/` directory.
 
 The application is now runnable using `java -jar {buildtool.build-dir}/quarkus-app/quarkus-run.jar`.
 
 If you want to build an _über-jar_, execute the following command:
+
 ```shell script
 {buildtool.cli} {buildtool.cmd.package-uber-jar}
 ```
@@ -42,19 +46,21 @@ The application, packaged as an _über-jar_, is now runnable using `java -jar {b
 
 ## Creating a native executable
 
-You can create a native executable using: 
+You can create a native executable using:
+
 ```shell script
 {buildtool.cli} {buildtool.cmd.package-native}
 ```
 
-Or, if you don't have GraalVM installed, you can run the native executable build in a container using: 
+Or, if you don't have GraalVM installed, you can run the native executable build in a container using:
+
 ```shell script
 {buildtool.cli} {buildtool.cmd.package-native-container}
 ```
 
 You can then execute your native executable with: `./{buildtool.build-dir}/{project.artifact-id}-{project.version}-runner`
 
-If you want to learn more about building native executables, please consult {buildtool.guide}.
+If you want to learn more about building native executables, please consult <{buildtool.guide}>.
 {#if input.selected-extensions}
 
 ## Related Guides

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
@@ -2,29 +2,33 @@
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
-If you want to learn more about Quarkus, please visit its website: https://quarkus.io/ .
+If you want to learn more about Quarkus, please visit its website: <https://quarkus.io/>.
 
 ## Running the application in dev mode
 
 You can run your application in dev mode that enables live coding using:
+
 ```shell script
 mvn compile quarkus:dev
 ```
 
-> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at http://localhost:8080/q/dev/.
+> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at <http://localhost:8080/q/dev/>.
 
 ## Packaging and running the application
 
 The application can be packaged using:
+
 ```shell script
 mvn package
 ```
+
 It produces the `quarkus-run.jar` file in the `target/quarkus-app/` directory.
 Be aware that it’s not an _über-jar_ as the dependencies are copied into the `target/quarkus-app/lib/` directory.
 
 The application is now runnable using `java -jar target/quarkus-app/quarkus-run.jar`.
 
 If you want to build an _über-jar_, execute the following command:
+
 ```shell script
 mvn package -Dquarkus.package.jar.type=uber-jar
 ```
@@ -33,16 +37,18 @@ The application, packaged as an _über-jar_, is now runnable using `java -jar ta
 
 ## Creating a native executable
 
-You can create a native executable using: 
+You can create a native executable using:
+
 ```shell script
 mvn package -Dnative
 ```
 
-Or, if you don't have GraalVM installed, you can run the native executable build in a container using: 
+Or, if you don't have GraalVM installed, you can run the native executable build in a container using:
+
 ```shell script
 mvn package -Dnative -Dquarkus.native.container-build=true
 ```
 
 You can then execute your native executable with: `./target/test-codestart-1.0.0-codestart-runner`
 
-If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.
+If you want to learn more about building native executables, please consult <https://quarkus.io/guides/maven-tooling>.

--- a/integration-tests/keycloak-authorization/README.md
+++ b/integration-tests/keycloak-authorization/README.md
@@ -6,13 +6,13 @@ By default, the tests of this module are disabled.
 
 To run the tests in a standard JVM with Keycloak Server started as a Docker container, you can run the following command:
 
-```
+```shell
 mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
-```
+```shell
 mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
@@ -20,7 +20,7 @@ If you don't want to run Keycloak Server as a Docker container, you can start yo
 
 You can then run the tests as follows (either with `-Dnative` or not):
 
-```
+```shell
 mvn clean install -Dtest-containers
 ```
 

--- a/integration-tests/logging-gelf/README.md
+++ b/integration-tests/logging-gelf/README.md
@@ -10,7 +10,7 @@ To run them, you first need to start a Graylog server and it's needed dependenci
 
 The following commands will launch MongoDB, Elasticsearch and Graylog using Docker Compose then create a UDP input.
 
-```
+```shell
 # Launch Graylog and it's components (MongoDB and Elasticsearch)
 docker-compose -f src/test/resources/docker-compose-graylog.yml up
 
@@ -22,22 +22,22 @@ http://localhost:9000/api/system/inputs
 
 When everything is launched and ready, you can run the tests in a standard JVM with the following command:
 
-```
+```shell
 mvn clean test -Dtest-gelf
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
-```
+```shell
 mvn clean integration-test -Dtest-containers -Dnative
 ```
 
 ## Testing with ELK (Elasticsearch, Logstash, Kibana) aka the Elastic Stack
 
-You can also run the test with an ELK cluster, in this case, the test will fail as it will try to access Graylog to validate 
+You can also run the test with an ELK cluster, in this case, the test will fail as it will try to access Graylog to validate
 that the events are correctly sent. So you should assert yourself that it works.
 
-First, you need to create a Logstash pipeline file with a GELF input, we will put it inside ` $HOME/pipelines/gelf.conf`
+First, you need to create a Logstash pipeline file with a GELF input, we will put it inside `$HOME/pipelines/gelf.conf`
 
 ```
 input {
@@ -56,14 +56,13 @@ output {
 
 Then you can use the following commands to run an ELK cluster using the provided docker compose:
 
-```
+```shell
 # Launch ELK (Elasticsearch, Logstash, Kibana)
 docker-compose -f src/test/resources/docker-compose-elk.yml up
 ```
 
 Finally, run the test via `mvn clean install -Dtest-containers -Dmaven.test.failure.ignore` and manually verify that the log
-events has been pushed to ELK. You can use Kibana on http://localhost:5601/ to access those logs.
-
+events has been pushed to ELK. You can use Kibana on <http://localhost:5601/> to access those logs.
 
 ## Testing with EFK (Elasticsearch, Fluentd, Kibana)
 
@@ -94,10 +93,10 @@ Then, you need to create a configuration file that will defines an input of GELF
 
 Then you can use the following commands to run an EFK cluster using the provided docker compose:
 
-```
+```shell
 # Launch EFK (Elasticsearch, Fluentd, Kibana)
 docker-compose -f src/test/resources/docker-compose-efk.yml up
 ```
 
 Finally, run the test via `mvn clean install -Dtest-containers -Dmaven.test.failure.ignore` and manually verify that the log
-events has been pushed to EFK. You can use Kibana on http://localhost:5601/ to access those logs.
+events has been pushed to EFK. You can use Kibana on <http://localhost:5601/> to access those logs.

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_README.md
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_README.md
@@ -24,4 +24,4 @@ The layout should follow the [Antora's Standard File and Directory Set](https://
 
 Once the docs are ready to be published, please open a PR including this repository in the [Quarkiverse Docs Antora playbook](https://github.com/quarkiverse/quarkiverse-docs/blob/main/antora-playbook.yml#L7). See an example [here](https://github.com/quarkiverse/quarkiverse-docs/pull/1)
 
-Your documentation will then be published to the https://docs.quarkiverse.io/ website.
+Your documentation will then be published to the <https://docs.quarkiverse.io/> website.

--- a/integration-tests/oidc-code-flow/README.md
+++ b/integration-tests/oidc-code-flow/README.md
@@ -6,13 +6,13 @@ By default, the tests of this module are disabled.
 
 To run the tests in a standard JVM with Keycloak Server started as a Docker container, you can run the following command:
 
-```
+```shell
 mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
-```
+```shell
 mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
@@ -20,7 +20,7 @@ If you don't want to run Keycloak Server as a Docker container, you can start yo
 
 You can then run the tests as follows (either with `-Dnative` or not):
 
-```
+```shell
 mvn clean install -Dtest-containers
 ```
 

--- a/integration-tests/oidc-tenancy/README.md
+++ b/integration-tests/oidc-tenancy/README.md
@@ -6,13 +6,13 @@ By default, the tests of this module are disabled.
 
 To run the tests in a standard JVM with Keycloak Server started as a Docker container, you can run the following command:
 
-```
+```shell
 mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
-```
+```shell
 mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
@@ -20,7 +20,7 @@ If you don't want to run Keycloak Server as a Docker container, you can start yo
 
 You can then run the tests as follows (either with `-Dnative` or not):
 
-```
+```shell
 mvn clean install -Dtest-containers
 ```
 


### PR DESCRIPTION
Closes #40147

Fixed some non intrusive warnings: in some `.md` files

- MD009: Remove extra trailing spaces
- MD031: Add new line
- MD034: Add wrappers to URL (<>)
- MD038: Remove extra spaces from code span element
- MD040: Specify language on code block
- ~MD051: Fix Link fragments in `CONTRIBUTING.md` index~ (rolled back)

PS:
- [markdown-toc](http://ecotrust-canada.github.io/markdown-toc/) has a bug where generates bad links when special characters are used in headings
- `CONTRIBUTING.md` still has 192  warnings that should be reviewed:
    - MD001/heading-increment: Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]
    - MD004/ul-style: Unordered list style [Expected: dash; Actual: asterisk]
    - MD007/ul-indent: Unordered list indentation [Expected: 2; Actual: 4]
    - MD033/no-inline-html: Inline HTML [Element: a]
    - MD036/no-emphasis-as-heading: Emphasis used instead of a heading
    - MD040/fenced-code-language: Fenced code blocks should have a language specified
    - MD049/emphasis-style: Emphasis style [Expected: asterisk; Actual: underscore]


