### PR TITLE
QuarkusComponentTest: fix `@InjectMock` inconsistency

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1682,7 +1682,8 @@ Finally, the CDI request context is activated and terminated per each test metho
 
 Test class fields annotated with `@jakarta.inject.Inject` and `@io.quarkus.test.InjectMock` are injected after a test instance is created.
 Dependent beans injected into these fields are correctly destroyed before a test instance is destroyed.
-Parameters of a test method for which a matching bean exists are resolved unless annotated with `@io.quarkus.test.component.SkipInject`.
+Parameters of a test method for which a matching bean exists are resolved unless annotated with `@io.quarkus.test.component.SkipInject` or `@org.mockito.Mock`.
+There are also some JUnit built-in parameters, such as `RepetitionInfo` and `TestInfo`, which are skipped automatically.
 Dependent beans injected into the test method arguments are correctly destroyed after the test method completes.
 
 NOTE: Arguments of a `@ParameterizedTest` method that are provided by an `ArgumentsProvider`, for example with `@org.junit.jupiter.params.provider.ValueArgumentsProvider`, must be annotated with `@SkipInject`. 
@@ -1694,6 +1695,34 @@ Instead, a synthetic bean is registered automatically for each combination of re
 The bean has the `@Singleton` scope so it's shared across all injection points with the same required type and qualifiers.
 The injected reference is an _unconfigured_ Mockito mock.
 You can inject the mock in your test using the `io.quarkus.test.InjectMock` annotation and leverage the Mockito API to configure the behavior.
+
+[NOTE]
+====
+`@InjectMock` is not intended as a universal replacement for functionality provided by the Mockito JUnit extension.
+It's meant to be used for configuration of unsatisfied dependencies of CDI beans.
+You can use the `QuarkusComponentTest` and `MockitoExtension` side by side.
+
+[source, java]
+----
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@QuarkusComponentTest
+public class FooTest {
+
+    @TestConfigProperty(key = "bar", value = "true")
+    @Test
+    public void testPing(Foo foo, @InjectMock Charlie charlieMock, @Mock Ping ping) { 
+        Mockito.when(ping.pong()).thenReturn("OK");
+        Mockito.when(charlieMock.ping()).thenReturn(ping);
+        assertEquals("OK", foo.ping());
+    }
+}
+----
+
+====
 
 === Custom Mocks For Unsatisfied Dependencies
 

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/mockito/MockitoExtensionTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/mockito/MockitoExtensionTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.test.component.mockito;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class MockitoExtensionTest {
+
+    // Bar - component under test, real bean
+    // Baz - mock of the synthetic bean registered to satisfy Bar#baz
+    // Foo - plain Mockito mock
+    @ExtendWith(MockitoExtension.class)
+    @Test
+    public void testInjectMock(Bar bar, @InjectMock Baz baz, @Mock Foo foo) {
+        Mockito.when(foo.pong()).thenReturn(false);
+        Mockito.when(baz.ping()).thenReturn(foo);
+        assertFalse(bar.ping().pong());
+    }
+
+    @Singleton
+    public static class Bar {
+
+        @Inject
+        Baz baz;
+
+        Foo ping() {
+            return baz.ping();
+        }
+
+    }
+
+    public static class Baz {
+
+        Foo ping() {
+            return null;
+        }
+
+    }
+
+    public static class Foo {
+
+        boolean pong() {
+            return true;
+        }
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectMockTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectMockTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.test.component.paraminject;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class ParameterInjectMockTest {
+
+    // Foo is mocked even if it's not a dependency of a tested component
+    @Test
+    public void testInjectMock(@InjectMock MyFoo foo) {
+        Mockito.when(foo.ping()).thenReturn(false);
+        assertFalse(foo.ping());
+    }
+
+    public static class MyFoo {
+
+        boolean ping() {
+            return true;
+        }
+    }
+
+}


### PR DESCRIPTION
- take into consideration method params with `@InjectMock` when marking beans as unremovable
- document that `@InjectMock` is not intended as a universal replacement for the functionality provided by the Mockito JUnit extension.
- also skip param injection for params annotated with `@org.mockito.Mock` so that `@SkipInject` is not needed.
- fixes #41224