### PR TITLE
Remove obsolete comment about JavaParser in WebSockets Next

### DIFF
--- a/extensions/websockets-next/deployment/pom.xml
+++ b/extensions/websockets-next/deployment/pom.xml
@@ -96,8 +96,7 @@
             <properties>
                 <maven.compiler.target>21</maven.compiler.target>
                 <maven.compiler.source>21</maven.compiler.source>
-                <!-- javaparser 3.25.10 used by impsort-maven-plugin does not define the "language level" for 21 -->
-                <!--maven.compiler.release>21</maven.compiler.release-->
+                <maven.compiler.release>21</maven.compiler.release>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
Java Parser 3.26 (which is already being used in Quarkus) should now work with Java 21 source code.

~~I am opening this as a draft so CI can run on my fork~~