### PR TITLE
Update 5.10.3 JUnit in a few more places

### DIFF
--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ plugin-publish = "1.2.1"
 kotlin = "2.0.0"
 smallrye-config = "3.8.3"
 
-junit5 = "5.10.2"
+junit5 = "5.10.3"
 assertj = "3.26.0"
 
 [plugins]

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -41,7 +41,7 @@
         <assertj.version>3.26.0</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.10.3</junit.jupiter.version>
         <maven-core.version>3.9.8</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.9.0.M3</sisu.version><!-- Keep in sync with maven-core.version -->
         <maven-plugin-annotations.version>3.13.0</maven-plugin-annotations.version>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -40,7 +40,7 @@
         <maven-core.version>3.9.8</maven-core.version>
         <jackson-bom.version>2.17.1</jackson-bom.version>
         <smallrye-beanbag.version>1.5.2</smallrye-beanbag.version>
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.10.3</junit.jupiter.version>
     </properties>
     <build>
         <testResources>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -45,7 +45,7 @@
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.10.0</impsort-maven-plugin.version>
 
-        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.jupiter.version>5.10.3</junit.jupiter.version>
         <assertj.version>3.26.0</assertj.version>
     </properties>
 

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -51,7 +51,7 @@
         <assertj.version>3.26.0</assertj.version>
         <jackson-bom.version>2.17.1</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
-        <junit.version>5.10.2</junit.version>
+        <junit.version>5.10.3</junit.version>
         <commons-compress.version>1.26.2</commons-compress.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>
         <mockito.version>5.12.0</mockito.version>


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/41528 bumped the version of JUnit used by main Quarkus to 5.10.3, but there's some sneaky extra references to JUnit versions hardcoded in various parts of the codebase. This PR mops them up.