### PR TITLE
Do not rethrow SmallRye Config ConfigValidationException in Quarkus ConfigException

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/RuntimeConfigSetupBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/RuntimeConfigSetupBuildStep.java
@@ -10,14 +10,11 @@ import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.MainBytecodeRecorderBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
-import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.TryBlock;
 import io.quarkus.runtime.StartupContext;
 import io.quarkus.runtime.StartupTask;
-import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class RuntimeConfigSetupBuildStep {
     private static final String RUNTIME_CONFIG_STARTUP_TASK_CLASS_NAME = "io.quarkus.deployment.steps.RuntimeConfigSetup";
@@ -40,17 +37,11 @@ public class RuntimeConfigSetupBuildStep {
                 .interfaces(StartupTask.class).build()) {
 
             try (MethodCreator method = clazz.getMethodCreator("deploy", void.class, StartupContext.class)) {
-                TryBlock tryBlock = method.tryBlock();
-                tryBlock.invokeVirtualMethod(
-                        ofMethod(StartupContext.class, "setCurrentBuildStepName", void.class, String.class),
+                method.invokeVirtualMethod(ofMethod(StartupContext.class, "setCurrentBuildStepName", void.class, String.class),
                         method.getMethodParam(0), method.load("RuntimeConfigSetupBuildStep.setupRuntimeConfig"));
 
-                tryBlock.invokeStaticMethod(C_CREATE_RUN_TIME_CONFIG);
-                tryBlock.returnValue(null);
-
-                CatchBlockCreator cb = tryBlock.addCatch(RuntimeException.class);
-                cb.throwException(ConfigurationException.class, "Failed to read configuration properties",
-                        cb.getCaughtException());
+                method.invokeStaticMethod(C_CREATE_RUN_TIME_CONFIG);
+                method.returnValue(null);
             }
         }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -188,9 +188,8 @@ public class ApplicationLifecycleManager {
                         }
                         applicationLogger.warn("You can try to kill it with 'kill -9 <pid>'.");
                     }
-                } else if (ExceptionUtil.isAnyCauseInstanceOf(e, ConfigurationException.class)) {
+                } else if (rootCause instanceof ConfigurationException) {
                     System.err.println(rootCause.getMessage());
-                    e.printStackTrace();
                 } else if (rootCause instanceof PreventFurtherStepsException
                         && !StringUtil.isNullOrEmpty(rootCause.getMessage())) {
                     System.err.println(rootCause.getMessage());

--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -24,11 +24,11 @@ import org.wildfly.common.lock.Locks;
 
 import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.runner.RunnerClassLoader;
-import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.runtime.graal.DiagnosticPrinter;
 import io.quarkus.runtime.util.ExceptionUtil;
 import io.quarkus.runtime.util.StringUtil;
+import io.smallrye.config.ConfigValidationException;
 import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
@@ -188,15 +188,13 @@ public class ApplicationLifecycleManager {
                         }
                         applicationLogger.warn("You can try to kill it with 'kill -9 <pid>'.");
                     }
-                } else if (rootCause instanceof ConfigurationException) {
+                } else if (rootCause instanceof ConfigurationException || rootCause instanceof ConfigValidationException) {
                     System.err.println(rootCause.getMessage());
                 } else if (rootCause instanceof PreventFurtherStepsException
                         && !StringUtil.isNullOrEmpty(rootCause.getMessage())) {
                     System.err.println(rootCause.getMessage());
                 } else {
-                    // If it is not a ConfigurationException it should be safe to call ConfigProvider.getConfig here
-                    applicationLogger.errorv(e, "Failed to start application (with profile {0})",
-                            ConfigUtils.getProfiles());
+                    applicationLogger.errorv(e, "Failed to start application");
                     ensureConsoleLogsDrained();
                 }
             }

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ExceptionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ExceptionUtil.java
@@ -86,17 +86,6 @@ public class ExceptionUtil {
         return chain.isEmpty() ? null : chain.get(chain.size() - 1);
     }
 
-    public static <T> boolean isAnyCauseInstanceOf(Throwable exception, Class<T> classToCheck) {
-        Throwable curr = exception;
-        do {
-            if (classToCheck.isInstance(curr)) {
-                return true;
-            }
-            curr = curr.getCause();
-        } while (curr != null);
-        return false;
-    }
-
     /**
      * Creates and returns a new {@link Throwable} which has the following characteristics:
      * <ul>

--- a/core/runtime/src/test/java/io/quarkus/runtime/util/ExceptionUtilTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/util/ExceptionUtilTest.java
@@ -13,8 +13,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.runtime.configuration.ConfigurationException;
-
 /**
  *
  */
@@ -61,11 +59,6 @@ public class ExceptionUtilTest {
         assertEquals(NullPointerException.class, ExceptionUtil.getRootCause(new NullPointerException()).getClass());
     }
 
-    @Test
-    public void testIsAnyCauseInstanceOf() {
-        assertTrue(ExceptionUtil.isAnyCauseInstanceOf(generateConfigurationException(), ConfigurationException.class));
-    }
-
     private Throwable generateException() {
         try {
             try {
@@ -86,26 +79,4 @@ public class ExceptionUtilTest {
         }
         throw new RuntimeException("Should not reach here");
     }
-
-    private Throwable generateConfigurationException() {
-        try {
-            try {
-                Integer.parseInt("23.23232");
-            } catch (NumberFormatException nfe) {
-                throw new ConfigurationException("Incorrect param", nfe);
-            }
-        } catch (ConfigurationException ce) {
-            try {
-                throw new IOException("Request processing failed", ce);
-            } catch (IOException e) {
-                try {
-                    throw new IOError(e);
-                } catch (IOError ie) {
-                    return new RuntimeException("Unexpected exception", ie);
-                }
-            }
-        }
-        throw new RuntimeException("Should not reach here");
-    }
-
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/PemWithoutKeyTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/PemWithoutKeyTest.java
@@ -30,7 +30,7 @@ public class PemWithoutKeyTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
                     .add(new StringAsset(configuration), "application.properties"))
-            .assertException(t -> assertThat(t.getCause().getMessage()).contains("quarkus.tls.key-store.pem.0.key"));
+            .assertException(t -> assertThat(t.getMessage()).contains("quarkus.tls.key-store.pem.0.key"));
 
     @Test
     void test() throws KeyStoreException, CertificateParsingException {


### PR DESCRIPTION
Reverts https://github.com/quarkusio/quarkus/pull/37543 and provides a different fix.

I think wrapping SmallRye Config `ConfigValidationException` in Quarkus `ConfigException` is misleading because of the extra exception and the added message, which does not represent the actual problem(s). `ConfigValidationException` already records multiple exceptions that can happen during Config setup to a single summary of problems. The added exception and message `Failed to read configuration properties` when that was not the problem confused me a bit :)

This also eliminates the config profile printing in the error from the original issue https://github.com/quarkusio/quarkus/issues/36376. I think it does not add any value.