### PR TITLE
Bump up quarkus-build-caching-extension to 1.2

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -12,7 +12,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>quarkus-build-caching-extension</artifactId>
-        <version>1.1</version>
+        <version>1.2</version>
     </extension>
     <extension>
         <groupId>io.quarkus.develocity</groupId>


### PR DESCRIPTION
This update will allow to:
- Fix caching being disabled when using `quarkus.package.type`
- Benefit from improved logging

See release notes [here](https://github.com/gradle/develocity-build-config-samples/blob/main/quarkus-build-caching-extension/release/changes.md)

cc @gsmet 