### PR TITLE
Revert "Bump narayana.version from 7.0.1.Final to 7.0.2.Final"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -99,7 +99,7 @@
         <classmate.version>1.7.0</classmate.version>
         <!-- See root POM for hibernate-orm.version, hibernate-reactive.version, hibernate-validator.version,
              hibernate-search.version, antlr.version, bytebuddy.version, hibernate-commons-annotations.version -->
-        <narayana.version>7.0.2.Final</narayana.version>
+        <narayana.version>7.0.1.Final</narayana.version>
         <agroal.version>2.4</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
         <elasticsearch-opensource-components.version>8.14.1</elasticsearch-opensource-components.version>


### PR DESCRIPTION
Please wait before updating Narayana to 7.0.2.Final since a minor change appeared to have a greater impact and we are still evaluating it. 
See the issue (https://github.com/snowdrop/narayana-spring-boot/pull/148#issuecomment-2196979269) and discussion on Zulip (https://narayana.zulipchat.com/#narrow/stream/323715-developers/topic/JBTM-3879.20and.207.2E0.2E2.2EFinal) 