### PR TITLE
OIDC client support for using JWTs as Authorization Grants

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -361,6 +361,15 @@ public class OidcCommonConfig {
             @ConfigItem(defaultValue = "10")
             public int lifespan = 10;
 
+            /**
+             * If true then the client authentication token is a JWT bearer grant assertion. Instead of producing
+             * 'client_assertion'
+             * and 'client_assertion_type' form properties, only 'assertion' is produced.
+             * This option is only supported by the OIDC client extension.
+             */
+            @ConfigItem(defaultValue = "false")
+            public boolean assertion = false;
+
             public Optional<String> getSecret() {
                 return secret;
             }
@@ -439,6 +448,14 @@ public class OidcCommonConfig {
 
             public void setSource(Source source) {
                 this.source = source;
+            }
+
+            public boolean isAssertion() {
+                return assertion;
+            }
+
+            public void setAssertion(boolean assertion) {
+                this.assertion = assertion;
             }
 
         }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -296,6 +296,10 @@ public class OidcCommonUtils {
         return clientSecretMethod(creds) == Secret.Method.POST_JWT && isClientJwtAuthRequired(creds);
     }
 
+    public static boolean isJwtAssertion(Credentials creds) {
+        return creds.getJwt().isAssertion();
+    }
+
     public static String clientSecret(Credentials creds) {
         return creds.secret.orElse(creds.clientSecret.value.orElseGet(fromCredentialsProvider(creds.clientSecret.provider)));
     }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -7,6 +7,8 @@ public final class OidcConstants {
     public static final String CLIENT_ASSERTION = "client_assertion";
     public static final String CLIENT_ASSERTION_TYPE = "client_assertion_type";
     public static final String JWT_BEARER_CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+    public static final String JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+    public static final String JWT_BEARER_GRANT_ASSERTION = "assertion";
 
     public static final String CLIENT_CREDENTIALS_GRANT = "client_credentials";
     public static final String PASSWORD_GRANT = "password";

--- a/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
+++ b/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
@@ -17,6 +17,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClientConfig.Grant;
 import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.token.propagation.runtime.AbstractTokenRequestFilter;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.security.credential.TokenCredential;
@@ -54,7 +55,7 @@ public class AccessTokenRequestFilter extends AbstractTokenRequestFilter {
             if (exchangeTokenGrantType == Grant.Type.EXCHANGE) {
                 exchangeTokenProperty = "subject_token";
             } else if (exchangeTokenGrantType == Grant.Type.JWT) {
-                exchangeTokenProperty = "assertion";
+                exchangeTokenProperty = OidcConstants.JWT_BEARER_GRANT_ASSERTION;
             } else {
                 throw new ConfigurationException("Token exchange is required but OIDC client is configured "
                         + "to use the " + exchangeTokenGrantType.getGrantType() + " grantType");

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -42,6 +42,10 @@ public class FrontendResource {
     OidcClient tokensWithoutHeader;
 
     @Inject
+    @NamedOidcClient("jwtbearer-grant")
+    OidcClient jwtBearerGrantClient;
+
+    @Inject
     OidcClients clients;
 
     @GET
@@ -54,6 +58,12 @@ public class FrontendResource {
     @Path("crashTest")
     public String crashTest() {
         return protectedResourceServiceCrashTestClient.echoToken();
+    }
+
+    @GET
+    @Path("echoTokenJwtBearerGrant")
+    public String echoTokenJwtBearerGrant() {
+        return jwtBearerGrantClient.getTokens().await().indefinitely().getAccessToken();
     }
 
     @GET

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -13,6 +13,14 @@ quarkus.oidc-client.jwtbearer.token-path=/tokens-jwtbearer
 quarkus.oidc-client.jwtbearer.client-id=quarkus-app
 quarkus.oidc-client.jwtbearer.credentials.jwt.source=bearer
 
+quarkus.oidc-client.jwtbearer-grant.auth-server-url=${keycloak.url}
+quarkus.oidc-client.jwtbearer-grant.discovery-enabled=false
+quarkus.oidc-client.jwtbearer-grant.token-path=/tokens-jwtbearer-grant
+quarkus.oidc-client.jwtbearer-grant.grant.type=jwt
+quarkus.oidc-client.jwtbearer-grant.client-id=quarkus-app
+quarkus.oidc-client.jwtbearer-grant.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+quarkus.oidc-client.jwtbearer-grant.credentials.jwt.assertion=true
+
 quarkus.oidc-client.password-grant-public-client.token-path=${keycloak.url}/tokens_public_client
 quarkus.oidc-client.password-grant-public-client.client-id=quarkus-app
 quarkus.oidc-client.password-grant-public-client.grant.type=password

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -45,6 +45,14 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                         .withBody(
                                 "{\"access_token\":\"access_token_jwt_bearer\", \"expires_in\":4, \"refresh_token\":\"refresh_token_jwt_bearer\"}")));
+        server.stubFor(WireMock.post("/tokens-jwtbearer-grant")
+                .withRequestBody(containing("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&"
+                        + "assertion="))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                        .withBody(
+                                "{\"access_token\":\"access_token_jwt_bearer_grant\", \"expires_in\":4, \"refresh_token\":\"refresh_token_jwt_bearer\"}")));
         server.stubFor(WireMock.post("/tokens_public_client")
                 .withRequestBody(matching("grant_type=password&username=alice&password=alice&client_id=quarkus-app"))
                 .willReturn(WireMock

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -45,6 +45,14 @@ public class OidcClientTest {
     }
 
     @Test
+    public void testEchoTokensJwtBearerGrant() {
+        RestAssured.when().get("/frontend/echoTokenJwtBearerGrant")
+                .then()
+                .statusCode(200)
+                .body(equalTo("access_token_jwt_bearer_grant"));
+    }
+
+    @Test
     public void testEchoAndRefreshTokens() {
         // access_token_1 and refresh_token_1 are acquired using a password grant request.
         // access_token_1 expires in 4 seconds, refresh_token_1 has no lifespan limit as no `refresh_expires_in` property is returned.


### PR DESCRIPTION
Fixes #40905.

This PR builds on the work started by @argenstijn and makes it possible to send OIDC client JWT authentication token as a JWT bearer grant assertion to support a Salesforce integration.

OIDC client must always authenticate to the OIDC server in order to complete a token grant exchange. There could be many types of grants, and many types of the OIDC client authentication. For example, OIDC client can start a client credentials grant token exchange and provide a client id and secret to authenticate. In fact, a client credentials grant can be supported instead by a client JWT authentication options.

In the Salesforce case, the client JWT authentication token plays the role of the JWT bearer grant assertion value. Essentially it is like a client credentials grant, but instead of setting the `grant_type` to `client_credentials` and supplying the JWT authentication token as client assertion authentication parameters, Salesforce expects a JWT bearer grant type whose value is the same authentication token expressed as an `assertion` property.

The PR is very simple, it adds an `assertion` boolean property to the JWT authentication group (instead of originally suggested `grant`) and if it is set, OIDC client passes it as an `assertion` form property if the correct JWT bearer grant is configured by the user. Test is added to confirm it works as expected