### PR TITLE
Quarkus Update - Provide more context when an error occurs

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -123,7 +123,7 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
             final QuarkusCommandOutcome result = invoker.execute();
             if (!result.isSuccess()) {
                 throw new MojoExecutionException(
-                        "Failed to apply the updates.");
+                        "Failed to apply the updates: " + result.getMessage());
             }
         } catch (QuarkusUpdateExitErrorException e) {
             throw new MojoExecutionException(e.getMessage());

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/data/QuarkusCommandOutcome.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/data/QuarkusCommandOutcome.java
@@ -1,22 +1,33 @@
 package io.quarkus.devtools.commands.data;
 
+import java.util.Objects;
+
 public class QuarkusCommandOutcome extends ValueMap<QuarkusCommandOutcome> {
 
     public static QuarkusCommandOutcome success() {
-        return new QuarkusCommandOutcome(true);
+        return new QuarkusCommandOutcome(true, null);
     }
 
-    public static QuarkusCommandOutcome failure() {
-        return new QuarkusCommandOutcome(false);
+    public static QuarkusCommandOutcome failure(String message) {
+        Objects.requireNonNull(message, "Message may not be null in case of a failure");
+
+        return new QuarkusCommandOutcome(false, message);
     }
 
     private final boolean success;
 
-    public QuarkusCommandOutcome(boolean success) {
+    private final String message;
+
+    private QuarkusCommandOutcome(boolean success, String message) {
         this.success = success;
+        this.message = message;
     }
 
     public boolean isSuccess() {
         return success;
+    }
+
+    public String getMessage() {
+        return message;
     }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/AddExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/AddExtensionsCommandHandler.java
@@ -64,7 +64,7 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
                         .forEach(a -> invocation.log()
                                 .info(MessageIcons.NOOP_ICON + " Extension " + a.getGroupId() + ":" + a.getArtifactId()
                                         + " was already installed"));
-                return new QuarkusCommandOutcome(true).setValue(AddExtensions.OUTCOME_UPDATED, result.isSourceUpdated());
+                return QuarkusCommandOutcome.success().setValue(AddExtensions.OUTCOME_UPDATED, result.isSourceUpdated());
             } else if (!extensionInstallPlan.getUnmatchedKeywords().isEmpty()) {
                 invocation.log()
                         .info(ERROR_ICON + " Nothing installed because keyword(s) '"
@@ -87,7 +87,7 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
             throw new QuarkusCommandException("Failed to add extensions", e);
         }
 
-        return new QuarkusCommandOutcome(false).setValue(AddExtensions.OUTCOME_UPDATED, false);
+        return QuarkusCommandOutcome.failure("see logs above for more details").setValue(AddExtensions.OUTCOME_UPDATED, false);
     }
 
     public ExtensionInstallPlan planInstallation(QuarkusCommandInvocation invocation, Collection<String> keywords)

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/RemoveExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/RemoveExtensionsCommandHandler.java
@@ -34,7 +34,7 @@ public class RemoveExtensionsCommandHandler implements QuarkusCommandHandler {
 
         final List<ArtifactCoords> extensionsToRemove = computeCoordsFromQuery(invocation, extensionsQuery);
         if (extensionsToRemove == null) {
-            return new QuarkusCommandOutcome(false).setValue(RemoveExtensions.OUTCOME_UPDATED, false);
+            return QuarkusCommandOutcome.failure("no extensions to remove").setValue(RemoveExtensions.OUTCOME_UPDATED, false);
         }
         final ExtensionManager extensionManager = invocation.getValue(EXTENSION_MANAGER,
                 invocation.getQuarkusProject().getExtensionManager());
@@ -46,7 +46,7 @@ public class RemoveExtensionsCommandHandler implements QuarkusCommandHandler {
                     .forEach(a -> invocation.log()
                             .info(MessageIcons.SUCCESS_ICON + " Extension " + a.getGroupId() + ":" + a.getArtifactId()
                                     + " has been uninstalled"));
-            return new QuarkusCommandOutcome(true).setValue(RemoveExtensions.OUTCOME_UPDATED, result.isSourceUpdated());
+            return QuarkusCommandOutcome.success().setValue(RemoveExtensions.OUTCOME_UPDATED, result.isSourceUpdated());
         } catch (IOException e) {
             throw new QuarkusCommandException("Failed to remove extensions", e);
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -51,8 +51,11 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
         if (projectJavaVersion.isEmpty()) {
             String instruction = invocation.getQuarkusProject().getBuildTool().isAnyGradle() ? "java>targetCompatibility"
                     : "maven.compiler.release property";
-            invocation.log().error(String.format("Project Java version not detected, set %s to fix the error.", instruction));
-            return QuarkusCommandOutcome.failure();
+            String error = String.format("Project Java version not detected, set %s in your build file to fix the error.",
+                    instruction);
+
+            invocation.log().error(error);
+            return QuarkusCommandOutcome.failure(error);
         } else {
             invocation.log().info("Detected project Java version: %s", projectJavaVersion);
         }
@@ -64,8 +67,10 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                 invocation.getQuarkusProject().getExtensionsCatalog());
         final ArtifactCoords projectQuarkusPlatformBom = getProjectQuarkusPlatformBOM(currentState);
         if (projectQuarkusPlatformBom == null) {
-            invocation.log().error("The project does not import any Quarkus platform BOM");
-            return QuarkusCommandOutcome.failure();
+            String error = "The project does not import any Quarkus platform BOM";
+
+            invocation.log().error(error);
+            return QuarkusCommandOutcome.failure(error);
         }
         if (Objects.equals(projectQuarkusPlatformBom.getVersion(), targetPlatformVersion)) {
             ProjectInfoCommandHandler.logState(currentState, perModule, true, invocation.getQuarkusProject().log());


### PR DESCRIPTION
Sure you can scroll to see the logs but really, we can push the error message to the exception so that you don't have to scroll.