### PR TITLE
Attempt to alleviate QuarkusClassLoader leaks

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -25,6 +25,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.classloading.MemoryClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.prebuild.CodeGenException;
 import io.quarkus.deployment.codegen.CodeGenData;
@@ -338,7 +339,7 @@ public class CodeGenerator {
 
             // we don't want to load config services from the current module because they haven't been compiled yet
             final QuarkusClassLoader.Builder configClBuilder = QuarkusClassLoader.builder("CodeGenerator Config ClassLoader",
-                    deploymentClassLoader, false);
+                    QuarkusClassLoaderType.DEPLOYMENT, deploymentClassLoader, false);
             if (!allowedConfigServices.isEmpty()) {
                 configClBuilder.addElement(new MemoryClassPathElement(allowedConfigServices, true));
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -1,6 +1,5 @@
 package io.quarkus.deployment;
 
-import java.io.Closeable;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -181,9 +180,6 @@ public class QuarkusAugmentor {
                         .releaseConfig(deploymentClassLoader);
             } catch (Exception ignore) {
 
-            }
-            if (deploymentClassLoader instanceof Closeable) {
-                ((Closeable) deploymentClassLoader).close();
             }
             Thread.currentThread().setContextClassLoader(originalClassLoader);
             buildCloseables.close();

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -136,7 +136,7 @@ public class JunitTestRunner {
             long start = System.currentTimeMillis();
             ClassLoader old = Thread.currentThread().getContextClassLoader();
             QuarkusClassLoader tcl = testApplication.createDeploymentClassLoader();
-            LogCapturingOutputFilter logHandler = new LogCapturingOutputFilter(testApplication, true, true,
+            LogCapturingOutputFilter logHandler = new LogCapturingOutputFilter(true, true,
                     TestSupport.instance().get()::isDisplayTestOutput);
             Thread.currentThread().setContextClassLoader(tcl);
             Consumer currentTestAppConsumer = (Consumer) tcl.loadClass(CurrentTestApplication.class.getName())

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/LogCapturingOutputFilter.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/LogCapturingOutputFilter.java
@@ -10,21 +10,19 @@ import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 
 public class LogCapturingOutputFilter implements BiPredicate<String, Boolean> {
     private static final Logger log = Logger.getLogger(LogCapturingOutputFilter.class);
 
-    private final CuratedApplication application;
     private final List<String> logOutput = new ArrayList<>();
     private final List<String> errorOutput = new ArrayList<>();
     private final boolean mergeErrorStream;
     private final boolean convertToHtml;
     private final Supplier<Boolean> finalPredicate;
 
-    public LogCapturingOutputFilter(CuratedApplication application, boolean mergeErrorStream, boolean convertToHtml,
+    public LogCapturingOutputFilter(boolean mergeErrorStream, boolean convertToHtml,
             Supplier<Boolean> finalPredicate) {
-        this.application = application;
         this.mergeErrorStream = mergeErrorStream;
         this.convertToHtml = convertToHtml;
         this.finalPredicate = finalPredicate;
@@ -50,8 +48,8 @@ public class LogCapturingOutputFilter implements BiPredicate<String, Boolean> {
             return true;
         }
         while (cl.getParent() != null) {
-            if (cl == application.getAugmentClassLoader()
-                    || cl == application.getBaseRuntimeClassLoader()) {
+            if (cl instanceof QuarkusClassLoader
+                    && (((QuarkusClassLoader) cl).isAugmentation() || ((QuarkusClassLoader) cl).isBaseRuntime())) {
                 //TODO: for convenience we save the log records as HTML rather than ANSI here
                 synchronized (logOutput) {
                     if (convertToHtml) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -31,6 +31,7 @@ import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.app.QuarkusBootstrap.Mode;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.dev.ClassScanResult;
 import io.quarkus.deployment.dev.CompilationProvider;
@@ -220,6 +221,7 @@ public class TestSupport implements TestController {
                                 if (clBuilder == null) {
                                     clBuilder = QuarkusClassLoader.builder("Continuous Testing Parent-First"
                                             + curatedApplication.getClassLoaderNameSuffix(),
+                                            QuarkusClassLoaderType.BOOTSTRAP,
                                             getClass().getClassLoader().getParent(), false);
                                 }
                                 clBuilder.addElement(ClassPathElement.fromDependency(d));

--- a/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
@@ -42,102 +42,106 @@ public class JBangAugmentorImpl implements BiConsumer<CuratedApplication, Map<St
 
         QuarkusClassLoader classLoader = curatedApplication.getAugmentClassLoader();
 
-        QuarkusBootstrap quarkusBootstrap = curatedApplication.getQuarkusBootstrap();
-        QuarkusAugmentor.Builder builder = QuarkusAugmentor.builder()
-                .setRoot(quarkusBootstrap.getApplicationRoot())
-                .setClassLoader(classLoader)
-                .addFinal(ApplicationClassNameBuildItem.class)
-                .setTargetDir(quarkusBootstrap.getTargetDirectory())
-                .setDeploymentClassLoader(curatedApplication.createDeploymentClassLoader())
-                .setBuildSystemProperties(quarkusBootstrap.getBuildSystemProperties())
-                .setEffectiveModel(curatedApplication.getApplicationModel());
-        if (quarkusBootstrap.getBaseName() != null) {
-            builder.setBaseName(quarkusBootstrap.getBaseName());
-        }
-        if (quarkusBootstrap.getOriginalBaseName() != null) {
-            builder.setOriginalBaseName(quarkusBootstrap.getOriginalBaseName());
-        }
+        try (QuarkusClassLoader deploymentClassLoader = curatedApplication.createDeploymentClassLoader()) {
+            QuarkusBootstrap quarkusBootstrap = curatedApplication.getQuarkusBootstrap();
+            QuarkusAugmentor.Builder builder = QuarkusAugmentor.builder()
+                    .setRoot(quarkusBootstrap.getApplicationRoot())
+                    .setClassLoader(classLoader)
+                    .addFinal(ApplicationClassNameBuildItem.class)
+                    .setTargetDir(quarkusBootstrap.getTargetDirectory())
+                    .setDeploymentClassLoader(curatedApplication.createDeploymentClassLoader())
+                    .setBuildSystemProperties(quarkusBootstrap.getBuildSystemProperties())
+                    .setEffectiveModel(curatedApplication.getApplicationModel());
+            if (quarkusBootstrap.getBaseName() != null) {
+                builder.setBaseName(quarkusBootstrap.getBaseName());
+            }
+            if (quarkusBootstrap.getOriginalBaseName() != null) {
+                builder.setOriginalBaseName(quarkusBootstrap.getOriginalBaseName());
+            }
 
-        boolean auxiliaryApplication = curatedApplication.getQuarkusBootstrap().isAuxiliaryApplication();
-        builder.setAuxiliaryApplication(auxiliaryApplication);
-        builder.setAuxiliaryDevModeType(
-                curatedApplication.getQuarkusBootstrap().isHostApplicationIsTestOnly() ? DevModeType.TEST_ONLY
-                        : (auxiliaryApplication ? DevModeType.LOCAL : null));
-        builder.setLaunchMode(LaunchMode.NORMAL);
-        builder.setRebuild(quarkusBootstrap.isRebuild());
-        builder.setLiveReloadState(
-                new LiveReloadBuildItem(false, Collections.emptySet(), new HashMap<>(), null));
-        for (AdditionalDependency i : quarkusBootstrap.getAdditionalApplicationArchives()) {
-            //this gets added to the class path either way
-            //but we only need to add it to the additional app archives
-            //if it is forced as an app archive
-            if (i.isForceApplicationArchive()) {
-                builder.addAdditionalApplicationArchive(i.getResolvedPaths());
-            }
-        }
-        builder.addBuildChainCustomizer(new Consumer<BuildChainBuilder>() {
-            @Override
-            public void accept(BuildChainBuilder builder) {
-                final BuildStepBuilder stepBuilder = builder.addBuildStep((ctx) -> {
-                    ctx.produce(new ProcessInheritIODisabledBuildItem());
-                });
-                stepBuilder.produces(ProcessInheritIODisabledBuildItem.class).build();
-            }
-        });
-        builder.excludeFromIndexing(quarkusBootstrap.getExcludeFromClassPath());
-        builder.addFinal(GeneratedClassBuildItem.class);
-        builder.addFinal(MainClassBuildItem.class);
-        builder.addFinal(GeneratedResourceBuildItem.class);
-        builder.addFinal(TransformedClassesBuildItem.class);
-        builder.addFinal(DeploymentResultBuildItem.class);
-        // note: quarkus.package.type is deprecated
-        boolean nativeRequested = "native".equals(System.getProperty("quarkus.package.type"))
-                || "true".equals(System.getProperty("quarkus.native.enabled"));
-        boolean containerBuildRequested = Boolean.getBoolean("quarkus.container-image.build");
-        if (nativeRequested) {
-            builder.addFinal(NativeImageBuildItem.class);
-        }
-        if (containerBuildRequested) {
-            //TODO: this is a bit ugly
-            //we don't necessarily need these artifacts
-            //but if we include them it does mean that you can auto create docker images
-            //and deploy to kube etc
-            //for an ordinary build with no native and no docker this is a waste
-            builder.addFinal(ArtifactResultBuildItem.class);
-        }
-
-        try {
-            BuildResult buildResult = builder.build().run();
-            Map<String, byte[]> result = new HashMap<>();
-            for (GeneratedClassBuildItem i : buildResult.consumeMulti(GeneratedClassBuildItem.class)) {
-                result.put(i.getName().replace(".", "/") + ".class", i.getClassData());
-            }
-            for (GeneratedResourceBuildItem i : buildResult.consumeMulti(GeneratedResourceBuildItem.class)) {
-                result.put(i.getName(), i.getData());
-            }
-            for (Map.Entry<Path, Set<TransformedClassesBuildItem.TransformedClass>> entry : buildResult
-                    .consume(TransformedClassesBuildItem.class).getTransformedClassesByJar().entrySet()) {
-                for (TransformedClassesBuildItem.TransformedClass transformed : entry.getValue()) {
-                    if (transformed.getData() != null) {
-                        result.put(transformed.getFileName(), transformed.getData());
-                    } else {
-                        log.warn("Unable to remove resource " + transformed.getFileName()
-                                + " as this is not supported in JBangf");
-                    }
+            boolean auxiliaryApplication = curatedApplication.getQuarkusBootstrap().isAuxiliaryApplication();
+            builder.setAuxiliaryApplication(auxiliaryApplication);
+            builder.setAuxiliaryDevModeType(
+                    curatedApplication.getQuarkusBootstrap().isHostApplicationIsTestOnly() ? DevModeType.TEST_ONLY
+                            : (auxiliaryApplication ? DevModeType.LOCAL : null));
+            builder.setLaunchMode(LaunchMode.NORMAL);
+            builder.setRebuild(quarkusBootstrap.isRebuild());
+            builder.setLiveReloadState(
+                    new LiveReloadBuildItem(false, Collections.emptySet(), new HashMap<>(), null));
+            for (AdditionalDependency i : quarkusBootstrap.getAdditionalApplicationArchives()) {
+                //this gets added to the class path either way
+                //but we only need to add it to the additional app archives
+                //if it is forced as an app archive
+                if (i.isForceApplicationArchive()) {
+                    builder.addAdditionalApplicationArchive(i.getResolvedPaths());
                 }
             }
-            resultMap.put("files", result);
-            final List<String> javaargs = new ArrayList<>();
-            javaargs.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager");
-            javaargs.add(
-                    "-Djava.util.concurrent.ForkJoinPool.common.threadFactory=io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory");
-            resultMap.put("java-args", javaargs);
-            resultMap.put("main-class", buildResult.consume(MainClassBuildItem.class).getClassName());
+            builder.addBuildChainCustomizer(new Consumer<BuildChainBuilder>() {
+                @Override
+                public void accept(BuildChainBuilder builder) {
+                    final BuildStepBuilder stepBuilder = builder.addBuildStep((ctx) -> {
+                        ctx.produce(new ProcessInheritIODisabledBuildItem());
+                    });
+                    stepBuilder.produces(ProcessInheritIODisabledBuildItem.class).build();
+                }
+            });
+            builder.excludeFromIndexing(quarkusBootstrap.getExcludeFromClassPath());
+            builder.addFinal(GeneratedClassBuildItem.class);
+            builder.addFinal(MainClassBuildItem.class);
+            builder.addFinal(GeneratedResourceBuildItem.class);
+            builder.addFinal(TransformedClassesBuildItem.class);
+            builder.addFinal(DeploymentResultBuildItem.class);
+            // note: quarkus.package.type is deprecated
+            boolean nativeRequested = "native".equals(System.getProperty("quarkus.package.type"))
+                    || "true".equals(System.getProperty("quarkus.native.enabled"));
+            boolean containerBuildRequested = Boolean.getBoolean("quarkus.container-image.build");
             if (nativeRequested) {
-                resultMap.put("native-image", buildResult.consume(NativeImageBuildItem.class).getPath());
+                builder.addFinal(NativeImageBuildItem.class);
             }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+            if (containerBuildRequested) {
+                //TODO: this is a bit ugly
+                //we don't necessarily need these artifacts
+                //but if we include them it does mean that you can auto create docker images
+                //and deploy to kube etc
+                //for an ordinary build with no native and no docker this is a waste
+                builder.addFinal(ArtifactResultBuildItem.class);
+            }
+
+            try {
+                BuildResult buildResult = builder.build().run();
+                Map<String, byte[]> result = new HashMap<>();
+                for (GeneratedClassBuildItem i : buildResult.consumeMulti(GeneratedClassBuildItem.class)) {
+                    result.put(i.getName().replace(".", "/") + ".class", i.getClassData());
+                }
+                for (GeneratedResourceBuildItem i : buildResult.consumeMulti(GeneratedResourceBuildItem.class)) {
+                    result.put(i.getName(), i.getData());
+                }
+                for (Map.Entry<Path, Set<TransformedClassesBuildItem.TransformedClass>> entry : buildResult
+                        .consume(TransformedClassesBuildItem.class).getTransformedClassesByJar().entrySet()) {
+                    for (TransformedClassesBuildItem.TransformedClass transformed : entry.getValue()) {
+                        if (transformed.getData() != null) {
+                            result.put(transformed.getFileName(), transformed.getData());
+                        } else {
+                            log.warn("Unable to remove resource " + transformed.getFileName()
+                                    + " as this is not supported in JBangf");
+                        }
+                    }
+                }
+                resultMap.put("files", result);
+                final List<String> javaargs = new ArrayList<>();
+                javaargs.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager");
+                javaargs.add(
+                        "-Djava.util.concurrent.ForkJoinPool.common.threadFactory=io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory");
+                resultMap.put("java-args", javaargs);
+                resultMap.put("main-class", buildResult.consume(MainClassBuildItem.class).getClassName());
+                if (nativeRequested) {
+                    resultMap.put("native-image", buildResult.consume(NativeImageBuildItem.class).getPath());
+                }
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -93,13 +93,13 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
         } catch (Exception any) {
             throw new MojoExecutionException("Quarkus code generation phase has failed", any);
         } finally {
-            // in case of test mode, we can't share the bootstrapped app with the testing plugins, so we are closing it right away
-            if (test && curatedApplication != null) {
-                curatedApplication.close();
-            }
             Thread.currentThread().setContextClassLoader(originalTccl);
             if (deploymentClassLoader != null) {
                 deploymentClassLoader.close();
+            }
+            // in case of test mode, we can't share the bootstrapped app with the testing plugins, so we are closing it right away
+            if (test && curatedApplication != null) {
+                curatedApplication.close();
             }
         }
     }

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/RequestDispatcher.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/RequestDispatcher.java
@@ -58,11 +58,13 @@ public class RequestDispatcher {
             HttpRequest vertxReq, HttpResponse vertxResp, boolean handleNotFound, Throwable throwable) throws IOException {
 
         ClassLoader old = Thread.currentThread().getContextClassLoader();
+        boolean providerFactoryPushedToThreadLocal = false;
         try {
             Thread.currentThread().setContextClassLoader(classLoader);
             ResteasyProviderFactory defaultInstance = ResteasyProviderFactory.getInstance();
             if (defaultInstance instanceof ThreadLocalResteasyProviderFactory) {
                 ThreadLocalResteasyProviderFactory.push(providerFactory);
+                providerFactoryPushedToThreadLocal = true;
             }
 
             try {
@@ -88,8 +90,7 @@ public class RequestDispatcher {
             }
         } finally {
             try {
-                ResteasyProviderFactory defaultInstance = ResteasyProviderFactory.getInstance();
-                if (defaultInstance instanceof ThreadLocalResteasyProviderFactory) {
+                if (providerFactoryPushedToThreadLocal) {
                     ThreadLocalResteasyProviderFactory.pop();
                 }
             } finally {

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/NoPathInTheAppTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/NoPathInTheAppTest.java
@@ -33,8 +33,8 @@ public class NoPathInTheAppTest {
     }
 
     @AfterEach
-    public void shutdown() {
-        server.shutdown();
+    public void stop() {
+        server.stop();
     }
 
     @Test

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkResponseTimeLoadBalancerTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkResponseTimeLoadBalancerTest.java
@@ -39,8 +39,8 @@ public class StorkResponseTimeLoadBalancerTest {
     }
 
     @AfterAll
-    public static void shutDown() {
-        server.shutdown();
+    public static void stop() {
+        server.stop();
     }
 
     @RestClient

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/TrustAllTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/TrustAllTest.java
@@ -41,8 +41,8 @@ public class TrustAllTest {
     }
 
     @AfterEach
-    public void cleanUp() {
-        server.shutdown();
+    public void stop() {
+        server.stop();
     }
 
     @Test

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
@@ -208,7 +208,8 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
 
     protected class OpenArchivePathTree extends DirectoryPathTree {
 
-        private final FileSystem fs;
+        // we don't make the field final as we want to nullify it on close
+        private volatile FileSystem fs;
         private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
         protected OpenArchivePathTree(FileSystem fs) {
@@ -336,6 +337,10 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
                     throw e;
                 } finally {
                     lock.writeLock().unlock();
+                    // even when we close the fs, everything is kept as is in the fs instance
+                    // and typically the cen, which is quite large
+                    // let's make sure the fs is nullified for it to be garbage collected
+                    fs = null;
                 }
             }
         }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -23,6 +23,7 @@ import io.quarkus.bootstrap.classloading.ClassPathResource;
 import io.quarkus.bootstrap.classloading.FilteredClassPathElement;
 import io.quarkus.bootstrap.classloading.MemoryClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.DependencyFlags;
@@ -194,6 +195,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             //first run, we need to build all the class loaders
             QuarkusClassLoader.Builder builder = QuarkusClassLoader.builder(
                     "Augmentation Class Loader: " + quarkusBootstrap.getMode() + getClassLoaderNameSuffix(),
+                    QuarkusClassLoaderType.AUGMENTATION,
                     quarkusBootstrap.getBaseClassLoader(), !quarkusBootstrap.isIsolateDeployment())
                     .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled());
             builder.addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners());
@@ -239,6 +241,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         if (baseRuntimeClassLoader == null) {
             QuarkusClassLoader.Builder builder = QuarkusClassLoader.builder(
                     "Quarkus Base Runtime ClassLoader: " + quarkusBootstrap.getMode() + getClassLoaderNameSuffix(),
+                    QuarkusClassLoaderType.BASE_RUNTIME,
                     quarkusBootstrap.getBaseClassLoader(), false)
                     .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled());
             builder.addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners());
@@ -317,6 +320,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         //first run, we need to build all the class loaders
         QuarkusClassLoader.Builder builder = QuarkusClassLoader
                 .builder("Deployment Class Loader: " + quarkusBootstrap.getMode() + getClassLoaderNameSuffix(),
+                        QuarkusClassLoaderType.DEPLOYMENT,
                         getAugmentClassLoader(), false)
                 .addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners())
                 .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled())
@@ -366,6 +370,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                                 + getClassLoaderNameSuffix()
                                 + " restart no:"
                                 + runtimeClassLoaderCount.getAndIncrement(),
+                        QuarkusClassLoaderType.RUNTIME,
                         getBaseRuntimeClassLoader(), false)
                 .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled())
                 .setAggregateParentResources(true);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -1,5 +1,6 @@
 package io.quarkus.bootstrap.app;
 
+import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -30,5 +31,7 @@ public interface StartupAction {
      * Runs the application by running the main method of the main class, and runs it to completion
      */
     int runMainClassBlocking(String... args) throws Exception;
+
+    void addRuntimeCloseTask(Closeable closeTask);
 
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -35,6 +35,8 @@ import org.jboss.logging.Logger;
  */
 public class QuarkusClassLoader extends ClassLoader implements Closeable {
     private static final Logger log = Logger.getLogger(QuarkusClassLoader.class);
+    private static final Logger lifecycleLog = Logger.getLogger(QuarkusClassLoader.class.getName() + ".lifecycle");
+
     protected static final String META_INF_SERVICES = "META-INF/services/";
     protected static final String JAVA = "java.";
 
@@ -152,6 +154,8 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         this.classLoaderEventListeners = builder.classLoaderEventListeners.isEmpty() ? Collections.emptyList()
                 : builder.classLoaderEventListeners;
         setDefaultAssertionStatus(builder.assertionsEnabled);
+
+        lifecycleLog.infof(new RuntimeException("Created to log a stacktrace"), "Creating class loader %s", name);
     }
 
     public static Builder builder(String name, ClassLoader parent, boolean parentFirst) {
@@ -652,6 +656,9 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
             }
             closing = true;
         }
+
+        lifecycleLog.infof(new RuntimeException("Created to log a stacktrace"), "Closing class loader %s", name);
+
         List<Runnable> tasks;
         synchronized (closeTasks) {
             tasks = new ArrayList<>(closeTasks);
@@ -713,7 +720,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     private void ensureOpen() {
         if (closed) {
-            throw new IllegalStateException("This class loader has been closed");
+            throw new IllegalStateException("Class loader " + name + " has been closed and may not be accessed anymore");
         }
     }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -695,7 +695,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         definedPackages.clear();
         resettableElement = null;
         transformedClasses = null;
-        state = null;
+        state.clear();
         closeTasks.clear();
         classLoaderEventListeners.clear();
 
@@ -921,6 +921,11 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
             this.loadableResources = loadableResources;
             this.bannedResources = bannedResources;
             this.parentFirstResources = parentFirstResources;
+        }
+
+        void clear() {
+            // when the CL is closed, we make sure the resources are not loadable anymore
+            loadableResources.clear();
         }
     }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -30,6 +30,8 @@ import java.util.jar.Manifest;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
+
 /**
  * The ClassLoader used for non production Quarkus applications (i.e. dev and test mode).
  */
@@ -90,6 +92,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
     }
 
     private final String name;
+    private final QuarkusClassLoaderType type;
     private final List<ClassPathElement> elements;
     private final ConcurrentMap<ClassPathElement, ProtectionDomain> protectionDomains = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Package> definedPackages = new ConcurrentHashMap<>();
@@ -142,6 +145,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         // stacktraces become very ugly if we do that.
         super(builder.parent);
         this.name = builder.name;
+        this.type = builder.type;
         this.elements = builder.elements;
         this.bannedElements = builder.bannedElements;
         this.parentFirstElements = builder.parentFirstElements;
@@ -158,8 +162,8 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         lifecycleLog.infof(new RuntimeException("Created to log a stacktrace"), "Creating class loader %s", name);
     }
 
-    public static Builder builder(String name, ClassLoader parent, boolean parentFirst) {
-        return new Builder(name, parent, parentFirst);
+    public static Builder builder(String name, QuarkusClassLoaderType type, ClassLoader parent, boolean parentFirst) {
+        return new Builder(name, type, parent, parentFirst);
     }
 
     private String sanitizeName(String name) {
@@ -724,13 +728,34 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         }
     }
 
+    public boolean isBootstrap() {
+        return type == QuarkusClassLoaderType.BOOTSTRAP;
+    }
+
+    public boolean isAugmentation() {
+        return type == QuarkusClassLoaderType.AUGMENTATION;
+    }
+
+    public boolean isDeployment() {
+        return type == QuarkusClassLoaderType.DEPLOYMENT;
+    }
+
+    public boolean isBaseRuntime() {
+        return type == QuarkusClassLoaderType.BASE_RUNTIME;
+    }
+
+    public boolean isRuntime() {
+        return type == QuarkusClassLoaderType.RUNTIME;
+    }
+
     @Override
     public String toString() {
-        return "QuarkusClassLoader:" + name + "@" + Integer.toHexString(hashCode());
+        return "QuarkusClassLoader[type=" + type + ", name=" + name + ", id=" + Integer.toHexString(hashCode()) + "]";
     }
 
     public static class Builder {
         final String name;
+        final QuarkusClassLoaderType type;
         final ClassLoader parent;
         final List<ClassPathElement> elements = new ArrayList<>();
         final List<ClassPathElement> bannedElements = new ArrayList<>();
@@ -743,8 +768,9 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         boolean assertionsEnabled;
         private final ArrayList<ClassLoaderEventListener> classLoaderEventListeners = new ArrayList<>(5);
 
-        public Builder(String name, ClassLoader parent, boolean parentFirst) {
+        public Builder(String name, QuarkusClassLoaderType type, ClassLoader parent, boolean parentFirst) {
             this.name = name;
+            this.type = type;
             this.parent = parent;
             this.parentFirst = parentFirst;
         }
@@ -895,6 +921,15 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
             this.bannedResources = bannedResources;
             this.parentFirstResources = parentFirstResources;
         }
+    }
+
+    public enum QuarkusClassLoaderType {
+
+        BOOTSTRAP,
+        AUGMENTATION,
+        DEPLOYMENT,
+        BASE_RUNTIME,
+        RUNTIME;
     }
 
     @Override

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -159,7 +159,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
                 : builder.classLoaderEventListeners;
         setDefaultAssertionStatus(builder.assertionsEnabled);
 
-        lifecycleLog.infof(new RuntimeException("Created to log a stacktrace"), "Creating class loader %s", name);
+        lifecycleLog.debugf(new RuntimeException("Created to log a stacktrace"), "Creating class loader %s", this);
     }
 
     public static Builder builder(String name, QuarkusClassLoaderType type, ClassLoader parent, boolean parentFirst) {
@@ -661,7 +661,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
             closing = true;
         }
 
-        lifecycleLog.infof(new RuntimeException("Created to log a stacktrace"), "Closing class loader %s", name);
+        lifecycleLog.debugf(new RuntimeException("Created to log a stacktrace"), "Closing class loader %s", this);
 
         List<Runnable> tasks;
         synchronized (closeTasks) {
@@ -724,7 +724,8 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     private void ensureOpen() {
         if (closed) {
-            throw new IllegalStateException("Class loader " + name + " has been closed and may not be accessed anymore");
+            lifecycleLog.errorf(new RuntimeException("Created to log a stacktrace"),
+                    "Class loader %s has been closed and may not be accessed anymore", this);
         }
     }
 

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingInterruptTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingInterruptTestCase.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.util.IoUtils;
 
 public class ClassLoadingInterruptTestCase {
@@ -23,7 +24,8 @@ public class ClassLoadingInterruptTestCase {
         try {
             jar.as(ExplodedExporter.class).exportExploded(path.toFile(), "tmp");
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader.builder("test", QuarkusClassLoaderType.BOOTSTRAP,
+                    getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
                     .build();
             Class<?> c = cl.loadClass(InterruptClass.class.getName());

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingPathTreeResourceUrlTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingPathTreeResourceUrlTestCase.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.util.IoUtils;
 
 public class ClassLoadingPathTreeResourceUrlTestCase {
@@ -36,7 +37,8 @@ public class ClassLoadingPathTreeResourceUrlTestCase {
         try {
             jar.as(ExplodedExporter.class).exportExploded(path.toFile(), "tmp");
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
                     .build();
             URL res = cl.getResource("a.txt");
@@ -74,7 +76,8 @@ public class ClassLoadingPathTreeResourceUrlTestCase {
         final Path tmpDir = Files.createTempDirectory(testPath);
         try {
             jar.as(ExplodedExporter.class).exportExploded(tmpDir.toFile(), "tmpcltest");
-            final ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            final ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(tmpDir.resolve("tmpcltest"), true))
                     .build();
 
@@ -102,7 +105,8 @@ public class ClassLoadingPathTreeResourceUrlTestCase {
         try {
             jar.as(ZipExporter.class).exportTo(path.toFile(), true);
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path, true))
                     .build();
             URL res = cl.getResource("a.txt");

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingResourceUrlTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingResourceUrlTestCase.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.MemoryClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.util.IoUtils;
 
 //see https://github.com/quarkusio/quarkus/issues/10943
@@ -41,7 +42,8 @@ public class ClassLoadingResourceUrlTestCase {
         try {
             jar.as(ExplodedExporter.class).exportExploded(path.toFile(), "tmp");
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
                     .build();
             URL res = cl.getResource("a.txt");
@@ -79,7 +81,8 @@ public class ClassLoadingResourceUrlTestCase {
         final Path tmpDir = Files.createTempDirectory(testPath);
         try {
             jar.as(ExplodedExporter.class).exportExploded(tmpDir.toFile(), "tmpcltest");
-            final ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            final ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(tmpDir.resolve("tmpcltest"), true))
                     .build();
 
@@ -107,7 +110,8 @@ public class ClassLoadingResourceUrlTestCase {
         try {
             jar.as(ZipExporter.class).exportTo(path.toFile(), true);
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path, true))
                     .build();
             URL res = cl.getResource("a.txt");
@@ -134,7 +138,8 @@ public class ClassLoadingResourceUrlTestCase {
         long start = System.currentTimeMillis();
         Thread.sleep(2);
 
-        ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+        ClassLoader cl = QuarkusClassLoader
+                .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                 .addElement(
                         new MemoryClassPathElement(Collections.singletonMap("a.txt", "hello".getBytes(StandardCharsets.UTF_8)),
                                 true))

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/MultiReleaseJarTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/MultiReleaseJarTestCase.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.util.IoUtils;
 
 public class MultiReleaseJarTestCase {
@@ -51,7 +52,8 @@ public class MultiReleaseJarTestCase {
 
     @Test
     public void shouldLoadMultiReleaseJarOnJDK9Plus() throws IOException {
-        try (QuarkusClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+        try (QuarkusClassLoader cl = QuarkusClassLoader.builder("test", QuarkusClassLoaderType.BOOTSTRAP,
+                getClass().getClassLoader(), false)
                 .addElement(ClassPathElement.fromPath(jarPath, true))
                 .build()) {
             URL resource = cl.getResource("foo.txt");

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -58,6 +58,7 @@ import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.classloading.ClassLoaderEventListener;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildException;
@@ -638,6 +639,7 @@ public class QuarkusUnitTest
                 if (!allowTestClassOutsideDeployment) {
                     quarkusUnitTestClassLoader = QuarkusClassLoader
                             .builder("QuarkusUnitTest ClassLoader for " + extensionContext.getDisplayName(),
+                                    QuarkusClassLoaderType.BOOTSTRAP,
                                     getClass().getClassLoader(), false)
                             .addClassLoaderEventListeners(this.classLoadListeners)
                             .addBannedElement(ClassPathElement.fromPath(testLocation, true)).build();

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -86,7 +86,7 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
     private LaunchResult doLaunch(ExtensionContext context, Class<? extends QuarkusTestProfile> selectedProfile,
             String[] arguments) throws Exception {
         ensurePrepared(context, selectedProfile);
-        LogCapturingOutputFilter filter = new LogCapturingOutputFilter(prepareResult.curatedApplication, false, false,
+        LogCapturingOutputFilter filter = new LogCapturingOutputFilter(false, false,
                 () -> true);
         QuarkusConsole.addOutputFilter(filter);
         try {


### PR DESCRIPTION
This won't fix the leaks as there are multiple reasons why CLs are leaking in tests and dev mode but... I thought we should consider at least reducing the consequences of the leaks by clearing the resources and making sure that the `ZipFileSystem` can be garbage collected, together with some other elements.

Now there's something a bit odd, if I set `state` to `null`, I have a very weird error:

> Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.LinkageError: loader constraint violation: loader 'app' wants to load interface io.netty.util.internal.shaded.org.jctools.queues.IndexedQueueSizeUtil$IndexedQueue. A different interface with the same name was previously loaded by io.quarkus.bootstrap.classloading.QuarkusClassLoader @7c4921f1. (io.netty.util.internal.shaded.org.jctools.queues.IndexedQueueSizeUtil$IndexedQueue is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @7c4921f1, parent loader 'app') [in thread "build-36"]

Which means that somehow the closed class loader is still in use - which is extremely weird... If someone has an idea, I'm interested.

Commit messages have a bit more details.

Related to #41158 and #41156 .