### PR TITLE
Remove duplicated jctools in BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -376,11 +376,6 @@
                 <artifactId>opensearch-testcontainers</artifactId>
                 <version>${opensearch-testcontainers.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.jctools</groupId>
-                <artifactId>jctools-core</artifactId>
-                <version>${jctools-core.version}</version>
-            </dependency>
             <!-- OpenTelemetry components, imported as a BOM -->
             <dependency>
                 <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
- This reverts the jctools declaration in the quarkus-bom introduced in 447735586bf5abbc6e891067d1a68578b42306c1
