### PR TITLE
Avoid NumberFormatException for Java 1.8

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/JavaVersion.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/JavaVersion.java
@@ -19,7 +19,11 @@ public final class JavaVersion {
     }
 
     public JavaVersion(String version) {
-        this.version = version;
+        if (version != null && version.startsWith("1.")) {
+            this.version = version.substring(2);
+        } else {
+            this.version = version;
+        }
     }
 
     public boolean isEmpty() {

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/JavaVersionTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/JavaVersionTest.java
@@ -15,6 +15,12 @@ import org.junit.jupiter.api.Test;
 class JavaVersionTest {
 
     @Test
+    public void givenJavaVersion8ShouldReturn8() {
+        assertEquals(8, new JavaVersion("8").getAsInt());
+        assertEquals(8, new JavaVersion("1.8").getAsInt());
+    }
+
+    @Test
     public void givenJavaVersion17ShouldReturn17() {
         assertEquals("17", computeJavaVersion(JAVA, "17"));
     }


### PR DESCRIPTION
I had to update (with `quarkus update`) a very old Quarkus project that was having 1.8 as a maven.compiler.target and this led to an error that is less than ideal.

This will make you go a bit further and get a proper message saying Java 1.8 is not supported.