### PR TITLE
Fix a disabled OidcClient REST client issue

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -248,17 +248,17 @@ public class OidcClientRecorder {
 
         @Override
         public Uni<Tokens> getTokens(Map<String, String> additionalGrantParameters) {
-            throw new DisabledOidcClientException(message);
+            return Uni.createFrom().failure(new DisabledOidcClientException(message));
         }
 
         @Override
         public Uni<Tokens> refreshTokens(String refreshToken, Map<String, String> additionalGrantParameters) {
-            throw new DisabledOidcClientException(message);
+            return Uni.createFrom().failure(new DisabledOidcClientException(message));
         }
 
         @Override
         public Uni<Boolean> revokeAccessToken(String accessToken, Map<String, String> additionalParameters) {
-            throw new DisabledOidcClientException(message);
+            return Uni.createFrom().failure(new DisabledOidcClientException(message));
         }
 
         @Override

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -24,6 +25,10 @@ public class FrontendResource {
     @Inject
     @RestClient
     ProtectedResourceServiceNamedFilter protectedResourceServiceNamedFilter;
+
+    @Inject
+    @RestClient
+    ProtectedResourceServiceDisabledClient protectedResourceServiceDisabledClient;
 
     @Inject
     @RestClient
@@ -48,6 +53,14 @@ public class FrontendResource {
     @Produces("text/plain")
     public Uni<String> userNameNamedFilter() {
         return protectedResourceServiceNamedFilter.getUserName();
+    }
+
+    @GET
+    @Path("userNameDisabledClient")
+    @Produces("text/plain")
+    public Uni<String> userNameDisabledClient() {
+        return protectedResourceServiceDisabledClient.getUserName()
+                .onFailure(WebApplicationException.class).recoverWithItem(t -> t.getMessage());
     }
 
     @GET

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceDisabledClient.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceDisabledClient.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+import io.smallrye.mutiny.Uni;
+
+@RegisterRestClient
+@OidcClientFilter("disabled-client")
+@Path("/")
+public interface ProtectedResourceServiceDisabledClient {
+
+    @GET
+    @Produces("text/plain")
+    @Path("userNameReactive")
+    Uni<String> getUserName();
+}

--- a/integration-tests/oidc-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-reactive/src/main/resources/application.properties
@@ -10,6 +10,14 @@ quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
 
+quarkus.oidc-client.disabled-client.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.disabled-client.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.disabled-client.client-enabled=false
+quarkus.oidc-client.disabled-client.credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client.disabled-client.grant.type=password
+quarkus.oidc-client.disabled-client.grant-options.password.username=alice
+quarkus.oidc-client.disabled-client.grant-options.password.password=alice
+
 quarkus.oidc-client.named-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.named-client.client-id=${quarkus.oidc.client-id}
 quarkus.oidc-client.named-client.credentials.secret=${quarkus.oidc.credentials.secret}
@@ -27,6 +35,7 @@ quarkus.oidc-client.misconfigured-client.grant-options.password.password=bob
 io.quarkus.it.keycloak.ProtectedResourceServiceCustomFilter/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.ProtectedResourceServiceReactiveFilter/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.ProtectedResourceServiceNamedFilter/mp-rest/url=http://localhost:8081/protected
+io.quarkus.it.keycloak.ProtectedResourceServiceDisabledClient/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.MisconfiguredClientFilter/mp-rest/url=http://localhost:8081/protected
 
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE

--- a/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -55,6 +55,15 @@ public class OidcClientTest {
     }
 
     @Test
+    public void testGetUserNameDisabledClient() {
+        RestAssured.given().header("Accept", "text/plain")
+                .when().get("/frontend/userNameDisabledClient")
+                .then()
+                .statusCode(200)
+                .body(containsString("Unauthorized, status code 401"));
+    }
+
+    @Test
     public void testGetUserNameMisconfiguredClientFilter() {
         RestAssured.given().header("Accept", "text/plain")
                 .when().get("/frontend/userNameMisconfiguredClientFilter")


### PR DESCRIPTION
The earlier update which I thought was obviously fixing it was correct but incomplete (or may be I tried something with Resteasy Classic which made me believe it was complete, unfortunately I don't remember now).

So this PR fixes it properly and this fix is supported by the test.
The test adds a disabled OidcClient tenant, the flow is: test calls FrontentResource which uses RESTClient to call a secured ProtectedResource - which can only be accessed if OidcClient acquired the token. But because OidcClient is disabled, the request to ProtectedResource goes without the token (as opposed to be terminated with DisabledOidcClientException) and therefore  401 is returned from ProtectedResource and is passed further back to the test code to confirm

- Fixes: #40886