### PR TITLE
Set the target file in the Model

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtils.java
@@ -232,7 +232,9 @@ public class ModelUtils {
     }
 
     public static Model readModel(final Path pomXml) throws IOException {
-        return readModel(Files.newInputStream(pomXml));
+        Model model = readModel(Files.newInputStream(pomXml));
+        model.setPomFile(pomXml.toFile());
+        return model;
     }
 
     public static Model readModel(InputStream stream) throws IOException {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -381,7 +381,7 @@ public class MavenProjectBuildFile extends BuildFile {
             return;
         }
         try {
-            model = ModelUtils.readModel(projectPom);
+            model = MojoUtils.readPom(projectPom.toFile());
         } catch (IOException e) {
             throw new RuntimeException("Failed to read " + projectPom, e);
         }


### PR DESCRIPTION
This is necessary so `maven-model-helper` can know which pom.xml the change refers to.

- Fixes #40853
