### PR TITLE
Update SmallRye Config to 3.8.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>3.1.1</microprofile-openapi.version>
         <smallrye-common.version>2.3.0</smallrye-common.version>
-        <smallrye-config.version>3.8.2</smallrye-config.version>
+        <smallrye-config.version>3.8.3</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>3.10.0</smallrye-open-api.version>


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.8.3</h2>
    <ul>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1180">#1180</a> Env matching names before mappings</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1179">#1179</a> Remove TestNG</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1177">#1177</a> Bump version.curator from 5.6.0 to 5.7.0</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1176">#1176</a> fix factory generic</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1147">#1175</a> Improve message on mapping generation failure</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1174">#1174</a> Bump io.smallrye:smallrye-parent from 43 to 44</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1172">#1172</a> Bump org.apache.maven.plugins:maven-shade-plugin from 3.5.3 to 3.6.0</li>
    </ul>
</blockquote>

<summary>Quarkus:</summary>

- Fixes #41296 
- Fixes #41344
