### PR TITLE
Highlight Hibernate generated SQL queries

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -438,6 +438,10 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
             if (persistenceUnitConfig.log().formatSql()) {
                 runtimeSettingsBuilder.put(AvailableSettings.FORMAT_SQL, "true");
             }
+
+            if (persistenceUnitConfig.log().highlightSql()) {
+                runtimeSettingsBuilder.put(AvailableSettings.HIGHLIGHT_SQL, "true");
+            }
         }
 
         if (persistenceUnitConfig.log().jdbcWarnings().isPresent()) {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -182,6 +182,12 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
         boolean formatSql();
 
         /**
+         * Highlight the SQL logs if SQL log is enabled
+         */
+        @WithDefault("true")
+        boolean highlightSql();
+
+        /**
          * Whether JDBC warnings should be collected and logged.
          */
         @ConfigDocDefault("depends on dialect")

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -346,6 +346,10 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
             if (persistenceUnitConfig.log().formatSql()) {
                 runtimeSettingsBuilder.put(AvailableSettings.FORMAT_SQL, "true");
             }
+
+            if (persistenceUnitConfig.log().highlightSql()) {
+                runtimeSettingsBuilder.put(AvailableSettings.HIGHLIGHT_SQL, "true");
+            }
         }
 
         if (persistenceUnitConfig.log().jdbcWarnings().isPresent()) {


### PR DESCRIPTION
This is done by default when `quarkus.hibernate-orm.log.sql` is set to `true`, but it can be controlled explicitly via `quarkus.hibernate-orm.log.highlight-sql`.

- Closes: #40921 