### PR TITLE
Add new `WithTestResource` annotation and deprecate `QuarkusTestResource`

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/messaging-codestart/java/src/test/java/org/acme/MyMessagingApplicationTest.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/messaging-codestart/java/src/test/java/org/acme/MyMessagingApplicationTest.java
@@ -1,6 +1,6 @@
 package org.acme;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
 

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -700,8 +700,8 @@ This will allow you to test your application even when it is compiled into a nat
 
 . Add the following specific annotation on any class in your integration tests for running integration tests in both JVM or native executables:
 +
-* `@QuarkusTestResource(H2DatabaseTestResource.class)`
-* `@QuarkusTestResource(DerbyDatabaseTestResource.class)`
+* `@WithTestResource(H2DatabaseTestResource.class)`
+* `@WithTestResource(DerbyDatabaseTestResource.class)`
 +
 This ensures that the test suite starts and terminates the managed database in a separate process as required for test execution.
 +
@@ -710,10 +710,10 @@ This ensures that the test suite starts and terminates the managed database in a
 ----
 package my.app.integrationtests.db;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(H2DatabaseTestResource.class)
 public class TestResources {
 }
 ----

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -550,7 +550,7 @@ public class MockGreetingProfile implements QuarkusTestProfile { <1>
      * Additional {@link QuarkusTestResourceLifecycleManager} classes (along with their init params) to be used from this
      * specific test profile.
      *
-     * If this method is not overridden, then only the {@link QuarkusTestResourceLifecycleManager} classes enabled via the {@link io.quarkus.test.common.QuarkusTestResource} class
+     * If this method is not overridden, then only the {@link QuarkusTestResourceLifecycleManager} classes enabled via the {@link io.quarkus.test.common.WithTestResource} class
      * annotation will be used for the tests using this profile (which is the same behavior as tests that don't use a profile at all).
      */
     @Override
@@ -1086,13 +1086,12 @@ If you are using Quarkus Security, check out the xref:security-testing.adoc[Test
 [[quarkus-test-resource]]
 == Starting services before the Quarkus application starts
 
-A very common need is to start some services on which your Quarkus application depends, before the Quarkus application starts for testing. To address this need, Quarkus provides `@io.quarkus.test.common.QuarkusTestResource` and `io.quarkus.test.common.QuarkusTestResourceLifecycleManager`.
+A very common need is to start some services on which your Quarkus application depends, before the Quarkus application starts for testing. To address this need, Quarkus provides `@io.quarkus.test.common.WithTestResource` and `io.quarkus.test.common.QuarkusTestResourceLifecycleManager`.
 
-By simply annotating any test in the test suite with `@QuarkusTestResource`, Quarkus will run the corresponding `QuarkusTestResourceLifecycleManager` before any tests are run.
-A test suite is also free to utilize multiple `@QuarkusTestResource` annotations, in which case all the corresponding `QuarkusTestResourceLifecycleManager` objects will be run before the tests. When using multiple test resources they can be started concurrently. For that you need to set `@QuarkusTestResource(parallel = true)`.
+By simply annotating any test in the test suite with `@WithTestResource`, Quarkus will run the corresponding `QuarkusTestResourceLifecycleManager` before any tests are run.
+A test suite is also free to utilize multiple `@WithTestResource` annotations, in which case all the corresponding `QuarkusTestResourceLifecycleManager` objects will be run before the tests. When using multiple test resources they can be started concurrently. For that you need to set `@WithTestResource(parallel = true)`.
 
-NOTE: Test resources are global, even if they are defined on a test class or custom profile, which means they will all be activated for all tests, even though we do
-remove duplicates. If you want to only enable a test resource on a single test class or test profile, you can use `@QuarkusTestResource(restrictToAnnotatedClass = true)`.
+NOTE: Test resources are applied for a given test class or custom profile. To activate for all tests you can use `@WithTestResource(restrictToAnnotatedClass = false)`.
 
 Quarkus provides a few implementations of `QuarkusTestResourceLifecycleManager` out of the box (see `io.quarkus.test.h2.H2DatabaseTestResource` which starts an H2 database, or `io.quarkus.test.kubernetes.client.KubernetesServerTestResource` which starts a mock Kubernetes API server),
 but it is common to create custom implementations to address specific application needs.
@@ -1109,7 +1108,7 @@ If for example you have a test like the following:
 [source,java]
 ----
 @QuarkusTest
-@QuarkusTestResource(MyWireMockResource.class)
+@WithTestResource(MyWireMockResource.class)
 public class MyTest {
 
     @InjectWireMock // this a custom annotation you are defining in your own application
@@ -1160,7 +1159,7 @@ any necessary injections into the test class.
 
 === Annotation-based test resources
 
-It is possible to write test resources that are enabled and configured using annotations. This is enabled by placing the `@QuarkusTestResource`
+It is possible to write test resources that are enabled and configured using annotations. This is enabled by placing the `@WithTestResource`
 on an annotation which will be used to enable and configure the test resource.
 
 For example, this defines the `@WithKubernetesTestServer` annotation, which you can use on your tests to activate the `KubernetesServerTestResource`,
@@ -1168,7 +1167,7 @@ but only for the annotated test class. You can also place them on your `QuarkusT
 
 [source,java]
 ----
-@QuarkusTestResource(KubernetesServerTestResource.class)
+@WithTestResource(KubernetesServerTestResource.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface WithKubernetesTestServer {
@@ -1212,12 +1211,12 @@ public class KubernetesServerTestResource
 }
 ----
 
-If you want to make the annotation repeatable, the containing annotation type must be annotated with `@QuarkusTestResourceRepeatable`.
+If you want to make the annotation repeatable, the containing annotation type must be annotated with `@WithTestResourceRepeatable`.
 For example, this would define a repeatable `@WithRepeatableTestResource` annotation.
 
 [source,java]
 ----
-@QuarkusTestResource(KubernetesServerTestResource.class)
+@WithTestResource(KubernetesServerTestResource.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Repeatable(WithRepeatableTestResource.List.class)
@@ -1227,7 +1226,7 @@ public @interface WithRepeatableTestResource {
 
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.RUNTIME)
-    @QuarkusTestResourceRepeatable(WithRepeatableTestResource.class)
+    @WithTestResourceRepeatable(WithRepeatableTestResource.class)
     @interface List {
         WithRepeatableTestResource[] value();
     }
@@ -1412,7 +1411,7 @@ public class CustomResource implements QuarkusTestResourceLifecycleManager, DevS
 }
 ----
 
-`CustomResource` would be activated on a `@QuarkusIntegrationTest` using `@QuarkusTestResource` as is described in the corresponding section of this doc.
+`CustomResource` would be activated on a `@QuarkusIntegrationTest` using `@WithTestResource` as is described in the corresponding section of this doc.
 
 === Executing against a running application
 

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -440,7 +440,7 @@ what we send.
 ----
 package org.acme.kafka;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
@@ -607,7 +607,7 @@ public class KafkaAndSchemaRegistryTestResource implements QuarkusTestResourceLi
 [source,java]
 ----
 @QuarkusTest
-@QuarkusTestResource(KafkaAndSchemaRegistryTestResource.class)
+@WithTestResource(KafkaAndSchemaRegistryTestResource.class)
 public class MovieResourceTest {
     ...
 }

--- a/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
@@ -468,7 +468,7 @@ what we send.
 ----
 package org.acme.kafka;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
@@ -635,7 +635,7 @@ public class KafkaAndSchemaRegistryTestResource implements QuarkusTestResourceLi
 [source,java]
 ----
 @QuarkusTest
-@QuarkusTestResource(KafkaAndSchemaRegistryTestResource.class)
+@WithTestResource(KafkaAndSchemaRegistryTestResource.class)
 public class MovieResourceTest {
     ...
 }

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -2236,7 +2236,7 @@ Create a Quarkus Test using the test resource created above:
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaTestResourceLifecycleManager.class)
+@WithTestResource(KafkaTestResourceLifecycleManager.class)
 class BaristaTest {
 
     @Inject
@@ -2295,7 +2295,7 @@ public class BeverageProcessor {
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaTestResourceLifecycleManager.class)
+@WithTestResource(KafkaTestResourceLifecycleManager.class)
 class BaristaTest {
 
     @Inject
@@ -2380,7 +2380,7 @@ For using `KafkaCompanion` API in tests, start by adding the following dependenc
 
 which provides `io.quarkus.test.kafka.KafkaCompanionResource` - an implementation of `io.quarkus.test.common.QuarkusTestResourceLifecycleManager`.
 
-Then use `@QuarkusTestResource` to configure the Kafka Companion in tests, for example:
+Then use `@WithTestResource` to configure the Kafka Companion in tests, for example:
 
 [source, java]
 ----
@@ -2391,7 +2391,7 @@ import java.util.UUID;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
@@ -2399,7 +2399,7 @@ import io.smallrye.reactive.messaging.kafka.companion.ConsumerTask;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaCompanionResource.class)
+@WithTestResource(KafkaCompanionResource.class)
 public class OrderProcessorTest {
 
     @InjectKafkaCompanion // <1>
@@ -2430,7 +2430,7 @@ If the Kafka Dev Service is available during tests, `KafkaCompanionResource` use
 The configuration of the created Kafka broker can be customized using `@ResourceArg`, for example:
 [source,java]
 ----
-@QuarkusTestResource(value = KafkaCompanionResource.class, initArgs = {
+@WithTestResource(value = KafkaCompanionResource.class, initArgs = {
         @ResourceArg(name = "strimzi.kafka.image", value = "quay.io/strimzi-test-container/test-container:0.106.0-kafka-3.7.0"), // Image name
         @ResourceArg(name = "kafka.port", value = "9092"), // Fixed port for kafka, by default it will be exposed on a random port
         @ResourceArg(name = "kraft", value = "true"), // Enable Kraft mode

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -260,7 +260,7 @@ public class MyTest {
 }
 ----
 
-Alternately, you can create an extension of the `KubernetesServerTestResource` class to ensure all your `@QuarkusTest` enabled test classes share the same mock server setup via the `QuarkusTestResource` annotation:
+Alternately, you can create an extension of the `KubernetesServerTestResource` class to ensure all your `@QuarkusTest` enabled test classes share the same mock server setup via the `WithTestResource` annotation:
 
 [source%nowrap,java]
 ----
@@ -278,7 +278,7 @@ public class CustomKubernetesMockServerTestResource extends KubernetesServerTest
 and use this in your other test classes as follows:
 [source%nowrap,java]
 ----
-@QuarkusTestResource(CustomKubernetesMockServerTestResource.class)
+@WithTestResource(CustomKubernetesMockServerTestResource.class)
 @QuarkusTest
 public class KubernetesClientTest {
 
@@ -478,7 +478,7 @@ Mock support is also provided in a similar fashion:
 
 [source, java]
 ----
-@QuarkusTestResource(OpenShiftMockServerTestResource.class)
+@WithTestResource(OpenShiftMockServerTestResource.class)
 @QuarkusTest
 public class OpenShiftClientTest {
 

--- a/docs/src/main/asciidoc/messaging.adoc
+++ b/docs/src/main/asciidoc/messaging.adoc
@@ -703,7 +703,7 @@ Create a `@QuarkusTest` using the test resource created above:
 
 [source, java]
 ----
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import io.smallrye.reactive.messaging.memory.InMemorySink;
@@ -718,7 +718,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
-@QuarkusTestResource(InMemoryConnectorLifecycleManager.class)
+@WithTestResource(InMemoryConnectorLifecycleManager.class)
 class MyMessagingApplicationTest {
 
     @Inject

--- a/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
+++ b/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
@@ -113,11 +113,11 @@ And for the least 'auto-magical' usage in the tests, simply disable both (Dev Re
 quarkus.observability.enabled=false
 ----
 
-And then explicitly list LGTM Dev Resource in the test as a `@QuarkusTestResource` resource:
+And then explicitly list LGTM Dev Resource in the test as a `@WithTestResource` resource:
 [source, java]
 ----
 @QuarkusTest
-@QuarkusTestResource(value = LgtmResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(LgtmResource.class)
 @TestProfile(QuarkusTestResourceTestProfile.class)
 public class LgtmLifecycleTest extends LgtmTestBase {
 }

--- a/docs/src/main/asciidoc/observability-devservices.adoc
+++ b/docs/src/main/asciidoc/observability-devservices.adoc
@@ -20,7 +20,7 @@ NOTE: Each Dev Resource implementation is an `@QuarkusTestResourceLifecycleManag
 
 * explicitly disable Dev Services and enable Dev Resources and use less-heavy concept of starting and stopping Dev Resources
 
-* explicitly disable both Dev Services and Dev Resources, and use Quarkus' `@QuarkusTestResource` testing concept (see Note)
+* explicitly disable both Dev Services and Dev Resources, and use Quarkus' `@WithTestResource` testing concept (see Note)
 
 You can either add Observability extension dependency along with needed Dev Resources dependencies, or you use existing `sinks` - pom.xml files which add Observability extension dependency along with other required dependencies for certain technology stacks; e.g. `victoriametrics` sink would have `quarkus-observability-devresource-victoriametrics` and `quarkus-victoriametrics-client` dependencies already included in the `pom.xml`.
 

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1856,13 +1856,13 @@ testImplementation("org.wiremock:wiremock:$wiremockVersion") <1>
 ----
 <1> Use a proper Wiremock version. All available versions can be found link:https://search.maven.org/artifact/org.wiremock/wiremock[here].
 
-In Quarkus tests when some service needs to be started before the Quarkus tests are ran, we utilize the `@io.quarkus.test.common.QuarkusTestResource`
+In Quarkus tests when some service needs to be started before the Quarkus tests are ran, we utilize the `@io.quarkus.test.common.WithTestResource`
 annotation to specify a `io.quarkus.test.common.QuarkusTestResourceLifecycleManager` which can start the service and supply configuration
 values that Quarkus will use.
 
 [NOTE]
 ====
-For more details about `@QuarkusTestResource` refer to  xref:getting-started-testing.adoc#quarkus-test-resource[this part of the documentation].
+For more details about `@WithTestResource` refer to  xref:getting-started-testing.adoc#quarkus-test-resource[this part of the documentation].
 ====
 
 Let's create an implementation of `QuarkusTestResourceLifecycleManager` called `WiremockExtensions` like so:
@@ -1926,16 +1926,11 @@ The `ExtensionsResourceTest` test class needs to be annotated like so:
 [source,java]
 ----
 @QuarkusTest
-@QuarkusTestResource(WireMockExtensions.class)
+@WithTestResource(WireMockExtensions.class)
 public class ExtensionsResourceTest {
 
 }
 ----
-
-[WARNING]
-====
-`@QuarkusTestResource` applies to all tests, not just `ExtensionsResourceTest`.
-====
 
 == Known limitations
 

--- a/docs/src/main/asciidoc/resteasy-client.adoc
+++ b/docs/src/main/asciidoc/resteasy-client.adoc
@@ -317,11 +317,11 @@ import static org.hamcrest.Matchers.greaterThan;
 import org.acme.rest.client.resources.WireMockExtensionsResource;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(WireMockExtensionsResource.class)
+@WithTestResource(WireMockExtensionsResource.class)
 public class ExtensionsResourceTest {
 
     @Test

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -348,13 +348,13 @@ testImplementation("org.wiremock:wiremock:${wiremock.version}") <1>
 ----
 <1> Use a proper Wiremock version. All available versions can be found link:https://search.maven.org/artifact/org.wiremock/wiremock[here].
 
-In Quarkus tests when some service needs to be started before the Quarkus tests are ran, we utilize the `@io.quarkus.test.common.QuarkusTestResource`
+In Quarkus tests when some service needs to be started before the Quarkus tests are ran, we utilize the `@io.quarkus.test.common.WithTestResource`
 annotation to specify a `io.quarkus.test.common.QuarkusTestResourceLifecycleManager` which can start the service and supply configuration
 values that Quarkus will use.
 
 [NOTE]
 ====
-For more details about `@QuarkusTestResource` refer to xref:getting-started-testing.adoc#quarkus-test-resource[this part of the documentation].
+For more details about `@WithTestResource` refer to xref:getting-started-testing.adoc#quarkus-test-resource[this part of the documentation].
 ====
 
 Let's create an implementation of `QuarkusTestResourceLifecycleManager` called `MockAuthorizationServerTestResource` like so:
@@ -402,14 +402,14 @@ public class MockAuthorizationServerTestResource implements QuarkusTestResourceL
 <5> When all tests have finished, shutdown Wiremock.
 
 
-Your test class needs to be annotated like with `@QuarkusTestResource(MockAuthorizationServerTestResource.class)` to use this `QuarkusTestResourceLifecycleManager`.
+Your test class needs to be annotated like with `@WithTestResource(MockAuthorizationServerTestResource.class)` to use this `QuarkusTestResourceLifecycleManager`.
 
 Below is an example of a test that uses the `MockAuthorizationServerTestResource`.
 
 [source,java]
 ----
 @QuarkusTest
-@QuarkusTestResource(MockAuthorizationServerTestResource.class) // <1>
+@WithTestResource(MockAuthorizationServerTestResource.class) // <1>
 class TokenSecuredResourceTest {
     // use whatever token you want as the mock OAuth server will accept all tokens
     private static final String BEARER_TOKEN = "337aab0f-b547-489b-9dbd-a54dc7bdf20d"; // <2>
@@ -441,13 +441,6 @@ class TokenSecuredResourceTest {
 <1> Use the previously created `MockAuthorizationServerTestResource` as a Quarkus test resource.
 <2> Define whatever token you want, it will not be validated by the OAuth2 mock authorization server.
 <3> Use this token inside the `Authorization` header to trigger OAuth2 authentication.
-
-
-[WARNING]
-====
-`@QuarkusTestResource` applies to all tests, not just `TokenSecuredResourceTest`.
-====
-
 
 == References
 

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -617,14 +617,14 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 import io.smallrye.jwt.build.Jwt;
 
 @QuarkusTest
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(OidcWiremockTestResource.class)
 public class BearerTokenAuthorizationTest {
 
     @Test
@@ -926,13 +926,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(KeycloakTestResourceLifecycleManager.class)
 public class BearerTokenAuthorizationTest {
 
     @Test

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1754,12 +1754,12 @@ import org.htmlunit.WebClient;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 
 @QuarkusTest
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(OidcWiremockTestResource.class)
 public class CodeFlowAuthorizationTest {
 
     @Test
@@ -1822,7 +1822,7 @@ quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 ----
 
 Finally, write a test code the same way as it is described in the <<integration-testing-wiremock,Wiremock>> section.
-The only difference is that `@QuarkusTestResource` is no longer needed:
+The only difference is that `@WithTestResource` is no longer needed:
 
 [source, java]
 ----
@@ -1878,14 +1878,14 @@ Then, configure the Maven Surefire plugin as follows (and similarly the Maven Fa
 ----
 
 Now, set the configuration and write the test code the same way as it is described in the <<integration-testing-wiremock,Wiremock>> section.
-The only difference is the name of `QuarkusTestResource`:
+The only difference is the name of `WithTestResource`:
 
 [source, java]
 ----
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(KeycloakTestResourceLifecycleManager.class)
 public class CodeFlowAuthorizationTest {
 }
 ----

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/TestResources.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.agroal.test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/CacheTest.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/CacheTest.java
@@ -5,11 +5,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.elytron.security.ldap.rest.SingleRoleSecuredServlet;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.ldap.LdapServerTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(LdapServerTestResource.class)
+@WithTestResource(value = LdapServerTestResource.class, restrictToAnnotatedClass = false)
 public class CacheTest {
     protected static Class[] testClasses = {
             SingleRoleSecuredServlet.class

--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/LdapSecurityRealmTest.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/LdapSecurityRealmTest.java
@@ -9,7 +9,7 @@ import io.quarkus.elytron.security.ldap.rest.RolesEndpointClassLevel;
 import io.quarkus.elytron.security.ldap.rest.SingleRoleSecuredServlet;
 import io.quarkus.elytron.security.ldap.rest.SubjectExposingResource;
 import io.quarkus.elytron.security.ldap.rest.TestApplication;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.ldap.LdapServerTestResource;
 import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
@@ -18,7 +18,7 @@ import io.restassured.specification.RequestSpecification;
  * Tests of BASIC authentication mechanism with the minimal config required
  */
 
-@QuarkusTestResource(LdapServerTestResource.class)
+@WithTestResource(value = LdapServerTestResource.class, restrictToAnnotatedClass = false)
 public abstract class LdapSecurityRealmTest {
 
     protected static Class[] testClasses = {

--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/SearchRecursiveTest.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/SearchRecursiveTest.java
@@ -5,11 +5,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.elytron.security.ldap.rest.SingleRoleSecuredServlet;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.ldap.LdapServerTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(LdapServerTestResource.class)
+@WithTestResource(value = LdapServerTestResource.class, restrictToAnnotatedClass = false)
 public class SearchRecursiveTest {
 
     protected static Class[] testClasses = {

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayTestResources.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayTestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.flyway.test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class FlywayTestResources {
 }

--- a/extensions/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseTestResources.java
+++ b/extensions/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseTestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.liquibase.test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class LiquibaseTestResources {
 }

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/NamedOidcClientFilterDevModeTest.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/NamedOidcClientFilterDevModeTest.java
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class NamedOidcClientFilterDevModeTest {
 
     private static final Class<?>[] testClasses = {

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientFilterDevModeTest.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/OidcClientFilterDevModeTest.java
@@ -19,11 +19,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class OidcClientFilterDevModeTest {
 
     private static final Class<?>[] testClasses = {

--- a/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/GraphQLClientUsingOidcClientTest.java
+++ b/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/GraphQLClientUsingOidcClientTest.java
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class GraphQLClientUsingOidcClientTest {
 
     private static final Class<?>[] testClasses = {

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/NamedOidcClientFilterDevModeTest.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/NamedOidcClientFilterDevModeTest.java
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class NamedOidcClientFilterDevModeTest {
 
     private static final Class<?>[] testClasses = {

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientInjectionTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientInjectionTestCase.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakRealmUserPasswordManager.class)
+@WithTestResource(value = KeycloakRealmUserPasswordManager.class, restrictToAnnotatedClass = false)
 public class NamedOidcClientInjectionTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtPrivateKeyStoreTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtPrivateKeyStoreTestCase.java
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakRealmClientCredentialsJwtPrivateKeyStoreManager.class)
+@WithTestResource(value = KeycloakRealmClientCredentialsJwtPrivateKeyStoreManager.class, restrictToAnnotatedClass = false)
 public class OidcClientCredentialsJwtPrivateKeyStoreTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtPrivateKeyTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtPrivateKeyTestCase.java
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakRealmClientCredentialsJwtPrivateKeyManager.class)
+@WithTestResource(value = KeycloakRealmClientCredentialsJwtPrivateKeyManager.class, restrictToAnnotatedClass = false)
 public class OidcClientCredentialsJwtPrivateKeyTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtSecretTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtSecretTestCase.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakRealmClientCredentialsJwtSecretManager.class)
+@WithTestResource(value = KeycloakRealmClientCredentialsJwtSecretManager.class, restrictToAnnotatedClass = false)
 public class OidcClientCredentialsJwtSecretTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsTestCase.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakRealmClientCredentialsManager.class)
+@WithTestResource(value = KeycloakRealmClientCredentialsManager.class, restrictToAnnotatedClass = false)
 public class OidcClientCredentialsTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientUserPasswordCustomFilterTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientUserPasswordCustomFilterTestCase.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakRealmUserPasswordCustomFilterManager.class)
+@WithTestResource(value = KeycloakRealmUserPasswordCustomFilterManager.class, restrictToAnnotatedClass = false)
 public class OidcClientUserPasswordCustomFilterTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientUserPasswordTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientUserPasswordTestCase.java
@@ -14,11 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 
-@QuarkusTestResource(KeycloakRealmUserPasswordManager.class)
+@WithTestResource(value = KeycloakRealmUserPasswordManager.class, restrictToAnnotatedClass = false)
 public class OidcClientUserPasswordTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenAnnotationTest.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenAnnotationTest.java
@@ -20,12 +20,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.oidc.token.propagation.AccessToken;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.oidc.client.OidcTestClient;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class AccessTokenAnnotationTest {
 
     final static OidcTestClient client = new OidcTestClient();

--- a/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationTest.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class OidcTokenPropagationTest {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationWithSecurityIdentityAugmentorLazyAuthTest.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationWithSecurityIdentityAugmentorLazyAuthTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class OidcTokenPropagationWithSecurityIdentityAugmentorLazyAuthTest {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationWithSecurityIdentityAugmentorTest.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/test/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationWithSecurityIdentityAugmentorTest.java
@@ -17,11 +17,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class OidcTokenPropagationWithSecurityIdentityAugmentorTest {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/AccessTokenAnnotationTest.java
+++ b/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/AccessTokenAnnotationTest.java
@@ -19,12 +19,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Unremovable;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.oidc.client.OidcTestClient;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class AccessTokenAnnotationTest {
 
     final static OidcTestClient client = new OidcTestClient();

--- a/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/OidcTokenPropagationTest.java
+++ b/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/OidcTokenPropagationTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.oidc.client.OidcTestClient;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class OidcTokenPropagationTest {
 
     final static OidcTestClient client = new OidcTestClient();

--- a/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/OidcTokenPropagationWithSecurityIdentityAugmentorLazyAuthTest.java
+++ b/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/OidcTokenPropagationWithSecurityIdentityAugmentorLazyAuthTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class OidcTokenPropagationWithSecurityIdentityAugmentorLazyAuthTest {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/OidcTokenPropagationWithSecurityIdentityAugmentorTest.java
+++ b/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/OidcTokenPropagationWithSecurityIdentityAugmentorTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class OidcTokenPropagationWithSecurityIdentityAugmentorTest {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeDefaultTenantTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeDefaultTenantTestCase.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class CodeFlowDevModeDefaultTenantTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -40,11 +40,11 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class CodeFlowDevModeTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyAccessTokenDisabledTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyAccessTokenDisabledTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class CodeFlowVerifyAccessTokenDisabledTest {
 
     @RegisterExtension

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyInjectedAccessTokenDisabledTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyInjectedAccessTokenDisabledTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class CodeFlowVerifyInjectedAccessTokenDisabledTest {
 
     @RegisterExtension

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeTenantReauthenticateTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeTenantReauthenticateTestCase.java
@@ -16,11 +16,11 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class CodeTenantReauthenticateTestCase {
     private static Class<?>[] testClasses = {
             TenantReauthentication.class,

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomIdentityProviderTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomIdentityProviderTestCase.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class CustomIdentityProviderTestCase {
 
     private static Class<?>[] testClasses = {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndBearerAuthCombinationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndBearerAuthCombinationTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.oidc.BearerTokenAuthentication;
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.quarkus.vertx.http.runtime.security.annotation.BasicAuthentication;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class ImplicitBasicAuthAndBearerAuthCombinationTest {
 
     @RegisterExtension

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndCodeFlowAuthCombinationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ImplicitBasicAuthAndCodeFlowAuthCombinationTest.java
@@ -21,11 +21,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.oidc.IdToken;
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class ImplicitBasicAuthAndCodeFlowAuthCombinationTest {
 
     @RegisterExtension

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/UserInfoRequiredDetectionTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/UserInfoRequiredDetectionTest.java
@@ -16,13 +16,13 @@ import io.quarkus.oidc.UserInfo;
 import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 import io.vertx.ext.web.Router;
 
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class UserInfoRequiredDetectionTest {
 
     @RegisterExtension

--- a/extensions/panache/mongodb-panache-common/deployment/src/test/java/io/quarkus/mongodb/panache/common/MongoDatabaseResolverTest.java
+++ b/extensions/panache/mongodb-panache-common/deployment/src/test/java/io/quarkus/mongodb/panache/common/MongoDatabaseResolverTest.java
@@ -26,12 +26,12 @@ import io.quarkus.mongodb.panache.common.runtime.MongoOperations;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
-@QuarkusTestResource(MongoReplicaSetTestResource.class)
+@WithTestResource(value = MongoReplicaSetTestResource.class, restrictToAnnotatedClass = false)
 @DisabledOnOs(OS.WINDOWS)
 public class MongoDatabaseResolverTest {
 

--- a/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/NamedRedisCacheTest.java
+++ b/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/NamedRedisCacheTest.java
@@ -14,9 +14,9 @@ import io.quarkus.arc.Arc;
 import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class NamedRedisCacheTest {
 
     private static final String KEY_1 = "1";

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/ClientInjectionTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/ClientInjectionTest.java
@@ -12,11 +12,11 @@ import io.quarkus.redis.client.RedisClient;
 import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.client.reactive.ReactiveRedisClient;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class ClientInjectionTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/CustomizerTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/CustomizerTest.java
@@ -17,11 +17,11 @@ import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.client.RedisOptionsCustomizer;
 import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.vertx.mutiny.redis.client.RedisAPI;
 import io.vertx.redis.client.RedisOptions;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class CustomizerTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/CustomCodecTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/CustomCodecTest.java
@@ -20,9 +20,9 @@ import io.quarkus.redis.datasource.codecs.Codecs;
 import io.quarkus.redis.datasource.hash.HashCommands;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class CustomCodecTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/DataSourceInjectionTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/DataSourceInjectionTest.java
@@ -16,9 +16,9 @@ import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class DataSourceInjectionTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/DataSourceTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/DataSourceTest.java
@@ -13,9 +13,9 @@ import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class DataSourceTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/devmode/RedisClientDevModeTestCase.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/devmode/RedisClientDevModeTestCase.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class RedisClientDevModeTestCase {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/devmode/RedisClientPreloadDevModeTestCase.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/devmode/RedisClientPreloadDevModeTestCase.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class RedisClientPreloadDevModeTestCase {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/BinaryTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/BinaryTest.java
@@ -16,9 +16,9 @@ import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class BinaryTest {
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/CacheTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/CacheTest.java
@@ -15,9 +15,9 @@ import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class CacheTest {
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/CounterTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/CounterTest.java
@@ -13,9 +13,9 @@ import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class CounterTest {
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/PubSubOnStartupTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/PubSubOnStartupTest.java
@@ -24,11 +24,11 @@ import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.runtime.Startup;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.Cancellable;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class PubSubOnStartupTest {
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/PubSubTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/patterns/PubSubTest.java
@@ -22,9 +22,9 @@ import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.runtime.Startup;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class PubSubTest {
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/DefaultFileForDefaultClientPreloadingTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/DefaultFileForDefaultClientPreloadingTest.java
@@ -15,9 +15,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class DefaultFileForDefaultClientPreloadingTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MissingFilePreloadTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MissingFilePreloadTest.java
@@ -15,9 +15,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class MissingFilePreloadTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MultiClientImportPreloadingTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MultiClientImportPreloadingTest.java
@@ -17,9 +17,9 @@ import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class MultiClientImportPreloadingTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MultiClientImportPreloadingWithFlushAllTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MultiClientImportPreloadingWithFlushAllTest.java
@@ -16,9 +16,9 @@ import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class MultiClientImportPreloadingWithFlushAllTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MultiClientImportPreloadingWithOnlyIfEmptyTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MultiClientImportPreloadingWithOnlyIfEmptyTest.java
@@ -16,9 +16,9 @@ import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class MultiClientImportPreloadingWithOnlyIfEmptyTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MultipleFilesForDefaultClientImportPreloadingTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/MultipleFilesForDefaultClientImportPreloadingTest.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class MultipleFilesForDefaultClientImportPreloadingTest {
 
     @RegisterExtension

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/NonDefaultFileForDefaultClientImportPreloadingTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/preloading/NonDefaultFileForDefaultClientImportPreloadingTest.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.deployment.client.RedisTestResource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(RedisTestResource.class)
+@WithTestResource(value = RedisTestResource.class, restrictToAnnotatedClass = false)
 public class NonDefaultFileForDefaultClientImportPreloadingTest {
 
     @RegisterExtension

--- a/integration-tests/cache/src/test/java/io/quarkus/it/cache/TreeTestCase.java
+++ b/integration-tests/cache/src/test/java/io/quarkus/it/cache/TreeTestCase.java
@@ -7,12 +7,12 @@ import static org.hamcrest.core.IsNot.not;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 @DisplayName("Tests the integration between panache and the cache extension")
 public class TreeTestCase {
 

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_test_java_ilove_quark_us_MyMessagingApplicationTest.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_test_java_ilove_quark_us_MyMessagingApplicationTest.java
@@ -1,6 +1,6 @@
 package ilove.quark.us;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
 

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_test_java_ilove_quark_us_MyMessagingApplicationTest.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_test_java_ilove_quark_us_MyMessagingApplicationTest.java
@@ -1,6 +1,6 @@
 package ilove.quark.us;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
 

--- a/integration-tests/elytron-security-jdbc/src/test/java/io/quarkus/elytron/security/jdbc/it/ElytronJdbcExtensionTestResources.java
+++ b/integration-tests/elytron-security-jdbc/src/test/java/io/quarkus/elytron/security/jdbc/it/ElytronJdbcExtensionTestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.elytron.security.jdbc.it;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class ElytronJdbcExtensionTestResources {
 }

--- a/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronLdapExtensionTestResources.java
+++ b/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronLdapExtensionTestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.elytron.security.ldap.it;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.ldap.LdapServerTestResource;
 
-@QuarkusTestResource(LdapServerTestResource.class)
+@WithTestResource(value = LdapServerTestResource.class, restrictToAnnotatedClass = false)
 public class ElytronLdapExtensionTestResources {
 }

--- a/integration-tests/gradle/src/main/resources/custom-filesystem-provider/application/src/test/java/org/acme/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/main/resources/custom-filesystem-provider/application/src/test/java/org/acme/ExampleResourceTest.java
@@ -1,23 +1,23 @@
 package org.acme;
 
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
 @QuarkusTest
-@QuarkusTestResource(TestResource.class)
+@WithTestResource(value = TestResource.class, restrictToAnnotatedClass = false)
 public class ExampleResourceTest {
 
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/hello")
-          .then()
-             .statusCode(200)
-             .body(is("hello"));
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 }

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/application/src/test/java/org/acme/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/application/src/test/java/org/acme/ExampleResourceTest.java
@@ -1,18 +1,18 @@
 package org.acme;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import jakarta.inject.Inject;
-
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.common.QuarkusTestResource;
-import org.junit.jupiter.api.Test;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
 @QuarkusTest
-@QuarkusTestResource(LibraryTestResource.class)
+@WithTestResource(value = LibraryTestResource.class, restrictToAnnotatedClass = false)
 public class ExampleResourceTest {
 
     @Inject
@@ -21,10 +21,10 @@ public class ExampleResourceTest {
     @Test
     public void testHelloEndpoint() {
         given()
-          .when().get("/hello")
-          .then()
-             .statusCode(200)
-             .body(is("hello"));
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
 
         assertEquals("test", libraryBean.getValue());
     }

--- a/integration-tests/grpc-hibernate/src/test/java/com/example/grpc/hibernate/TestResources.java
+++ b/integration-tests/grpc-hibernate/src/test/java/com/example/grpc/hibernate/TestResources.java
@@ -1,8 +1,8 @@
 package com.example.grpc.hibernate;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/TestResources.java
+++ b/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.envers;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/hibernate-orm-graphql-panache/src/test/java/io/quarkus/it/hibertnate/orm/graphql/panache/TestResources.java
+++ b/integration-tests/hibernate-orm-graphql-panache/src/test/java/io/quarkus/it/hibertnate/orm/graphql/panache/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.hibertnate.orm.graphql.panache;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/TestResources.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/TestResources.kt
@@ -1,6 +1,6 @@
 package io.quarkus.it.panache
 
-import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.WithTestResource
 import io.quarkus.test.h2.H2DatabaseTestResource
 
-@QuarkusTestResource(H2DatabaseTestResource::class) class TestResources
+@WithTestResource(H2DatabaseTestResource::class, restrictToAnnotatedClass = false) class TestResources

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/TestResources.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.panache;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/TestResources.java
+++ b/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.hibernate.orm.rest.data.panache;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/coordination/outboxpolling/TestResources.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/coordination/outboxpolling/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.hibernate.search.orm.elasticsearch.coordination.outboxpolling;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/TestResources.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.hibernate.search.orm.elasticsearch;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/TestResources.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.hibernate.search.orm.opensearch;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationException;
 import io.quarkus.test.InMemoryLogHandler;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -26,7 +26,7 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 
 @QuarkusTest
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class HibernateValidatorFunctionalityTest {
     private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
     private static final java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("io.quarkus");

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyViolationExceptionImpl;
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -26,8 +26,8 @@ import io.restassured.response.ValidatableResponse;
  * Test various Bean Validation operations running in Quarkus
  */
 @QuarkusTest
-@QuarkusTestResource(H2DatabaseTestResource.class)
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LOGGER, value = "io.quarkus"),
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING")
 })

--- a/integration-tests/infinispan-cache-jpa/src/test/java/io/quarkus/it/infinispan/cache/jpa/TestResources.java
+++ b/integration-tests/infinispan-cache-jpa/src/test/java/io/quarkus/it/infinispan/cache/jpa/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.infinispan.cache.jpa;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/jpa-db2/src/test/java/io/quarkus/it/jpa/db2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-db2/src/test/java/io/quarkus/it/jpa/db2/HibernateOrmNoWarningsTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         // Ignore logs about schema management:

--- a/integration-tests/jpa-derby/src/test/java/io/quarkus/it/jpa/derby/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-derby/src/test/java/io/quarkus/it/jpa/derby/HibernateOrmNoWarningsTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         // Ignore logs about schema management:

--- a/integration-tests/jpa-derby/src/test/java/io/quarkus/it/jpa/derby/TestResources.java
+++ b/integration-tests/jpa-derby/src/test/java/io/quarkus/it/jpa/derby/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.jpa.derby;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.derby.DerbyDatabaseTestResource;
 
-@QuarkusTestResource(DerbyDatabaseTestResource.class)
+@WithTestResource(value = DerbyDatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/jpa-h2-embedded/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-h2-embedded/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         // Ignore logs about schema management:

--- a/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         //We actually have a single warning, caused by the intentional peculiarities of io.quarkus.it.jpa.h2.CompanyCustomer:

--- a/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/HibernateOrmNoWarningsTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         // Ignore logs about schema management:

--- a/integration-tests/jpa-mssql/src/test/java/io/quarkus/it/jpa/mssql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-mssql/src/test/java/io/quarkus/it/jpa/mssql/HibernateOrmNoWarningsTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         // Ignore logs about schema management:

--- a/integration-tests/jpa-mysql/src/test/java/io/quarkus/it/jpa/mysql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-mysql/src/test/java/io/quarkus/it/jpa/mysql/HibernateOrmNoWarningsTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         // Ignore logs about schema management:

--- a/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         // Ignore logs about schema management:

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/HibernateOrmNoWarningsTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.LogCollectingTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -19,7 +19,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * hence the lack of a corresponding native mode test.
  */
 @QuarkusTest
-@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+@WithTestResource(value = LogCollectingTestResource.class, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         // Ignore logs about schema management:

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/TestResources.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.jpa.configurationless;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAvroIT.java
+++ b/integration-tests/kafka-avro-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaAvroIT.java
@@ -5,12 +5,12 @@ import org.junit.jupiter.api.BeforeAll;
 import io.apicurio.registry.rest.client.RegistryClientFactory;
 import io.apicurio.rest.client.VertxHttpClientProvider;
 import io.quarkus.it.kafka.avro.AvroKafkaCreator;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.vertx.core.Vertx;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(value = KafkaResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(KafkaResource.class)
 public class KafkaAvroIT extends KafkaAvroTestBase {
 
     AvroKafkaCreator creator;

--- a/integration-tests/kafka-json-schema-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaJsonSchemaIT.java
+++ b/integration-tests/kafka-json-schema-apicurio2/src/test/java/io/quarkus/it/kafka/KafkaJsonSchemaIT.java
@@ -5,12 +5,12 @@ import org.junit.jupiter.api.BeforeAll;
 import io.apicurio.registry.rest.client.RegistryClientFactory;
 import io.apicurio.rest.client.VertxHttpClientProvider;
 import io.quarkus.it.kafka.jsonschema.JsonSchemaKafkaCreator;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.vertx.core.Vertx;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(value = KafkaResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(KafkaResource.class)
 public class KafkaJsonSchemaIT extends KafkaJsonSchemaTestBase {
 
     JsonSchemaKafkaCreator creator;

--- a/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaOauthIT.java
+++ b/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaOauthIT.java
@@ -1,10 +1,10 @@
 package io.quarkus.it.kafka;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(KafkaKeycloakTestResource.class)
+@WithTestResource(value = KafkaKeycloakTestResource.class, restrictToAnnotatedClass = false)
 public class KafkaOauthIT extends KafkaOauthTest {
 
 }

--- a/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaOauthTest.java
+++ b/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaOauthTest.java
@@ -8,12 +8,12 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaKeycloakTestResource.class)
+@WithTestResource(value = KafkaKeycloakTestResource.class, restrictToAnnotatedClass = false)
 public class KafkaOauthTest {
 
     protected static final TypeRef<List<String>> TYPE_REF = new TypeRef<List<String>>() {

--- a/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/KafkaSaslIT.java
+++ b/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/KafkaSaslIT.java
@@ -8,12 +8,12 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(KafkaSaslTestResource.class)
+@WithTestResource(value = KafkaSaslTestResource.class, restrictToAnnotatedClass = false)
 public class KafkaSaslIT {
 
     protected static final TypeRef<List<String>> TYPE_REF = new TypeRef<List<String>>() {

--- a/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/KafkaSaslTest.java
+++ b/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/KafkaSaslTest.java
@@ -8,12 +8,12 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaSaslTestResource.class)
+@WithTestResource(value = KafkaSaslTestResource.class, restrictToAnnotatedClass = false)
 public class KafkaSaslTest {
 
     protected static final TypeRef<List<String>> TYPE_REF = new TypeRef<List<String>>() {

--- a/integration-tests/kafka-sasl/src/test/java/io/quarkus/it/kafka/SaslKafkaConsumerIT.java
+++ b/integration-tests/kafka-sasl/src/test/java/io/quarkus/it/kafka/SaslKafkaConsumerIT.java
@@ -1,10 +1,10 @@
 package io.quarkus.it.kafka;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(KafkaSASLTestResource.class)
+@WithTestResource(value = KafkaSASLTestResource.class, restrictToAnnotatedClass = false)
 public class SaslKafkaConsumerIT extends SaslKafkaConsumerTest {
 
 }

--- a/integration-tests/kafka-sasl/src/test/java/io/quarkus/it/kafka/SaslKafkaConsumerTest.java
+++ b/integration-tests/kafka-sasl/src/test/java/io/quarkus/it/kafka/SaslKafkaConsumerTest.java
@@ -13,12 +13,12 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaSASLTestResource.class)
+@WithTestResource(value = KafkaSASLTestResource.class, restrictToAnnotatedClass = false)
 public class SaslKafkaConsumerTest {
 
     public Producer<Integer, String> createProducer() {

--- a/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyCodecTest.java
+++ b/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyCodecTest.java
@@ -5,13 +5,13 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.mapper.ObjectMapperType;
 
-@QuarkusTestResource(KafkaTestResource.class)
+@WithTestResource(value = KafkaTestResource.class, restrictToAnnotatedClass = false)
 @QuarkusTest
 public class KafkaSnappyCodecTest {
 

--- a/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyConsumerTest.java
+++ b/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyConsumerTest.java
@@ -14,13 +14,13 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.mapper.ObjectMapperType;
 
-@QuarkusTestResource(KafkaTestResource.class)
+@WithTestResource(value = KafkaTestResource.class, restrictToAnnotatedClass = false)
 @QuarkusTest
 public class KafkaSnappyConsumerTest {
 

--- a/integration-tests/kafka-ssl/src/test/java/io/quarkus/it/kafka/SslKafkaConsumerITCase.java
+++ b/integration-tests/kafka-ssl/src/test/java/io/quarkus/it/kafka/SslKafkaConsumerITCase.java
@@ -1,10 +1,10 @@
 package io.quarkus.it.kafka;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(KafkaSSLTestResource.class)
+@WithTestResource(value = KafkaSSLTestResource.class, restrictToAnnotatedClass = false)
 public class SslKafkaConsumerITCase extends SslKafkaConsumerTest {
 
 }

--- a/integration-tests/kafka-ssl/src/test/java/io/quarkus/it/kafka/SslKafkaConsumerTest.java
+++ b/integration-tests/kafka-ssl/src/test/java/io/quarkus/it/kafka/SslKafkaConsumerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import io.quarkus.it.kafka.ssl.CertificateFormat;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import me.escoffier.certs.Format;
@@ -28,7 +28,7 @@ import me.escoffier.certs.junit5.Certificates;
                 Format.PEM }, password = "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L")
 }, baseDir = "target/certs")
 @QuarkusTest
-@QuarkusTestResource(KafkaSSLTestResource.class)
+@WithTestResource(value = KafkaSSLTestResource.class, restrictToAnnotatedClass = false)
 public class SslKafkaConsumerTest {
 
     public static Producer<Integer, String> createProducer(CertificateFormat format) {

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsCdiEventTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsCdiEventTest.java
@@ -5,10 +5,10 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTestResource(KafkaSSLTestResource.class)
+@WithTestResource(value = KafkaSSLTestResource.class, restrictToAnnotatedClass = false)
 @QuarkusTest
 public class KafkaStreamsCdiEventTest {
 

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsPropertiesTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsPropertiesTest.java
@@ -11,10 +11,10 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTestResource(KafkaSSLTestResource.class)
+@WithTestResource(value = KafkaSSLTestResource.class, restrictToAnnotatedClass = false)
 @QuarkusTest
 public class KafkaStreamsPropertiesTest {
 

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsStartupFailureTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsStartupFailureTest.java
@@ -17,13 +17,13 @@ import org.junit.jupiter.api.Timeout;
 
 import io.quarkus.kafka.streams.runtime.KafkaStreamsTopologyManager;
 import io.quarkus.runtime.Application;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KafkaSSLTestResource.class)
+@WithTestResource(value = KafkaSSLTestResource.class, restrictToAnnotatedClass = false)
 @TestProfile(KafkaStreamsStartupFailureTest.NonExistingTopicProfile.class)
 @QuarkusTest
 public class KafkaStreamsStartupFailureTest {

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -29,11 +29,11 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
 import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KafkaSSLTestResource.class)
+@WithTestResource(value = KafkaSSLTestResource.class, restrictToAnnotatedClass = false)
 @QuarkusTest
 public class KafkaStreamsTest {
 

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaCodecTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaCodecTest.java
@@ -5,14 +5,14 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.mapper.ObjectMapperType;
 
-@QuarkusTestResource(KafkaCompanionResource.class)
+@WithTestResource(value = KafkaCompanionResource.class, restrictToAnnotatedClass = false)
 @QuarkusTest
 public class KafkaCodecTest {
 

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaConsumerTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaConsumerTest.java
@@ -7,7 +7,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
@@ -16,7 +16,7 @@ import io.restassured.config.ObjectMapperConfig;
 import io.restassured.mapper.ObjectMapperType;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 
-@QuarkusTestResource(KafkaCompanionResource.class)
+@WithTestResource(value = KafkaCompanionResource.class, restrictToAnnotatedClass = false)
 @QuarkusTest
 public class KafkaConsumerTest {
 

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaProducerTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaProducerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
@@ -19,7 +19,7 @@ import io.restassured.mapper.ObjectMapperType;
 import io.smallrye.reactive.messaging.kafka.companion.ConsumerTask;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 
-@QuarkusTestResource(KafkaCompanionResource.class)
+@WithTestResource(value = KafkaCompanionResource.class, restrictToAnnotatedClass = false)
 @QuarkusTest
 public class KafkaProducerTest {
 

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
@@ -17,7 +17,7 @@ import org.htmlunit.util.Cookie;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
@@ -29,7 +29,7 @@ import io.vertx.ext.web.client.WebClient;
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 @QuarkusTest
-@QuarkusTestResource(KeycloakLifecycleManager.class)
+@WithTestResource(value = KeycloakLifecycleManager.class, restrictToAnnotatedClass = false)
 public class PolicyEnforcerTest {
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/AbsentConfigMapPropertiesPMT.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/AbsentConfigMapPropertiesPMT.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusProdModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(CustomKubernetesMockServerTestResource.class)
 public class AbsentConfigMapPropertiesPMT {
 
     @RegisterExtension

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/ConfigMapPropertiesTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/ConfigMapPropertiesTest.java
@@ -5,10 +5,10 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(CustomKubernetesMockServerTestResource.class)
 @QuarkusTest
 public class ConfigMapPropertiesTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -18,7 +18,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.client.internal.CertUtils;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.MockServer;
 import io.restassured.RestAssured;
@@ -27,7 +27,7 @@ import io.restassured.RestAssured;
  * KubernetesClientTest.TestResource contains the entire process of setting up the Mock Kubernetes API Server
  * It has to live there otherwise the Kubernetes client in native mode won't be able to locate the mock API Server
  */
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(CustomKubernetesMockServerTestResource.class)
 @QuarkusTest
 public class KubernetesClientTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import io.restassured.RestAssured;
@@ -17,7 +17,7 @@ import io.restassured.RestAssured;
  * KubernetesClientTest.TestResource contains the entire process of setting up the Mock Kubernetes API Server
  * It has to live there otherwise the Kubernetes client in native mode won't be able to locate the mock API Server
  */
-@QuarkusTestResource(value = CustomKubernetesTestServerTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(CustomKubernetesTestServerTestResource.class)
 @QuarkusTest
 class KubernetesNewClientTest {
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/NamespacedConfigMapPropertiesTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/NamespacedConfigMapPropertiesTest.java
@@ -5,12 +5,12 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(CustomKubernetesMockServerTestResource.class)
 @TestProfile(NamespacedConfigMapPropertiesTest.MyProfile.class)
 @QuarkusTest
 public class NamespacedConfigMapPropertiesTest {

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/SecretPropertiesTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/SecretPropertiesTest.java
@@ -5,10 +5,10 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTestResource(value = CustomKubernetesMockServerTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(CustomKubernetesMockServerTestResource.class)
 @QuarkusTest
 public class SecretPropertiesTest {
 

--- a/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/FruitResourceTest.java
+++ b/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/FruitResourceTest.java
@@ -18,13 +18,13 @@ import org.junit.jupiter.api.condition.OS;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoClient;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.mongodb.MongoTestResource;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@QuarkusTestResource(MongoTestResource.class)
+@WithTestResource(value = MongoTestResource.class, restrictToAnnotatedClass = false)
 @DisabledOnOs(OS.WINDOWS)
 class FruitResourceTest {
 

--- a/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/NativeFruitResourceTestIT.java
+++ b/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/NativeFruitResourceTestIT.java
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.mongodb.MongoTestResource;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(MongoTestResource.class)
+@WithTestResource(value = MongoTestResource.class, restrictToAnnotatedClass = false)
 @DisabledOnOs(OS.WINDOWS)
 class NativeFruitResourceTestIT {
     @Test

--- a/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseTestResources.java
+++ b/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseTestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.liquibase;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class LiquibaseTestResources {
 }

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingFilterTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingFilterTest.java
@@ -5,11 +5,11 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(SetRuntimeLogLevels.class)
+@WithTestResource(value = SetRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingFilterTest {
 
     @Test

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelAboveTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelAboveTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -13,7 +13,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * and this can be further tweaked at runtime to go to above to an even higher level.
  */
 @QuarkusTest
-@QuarkusTestResource(SetRuntimeLogLevels.class)
+@WithTestResource(value = SetRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelAboveTest {
 
     @Test

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelBelowChildTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelBelowChildTest.java
@@ -5,14 +5,14 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
  * Test verifies that a min-level override that goes below the default min-level is applied correctly.
  */
 @QuarkusTest
-@QuarkusTestResource(SetRuntimeLogLevels.class)
+@WithTestResource(value = SetRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelBelowChildTest {
 
     @Test

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelBelowTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelBelowTest.java
@@ -5,14 +5,14 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
  * Test verifies that a min-level override that goes below the default min-level is applied correctly.
  */
 @QuarkusTest
-@QuarkusTestResource(SetRuntimeLogLevels.class)
+@WithTestResource(value = SetRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelBelowTest {
 
     @Test

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelByDefaultTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelByDefaultTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -16,7 +16,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * say to DEBUG, the code works as expected.
  */
 @QuarkusTest
-@QuarkusTestResource(SetRuntimeLogLevels.class)
+@WithTestResource(value = SetRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelByDefaultTest {
 
     @Test

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelPromoteSubTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelPromoteSubTest.java
@@ -5,14 +5,14 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
  * This test verifies that log levels are promoted to min-level when set below, even for subpackages.
  */
 @QuarkusTest
-@QuarkusTestResource(SetRuntimeLogLevels.class)
+@WithTestResource(value = SetRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelPromoteSubTest {
 
     @Test

--- a/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelPromoteTest.java
+++ b/integration-tests/logging-min-level-set/src/test/java/io/quarkus/it/logging/minlevel/set/LoggingMinLevelPromoteTest.java
@@ -5,14 +5,14 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
  * This test verifies that log levels are promoted to min-level when set below.
  */
 @QuarkusTest
-@QuarkusTestResource(SetRuntimeLogLevels.class)
+@WithTestResource(value = SetRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelPromoteTest {
 
     @Test

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelAboveTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelAboveTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -13,7 +13,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * and only messages at same runtime log level or above are shown.
  */
 @QuarkusTest
-@QuarkusTestResource(SetCategoryRuntimeLogLevels.class)
+@WithTestResource(value = SetCategoryRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelAboveTest {
 
     @Test

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelByDefaultTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelByDefaultTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -13,7 +13,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * and there's no applicable runtime log level override.
  */
 @QuarkusTest
-@QuarkusTestResource(SetCategoryRuntimeLogLevels.class)
+@WithTestResource(value = SetCategoryRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelByDefaultTest {
 
     @Test

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelGlobalTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelGlobalTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -13,7 +13,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * and the global log level is below it.
  */
 @QuarkusTest
-@QuarkusTestResource(SetGlobalRuntimeLogLevel.class)
+@WithTestResource(value = SetGlobalRuntimeLogLevel.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelGlobalTest {
 
     @Test

--- a/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelPromoteTest.java
+++ b/integration-tests/logging-min-level-unset/src/test/java/io/quarkus/it/logging/minlevel/unset/LoggingMinLevelPromoteTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -16,7 +16,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * it will be automatically promoted to DEBUG.
  */
 @QuarkusTest
-@QuarkusTestResource(SetCategoryRuntimeLogLevels.class)
+@WithTestResource(value = SetCategoryRuntimeLogLevels.class, restrictToAnnotatedClass = false)
 public class LoggingMinLevelPromoteTest {
 
     @Test

--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerIT.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerIT.java
@@ -1,10 +1,10 @@
 package io.quarkus.it.mailer;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(MailpitTestResource.class)
+@WithTestResource(value = MailpitTestResource.class, restrictToAnnotatedClass = false)
 public class MailerIT extends MailerTest {
 
 }

--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import io.quarkus.it.mailer.mailpit.MailPitClient;
 import io.quarkus.it.mailer.mailpit.Message;
 import io.quarkus.it.mailer.mailpit.Recipient;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonObject;
@@ -27,8 +27,8 @@ import io.vertx.core.json.JsonObject;
  */
 @DisabledOnOs({ OS.WINDOWS })
 @QuarkusTest
-@QuarkusTestResource(MailpitTestResource.class)
-@QuarkusTestResource(MailpitFullTlsTestResource.class)
+@WithTestResource(value = MailpitTestResource.class, restrictToAnnotatedClass = false)
+@WithTestResource(value = MailpitFullTlsTestResource.class, restrictToAnnotatedClass = false)
 public class MailerTest {
     private MailPitClient client;
     private MailPitClient clientTls;

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/GetExceptionsInTestResourceTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/GetExceptionsInTestResourceTestCase.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTestExtension;
 
 @ExtendWith({ GetExceptionsInTestResourceTestCase.IgnoreCustomExceptions.class, QuarkusTestExtension.class })
-@QuarkusTestResource(restrictToAnnotatedClass = true, value = GetExceptionsInTestResourceTestCase.KeepContextTestResource.class)
+@WithTestResource(GetExceptionsInTestResourceTestCase.KeepContextTestResource.class)
 public class GetExceptionsInTestResourceTestCase {
 
     public static final AtomicReference<QuarkusTestResourceLifecycleManager.Context> CONTEXT = new AtomicReference<>();

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedWithResourcesTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedWithResourcesTestCase.java
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -28,7 +28,7 @@ import io.quarkus.test.junit.QuarkusTest;
  */
 @QuarkusTest
 @Tag("nested")
-@QuarkusTestResource(value = QuarkusTestNestedWithResourcesTestCase.DummyTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(QuarkusTestNestedWithResourcesTestCase.DummyTestResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class QuarkusTestNestedWithResourcesTestCase {
 

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestResources.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/TestResources.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.micrometer.prometheus;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
@@ -12,13 +12,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.mongodb.health.MongoHealthCheck;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.mongodb.MongoTestResource;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(value = MongoTestResource.class)
+@WithTestResource(value = MongoTestResource.class, restrictToAnnotatedClass = false)
 public class BookResourceTest {
     private static Jsonb jsonb;
 

--- a/integration-tests/mongodb-panache-kotlin/src/test/kotlin/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/test/kotlin/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.kt
@@ -4,11 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.quarkus.it.mongodb.panache.book.BookDetail
-import io.quarkus.it.mongodb.panache.person.Person
-import io.quarkus.test.common.QuarkusTestResource
-import io.quarkus.test.junit.QuarkusTest
-import io.quarkus.test.mongodb.MongoTestResource
 import io.restassured.RestAssured
 import io.restassured.RestAssured.get
 import io.restassured.common.mapper.TypeRef
@@ -19,12 +14,17 @@ import java.util.Calendar
 import java.util.Collections
 import java.util.Date
 import java.util.GregorianCalendar
+import io.quarkus.it.mongodb.panache.book.BookDetail
+import io.quarkus.it.mongodb.panache.person.Person
+import io.quarkus.test.common.WithTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.mongodb.MongoTestResource
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 @QuarkusTest
-@QuarkusTestResource(MongoTestResource::class)
+@WithTestResource(MongoTestResource::class, restrictToAnnotatedClass = false)
 open class MongodbPanacheResourceTest {
     @Test
     fun testBookEntity() {

--- a/integration-tests/mongodb-panache-kotlin/src/test/kotlin/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.kt
+++ b/integration-tests/mongodb-panache-kotlin/src/test/kotlin/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.kt
@@ -4,22 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.quarkus.it.mongodb.panache.BookDTO
-import io.quarkus.it.mongodb.panache.book.BookDetail
-import io.quarkus.it.mongodb.panache.person.Person
-import io.quarkus.test.common.QuarkusTestResource
-import io.quarkus.test.junit.QuarkusTest
-import io.quarkus.test.mongodb.MongoTestResource
 import io.restassured.RestAssured
 import io.restassured.RestAssured.get
 import io.restassured.common.mapper.TypeRef
 import io.restassured.config.ObjectMapperConfig
 import io.restassured.parsing.Parser
 import io.restassured.response.Response
-import jakarta.ws.rs.client.Client
-import jakarta.ws.rs.client.ClientBuilder
-import jakarta.ws.rs.client.WebTarget
-import jakarta.ws.rs.sse.SseEventSource
 import java.io.IOException
 import java.time.Duration
 import java.util.Calendar
@@ -27,6 +17,16 @@ import java.util.Collections
 import java.util.Date
 import java.util.GregorianCalendar
 import java.util.concurrent.atomic.LongAdder
+import jakarta.ws.rs.client.Client
+import jakarta.ws.rs.client.ClientBuilder
+import jakarta.ws.rs.client.WebTarget
+import jakarta.ws.rs.sse.SseEventSource
+import io.quarkus.it.mongodb.panache.BookDTO
+import io.quarkus.it.mongodb.panache.book.BookDetail
+import io.quarkus.it.mongodb.panache.person.Person
+import io.quarkus.test.common.WithTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.mongodb.MongoTestResource
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
 @QuarkusTest
-@QuarkusTestResource(MongoTestResource::class)
+@WithTestResource(MongoTestResource::class, restrictToAnnotatedClass = false)
 internal open class ReactiveMongodbPanacheResourceTest {
     companion object {
         private val LIST_OF_BOOK_TYPE_REF: TypeRef<List<BookDTO>> =

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongoTestResources.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongoTestResources.java
@@ -1,9 +1,9 @@
 package io.quarkus.it.mongodb.panache;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
 
-@QuarkusTestResource(MongoReplicaSetTestResource.class)
+@WithTestResource(value = MongoReplicaSetTestResource.class, restrictToAnnotatedClass = false)
 public class MongoTestResources {
 
 }

--- a/integration-tests/mongodb-rest-data-panache/src/test/java/io/quarkus/it/mongodb/rest/data/panache/MongoDbRestDataPanacheTest.java
+++ b/integration-tests/mongodb-rest-data-panache/src/test/java/io/quarkus/it/mongodb/rest/data/panache/MongoDbRestDataPanacheTest.java
@@ -17,14 +17,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.mongodb.MongoTestResource;
 import io.restassured.response.Response;
 
 @QuarkusTest
-@QuarkusTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = MongoTestResource.PORT, value = "37017"))
+@WithTestResource(value = MongoTestResource.class, restrictToAnnotatedClass = false, initArgs = @ResourceArg(name = MongoTestResource.PORT, value = "37017"))
 class MongoDbRestDataPanacheTest {
 
     private Author dostoevsky;

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmLifecycleTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmLifecycleTest.java
@@ -5,12 +5,12 @@ import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.observability.devresource.lgtm.LgtmResource;
 import io.quarkus.observability.test.support.QuarkusTestResourceTestProfile;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@QuarkusTestResource(value = LgtmResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(LgtmResource.class)
 @TestProfile(QuarkusTestResourceTestProfile.class)
 @DisabledOnOs(OS.WINDOWS)
 public class LgtmLifecycleTest extends LgtmTestBase {

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -25,12 +25,12 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class OidcClientTest {
 
     @InjectWireMock

--- a/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -21,12 +21,12 @@ import org.awaitility.core.ThrowingRunnable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class OidcClientTest {
 
     @Test

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.oidc.runtime.OidcUtils;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.restassured.RestAssured;
@@ -45,7 +45,7 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class CodeFlowTest {
 
     KeycloakTestClient client = new KeycloakTestClient();

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -26,7 +26,7 @@ import org.htmlunit.util.Cookie;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.restassured.RestAssured;
@@ -40,7 +40,7 @@ import io.vertx.mutiny.core.http.HttpClient;
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class BearerTokenAuthorizationTest {
 
     private KeycloakTestClient client = new KeycloakTestClient();

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/TestSecurityCombiningAuthMechTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/TestSecurityCombiningAuthMechTest.java
@@ -14,7 +14,7 @@ import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
@@ -22,7 +22,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class TestSecurityCombiningAuthMechTest {
 
     @TestHTTPEndpoint(MultipleAuthMechResource.class)

--- a/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
+++ b/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
@@ -5,13 +5,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class OidcTokenPropagationTest {
 
     final KeycloakTestClient client = new KeycloakTestClient();
@@ -44,7 +44,7 @@ public class OidcTokenPropagationTest {
         // Note this test does pass if Keycloak is started manually,
         // 'quarkus' realm, 'quarkus-app' and 'quarkus-app-exchange' clients, and 'alice' user is created
         // and the token-exchange permission is added to the clients as per the Keycloak docs.
-        // It can be confirmed by commenting @QuarkusTestResource above
+        // It can be confirmed by commenting @WithTestResource above
         // and running the tests as 'mvn clean install -Dtest-containers'
 
         RestAssured.given().auth().oauth2(getAccessToken("alice"))

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -23,7 +23,7 @@ import io.smallrye.jwt.build.Jwt;
 
 @QuarkusTest
 @TestProfile(AnnotationBasedTenantTest.NoProactiveAuthTestProfile.class)
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class AnnotationBasedTenantTest {
     public static class NoProactiveAuthTestProfile implements QuarkusTestProfile {
         public Map<String, String> getConfigOverrides() {

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerOpaqueTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerOpaqueTokenAuthorizationTest.java
@@ -14,14 +14,14 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 
 import io.quarkus.oidc.common.runtime.OidcConstants;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.oidc.server.OidcWireMock;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class BearerOpaqueTokenAuthorizationTest {
 
     @OidcWireMock

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -30,7 +30,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.oidc.runtime.TrustStoreUtils;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.oidc.server.OidcWireMock;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
@@ -43,7 +43,7 @@ import io.smallrye.jwt.util.ResourceUtils;
 import io.vertx.core.json.JsonObject;
 
 @QuarkusTest
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class BearerTokenAuthorizationTest {
 
     @OidcWireMock

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -41,7 +41,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.runtime.OidcUtils;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.oidc.server.OidcWireMock;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
@@ -51,7 +51,7 @@ import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.vertx.core.json.JsonObject;
 
 @QuarkusTest
-@QuarkusTestResource(OidcWiremockTestResource.class)
+@WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
 public class CodeFlowAuthorizationTest {
 
     @OidcWireMock

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -12,7 +12,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
@@ -20,7 +20,7 @@ import io.restassured.RestAssured;
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 @QuarkusTest
-@QuarkusTestResource(KeycloakXTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakXTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class BearerTokenAuthorizationTest {
 
     @Test

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/WebsocketOidcTestCase.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/WebsocketOidcTestCase.java
@@ -15,13 +15,13 @@ import jakarta.websocket.Session;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.websockets.BearerTokenClientEndpointConfigurator;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakXTestResourceLifecycleManager.class)
+@WithTestResource(value = KeycloakXTestResourceLifecycleManager.class, restrictToAnnotatedClass = false)
 public class WebsocketOidcTestCase {
 
     @TestHTTPResource("secured-hello")

--- a/integration-tests/openshift-client/src/test/java/io/quarkus/it/openshift/client/OpenShiftClientTest.java
+++ b/integration-tests/openshift-client/src/test/java/io/quarkus/it/openshift/client/OpenShiftClientTest.java
@@ -10,13 +10,13 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.MockServer;
 import io.quarkus.test.kubernetes.client.OpenShiftMockServerTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(OpenShiftMockServerTestResource.class)
+@WithTestResource(value = OpenShiftMockServerTestResource.class, restrictToAnnotatedClass = false)
 @QuarkusTest
 public class OpenShiftClientTest {
 

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2OpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2OpenTelemetryJdbcInstrumentationTest.java
@@ -3,12 +3,12 @@ package io.quarkus.it.opentelemetry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @EnabledIfSystemProperty(named = "enable-db2", matches = "true")
 @QuarkusTest
-@QuarkusTestResource(value = Db2LifecycleManager.class, restrictToAnnotatedClass = true)
+@WithTestResource(Db2LifecycleManager.class)
 public class Db2OpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
 
     @Test

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbOpenTelemetryJdbcInstrumentationTest.java
@@ -2,11 +2,11 @@ package io.quarkus.it.opentelemetry;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = MariaDbLifecycleManager.class, restrictToAnnotatedClass = true)
+@WithTestResource(MariaDbLifecycleManager.class)
 public class MariaDbOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
 
     @Test

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleOpenTelemetryJdbcInstrumentationTest.java
@@ -2,11 +2,11 @@ package io.quarkus.it.opentelemetry;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OracleLifecycleManager.class, restrictToAnnotatedClass = true)
+@WithTestResource(OracleLifecycleManager.class)
 public class OracleOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
 
     @Test

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgresOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgresOpenTelemetryJdbcInstrumentationTest.java
@@ -2,11 +2,11 @@ package io.quarkus.it.opentelemetry;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = PostgreSqlLifecycleManager.class, restrictToAnnotatedClass = true)
+@WithTestResource(PostgreSqlLifecycleManager.class)
 public class PostgresOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
 
     @Test

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceTest.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceTest.java
@@ -14,14 +14,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.mongodb.MongoTestResource;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@QuarkusTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = MongoTestResource.VERSION, value = "V6_0"))
+@WithTestResource(value = MongoTestResource.class, restrictToAnnotatedClass = false, initArgs = @ResourceArg(name = MongoTestResource.VERSION, value = "V6_0"))
 class BookResourceTest {
 
     private final TypeRef<List<Book>> bookListType = new TypeRef<>() {

--- a/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
+++ b/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceId;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
@@ -33,7 +33,7 @@ import io.restassured.common.mapper.TypeRef;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaCompanionResource.class)
+@WithTestResource(value = KafkaCompanionResource.class, restrictToAnnotatedClass = false)
 public class OpenTelemetryTestCase {
     @TestHTTPResource("direct")
     URL directUrl;

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryWithSpanAtStartupTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryWithSpanAtStartupTest.java
@@ -25,11 +25,11 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.quarkus.runtime.Startup;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTestResource(restrictToAnnotatedClass = true, value = OpenTelemetryWithSpanAtStartupTest.MyWireMockResource.class)
+@WithTestResource(OpenTelemetryWithSpanAtStartupTest.MyWireMockResource.class)
 @QuarkusTest
 public class OpenTelemetryWithSpanAtStartupTest {
 

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSNoCompressionTest.java
@@ -2,11 +2,11 @@ package io.quarkus.it.opentelemetry.vertx.exporter.grpc;
 
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, restrictToAnnotatedClass = true)
+@WithTestResource(OtelCollectorLifecycleManager.class)
 public class GrpcNoTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcNoTLSWithCompressionTest.java
@@ -2,12 +2,12 @@ package io.quarkus.it.opentelemetry.vertx.exporter.grpc;
 
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableCompression", value = "true"), restrictToAnnotatedClass = true)
+@WithTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableCompression", value = "true"))
 public class GrpcNoTLSWithCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSNoCompressionTest.java
@@ -2,12 +2,12 @@ package io.quarkus.it.opentelemetry.vertx.exporter.grpc;
 
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableTLS", value = "true"), restrictToAnnotatedClass = true)
+@WithTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "enableTLS", value = "true"))
 public class GrpcWithTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/grpc/GrpcWithTLSWithCompressionTest.java
@@ -2,15 +2,15 @@ package io.quarkus.it.opentelemetry.vertx.exporter.grpc;
 
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
+@WithTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
         @ResourceArg(name = "enableCompression", value = "true")
-}, restrictToAnnotatedClass = true)
+})
 public class GrpcWithTLSWithCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSNoCompressionTest.java
@@ -2,12 +2,12 @@ package io.quarkus.it.opentelemetry.vertx.exporter.http;
 
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"), restrictToAnnotatedClass = true)
+@WithTestResource(value = OtelCollectorLifecycleManager.class, initArgs = @ResourceArg(name = "protocol", value = "http/protobuf"))
 public class HttpNoTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpNoTLSWithCompressionTest.java
@@ -2,15 +2,15 @@ package io.quarkus.it.opentelemetry.vertx.exporter.http;
 
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
+@WithTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableCompression", value = "true"),
         @ResourceArg(name = "protocol", value = "http/protobuf")
-}, restrictToAnnotatedClass = true)
+})
 public class HttpNoTLSWithCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSNoCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSNoCompressionTest.java
@@ -2,15 +2,15 @@ package io.quarkus.it.opentelemetry.vertx.exporter.http;
 
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
+@WithTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
         @ResourceArg(name = "protocol", value = "http/protobuf")
-}, restrictToAnnotatedClass = true)
+})
 public class HttpWithTLSNoCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithCompressionTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithCompressionTest.java
@@ -2,16 +2,16 @@ package io.quarkus.it.opentelemetry.vertx.exporter.http;
 
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
+@WithTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
         @ResourceArg(name = "enableCompression", value = "true"),
         @ResourceArg(name = "protocol", value = "http/protobuf")
-}, restrictToAnnotatedClass = true)
+})
 public class HttpWithTLSWithCompressionTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithCompressionUsingRegistryTest.java
+++ b/integration-tests/opentelemetry-vertx-exporter/src/test/java/io/quarkus/it/opentelemetry/vertx/exporter/http/HttpWithTLSWithCompressionUsingRegistryTest.java
@@ -2,17 +2,17 @@ package io.quarkus.it.opentelemetry.vertx.exporter.http;
 
 import io.quarkus.it.opentelemetry.vertx.exporter.AbstractExporterTest;
 import io.quarkus.it.opentelemetry.vertx.exporter.OtelCollectorLifecycleManager;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
+@WithTestResource(value = OtelCollectorLifecycleManager.class, initArgs = {
         @ResourceArg(name = "enableTLS", value = "true"),
         @ResourceArg(name = "enableCompression", value = "true"),
         @ResourceArg(name = "protocol", value = "http/protobuf"),
         @ResourceArg(name = "tlsRegistryName", value = "otel")
-}, restrictToAnnotatedClass = true)
+})
 public class HttpWithTLSWithCompressionUsingRegistryTest extends AbstractExporterTest {
 
 }

--- a/integration-tests/picocli-native/src/test/java/io/quarkus/it/picocli/PicocliTest.java
+++ b/integration-tests/picocli-native/src/test/java/io/quarkus/it/picocli/PicocliTest.java
@@ -8,15 +8,15 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import io.quarkus.test.junit.main.QuarkusMainLauncher;
 import io.quarkus.test.junit.main.QuarkusMainTest;
 
 @QuarkusMainTest
-@QuarkusTestResource(PicocliTest.TestResource.class)
+@WithTestResource(value = PicocliTest.TestResource.class, restrictToAnnotatedClass = false)
 public class PicocliTest {
 
     private String value;

--- a/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/TestResources.java
+++ b/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.quartz;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/qute/src/test/java/io/quarkus/it/qute/TestResources.java
+++ b/integration-tests/qute/src/test/java/io/quarkus/it/qute/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.qute;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/reactive-messaging-amqp/src/test/java/io/quarkus/it/amqp/AmqpConnectorTest.java
+++ b/integration-tests/reactive-messaging-amqp/src/test/java/io/quarkus/it/amqp/AmqpConnectorTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@QuarkusTestResource(AmqpBroker.class)
+@WithTestResource(value = AmqpBroker.class, restrictToAnnotatedClass = false)
 @DisabledOnOs(OS.WINDOWS)
 public class AmqpConnectorTest {
 

--- a/integration-tests/reactive-messaging-hibernate-orm/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
+++ b/integration-tests/reactive-messaging-hibernate-orm/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.it.kafka.fruit.Fruit;
 import io.quarkus.it.kafka.people.PeopleState;
 import io.quarkus.it.kafka.people.Person;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
 import io.quarkus.test.kafka.KafkaCompanionResource;
@@ -26,7 +26,7 @@ import io.restassured.http.ContentType;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaCompanionResource.class)
+@WithTestResource(value = KafkaCompanionResource.class, restrictToAnnotatedClass = false)
 public class KafkaConnectorTest {
 
     protected static final TypeRef<List<Fruit>> TYPE_REF = new TypeRef<List<Fruit>>() {

--- a/integration-tests/reactive-messaging-hibernate-reactive/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
+++ b/integration-tests/reactive-messaging-hibernate-reactive/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
@@ -12,14 +12,14 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaCompanionResource.class)
+@WithTestResource(value = KafkaCompanionResource.class, restrictToAnnotatedClass = false)
 public class KafkaConnectorTest {
 
     protected static final TypeRef<List<Fruit>> FRUIT_TYPE_REF = new TypeRef<List<Fruit>>() {

--- a/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
+++ b/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kafka.KafkaCompanionResource;
@@ -25,7 +25,7 @@ import io.restassured.response.Response;
 import io.smallrye.reactive.messaging.kafka.commit.ProcessingState;
 
 @QuarkusTest
-@QuarkusTestResource(KafkaCompanionResource.class)
+@WithTestResource(value = KafkaCompanionResource.class, restrictToAnnotatedClass = false)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class KafkaConnectorTest {
 

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
@@ -15,13 +15,13 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.it.rabbitmq.RabbitMQConnectorDynCredsTest.RabbitMQResource;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@QuarkusTestResource(RabbitMQResource.class)
+@WithTestResource(value = RabbitMQResource.class, restrictToAnnotatedClass = false)
 public class RabbitMQConnectorDynCredsTest {
 
     public static class RabbitMQResource implements QuarkusTestResourceLifecycleManager {

--- a/integration-tests/rest-client-reactive-stork/src/test/java/io/quarkus/it/rest/reactive/stork/RestClientReactiveStorkTest.java
+++ b/integration-tests/rest-client-reactive-stork/src/test/java/io/quarkus/it/rest/reactive/stork/RestClientReactiveStorkTest.java
@@ -12,15 +12,15 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.it.rest.client.reactive.stork.MyServiceDiscoveryProvider;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.response.Response;
 import io.vertx.core.Vertx;
 
 @QuarkusTest
-@QuarkusTestResource(SlowWiremockServer.class)
-@QuarkusTestResource(FastWiremockServer.class)
+@WithTestResource(value = SlowWiremockServer.class, restrictToAnnotatedClass = false)
+@WithTestResource(value = FastWiremockServer.class, restrictToAnnotatedClass = false)
 public class RestClientReactiveStorkTest {
 
     @Test

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestCase.java
@@ -6,12 +6,12 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.it.rest.client.wronghost.ExternalWrongHostTestResourceUsingHostnameVerifier;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(ExternalTlsTrustAllTestResource.class)
-@QuarkusTestResource(value = ExternalWrongHostTestResourceUsingHostnameVerifier.class, restrictToAnnotatedClass = true)
+@WithTestResource(value = ExternalTlsTrustAllTestResource.class, restrictToAnnotatedClass = false)
+@WithTestResource(ExternalWrongHostTestResourceUsingHostnameVerifier.class)
 public class ExternalTlsTrustAllTestCase {
 
     @Test

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingHostnameVerifierTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingHostnameVerifierTestCase.java
@@ -1,9 +1,9 @@
 package io.quarkus.it.rest.client.wronghost;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = ExternalWrongHostTestResourceUsingHostnameVerifier.class, restrictToAnnotatedClass = true)
+@WithTestResource(ExternalWrongHostTestResourceUsingHostnameVerifier.class)
 public class ExternalWrongHostUsingHostnameVerifierTestCase extends BaseExternalWrongHostTestCase {
 }

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingVerifyHostTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingVerifyHostTestCase.java
@@ -1,9 +1,9 @@
 package io.quarkus.it.rest.client.wronghost;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = ExternalWrongHostTestResourceUsingVerifyHost.class, restrictToAnnotatedClass = true)
+@WithTestResource(ExternalWrongHostTestResourceUsingVerifyHost.class)
 public class ExternalWrongHostUsingVerifyHostTestCase extends BaseExternalWrongHostTestCase {
 }

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/ReactiveMessagingTest.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/ReactiveMessagingTest.kt
@@ -1,18 +1,18 @@
 package io.quarkus.it.resteasy.reactive.kotlin
 
-import io.quarkus.test.common.QuarkusTestResource
-import io.quarkus.test.junit.QuarkusTest
 import io.restassured.RestAssured.get
 import io.restassured.common.mapper.TypeRef
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import java.time.Duration
+import io.quarkus.test.common.WithTestResource
+import io.quarkus.test.junit.QuarkusTest
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 @QuarkusTest
-@QuarkusTestResource(KafkaTestResource::class)
+@WithTestResource(KafkaTestResource::class, restrictToAnnotatedClass = false)
 class ReactiveMessagingTest {
 
     private val TYPE_REF: TypeRef<List<Country>> = object : TypeRef<List<Country>>() {}

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/TestResources.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.context.test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/GraphQLAuthExpiryTest.java
+++ b/integration-tests/smallrye-graphql-client-keycloak/src/test/java/io/quarkus/it/smallrye/graphql/keycloak/GraphQLAuthExpiryTest.java
@@ -6,7 +6,7 @@ import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -14,7 +14,7 @@ import io.quarkus.test.junit.QuarkusTest;
  * See `GraphQLClientTester` for the actual testing code that uses GraphQL clients.
  */
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class GraphQLAuthExpiryTest {
 
     @TestHTTPResource

--- a/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtOidcWebAppTest.java
+++ b/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtOidcWebAppTest.java
@@ -10,12 +10,12 @@ import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class SmallRyeJwtOidcWebAppTest {
 
     @Test

--- a/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
@@ -5,13 +5,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class OidcTokenPropagationTest {
 
     @Test

--- a/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtGrpcAuthorizationTest.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtGrpcAuthorizationTest.java
@@ -3,12 +3,12 @@ package io.quarkus.it.keycloak;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@WithTestResource(value = KeycloakRealmResourceManager.class, restrictToAnnotatedClass = false)
 public class SmallRyeJwtGrpcAuthorizationTest {
 
     @Test

--- a/integration-tests/spring-cloud-config-client/src/test/java/io/quarkus/spring/cloud/config/client/runtime/CommonAndTestProfilesTest.java
+++ b/integration-tests/spring-cloud-config-client/src/test/java/io/quarkus/spring/cloud/config/client/runtime/CommonAndTestProfilesTest.java
@@ -7,11 +7,11 @@ import static org.hamcrest.Matchers.equalTo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(SpringCloudConfigServerResource.class)
+@WithTestResource(value = SpringCloudConfigServerResource.class, restrictToAnnotatedClass = false)
 @Tag("common")
 @Tag("test")
 public class CommonAndTestProfilesTest {

--- a/integration-tests/spring-cloud-config-client/src/test/java/io/quarkus/spring/cloud/config/client/runtime/OnlyTestProfileTest.java
+++ b/integration-tests/spring-cloud-config-client/src/test/java/io/quarkus/spring/cloud/config/client/runtime/OnlyTestProfileTest.java
@@ -7,11 +7,11 @@ import static org.hamcrest.Matchers.equalTo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(SpringCloudConfigServerResource.class)
+@WithTestResource(value = SpringCloudConfigServerResource.class, restrictToAnnotatedClass = false)
 @Tag("test")
 @Tag("test-only")
 public class OnlyTestProfileTest {

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/TestResources.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.spring.data.jpa;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/TestResources.java
+++ b/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.spring.data.rest;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/CustomResource.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/CustomResource.java
@@ -7,11 +7,11 @@ import java.lang.annotation.Target;
 
 import jakarta.enterprise.inject.Stereotype;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@QuarkusTestResource(LifecycleManager.class)
+@WithTestResource(value = LifecycleManager.class, restrictToAnnotatedClass = false)
 @Stereotype
 public @interface CustomResource {
 

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/CustomResourceWithList.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/CustomResourceWithList.java
@@ -7,12 +7,12 @@ import java.lang.annotation.Target;
 
 import jakarta.enterprise.inject.Stereotype;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@QuarkusTestResource.List({
-        @QuarkusTestResource(LifecycleManager.class)
+@WithTestResource.List({
+        @WithTestResource(value = LifecycleManager.class, restrictToAnnotatedClass = false)
 })
 @Stereotype
 public @interface CustomResourceWithList {

--- a/integration-tests/virtual-threads/amqp-virtual-threads/src/test/java/io/quarkus/it/vthreads/amqp/VirtualThreadTest.java
+++ b/integration-tests/virtual-threads/amqp-virtual-threads/src/test/java/io/quarkus/it/vthreads/amqp/VirtualThreadTest.java
@@ -11,13 +11,13 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit5.virtual.ShouldNotPin;
 import io.quarkus.test.junit5.virtual.VirtualThreadUnit;
 
 @QuarkusTest
-@QuarkusTestResource(WireMockExtension.class)
+@WithTestResource(value = WireMockExtension.class, restrictToAnnotatedClass = false)
 @VirtualThreadUnit
 @ShouldNotPin
 public class VirtualThreadTest {

--- a/integration-tests/virtual-threads/jms-virtual-threads/src/test/java/io/quarkus/it/vthreads/jms/VirtualThreadTest.java
+++ b/integration-tests/virtual-threads/jms-virtual-threads/src/test/java/io/quarkus/it/vthreads/jms/VirtualThreadTest.java
@@ -11,13 +11,13 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit5.virtual.ShouldNotPin;
 import io.quarkus.test.junit5.virtual.VirtualThreadUnit;
 
 @QuarkusTest
-@QuarkusTestResource(WireMockExtension.class)
+@WithTestResource(value = WireMockExtension.class, restrictToAnnotatedClass = false)
 @VirtualThreadUnit
 @ShouldNotPin
 public class VirtualThreadTest {

--- a/integration-tests/virtual-threads/kafka-virtual-threads/src/test/java/io/quarkus/it/vthreads/kafka/VirtualThreadTest.java
+++ b/integration-tests/virtual-threads/kafka-virtual-threads/src/test/java/io/quarkus/it/vthreads/kafka/VirtualThreadTest.java
@@ -11,13 +11,13 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit5.virtual.ShouldNotPin;
 import io.quarkus.test.junit5.virtual.VirtualThreadUnit;
 
 @QuarkusTest
-@QuarkusTestResource(WireMockExtension.class)
+@WithTestResource(value = WireMockExtension.class, restrictToAnnotatedClass = false)
 @VirtualThreadUnit
 @ShouldNotPin
 public class VirtualThreadTest {

--- a/integration-tests/virtual-threads/mailer-virtual-threads/src/test/java/io/quarkus/virtual/mail/RunOnVirtualThreadTest.java
+++ b/integration-tests/virtual-threads/mailer-virtual-threads/src/test/java/io/quarkus/virtual/mail/RunOnVirtualThreadTest.java
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit5.virtual.ShouldNotPin;
 import io.quarkus.test.junit5.virtual.VirtualThreadUnit;
@@ -15,7 +15,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 @QuarkusTest
-@QuarkusTestResource(MailHogResource.class)
+@WithTestResource(value = MailHogResource.class, restrictToAnnotatedClass = false)
 @VirtualThreadUnit
 @ShouldNotPin
 class RunOnVirtualThreadTest {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
@@ -9,7 +9,7 @@ import java.util.function.Predicate;
  * Manage the lifecycle of a test resource, for instance a H2 test server.
  * <p>
  * These resources are started before the first test is run, and are closed
- * at the end of the test suite. They are configured via the {@link QuarkusTestResource}
+ * at the end of the test suite. They are configured via the {@link WithTestResource}
  * annotation, which can be placed on any class in the test suite.
  *
  * These can also be loaded via a service loader mechanism, however if a service
@@ -55,7 +55,7 @@ public interface QuarkusTestResourceLifecycleManager {
      *
      * The {@code args} is never null
      *
-     * @see QuarkusTestResource#initArgs()
+     * @see WithTestResource#initArgs()
      */
     default void init(Map<String, String> initArgs) {
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ResourceArg.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ResourceArg.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 /**
  * Uses to define arguments of for {@code QuarkusTestResource}
  *
- * see {@link QuarkusTestResource#initArgs()}
+ * see {@link WithTestResource#initArgs()}
  */
 @Target({})
 @Retention(RetentionPolicy.RUNTIME)

--- a/test-framework/common/src/main/java/io/quarkus/test/common/WithTestResource.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/WithTestResource.java
@@ -8,27 +8,31 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Map;
 
-import io.quarkus.test.common.QuarkusTestResource.List;
+import io.quarkus.test.common.WithTestResource.List;
 
 /**
  * Used to define a test resource.
  *
- * <b>All</b> {@code QuarkusTestResource} annotations in the test module
+ * <b>All</b> {@code WithTestResource} annotations in the test module
  * are discovered (regardless of the test which contains the annotation)
  * and their corresponding {@code QuarkusTestResourceLifecycleManager}
  * started <b>before</b> <b>any</b> test is run.
  *
  * Note that test resources are never restarted when running {@code @Nested} test classes.
- *
- * @deprecated Use the new {@link WithTestResource} instead. It will be a long while before this is removed, but better to move
- *             to the replacement sooner than later.
+ * <p>
+ * This replaces {@link QuarkusTestResource}. The only difference is that the default value for
+ * {@link #restrictToAnnotatedClass()} {@code == true}.
+ * </p>
+ * <p>
+ * This means that any resources managed by {@link #value()} apply to an individual test class or test profile, unlike with
+ * {@link QuarkusTestResource} where a resource applies to all test classes.
+ * </p>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Repeatable(List.class)
-@Deprecated(forRemoval = true)
-public @interface QuarkusTestResource {
+public @interface WithTestResource {
 
     /**
      * @return The class managing the lifecycle of the test resource.
@@ -52,13 +56,12 @@ public @interface QuarkusTestResource {
      * Note that this defaults to true for meta-annotations since meta-annotations are only considered
      * for the current test class or test profile.
      */
-    boolean restrictToAnnotatedClass() default false;
+    boolean restrictToAnnotatedClass() default true;
 
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.RUNTIME)
     @Documented
-    @Deprecated(forRemoval = true)
     @interface List {
-        QuarkusTestResource[] value();
+        WithTestResource[] value();
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/WithTestResourceRepeatable.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/WithTestResourceRepeatable.java
@@ -9,21 +9,17 @@ import java.lang.annotation.Target;
 
 /**
  * Used to indicate the type of the <em>repeatable annotation
- * type</em> annotated with a {@code QuarkusTestResource} annotations.
+ * type</em> annotated with a {@link WithTestResource} annotations.
  *
  * <p>
- *
- * @deprecated Use {@link WithTestResourceRepeatable} instead
- *             </p>
  */
 @Target(ElementType.ANNOTATION_TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Deprecated(forRemoval = true)
-public @interface QuarkusTestResourceRepeatable {
+public @interface WithTestResourceRepeatable {
 
     /**
-     * @return The class annotated with a {@code QuarkusTestResource} annotations.
+     * @return The class annotated with a {@link WithTestResource} annotations.
      */
     Class<? extends Annotation> value();
 }

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerInjectorTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerInjectorTest.java
@@ -9,13 +9,15 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestResourceManagerInjectorTest {
 
-    @Test
-    void testTestInjector() {
-        TestResourceManager manager = new TestResourceManager(UsingInjectorTest.class);
+    @ParameterizedTest
+    @ValueSource(classes = { UsingInjectorTest.class, UsingInjectorTest2.class })
+    void testTestInjector(Class<?> clazz) {
+        TestResourceManager manager = new TestResourceManager(clazz);
         manager.start();
 
         Foo foo = new Foo();
@@ -27,8 +29,12 @@ public class TestResourceManagerInjectorTest {
         Assertions.assertEquals("dummy", foo.dummy.value);
     }
 
-    @QuarkusTestResource(UsingTestInjectorLifecycleManager.class)
+    @WithTestResource(value = UsingTestInjectorLifecycleManager.class, restrictToAnnotatedClass = false)
     public static class UsingInjectorTest {
+    }
+
+    @QuarkusTestResource(UsingTestInjectorLifecycleManager.class)
+    public static class UsingInjectorTest2 {
     }
 
     public static class UsingTestInjectorLifecycleManager implements QuarkusTestResourceLifecycleManager {

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerTest.java
@@ -13,41 +13,50 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestResourceManagerTest {
 
     private static final String OVERRIDEN_KEY = "overridenKey";
     public static boolean parallelTestResourceRunned = false;
 
-    @Test
-    void testRepeatableAnnotationsAreIndexed() {
+    @ParameterizedTest
+    @ValueSource(classes = { MyTest.class, MyTest2.class })
+    void testRepeatableAnnotationsAreIndexed(Class<?> clazz) {
         AtomicInteger counter = new AtomicInteger();
-        TestResourceManager manager = new TestResourceManager(MyTest.class);
+        TestResourceManager manager = new TestResourceManager(clazz);
         manager.inject(counter);
         assertThat(counter.intValue()).isEqualTo(2);
     }
 
-    @Test
-    void testSequentialResourcesRunSequentially() {
-        TestResourceManager manager = new TestResourceManager(SequentialTestResourcesTest.class);
+    @ParameterizedTest
+    @ValueSource(classes = { SequentialTestResourcesTest.class, SequentialTestResourcesTest2.class })
+    void testSequentialResourcesRunSequentially(Class<?> clazz) {
+        TestResourceManager manager = new TestResourceManager(clazz);
         Map<String, String> props = manager.start();
         Assertions.assertEquals("value1", props.get("key1"));
         Assertions.assertEquals("value2", props.get("key2"));
         Assertions.assertEquals("value2", props.get(OVERRIDEN_KEY));
     }
 
-    @Test
-    void testParallelResourcesRunInParallel() {
-        TestResourceManager manager = new TestResourceManager(ParallelTestResourcesTest.class);
+    @ParameterizedTest
+    @ValueSource(classes = { ParallelTestResourcesTest.class, ParallelTestResourcesTest2.class })
+    void testParallelResourcesRunInParallel(Class<?> clazz) {
+        TestResourceManager manager = new TestResourceManager(clazz);
         Map<String, String> props = manager.start();
         Assertions.assertEquals("value1", props.get("key1"));
         Assertions.assertEquals("value2", props.get("key2"));
     }
 
+    @WithTestResource(value = FirstLifecycleManager.class, restrictToAnnotatedClass = false)
+    @WithTestResource(value = SecondLifecycleManager.class, restrictToAnnotatedClass = false)
+    public static class MyTest {
+    }
+
     @QuarkusTestResource(FirstLifecycleManager.class)
     @QuarkusTestResource(SecondLifecycleManager.class)
-    public static class MyTest {
+    public static class MyTest2 {
     }
 
     public static class FirstLifecycleManager implements QuarkusTestResourceLifecycleManager {
@@ -90,9 +99,14 @@ public class TestResourceManagerTest {
         }
     }
 
+    @WithTestResource(value = FirstSequentialQuarkusTestResource.class, restrictToAnnotatedClass = false)
+    @WithTestResource(value = SecondSequentialQuarkusTestResource.class, restrictToAnnotatedClass = false)
+    public static class SequentialTestResourcesTest {
+    }
+
     @QuarkusTestResource(FirstSequentialQuarkusTestResource.class)
     @QuarkusTestResource(SecondSequentialQuarkusTestResource.class)
-    public static class SequentialTestResourcesTest {
+    public static class SequentialTestResourcesTest2 {
     }
 
     public static class FirstSequentialQuarkusTestResource implements QuarkusTestResourceLifecycleManager {
@@ -136,9 +150,14 @@ public class TestResourceManagerTest {
         }
     }
 
+    @WithTestResource(value = FirstParallelQuarkusTestResource.class, parallel = true, restrictToAnnotatedClass = false)
+    @WithTestResource(value = SecondParallelQuarkusTestResource.class, parallel = true, restrictToAnnotatedClass = false)
+    public static class ParallelTestResourcesTest {
+    }
+
     @QuarkusTestResource(value = FirstParallelQuarkusTestResource.class, parallel = true)
     @QuarkusTestResource(value = SecondParallelQuarkusTestResource.class, parallel = true)
-    public static class ParallelTestResourcesTest {
+    public static class ParallelTestResourcesTest2 {
     }
 
     public static class FirstParallelQuarkusTestResource implements QuarkusTestResourceLifecycleManager {
@@ -183,9 +202,11 @@ public class TestResourceManagerTest {
         }
     }
 
-    @Test
-    void testAnnotationBased() {
-        TestResourceManager manager = new TestResourceManager(RepeatableAnnotationBasedTestResourcesTest.class);
+    @ParameterizedTest
+    @ValueSource(classes = { RepeatableAnnotationBasedTestResourcesTest.class,
+            RepeatableAnnotationBasedTestResourcesTest2.class })
+    void testAnnotationBased(Class<?> clazz) {
+        TestResourceManager manager = new TestResourceManager(clazz);
         manager.init("test");
         Map<String, String> props = manager.start();
         Assertions.assertEquals("value", props.get("annotationkey1"));
@@ -214,7 +235,29 @@ public class TestResourceManagerTest {
         }
     }
 
-    @QuarkusTestResource(AnnotationBasedQuarkusTestResource.class)
+    public static class AnnotationBasedQuarkusTestResource2
+            implements QuarkusTestResourceConfigurableLifecycleManager<WithAnnotationBasedTestResource2> {
+
+        private String key;
+
+        @Override
+        public void init(WithAnnotationBasedTestResource2 annotation) {
+            this.key = annotation.key();
+        }
+
+        @Override
+        public Map<String, String> start() {
+            Map<String, String> props = new HashMap<>();
+            props.put(key, "value");
+            return props;
+        }
+
+        @Override
+        public void stop() {
+        }
+    }
+
+    @WithTestResource(value = AnnotationBasedQuarkusTestResource.class, restrictToAnnotatedClass = false)
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     @Repeatable(WithAnnotationBasedTestResource.List.class)
@@ -223,14 +266,34 @@ public class TestResourceManagerTest {
 
         @Target(ElementType.TYPE)
         @Retention(RetentionPolicy.RUNTIME)
-        @QuarkusTestResourceRepeatable(WithAnnotationBasedTestResource.class)
+        @WithTestResourceRepeatable(WithAnnotationBasedTestResource.class)
         @interface List {
             WithAnnotationBasedTestResource[] value();
+        }
+    }
+
+    @QuarkusTestResource(AnnotationBasedQuarkusTestResource2.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Repeatable(WithAnnotationBasedTestResource2.List.class)
+    public @interface WithAnnotationBasedTestResource2 {
+        String key() default "";
+
+        @Target(ElementType.TYPE)
+        @Retention(RetentionPolicy.RUNTIME)
+        @QuarkusTestResourceRepeatable(WithAnnotationBasedTestResource2.class)
+        @interface List {
+            WithAnnotationBasedTestResource2[] value();
         }
     }
 
     @WithAnnotationBasedTestResource(key = "annotationkey1")
     @WithAnnotationBasedTestResource(key = "annotationkey2")
     public static class RepeatableAnnotationBasedTestResourcesTest {
+    }
+
+    @WithAnnotationBasedTestResource2(key = "annotationkey1")
+    @WithAnnotationBasedTestResource2(key = "annotationkey2")
+    public static class RepeatableAnnotationBasedTestResourcesTest2 {
     }
 }

--- a/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/WithFunction.java
+++ b/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/WithFunction.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
 /**
  * This annotation can be used to start a Google Cloud Function for a test.
@@ -15,7 +15,7 @@ import io.quarkus.test.common.QuarkusTestResource;
  *
  * @see CloudFunctionTestResource
  */
-@QuarkusTestResource(value = CloudFunctionTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(CloudFunctionTestResource.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface WithFunction {

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/LogCollectingTestResource.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/LogCollectingTestResource.java
@@ -34,7 +34,7 @@ public class LogCollectingTestResource implements QuarkusTestResourceLifecycleMa
     public static LogCollectingTestResource current() {
         if (current == null) {
             throw new IllegalStateException(
-                    LogCollectingTestResource.class.getName() + " must be registered with @QuarkusTestResource");
+                    LogCollectingTestResource.class.getName() + " must be registered with @WithTestResource");
         }
         return current;
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestProfile.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestProfile.java
@@ -51,7 +51,7 @@ public interface QuarkusTestProfile {
      * specific test profile.
      *
      * If this method is not overridden, then only the {@link QuarkusTestResourceLifecycleManager} classes enabled via the
-     * {@link io.quarkus.test.common.QuarkusTestResource} class
+     * {@link io.quarkus.test.common.WithTestResource} class
      * annotation will be used for the tests using this profile (which is the same behavior as tests that don't use a profile at
      * all).
      */

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/WithKubernetesTestServer.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/WithKubernetesTestServer.java
@@ -7,13 +7,13 @@ import java.lang.annotation.Target;
 import java.util.function.Consumer;
 
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
 /**
  * Use on your test resource to get a mock {@link KubernetesServer} spawn up, and injectable with {@link KubernetesTestServer}.
  * This annotation is only active when used on a test class, and only for this test class.
  */
-@QuarkusTestResource(value = KubernetesServerTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(KubernetesServerTestResource.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface WithKubernetesTestServer {

--- a/test-framework/oidc-server/src/test/java/io/quarkus/test/oidc/server/OidcWiremockTestResourceInjectionTest.java
+++ b/test-framework/oidc-server/src/test/java/io/quarkus/test/oidc/server/OidcWiremockTestResourceInjectionTest.java
@@ -1,13 +1,13 @@
 package io.quarkus.test.oidc.server;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.TestResourceManager;
+import io.quarkus.test.common.WithTestResource;
 
 /**
  * Validates the injection of {@link WireMockServer} objects into test instances by {@link OidcWiremockTestResource}.
@@ -24,7 +24,7 @@ class OidcWiremockTestResourceInjectionTest {
         assertNotNull(test.server);
     }
 
-    @QuarkusTestResource(OidcWiremockTestResource.class)
+    @WithTestResource(value = OidcWiremockTestResource.class, restrictToAnnotatedClass = false)
     public static class CustomTest {
         @OidcWireMock
         WireMockServer server;

--- a/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/WithOpenShiftTestServer.java
+++ b/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/WithOpenShiftTestServer.java
@@ -7,13 +7,13 @@ import java.lang.annotation.Target;
 import java.util.function.Consumer;
 
 import io.fabric8.openshift.client.server.mock.OpenShiftServer;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
 /**
  * Use on your test resource to get a mock {@link OpenShiftServer} spawn up, and injectable with {@link OpenShiftTestServer}.
  * This annotation is only active when used on a test class, and only for this test class.
  */
-@QuarkusTestResource(value = OpenShiftServerTestResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(OpenShiftServerTestResource.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface WithOpenShiftTestServer {


### PR DESCRIPTION
New annotation replacing `@QuarkusTestResource` which sets `restrictAnnotatedClass=true` by default. Also deprecates existing `@QuarkusTestResource` annotation.

I refactored all of the tests in Quarkus to use the new annotation and made it so `restrictAnnotatedClass` for every test formerly using `@QuarkusTestResource` was unchanged. I also added some new tests to be sure both `@QuarkusTestResource` and `@WithTestResource` annotations work correctly.

- Closes #37853