### PR TITLE
Bump Keycloak version to 25.0.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -178,7 +178,7 @@
         <mockito.version>5.12.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <quarkus-security.version>2.1.0</quarkus-security.version>
-        <keycloak.version>24.0.4</keycloak.version>
+        <keycloak.version>25.0.0</keycloak.version>
         <logstash-gelf.version>1.15.1</logstash-gelf.version>
         <checker-qual.version>3.44.0</checker-qual.version>
         <error-prone-annotations.version>2.28.0</error-prone-annotations.version>
@@ -5959,18 +5959,6 @@
                 <version>${quarkus-spring-boot-api.version}</version>
             </dependency>
 
-            <!-- Keycloak -->
-            <dependency>
-                <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-adapter-core</artifactId>
-                <version>${keycloak.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-core</artifactId>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -102,7 +102,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update bom/application/pom.xml and KeycloakBuildTimeConfig/DevServicesConfig in quarkus-oidc/deployment to match the version -->
-        <keycloak.version>24.0.4</keycloak.version>
+        <keycloak.version>25.0.0</keycloak.version>
         <keycloak.wildfly.version>19.0.3</keycloak.wildfly.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.version}</keycloak.docker.image>
         <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.wildfly.version}-legacy</keycloak.docker.legacy.image>

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -258,7 +258,7 @@ For more information, see xref:security-oidc-bearer-token-authentication.adoc#in
 [[keycloak-initialization]]
 === Keycloak initialization
 
-The `quay.io/keycloak/keycloak:24.0.4` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
+The `quay.io/keycloak/keycloak:25.0.0` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
 `quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name.
 For example, set it to `quay.io/keycloak/keycloak:19.0.3-legacy` to use a Keycloak distribution powered by WildFly.
 Be aware that a Quarkus-based Keycloak distribution is only available starting from Keycloak `20.0.0`.

--- a/extensions/keycloak-admin-resteasy-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-resteasy-client/runtime/pom.xml
@@ -32,10 +32,6 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/extensions/oidc-client/deployment/pom.xml
+++ b/extensions/oidc-client/deployment/pom.xml
@@ -51,11 +51,6 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <scope>test</scope>
             <exclusions>

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -34,7 +34,7 @@ public class DevServicesConfig {
      * ends with `-legacy`.
      * Override with `quarkus.keycloak.devservices.keycloak-x-image`.
      */
-    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:24.0.4")
+    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:25.0.0")
     public String imageName;
 
     /**

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -109,7 +109,7 @@ public class KeycloakDevServicesProcessor {
     private static final String KEYCLOAK_QUARKUS_HOSTNAME = "KC_HOSTNAME";
     private static final String KEYCLOAK_QUARKUS_ADMIN_PROP = "KEYCLOAK_ADMIN";
     private static final String KEYCLOAK_QUARKUS_ADMIN_PASSWORD_PROP = "KEYCLOAK_ADMIN_PASSWORD";
-    private static final String KEYCLOAK_QUARKUS_START_CMD = "start --http-enabled=true --hostname-strict=false --hostname-strict-https=false "
+    private static final String KEYCLOAK_QUARKUS_START_CMD = "start --http-enabled=true --hostname-strict=false "
             + "--spi-user-profile-declarative-user-profile-config-file=/opt/keycloak/upconfig.json";
 
     private static final String JAVA_OPTS = "JAVA_OPTS";

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -431,7 +431,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     private Uni<TokenVerificationResult> verifyCodeFlowAccessTokenUni(Map<String, Object> requestData,
             TokenAuthenticationRequest request,
             TenantConfigContext resolvedContext, UserInfo userInfo) {
-        if (request.getToken() instanceof IdTokenCredential
+        if (isIdToken(request)
                 && (resolvedContext.oidcConfig.authentication.verifyAccessToken
                         || resolvedContext.oidcConfig.roles.source.orElse(null) == Source.accesstoken)) {
             final String codeAccessToken = (String) requestData.get(OidcConstants.ACCESS_TOKEN_VALUE);
@@ -469,7 +469,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             return introspectTokenUni(resolvedContext, token, false);
         } else if (resolvedContext.oidcConfig.jwks.resolveEarly) {
             // Verify JWT token with the local JWK keys with a possible remote introspection fallback
-            final String nonce = (String) requestData.get(OidcConstants.NONCE);
+            final String nonce = tokenCred instanceof IdTokenCredential ? (String) requestData.get(OidcConstants.NONCE) : null;
             try {
                 LOG.debug("Verifying the JWT token with the local JWK keys");
                 return Uni.createFrom()

--- a/integration-tests/oidc-client-reactive/pom.xml
+++ b/integration-tests/oidc-client-reactive/pom.xml
@@ -21,10 +21,6 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/integration-tests/oidc-client/pom.xml
+++ b/integration-tests/oidc-client/pom.xml
@@ -22,10 +22,6 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/integration-tests/oidc-code-flow/pom.xml
+++ b/integration-tests/oidc-code-flow/pom.xml
@@ -53,11 +53,6 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -57,8 +57,7 @@ public class CustomTenantResolver implements TenantResolver {
         }
 
         if (path.contains("tenant-https")) {
-            if (context.getCookie("q_session_tenant-https_test_chunk_1") != null
-                    && context.getCookie("q_session_tenant-https_test_chunk_2") != null) {
+            if (context.getCookie("q_session_tenant-https_test") != null) {
                 context.put("reauthenticated", "true");
                 return context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
             } else {
@@ -67,8 +66,7 @@ public class CustomTenantResolver implements TenantResolver {
         }
 
         if (path.contains("tenant-nonce")) {
-            if (context.getCookie("q_session_tenant-nonce_chunk_1") != null
-                    && context.getCookie("q_session_tenant-nonce_chunk_2") != null) {
+            if (context.getCookie("q_session_tenant-nonce") != null) {
                 context.put("reauthenticated", "true");
                 return context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
             } else {

--- a/integration-tests/oidc-tenancy/pom.xml
+++ b/integration-tests/oidc-tenancy/pom.xml
@@ -32,10 +32,6 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -11,14 +11,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import org.htmlunit.CookieManager;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.WebClient;
@@ -310,9 +306,8 @@ public class BearerTokenAuthorizationTest {
             page = loginForm.getInputByName("login").click();
             assertEquals("tenant-web-app2:alice", page.getBody().asNormalizedText());
             assertNull(getSessionCookie(webClient, "tenant-web-app"));
-            List<Cookie> sessionCookieChunks = getSessionCookies(webClient, "tenant-web-app2");
-            assertNotNull(sessionCookieChunks);
-            assertEquals(2, sessionCookieChunks.size());
+            Cookie sessionCookie = getSessionCookie(webClient, "tenant-web-app2");
+            assertNotNull(sessionCookie);
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -936,18 +931,5 @@ public class BearerTokenAuthorizationTest {
 
     private Cookie getSessionRtCookie(WebClient webClient, String tenantId) {
         return webClient.getCookieManager().getCookie("q_session_rt" + (tenantId == null ? "_Default_test" : "_" + tenantId));
-    }
-
-    private List<Cookie> getSessionCookies(WebClient webClient, String tenantId) {
-        String sessionCookieNameChunk = "q_session" + (tenantId == null ? "" : "_" + tenantId) + "_chunk_";
-        CookieManager cookieManager = webClient.getCookieManager();
-        SortedMap<String, Cookie> sessionCookies = new TreeMap<>();
-        for (Cookie cookie : cookieManager.getCookies()) {
-            if (cookie.getName().startsWith(sessionCookieNameChunk)) {
-                sessionCookies.put(cookie.getName(), cookie);
-            }
-        }
-
-        return sessionCookies.isEmpty() ? null : new ArrayList<Cookie>(sessionCookies.values());
     }
 }

--- a/integration-tests/oidc-token-propagation/pom.xml
+++ b/integration-tests/oidc-token-propagation/pom.xml
@@ -15,10 +15,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>

--- a/integration-tests/oidc/pom.xml
+++ b/integration-tests/oidc/pom.xml
@@ -29,11 +29,6 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakXTestResourceLifecycleManager.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakXTestResourceLifecycleManager.java
@@ -54,7 +54,7 @@ public class KeycloakXTestResourceLifecycleManager implements QuarkusTestResourc
                 .withClasspathResourceMapping("/upconfig.json", "/opt/keycloak/upconfig.json", BindMode.READ_ONLY)
                 .withCommand("build --https-client-auth=required")
                 .withCommand(String.format(
-                        "start --https-client-auth=required --hostname-strict=false --hostname-strict-https=false"
+                        "start --https-client-auth=required --hostname-strict=false"
                                 + " --https-key-store-file=%s --https-trust-store-file=%s --https-trust-store-password=password"
                                 + " --spi-user-profile-declarative-user-profile-config-file=/opt/keycloak/upconfig.json",
                         SERVER_KEYSTORE_MOUNTED_PATH, SERVER_TRUSTSTORE_MOUNTED_PATH));

--- a/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
+++ b/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
@@ -21,10 +21,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-oracle-client</artifactId>
         </dependency>

--- a/integration-tests/smallrye-jwt-token-propagation/pom.xml
+++ b/integration-tests/smallrye-jwt-token-propagation/pom.xml
@@ -21,10 +21,6 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/test-framework/keycloak-server/pom.xml
+++ b/test-framework/keycloak-server/pom.xml
@@ -15,10 +15,6 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
This PR bumps Keycloak version to 25.0.0 alongside the following changes:
* Removed `keycloak-adapter-core` from the bom since it is no longer shipped starting from Keycloak 25.0.0
* `nonce` claim is no longer included in the access token, but only in the ID token, https://www.keycloak.org/docs/25.0.0/upgrading/#nonce-claim-is-only-added-to-the-id-token, so I had to fix the Quarkus code expecting it also be included in the access token - in fact it was not really intended to work for the access token, the test where both ID and access tokens were checked to contain `nonce` was passing by chance due to earlier Keycloak version including it in the access token, but the OIDC spec itself is only concerned about `nonce` being set in the original ID token
*  Access token is slimmer now, so I had to fix a few tests where multiple session cookie chunks where expected, now it is just a single session cookie
* Removed the old startup property which is no longer supported by default

CC @mposolda