### PR TITLE
Generate dependency list for Develocity consumption

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -17,6 +17,6 @@
     <extension>
         <groupId>io.quarkus.develocity</groupId>
         <artifactId>quarkus-project-develocity-extension</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </extension>
 </extensions>

--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -744,8 +744,9 @@ It will log the changed options and save the current values of each of the optio
 
 ==== Dump Quarkus application dependencies
 
-In addition to dumping configuration values, `track-config-changes` goal also dumps all the Quarkus application dependencies, including Quarkus build time dependencies, along with their checksums (Adler32). This file could be used to check whether Quarkus build classpath has changed since the previous run.
-By default, the dependency checksums will be stored under `target/quarkus-prod-dependency-checksums.txt` file. A different location could be configured using plugin parameters.
+In addition to dumping configuration values, `track-config-changes` goal also dumps all the Quarkus application dependencies, including Quarkus build time dependencies.
+This file could be used to check whether Quarkus build classpath has changed since the previous run, for instance together with Develocity's ability to checksum a classpath.
+By default, the list of dependencies will be stored under `target/quarkus-prod-dependencies.txt` file. A different location could be configured using plugin parameters.
 
 ==== Dump current build configuration when the recorded configuration isn't found
 


### PR DESCRIPTION
We used to build the hashes ourselves but it's best to use the Develocity infrastructure for that.

Fixes #39256