### PR TITLE
Enable configuration of the Vert.x address resolver and  cache directory via Quarkus properties

### DIFF
--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -1214,7 +1214,13 @@ In environments with read only file systems you may receive errors of the form:
 java.lang.IllegalStateException: Failed to create cache dir
 ----
 
-Assuming `/tmp/` is writable this can be fixed by setting the `vertx.cacheDirBase` property to point to a directory in `/tmp/` for instance in OpenShift by creating an environment variable `JAVA_OPTS` with the value `-Dvertx.cacheDirBase=/tmp/vertx`.
+Assuming `/tmp/` is writable this can be fixed by setting the `vertx.cacheDirBase` property to point to a directory in `/tmp/` for instance in Kubernetes by creating an environment variable `JAVA_OPTS` with the value `-Dvertx.cacheDirBase=/tmp/vertx`, or setting the `quarkus.vertx.cache-directory` property in `application.properties`:
+
+[source, properties]
+----
+quarkus.vertx.cache-directory=/tmp/vertx
+----
+
 
 [[customizing-the-vert-x-configuration]]
 == Customize the Vert.x configuration

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -327,7 +327,12 @@ public class VertxCoreRecorder {
                 .setClassPathResolvingEnabled(conf.classpathResolving());
 
         String fileCacheDir = System.getProperty(CACHE_DIR_BASE_PROP_NAME);
+        if (fileCacheDir != null) {
+            fileCacheDir = conf.cacheDirectory().orElse(null);
+        }
+
         if (fileCacheDir == null) {
+            // If not set, make sure we can create a directory in the temp directory.
             File tmp = new File(System.getProperty("java.io.tmpdir", ".") + File.separator + VERTX_CACHE);
             boolean cacheDirRequired = conf.caching() || conf.classpathResolving();
             if (!tmp.isDirectory() && cacheDirRequired) {
@@ -360,6 +365,8 @@ public class VertxCoreRecorder {
                     });
                 }
             }
+        } else {
+            fileSystemOptions.setFileCacheDir(fileCacheDir);
         }
 
         options.setFileSystemOptions(fileSystemOptions);
@@ -503,6 +510,27 @@ public class VertxCoreRecorder {
         opts.setCacheNegativeTimeToLive(ar.cacheNegativeTimeToLive());
         opts.setMaxQueries(ar.maxQueries());
         opts.setQueryTimeout(ar.queryTimeout().toMillis());
+        opts.setHostsRefreshPeriod(ar.hostRefreshPeriod());
+        opts.setOptResourceEnabled(ar.optResourceEnabled());
+        opts.setRdFlag(ar.rdFlag());
+        opts.setNdots(ar.ndots());
+        opts.setRoundRobinInetAddress(ar.roundRobinInetAddress());
+
+        if (ar.hostsPath().isPresent()) {
+            opts.setHostsPath(ar.hostsPath().get());
+        }
+
+        if (ar.servers().isPresent()) {
+            opts.setServers(ar.servers().get());
+        }
+
+        if (ar.searchDomains().isPresent()) {
+            opts.setSearchDomains(ar.searchDomains().get());
+        }
+
+        if (ar.rotateServers().isPresent()) {
+            opts.setRotateServers(ar.rotateServers().get());
+        }
 
         options.setAddressResolverOptions(opts);
     }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/AddressResolverConfiguration.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/AddressResolverConfiguration.java
@@ -1,6 +1,8 @@
 package io.quarkus.vertx.core.runtime.config;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
@@ -39,4 +41,69 @@ public interface AddressResolverConfiguration {
      */
     @WithDefault("5S")
     Duration queryTimeout();
+
+    /**
+     * Set the path of an alternate hosts configuration file to use instead of the one provided by the os.
+     * <p/>
+     * The default value is `null`, so the operating system hosts config (e.g. `/etc/hosts`) is used.
+     */
+    Optional<String> hostsPath();
+
+    /**
+     * Set the hosts configuration refresh period in millis, {@code 0} (default) disables it.
+     * <p/>
+     * The resolver caches the hosts configuration (configured using `quarkus.vertx.resolver.hosts-path` after it has read it.
+     * When the content of this file can change, setting a positive refresh period will load the configuration
+     * file again when necessary.
+     */
+    @WithDefault("0")
+    int hostRefreshPeriod();
+
+    /**
+     * Set the list of DNS server addresses, an address is the IP of the dns server, followed by an optional
+     * colon and a port, e.g {@code 8.8.8.8} or {code 192.168.0.1:40000}. When the list is empty, the resolver
+     * will use the list of the system DNS server addresses from the environment, if that list cannot be retrieved
+     * it will use Google's public DNS servers {@code "8.8.8.8"} and {@code "8.8.4.4"}.
+     **/
+    Optional<List<String>> servers();
+
+    /**
+     * Set to true to enable the automatic inclusion in DNS queries of an optional record that hints
+     * the remote DNS server about how much data the resolver can read per response.
+     */
+    @WithDefault("false")
+    boolean optResourceEnabled();
+
+    /**
+     * Set the DNS queries <i>Recursion Desired</i> flag value.
+     */
+    @WithDefault("true")
+    boolean rdFlag();
+
+    /**
+     * Set the lists of DNS search domains.
+     * <p/>
+     * When the search domain list is null, the effective search domain list will be populated using
+     * the system DNS search domains.
+     */
+    Optional<List<String>> searchDomains();
+
+    /**
+     * Set the ndots value used when resolving using search domains, the default value is {@code -1} which
+     * determines the value from the OS on Linux or uses the value {@code 1}.
+     */
+    @WithDefault("-1")
+    int ndots();
+
+    /**
+     * Set to {@code true} to enable round-robin selection of the dns server to use. It spreads the query load
+     * among the servers and avoids all lookup to hit the first server of the list.
+     */
+    Optional<Boolean> rotateServers();
+
+    /**
+     * Set to {@code true} to enable round-robin inet address selection of the ip address to use.
+     */
+    @WithDefault("false")
+    boolean roundRobinInetAddress();
 }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.core.runtime.config;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -17,6 +18,15 @@ public interface VertxConfiguration {
      */
     @WithDefault("true")
     boolean caching();
+
+    /**
+     * Configure the file cache directory.
+     * When not set, the cache is stored in the system temporary directory (read from the `java.io.tmpdir` system property).
+     * If the `java.io.tmpdir` is not set `.` is used.
+     * <p>
+     * Note that this property is ignored if the `vertx.cacheDirBase` system property is set.
+     */
+    Optional<String> cacheDirectory();
 
     /**
      * Enables or disabled the Vert.x classpath resource resolver.
@@ -67,7 +77,7 @@ public interface VertxConfiguration {
 
     /**
      * The executor growth resistance.
-     *
+     * <p>
      * A resistance factor applied after the core pool is full; values applied here will cause that fraction
      * of submissions to create new threads when no idle thread is available. A value of {@code 0.0f} implies that
      * threads beyond the core size should be created as aggressively as threads within it; a value of {@code 1.0f}

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -139,6 +139,51 @@ public class VertxCoreProducerTest {
                     public int cacheMaxTimeToLive() {
                         return 3;
                     }
+
+                    @Override
+                    public Optional<String> hostsPath() {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public int hostRefreshPeriod() {
+                        return 0;
+                    }
+
+                    @Override
+                    public Optional<List<String>> servers() {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public boolean optResourceEnabled() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean rdFlag() {
+                        return false;
+                    }
+
+                    @Override
+                    public Optional<List<String>> searchDomains() {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public int ndots() {
+                        return 0;
+                    }
+
+                    @Override
+                    public Optional<Boolean> rotateServers() {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public boolean roundRobinInetAddress() {
+                        return false;
+                    }
                 };
             }
         };
@@ -180,6 +225,11 @@ public class VertxCoreProducerTest {
         @Override
         public boolean caching() {
             return true;
+        }
+
+        @Override
+        public Optional<String> cacheDirectory() {
+            return Optional.empty();
         }
 
         @Override
@@ -516,6 +566,51 @@ public class VertxCoreProducerTest {
                 @Override
                 public int cacheMaxTimeToLive() {
                     return Integer.MAX_VALUE;
+                }
+
+                @Override
+                public Optional<String> hostsPath() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public int hostRefreshPeriod() {
+                    return 0;
+                }
+
+                @Override
+                public Optional<List<String>> servers() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public boolean optResourceEnabled() {
+                    return false;
+                }
+
+                @Override
+                public boolean rdFlag() {
+                    return false;
+                }
+
+                @Override
+                public Optional<List<String>> searchDomains() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public int ndots() {
+                    return 0;
+                }
+
+                @Override
+                public Optional<Boolean> rotateServers() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public boolean roundRobinInetAddress() {
+                    return false;
                 }
             };
         }


### PR DESCRIPTION
This PR introduces new configuration properties for fine-tuning the Vert.x address resolver and setting the cache directory through Quarkus properties. The system property will still be read if set to maintain backward compatibility.
