### PR TITLE
[3.8] Move hibernate-orm/deployment devmode tests to a separate surefire execution

### DIFF
--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -119,6 +119,35 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- These tests seem to leak metaspace memory
+                                 so we run them in a separate, short-lived JVM -->
+                            <excludedGroups>devmode</excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>devmode-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- These tests seem to leak metaspace memory
+                                 so we run them in a separate, short-lived JVM -->
+                            <groups>devmode</groups>
+                            <!-- We could consider setting reuseForks=false if we
+                                 really need to run every single test in its own JVM -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateHotReloadDevModeTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateHotReloadDevModeTest.java
@@ -8,6 +8,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -16,7 +17,8 @@ import io.quarkus.test.ContinuousTestingTestUtils.TestStatus;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
-public class HibernateHotReloadTestCase {
+@Tag(TestTags.DEVMODE)
+public class HibernateHotReloadDevModeTest {
 
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateSchemaRecreateDevConsoleTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateSchemaRecreateDevConsoleTestCase.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -14,6 +15,7 @@ import io.quarkus.devui.tests.DevUIJsonRPCTest;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
+@Tag(TestTags.DEVMODE)
 public class HibernateSchemaRecreateDevConsoleTestCase extends DevUIJsonRPCTest {
 
     @RegisterExtension

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/TestTags.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/TestTags.java
@@ -1,0 +1,10 @@
+package io.quarkus.hibernate.orm;
+
+public class TestTags {
+    /**
+     * Tag for tests that use {@link io.quarkus.test.QuarkusDevModeTest},
+     * so that surefire config can run them in a different execution
+     * and keep the metaspace memory leaks there.
+     */
+    public static final String DEVMODE = "devmode";
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/HibernateOrmDevControllerFailingDDLGenerationTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/HibernateOrmDevControllerFailingDDLGenerationTestCase.java
@@ -2,12 +2,15 @@ package io.quarkus.hibernate.orm.dev;
 
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
+@Tag(TestTags.DEVMODE)
 public class HibernateOrmDevControllerFailingDDLGenerationTestCase {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/HibernateOrmDevControllerTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/HibernateOrmDevControllerTestCase.java
@@ -2,12 +2,15 @@ package io.quarkus.hibernate.orm.dev;
 
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
+@Tag(TestTags.DEVMODE)
 public class HibernateOrmDevControllerTestCase {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsImportSqlHotReloadScriptTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsImportSqlHotReloadScriptTest.java
@@ -4,9 +4,11 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.function.Function;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.inventory.Plane;
 import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.shared.SharedEntity;
 import io.quarkus.hibernate.orm.multiplepersistenceunits.model.annotation.user.User;
@@ -17,6 +19,7 @@ import io.restassured.RestAssured;
 /**
  * See https://github.com/quarkusio/quarkus/issues/13722
  */
+@Tag(TestTags.DEVMODE)
 public class MultiplePersistenceUnitsImportSqlHotReloadScriptTest {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoting_strategies/JPAQuotedIdentifiersTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoting_strategies/JPAQuotedIdentifiersTest.java
@@ -1,7 +1,9 @@
 package io.quarkus.hibernate.orm.quoting_strategies;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 
 /**
@@ -9,6 +11,7 @@ import io.quarkus.test.QuarkusDevModeTest;
  * <p>
  * To resolve the simulated situation, this test uses the quoting strategy {@code all-except-column-definitions}.
  */
+@Tag(TestTags.DEVMODE)
 public class JPAQuotedIdentifiersTest extends AbstractJPAQuotedTest {
 
     @RegisterExtension

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoting_strategies/JPAQuotedKeywordsTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoting_strategies/JPAQuotedKeywordsTest.java
@@ -1,7 +1,9 @@
 package io.quarkus.hibernate.orm.quoting_strategies;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 
 /**
@@ -9,6 +11,7 @@ import io.quarkus.test.QuarkusDevModeTest;
  * <p>
  * To resolve the simulated situation, this test uses the quoting strategy {@code auto-keywords}.
  */
+@Tag(TestTags.DEVMODE)
 public class JPAQuotedKeywordsTest extends AbstractJPAQuotedTest {
 
     @RegisterExtension

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/scripts/GenerateScriptNotAppendedTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/scripts/GenerateScriptNotAppendedTestCase.java
@@ -7,11 +7,14 @@ import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 
+@Tag(TestTags.DEVMODE)
 public class GenerateScriptNotAppendedTestCase {
 
     @RegisterExtension

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/AddNewSqlLoadScriptTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/AddNewSqlLoadScriptTestCase.java
@@ -1,13 +1,16 @@
 package io.quarkus.hibernate.orm.sql_load_script;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
+@Tag(TestTags.DEVMODE)
 public class AddNewSqlLoadScriptTestCase {
     @RegisterExtension
     static QuarkusDevModeTest runner = new QuarkusDevModeTest()

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportSqlHotReloadScriptTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportSqlHotReloadScriptTestCase.java
@@ -4,13 +4,16 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.function.Function;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
+@Tag(TestTags.DEVMODE)
 public class ImportSqlHotReloadScriptTestCase {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/IntroducingDefaultImportScriptTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/IntroducingDefaultImportScriptTestCase.java
@@ -1,13 +1,16 @@
 package io.quarkus.hibernate.orm.sql_load_script;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
+@Tag(TestTags.DEVMODE)
 public class IntroducingDefaultImportScriptTestCase {
 
     @RegisterExtension

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/hbm/HbmXmlHotReloadExplicitFileTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/hbm/HbmXmlHotReloadExplicitFileTestCase.java
@@ -3,13 +3,16 @@ package io.quarkus.hibernate.orm.xml.hbm;
 import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.SchemaUtil;
 import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 
+@Tag(TestTags.DEVMODE)
 public class HbmXmlHotReloadExplicitFileTestCase {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/orm/OrmXmlHotReloadExplicitFileTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/orm/OrmXmlHotReloadExplicitFileTestCase.java
@@ -3,13 +3,16 @@ package io.quarkus.hibernate.orm.xml.orm;
 import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.SchemaUtil;
 import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 
+@Tag(TestTags.DEVMODE)
 public class OrmXmlHotReloadExplicitFileTestCase {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/orm/OrmXmlHotReloadImplicitFileTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/orm/OrmXmlHotReloadImplicitFileTestCase.java
@@ -3,13 +3,16 @@ package io.quarkus.hibernate.orm.xml.orm;
 import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.SchemaUtil;
 import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.hibernate.orm.TestTags;
 import io.quarkus.test.QuarkusDevModeTest;
 
+@Tag(TestTags.DEVMODE)
 public class OrmXmlHotReloadImplicitFileTestCase {
     @RegisterExtension
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()


### PR DESCRIPTION
In the hope this will reduce the impact of QuarkusDevModeTest metaspace memory leaks.

Backport of #40864 to branch 3.8.

@gsmet I thought we would want to backport soon in a separate PR, given this may make CI reliable on the 3.8 branch (which impacts Hibernate ORM CI in particular)?