### PR TITLE
Make -Dquickly a bit faster

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -525,6 +525,7 @@
                     <executions>
                         <execution>
                             <id>enforce</id>
+                            <phase>${maven-enforcer-plugin.phase}</phase>
                             <configuration>
                                 <rules>
                                     <dependencyConvergence/>
@@ -679,7 +680,7 @@
                                 <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
                                 <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>
                             </configuration>
-                            <phase>compile</phase>
+                            <phase>${forbiddenapis-maven-plugin.phase}</phase>
                             <goals>
                                 <goal>check</goal>
                             </goals>

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -190,6 +190,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -282,6 +282,7 @@
                 <executions>
                     <execution>
                         <id>enforce-quarkus-maven-plugin</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <configuration>
                             <rules>
                                 <bannedDependencies>

--- a/extensions/observability-devservices/pom.xml
+++ b/extensions/observability-devservices/pom.xml
@@ -37,6 +37,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <configuration>
                             <rules combine.self="override">
                                 <dependencyConvergence/>

--- a/extensions/panache/panache-mock/pom.xml
+++ b/extensions/panache/panache-mock/pom.xml
@@ -54,6 +54,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <configuration>
                             <rules combine.self="override">
                                 <dependencyConvergence/>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -228,6 +228,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/extensions/security/test-utils/pom.xml
+++ b/extensions/security/test-utils/pom.xml
@@ -65,6 +65,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <configuration>
                             <rules combine.self="override">
                                 <dependencyConvergence/>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -212,6 +212,7 @@
                     <executions>
                         <execution>
                             <id>enforce</id>
+                            <phase>${maven-enforcer-plugin.phase}</phase>
                             <configuration>
                                 <rules>
                                     <dependencyConvergence/>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -125,6 +125,7 @@
                     <executions>
                         <execution>
                             <id>enforce</id>
+                            <phase>${maven-enforcer-plugin.phase}</phase>
                             <configuration>
                                 <rules>
                                     <dependencyConvergence/>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -92,6 +92,7 @@
                     <executions>
                         <execution>
                             <id>enforce</id>
+                            <phase>${maven-enforcer-plugin.phase}</phase>
                             <configuration>
                                 <rules>
                                     <dependencyConvergence/>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -97,6 +97,7 @@
                     <executions>
                         <execution>
                             <id>enforce</id>
+                            <phase>${maven-enforcer-plugin.phase}</phase>
                             <configuration>
                                 <rules>
                                     <dependencyConvergence/>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -129,6 +129,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -129,6 +129,7 @@
                     <executions>
                         <execution>
                             <id>enforce</id>
+                            <phase>${maven-enforcer-plugin.phase}</phase>
                             <configuration>
                                 <rules>
                                     <dependencyConvergence/>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -424,6 +424,7 @@
                     <executions>
                         <execution>
                             <id>enforce</id>
+                            <phase>${maven-enforcer-plugin.phase}</phase>
                             <configuration>
                                 <rules>
                                     <dependencyConvergence/>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -227,6 +227,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <configuration>
                             <rules>
                                 <externalRules>

--- a/integration-tests/kubernetes-client/pom.xml
+++ b/integration-tests/kubernetes-client/pom.xml
@@ -160,6 +160,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/integration-tests/openshift-client/pom.xml
+++ b/integration-tests/openshift-client/pom.xml
@@ -116,6 +116,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -37,6 +37,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/integration-tests/virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/pom.xml
@@ -51,6 +51,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,9 @@
         <skipDocs>false</skipDocs>
         <skip.gradle.tests>false</skip.gradle.tests>
 
+        <maven-enforcer-plugin.phase>validate</maven-enforcer-plugin.phase>
+        <forbiddenapis-maven-plugin.phase>verify</forbiddenapis-maven-plugin.phase>
+
         <owasp-dependency-check-plugin.version>9.0.7</owasp-dependency-check-plugin.version>
 
         <!-- Dependency versions -->
@@ -186,11 +189,13 @@
                 <skipITs>true</skipITs>
                 <skipDocs>true</skipDocs>
                 <enforcer.skip>true</enforcer.skip>
+                <maven-enforcer-plugin.phase>none</maven-enforcer-plugin.phase>
                 <skipExtensionValidation>true</skipExtensionValidation>
                 <skip.gradle.tests>true</skip.gradle.tests>
                 <invoker.skip>true</invoker.skip>   <!-- maven-invoker-plugin -->
                 <jbang.skip>true</jbang.skip> <!-- jbang-maven-plugin -->
                 <forbiddenapis.skip>true</forbiddenapis.skip> <!-- forbidden-apis maven plugin -->
+                <forbiddenapis-maven-plugin.phase>none</forbiddenapis-maven-plugin.phase>
                 <skipCodestartValidation>true</skipCodestartValidation>
                 <truststore.skip>true</truststore.skip>
             </properties>

--- a/tcks/pom.xml
+++ b/tcks/pom.xml
@@ -26,6 +26,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/test-framework/kubernetes-client/pom.xml
+++ b/test-framework/kubernetes-client/pom.xml
@@ -75,6 +75,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/test-framework/openshift-client/pom.xml
+++ b/test-framework/openshift-client/pom.xml
@@ -65,6 +65,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -59,6 +59,7 @@
                 <executions>
                     <execution>
                         <id>enforce</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
                         <configuration>
                             <rules combine.self="override">
                                 <dependencyConvergence/>


### PR DESCRIPTION
Instantiation the plugins can actually be costly when we have so many artifacts.
For now, I have only applied this trick where it makes a great difference and has a low cost of maintenance.
We could also do it for Surefire.

Per a discussion with @ppalaga.