### PR TITLE
use the /q prefix

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-endpoints.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-endpoints.js
@@ -50,7 +50,7 @@ export class QwcEndpoints extends LitElement {
     }
         
     async load() {
-        const response = await fetch("/quarkus404", {
+        const response = await fetch("/q/quarkus404", {
 		method: 'GET',
 		headers: {
 			'Accept': 'application/json'


### PR DESCRIPTION
Assume you have the following config

quarkus.http.auth.permission.all.paths=/*
quarkus.http.auth.permission.all.policy=deny

quarkus.http.auth.permission.public.paths=/,/q/*
quarkus.http.auth.permission.public.policy=permit

Which will block requests to /quarkus404, instead of adding it to public.paths we can change the url to /q/quarkus404 which also aligns it with the rest of the DEV-UI urls