### PR TITLE
Set default value of `quarkus.jacoco.title` to `quarkus.application.name`

### DIFF
--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
@@ -52,7 +52,7 @@ public class JacocoConfig {
     /**
      * Name of the root node HTML report pages.
      */
-    @ConfigItem
+    @ConfigItem(defaultValue = "${quarkus.application.name}")
     public Optional<String> title;
 
     /**


### PR DESCRIPTION
Closes #40993 

`quarkus.jacoco.title` now defaults to `quarkus.application.name`


### Original:
![image](https://github.com/quarkusio/quarkus/assets/405347/1405312b-c0dc-4666-bb74-f3413a4e1a29)

### Expected change:
![image](https://github.com/quarkusio/quarkus/assets/405347/644d8da7-2c49-4656-86d0-7e1127726b9e)


### Additional notes:
- Looks like docs generate automatically:
    - Origin: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/all-config.adoc?plain=1
    - Destination: https://quarkus.io/guides/all-config#quarkus-jacoco_quarkus-jacoco-title
- `./mvnw -Dquickly` completes successfully on local
- It works when doing `%test.quarkus.jacoco.title=${quarkus.application.name}` on new project with current Quarkus version, so in theory the change should work. Unable to test locally if change works (generation report commands do not work on Windows).
