### PR TITLE
Add missing guide link for websockets next

### DIFF
--- a/extensions/websockets-next/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/websockets-next/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,6 +10,7 @@ metadata:
   - "http"
   categories:
   - "web"
+  guide: https://quarkus.io/guides/websockets-next-reference
   status: "experimental"
   config:
   - "quarkus.websockets.next"


### PR DESCRIPTION
See [discussion](https://github.com/quarkusio/quarkus/pull/41476#issuecomment-2192014838) over in #41476.

I deliberated between the reference, https://quarkus.io/guides/websockets-next-reference, and the tutorial, https://quarkus.io/guides/websockets-next-tutorial. I went with the reference in the end. 