### PR TITLE
Bump smallrye-open-api from 3.10.0 to 3.12.0, use new builder API

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -55,7 +55,7 @@
         <smallrye-config.version>3.9.1</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>3.10.0</smallrye-open-api.version>
+        <smallrye-open-api.version>3.12.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.10.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.4.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.0</smallrye-jwt.version>

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/MediaTypeConfigSource.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/MediaTypeConfigSource.java
@@ -1,0 +1,39 @@
+package io.quarkus.smallrye.openapi.deployment;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.smallrye.openapi.api.SmallRyeOASConfig;
+
+public class MediaTypeConfigSource implements ConfigSource {
+
+    private final Map<String, String> mediaTypes = new HashMap<>();
+
+    public MediaTypeConfigSource() {
+        mediaTypes.put(SmallRyeOASConfig.DEFAULT_PRODUCES_STREAMING, "application/octet-stream");
+        mediaTypes.put(SmallRyeOASConfig.DEFAULT_CONSUMES_STREAMING, "application/octet-stream");
+        mediaTypes.put(SmallRyeOASConfig.DEFAULT_PRODUCES, "application/json");
+        mediaTypes.put(SmallRyeOASConfig.DEFAULT_CONSUMES, "application/json");
+        mediaTypes.put(SmallRyeOASConfig.DEFAULT_PRODUCES_PRIMITIVES, "text/plain");
+        mediaTypes.put(SmallRyeOASConfig.DEFAULT_CONSUMES_PRIMITIVES, "text/plain");
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return mediaTypes.keySet();
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return mediaTypes.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/RESTEasyExtension.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/RESTEasyExtension.java
@@ -12,9 +12,8 @@ import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
 import io.quarkus.deployment.util.ServiceUtil;
-import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
 
-public class RESTEasyExtension implements AnnotationScannerExtension {
+public class RESTEasyExtension {
 
     private static final DotName DOTNAME_PROVIDER = DotName.createSimple("jakarta.ws.rs.ext.Provider");
     private static final DotName DOTNAME_ASYNC_RESPONSE_PROVIDER = DotName
@@ -90,7 +89,6 @@ public class RESTEasyExtension implements AnnotationScannerExtension {
         }
     }
 
-    @Override
     public Type resolveAsyncType(Type type) {
         if (type.kind() == Type.Kind.PARAMETERIZED_TYPE
                 && asyncTypes.contains(type.name())) {

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/DefaultInfoFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/DefaultInfoFilter.java
@@ -1,0 +1,35 @@
+package io.quarkus.smallrye.openapi.deployment.filter;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.info.Info;
+
+public class DefaultInfoFilter implements OASFilter {
+
+    final Config config;
+
+    public DefaultInfoFilter(Config config) {
+        this.config = config;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+        Info info = openAPI.getInfo();
+
+        if (info == null) {
+            info = OASFactory.createInfo();
+            openAPI.setInfo(info);
+        }
+
+        if (info.getTitle() == null) {
+            String title = config.getOptionalValue("quarkus.application.name", String.class).orElse("Generated");
+            info.setTitle(title + " API");
+        }
+        if (info.getVersion() == null) {
+            String version = config.getOptionalValue("quarkus.application.version", String.class).orElse("1.0");
+            info.setVersion((version == null ? "1.0" : version));
+        }
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/extensions/smallrye-openapi/deployment/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+io.quarkus.smallrye.openapi.deployment.MediaTypeConfigSource

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/CustomPathExtensionTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/CustomPathExtensionTest.java
@@ -1,32 +1,24 @@
 package io.quarkus.smallrye.openapi.deployment;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
 import org.jboss.jandex.Index;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.Mockito;
-
-import io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner;
 
 class CustomPathExtensionTest {
-
-    AnnotationScanner scanner;
-
-    @BeforeEach
-    void setup() {
-        scanner = Mockito.mock(AnnotationScanner.class);
-    }
 
     @Test
     void testContextPathNotInvokedForEmptyPaths() {
         CustomPathExtension ext = new CustomPathExtension("/", "");
-        ext.processScannerApplications(scanner, Collections.emptyList());
-        Mockito.verify(scanner, Mockito.never()).setContextRoot(Mockito.anyString());
+        String contextRoot = ext.resolveContextRoot(Collections.emptyList());
+        assertNull(contextRoot);
     }
 
     @ParameterizedTest
@@ -38,8 +30,8 @@ class CustomPathExtensionTest {
     })
     void testContextPathGenerationWithoutApplicationPathAnnotation(String rootPath, String appPath, String expected) {
         CustomPathExtension ext = new CustomPathExtension(rootPath, appPath);
-        ext.processScannerApplications(scanner, Collections.emptyList());
-        Mockito.verify(scanner).setContextRoot(expected);
+        String contextRoot = ext.resolveContextRoot(Collections.emptyList());
+        assertEquals(expected, contextRoot);
     }
 
     @ParameterizedTest
@@ -56,8 +48,8 @@ class CustomPathExtensionTest {
         }
 
         CustomPathExtension ext = new CustomPathExtension(rootPath, appPath);
-        ext.processScannerApplications(scanner, List.of(Index.of(TestApp.class).getClassByName(TestApp.class)));
-        Mockito.verify(scanner, Mockito.times(times)).setContextRoot(times > 0 ? expected : Mockito.anyString());
+        String contextRoot = ext.resolveContextRoot(List.of(Index.of(TestApp.class).getClassByName(TestApp.class)));
+        assertEquals(expected, contextRoot);
     }
 
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
@@ -35,6 +35,6 @@ public class OpenApiWithConfigTestCase {
                 .body("paths", Matchers.hasKey("/openapi"))
                 .body("paths", Matchers.not(Matchers.hasKey("/resource")));
 
-        System.clearProperty(io.smallrye.openapi.api.constants.OpenApiConstants.INFO_TITLE);
+        System.clearProperty(io.smallrye.openapi.api.SmallRyeOASConfig.INFO_TITLE);
     }
 }

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
@@ -5,17 +5,20 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.microprofile.config.spi.Converter;
+import org.eclipse.microprofile.openapi.OASConfig;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Converters;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 import io.smallrye.openapi.api.OpenApiConfig.OperationIdStrategy;
+import io.smallrye.openapi.api.SmallRyeOASConfig;
 
 /**
  * Maps config from MicroProfile and SmallRye to Quarkus
  */
 public class OpenApiConfigMapping extends RelocateConfigSourceInterceptor {
+    private static final long serialVersionUID = 1L;
     private static final Map<String, String> RELOCATIONS = relocations();
     private static final Converter<OperationIdStrategy> OPERATION_ID_STRATEGY_CONVERTER = Converters
             .getImplicitConverter(OperationIdStrategy.class);
@@ -27,31 +30,30 @@ public class OpenApiConfigMapping extends RelocateConfigSourceInterceptor {
     @Override
     public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
         ConfigValue configValue = super.getValue(context, name);
+
         // Special case for enum. The converter run after the interceptors, so we have to do this here.
-        if (name.equals(io.smallrye.openapi.api.constants.OpenApiConstants.OPERATION_ID_STRAGEGY)) {
-            if (configValue != null) {
-                String correctValue = OPERATION_ID_STRATEGY_CONVERTER.convert(configValue.getValue()).toString();
-                configValue = configValue.withValue(correctValue);
-            }
+        if (configValue != null && name.equals(SmallRyeOASConfig.OPERATION_ID_STRAGEGY)) {
+            String correctValue = OPERATION_ID_STRATEGY_CONVERTER.convert(configValue.getValue()).toString();
+            configValue = configValue.withValue(correctValue);
         }
+
         return configValue;
     }
 
     private static Map<String, String> relocations() {
         Map<String, String> relocations = new HashMap<>();
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.VERSION, QUARKUS_OPEN_API_VERSION);
-        mapKey(relocations, org.eclipse.microprofile.openapi.OASConfig.SERVERS, QUARKUS_SERVERS);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_TITLE, QUARKUS_INFO_TITLE);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_VERSION, QUARKUS_INFO_VERSION);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_DESCRIPTION, QUARKUS_INFO_DESCRIPTION);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_TERMS, QUARKUS_INFO_TERMS);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_CONTACT_EMAIL, QUARKUS_INFO_CONTACT_EMAIL);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_CONTACT_NAME, QUARKUS_INFO_CONTACT_NAME);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_CONTACT_URL, QUARKUS_INFO_CONTACT_URL);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_LICENSE_NAME, QUARKUS_INFO_LICENSE_NAME);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_LICENSE_URL, QUARKUS_INFO_LICENSE_URL);
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.OPERATION_ID_STRAGEGY,
-                QUARKUS_OPERATION_ID_STRATEGY);
+        mapKey(relocations, SmallRyeOASConfig.VERSION, QUARKUS_OPEN_API_VERSION);
+        mapKey(relocations, OASConfig.SERVERS, QUARKUS_SERVERS);
+        mapKey(relocations, SmallRyeOASConfig.INFO_TITLE, QUARKUS_INFO_TITLE);
+        mapKey(relocations, SmallRyeOASConfig.INFO_VERSION, QUARKUS_INFO_VERSION);
+        mapKey(relocations, SmallRyeOASConfig.INFO_DESCRIPTION, QUARKUS_INFO_DESCRIPTION);
+        mapKey(relocations, SmallRyeOASConfig.INFO_TERMS, QUARKUS_INFO_TERMS);
+        mapKey(relocations, SmallRyeOASConfig.INFO_CONTACT_EMAIL, QUARKUS_INFO_CONTACT_EMAIL);
+        mapKey(relocations, SmallRyeOASConfig.INFO_CONTACT_NAME, QUARKUS_INFO_CONTACT_NAME);
+        mapKey(relocations, SmallRyeOASConfig.INFO_CONTACT_URL, QUARKUS_INFO_CONTACT_URL);
+        mapKey(relocations, SmallRyeOASConfig.INFO_LICENSE_NAME, QUARKUS_INFO_LICENSE_NAME);
+        mapKey(relocations, SmallRyeOASConfig.INFO_LICENSE_URL, QUARKUS_INFO_LICENSE_URL);
+        mapKey(relocations, SmallRyeOASConfig.OPERATION_ID_STRAGEGY, QUARKUS_OPERATION_ID_STRATEGY);
         return Collections.unmodifiableMap(relocations);
     }
 


### PR DESCRIPTION
smallrye-open-api 3.11 introduced a new builder style API that consolidates the process of building an OpenAPI model from the various sources (reader, static file, and annotations). This PR migrates to the new API and picks up several fixes for reported Quarkus issues as noted below.

Fixes https://github.com/quarkusio/quarkus/issues/42101
Fixes https://github.com/quarkusio/quarkus/issues/42221