### PR TITLE
Update to gRPC 1.65.0 and Netty 4.1.111

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -134,7 +134,7 @@
         <infinispan.version>15.0.5.Final</infinispan.version>
         <infinispan.protostream.version>5.0.5.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
-        <netty.version>4.1.110.Final</netty.version>
+        <netty.version>4.1.111.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>

--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -211,8 +211,6 @@ The `client-name` is the name set in the `@GrpcClient` or derived from the injec
 The following examples uses _hello_ as the client name.
 Don't forget to replace it with the name you used in the `@GrpcClient` annotation.
 
-IMPORTANT: When you enable `quarkus.grpc.clients."client-name".use-quarkus-grpc-client`, you are then using the new Vert.x gRPC channel implementation, so not all configuration properties can still be applied. And currently there is no Stork support yet.
-
 IMPORTANT: When you enable `quarkus.grpc.clients."client-name".xds.enabled`, it's the xDS that should handle most of the configuration above.
 
 === Enabling TLS

--- a/docs/src/main/asciidoc/stork-reference.adoc
+++ b/docs/src/main/asciidoc/stork-reference.adoc
@@ -20,7 +20,7 @@ include::{includes}/extension-status.adoc[]
 The current integration of Stork supports:
 
 * the REST Client
-* the gRPC clients
+* the gRPC clients (using the Vert.x gRPC client is recommended)
 
 Warning: The gRPC client integration does not support statistic-based load balancers.
 

--- a/integration-tests/grpc-stork-response-time/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkResponseTimeCollectionTest.java
+++ b/integration-tests/grpc-stork-response-time/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkResponseTimeCollectionTest.java
@@ -1,7 +1,16 @@
 package io.quarkus.grpc.examples.stork;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 class GrpcStorkResponseTimeCollectionTest extends GrpcStorkResponseTimeCollectionTestBase {
+
+    @Test
+    @Disabled("Disabled because of https://github.com/grpc/grpc-java/commit/8844cf7b87a04dd2d2e4a74cd0f0e3f4fed14113 which does not call the load balancer for each call anymore.")
+    public void shouldCallConfigurableIfFaster() {
+
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,9 @@
         <hibernate-search.version>7.1.1.Final</hibernate-search.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
-        <grpc.version>1.64.0</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
-        <grpc-jprotoc.version>1.2.1</grpc-jprotoc.version>
-        <protoc.version>3.25.0</protoc.version>
+        <grpc.version>1.65.0</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
+        <grpc-jprotoc.version>1.2.2</grpc-jprotoc.version>
+        <protoc.version>3.25.3</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
         <proto-google-common-protos.version>2.41.0</proto-google-common-protos.version>
 


### PR DESCRIPTION
Update to gRPC 1.65.0 and Netty 4.1.111

This commit updates the gRPC version to 1.65.0 and enables the switch to Netty 4.1.111. Additionally, it updates several gRPC-related dependencies:
- jprotoc to 1.2.2
- protoc to 3.25.3
- protobuf-java to 3.25.3

Disable Stork "least response time" IT when using the gRPC Java client. This is because, in gRPC 1.65.0, the load balancer is only called once if the calls are queued. The Vert.x-based client is still behaving normally. When using the gRPC Java client, there is a change in behavior, but the load balancer will still be called for non-concurrent calls.