### PR TITLE
Update quarkus-build-caching-extension to 1.3

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -12,7 +12,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>quarkus-build-caching-extension</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
     </extension>
     <extension>
         <groupId>io.quarkus.develocity</groupId>


### PR DESCRIPTION
Should fix the failing tests due to the cache not including quarkus-artifact.properties.
We will need to merge this update in all supported branches and then clear the cache.