### PR TITLE
Register `java.sql.*isClosed` methods for reflection

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -2,7 +2,10 @@ package io.quarkus.agroal.deployment;
 
 import static io.quarkus.deployment.Capability.OPENTELEMETRY_TRACER;
 
+import java.sql.Connection;
 import java.sql.Driver;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -60,6 +63,7 @@ import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.narayana.jta.deployment.NarayanaInitBuildItem;
@@ -420,5 +424,16 @@ class AgroalProcessor {
         reflectiveClassProducer.produce(ReflectiveClassBuildItem.builder(
                 "com.sun.rowset.providers.RIOptimisticProvider",
                 "com.sun.rowset.providers.RIXMLProvider").build());
+    }
+
+    /**
+     * Required with GraalVM for JDK 23 and up
+     */
+    @BuildStep()
+    List<ReflectiveMethodBuildItem> registerIsClosedMethod() {
+        return List.of(
+                new ReflectiveMethodBuildItem(Statement.class.getName(), "isClosed", new Class[0]),
+                new ReflectiveMethodBuildItem(Connection.class.getName(), "isClosed", new Class[0]),
+                new ReflectiveMethodBuildItem(ResultSet.class.getName(), "isClosed", new Class[0]));
     }
 }


### PR DESCRIPTION
These methods are reflectively accessed starting with GraalVM for JDK
23, due to https://bugs.openjdk.org/browse/JDK-8229959 AFAIU.

Resolves errors in integration tests, see https://github.com/graalvm/mandrel/actions/runs/9540048142/job/26291954634#step:12:608