### PR TITLE
Fix a duplicate dependency in mongodb-client

### DIFF
--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -58,11 +58,6 @@
             <artifactId>quarkus-kubernetes-service-binding</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry</artifactId>
-            <optional>true</optional>
-        </dependency>
 
         <!-- Add the health extension as optional as we will produce the health check only if it's included -->
         <dependency>


### PR DESCRIPTION
Probably due to a non-rebased PR. Shit happens.