### PR TITLE
Clean up tracing option from dev services for 15.0

### DIFF
--- a/docs/src/main/asciidoc/infinispan-dev-services.adoc
+++ b/docs/src/main/asciidoc/infinispan-dev-services.adoc
@@ -120,7 +120,7 @@ quarkus.infinispan-client.conn-2.devservices.enabled=true
 
 Infinispan supports server tracing using OpenTelemetry. Starting from Infinispan 15.0, you need
 to configure tracing in the server's settings.
-To enable this in Dev Services, you need to add extra settings to the running server using the
+To enable tracing in Dev Services, you need to add extra settings using the
 `quarkus.infinispan-client.devservices.config-files` property.
 
 [source, yaml]
@@ -135,10 +135,10 @@ infinispan:
                         security: false <5>
 ----
 <1> Collector endpoint. Assuming a container service name 'jaeger' is running.
-<2> Enables tracing
+<2> Enables tracing.
 <3> Exporter protocol. OLTP is the OpenTelemetry protocol.
-<4> The service name that will be registered in the tracing collector, Jaeger in this case
-<5> Enables 'security' category tracing
+<4> The service name that will be registered in the tracing collector, Jaeger in this case.
+<5> Enables 'security' category tracing.
 
 See below the equivalent in XML and JSON.
 
@@ -173,7 +173,8 @@ See below the equivalent in XML and JSON.
 }
 ----
 
-You need name the Jaeger service or get the IP running the following command and configure the exporter endpoint.
+You need to name the Jaeger service or get the IP running the following command to configure the exporter endpoint.
+
 [source,bash]
 ----
 docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' jaeger

--- a/docs/src/main/asciidoc/infinispan-dev-services.adoc
+++ b/docs/src/main/asciidoc/infinispan-dev-services.adoc
@@ -118,12 +118,62 @@ quarkus.infinispan-client.conn-2.devservices.enabled=true
 
 == Tracing with OpenTelemetry
 
-Infinispan supports instrumentation of the server via OpenTelemetry. Enable tracing setting `quarkus.infinispan-client.devservices.tracing.enabled` to true.
-The default otlp exporter endpoint is `http://localhost:4317`.
-If you are running Jaeger in a container as explained in the xref:opentelemetry.adoc[OpenTelemetry guide], since the containers
-are running in the default network, Infinispan container won't have access to localhost.
-You need to get the IP running the following command and configure the `quarkus.infinispan-client.devservices.tracing.exporter.otlp.endpoint` property.
+Infinispan supports server tracing using OpenTelemetry. Starting from Infinispan 15.0, you need
+to configure tracing in the server's settings.
+To enable this in Dev Services, you need to add extra settings to the running server using the
+`quarkus.infinispan-client.devservices.config-files` property.
 
+[source, yaml]
+----
+infinispan:
+        cacheContainer:
+                tracing:
+                        collector-endpoint: "http://jaeger:4318" <1>
+                        enabled: true <2>
+                        exporter-protocol: "OTLP" <3>
+                        service-name: "infinispan-server" <4>
+                        security: false <5>
+----
+<1> Collector endpoint. Assuming a container service name 'jaeger' is running.
+<2> Enables tracing
+<3> Exporter protocol. OLTP is the OpenTelemetry protocol.
+<4> The service name that will be registered in the tracing collector, Jaeger in this case
+<5> Enables 'security' category tracing
+
+See below the equivalent in XML and JSON.
+
+[source, xml]
+----
+<infinispan>
+  <cache-container statistics="true">
+    <tracing collector-endpoint="http://jaeger:4318"
+             enabled="true"
+             exporter-protocol="OTLP"
+             service-name="infinispan-server"
+             security="false" />
+  </cache-container>
+</infinispan>
+----
+
+[source, json]
+----
+{
+  "infinispan" : {
+    "cache-container" : {
+      "statistics" : true,
+      "tracing" : {
+        "collector-endpoint" : "http://jaeger:4318",
+        "enabled" : true,
+        "exporter-protocol" : "OTLP",
+        "service-name" : "infinispan-server",
+        "security" : false
+      }
+    }
+  }
+}
+----
+
+You need name the Jaeger service or get the IP running the following command and configure the exporter endpoint.
 [source,bash]
 ----
 docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' jaeger

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -200,11 +200,11 @@ public class InfinispanDevServiceProcessor {
 
         if (!dockerStatusBuildItem.isDockerAvailable()) {
             log.warn(
-                    "Please configure 'quarkus.infinispan-client.hosts' or 'quarkus.infinispan-client.uri' or get a working docker instance");
+                    "Please configure 'quarkus.infinispan-client.hosts' or 'quarkus.infinispan-client.uri' or get a working Docker instance");
             return null;
         }
-        log.infof("Starting Dev Service for connection %s", clientName);
-        log.infof("Apply Dev Services config %s", devServicesConfig);
+        log.infof("Starting Dev Services for connection %s", clientName);
+        log.infof("Applying Dev Services config %s", devServicesConfig);
 
         Supplier<RunningDevService> infinispanServerSupplier = () -> {
             QuarkusInfinispanContainer infinispanContainer = new QuarkusInfinispanContainer(clientName, devServicesConfig,
@@ -283,11 +283,11 @@ public class InfinispanDevServiceProcessor {
                 return " -c " + userConfigFile;
             }).collect(Collectors.joining())).orElse("");
 
-            if (config.tracing.isPresent()) {
+            if (config.tracing.orElse(false)) {
                 log.warn(
-                        "Starting with Infinispan 15.0, Infinispan support for instrumentation of the server via OpenTelemetry has evolved. Enabling tracing setting `quarkus.infinispan-client.devservices.tracing.enabled` to true won't work.\n"
+                        "Starting with Infinispan 15.0, Infinispan support for instrumentation of the server via OpenTelemetry has evolved. Enabling tracing by setting `quarkus.infinispan-client.devservices.tracing.enabled=true` doesn't work anymore.\n"
                                 +
-                                "You need to use the `quarkus.infinispan-client.devservices.tracing.enabled` property and provide a JSON, XML or YAML file as follows. Check xref:infinispan-dev-services.adoc[Infinispan Dev Services guide]");
+                                "You need to use the `quarkus.infinispan-client.devservices.tracing.enabled` property and provide a JSON, XML or YAML file as follows. Check https://quarkus.io/guides/infinispan-dev-services for more information");
                 log.warn("infinispan:\n" +
                         "        cacheContainer:\n" +
                         "                tracing:\n" +

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -283,13 +283,23 @@ public class InfinispanDevServiceProcessor {
                 return " -c " + userConfigFile;
             }).collect(Collectors.joining())).orElse("");
 
+            if (config.tracing.isPresent()) {
+                log.warn(
+                        "Starting with Infinispan 15.0, Infinispan support for instrumentation of the server via OpenTelemetry has evolved. Enabling tracing setting `quarkus.infinispan-client.devservices.tracing.enabled` to true won't work.\n"
+                                +
+                                "You need to use the `quarkus.infinispan-client.devservices.tracing.enabled` property and provide a JSON, XML or YAML file as follows. Check xref:infinispan-dev-services.adoc[Infinispan Dev Services guide]");
+                log.warn("infinispan:\n" +
+                        "        cacheContainer:\n" +
+                        "                tracing:\n" +
+                        "                        collector-endpoint: \"http://jaeger:4318\"\n" +
+                        "                        enabled: true\n" +
+                        "                        exporter-protocol: \"OTLP\"\n" +
+                        "                        service-name: \"infinispan-server\"\n" +
+                        "                        security: false");
+            }
+
             if (config.mcastPort.isPresent()) {
                 command = command + " -Djgroups.mcast_port=" + config.mcastPort.getAsInt();
-            }
-            if (config.tracing.isPresent()) {
-                command = command + " -Dinfinispan.tracing.enabled=" + config.tracing.get();
-                command = command + " -Dotel.exporter.otlp.endpoint=" + config.exporterOtlpEndpoint.get();
-                command = command + " -Dotel.service.name=infinispan-server-service -Dotel.metrics.exporter=none";
             }
 
             config.artifacts.ifPresent(a -> withArtifacts(a.toArray(new String[0])));

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanDevServicesConfig.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanDevServicesConfig.java
@@ -113,12 +113,14 @@ public class InfinispanDevServicesConfig {
      * Runs the Infinispan Server container with tracing enabled. Traces are disabled by default
      */
     @ConfigItem(name = "tracing.enabled", defaultValue = "false")
+    @Deprecated(forRemoval = true)
     public Optional<Boolean> tracing;
 
     /**
      * Sets Infinispan Server otlp endpoint. Default value is http://localhost:4317
      */
     @ConfigItem(name = "tracing.exporter.otlp.endpoint", defaultValue = "http://localhost:4317")
+    @Deprecated(forRemoval = true)
     public Optional<String> exporterOtlpEndpoint;
 
     /**


### PR DESCRIPTION
Infinispan 15.0 has changed the way tracing can be enabled 
see: https://github.com/infinispan/infinispan-simple-tutorials/tree/main/infinispan-remote/opentelemetry/docker-compose
