### PR TITLE
Fix encoding of '?' in query parameter values by Encode.encodeQueryParam(..)

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/Encode.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/Encode.java
@@ -95,7 +95,9 @@ public class Encode {
                 case '.':
                 case '_':
                 case '~':
+                    continue;
                 case '?':
+                    queryNameValueEncoding[i] = "%3F";
                     continue;
                 case ' ':
                     queryNameValueEncoding[i] = "+";

--- a/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/util/EncodeTest.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/util/EncodeTest.java
@@ -15,4 +15,11 @@ class EncodeTest {
         assertEquals(encodedEmoji, Encode.encodePath(emoji));
         assertEquals(encodedEmoji, Encode.encodeQueryParam(emoji));
     }
+
+    @Test
+    void encodeQuestionMarkQueryParameterValue() {
+        String uriQueryValue = "bar?a=b";
+        String encoded = URLEncoder.encode(uriQueryValue, StandardCharsets.UTF_8);
+        assertEquals(encoded, Encode.encodeQueryParam(uriQueryValue));
+    }
 }


### PR DESCRIPTION
Previously `?` in query parameter values where encoded as is which caused invalid URL values. We now replace `?` characters in query parameter values with `%3F`.

Fixes #41060