### PR TITLE
Fix RESTEasy Classic GZIP max input in native mode

### DIFF
--- a/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -58,6 +58,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.util.ServiceUtil;
+import io.quarkus.resteasy.common.runtime.ResteasyCommonConfig;
 import io.quarkus.resteasy.common.runtime.ResteasyInjectorFactoryRecorder;
 import io.quarkus.resteasy.common.runtime.config.ResteasyConfigBuilder;
 import io.quarkus.resteasy.common.runtime.providers.ServerFormUrlEncodedProvider;
@@ -65,10 +66,6 @@ import io.quarkus.resteasy.common.spi.ResteasyConfigBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyDotNames;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.runtime.RuntimeValue;
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConfigRoot;
-import io.quarkus.runtime.configuration.MemorySize;
 
 public class ResteasyCommonProcessor {
 
@@ -101,31 +98,6 @@ public class ResteasyCommonProcessor {
     private static final String[] WILDCARD_MEDIA_TYPE_ARRAY = { MediaType.WILDCARD };
 
     private ResteasyCommonConfig resteasyCommonConfig;
-
-    @ConfigRoot(name = "resteasy")
-    public static final class ResteasyCommonConfig {
-        /**
-         * Enable gzip support for REST
-         */
-        public ResteasyCommonConfigGzip gzip;
-    }
-
-    @ConfigGroup
-    public static final class ResteasyCommonConfigGzip {
-        /**
-         * If gzip is enabled
-         */
-        @ConfigItem
-        public boolean enabled;
-        /**
-         * Maximum deflated file bytes size
-         * <p>
-         * If the limit is exceeded, Resteasy will return Response
-         * with status 413("Request Entity Too Large")
-         */
-        @ConfigItem(defaultValue = "10M")
-        public MemorySize maxInput;
-    }
 
     @BuildStep
     void addStaticInitConfigSourceProvider(
@@ -164,7 +136,7 @@ public class ResteasyCommonProcessor {
     @BuildStep
     void setupGzipProviders(BuildProducer<ResteasyJaxrsProviderBuildItem> providers) {
         // If GZIP support is enabled, enable it
-        if (resteasyCommonConfig.gzip.enabled) {
+        if (resteasyCommonConfig.gzip().enabled()) {
             providers.produce(new ResteasyJaxrsProviderBuildItem(AcceptEncodingGZIPFilter.class.getName()));
             providers.produce(new ResteasyJaxrsProviderBuildItem(GZIPDecodingInterceptor.class.getName()));
             providers.produce(new ResteasyJaxrsProviderBuildItem(GZIPEncodingInterceptor.class.getName()));

--- a/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/ResteasyCommonConfig.java
+++ b/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/ResteasyCommonConfig.java
@@ -1,0 +1,36 @@
+package io.quarkus.resteasy.common.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_AND_RUN_TIME_FIXED;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.configuration.MemorySize;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigRoot(phase = BUILD_AND_RUN_TIME_FIXED)
+@ConfigMapping(prefix = "quarkus.resteasy")
+public interface ResteasyCommonConfig {
+
+    /**
+     * Enable gzip support for REST
+     */
+    ResteasyCommonConfigGzip gzip();
+
+    interface ResteasyCommonConfigGzip {
+        /**
+         * If gzip is enabled
+         */
+        @WithDefault("false")
+        boolean enabled();
+
+        /**
+         * Maximum deflated file bytes size
+         * <p>
+         * If the limit is exceeded, Resteasy will return Response
+         * with status 413("Request Entity Too Large")
+         */
+        @WithDefault("10M")
+        MemorySize maxInput();
+    }
+
+}

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -77,8 +77,8 @@ import io.quarkus.deployment.util.JandexUtil;
 import io.quarkus.gizmo.Gizmo;
 import io.quarkus.jaxrs.spi.deployment.AdditionalJaxRsResourceMethodAnnotationsBuildItem;
 import io.quarkus.resteasy.common.deployment.JaxrsProvidersToRegisterBuildItem;
-import io.quarkus.resteasy.common.deployment.ResteasyCommonProcessor.ResteasyCommonConfig;
 import io.quarkus.resteasy.common.runtime.QuarkusInjectorFactory;
+import io.quarkus.resteasy.common.runtime.ResteasyCommonConfig;
 import io.quarkus.resteasy.common.spi.ResteasyDotNames;
 import io.quarkus.resteasy.server.common.runtime.QuarkusResteasyDeployment;
 import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceDefiningAnnotationBuildItem;
@@ -421,9 +421,9 @@ public class ResteasyServerCommonProcessor {
             deploymentCustomizer.getConsumer().accept(deployment);
         }
 
-        if (commonConfig.gzip.enabled) {
+        if (commonConfig.gzip().enabled()) {
             resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_GZIP_MAX_INPUT,
-                    Long.toString(commonConfig.gzip.maxInput.asLongValue()));
+                    Long.toString(commonConfig.gzip().maxInput().asLongValue()));
         }
         resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_UNWRAPPED_EXCEPTIONS,
                 ArcUndeclaredThrowableException.class.getName());

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyConfigurationMPConfig.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyConfigurationMPConfig.java
@@ -67,6 +67,11 @@ public class ResteasyConfigurationMPConfig implements ResteasyConfiguration {
     }
 
     private static Optional<String> getGzipMaxInput(Config config) {
+        if (config.getOptionalValue("resteasy.gzip.max.input", String.class).isPresent()) {
+            // resteasy-specific properties have priority
+            return Optional.empty();
+        }
+
         Optional<MemorySize> rawValue = config.getOptionalValue("quarkus.resteasy.gzip.max-input", MemorySize.class);
 
         if (rawValue.isEmpty()) {


### PR DESCRIPTION
Quarkus QE tried to test https://github.com/quarkusio/quarkus/pull/39828 in native mode but it doesn't work because https://github.com/quarkusio/quarkus/blob/main/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyConfigurationMPConfig.java is executed during the runtime while https://github.com/quarkusio/quarkus/blob/main/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java#L127 is a build-time property. I propose to just convert whole config to the build-time runtime-fixed, but there are more fine-grained approaches possible.

See failure here: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/9410317682/job/25922118169