### PR TITLE
Recompute unsafe ArrayIndexShift vallue in shaded jctools

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -613,6 +613,14 @@ final class Target_SslContext {
     }
 }
 
+@TargetClass(className = "io.netty.util.internal.shaded.org.jctools.util.UnsafeLongArrayAccess")
+final class Target_io_netty_util_internal_shaded_org_jctools_util_UnsafeRefArrayAccess {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.ArrayIndexShift, declClass = Object[].class)
+    public static int LONG_ELEMENT_SHIFT;
+}
+
 class IsBouncyNotThere implements BooleanSupplier {
 
     @Override


### PR DESCRIPTION
Removes warning:

```
Warning: RecomputeFieldValue.ArrayIndexScale automatic substitution
failed. The automatic substitution registration was attempted because a
call to jdk.internal.misc.Unsafe.arrayIndexScale(Class) was detected in
the static initializer of
io.netty.util.internal.shaded.org.jctools.util.UnsafeLongArrayAccess. Detailed
failure reason(s): Could not determine the field where the value
produced by the call to jdk.internal.misc.Unsafe.arrayIndexScale(Class)
for the array index scale computation is stored. The call is not
directly followed by a field store or by a sign extend node followed
directly by a field store.
```

See https://github.com/quarkusio/quarkus/actions/runs/9544560942/job/26304099563#step:16:465

Closes https://github.com/Karm/mandrel-integration-tests/issues/260