### PR TITLE
Scheduler - introduce build item which can enforce scheduler startup

### DIFF
--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/BuildItemForcedSchedulerStartTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/BuildItemForcedSchedulerStartTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.quartz.test.programmatic;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.scheduler.deployment.ForceStartSchedulerBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BuildItemForcedSchedulerStartTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+
+                    @Override
+                    public void execute(BuildContext context) {
+                        context.produce(new ForceStartSchedulerBuildItem());
+                    }
+                }).produces(ForceStartSchedulerBuildItem.class).build();
+            }
+        };
+    }
+
+    @Inject
+    Scheduler scheduler;
+
+    static final CountDownLatch SYNC_LATCH = new CountDownLatch(1);
+
+    @Test
+    public void testScheduler() throws InterruptedException {
+        assertTrue(scheduler.isRunning());
+
+        scheduler.newJob("foo")
+                .setInterval("1s")
+                .setTask(ec -> SYNC_LATCH.countDown())
+                .schedule();
+
+        assertTrue(SYNC_LATCH.await(5, TimeUnit.SECONDS));
+    }
+}

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -198,7 +198,7 @@ public class QuartzSchedulerImpl implements QuartzScheduler {
         if (!enabled) {
             LOGGER.info("Quartz scheduler is disabled by config property and will not be started");
             this.scheduler = null;
-        } else if (!forceStart && context.getScheduledMethods().isEmpty()) {
+        } else if (!forceStart && context.getScheduledMethods().isEmpty() && !context.forceSchedulerStart()) {
             LOGGER.info("No scheduled business methods found - Quartz scheduler will not be started");
             this.scheduler = null;
         } else {

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SchedulerContext.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SchedulerContext.java
@@ -11,6 +11,8 @@ public interface SchedulerContext {
 
     List<ScheduledMethod> getScheduledMethods();
 
+    boolean forceSchedulerStart();
+
     @SuppressWarnings("unchecked")
     default ScheduledInvoker createInvoker(String invokerClassName) {
         try {

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/ForceStartSchedulerBuildItem.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/ForceStartSchedulerBuildItem.java
@@ -1,0 +1,12 @@
+package io.quarkus.scheduler.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A marker item which forces Quarkus Scheduler initialization regardless of presence of any
+ * {@link io.quarkus.scheduler.Scheduled} methods.
+ * <p>
+ * This option is similar to using scheduler subsystem configuration option {@code quarkus.scheduler.start-mode=forced}.
+ */
+public final class ForceStartSchedulerBuildItem extends MultiBuildItem {
+}

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -296,7 +296,7 @@ public class SchedulerProcessor {
     public FeatureBuildItem build(SchedulerConfig config, BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             SchedulerRecorder recorder, List<ScheduledBusinessMethodItem> scheduledMethods,
             BuildProducer<GeneratedClassBuildItem> generatedClasses, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            AnnotationProxyBuildItem annotationProxy) {
+            AnnotationProxyBuildItem annotationProxy, List<ForceStartSchedulerBuildItem> schedulerForcedStartItems) {
 
         List<MutableScheduledMethod> scheduledMetadata = new ArrayList<>();
         ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClasses, new Function<String, String>() {
@@ -330,7 +330,7 @@ public class SchedulerProcessor {
         }
 
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(SchedulerContext.class).setRuntimeInit()
-                .supplier(recorder.createContext(config, scheduledMetadata))
+                .supplier(recorder.createContext(config, scheduledMetadata, !schedulerForcedStartItems.isEmpty()))
                 .done());
 
         return new FeatureBuildItem(Feature.SCHEDULER);

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/BuildItemForcedSchedulerStartTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/BuildItemForcedSchedulerStartTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.scheduler.test.programmatic;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.scheduler.deployment.ForceStartSchedulerBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BuildItemForcedSchedulerStartTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+
+                    @Override
+                    public void execute(BuildContext context) {
+                        context.produce(new ForceStartSchedulerBuildItem());
+                    }
+                }).produces(ForceStartSchedulerBuildItem.class).build();
+            }
+        };
+    }
+
+    @Inject
+    Scheduler scheduler;
+
+    static final CountDownLatch SYNC_LATCH = new CountDownLatch(1);
+
+    @Test
+    public void testScheduler() throws InterruptedException {
+        assertTrue(scheduler.isRunning());
+
+        scheduler.newJob("foo")
+                .setInterval("1s")
+                .setTask(ec -> SYNC_LATCH.countDown())
+                .schedule();
+
+        assertTrue(SYNC_LATCH.await(5, TimeUnit.SECONDS));
+    }
+}

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRecorder.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRecorder.java
@@ -16,7 +16,7 @@ import io.quarkus.scheduler.common.runtime.SchedulerContext;
 public class SchedulerRecorder {
 
     public Supplier<Object> createContext(SchedulerConfig config,
-            List<MutableScheduledMethod> scheduledMethods) {
+            List<MutableScheduledMethod> scheduledMethods, boolean forceSchedulerStart) {
         // Defensive design - make an immutable copy of the scheduled method metadata
         List<ScheduledMethod> metadata = immutableCopy(scheduledMethods);
         return new Supplier<Object>() {
@@ -32,6 +32,11 @@ public class SchedulerRecorder {
                     @Override
                     public List<ScheduledMethod> getScheduledMethods() {
                         return metadata;
+                    }
+
+                    @Override
+                    public boolean forceSchedulerStart() {
+                        return forceSchedulerStart;
                     }
                 };
             }

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
@@ -129,7 +129,7 @@ public class SimpleScheduler implements Scheduler {
         }
 
         StartMode startMode = schedulerRuntimeConfig.startMode.orElse(StartMode.NORMAL);
-        if (startMode == StartMode.NORMAL && context.getScheduledMethods().isEmpty()) {
+        if (startMode == StartMode.NORMAL && context.getScheduledMethods().isEmpty() && !context.forceSchedulerStart()) {
             this.scheduledExecutor = null;
             LOG.info("No scheduled business methods found - Simple scheduler will not be started");
             return;


### PR DESCRIPTION
Fixes #41189 

Was this what you meant @mkouba?
Technically, the build item could support an enum to differentiate between `forced` and `halted` modes but I am not sure if the halted mode makes any sense in this regard.