### PR TITLE
Replace 'bare mortal' with a more idiomatic English expression

### DIFF
--- a/docs/src/main/asciidoc/mutiny-primer.adoc
+++ b/docs/src/main/asciidoc/mutiny-primer.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Mutiny - Async for bare mortal
+= Mutiny - Async for mere mortals
 include::_attributes.adoc[]
 :categories: reactive
 :topics: mutiny,reactive


### PR DESCRIPTION
This is a "what do you think?" PR, not a "you must do this" PR. The expression "for bare mortal" isn't very idiomatic in English. I did a [quick google](https://www.google.com/search?client=firefox-b-e&q=%22bare+mortal%22#ip=1) to double-check, and the top hits were all this page, and then I found one other use: "how can a bare mortal like me ...". Most other uses were a Thomas Pynchon quote, "the bare mortal world that is our home”, where the phrase has a different meaning. 

What I'd say is "mere mortals" instead. It's [widely used](https://www.google.com/search?q=for+mere+mortals) to mean "accessible". 

Now, because it's so widely used, it's less distinctive, and it lacks some of the Franglish charm of "bare mortal." In interface design, we should always go for the principle of least surprise, but I'm less sure about what's best in language use.