### PR TITLE
Do not keep the startupProblem in the static field of ApplicationStateNotification

### DIFF
--- a/core/devmode-spi/src/main/java/io/quarkus/dev/appstate/ApplicationStateNotification.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/appstate/ApplicationStateNotification.java
@@ -55,7 +55,12 @@ public class ApplicationStateNotification {
             }
         }
         if (startupProblem != null) {
-            throw new ApplicationStartException(startupProblem);
+            // let's not keep the startupProblem around in the static field
+            // as it keeps a reference to the Application in the backtrace
+            Throwable localStartupProblem = startupProblem;
+            startupProblem = null;
+
+            throw new ApplicationStartException(localStartupProblem);
         }
     }
 


### PR DESCRIPTION
It keeps a reference to the Application and the class loader in the backtrace.