### PR TITLE
Fix log warning when application port is already used

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -183,7 +183,7 @@ public class ApplicationLifecycleManager {
                     } else {
                         for (Integer port : ports) {
                             applicationLogger
-                                    .warnf("Use 'ss -anop | grep %d' or 'netstat -anop | grep %d' to identify the process occupying the port.",
+                                    .warnf("Use 'ss -anop | grep %1$d' or 'netstat -anop | grep %1$d' to identify the process occupying the port.",
                                             port);
                         }
                         applicationLogger.warn("You can try to kill it with 'kill -9 <pid>'.");


### PR DESCRIPTION
The issue was introduced in https://github.com/quarkusio/quarkus/pull/40175 .