### PR TITLE
Bump kubernetes-client-bom from 6.12.1 to 6.13.0

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -35,6 +35,7 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.extension.ExtensionAdapter;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import io.fabric8.kubernetes.client.utils.OpenIDConnectionUtils;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -220,6 +221,11 @@ public class KubernetesClientProcessor {
                 .produce(ReflectiveClassBuildItem.builder(Config.ExecCredential.class,
                         Config.ExecCredentialSpec.class,
                         Config.ExecCredentialStatus.class).methods().fields().build());
+        // OpenID support
+        reflectiveClasses
+                .produce(ReflectiveClassBuildItem.builder(OpenIDConnectionUtils.OpenIdConfiguration.class,
+                        OpenIDConnectionUtils.OAuthToken.class)
+                        .methods().fields().build());
 
         if (log.isDebugEnabled()) {
             final String watchedClassNames = watchedClasses

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
         <!-- Dependency versions -->
         <jacoco.version>0.8.12</jacoco.version>
-        <kubernetes-client.version>6.12.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.13.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.4.0</rest-assured.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->


### PR DESCRIPTION
Kubernetes Client 6.13.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.13.0

/cc @metacosm