### PR TITLE
Fix oidc-client token retrieval under concurrency

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -77,7 +77,9 @@ public class TokensHelper {
                     tokenRequestStateUpdater.set(TokensHelper.this, null);
                 }
             }
-        });
+        })
+                // prevent next subscriptions to trigger multiple times the HTTP request before the end of the first one
+                .memoize().indefinitely();
     }
 
     static class TokenRequestState {

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -27,6 +27,10 @@ public class FrontendResource {
 
     @Inject
     @RestClient
+    ProtectedResourceServiceCrashTestClient protectedResourceServiceCrashTestClient;
+
+    @Inject
+    @RestClient
     JwtBearerAuthenticationOidcClient jwtBearerAuthenticationOidcClient;
 
     @Inject
@@ -44,6 +48,12 @@ public class FrontendResource {
     @Path("echoToken")
     public String echoToken() {
         return protectedResourceServiceOidcClient.echoToken();
+    }
+
+    @GET
+    @Path("crashTest")
+    public String crashTest() {
+        return protectedResourceServiceCrashTestClient.echoToken();
     }
 
     @GET

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceCrashTestClient.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/ProtectedResourceServiceCrashTestClient.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+
+/**
+ * Made for use in concurrent tests that need a reproducible state (without token initially) for race conditions.
+ */
+@RegisterRestClient(configKey = "crash-test")
+@OidcClientFilter("crash-test")
+@Path("/")
+public interface ProtectedResourceServiceCrashTestClient {
+
+    @GET
+    String echoToken();
+}

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -62,8 +62,19 @@ quarkus.oidc-client.device-code-grant.credentials.client-secret.value=secret
 quarkus.oidc-client.device-code-grant.credentials.client-secret.method=POST
 quarkus.oidc-client.device-code-grant.grant.type=device
 
+quarkus.oidc-client.crash-test.auth-server-url=${keycloak.url}
+quarkus.oidc-client.crash-test.discovery-enabled=false
+quarkus.oidc-client.crash-test.token-path=/tokens-with-delay
+quarkus.oidc-client.crash-test.client-id=quarkus-app
+quarkus.oidc-client.crash-test.credentials.secret=secret
+quarkus.oidc-client.crash-test.grant.type=password
+quarkus.oidc-client.crash-test.grant-options.password.username=alice
+quarkus.oidc-client.crash-test.grant-options.password.password=alice
+quarkus.oidc-client.crash-test.early-tokens-acquisition=false
+
 io.quarkus.it.keycloak.ProtectedResourceServiceOidcClient/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.JwtBearerAuthenticationOidcClient/mp-rest/url=http://localhost:8081/protected
+io.quarkus.it.keycloak.ProtectedResourceServiceCrashTestClient/mp-rest/url=http://localhost:8081/protected
 
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE


### PR DESCRIPTION
Hi there 👋,

This PR fix a bug that leads to retrieve as much as tokens than the number of concurrent calls to the REST Client (more details: #40923)

The correction consist of using the `Uni.memorize()` to prevent a second call to the same `Uni<Tokens>` to trigger a new request to the auth server.

Such race conditions cases are tricky to test, so I did a new end-to-end case with Wiremock to have a clear and reproducible state  with : 
- a separate oidc-client configuration in order to not affect other tests cases
- [`early-tokens-acquisition`](https://quarkus.io/guides/security-openid-connect-client-reference#quarkus-oidc-client_quarkus-oidc-client-early-tokens-acquisition) feature disabled, because it was hiding this bug the first time the token was retrieved after application starts (except in reactive favour)
- Some delay defined in Wiremock to ensure the race condition case happens

Following [the advices](https://github.com/quarkusio/quarkus/issues/40923#issuecomment-2142947483) of @sberyozkin
/cc @michalvavrik, @stuartwdouglas, @cescoffier, @jponge

Thx

- Fixes: #40923