### PR TITLE
[3.8] Bump kafka3.version from 3.6.1 to 3.7.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -149,7 +149,7 @@
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>
         <mutiny.version>2.5.8</mutiny.version>
-        <kafka3.version>3.6.1</kafka3.version>
+        <kafka3.version>3.7.0</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
         <snappy.version>1.1.10.5</snappy.version>
         <strimzi-test-container.version>0.100.0</strimzi-test-container.version>

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -96,6 +96,12 @@ class KafkaStreamsProcessor {
         reflectiveClasses.produce(ReflectiveClassBuildItem
                 .builder("org.apache.kafka.streams.processor.internals.StateDirectory$StateDirectoryProcessFile")
                 .methods().fields().build());
+
+        // Listed in BuiltInDslStoreSuppliers
+        reflectiveClasses.produce(ReflectiveClassBuildItem
+                .builder("org.apache.kafka.streams.state.BuiltInDslStoreSuppliers$RocksDBDslStoreSuppliers",
+                        "org.apache.kafka.streams.state.BuiltInDslStoreSuppliers$InMemoryDslStoreSuppliers")
+                .build());
     }
 
     private void registerClassesThatClientMaySpecify(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
@@ -103,6 +109,16 @@ class KafkaStreamsProcessor {
         Properties properties = buildKafkaStreamsProperties(launchMode.getLaunchMode());
         registerExceptionHandler(reflectiveClasses, properties);
         registerDefaultSerdes(reflectiveClasses, properties);
+        registerDslStoreSupplier(reflectiveClasses, properties);
+    }
+
+    private void registerDslStoreSupplier(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+            Properties kafkaStreamsProperties) {
+        String dlsStoreSupplierClassName = kafkaStreamsProperties.getProperty("dsl.store.suppliers.class");
+
+        if (dlsStoreSupplierClassName != null) {
+            registerClassName(reflectiveClasses, dlsStoreSupplierClassName);
+        }
     }
 
     private void registerExceptionHandler(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,


### PR DESCRIPTION
Kafka Streams register DslStoreSuppliers for reflective access in native