### PR TITLE
Update to Vert.x 4.5.8 and Netty 4.1.110

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -34,7 +34,7 @@
         <opentelemetry.version>1.32.0</opentelemetry.version>
         <opentelemetry-alpha.version>1.32.0-alpha</opentelemetry-alpha.version>
         <opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version> <!-- keep in sync with opentelemetry-java-instrumentation in the alpha bom-->
-        <quarkus-http.version>5.2.2.Final</quarkus-http.version>
+        <quarkus-http.version>5.3.0</quarkus-http.version>
         <micrometer.version>1.12.5</micrometer.version><!-- keep in sync with hdrhistogram -->
         <hdrhistogram.version>2.1.12</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>
@@ -61,7 +61,7 @@
         <smallrye-context-propagation.version>2.1.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.12.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.13.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.21.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.6.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
@@ -113,7 +113,7 @@
         <wildfly-elytron.version>2.4.2.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.1.4.SP1</jboss-marshalling.version>
         <jboss-threads.version>3.6.1.Final</jboss-threads.version>
-        <vertx.version>4.5.7</vertx.version>
+        <vertx.version>4.5.8</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -134,7 +134,7 @@
         <infinispan.version>15.0.4.Final</infinispan.version>
         <infinispan.protostream.version>5.0.4.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
-        <netty.version>4.1.108.Final</netty.version>
+        <netty.version>4.1.110.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
@@ -58,7 +58,8 @@ public class GrpcServerConfiguration {
     /**
      * The max inbound message size in bytes.
      */
-    public @ConfigItem OptionalInt maxInboundMessageSize;
+    @ConfigItem
+    public OptionalInt maxInboundMessageSize;
 
     /**
      * The max inbound metadata size in bytes

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
 
         <mutiny.version>2.6.0</mutiny.version>
         <smallrye-common.version>2.3.0</smallrye-common.version>
-        <vertx.version>4.5.7</vertx.version>
+        <vertx.version>4.5.8</vertx.version>
         <rest-assured.version>5.4.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.17.1</jackson-bom.version>


### PR DESCRIPTION
- bump Mutiny Bindings to 3.13.0
- bump Quarkus HTTP to 5.3.0
- update Netty SSL released substitutions


Netty 4.1.111 causes a problem in gRPC. It seems to be a frame size issue. Need to be investigated.
