### PR TITLE
Update kindcontainer to 1.4.6

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -201,7 +201,7 @@
         <docker-java.version>3.3.6</docker-java.version> <!-- must be the version Testcontainers use -->
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.0.0</opensearch-testcontainers.version>
-        <com.dajudge.kindcontainer>1.4.5</com.dajudge.kindcontainer>
+        <com.dajudge.kindcontainer>1.4.6</com.dajudge.kindcontainer>
         <aesh.version>2.8.2</aesh.version>
         <aesh-readline.version>2.6</aesh-readline.version>
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with aesh-readline and dekorate -->


### PR DESCRIPTION
Bumping kindcontainer if possible, CI tests seem to be all ok https://github.com/gonmmarques/quarkus/actions/runs/9595047219

I noticed also that it seems the dependabot is not opening PR for this dependency, should it be added?
