### PR TITLE
Use dependabot to manage github action versions in generated projects

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/dependabot.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
It's a bit tedious for quarkiverse extension owners to deal with warnings about deprecated versions of github actions and manually update them in my quarkiverse project. Since we generate a workflow file as part of the template, and also a dependabot file, I don't see a downside to having dependabot manage the actions versions. 

What do others think?