### PR TITLE
Update to maven 3.9.7 and compiler plugin to 3.13.0

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
-distributionSha256Sum=80b3b63df0e40ca8cde902bb1a40e4488ede24b3f282bd7bd6fba8eb5a7e055c
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+distributionSha256Sum=7822eb593d29558d8edf87845a2c47e36e2a89d17a84cd2390824633214ed423
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 java=17.0.10-tem
-mvnd=1.0-m7-m39
+mvnd=1.0-m8-m39

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -19,7 +19,7 @@
         <!-- Maven plugin versions -->
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
-        <compiler-plugin.version>3.12.1</compiler-plugin.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <kotlin.version>2.0.0</kotlin.version>
         <dokka.version>1.9.20</dokka.version>
         <scala.version>2.13.12</scala.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -62,7 +62,7 @@
         <supported-maven-versions>[${maven.min.version},)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.9.6</proposed-maven-version>
+        <proposed-maven-version>3.9.7</proposed-maven-version>
         <maven-wrapper.version>3.2.0</maven-wrapper.version>
         <gradle-wrapper.version>8.7</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -165,7 +165,7 @@ Your extension is a multi-module project. So let's start by checking out the par
     <module>runtime</module>
   </modules>
   <properties>
-    <compiler-plugin.version>3.12.1</compiler-plugin.version><!--2-->
+    <compiler-plugin.version>3.13.0</compiler-plugin.version><!--2-->
     <failsafe-plugin.version>${surefire-plugin.version}</failsafe-plugin.version>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -877,7 +877,7 @@ $ mvn clean compile quarkus:dev
 [INFO] Using 'UTF-8' encoding to copy filtered resources.
 [INFO] Copying 1 resource
 [INFO]
-[INFO] --- maven-compiler-plugin:3.12.1:compile (default-compile) @ greeting-app ---
+[INFO] --- maven-compiler-plugin:3.13.0:compile (default-compile) @ greeting-app ---
 [INFO] Nothing to compile - all classes are up to date
 [INFO]
 [INFO] --- quarkus-maven-plugin:{quarkus-version}:dev (default-cli) @ greeting-app ---

--- a/docs/src/main/asciidoc/jreleaser.adoc
+++ b/docs/src/main/asciidoc/jreleaser.adoc
@@ -619,7 +619,7 @@ As a reference, these are the full contents of the `pom.xml`:
   <properties>
     <executable-suffix/>
     <distribution.directory>${project.build.directory}/distributions</distribution.directory>
-    <compiler-plugin.version>3.12.1</compiler-plugin.version>
+    <compiler-plugin.version>3.13.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -8,7 +8,7 @@
     <version>\${version}</version>
     <properties>
         <assembly-plugin.version>3.1.0</assembly-plugin.version>
-        <compiler-plugin.version>3.12.1</compiler-plugin.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>

--- a/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -8,7 +8,7 @@
     <version>\${version}</version>
     <properties>
         <assembly-plugin.version>3.1.0</assembly-plugin.version>
-        <compiler-plugin.version>3.12.1</compiler-plugin.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>\${artifactId}</artifactId>
     <version>\${version}</version>
     <properties>
-        <compiler-plugin.version>3.12.1</compiler-plugin.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>

--- a/extensions/funqy/funqy-amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>\${artifactId}</artifactId>
     <version>\${version}</version>
     <properties>
-        <compiler-plugin.version>3.12.1</compiler-plugin.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -61,7 +61,7 @@
         <version.cdi-tck>4.1.0</version.cdi-tck>
         <version.junit4>4.13.2</version.junit4>
         <!-- Maven plugin versions -->
-        <version.compiler.plugin>3.12.1</version.compiler.plugin>
+        <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
     </properties>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -45,11 +45,11 @@
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
-        <maven-core.version>3.9.6</maven-core.version><!-- Keep in sync with sisu.version -->
+        <maven-core.version>3.9.7</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.9.0.M2</sisu.version><!-- Keep in sync with maven-core.version -->
-        <maven-plugin-annotations.version>3.10.2</maven-plugin-annotations.version>
-        <maven-resolver.version>1.9.18</maven-resolver.version>
-        <maven-shared-utils.version>3.3.4</maven-shared-utils.version> <!-- Keep in sync with maven-core.version (force this version on maven-invoker) -->
+        <maven-plugin-annotations.version>3.13.0</maven-plugin-annotations.version>
+        <maven-resolver.version>1.9.20</maven-resolver.version>
+        <maven-shared-utils.version>3.4.2</maven-shared-utils.version> <!-- Keep in sync with maven-core.version (force this version on maven-invoker) -->
         <maven-wagon.version>3.5.3</maven-wagon.version>
         <httpcore.version>4.4.16</httpcore.version><!-- Keep in sync with maven-wagon.version (wagon-http 3.4.3 brings in 4.4.13 and 4.4.14) -->
         <httpclient.version>4.5.14</httpclient.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -34,7 +34,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.inject.version>1</javax.inject.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.compiler.plugin>3.12.1</version.compiler.plugin>
+        <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <jandex.version>3.2.0</jandex.version>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -37,7 +37,7 @@
         <!-- Keeping 3.0.0.M3 because 3.2.1 requires class changes -->
         <enforcer-api.version>3.0.0-M3</enforcer-api.version>
         <maven-invoker-plugin.version>3.7.0</maven-invoker-plugin.version>
-        <maven-core.version>3.9.6</maven-core.version>
+        <maven-core.version>3.9.7</maven-core.version>
 
         <!--
            Supported Maven versions, interpreted as a version range (Also defined in build-parent)

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
         <maven-core.version>3.9.7</maven-core.version>
-        <version.compiler.plugin>3.12.1</version.compiler.plugin>
+        <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <jackson-bom.version>2.17.1</jackson-bom.version>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -37,7 +37,7 @@
         <!-- Not sure exactly why but the Maven plugins need to be compiled with Java 11 -->
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
-        <maven-core.version>3.9.6</maven-core.version>
+        <maven-core.version>3.9.7</maven-core.version>
         <version.compiler.plugin>3.12.1</version.compiler.plugin>
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.2.5</version.surefire.plugin>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <compiler.plugin.version>3.12.1</compiler.plugin.version>
+        <compiler.plugin.version>3.13.0</compiler.plugin.version>
         <enforcer.plugin.version>3.2.1</enforcer.plugin.version>
         <surefire.plugin.version>3.2.5</surefire.plugin.version>
         <jandex.version>3.2.0</jandex.version>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -20,7 +20,7 @@
         <version.buildhelper.plugin>3.6.0</version.buildhelper.plugin>
         <version.buildnumber.plugin>3.0.0</version.buildnumber.plugin>
         <version.clean.plugin>3.2.0</version.clean.plugin>
-        <version.compiler.plugin>3.12.1</version.compiler.plugin>
+        <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.deploy.plugin>3.1.1</version.deploy.plugin>
         <version.plugin.plugin>3.11.0</version.plugin.plugin>
         <version.enforcer.plugin>3.3.0</version.enforcer.plugin>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -43,7 +43,7 @@
         <version.jandex>3.2.0</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>
         <version.jboss-logging>3.6.0.Final</version.jboss-logging>
-        <version.compiler.plugin>3.12.1</version.compiler.plugin>
+        <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <version.smallrye-mutiny>2.6.0</version.smallrye-mutiny>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -56,7 +56,7 @@
         <gizmo.version>1.8.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
-        <version.compiler.plugin>3.12.1</version.compiler.plugin>
+        <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <mutiny.version>2.6.0</mutiny.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -48,7 +48,7 @@
         <jandex.version>3.2.0</jandex.version>
         <bytebuddy.version>1.14.11</bytebuddy.version>
         <junit5.version>5.10.2</junit5.version>
-        <maven.version>3.9.6</maven.version>
+        <maven.version>3.9.7</maven.version>
         <assertj.version>3.26.0</assertj.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>
         <jboss-logmanager.version>3.0.6.Final</jboss-logmanager.version>

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -445,7 +445,7 @@
         "supported-maven-versions": "[3.6.2,)",
         "minimum-java-version": "11",
         "recommended-java-version": "17",
-        "proposed-maven-version": "3.9.6",
+        "proposed-maven-version": "3.9.7",
         "maven-wrapper-version": "3.2.0",
         "gradle-wrapper-version": "8.7"
       }

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- These properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.9.6</proposed-maven-version>
+        <proposed-maven-version>3.9.7</proposed-maven-version>
         <maven-wrapper.version>3.2.0</maven-wrapper.version>
         <gradle-wrapper.version>8.7</gradle-wrapper.version>
 

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -42,7 +42,7 @@
         <gradle-wrapper.version>8.7</gradle-wrapper.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
-        <compiler-plugin.version>3.12.1</compiler-plugin.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <kotlin.version>1.6.0</kotlin.version>
         <scala.version>2.13.12</scala.version>
         <scala-plugin.version>4.4.0</scala-plugin.version>


### PR DESCRIPTION
Updates maven to 3.9.7
Updates maven compiler plugin to 3.13.0
~~Maven wrapper was still using 3.9.3, unsure if that was wanted so changed it in a seperate commit~~
Updated maven wrapper to 3.9.5 and updated according mvnd in `.sdkmanrc`

Ran the following to test locally `./mvnw clean install -Dquickly`