### PR TITLE
Add missing description for websockets next

### DIFF
--- a/extensions/websockets-next/pom.xml
+++ b/extensions/websockets-next/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>quarkus-websockets-next-parent</artifactId>
     <name>Quarkus - WebSockets Next</name>
+    <description>A new implementation of the WebSocket API that is more efficient and easier to use. It is also designed to work efficiently with Quarkus' reactive programming model and the Quarkus' networking layer.</description>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>


### PR DESCRIPTION
Without a description in the pom, extensions inherit the parent description. That gives [the following](https://quarkus.io/extensions/io.quarkus/quarkus-websockets-next/):
<img width="231" alt="image" src="https://github.com/quarkusio/quarkus/assets/11509290/a8fe0db9-879c-4918-8b2d-349ec3eb735c">
 