### PR TITLE
Bump aesh (2.7 to 2.8.2) & aesh-readline (2.4 to 2.6)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -202,8 +202,8 @@
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.0.0</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>1.4.5</com.dajudge.kindcontainer>
-        <aesh.version>2.7</aesh.version>
-        <aesh-readline.version>2.4</aesh-readline.version>
+        <aesh.version>2.8.2</aesh.version>
+        <aesh-readline.version>2.6</aesh-readline.version>
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with aesh-readline and dekorate -->
         <jgit.version>6.10.0.202406032230-r</jgit.version>
         <!-- these two artifacts needs to be compatible together -->


### PR DESCRIPTION
- Fixes: #39575

~~This is a draft PR, until `org.aesh:readline:2.5` is [released and published to maven central](https://github.com/aeshell/aesh-readline/pull/69#issuecomment-2139926419) (cc @stalep)~~