### PR TITLE
Fix Asciidoc callouts in "Deploying to Kubernetes" documentation

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -1462,9 +1462,9 @@ spec:
           protocol: "TCP"
       serviceAccount: "kubernetes-quickstart"
 ----
-<1> Retained were the provided replicas,
+<1> The provided replicas,
 <2> labels and
-<3> environment variables.
+<3> environment variables were retained.
 <4> However, the image and
 <5> the container port were modified.
 

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -1462,8 +1462,13 @@ spec:
           protocol: "TCP"
       serviceAccount: "kubernetes-quickstart"
 ----
+<1> Retained were the provided replicas,
+<2> labels and
+<3> environment variables.
+<4> However, the image and
+<5> the container port were modified.
 
-The provided replicas <1>, labels <2> and environment variables <3>  were retained. However, the image <4> and container port <5> were modified. Moreover, the default annotations have been added.
+Moreover, the default annotations have been added.
 
 [NOTE]
 ====


### PR DESCRIPTION
The callouts were not at the beginning of the line and therefore not rendered correctly. 