### PR TITLE
Docker-build fails to detect podman: add back detectContainerRuntime() method for backwards compatibility

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
@@ -43,6 +43,10 @@ public final class ContainerRuntimeUtil {
      * @return a fully resolved {@link ContainerRuntime} indicating if Docker or Podman is available and in rootless mode or not
      * @throws IllegalStateException if no container runtime was found to build the image
      */
+    public static ContainerRuntime detectContainerRuntime() {
+        return detectContainerRuntime(true);
+    }
+
     public static ContainerRuntime detectContainerRuntime(ContainerRuntime... orderToCheckRuntimes) {
         return detectContainerRuntime(true, orderToCheckRuntimes);
     }


### PR DESCRIPTION
Fixup PR #41100 issue #41085

https://github.com/quarkusio/quarkus/pull/41100 replaced `detectContainerRuntime()` with `detectContainerRuntime(ContainerRuntime... orderToCheckRuntimes)` which makes all callers of detectContainerRuntime() fail with `NoSuchMethodException` unless they are recompiled.