### PR TITLE
Add launch instructions to command mode guide

### DIFF
--- a/docs/src/main/asciidoc/command-mode-reference.adoc
+++ b/docs/src/main/asciidoc/command-mode-reference.adoc
@@ -137,6 +137,24 @@ thread (A non-command mode application is essentially just running an applicatio
 If you want to shut down a running application and you are not in the main thread, then you should call `Quarkus.asyncExit`
 in order to unblock the main thread and initiate the shutdown process.
 
+=== Running the application 
+
+To run the command mode application on the JVM, first build it using `mvnw package` or equivalent. 
+
+Then launch it:
+
+[source,shell]
+----
+java -jar target/quarkus-app/quarkus-run.jar
+----
+
+You can also build a native application with `mvnw package -Dnative`, and launch it with something like:
+
+[source,shell]
+----
+./target/getting-started-command-mode-1.0-SNAPSHOT-runner
+----
+
 === Development Mode
 
 Also, for command mode applications, the dev mode is supported.


### PR DESCRIPTION
I missed the instructions on how to launch the app. 

Advantages of putting them in: 
- People using this article have all the information they need, and don't need to try searching in their `target` folder to figure out the right invocation 

Disadvantages of putting the commands in:
- The information is available elsewhere, so this is duplication 
- The information isn't 'unique' to command mode 

WDYT?