### PR TITLE
Revert "Bump net.revelc.code.formatter:formatter-maven-plugin"

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -127,7 +127,7 @@
 
         <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
-        <formatter-maven-plugin.version>2.24.0</formatter-maven-plugin.version>
+        <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.10.0</impsort-maven-plugin.version>
         <maven-invoker-plugin.version>3.7.0</maven-invoker-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -246,7 +246,7 @@
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
-                    <version>2.24.0</version>
+                    <version>2.23.0</version>
                     <dependencies>
                         <dependency>
                             <artifactId>quarkus-ide-config</artifactId>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -79,7 +79,7 @@
         <gradle-tooling.version>8.7</gradle-tooling.version>
         <quarkus-fs-util.version>0.0.10</quarkus-fs-util.version>
         <org-crac.version>0.1.3</org-crac.version>
-        <formatter-maven-plugin.version>2.24.0</formatter-maven-plugin.version>
+        <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.10.0</impsort-maven-plugin.version>
     </properties>
     <modules>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.24.0</version>
+                <version>2.23.0</version>
                 <dependencies>
                     <dependency>
                         <artifactId>quarkus-ide-config</artifactId>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -134,7 +134,7 @@
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
-                    <version>2.24.0</version>
+                    <version>2.23.0</version>
                     <dependencies>
                         <dependency>
                             <artifactId>quarkus-ide-config</artifactId>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -42,7 +42,7 @@
         <enforcer.plugin.version>3.2.1</enforcer.plugin.version>
         <surefire.plugin.version>3.2.5</surefire.plugin.version>
         <jandex.version>3.2.0</jandex.version>
-        <formatter-maven-plugin.version>2.24.0</formatter-maven-plugin.version>
+        <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.10.0</impsort-maven-plugin.version>
 
         <junit.jupiter.version>5.10.2</junit.jupiter.version>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -25,7 +25,7 @@
         <version.plugin.plugin>3.11.0</version.plugin.plugin>
         <version.enforcer.plugin>3.3.0</version.enforcer.plugin>
         <version.exec.plugin>3.1.0</version.exec.plugin>
-        <version.formatter.plugin>2.24.0</version.formatter.plugin>
+        <version.formatter.plugin>2.23.0</version.formatter.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.impsort.plugin>1.10.0</version.impsort.plugin>
         <version.install.plugin>3.1.1</version.install.plugin>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -163,7 +163,7 @@
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
-                    <version>2.24.0</version>
+                    <version>2.23.0</version>
                     <dependencies>
                         <dependency>
                             <artifactId>quarkus-ide-config</artifactId>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -458,7 +458,7 @@
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
-                    <version>2.24.0</version>
+                    <version>2.23.0</version>
                     <dependencies>
                         <dependency>
                             <artifactId>quarkus-ide-config</artifactId>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -260,7 +260,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.24.0</version>
+                <version>2.23.0</version>
                 <dependencies>
                     <dependency>
                         <artifactId>quarkus-ide-config</artifactId>


### PR DESCRIPTION
This reverts commit de05f697f87056537b2f93ca55a9a61d26bd3051.

With 2.24.0 re-formatting doesn't seem to happen anymore. An easy way to verify it would be to select a module and run
```
mvn -Dformatter-maven-plugin.version=2.24.0 compile
```
and 
```
mvn -Dformatter-maven-plugin.version=2.23.0 compile
```

EDIT: https://github.com/revelc/formatter-maven-plugin/issues/894