### PR TITLE
Qute: skip type-safe validation for JsonObject

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/JsonObjectProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/JsonObjectProcessor.java
@@ -1,18 +1,30 @@
 package io.quarkus.qute.deployment;
 
+import java.util.function.Predicate;
+
+import org.jboss.jandex.DotName;
+
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.qute.runtime.jsonobject.JsonObjectValueResolver;
+import io.quarkus.qute.deployment.TypeCheckExcludeBuildItem.TypeCheck;
 
 public class JsonObjectProcessor {
 
     @BuildStep
-    void init(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> beans) {
+    void init(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> beans,
+            BuildProducer<TypeCheckExcludeBuildItem> typeCheckExcludes) {
         if (capabilities.isPresent(Capability.VERTX)) {
-            beans.produce(new AdditionalBeanBuildItem(JsonObjectValueResolver.class));
+            beans.produce(new AdditionalBeanBuildItem("io.quarkus.qute.runtime.jsonobject.JsonObjectValueResolver"));
+            DotName jsonObjectName = DotName.createSimple("io.vertx.core.json.JsonObject");
+            typeCheckExcludes.produce(new TypeCheckExcludeBuildItem(new Predicate<TypeCheckExcludeBuildItem.TypeCheck>() {
+                @Override
+                public boolean test(TypeCheck tc) {
+                    return tc.classNameEquals(jsonObjectName);
+                }
+            }));
         }
     }
 }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/jsonobject/JsonObjectValueResolverTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/jsonobject/JsonObjectValueResolverTest.java
@@ -2,14 +2,12 @@ package io.quarkus.qute.deployment.jsonobject;
 
 import java.util.HashMap;
 
-import jakarta.inject.Inject;
-
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
 import io.quarkus.test.QuarkusUnitTest;
 import io.vertx.core.json.JsonObject;
 
@@ -18,20 +16,20 @@ public class JsonObjectValueResolverTest {
     @RegisterExtension
     static final QuarkusUnitTest quarkusApp = new QuarkusUnitTest()
             .withApplicationRoot(
-                    app -> app.addAsResource(new StringAsset(
-                            "{tool.name} {tool.fieldNames} {tool.fields} {tool.size} {tool.empty} {tool.isEmpty} {tool.get('name')} {tool.containsKey('name')}"),
-                            "templates/foo.txt"));
+                    app -> app.addClass(foo.class)
+                            .addAsResource(new StringAsset(
+                                    "{tool.name} {tool.fieldNames} {tool.fields} {tool.size} {tool.empty} {tool.isEmpty} {tool.get('name')} {tool.containsKey('name')}"),
+                                    "templates/JsonObjectValueResolverTest/foo.txt"));
 
-    @Inject
-    Template foo;
+    record foo(JsonObject tool) implements TemplateInstance {
+    }
 
     @Test
     void testJsonObjectValueResolver() {
         HashMap<String, Object> toolMap = new HashMap<>();
         toolMap.put("name", "Roq");
         JsonObject jsonObject = new JsonObject(toolMap);
-        String render = foo.data("tool", jsonObject).render();
-
-        Assertions.assertThat(render).isEqualTo("Roq [name] [name] 1 false false Roq true");
+        String result = new foo(jsonObject).render();
+        Assertions.assertThat(result).isEqualTo("Roq [name] [name] 1 false false Roq true");
     }
 }


### PR DESCRIPTION
-if JsonObjectValueResolver is registered

This is a follow-up of https://github.com/quarkusio/quarkus/pull/41403.