### PR TITLE
Add marko-bekhta to GitHub integrations for Hibernate Search and Elasticsearch

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -147,7 +147,7 @@ triage:
         - integration-tests/hibernate-search
     - id: elasticsearch
       labels: [area/elasticsearch]
-      title: "elasticsearch"
+      title: "(elasticsearch|opensearch)"
       notify: [gsmet, yrodiere, loicmathieu]
       notifyInPullRequest: true
       directories:

--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -139,7 +139,7 @@ triage:
     - id: hibernate-search
       labels: [area/hibernate-search]
       title: "hibernate.search"
-      notify: [gsmet, yrodiere]
+      notify: [gsmet, marko-bekhta, yrodiere]
       notifyInPullRequest: true
       directories:
         # No trailing slashes: we also match sibling directories starting with these names
@@ -148,7 +148,7 @@ triage:
     - id: elasticsearch
       labels: [area/elasticsearch]
       title: "(elasticsearch|opensearch)"
-      notify: [gsmet, yrodiere, loicmathieu]
+      notify: [gsmet, marko-bekhta, yrodiere, loicmathieu]
       notifyInPullRequest: true
       directories:
         # No trailing slashes: we also match sibling directories starting with these names
@@ -157,7 +157,7 @@ triage:
     - id: hibernate-validator
       labels: [area/hibernate-validator]
       title: "hibernate.validator"
-      notify: [gsmet, yrodiere]
+      notify: [gsmet, marko-bekhta, yrodiere]
       directories:
         # No trailing slashes: we also match sibling directories starting with these names
         - extensions/hibernate-validator

--- a/.github/quarkus-github-lottery.yml
+++ b/.github/quarkus-github-lottery.yml
@@ -29,12 +29,12 @@ participants:
       maxIssues: 3
     maintenance:
       labels: ["area/hibernate-orm", "area/hibernate-search", "area/elasticsearch"]
-      days: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
+      days: ["WEDNESDAY"]
       feedback:
         needed:
-          maxIssues: 4
+          maxIssues: 10
         provided:
-          maxIssues: 2
+          maxIssues: 10
       stale:
         maxIssues: 5
   - username: "gsmet"

--- a/.github/quarkus-github-lottery.yml
+++ b/.github/quarkus-github-lottery.yml
@@ -37,6 +37,18 @@ participants:
           maxIssues: 10
       stale:
         maxIssues: 5
+  - username: "marko-bekhta"
+    timezone: "Europe/Warsaw"
+    maintenance:
+      labels: ["area/hibernate-search", "area/elasticsearch", "area/hibernate-validator"]
+      days: ["WEDNESDAY"]
+      feedback:
+        needed:
+          maxIssues: 10
+        provided:
+          maxIssues: 10
+      stale:
+        maxIssues: 5
   - username: "gsmet"
     timezone: "Europe/Paris"
     triage:


### PR DESCRIPTION
If you agree @marko-bekhta, please approve the PR. Otherwise suggest changes; the lottery settings in particular are pretty arbitrary, feel free to pick what fits your needs (specific day(s), ...).

EDIT: Also, see [here](https://github.com/quarkusio/quarkus-github-lottery?tab=readme-ov-file#quarkus-github-lottery) to know more about the lottery. Essentially it will regularly send you a notification about Hibernate Search or Elasticsearch issues that need your attention.

Also includes a few unrelated minor changes to bot/lottery config.