### PR TITLE
Provide a configuration option for disabling live-reload

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -113,8 +113,11 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                 StartupAction start = augmentAction.createInitialRuntimeApplication();
 
                 runner = start.runMainClass(context.getArgs());
-                RuntimeUpdatesProcessor.INSTANCE.setConfiguredInstrumentationEnabled(
-                        runner.getConfigValue("quarkus.live-reload.instrumentation", Boolean.class).orElse(false));
+                RuntimeUpdatesProcessor.INSTANCE
+                        .setConfiguredInstrumentationEnabled(
+                                runner.getConfigValue("quarkus.live-reload.instrumentation", Boolean.class).orElse(false))
+                        .setLiveReloadEnabled(
+                                runner.getConfigValue("quarkus.live-reload.enabled", Boolean.class).orElse(false));
                 firstStartCompleted = true;
                 notifyListenersAfterStart();
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -619,6 +619,11 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
         return configuredInstrumentationEnabled;
     }
 
+    public RuntimeUpdatesProcessor setLiveReloadEnabled(boolean liveReloadEnabled) {
+        this.liveReloadEnabled = liveReloadEnabled;
+        return this;
+    }
+
     public RuntimeUpdatesProcessor setConfiguredInstrumentationEnabled(boolean configuredInstrumentationEnabled) {
         this.configuredInstrumentationEnabled = configuredInstrumentationEnabled;
         return this;

--- a/core/runtime/src/main/java/io/quarkus/runtime/LiveReloadConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LiveReloadConfig.java
@@ -12,6 +12,12 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class LiveReloadConfig {
 
     /**
+     * Whether the live-reload feature should be enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    boolean enabled;
+
+    /**
      * Whether Quarkus should enable its ability to not do a full restart
      * when changes to classes are compatible with JVM instrumentation.
      *


### PR DESCRIPTION
The interesting thing is that we essentially already had the core functionality (added in #17035) - it just happened
to only be accessible via pressing 'l' on the Quarkus command line (after the application had started).

This change introduces `quarkus.live-reload.enabled` which by default is `true`

- Closes: #32813
- Closes: #38374