### PR TITLE
Remove invalid parent pom configuration

### DIFF
--- a/extensions/oidc-client-filter/deployment/pom.xml
+++ b/extensions/oidc-client-filter/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-client-oidc-filter-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-client-filter/runtime/pom.xml
+++ b/extensions/oidc-client-filter/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-client-oidc-filter-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-client-graphql/deployment/pom.xml
+++ b/extensions/oidc-client-graphql/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-client-graphql-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-client-graphql/runtime/pom.xml
+++ b/extensions/oidc-client-graphql/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-client-graphql-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-client-reactive-filter/deployment/pom.xml
+++ b/extensions/oidc-client-reactive-filter/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-oidc-filter-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-client-reactive-filter/runtime/pom.xml
+++ b/extensions/oidc-client-reactive-filter/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-oidc-filter-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-client/deployment/pom.xml
+++ b/extensions/oidc-client/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-client-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-client/runtime/pom.xml
+++ b/extensions/oidc-client/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-client-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-common/deployment/pom.xml
+++ b/extensions/oidc-common/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-common/runtime/pom.xml
+++ b/extensions/oidc-common/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-common-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-db-token-state-manager/deployment/pom.xml
+++ b/extensions/oidc-db-token-state-manager/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-db-token-state-manager-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-db-token-state-manager/runtime/pom.xml
+++ b/extensions/oidc-db-token-state-manager/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-oidc-db-token-state-manager-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-token-propagation-reactive/deployment/pom.xml
+++ b/extensions/oidc-token-propagation-reactive/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-oidc-token-propagation-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-token-propagation-reactive/runtime/pom.xml
+++ b/extensions/oidc-token-propagation-reactive/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-rest-client-oidc-token-propagation-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-token-propagation/deployment/pom.xml
+++ b/extensions/oidc-token-propagation/deployment/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-client-oidc-token-propagation-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/oidc-token-propagation/runtime/pom.xml
+++ b/extensions/oidc-token-propagation/runtime/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>quarkus-resteasy-client-oidc-token-propagation-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This does not change the final behavior of Maven,
but it does stop the IDE from complaining about
an invalid parent pom configuration