### PR TITLE
Move Hibernate-related Maven properties to root POM 

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -97,17 +97,8 @@
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <commons-codec.version>1.17.0</commons-codec.version>
         <classmate.version>1.7.0</classmate.version>
-        <!-- WARNING: When updating, also align other properties on this version:
-             bytebuddy.version (just below), hibernate-orm.version-for-documentation (in docs/pom.xml)
-             and both hibernate-orm.version and antlr.version in build-parent/pom.xml
-             WARNING again for diffs that don't provide enough context: when updating, see above -->
-        <hibernate-orm.version>6.5.2.Final</hibernate-orm.version>
-        <bytebuddy.version>1.14.15</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
-        <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
-        <hibernate-reactive.version>2.3.1.Final</hibernate-reactive.version>
-        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
-        <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
-        <hibernate-search.version>7.1.1.Final</hibernate-search.version>
+        <!-- See root POM for hibernate-orm.version, hibernate-reactive.version, hibernate-validator.version,
+             hibernate-search.version, antlr.version, bytebuddy.version, hibernate-commons-annotations.version -->
         <narayana.version>7.0.1.Final</narayana.version>
         <agroal.version>2.4</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
@@ -186,7 +177,6 @@
         <quarkus-spring-boot-api.version>2.1.SP1</quarkus-spring-boot-api.version>
         <mockito.version>5.12.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
-        <antlr.version>4.13.0</antlr.version><!-- needs to align with same property in build-parent/pom.xml -->
         <quarkus-security.version>2.0.3.Final</quarkus-security.version>
         <keycloak.version>24.0.4</keycloak.version>
         <logstash-gelf.version>1.15.1</logstash-gelf.version>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -37,10 +37,6 @@
         <generated-dir>${project.basedir}/../target/asciidoc/generated</generated-dir>
         <code-examples-dir>${generated-dir}/examples</code-examples-dir>
         <vale.image>docker.io/jdkato/vale:v2.15.5</vale.image>
-
-        <!-- Keep these in sync with the full versions in bom/application/pom.xml -->
-        <hibernate-orm.version-for-documentation>6.5</hibernate-orm.version-for-documentation>
-        <hibernate-search.version-for-documentation>7.1</hibernate-search.version-for-documentation>
     </properties>
 
     <name>Quarkus - Documentation</name>
@@ -3016,6 +3012,34 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>parse-version-hibernate-orm</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <propertyPrefix>hibernate-orm</propertyPrefix>
+                            <versionString>${hibernate-orm.version}</versionString>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>parse-version-hibernate-search</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <propertyPrefix>hibernate-search</propertyPrefix>
+                            <versionString>${hibernate-search.version}</versionString>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -25,8 +25,10 @@
 :grpc-version: ${grpc.version}
 :protoc-version: ${protoc.version}
 :gcf-invoker-version: ${gcf-invoker.version}
-:hibernate-orm-version: ${hibernate-orm.version-for-documentation}
-:hibernate-search-version: ${hibernate-search.version-for-documentation}
+// Cannot simply use the name 'hibernate-*-version' here as it somehow gets
+// overridden to the full version, at least when building locally.
+:hibernate-orm-version-major-minor: ${hibernate-orm.majorVersion}.${hibernate-orm.minorVersion}
+:hibernate-search-version-major-minor: ${hibernate-search.majorVersion}.${hibernate-search.minorVersion}
 // .
 :quarkus-home-url: ${quarkus-home-url}
 :quarkus-org-url: https://github.com/quarkusio
@@ -49,8 +51,8 @@
 :quickstarts-blob-url: ${quickstarts-base-url}/blob/main
 :quickstarts-tree-url: ${quickstarts-base-url}/tree/main
 // .
-:hibernate-orm-docs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version}/userguide/html_single/Hibernate_User_Guide.html
-:hibernate-search-docs-url: https://docs.jboss.org/hibernate/search/{hibernate-search-version}/reference/en-US/html_single/
+:hibernate-orm-docs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version-major-minor}/userguide/html_single/Hibernate_User_Guide.html
+:hibernate-search-docs-url: https://docs.jboss.org/hibernate/search/{hibernate-search-version-major-minor}/reference/en-US/html_single/
 // .
 :amazon-services-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/index.html
 :config-consul-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-extensions/dev/consul.html

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,18 @@
         <owasp-dependency-check-plugin.version>9.0.7</owasp-dependency-check-plugin.version>
 
         <!-- Dependency versions -->
+        <!-- Properties below are set in this file because they are used
+             in the BOM as well as other POMs (build-parent/pom.xml, docs/pom.xml, ...) -->
         <jacoco.version>0.8.12</jacoco.version>
         <kubernetes-client.version>6.13.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.4.0</rest-assured.version>
+        <hibernate-orm.version>6.5.2.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
+        <bytebuddy.version>1.14.15</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
+        <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
+        <hibernate-reactive.version>2.3.1.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
+        <hibernate-search.version>7.1.1.Final</hibernate-search.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.64.0</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->


### PR DESCRIPTION
... and automate version parsing for the documentation.

To avoid having to repeat the same version in various places, because
that leads to Yoann just forgetting about it and making a mess.

Based on #40956, which should be merged first.