### PR TITLE
Don't force flush mode to FlushMode.ALWAYS

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/JTASessionOpener.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/JTASessionOpener.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.orm.runtime.session;
 
-import org.hibernate.FlushMode;
 import org.hibernate.Session;
 import org.hibernate.SessionBuilder;
 import org.hibernate.SessionFactory;
@@ -31,8 +30,7 @@ public class JTASessionOpener {
         return sessionFactory.withOptions()
                 .autoClose(true) // .owner() is deprecated as well, so it looks like we need to rely on deprecated code...
                 .connectionHandlingMode(
-                        PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION)
-                .flushMode(FlushMode.ALWAYS);
+                        PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION);
     }
 
     private final SessionFactory sessionFactory;


### PR DESCRIPTION
Leave the flush mode to its default value in Hibernate ORM, which should smartly flush when necessary, and no more.

Discussed with more knowledgeable people [here](https://hibernate.zulipchat.com/#narrow/stream/132094-hibernate-orm-dev/topic/FlushMode.2EALWAYS), and this seems like the right thing to do. I wouldn't backport though, as you can expect some behavior changes -- though mostly (only?) for the better.

Fixes #41115 