### PR TITLE
Provide keyringName configuration to OIDC CredentialsProvider lookup 

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -133,6 +133,8 @@ quarkus.oidc.client-id=quarkus-app
 
 # This is a key which will be used to retrieve a secret from the map of credentials returned from CredentialsProvider
 quarkus.oidc.credentials.client-secret.provider.key=mysecret-key
+# This is the keyring provided to the CredentialsProvider when looking up the secret, set only if required by the CredentialsProvider implementation
+quarkus.oidc.credentials.client-secret.provider.keyring-name=oidc
 # Set it only if more than one CredentialsProvider can be registered
 quarkus.oidc.credentials.client-secret.provider.name=oidc-credentials-provider
 ----
@@ -165,6 +167,8 @@ quarkus.oidc.client-id=quarkus-app
 
 # This is a key which will be used to retrieve a secret from the map of credentials returned from CredentialsProvider
 quarkus.oidc.credentials.jwt.secret-provider.key=mysecret-key
+# This is the keyring provided to the CredentialsProvider when looking up the secret, set only if required by the CredentialsProvider implementation
+quarkus.oidc.credentials.client-secret.provider.keyring-name=oidc
 # Set it only if more than one CredentialsProvider can be registered
 quarkus.oidc.credentials.jwt.secret-provider.name=oidc-credentials-provider
 ----

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -725,6 +725,8 @@ quarkus.oidc-client.client-id=quarkus-app
 
 # This key is used to retrieve a secret from the map of credentials returned from CredentialsProvider
 quarkus.oidc-client.credentials.client-secret.provider.key=mysecret-key
+# This is the keyring provided to the CredentialsProvider when looking up the secret, set only if required by the CredentialsProvider implementation
+quarkus.oidc.credentials.client-secret.provider.keyring-name=oidc
 # Set it only if more than one CredentialsProvider can be registered
 quarkus.oidc-client.credentials.client-secret.provider.name=oidc-credentials-provider
 ----
@@ -757,6 +759,8 @@ quarkus.oidc-client.client-id=quarkus-app
 
 # This is a key that will be used to retrieve a secret from the map of credentials returned from CredentialsProvider
 quarkus.oidc-client.credentials.jwt.secret-provider.key=mysecret-key
+# This is the keyring provided to the CredentialsProvider when looking up the secret, set only if required by the CredentialsProvider implementation
+quarkus.oidc.credentials.client-secret.provider.keyring-name=oidc
 # Set it only if more than one CredentialsProvider can be registered
 quarkus.oidc-client.credentials.jwt.secret-provider.name=oidc-credentials-provider
 ----

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
@@ -5,4 +5,5 @@ quarkus.oidc.credentials.secret=secret
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.client-id=${quarkus.oidc.client-id}
 quarkus.oidc-client.credentials.client-secret.provider.name=vault-secret-provider
+quarkus.oidc-client.credentials.client-secret.provider.keyring-name=oidc
 quarkus.oidc-client.credentials.client-secret.provider.key=secret-from-vault

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -467,11 +467,21 @@ public class OidcCommonConfig {
         public static class Provider {
 
             /**
-             * The CredentialsProvider name, which should only be set if more than one CredentialsProvider is
+             * The CredentialsProvider bean name, which should only be set if more than one CredentialsProvider is
              * registered
              */
             @ConfigItem
             public Optional<String> name = Optional.empty();
+
+            /**
+             * The CredentialsProvider keyring name.
+             * The keyring name is only required when the CredentialsProvider being
+             * used requires the keyring name to look up the secret, which is often the case when a CredentialsProvider is
+             * shared by multiple extensions to retrieve credentials from a more dynamic source like a vault instance or secret
+             * manager
+             */
+            @ConfigItem
+            public Optional<String> keyringName = Optional.empty();
 
             /**
              * The CredentialsProvider client secret key
@@ -485,6 +495,14 @@ public class OidcCommonConfig {
 
             public void setName(String name) {
                 this.name = Optional.of(name);
+            }
+
+            public Optional<String> getKeyringName() {
+                return keyringName;
+            }
+
+            public void setKeyringName(String keyringName) {
+                this.keyringName = Optional.of(keyringName);
             }
 
             public Optional<String> getKey() {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -319,10 +319,9 @@ public class OidcCommonUtils {
             public String get() {
                 if (provider.key.isPresent()) {
                     String providerName = provider.name.orElse(null);
+                    String keyringName = provider.keyringName.orElse(null);
                     CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(providerName);
-                    if (credentialsProvider != null) {
-                        return credentialsProvider.getCredentials(providerName).get(provider.key.get());
-                    }
+                    return credentialsProvider.getCredentials(keyringName).get(provider.key.get());
                 }
                 return null;
             }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/SecretProvider.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/SecretProvider.java
@@ -14,7 +14,11 @@ public class SecretProvider implements CredentialsProvider {
 
     @Override
     public Map<String, String> getCredentials(String credentialsProviderName) {
-        return Collections.singletonMap("secret-from-vault", "secret");
+        if ("oidc".equals(credentialsProviderName)) {
+            return Collections.singletonMap("secret-from-vault", "secret");
+        } else {
+            return Map.of();
+        }
     }
 
 }

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -2,6 +2,7 @@ quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-enabled=false
 quarkus.oidc.client-id=${oidc.client-id}
 quarkus.oidc.credentials.client-secret.provider.name=vault-secret-provider
+quarkus.oidc.credentials.client-secret.provider.keyring-name=oidc
 # This is a wrong client secret key, will be updated to 'secret-from-vault' in the dev mode test
 quarkus.oidc.credentials.client-secret.provider.key=secret-from-vault-typo
 quarkus.oidc.application-type=web-app


### PR DESCRIPTION
Fixes #41265

- Removes redundant null-check on value returned by `CredentialsProviderFinder.find(String)`
- Modifies test to verify the appropriate keyring is provided to the `CredentialsProvider` test implementation
  - Took a slightly different strategy here than suggested in #41265, as concatenating the keyring name to the key would mean that the `Map.get(String)` call on [this line](https://github.com/quarkusio/quarkus/blob/d070b8128e8ebb4bb4330a6d5fe199bede9f73c6/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java#L324) would return `null` because the extension expects the map key to be the configured value for `quarkus.oidc.credentials.client-secret.provider.key`. Instead, we verify this functionality by only returning the stubbed secret in the `Map` if the keyring name matches our expectations. I think this is desirable as it more maps to how a production-like `CredentialsProvider` implementation would work.
 - Modifies the `OidcCommonUtils` logic to use the configured `keyringName`, or `null` to look up the OIDC client secret from the `CredentialsProvider`, as suggested by @sberyozkin in #41265. I wasn't sure if we should instead access this optional value by wrapping the codeblock in a `Optional.isPresent` check, like we do for the provider key config item, but happy to follow the suggestions of the Quarkus team.
- Updates documentation to reflect the new config item required to use the OIDC extension with a `CredentialsProvider`


Let me know if there's anything else I can do! 