### PR TITLE
Work around config doc issues for LGTM

### DIFF
--- a/extensions/observability-devservices/common/pom.xml
+++ b/extensions/observability-devservices/common/pom.xml
@@ -24,4 +24,22 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This is not an extension but we need to generate the config doc -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/ContainerConfig.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/ContainerConfig.java
@@ -3,8 +3,11 @@ package io.quarkus.observability.common.config;
 import java.util.Optional;
 import java.util.Set;
 
+import io.quarkus.runtime.annotations.ConfigDocIgnore;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
+@ConfigGroup
 public interface ContainerConfig {
 
     /**
@@ -19,7 +22,10 @@ public interface ContainerConfig {
 
     /**
      * The container image name to use, for container based DevServices providers.
+     * <p>
+     * Ignored for the config doc here as a more precise value will be defined in subinterfaces.
      */
+    @ConfigDocIgnore
     String imageName();
 
     /**
@@ -38,9 +44,10 @@ public interface ContainerConfig {
 
     /**
      * Network aliases.
-     *
-     * @return metwork aliases
+     * <p>
+     * Ignored for the config doc here as a more precise value will be defined in subinterfaces.
      */
+    @ConfigDocIgnore
     Optional<Set<String>> networkAliases();
 
     /**
@@ -51,7 +58,10 @@ public interface ContainerConfig {
      * starts a new container with this label set to the specified value.
      * <p>
      * This property is used when you need multiple shared containers.
+     * <p>
+     * Ignored for the config doc here as a more precise value will be defined in subinterfaces.
      */
+    @ConfigDocIgnore
     String label();
 
     /**

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/GrafanaConfig.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/GrafanaConfig.java
@@ -2,32 +2,33 @@ package io.quarkus.observability.common.config;
 
 import java.time.Duration;
 
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
+@ConfigGroup
 public interface GrafanaConfig extends ContainerConfig {
 
-    // copied from ContainerConfig, config hierarchy workaround
-
-    @WithDefault("true")
-    boolean enabled();
-
-    @WithDefault("true")
-    boolean shared();
-
-    @WithDefault("quarkus")
-    String serviceName();
-
-    // ---
-
+    /**
+     * The username.
+     */
     @WithDefault("admin")
     String username();
 
+    /**
+     * The password.
+     */
     @WithDefault("admin")
     String password();
 
+    /**
+     * The port of the Grafana container.
+     */
     @WithDefault("3000")
     int grafanaPort();
 
+    /**
+     * The timeout.
+     */
     @WithDefault("PT1M")
     Duration timeout();
 }

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
@@ -9,15 +9,28 @@ import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface LgtmConfig extends GrafanaConfig {
+
+    /**
+     * The name of the Grafana LGTM Docker image.
+     */
     @WithDefault(ContainerConstants.LGTM)
     String imageName();
 
+    /**
+     * The Docker network aliases.
+     */
     @WithDefault("lgtm,lgtm.testcontainer.docker")
     Optional<Set<String>> networkAliases();
 
+    /**
+     * The label of the container.
+     */
     @WithDefault("quarkus-dev-service-lgtm")
     String label();
 
+    /**
+     * The port on which LGTM's OTLP port will be exposed.
+     */
     @WithDefault("4318")
     int otlpPort();
 }

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/ModulesConfiguration.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/ModulesConfiguration.java
@@ -1,8 +1,14 @@
 package io.quarkus.observability.common.config;
 
 import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.smallrye.config.ConfigMapping;
 
+@ConfigMapping
 public interface ModulesConfiguration {
+
+    /**
+     * Grafana LGTM configuration
+     */
     @ConfigDocSection
     LgtmConfig lgtm();
 }

--- a/extensions/observability-devservices/runtime/pom.xml
+++ b/extensions/observability-devservices/runtime/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>quarkus-observability-devservices</artifactId>
-    <name>Quarkus - Observability Dev Services - Runtime</name>
+    <name>Quarkus - Observability Dev Services</name>
     <description>Serve and consume Observability Dev Services</description>
     <dependencies>
         <dependency>


### PR DESCRIPTION
There are several issues:
- first, the config doc processor is part of the extension processor for now, so you need to run it to analyze the config.
- second we need to mark at least one class with @ConfigMapping, otherwise the config groups cannot be analyzed as part of config mappings. This will go away in the future.
- then, the hierarchy here is quite weird with some methods overriding others, which is fine, except this is not properly handled in the config doc generator. For now, I just ignored the ones from the parent, but ideally, we should override them properly in the config doc generator.
- also I removed some inherited methods from GrafanaConfig and I'm not yet sure if it will break something so creating as draft.

Fixes #41285