### PR TITLE
Use Session instead of EntityManager in Panache internals

### DIFF
--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
@@ -15,9 +15,9 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.Id;
 
+import org.hibernate.Session;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -56,7 +56,7 @@ import io.quarkus.panache.common.deployment.TypeBundle;
 public final class KotlinPanacheResourceProcessor {
     private static final DotName DOTNAME_ID = DotName.createSimple(Id.class.getName());
     private static final DotName DOTNAME_PANACHE_ENTITY = DotName.createSimple(PanacheEntity.class.getName());
-    private static final Set<DotName> UNREMOVABLE_BEANS = singleton(createSimple(EntityManager.class.getName()));
+    private static final Set<DotName> UNREMOVABLE_BEANS = singleton(createSimple(Session.class.getName()));
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheCompanion.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheCompanion.kt
@@ -8,6 +8,7 @@ import io.quarkus.panache.common.impl.GenerateBridge
 import jakarta.persistence.EntityManager
 import jakarta.persistence.LockModeType
 import java.util.stream.Stream
+import org.hibernate.Session
 
 /**
  * Defines methods to be used via the companion objects of entities.
@@ -29,6 +30,13 @@ interface PanacheCompanionBase<Entity : PanacheEntityBase, Id : Any> {
      * @return the [EntityManager] for the [Entity]
      */
     @GenerateBridge fun getEntityManager(): EntityManager = throw implementationInjectionMissing()
+
+    /**
+     * Returns the [Session] for the [Entity] for extra operations (eg. CriteriaQueries)
+     *
+     * @return the [Session] for the [Entity]
+     */
+    @GenerateBridge fun getSession(): Session = throw implementationInjectionMissing()
 
     /**
      * Find an entity of this type by ID.

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheRepositoryBase.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheRepositoryBase.kt
@@ -8,6 +8,7 @@ import io.quarkus.panache.common.impl.GenerateBridge
 import jakarta.persistence.EntityManager
 import jakarta.persistence.LockModeType
 import java.util.stream.Stream
+import org.hibernate.Session
 
 /**
  * Represents a Repository for a specific type of entity `Entity`, with an ID type of `Id`.
@@ -25,6 +26,13 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @return the [EntityManager] for the [Entity]
      */
     @GenerateBridge fun getEntityManager(): EntityManager = throw implementationInjectionMissing()
+
+    /**
+     * Returns the [Session] for the [Entity] for extra operations (eg. CriteriaQueries)
+     *
+     * @return the [Session] for the [Entity]
+     */
+    @GenerateBridge fun getSession(): Session = throw implementationInjectionMissing()
 
     /**
      * Persist the given entity in the database, if not already persisted.
@@ -71,11 +79,10 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
     fun isPersistent(entity: Entity): Boolean = INSTANCE.isPersistent(entity)
 
     /**
-     * Flushes all pending changes to the database using the EntityManager for the [Entity] entity
-     * class.
+     * Flushes all pending changes to the database using the Session for the [Entity] entity class.
      */
     fun flush() {
-        getEntityManager().flush()
+        getSession().flush()
     }
 
     /**

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/KotlinJpaOperations.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/KotlinJpaOperations.kt
@@ -1,16 +1,16 @@
 package io.quarkus.hibernate.orm.panache.kotlin.runtime
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations
-import jakarta.persistence.EntityManager
+import org.hibernate.Session
 
 class KotlinJpaOperations : AbstractJpaOperations<PanacheQueryImpl<*>>() {
     override fun createPanacheQuery(
-        em: EntityManager,
+        session: Session,
         hqlQuery: String,
         originalQuery: String?,
         orderBy: String?,
         paramsArrayOrMap: Any?
-    ) = PanacheQueryImpl<Any>(em, hqlQuery, originalQuery, orderBy, paramsArrayOrMap)
+    ) = PanacheQueryImpl<Any>(session, hqlQuery, originalQuery, orderBy, paramsArrayOrMap)
 
     override fun list(query: PanacheQueryImpl<*>) = query.list()
 

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.kt
@@ -4,21 +4,22 @@ import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl
 import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import io.quarkus.panache.common.Page
 import io.quarkus.panache.common.Parameters
-import jakarta.persistence.EntityManager
 import jakarta.persistence.LockModeType
 import java.util.stream.Stream
+import org.hibernate.Session
 
 class PanacheQueryImpl<Entity : Any> : PanacheQuery<Entity> {
     private var delegate: CommonPanacheQueryImpl<Entity>
 
     internal constructor(
-        em: EntityManager?,
+        session: Session?,
         hqlQuery: String?,
         originalQuery: String?,
         orderBy: String?,
         paramsArrayOrMap: Any?
     ) {
-        delegate = CommonPanacheQueryImpl(em, hqlQuery, originalQuery, orderBy, paramsArrayOrMap)
+        delegate =
+            CommonPanacheQueryImpl(session, hqlQuery, originalQuery, orderBy, paramsArrayOrMap)
     }
 
     private constructor(delegate: CommonPanacheQueryImpl<Entity>) {

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -11,9 +11,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.Id;
 
+import org.hibernate.Session;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -52,7 +52,7 @@ public final class PanacheHibernateResourceProcessor {
     static final DotName DOTNAME_PANACHE_ENTITY = DotName.createSimple(PanacheEntity.class.getName());
     static final DotName DOTNAME_PANACHE_ENTITY_BASE = DotName.createSimple(PanacheEntityBase.class.getName());
 
-    private static final DotName DOTNAME_ENTITY_MANAGER = DotName.createSimple(EntityManager.class.getName());
+    private static final DotName DOTNAME_SESSION = DotName.createSimple(Session.class.getName());
 
     private static final DotName DOTNAME_ID = DotName.createSimple(Id.class.getName());
 
@@ -70,7 +70,7 @@ public final class PanacheHibernateResourceProcessor {
 
     @BuildStep
     UnremovableBeanBuildItem ensureBeanLookupAvailable() {
-        return new UnremovableBeanBuildItem(new UnremovableBeanBuildItem.BeanTypeExclusion(DOTNAME_ENTITY_MANAGER));
+        return new UnremovableBeanBuildItem(new UnremovableBeanBuildItem.BeanTypeExclusion(DOTNAME_SESSION));
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/EntityManagerTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/EntityManagerTest.java
@@ -17,8 +17,7 @@ public class EntityManagerTest {
 
     @Test
     void entityManagerShouldExist() {
-        MyEntity entity = new MyEntity();
-        assertNotNull(entity.getEntityManager());
+        assertNotNull(MyEntity.getEntityManager());
     }
 
 }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/EntityManagerTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/EntityManagerTest.java
@@ -20,4 +20,9 @@ public class EntityManagerTest {
         assertNotNull(MyEntity.getEntityManager());
     }
 
+    @Test
+    void sessionShouldExist() {
+        assertNotNull(MyEntity.getSession());
+    }
+
 }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitConfigTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitConfigTest.java
@@ -40,4 +40,11 @@ public class DefaultPersistenceUnitConfigTest {
 
         assertNotNull(SecondEntity.getEntityManager());
     }
+
+    @Test
+    void sessionShouldExist() {
+        assertNotNull(FirstEntity.getSession());
+
+        assertNotNull(SecondEntity.getSession());
+    }
 }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitConfigTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitConfigTest.java
@@ -36,10 +36,8 @@ public class DefaultPersistenceUnitConfigTest {
 
     @Test
     void entityManagerShouldExist() {
-        FirstEntity firstEntity = new FirstEntity();
-        assertNotNull(firstEntity.getEntityManager());
+        assertNotNull(FirstEntity.getEntityManager());
 
-        SecondEntity secondEntity = new SecondEntity();
-        assertNotNull(secondEntity.getEntityManager());
+        assertNotNull(SecondEntity.getEntityManager());
     }
 }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitFileTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitFileTest.java
@@ -41,10 +41,8 @@ public class DefaultPersistenceUnitFileTest {
 
     @Test
     void entityManagerShouldExist() {
-        FirstEntity firstEntity = new FirstEntity();
-        assertNotNull(firstEntity.getEntityManager());
+        assertNotNull(FirstEntity.getEntityManager());
 
-        SecondEntity secondEntity = new SecondEntity();
-        assertNotNull(secondEntity.getEntityManager());
+        assertNotNull(SecondEntity.getEntityManager());
     }
 }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitFileTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/DefaultPersistenceUnitFileTest.java
@@ -45,4 +45,11 @@ public class DefaultPersistenceUnitFileTest {
 
         assertNotNull(SecondEntity.getEntityManager());
     }
+
+    @Test
+    void sessionShouldExist() {
+        assertNotNull(FirstEntity.getSession());
+
+        assertNotNull(SecondEntity.getSession());
+    }
 }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/MultiplePersistenceUnitConfigTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/MultiplePersistenceUnitConfigTest.java
@@ -48,12 +48,10 @@ public class MultiplePersistenceUnitConfigTest {
 
     @Test
     void entityManagerShouldExist() {
-        FirstEntity firstEntity = new FirstEntity();
-        assertNotNull(firstEntity.getEntityManager());
-        assertEquals(firstEntity.getEntityManager(), defaultEntityManager);
+        assertNotNull(FirstEntity.getEntityManager());
+        assertEquals(FirstEntity.getEntityManager(), defaultEntityManager);
 
-        SecondEntity secondEntity = new SecondEntity();
-        assertNotNull(secondEntity.getEntityManager());
-        assertEquals(secondEntity.getEntityManager(), secondEntityManager);
+        assertNotNull(SecondEntity.getEntityManager());
+        assertEquals(SecondEntity.getEntityManager(), secondEntityManager);
     }
 }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/MultiplePersistenceUnitConfigTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/multiple_pu/MultiplePersistenceUnitConfigTest.java
@@ -7,6 +7,7 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
 import org.hamcrest.Matchers;
+import org.hibernate.Session;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -26,10 +27,15 @@ public class MultiplePersistenceUnitConfigTest {
 
     @Inject
     EntityManager defaultEntityManager;
+    @Inject
+    Session defaulSession;
 
     @Inject
     @PersistenceUnit("second")
     EntityManager secondEntityManager;
+    @Inject
+    @PersistenceUnit("second")
+    Session secondSession;
 
     @Test
     public void panacheOperations() {
@@ -53,5 +59,14 @@ public class MultiplePersistenceUnitConfigTest {
 
         assertNotNull(SecondEntity.getEntityManager());
         assertEquals(SecondEntity.getEntityManager(), secondEntityManager);
+    }
+
+    @Test
+    void sessionShouldExist() {
+        assertNotNull(FirstEntity.getSession());
+        assertEquals(FirstEntity.getSession(), defaulSession);
+
+        assertNotNull(SecondEntity.getSession());
+        assertEquals(SecondEntity.getSession(), secondSession);
     }
 }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/Panache.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/Panache.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.TransactionManager;
 
+import org.hibernate.Session;
+
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import io.quarkus.panache.common.Parameters;
@@ -22,7 +24,16 @@ public class Panache {
      * @return {@link EntityManager}
      */
     public static EntityManager getEntityManager() {
-        return JpaOperations.INSTANCE.getEntityManager();
+        return JpaOperations.INSTANCE.getSession();
+    }
+
+    /**
+     * Returns the default {@link Session}
+     *
+     * @return {@link Session}
+     */
+    public static Session getSession() {
+        return JpaOperations.INSTANCE.getSession();
     }
 
     /**
@@ -32,7 +43,17 @@ public class Panache {
      * @return {@link EntityManager}
      */
     public static EntityManager getEntityManager(Class<?> clazz) {
-        return JpaOperations.INSTANCE.getEntityManager(clazz);
+        return JpaOperations.INSTANCE.getSession(clazz);
+    }
+
+    /**
+     * Returns the {@link Session} for the given {@link Class<?> entity}
+     *
+     * @param clazz the entity class corresponding to the session persistence unit.
+     * @return {@link Session}
+     */
+    public static Session getSession(Class<?> clazz) {
+        return JpaOperations.INSTANCE.getSession(clazz);
     }
 
     /**
@@ -42,7 +63,17 @@ public class Panache {
      * @return {@link EntityManager}
      */
     public static EntityManager getEntityManager(String persistenceUnit) {
-        return JpaOperations.INSTANCE.getEntityManager(persistenceUnit);
+        return JpaOperations.INSTANCE.getSession(persistenceUnit);
+    }
+
+    /**
+     * Returns the {@link Session} for the given persistence unit
+     *
+     * @param persistenceUnit the persistence unit for this session.
+     * @return {@link Session}
+     */
+    public static Session getSession(String persistenceUnit) {
+        return JpaOperations.INSTANCE.getSession(persistenceUnit);
     }
 
     /**
@@ -99,7 +130,7 @@ public class Panache {
      * Flushes all pending changes to the database using the default entity manager.
      */
     public static void flush() {
-        getEntityManager().flush();
+        getSession().flush();
     }
 
     /**
@@ -108,7 +139,7 @@ public class Panache {
      * @param clazz the entity class corresponding to the entity manager persistence unit.
      */
     public static void flush(Class<?> clazz) {
-        getEntityManager(clazz).flush();
+        getSession(clazz).flush();
     }
 
     /**
@@ -117,6 +148,6 @@ public class Panache {
      * @param persistenceUnit the persistence unit for this entity manager.
      */
     public static void flush(String persistenceUnit) {
-        getEntityManager(persistenceUnit).flush();
+        getSession(persistenceUnit).flush();
     }
 }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
@@ -12,6 +12,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Transient;
 
+import org.hibernate.Session;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
@@ -38,6 +40,16 @@ public abstract class PanacheEntityBase {
      */
     @GenerateBridge
     public static EntityManager getEntityManager() {
+        throw implementationInjectionMissing();
+    }
+
+    /**
+     * Returns the {@link Session} for this entity class for extra operations (eg. CriteriaQueries)
+     *
+     * @return the {@link Session} for this entity class
+     */
+    @GenerateBridge
+    public static Session getSession() {
         throw implementationInjectionMissing();
     }
 

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
@@ -11,6 +11,8 @@ import java.util.stream.Stream;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 
+import org.hibernate.Session;
+
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
 import io.quarkus.panache.common.impl.GenerateBridge;
@@ -38,6 +40,16 @@ public interface PanacheRepositoryBase<Entity, Id> {
      */
     @GenerateBridge
     default EntityManager getEntityManager() {
+        throw implementationInjectionMissing();
+    }
+
+    /**
+     * Returns the {@link Session} for the <Entity> entity class for extra operations (eg. CriteriaQueries)
+     *
+     * @return the {@link Session} for the <Entity> entity class
+     */
+    @GenerateBridge
+    default Session getSession() {
         throw implementationInjectionMissing();
     }
 
@@ -99,7 +111,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * Flushes all pending changes to the database using the EntityManager for the <Entity> entity class.
      */
     default void flush() {
-        getEntityManager().flush();
+        getSession().flush();
     }
 
     // Queries

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
@@ -8,12 +8,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.Metamodel;
 
+import org.hibernate.Session;
 import org.hibernate.engine.spi.CascadeStyle;
 import org.hibernate.engine.spi.CascadingActions;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -32,10 +32,10 @@ public class AdditionalJpaOperations {
     public static PanacheQuery<?> find(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass, String query,
             String countQuery, Sort sort, Map<String, Object> params) {
         String findQuery = createFindQuery(entityClass, query, jpaOperations.paramCount(params));
-        EntityManager em = jpaOperations.getEntityManager(entityClass);
-        Query jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+        Session session = jpaOperations.getSession(entityClass);
+        Query jpaQuery = session.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
         JpaOperations.bindParameters(jpaQuery, params);
-        return new CustomCountPanacheQuery(em, jpaQuery, countQuery, params);
+        return new CustomCountPanacheQuery(session, jpaQuery, countQuery, params);
     }
 
     public static PanacheQuery<?> find(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass, String query,
@@ -47,20 +47,20 @@ public class AdditionalJpaOperations {
     public static PanacheQuery<?> find(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass, String query,
             String countQuery, Sort sort, Object... params) {
         String findQuery = createFindQuery(entityClass, query, jpaOperations.paramCount(params));
-        EntityManager em = jpaOperations.getEntityManager(entityClass);
-        Query jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+        Session session = jpaOperations.getSession(entityClass);
+        Query jpaQuery = session.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
         JpaOperations.bindParameters(jpaQuery, params);
-        return new CustomCountPanacheQuery(em, jpaQuery, countQuery, params);
+        return new CustomCountPanacheQuery(session, jpaQuery, countQuery, params);
     }
 
     public static long deleteAllWithCascade(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass) {
-        EntityManager em = jpaOperations.getEntityManager(entityClass);
+        Session session = jpaOperations.getSession(entityClass);
         //detecting the case where there are cascade-delete associations, and do the bulk delete query otherwise.
         if (deleteOnCascadeDetected(jpaOperations, entityClass)) {
             int count = 0;
             List<?> objects = jpaOperations.listAll(entityClass);
             for (Object entity : objects) {
-                em.remove(entity);
+                session.remove(entity);
                 count++;
             }
             return count;
@@ -77,12 +77,12 @@ public class AdditionalJpaOperations {
      * @return true if cascading delete is needed. False otherwise
      */
     private static boolean deleteOnCascadeDetected(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass) {
-        EntityManager em = jpaOperations.getEntityManager(entityClass);
-        Metamodel metamodel = em.getMetamodel();
+        Session session = jpaOperations.getSession(entityClass);
+        Metamodel metamodel = session.getMetamodel();
         EntityType<?> entity1 = metamodel.entity(entityClass);
         Set<Attribute<?, ?>> declaredAttributes = ((EntityTypeImpl) entity1).getDeclaredAttributes();
 
-        CascadeStyle[] propertyCascadeStyles = em.unwrap(SessionImplementor.class)
+        CascadeStyle[] propertyCascadeStyles = session.unwrap(SessionImplementor.class)
                 .getEntityPersister(entityClass.getName(), null)
                 .getPropertyCascadeStyles();
         boolean doCascade = Arrays.stream(propertyCascadeStyles)
@@ -96,12 +96,12 @@ public class AdditionalJpaOperations {
 
     public static <PanacheQueryType> long deleteWithCascade(AbstractJpaOperations<PanacheQueryType> jpaOperations,
             Class<?> entityClass, String query, Object... params) {
-        EntityManager em = jpaOperations.getEntityManager(entityClass);
+        Session session = jpaOperations.getSession(entityClass);
         if (deleteOnCascadeDetected(jpaOperations, entityClass)) {
             int count = 0;
             List<?> objects = jpaOperations.list(jpaOperations.find(entityClass, query, params));
             for (Object entity : objects) {
-                em.remove(entity);
+                session.remove(entity);
                 count++;
             }
             return count;
@@ -112,12 +112,12 @@ public class AdditionalJpaOperations {
     public static <PanacheQueryType> long deleteWithCascade(AbstractJpaOperations<PanacheQueryType> jpaOperations,
             Class<?> entityClass, String query,
             Map<String, Object> params) {
-        EntityManager em = jpaOperations.getEntityManager(entityClass);
+        Session session = jpaOperations.getSession(entityClass);
         if (deleteOnCascadeDetected(jpaOperations, entityClass)) {
             int count = 0;
             List<?> objects = jpaOperations.list(jpaOperations.find(entityClass, query, params));
             for (Object entity : objects) {
-                em.remove(entity);
+                session.remove(entity);
                 count++;
             }
             return count;

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
@@ -1,8 +1,8 @@
 package io.quarkus.hibernate.orm.panache.runtime;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 
+import org.hibernate.Session;
 import org.hibernate.query.spi.AbstractQuery;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl;
@@ -11,9 +11,9 @@ import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl;
 // see https://github.com/quarkusio/quarkus/issues/6214
 public class CustomCountPanacheQuery<Entity> extends PanacheQueryImpl<Entity> {
 
-    public CustomCountPanacheQuery(EntityManager em, Query jpaQuery, String customCountQuery,
+    public CustomCountPanacheQuery(Session session, Query jpaQuery, String customCountQuery,
             Object paramsArrayOrMap) {
-        super(new CommonPanacheQueryImpl<>(em, castQuery(jpaQuery).getQueryString(), null, null, paramsArrayOrMap) {
+        super(new CommonPanacheQueryImpl<>(session, castQuery(jpaQuery).getQueryString(), null, null, paramsArrayOrMap) {
             {
                 this.countQuery = customCountQuery;
             }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -3,7 +3,7 @@ package io.quarkus.hibernate.orm.panache.runtime;
 import java.util.List;
 import java.util.stream.Stream;
 
-import jakarta.persistence.EntityManager;
+import org.hibernate.Session;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
 
@@ -14,9 +14,9 @@ public class JpaOperations extends AbstractJpaOperations<PanacheQueryImpl<?>> {
     public static final JpaOperations INSTANCE = new JpaOperations();
 
     @Override
-    protected PanacheQueryImpl<?> createPanacheQuery(EntityManager em, String query, String originalQuery, String orderBy,
+    protected PanacheQueryImpl<?> createPanacheQuery(Session session, String query, String originalQuery, String orderBy,
             Object paramsArrayOrMap) {
-        return new PanacheQueryImpl<>(em, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -6,8 +6,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
+
+import org.hibernate.Session;
 
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl;
@@ -18,8 +19,8 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     private CommonPanacheQueryImpl<Entity> delegate;
 
-    PanacheQueryImpl(EntityManager em, String query, String originalQuery, String orderBy, Object paramsArrayOrMap) {
-        this.delegate = new CommonPanacheQueryImpl<>(em, query, originalQuery, orderBy, paramsArrayOrMap);
+    PanacheQueryImpl(Session session, String query, String originalQuery, String orderBy, Object paramsArrayOrMap) {
+        this.delegate = new CommonPanacheQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     protected PanacheQueryImpl(CommonPanacheQueryImpl<Entity> delegate) {

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/EntityDataAccessImplementor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/EntityDataAccessImplementor.java
@@ -5,7 +5,7 @@ import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.persistence.EntityManager;
+import org.hibernate.Session;
 
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ResultHandle;
@@ -97,10 +97,10 @@ final class EntityDataAccessImplementor implements DataAccessImplementor {
      */
     @Override
     public ResultHandle update(BytecodeCreator creator, ResultHandle entity) {
-        ResultHandle entityManager = creator.invokeStaticMethod(
-                ofMethod(entityClassName, "getEntityManager", EntityManager.class));
+        ResultHandle session = creator.invokeStaticMethod(
+                ofMethod(entityClassName, "getSession", Session.class));
         return creator.invokeInterfaceMethod(
-                ofMethod(EntityManager.class, "merge", Object.class, Object.class), entityManager, entity);
+                ofMethod(Session.class, "merge", Object.class, Object.class), session, entity);
     }
 
     /**

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/RepositoryDataAccessImplementor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/RepositoryDataAccessImplementor.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.persistence.EntityManager;
+import org.hibernate.Session;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -98,15 +98,15 @@ final class RepositoryDataAccessImplementor implements DataAccessImplementor {
     }
 
     /**
-     * Implements <code>JpaOperations.getEntityManager().merge(entity)</code>
+     * Implements <code>JpaOperations.getSession().merge(entity)</code>
      */
     @Override
     public ResultHandle update(BytecodeCreator creator, ResultHandle entity) {
-        MethodDescriptor getEntityManager = ofMethod(PanacheRepositoryBase.class, "getEntityManager",
-                EntityManager.class);
-        ResultHandle entityManager = creator.invokeInterfaceMethod(getEntityManager, getRepositoryInstance(creator));
+        MethodDescriptor getSession = ofMethod(PanacheRepositoryBase.class, "getSession",
+                Session.class);
+        ResultHandle session = creator.invokeInterfaceMethod(getSession, getRepositoryInstance(creator));
         return creator.invokeInterfaceMethod(
-                ofMethod(EntityManager.class, "merge", Object.class, Object.class), entityManager, entity);
+                ofMethod(Session.class, "merge", Object.class, Object.class), session, entity);
     }
 
     /**

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
@@ -16,9 +16,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 
+import org.hibernate.Session;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
@@ -240,13 +240,13 @@ public class StockMethodsAdder {
     private void generateMergeAndReturn(ResultHandle entity, BytecodeCreator bytecodeCreator,
             FieldDescriptor entityClassFieldDescriptor) {
         ResultHandle entityClass = bytecodeCreator.readInstanceField(entityClassFieldDescriptor, bytecodeCreator.getThis());
-        ResultHandle entityManager = bytecodeCreator.invokeVirtualMethod(
-                ofMethod(AbstractJpaOperations.class, "getEntityManager", EntityManager.class, Class.class),
+        ResultHandle session = bytecodeCreator.invokeVirtualMethod(
+                ofMethod(AbstractJpaOperations.class, "getSession", Session.class, Class.class),
                 bytecodeCreator.readStaticField(operationsField),
                 entityClass);
         entity = bytecodeCreator.invokeInterfaceMethod(
-                MethodDescriptor.ofMethod(EntityManager.class, "merge", Object.class, Object.class),
-                entityManager, entity);
+                MethodDescriptor.ofMethod(Session.class, "merge", Object.class, Object.class),
+                session, entity);
         bytecodeCreator.returnValue(entity);
     }
 

--- a/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/RepositorySupport.java
+++ b/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/RepositorySupport.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import jakarta.persistence.EntityManager;
-
 import io.quarkus.hibernate.orm.panache.Panache;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
@@ -42,16 +40,14 @@ public final class RepositorySupport {
     }
 
     public static Object getOne(AbstractJpaOperations<PanacheQuery<?>> operations, Class<?> entityClass, Object id) {
-        return operations.getEntityManager(entityClass).getReference(entityClass, id);
+        return operations.getSession(entityClass).getReference(entityClass, id);
     }
 
     public static void clear(Class<?> clazz) {
-        EntityManager em = Panache.getEntityManager(clazz);
-        em.clear();
+        Panache.getSession(clazz).clear();
     }
 
     public static void flush(Class<?> clazz) {
-        EntityManager em = Panache.getEntityManager(clazz);
-        em.flush();
+        Panache.getSession(clazz).clear();
     }
 }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -622,6 +622,7 @@ public class TestEndpoint {
     public String testModelDao() {
         personDao.flush();
         Assertions.assertNotNull(personDao.getEntityManager());
+        Assertions.assertNotNull(personDao.getSession());
 
         List<Person> persons = personDao.findAll().list();
         Assertions.assertEquals(0, persons.size());


### PR DESCRIPTION
https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Panache.20Hibernate.20-.20using.20Session

> `Session` offers better ways to implement things like queries returning optionals, and exposes things like `SelectionQuery` which is a better alternative to `Query`.
> 
> I don't think it would impact APIs, as `Session` extends `EntityManager`, and in Quarkus you can always convert an `EntityManager` to a `Session` using `unwrap` anyway.
> 
> The downside would be that people trying to mock EntityManager to test their Panache code would have to mock `Session` instead, but that's pretty much what they need to do at the moment anyway: https://github.com/quarkusio/quarkus/issues/40475#issuecomment-2126385430

This PR is *only* the switch to `Session`, no other change. I'll send other PRs if/when it turns out we can take advantage of `Session` methods.