### PR TITLE
Use SelectionQuery/MutationQuery wherever possible in Panache + avoid warning HHH000104

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -1245,7 +1245,7 @@ If you need to mock entity instance methods, such as `persist()` you can do it b
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import org.hibernate.Session;
-import org.hibernate.query.Query;
+import org.hibernate.query.SelectionQuery;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -1259,9 +1259,9 @@ public class PanacheMockingTest {
 
     @BeforeEach
     public void setup() {
-        Query mockQuery = Mockito.mock(Query.class);
+        SelectionQuery mockQuery = Mockito.mock(SelectionQuery.class);
         Mockito.doNothing().when(session).persist(Mockito.any());
-        Mockito.when(session.createQuery(Mockito.anyString())).thenReturn(mockQuery);
+        Mockito.when(session.createSelectionQuery(Mockito.anyString(), Mockito.any())).thenReturn(mockQuery);
         Mockito.when(mockQuery.getSingleResult()).thenReturn(0l);
     }
 

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.persistence.LockModeType;
-import jakarta.persistence.NonUniqueResultException;
 
 import org.hibernate.Filter;
 import org.hibernate.Session;
@@ -336,14 +335,9 @@ public class CommonPanacheQueryImpl<Entity> {
 
     @SuppressWarnings("unchecked")
     public <T extends Entity> Optional<T> singleResultOptional() {
-        SelectionQuery hibernateQuery = createQuery(2);
+        SelectionQuery hibernateQuery = createQuery();
         try (NonThrowingCloseable c = applyFilters()) {
-            List<T> list = hibernateQuery.getResultList();
-            if (list.size() > 1) {
-                throw new NonUniqueResultException();
-            }
-
-            return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
+            return hibernateQuery.uniqueResultOptional();
         }
     }
 

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -4,8 +4,12 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -14,7 +18,8 @@ import jakarta.persistence.NonUniqueResultException;
 
 import org.hibernate.Filter;
 import org.hibernate.Session;
-import org.hibernate.query.Query;
+import org.hibernate.query.SelectionQuery;
+import org.hibernate.query.spi.SqmQuery;
 
 import io.quarkus.hibernate.orm.panache.common.NestedProjectedClass;
 import io.quarkus.hibernate.orm.panache.common.ProjectedFieldName;
@@ -90,8 +95,8 @@ public class CommonPanacheQueryImpl<Entity> {
     public <T> CommonPanacheQueryImpl<T> project(Class<T> type) {
         String selectQuery = query;
         if (PanacheJpaUtil.isNamedQuery(query)) {
-            Query q = session.createNamedQuery(query.substring(1));
-            selectQuery = q.getQueryString();
+            SelectionQuery q = session.createNamedSelectionQuery(query.substring(1));
+            selectQuery = getQueryString(q);
         }
 
         String lowerCasedTrimmedQuery = PanacheJpaUtil.trimForAnalysis(selectQuery);
@@ -268,11 +273,11 @@ public class CommonPanacheQueryImpl<Entity> {
         if (count == null) {
             String selectQuery = query;
             if (PanacheJpaUtil.isNamedQuery(query)) {
-                Query q = session.createNamedQuery(query.substring(1));
-                selectQuery = q.getQueryString();
+                SelectionQuery q = session.createNamedSelectionQuery(query.substring(1));
+                selectQuery = getQueryString(q);
             }
 
-            Query countQuery = session.createQuery(countQuery(selectQuery));
+            SelectionQuery countQuery = session.createSelectionQuery(countQuery(selectQuery));
             if (paramsArrayOrMap instanceof Map)
                 AbstractJpaOperations.bindParameters(countQuery, (Map<String, Object>) paramsArrayOrMap);
             else
@@ -294,25 +299,25 @@ public class CommonPanacheQueryImpl<Entity> {
 
     @SuppressWarnings("unchecked")
     public <T extends Entity> List<T> list() {
-        Query jpaQuery = createQuery();
+        SelectionQuery hibernateQuery = createQuery();
         try (NonThrowingCloseable c = applyFilters()) {
-            return jpaQuery.getResultList();
+            return hibernateQuery.getResultList();
         }
     }
 
     @SuppressWarnings("unchecked")
     public <T extends Entity> Stream<T> stream() {
-        Query jpaQuery = createQuery();
+        SelectionQuery hibernateQuery = createQuery();
         try (NonThrowingCloseable c = applyFilters()) {
-            return jpaQuery.getResultStream();
+            return hibernateQuery.getResultStream();
         }
     }
 
     public <T extends Entity> T firstResult() {
-        Query jpaQuery = createQuery(1);
+        SelectionQuery hibernateQuery = createQuery(1);
         try (NonThrowingCloseable c = applyFilters()) {
             @SuppressWarnings("unchecked")
-            List<T> list = jpaQuery.getResultList();
+            List<T> list = hibernateQuery.getResultList();
             return list.isEmpty() ? null : list.get(0);
         }
     }
@@ -323,17 +328,17 @@ public class CommonPanacheQueryImpl<Entity> {
 
     @SuppressWarnings("unchecked")
     public <T extends Entity> T singleResult() {
-        Query jpaQuery = createQuery();
+        SelectionQuery hibernateQuery = createQuery();
         try (NonThrowingCloseable c = applyFilters()) {
-            return (T) jpaQuery.getSingleResult();
+            return (T) hibernateQuery.getSingleResult();
         }
     }
 
     @SuppressWarnings("unchecked")
     public <T extends Entity> Optional<T> singleResultOptional() {
-        Query jpaQuery = createQuery(2);
+        SelectionQuery hibernateQuery = createQuery(2);
         try (NonThrowingCloseable c = applyFilters()) {
-            List<T> list = jpaQuery.getResultList();
+            List<T> list = hibernateQuery.getResultList();
             if (list.size() > 1) {
                 throw new NonUniqueResultException();
             }
@@ -342,68 +347,68 @@ public class CommonPanacheQueryImpl<Entity> {
         }
     }
 
-    private Query createQuery() {
-        Query jpaQuery = createBaseQuery();
+    private SelectionQuery createQuery() {
+        SelectionQuery hibernateQuery = createBaseQuery();
 
         if (range != null) {
-            jpaQuery.setFirstResult(range.getStartIndex());
+            hibernateQuery.setFirstResult(range.getStartIndex());
             // range is 0 based, so we add 1
-            jpaQuery.setMaxResults(range.getLastIndex() - range.getStartIndex() + 1);
+            hibernateQuery.setMaxResults(range.getLastIndex() - range.getStartIndex() + 1);
         } else if (page != null) {
-            jpaQuery.setFirstResult(page.index * page.size);
-            jpaQuery.setMaxResults(page.size);
+            hibernateQuery.setFirstResult(page.index * page.size);
+            hibernateQuery.setMaxResults(page.size);
         } else {
             //no-op
         }
 
-        return jpaQuery;
+        return hibernateQuery;
     }
 
-    private Query createQuery(int maxResults) {
-        Query jpaQuery = createBaseQuery();
+    private SelectionQuery createQuery(int maxResults) {
+        SelectionQuery hibernateQuery = createBaseQuery();
 
         if (range != null) {
-            jpaQuery.setFirstResult(range.getStartIndex());
+            hibernateQuery.setFirstResult(range.getStartIndex());
         } else if (page != null) {
-            jpaQuery.setFirstResult(page.index * page.size);
+            hibernateQuery.setFirstResult(page.index * page.size);
         } else {
             //no-op
         }
-        jpaQuery.setMaxResults(maxResults);
+        hibernateQuery.setMaxResults(maxResults);
 
-        return jpaQuery;
+        return hibernateQuery;
     }
 
     @SuppressWarnings("unchecked")
-    private Query createBaseQuery() {
-        Query jpaQuery;
+    private SelectionQuery createBaseQuery() {
+        SelectionQuery hibernateQuery;
         if (PanacheJpaUtil.isNamedQuery(query)) {
             String namedQuery = query.substring(1);
-            jpaQuery = session.createNamedQuery(namedQuery, projectionType);
+            hibernateQuery = session.createNamedSelectionQuery(namedQuery, projectionType);
         } else {
             try {
-                jpaQuery = session.createQuery(orderBy != null ? query + orderBy : query, projectionType);
-            } catch (IllegalArgumentException x) {
+                hibernateQuery = session.createSelectionQuery(orderBy != null ? query + orderBy : query, projectionType);
+            } catch (RuntimeException x) {
                 throw NamedQueryUtil.checkForNamedQueryMistake(x, originalQuery);
             }
         }
 
         if (paramsArrayOrMap instanceof Map) {
-            AbstractJpaOperations.bindParameters(jpaQuery, (Map<String, Object>) paramsArrayOrMap);
+            AbstractJpaOperations.bindParameters(hibernateQuery, (Map<String, Object>) paramsArrayOrMap);
         } else {
-            AbstractJpaOperations.bindParameters(jpaQuery, (Object[]) paramsArrayOrMap);
+            AbstractJpaOperations.bindParameters(hibernateQuery, (Object[]) paramsArrayOrMap);
         }
 
         if (this.lockModeType != null) {
-            jpaQuery.setLockMode(lockModeType);
+            hibernateQuery.setLockMode(lockModeType);
         }
 
         if (hints != null) {
             for (Map.Entry<String, Object> hint : hints.entrySet()) {
-                jpaQuery.setHint(hint.getKey(), hint.getValue());
+                hibernateQuery.setHint(hint.getKey(), hint.getValue());
             }
         }
-        return jpaQuery;
+        return hibernateQuery;
     }
 
     private NonThrowingCloseable applyFilters() {
@@ -430,5 +435,19 @@ public class CommonPanacheQueryImpl<Entity> {
                 }
             }
         };
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static String getQueryString(SelectionQuery hibernateQuery) {
+        if (hibernateQuery instanceof SqmQuery) {
+            return ((SqmQuery) hibernateQuery).getQueryString();
+        } else if (hibernateQuery instanceof org.hibernate.query.Query) {
+            // In theory we never use a Query, but who knows.
+            return ((org.hibernate.query.Query) hibernateQuery).getQueryString();
+        } else {
+            throw new IllegalArgumentException("Unexpected Query class: '" + hibernateQuery.getClass().getName() + "', where '"
+                    + SqmQuery.class.getName() + "' or '"
+                    + org.hibernate.query.Query.class + "' is expected.");
+        }
     }
 }

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/NamedQueryUtil.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/NamedQueryUtil.java
@@ -43,10 +43,13 @@ public final class NamedQueryUtil {
         return false;
     }
 
-    public static RuntimeException checkForNamedQueryMistake(IllegalArgumentException x, String originalQuery) {
+    public static RuntimeException checkForNamedQueryMistake(RuntimeException x, String originalQuery) {
         if (originalQuery != null
-                && (x.getCause() instanceof SemanticException || x.getCause() instanceof ParsingException
-                        || x.getCause() instanceof SyntaxException)
+                && (isQueryStringException(x)
+                        // JPA APIs return IllegalArgumentException when the query string is invalid,
+                        // which is not helpful but mandated by spec,
+                        // but the cause is actually meaningful.
+                        || x instanceof IllegalArgumentException && isQueryStringException(x.getCause()))
                 && isNamedQuery(originalQuery)) {
             return new PanacheQueryException("Invalid query '" + originalQuery
                     + "' but it matches a known @NamedQuery, perhaps you should prefix it with a '#' to use it as a named query: '#"
@@ -54,5 +57,10 @@ public final class NamedQueryUtil {
         } else {
             return x;
         }
+    }
+
+    private static boolean isQueryStringException(Throwable x) {
+        return x instanceof SemanticException || x instanceof ParsingException
+                || x instanceof SyntaxException;
     }
 }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import jakarta.persistence.Query;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.Metamodel;
@@ -18,6 +17,7 @@ import org.hibernate.engine.spi.CascadeStyle;
 import org.hibernate.engine.spi.CascadingActions;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.metamodel.model.domain.internal.EntityTypeImpl;
+import org.hibernate.query.SelectionQuery;
 
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
@@ -33,9 +33,9 @@ public class AdditionalJpaOperations {
             String countQuery, Sort sort, Map<String, Object> params) {
         String findQuery = createFindQuery(entityClass, query, jpaOperations.paramCount(params));
         Session session = jpaOperations.getSession(entityClass);
-        Query jpaQuery = session.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
-        JpaOperations.bindParameters(jpaQuery, params);
-        return new CustomCountPanacheQuery(session, jpaQuery, countQuery, params);
+        SelectionQuery hibernateQuery = session.createSelectionQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+        JpaOperations.bindParameters(hibernateQuery, params);
+        return new CustomCountPanacheQuery(session, hibernateQuery, countQuery, params);
     }
 
     public static PanacheQuery<?> find(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass, String query,
@@ -48,9 +48,9 @@ public class AdditionalJpaOperations {
             String countQuery, Sort sort, Object... params) {
         String findQuery = createFindQuery(entityClass, query, jpaOperations.paramCount(params));
         Session session = jpaOperations.getSession(entityClass);
-        Query jpaQuery = session.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
-        JpaOperations.bindParameters(jpaQuery, params);
-        return new CustomCountPanacheQuery(session, jpaQuery, countQuery, params);
+        SelectionQuery hibernateQuery = session.createSelectionQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+        JpaOperations.bindParameters(hibernateQuery, params);
+        return new CustomCountPanacheQuery(session, hibernateQuery, countQuery, params);
     }
 
     public static long deleteAllWithCascade(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass) {

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
@@ -1,9 +1,7 @@
 package io.quarkus.hibernate.orm.panache.runtime;
 
-import jakarta.persistence.Query;
-
 import org.hibernate.Session;
-import org.hibernate.query.spi.AbstractQuery;
+import org.hibernate.query.SelectionQuery;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl;
 
@@ -11,21 +9,13 @@ import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl;
 // see https://github.com/quarkusio/quarkus/issues/6214
 public class CustomCountPanacheQuery<Entity> extends PanacheQueryImpl<Entity> {
 
-    public CustomCountPanacheQuery(Session session, Query jpaQuery, String customCountQuery,
+    public CustomCountPanacheQuery(Session session, SelectionQuery hibernateQuery, String customCountQuery,
             Object paramsArrayOrMap) {
-        super(new CommonPanacheQueryImpl<>(session, castQuery(jpaQuery).getQueryString(), null, null, paramsArrayOrMap) {
+        super(new CommonPanacheQueryImpl<>(session, CommonPanacheQueryImpl.getQueryString(hibernateQuery),
+                null, null, paramsArrayOrMap) {
             {
                 this.countQuery = customCountQuery;
             }
         });
-    }
-
-    @SuppressWarnings("rawtypes")
-    private static org.hibernate.query.sqm.internal.QuerySqmImpl castQuery(Query jpaQuery) {
-        if (!(jpaQuery instanceof org.hibernate.query.sqm.internal.QuerySqmImpl)) {
-            throw new IllegalArgumentException("Unexpected Query class: '" + jpaQuery.getClass().getName() + "', where '"
-                    + AbstractQuery.class.getName() + "' is expected.");
-        }
-        return (org.hibernate.query.sqm.internal.QuerySqmImpl) jpaQuery;
     }
 }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
@@ -195,10 +195,10 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
         return list(findAll(entityClass, sort));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Uni<Long> count(Class<?> entityClass) {
-        return (Uni) getSession()
-                .chain(session -> session.createQuery("SELECT COUNT(*) FROM " + PanacheJpaUtil.getEntityName(entityClass))
+        return getSession()
+                .chain(session -> session
+                        .createSelectionQuery("SELECT COUNT(*) FROM " + PanacheJpaUtil.getEntityName(entityClass), Long.class)
                         .getSingleResult());
     }
 
@@ -212,28 +212,29 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
                 return bindParameters(session.createNamedQuery(namedQueryName, Long.class), params).getSingleResult();
             });
 
-        return (Uni) getSession().chain(session -> bindParameters(
-                session.createQuery(PanacheJpaUtil.createCountQuery(entityClass, panacheQuery, paramCount(params))),
+        return getSession().chain(session -> bindParameters(
+                session.createSelectionQuery(PanacheJpaUtil.createCountQuery(entityClass, panacheQuery, paramCount(params)),
+                        Long.class),
                 params).getSingleResult())
-                .onFailure(IllegalArgumentException.class)
-                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((IllegalArgumentException) x, panacheQuery));
+                .onFailure(RuntimeException.class)
+                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((RuntimeException) x, panacheQuery));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Uni<Long> count(Class<?> entityClass, String panacheQuery, Map<String, Object> params) {
 
         if (PanacheJpaUtil.isNamedQuery(panacheQuery))
-            return (Uni) getSession().chain(session -> {
+            return getSession().chain(session -> {
                 String namedQueryName = panacheQuery.substring(1);
                 NamedQueryUtil.checkNamedQuery(entityClass, namedQueryName);
                 return bindParameters(session.createNamedQuery(namedQueryName, Long.class), params).getSingleResult();
             });
 
-        return (Uni) getSession().chain(session -> bindParameters(
-                session.createQuery(PanacheJpaUtil.createCountQuery(entityClass, panacheQuery, paramCount(params))),
+        return getSession().chain(session -> bindParameters(
+                session.createSelectionQuery(PanacheJpaUtil.createCountQuery(entityClass, panacheQuery, paramCount(params)),
+                        Long.class),
                 params).getSingleResult())
-                .onFailure(IllegalArgumentException.class)
-                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((IllegalArgumentException) x, panacheQuery));
+                .onFailure(RuntimeException.class)
+                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((RuntimeException) x, panacheQuery));
     }
 
     public Uni<Long> count(Class<?> entityClass, String query, Parameters params) {
@@ -258,7 +259,8 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
     public Uni<Long> deleteAll(Class<?> entityClass) {
         return getSession().chain(
-                session -> session.createQuery("DELETE FROM " + PanacheJpaUtil.getEntityName(entityClass)).executeUpdate()
+                session -> session.createMutationQuery("DELETE FROM " + PanacheJpaUtil.getEntityName(entityClass))
+                        .executeUpdate()
                         .map(Integer::longValue));
     }
 
@@ -277,33 +279,35 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
     public Uni<Long> delete(Class<?> entityClass, String panacheQuery, Object... params) {
 
         if (PanacheJpaUtil.isNamedQuery(panacheQuery))
-            return (Uni) getSession().chain(session -> {
+            return getSession().chain(session -> {
                 String namedQueryName = panacheQuery.substring(1);
                 NamedQueryUtil.checkNamedQuery(entityClass, namedQueryName);
                 return bindParameters(session.createNamedQuery(namedQueryName), params).executeUpdate().map(Integer::longValue);
             });
 
         return getSession().chain(session -> bindParameters(
-                session.createQuery(PanacheJpaUtil.createDeleteQuery(entityClass, panacheQuery, paramCount(params))), params)
+                session.createMutationQuery(PanacheJpaUtil.createDeleteQuery(entityClass, panacheQuery, paramCount(params))),
+                params)
                 .executeUpdate().map(Integer::longValue))
-                .onFailure(IllegalArgumentException.class)
-                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((IllegalArgumentException) x, panacheQuery));
+                .onFailure(RuntimeException.class)
+                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((RuntimeException) x, panacheQuery));
     }
 
     public Uni<Long> delete(Class<?> entityClass, String panacheQuery, Map<String, Object> params) {
 
         if (PanacheJpaUtil.isNamedQuery(panacheQuery))
-            return (Uni) getSession().chain(session -> {
+            return getSession().chain(session -> {
                 String namedQueryName = panacheQuery.substring(1);
                 NamedQueryUtil.checkNamedQuery(entityClass, namedQueryName);
                 return bindParameters(session.createNamedQuery(namedQueryName), params).executeUpdate().map(Integer::longValue);
             });
 
         return getSession().chain(session -> bindParameters(
-                session.createQuery(PanacheJpaUtil.createDeleteQuery(entityClass, panacheQuery, paramCount(params))), params)
+                session.createMutationQuery(PanacheJpaUtil.createDeleteQuery(entityClass, panacheQuery, paramCount(params))),
+                params)
                 .executeUpdate().map(Integer::longValue))
-                .onFailure(IllegalArgumentException.class)
-                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((IllegalArgumentException) x, panacheQuery));
+                .onFailure(RuntimeException.class)
+                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((RuntimeException) x, panacheQuery));
     }
 
     public Uni<Long> delete(Class<?> entityClass, String query, Parameters params) {
@@ -326,8 +330,8 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
         String updateQuery = PanacheJpaUtil.createUpdateQuery(entityClass, panacheQuery, paramCount(params));
         return executeUpdate(updateQuery, params)
-                .onFailure(IllegalArgumentException.class)
-                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((IllegalArgumentException) x, panacheQuery));
+                .onFailure(RuntimeException.class)
+                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((RuntimeException) x, panacheQuery));
     }
 
     public Uni<Integer> executeUpdate(Class<?> entityClass, String panacheQuery, Map<String, Object> params) {
@@ -341,8 +345,8 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
         String updateQuery = PanacheJpaUtil.createUpdateQuery(entityClass, panacheQuery, paramCount(params));
         return executeUpdate(updateQuery, params)
-                .onFailure(IllegalArgumentException.class)
-                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((IllegalArgumentException) x, panacheQuery));
+                .onFailure(RuntimeException.class)
+                .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((RuntimeException) x, panacheQuery));
     }
 
     public Uni<Integer> update(Class<?> entityClass, String query, Map<String, Object> params) {
@@ -373,7 +377,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
         return query;
     }
 
-    public static Mutiny.SelectionQuery<?> bindParameters(Mutiny.SelectionQuery<?> query, Object[] params) {
+    public static <T extends Mutiny.AbstractQuery> T bindParameters(T query, Object[] params) {
         if (params == null || params.length == 0)
             return query;
         for (int i = 0; i < params.length; i++) {
@@ -382,16 +386,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
         return query;
     }
 
-    public static Mutiny.Query<?> bindParameters(Mutiny.Query<?> query, Map<String, Object> params) {
-        if (params == null || params.size() == 0)
-            return query;
-        for (Entry<String, Object> entry : params.entrySet()) {
-            query.setParameter(entry.getKey(), entry.getValue());
-        }
-        return query;
-    }
-
-    public static Mutiny.SelectionQuery<?> bindParameters(Mutiny.SelectionQuery<?> query, Map<String, Object> params) {
+    public static <T extends Mutiny.AbstractQuery> T bindParameters(T query, Map<String, Object> params) {
         if (params == null || params.size() == 0)
             return query;
         for (Entry<String, Object> entry : params.entrySet()) {
@@ -401,18 +396,12 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
     }
 
     public static Uni<Integer> executeUpdate(String query, Object... params) {
-        return getSession().chain(session -> {
-            Mutiny.Query<?> jpaQuery = session.createQuery(query);
-            bindParameters(jpaQuery, params);
-            return jpaQuery.executeUpdate();
-        });
+        return getSession().chain(session -> bindParameters(session.createMutationQuery(query), params)
+                .executeUpdate());
     }
 
     public static Uni<Integer> executeUpdate(String query, Map<String, Object> params) {
-        return getSession().chain(session -> {
-            Mutiny.Query<?> jpaQuery = session.createQuery(query);
-            bindParameters(jpaQuery, params);
-            return jpaQuery.executeUpdate();
-        });
+        return getSession().chain(session -> bindParameters(session.createMutationQuery(query), params)
+                .executeUpdate());
     }
 }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/NamedQueryUtil.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/NamedQueryUtil.java
@@ -53,10 +53,13 @@ public final class NamedQueryUtil {
         return null;
     }
 
-    public static RuntimeException checkForNamedQueryMistake(IllegalArgumentException x, String originalQuery) {
+    public static RuntimeException checkForNamedQueryMistake(RuntimeException x, String originalQuery) {
         if (originalQuery != null
-                && (x.getCause() instanceof SemanticException || x.getCause() instanceof ParsingException
-                        || x.getCause() instanceof SyntaxException)
+                && (isQueryStringException(x)
+                        // Some APIs return IllegalArgumentException when the query string is invalid,
+                        // which is not helpful and probably a result of trying to match JPA behavior,
+                        // but the cause is actually meaningful.
+                        || x instanceof IllegalArgumentException && isQueryStringException(x.getCause()))
                 && isNamedQuery(originalQuery)) {
             return new PanacheQueryException("Invalid query '" + originalQuery
                     + "' but it matches a known @NamedQuery, perhaps you should prefix it with a '#' to use it as a named query: '#"
@@ -64,5 +67,10 @@ public final class NamedQueryUtil {
         } else {
             return x;
         }
+    }
+
+    private static boolean isQueryStringException(Throwable x) {
+        return x instanceof SemanticException || x instanceof ParsingException
+                || x instanceof SyntaxException;
     }
 }

--- a/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
@@ -6,5 +6,3 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.statistics=true
 quarkus.hibernate-orm.metrics.enabled=true
-
-quarkus.package.decompiler.enabled=true

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheMockingTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheMockingTest.java
@@ -8,7 +8,7 @@ import jakarta.persistence.LockModeType;
 import jakarta.ws.rs.WebApplicationException;
 
 import org.hibernate.Session;
-import org.hibernate.query.Query;
+import org.hibernate.query.SelectionQuery;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
@@ -28,9 +28,9 @@ public class PanacheMockingTest {
 
     @BeforeEach
     public void setup() {
-        Query mockQuery = Mockito.mock(Query.class);
+        SelectionQuery mockQuery = Mockito.mock(SelectionQuery.class);
         Mockito.doNothing().when(session).persist(Mockito.any());
-        Mockito.when(session.createQuery(Mockito.anyString())).thenReturn(mockQuery);
+        Mockito.when(session.createSelectionQuery(Mockito.anyString(), Mockito.any())).thenReturn(mockQuery);
         Mockito.when(mockQuery.getSingleResult()).thenReturn(0l);
     }
 


### PR DESCRIPTION
1. Moves to `SelectionQuery`/`MutationQuery`, which are the recommended way to create queries in Hibernate when using native APIs (`Session`).
   * Side effect: works around https://hibernate.atlassian.net/browse/HHH-18306 in the upcoming ORM 6.6 upgrade -- hopefully we won't care because the problem will be fixed in 6.6.0.Final, but it's convenient for me in [my draft PR](https://github.com/quarkusio/quarkus/pull/41359) using 6.6.0.CR1.
2. Fixes #41459

Migration guide entry:

```adoc
== Hibernate ORM with Panache

=== Move to `SelectionQuery`/`MutationQuery`

Panache now relies on different methods to run queries:
instead of calling `Session#createQuery`, which returns a `Query` object,
Panache now calls `Session#createSelectionQuery`/`Session#createMutationQuery`,
which returns a `SelectionQuery`/`MutationQuery`.

This may affect applications in the following way:

* _Some_ exceptions thrown in case of misuse won't get wrapped anymore.
For example an invalid query `String` may result in a `SemanticException`,
whereas it used to result in an `IllegalArgumentException` whose cause was a `SemanticException`.
Exceptions thrown in case of unexpected database content are unaffected.
For example `NoResultException` will still be thrown as it used to be.
* Application tests using Panache and relying on a mocked `Session` may not work anymore,
until they adjust their mocking to mock `Session#createSelectionQuery`/`Session#createMutationQuery`
instead of `Session#createQuery`.
```