### PR TITLE
Make sure the TestResourceManager is closed before the CL is closed

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -1,5 +1,6 @@
 package io.quarkus.bootstrap.app;
 
+import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -30,5 +31,7 @@ public interface StartupAction {
      * Runs the application by running the main method of the main class, and runs it to completion
      */
     int runMainClassBlocking(String... args) throws Exception;
+
+    void addRuntimeCloseTask(Closeable closeTask);
 
 }


### PR DESCRIPTION
- The TestResourceManager is instantiated using the runtime class loader so we need to make sure we close it before we close the runtime class loader. Otherwise we can get into trouble if we need to load some additional classes.
- Also make sure that it is only closed once. It used to be closed once when the application is stopped and then again when the QuarkusTestExtensionState was closed.

Related to #41233