### PR TITLE
Add the notion of QuarkusClassLoaderType and avoid potentially creating CLs in LogCapturingOutputFilter

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -25,6 +25,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.classloading.MemoryClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.prebuild.CodeGenException;
 import io.quarkus.deployment.codegen.CodeGenData;
@@ -338,7 +339,7 @@ public class CodeGenerator {
 
             // we don't want to load config services from the current module because they haven't been compiled yet
             final QuarkusClassLoader.Builder configClBuilder = QuarkusClassLoader.builder("CodeGenerator Config ClassLoader",
-                    deploymentClassLoader, false);
+                    QuarkusClassLoaderType.DEPLOYMENT, deploymentClassLoader, false);
             if (!allowedConfigServices.isEmpty()) {
                 configClBuilder.addElement(new MemoryClassPathElement(allowedConfigServices, true));
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -136,7 +136,7 @@ public class JunitTestRunner {
             long start = System.currentTimeMillis();
             ClassLoader old = Thread.currentThread().getContextClassLoader();
             QuarkusClassLoader tcl = testApplication.createDeploymentClassLoader();
-            LogCapturingOutputFilter logHandler = new LogCapturingOutputFilter(testApplication, true, true,
+            LogCapturingOutputFilter logHandler = new LogCapturingOutputFilter(true, true,
                     TestSupport.instance().get()::isDisplayTestOutput);
             Thread.currentThread().setContextClassLoader(tcl);
             Consumer currentTestAppConsumer = (Consumer) tcl.loadClass(CurrentTestApplication.class.getName())

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/LogCapturingOutputFilter.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/LogCapturingOutputFilter.java
@@ -10,21 +10,19 @@ import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 
 public class LogCapturingOutputFilter implements BiPredicate<String, Boolean> {
     private static final Logger log = Logger.getLogger(LogCapturingOutputFilter.class);
 
-    private final CuratedApplication application;
     private final List<String> logOutput = new ArrayList<>();
     private final List<String> errorOutput = new ArrayList<>();
     private final boolean mergeErrorStream;
     private final boolean convertToHtml;
     private final Supplier<Boolean> finalPredicate;
 
-    public LogCapturingOutputFilter(CuratedApplication application, boolean mergeErrorStream, boolean convertToHtml,
+    public LogCapturingOutputFilter(boolean mergeErrorStream, boolean convertToHtml,
             Supplier<Boolean> finalPredicate) {
-        this.application = application;
         this.mergeErrorStream = mergeErrorStream;
         this.convertToHtml = convertToHtml;
         this.finalPredicate = finalPredicate;
@@ -50,8 +48,8 @@ public class LogCapturingOutputFilter implements BiPredicate<String, Boolean> {
             return true;
         }
         while (cl.getParent() != null) {
-            if (cl == application.getAugmentClassLoader()
-                    || cl == application.getBaseRuntimeClassLoader()) {
+            if (cl instanceof QuarkusClassLoader
+                    && (((QuarkusClassLoader) cl).isAugmentation() || ((QuarkusClassLoader) cl).isBaseRuntime())) {
                 //TODO: for convenience we save the log records as HTML rather than ANSI here
                 synchronized (logOutput) {
                     if (convertToHtml) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -31,6 +31,7 @@ import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.app.QuarkusBootstrap.Mode;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.dev.ClassScanResult;
 import io.quarkus.deployment.dev.CompilationProvider;
@@ -220,6 +221,7 @@ public class TestSupport implements TestController {
                                 if (clBuilder == null) {
                                     clBuilder = QuarkusClassLoader.builder("Continuous Testing Parent-First"
                                             + curatedApplication.getClassLoaderNameSuffix(),
+                                            QuarkusClassLoaderType.BOOTSTRAP,
                                             getClass().getClassLoader().getParent(), false);
                                 }
                                 clBuilder.addElement(ClassPathElement.fromDependency(d));

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -23,6 +23,7 @@ import io.quarkus.bootstrap.classloading.ClassPathResource;
 import io.quarkus.bootstrap.classloading.FilteredClassPathElement;
 import io.quarkus.bootstrap.classloading.MemoryClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.DependencyFlags;
@@ -194,6 +195,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             //first run, we need to build all the class loaders
             QuarkusClassLoader.Builder builder = QuarkusClassLoader.builder(
                     "Augmentation Class Loader: " + quarkusBootstrap.getMode() + getClassLoaderNameSuffix(),
+                    QuarkusClassLoaderType.AUGMENTATION,
                     quarkusBootstrap.getBaseClassLoader(), !quarkusBootstrap.isIsolateDeployment())
                     .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled());
             builder.addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners());
@@ -239,6 +241,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         if (baseRuntimeClassLoader == null) {
             QuarkusClassLoader.Builder builder = QuarkusClassLoader.builder(
                     "Quarkus Base Runtime ClassLoader: " + quarkusBootstrap.getMode() + getClassLoaderNameSuffix(),
+                    QuarkusClassLoaderType.BASE_RUNTIME,
                     quarkusBootstrap.getBaseClassLoader(), false)
                     .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled());
             builder.addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners());
@@ -317,6 +320,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         //first run, we need to build all the class loaders
         QuarkusClassLoader.Builder builder = QuarkusClassLoader
                 .builder("Deployment Class Loader: " + quarkusBootstrap.getMode() + getClassLoaderNameSuffix(),
+                        QuarkusClassLoaderType.DEPLOYMENT,
                         getAugmentClassLoader(), false)
                 .addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners())
                 .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled())
@@ -366,6 +370,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                                 + getClassLoaderNameSuffix()
                                 + " restart no:"
                                 + runtimeClassLoaderCount.getAndIncrement(),
+                        QuarkusClassLoaderType.RUNTIME,
                         getBaseRuntimeClassLoader(), false)
                 .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled())
                 .setAggregateParentResources(true);

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingInterruptTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingInterruptTestCase.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.util.IoUtils;
 
 public class ClassLoadingInterruptTestCase {
@@ -23,7 +24,8 @@ public class ClassLoadingInterruptTestCase {
         try {
             jar.as(ExplodedExporter.class).exportExploded(path.toFile(), "tmp");
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader.builder("test", QuarkusClassLoaderType.BOOTSTRAP,
+                    getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
                     .build();
             Class<?> c = cl.loadClass(InterruptClass.class.getName());

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingPathTreeResourceUrlTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingPathTreeResourceUrlTestCase.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.util.IoUtils;
 
 public class ClassLoadingPathTreeResourceUrlTestCase {
@@ -36,7 +37,8 @@ public class ClassLoadingPathTreeResourceUrlTestCase {
         try {
             jar.as(ExplodedExporter.class).exportExploded(path.toFile(), "tmp");
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
                     .build();
             URL res = cl.getResource("a.txt");
@@ -74,7 +76,8 @@ public class ClassLoadingPathTreeResourceUrlTestCase {
         final Path tmpDir = Files.createTempDirectory(testPath);
         try {
             jar.as(ExplodedExporter.class).exportExploded(tmpDir.toFile(), "tmpcltest");
-            final ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            final ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(tmpDir.resolve("tmpcltest"), true))
                     .build();
 
@@ -102,7 +105,8 @@ public class ClassLoadingPathTreeResourceUrlTestCase {
         try {
             jar.as(ZipExporter.class).exportTo(path.toFile(), true);
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path, true))
                     .build();
             URL res = cl.getResource("a.txt");

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingResourceUrlTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingResourceUrlTestCase.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.MemoryClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.util.IoUtils;
 
 //see https://github.com/quarkusio/quarkus/issues/10943
@@ -41,7 +42,8 @@ public class ClassLoadingResourceUrlTestCase {
         try {
             jar.as(ExplodedExporter.class).exportExploded(path.toFile(), "tmp");
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
                     .build();
             URL res = cl.getResource("a.txt");
@@ -79,7 +81,8 @@ public class ClassLoadingResourceUrlTestCase {
         final Path tmpDir = Files.createTempDirectory(testPath);
         try {
             jar.as(ExplodedExporter.class).exportExploded(tmpDir.toFile(), "tmpcltest");
-            final ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            final ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(tmpDir.resolve("tmpcltest"), true))
                     .build();
 
@@ -107,7 +110,8 @@ public class ClassLoadingResourceUrlTestCase {
         try {
             jar.as(ZipExporter.class).exportTo(path.toFile(), true);
 
-            ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+            ClassLoader cl = QuarkusClassLoader
+                    .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                     .addElement(ClassPathElement.fromPath(path, true))
                     .build();
             URL res = cl.getResource("a.txt");
@@ -134,7 +138,8 @@ public class ClassLoadingResourceUrlTestCase {
         long start = System.currentTimeMillis();
         Thread.sleep(2);
 
-        ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+        ClassLoader cl = QuarkusClassLoader
+                .builder("test", QuarkusClassLoaderType.BOOTSTRAP, getClass().getClassLoader(), false)
                 .addElement(
                         new MemoryClassPathElement(Collections.singletonMap("a.txt", "hello".getBytes(StandardCharsets.UTF_8)),
                                 true))

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/MultiReleaseJarTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/MultiReleaseJarTestCase.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.bootstrap.util.IoUtils;
 
 public class MultiReleaseJarTestCase {
@@ -51,7 +52,8 @@ public class MultiReleaseJarTestCase {
 
     @Test
     public void shouldLoadMultiReleaseJarOnJDK9Plus() throws IOException {
-        try (QuarkusClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
+        try (QuarkusClassLoader cl = QuarkusClassLoader.builder("test", QuarkusClassLoaderType.BOOTSTRAP,
+                getClass().getClassLoader(), false)
                 .addElement(ClassPathElement.fromPath(jarPath, true))
                 .build()) {
             URL resource = cl.getResource("foo.txt");

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -58,6 +58,7 @@ import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.classloading.ClassLoaderEventListener;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader.QuarkusClassLoaderType;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildException;
@@ -638,6 +639,7 @@ public class QuarkusUnitTest
                 if (!allowTestClassOutsideDeployment) {
                     quarkusUnitTestClassLoader = QuarkusClassLoader
                             .builder("QuarkusUnitTest ClassLoader for " + extensionContext.getDisplayName(),
+                                    QuarkusClassLoaderType.BOOTSTRAP,
                                     getClass().getClassLoader(), false)
                             .addClassLoaderEventListeners(this.classLoadListeners)
                             .addBannedElement(ClassPathElement.fromPath(testLocation, true)).build();

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -86,7 +86,7 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
     private LaunchResult doLaunch(ExtensionContext context, Class<? extends QuarkusTestProfile> selectedProfile,
             String[] arguments) throws Exception {
         ensurePrepared(context, selectedProfile);
-        LogCapturingOutputFilter filter = new LogCapturingOutputFilter(prepareResult.curatedApplication, false, false,
+        LogCapturingOutputFilter filter = new LogCapturingOutputFilter(false, false,
                 () -> true);
         QuarkusConsole.addOutputFilter(filter);
         try {


### PR DESCRIPTION
These `application.get*ClassLoader()` methods are a bit dangerous because they get or create a class loader.

Related to https://github.com/quarkusio/quarkus/issues/41233