### PR TITLE
Make quarkus.config-tracking.enabled optional

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/tracker/ConfigTrackingInterceptor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/tracker/ConfigTrackingInterceptor.java
@@ -62,7 +62,7 @@ public class ConfigTrackingInterceptor implements ConfigSourceInterceptor {
      * @param config configuration instance
      */
     public void configure(Config config) {
-        enabled = config.getValue("quarkus.config-tracking.enabled", boolean.class);
+        enabled = config.getOptionalValue("quarkus.config-tracking.enabled", boolean.class).orElse(false);
         if (enabled) {
             readOptions = new ConcurrentHashMap<>();
         }


### PR DESCRIPTION
From time to time, I get my build to complain about it not being in any config source.
I'm not sure what is the root cause but I don't think we need to make this config property mandatory anyway.