### PR TITLE
Adding test scope for dependency quarkus-security-test-utils in reactive routes

### DIFF
--- a/extensions/reactive-routes/deployment/pom.xml
+++ b/extensions/reactive-routes/deployment/pom.xml
@@ -67,6 +67,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-test-utils</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Something small I stumbled over.

Test dependency `quarkus-security-test-utils` was missing test scope

https://github.com/quarkusio/quarkus/blob/main/extensions/reactive-routes/deployment/pom.xml#L70