### PR TITLE
Modernize WatchServiceFileSystemWatcher and watch .env for dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -249,13 +249,17 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                             periodicTestCompile();
                         }
                     };
+                    // monitor .env as it can impact test execution
+                    testClassChangeWatcher.watchFiles(Path.of(context.getApplicationRoot().getProjectDirectory()),
+                            List.of(Path.of(".env")),
+                            callback);
                     Set<Path> nonExistent = new HashSet<>();
                     for (DevModeContext.ModuleInfo module : context.getAllModules()) {
                         for (Path path : module.getMain().getSourcePaths()) {
-                            testClassChangeWatcher.watchPath(path.toFile(), callback);
+                            testClassChangeWatcher.watchDirectoryRecursively(path, callback);
                         }
                         for (Path path : module.getMain().getResourcePaths()) {
-                            testClassChangeWatcher.watchPath(path.toFile(), callback);
+                            testClassChangeWatcher.watchDirectoryRecursively(path, callback);
                         }
                     }
                     for (DevModeContext.ModuleInfo module : context.getAllModules()) {
@@ -264,14 +268,14 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                                 if (!Files.isDirectory(path)) {
                                     nonExistent.add(path);
                                 } else {
-                                    testClassChangeWatcher.watchPath(path.toFile(), callback);
+                                    testClassChangeWatcher.watchDirectoryRecursively(path, callback);
                                 }
                             }
                             for (Path path : module.getTest().get().getResourcePaths()) {
                                 if (!Files.isDirectory(path)) {
                                     nonExistent.add(path);
                                 } else {
-                                    testClassChangeWatcher.watchPath(path.toFile(), callback);
+                                    testClassChangeWatcher.watchDirectoryRecursively(path, callback);
                                 }
                             }
                         }
@@ -287,7 +291,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                                         Path i = iterator.next();
                                         if (Files.isDirectory(i)) {
                                             iterator.remove();
-                                            testClassChangeWatcher.watchPath(i.toFile(), callback);
+                                            testClassChangeWatcher.watchDirectoryRecursively(i, callback);
                                             added = true;
                                         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filesystem/watch/FileChangeEvent.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filesystem/watch/FileChangeEvent.java
@@ -1,6 +1,6 @@
 package io.quarkus.deployment.dev.filesystem.watch;
 
-import java.io.File;
+import java.nio.file.Path;
 
 /**
  * The event object that is fired when a file system change is detected.
@@ -10,7 +10,7 @@ import java.io.File;
  */
 public class FileChangeEvent {
 
-    private final File file;
+    private final Path file;
     private final Type type;
 
     /**
@@ -19,7 +19,7 @@ public class FileChangeEvent {
      * @param file the file which is being watched
      * @param type the type of event that was encountered
      */
-    public FileChangeEvent(File file, Type type) {
+    public FileChangeEvent(Path file, Type type) {
         this.file = file;
         this.type = type;
     }
@@ -29,7 +29,7 @@ public class FileChangeEvent {
      *
      * @return the file which was being watched
      */
-    public File getFile() {
+    public Path getFile() {
         return file;
     }
 


### PR DESCRIPTION
Fixes #41282

I can't say I'm a big fan of the fix but we will have to live with this for now.

@stuartwdouglas while working on this, I stumbled upon a small issue: if we are filtering tests, the counter of run tests (`All 5 tests are passing (0 skipped)`) is not updated when we add filters (even when we force a re-run).
My understanding is that we actually don't clear the test results but only push diffs to the test results (in `TestState`). I wonder if when we fully rerun the tests, we should actually clear the status but I'm not entirely sure, that's what you wanted?
The reproducer here is quite useful: https://github.com/flyinfish/quarkus--continuous-testing-dotenv . Run dev mode, then uncomment the filters in `src/main/resources/application.properties` and you should see the problem.

@radcortez at some point, we should probably think of a way to achieve this in a fully supported manner as this thing is quite brittle :). Not sure it's high priority though.

