### PR TITLE
Avoid calling ResteasyProviderFactory.getInstance() when popping

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/RequestDispatcher.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/RequestDispatcher.java
@@ -58,11 +58,13 @@ public class RequestDispatcher {
             HttpRequest vertxReq, HttpResponse vertxResp, boolean handleNotFound, Throwable throwable) throws IOException {
 
         ClassLoader old = Thread.currentThread().getContextClassLoader();
+        boolean providerFactoryPushedToThreadLocal = false;
         try {
             Thread.currentThread().setContextClassLoader(classLoader);
             ResteasyProviderFactory defaultInstance = ResteasyProviderFactory.getInstance();
             if (defaultInstance instanceof ThreadLocalResteasyProviderFactory) {
                 ThreadLocalResteasyProviderFactory.push(providerFactory);
+                providerFactoryPushedToThreadLocal = true;
             }
 
             try {
@@ -88,8 +90,7 @@ public class RequestDispatcher {
             }
         } finally {
             try {
-                ResteasyProviderFactory defaultInstance = ResteasyProviderFactory.getInstance();
-                if (defaultInstance instanceof ThreadLocalResteasyProviderFactory) {
+                if (providerFactoryPushedToThreadLocal) {
                     ThreadLocalResteasyProviderFactory.pop();
                 }
             } finally {


### PR DESCRIPTION
When popping provider factory, what we actually want is pop it if something has been pushed.
It is better handled by setting a boolean if something has been pushed.

This allows class loading issues when the class loader has been closed and the request is still processing.

Related to #41233