### PR TITLE
Confirm that expired or wrong aud JWT cause 401 even if the cert chain is valid

### DIFF
--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -206,6 +206,7 @@ quarkus.oidc.bearer-certificate-full-chain.certificate-chain.trust-store-passwor
 
 quarkus.oidc.bearer-chain-custom-validator.certificate-chain.trust-store-file=truststore.p12
 quarkus.oidc.bearer-chain-custom-validator.certificate-chain.trust-store-password=storepassword
+quarkus.oidc.bearer-chain-custom-validator.token.audience=https://service.example.com
 
 quarkus.oidc.bearer-certificate-full-chain-root-only-wrongcname.certificate-chain.trust-store-file=truststore-rootcert.p12
 quarkus.oidc.bearer-certificate-full-chain-root-only-wrongcname.certificate-chain.trust-store-password=storepassword


### PR DESCRIPTION
Simple test update to confirm that if the OIDC token has a valid certificate chain but the general token verification fails (wrong audience, token is expired etc) then 401 is returned

CC @calvernaz