### PR TITLE
Do not (incorrectly) set the value of @GeneratedValue IDs in tests

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoting_strategies/Group.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoting_strategies/Group.java
@@ -2,8 +2,6 @@ package io.quarkus.hibernate.orm.quoting_strategies;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
@@ -24,7 +22,6 @@ public class Group {
     private String value;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "groupSeq")
     public Long getId() {
         return id;
     }

--- a/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/CrudAndPagedResourceTest.java
+++ b/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/CrudAndPagedResourceTest.java
@@ -342,8 +342,8 @@ class CrudAndPagedResourceTest {
     void shouldCreateAndUpdate() {
         Response createResponse = given().accept("application/json")
                 .and().contentType("application/json")
-                .and().body("{\"id\": \"101\", \"name\": \"test-update-create\"}")
-                .when().put("/crud-and-paged-records/101")
+                .and().body("{\"name\": \"test-update-create\"}")
+                .when().post("/crud-and-paged-records/")
                 .thenReturn();
         assertThat(createResponse.statusCode()).isEqualTo(201);
 
@@ -370,8 +370,8 @@ class CrudAndPagedResourceTest {
     void shouldCreateAndUpdateHal() {
         Response createResponse = given().accept("application/hal+json")
                 .and().contentType("application/json")
-                .and().body("{\"id\": \"102\", \"name\": \"test-update-create-hal\"}")
-                .when().put("/crud-and-paged-records/102")
+                .and().body("{\"name\": \"test-update-create-hal\"}")
+                .when().post("/crud-and-paged-records/")
                 .thenReturn();
         assertThat(createResponse.statusCode()).isEqualTo(201);
 

--- a/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/JpaResourceTest.java
+++ b/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/JpaResourceTest.java
@@ -342,8 +342,8 @@ class JpaResourceTest {
     void shouldCreateAndUpdate() {
         Response createResponse = given().accept("application/json")
                 .and().contentType("application/json")
-                .and().body("{\"id\": \"101\", \"name\": \"test-update-create\"}")
-                .when().put("/jpa-records/101")
+                .and().body("{\"name\": \"test-update-create\"}")
+                .when().post("/jpa-records/")
                 .thenReturn();
         assertThat(createResponse.statusCode()).isEqualTo(201);
 
@@ -370,8 +370,8 @@ class JpaResourceTest {
     void shouldCreateAndUpdateHal() {
         Response createResponse = given().accept("application/hal+json")
                 .and().contentType("application/json")
-                .and().body("{\"id\": \"102\", \"name\": \"test-update-create-hal\"}")
-                .when().put("/jpa-records/102")
+                .and().body("{\"name\": \"test-update-create-hal\"}")
+                .when().post("/jpa-records/")
                 .thenReturn();
         assertThat(createResponse.statusCode()).isEqualTo(201);
 

--- a/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/crud/DefaultCrudResourceTest.java
+++ b/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/crud/DefaultCrudResourceTest.java
@@ -149,8 +149,8 @@ class DefaultCrudResourceTest {
     void shouldCreateAndUpdate() {
         Response createResponse = given().accept("application/json")
                 .and().contentType("application/json")
-                .and().body("{\"id\": \"101\", \"name\": \"test-update-create\"}")
-                .when().put("/default-records/101")
+                .and().body("{\"name\": \"test-update-create\"}")
+                .when().post("/default-records/")
                 .thenReturn();
         assertThat(createResponse.statusCode()).isEqualTo(201);
 
@@ -177,8 +177,8 @@ class DefaultCrudResourceTest {
     void shouldCreateAndUpdateHal() {
         Response createResponse = given().accept("application/hal+json")
                 .and().contentType("application/json")
-                .and().body("{\"id\": \"102\", \"name\": \"test-update-create-hal\"}")
-                .when().put("/default-records/102")
+                .and().body("{\"name\": \"test-update-create-hal\"}")
+                .when().post("/default-records/")
                 .thenReturn();
         assertThat(createResponse.statusCode()).isEqualTo(201);
 

--- a/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/HibernateOrmRestDataPanacheTest.java
+++ b/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/HibernateOrmRestDataPanacheTest.java
@@ -268,7 +268,7 @@ class HibernateOrmRestDataPanacheTest {
         Response response = given().accept("application/json")
                 .and().contentType("application/json")
                 .and().body(book.toString())
-                .when().put("/books/100")
+                .when().post("/books/")
                 .thenReturn();
         assertThat(response.statusCode()).isEqualTo(201);
         assertThat(response.header("Location")).isNotEmpty();

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/complex/Parent.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/complex/Parent.java
@@ -1,14 +1,11 @@
 package io.quarkus.it.spring.data.jpa.complex;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
 public class Parent extends ParentBase {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     public Parent(Long id, String name, String detail, int age, float test, TestEnum testEnum) {

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/complex/Parent2.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/complex/Parent2.java
@@ -1,15 +1,12 @@
 package io.quarkus.it.spring.data.jpa.complex;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
 public class Parent2 extends ParentBase {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     public Parent2(String name, String detail, int age, float test, TestEnum testEnum, Long id) {

--- a/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/SpringDataRestTest.java
+++ b/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/SpringDataRestTest.java
@@ -218,7 +218,7 @@ class SpringDataRestTest {
         Response response = given().accept("application/json")
                 .and().contentType("application/json")
                 .and().body(book.toString())
-                .when().put("/books/100")
+                .when().post("/books/")
                 .thenReturn();
         assertThat(response.statusCode()).isEqualTo(201);
         assertThat(response.header("Location")).isNotEmpty();


### PR DESCRIPTION
It causes failures on Hibernate ORM 6.6, because it's forbidden, because it can cause ambiguity as to whether the entity is expected to already exist in DB. See https://docs.jboss.org/hibernate/orm/6.6/migration-guide/migration-guide.html#merge-versioned-deleted

Current behavior in Hibernate ORM 6.5 is to ignore the explicitly set ID,
so arguably even worse.

Some tests were succeeding by sheer chance, because the explicitly set ID happened to match the next value of the sequence.
Other tests were actually ignoring the explicitly set ID, and retrieving the generated one.

See also https://hibernate.zulipchat.com/#narrow/stream/132094-hibernate-orm-dev/topic/EntityManager.2Emerge

cc @geoand @FroMage since several of the (seemingly incorrect) tests are about Spring Data JPA, Spring Data Rest and Panache Rest.