### PR TITLE
Register additional caches for reflection for expire-after-access config option

### DIFF
--- a/extensions/caffeine/runtime/src/main/java/io/quarkus/caffeine/runtime/graal/CacheConstructorsFeature.java
+++ b/extensions/caffeine/runtime/src/main/java/io/quarkus/caffeine/runtime/graal/CacheConstructorsFeature.java
@@ -77,6 +77,7 @@ public class CacheConstructorsFeature implements Feature {
         return new String[] {
                 "com.github.benmanes.caffeine.cache.PDMS",
                 "com.github.benmanes.caffeine.cache.PSA",
+                "com.github.benmanes.caffeine.cache.PSAW",
                 "com.github.benmanes.caffeine.cache.PSMS",
                 "com.github.benmanes.caffeine.cache.PSW",
                 "com.github.benmanes.caffeine.cache.PSMW",
@@ -86,6 +87,7 @@ public class CacheConstructorsFeature implements Feature {
                 "com.github.benmanes.caffeine.cache.PSWMW",
                 "com.github.benmanes.caffeine.cache.SILMS",
                 "com.github.benmanes.caffeine.cache.SSA",
+                "com.github.benmanes.caffeine.cache.SSAW",
                 "com.github.benmanes.caffeine.cache.SSLA",
                 "com.github.benmanes.caffeine.cache.SSLMS",
                 "com.github.benmanes.caffeine.cache.SSMS",
@@ -106,7 +108,8 @@ public class CacheConstructorsFeature implements Feature {
                 "com.github.benmanes.caffeine.cache.SSSMSA",
                 "com.github.benmanes.caffeine.cache.SSSMSW",
                 "com.github.benmanes.caffeine.cache.SSSMSAW",
-                "com.github.benmanes.caffeine.cache.SSSW"
+                "com.github.benmanes.caffeine.cache.SSSW",
+                "com.github.benmanes.caffeine.cache.SSSAW"
         };
     }
 }

--- a/integration-tests/cache/src/main/resources/application.properties
+++ b/integration-tests/cache/src/main/resources/application.properties
@@ -6,6 +6,7 @@ quarkus.hibernate-orm.sql-load-script=import.sql
 # configure the caches
 quarkus.cache.caffeine."forest".expire-after-write=10M
 
+quarkus.cache.caffeine."expensiveResourceCache".expire-after-access=10M
 quarkus.cache.caffeine."expensiveResourceCache".expire-after-write=10M
 quarkus.cache.caffeine."expensiveResourceCache".metrics-enabled=true
 quarkus.cache.caffeine."getIfPresentCache".metrics-enabled=true


### PR DESCRIPTION
Relates to a [problem](https://github.com/apache/camel-quarkus/issues/6224#issuecomment-2192390841) observed by a `camel-quarkus-caffeine` user.