### PR TITLE
Fix WebSockets NEXT CDI events documentation as observed events qualifiers does not exist in the final version

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -523,18 +523,18 @@ For example, `OpenConnections#findByEndpointId(String)` makes it easy to find co
 
 === CDI events
 
-Quarkus fires a CDI event of type `io.quarkus.websockets.next.WebSocketConnection` with qualifier `@io.quarkus.websockets.next.ConnectionOpen` asynchronously when a new connection is opened.
-Moreover, a CDI event of type `WebSocketConnection` with qualifier `@io.quarkus.websockets.next.ConnectionClosed` is fired asynchronously when a connection is closed.
+Quarkus fires a CDI event of type `io.quarkus.websockets.next.WebSocketConnection` with qualifier `@io.quarkus.websockets.next.Open` asynchronously when a new connection is opened.
+Moreover, a CDI event of type `WebSocketConnection` with qualifier `@io.quarkus.websockets.next.Closed` is fired asynchronously when a connection is closed.
 
 [source, java]
 ----
 import jakarta.enterprise.event.ObservesAsync;
-import io.quarkus.websockets.next.ConnectionOpen;
+import io.quarkus.websockets.next.Open;
 import io.quarkus.websockets.next.WebSocketConnection;
 
 class MyBean {
 
-  void connectionOpened(@ObservesAsync @ConnectionOpen WebSocketConnection connection) { <1>
+  void connectionOpened(@ObservesAsync @Open WebSocketConnection connection) { <1>
      // This observer method is called when a connection is opened...
   }
 }


### PR DESCRIPTION
added here https://github.com/quarkusio/quarkus/pull/41032 I can see that docs is referring to the qualifiers that does not exist.