### PR TITLE
Clean up StartupContext when closing it

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/StartupContext.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/StartupContext.java
@@ -78,6 +78,8 @@ public class StartupContext implements Closeable {
     public void close() {
         runAllAndClear(shutdownTasks);
         runAllAndClear(lastShutdownTasks);
+        values.clear();
+        lastValue = null;
     }
 
     private void runAllAndClear(Deque<Runnable> tasks) {


### PR DESCRIPTION
Given StartupContext is a static field of ApplicationImpl, if too many class loaders are kept around (which is unfortunately still the case in our tests), we end up leaking the whole values of StartupContext.

When closing the context, we can clean up the values.

![Screenshot from 2024-07-01 18-54-04](https://github.com/quarkusio/quarkus/assets/1279749/9f971d3f-e28a-4c42-9c84-267732324318)
