### PR TITLE
Avoid closing Wiremock gracefully

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/NoPathInTheAppTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/NoPathInTheAppTest.java
@@ -33,8 +33,8 @@ public class NoPathInTheAppTest {
     }
 
     @AfterEach
-    public void shutdown() {
-        server.shutdown();
+    public void stop() {
+        server.stop();
     }
 
     @Test

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkResponseTimeLoadBalancerTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkResponseTimeLoadBalancerTest.java
@@ -39,8 +39,8 @@ public class StorkResponseTimeLoadBalancerTest {
     }
 
     @AfterAll
-    public static void shutDown() {
-        server.shutdown();
+    public static void stop() {
+        server.stop();
     }
 
     @RestClient

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/TrustAllTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/TrustAllTest.java
@@ -41,8 +41,8 @@ public class TrustAllTest {
     }
 
     @AfterEach
-    public void cleanUp() {
-        server.shutdown();
+    public void stop() {
+        server.stop();
     }
 
     @Test


### PR DESCRIPTION
There's no real need here and it tries to load classes after the CL has been closed as it starts a thread that shut down Wiremock a bit later and some new classes are needed.

Related to #41233