### PR TITLE
ORM/Panache: rely on ORM getResultCount

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
@@ -15,7 +15,7 @@ public class CustomCountPanacheQuery<Entity> extends PanacheQueryImpl<Entity> {
             Object paramsArrayOrMap) {
         super(new CommonPanacheQueryImpl<>(em, castQuery(jpaQuery).getQueryString(), null, null, paramsArrayOrMap) {
             {
-                this.countQuery = customCountQuery;
+                this.customCountQueryForSpring = customCountQuery;
             }
         });
     }

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -38,6 +38,8 @@ public class PanacheJpaUtil {
     /**
      * This turns an HQL (already expanded from Panache-QL) query into a count query, using text manipulation
      * if we can, because it's faster, or fall back to using the ORM HQL parser in {@link #getCountQueryUsingParser(String)}
+     *
+     * @deprecated we should use SelectionQuery.getResultCount() when supported by HR (ORM already supports it)
      */
     public static String getFastCountQuery(String query) {
         // try to generate a good count query from the existing query
@@ -85,6 +87,8 @@ public class PanacheJpaUtil {
     /**
      * This turns an HQL (already expanded from Panache-QL) query into a count query, using the
      * ORM HQL parser. Slow version, see {@link #getFastCountQuery(String)} for the fast version.
+     *
+     * @deprecated we should use SelectionQuery.getResultCount() when supported by HR (ORM already supports it)
      */
     public static String getCountQueryUsingParser(String query) {
         HqlLexer lexer = new HqlLexer(CharStreams.fromString(query));

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Bug40962Entity.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Bug40962Entity.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.panache;
+
+import jakarta.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class Bug40962Entity extends PanacheEntity {
+    public String name;
+    public String location;
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1841,6 +1842,18 @@ public class TestEndpoint {
         Assertions.assertEquals(0, query.count());
         Assertions.assertEquals(0,
                 Person.count("WITH id AS (SELECT p.id AS pid FROM Person2 AS p) SELECT count(*) FROM Person2 p"));
+        return "OK";
+    }
+
+    @GET
+    @Path("40962")
+    @Transactional
+    public String testBug40962() {
+        // should not throw
+        //        Bug40962Entity.find("name = :name ORDER BY locate(location, :location) DESC",
+        //                Map.of("name", "Demo", "location", "something")).count();
+        Bug40962Entity.find("FROM Bug40962Entity WHERE name = :name ORDER BY locate(location, :location) DESC",
+                Map.of("name", "Demo", "location", "something")).count();
         return "OK";
     }
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -254,4 +254,9 @@ public class PanacheFunctionalityTest {
     public void testBug36496() {
         RestAssured.when().get("/test/36496").then().body(is("OK"));
     }
+
+    @Test
+    public void testBug40962() {
+        RestAssured.when().get("/test/40962").then().body(is("OK"));
+    }
 }


### PR DESCRIPTION
This allows us to not care about which parameters are set on the count query, since `order by` parameters are ignored by ORM. Which is not the case if we write our own count query.

Note that this is not yet available in HR, so we have to keep the count query logic around until that's available.

Fixes #40962

This requires ORM 6.5.3 for https://hibernate.atlassian.net/browse/HHH-18234
Also requires HR supporting `getResultCount` https://github.com/hibernate/hibernate-reactive/issues/1932