### PR TITLE
Clear the Introspector caches in tests

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ClearCache.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ClearCache.java
@@ -1,5 +1,6 @@
 package io.quarkus.test;
 
+import java.beans.Introspector;
 import java.lang.reflect.Field;
 import java.util.Map;
 
@@ -10,14 +11,28 @@ public class ClearCache {
 
     private static final Logger log = Logger.getLogger(ClearCache.class);
 
-    public static void clearAnnotationCache() {
+    public static void clearCaches() {
+        clearAnnotationCache();
+        clearBeansIntrospectorCache();
+    }
+
+    private static void clearAnnotationCache() {
         try {
             Field f = AnnotationUtils.class.getDeclaredField("repeatableAnnotationContainerCache");
             f.setAccessible(true);
             ((Map) (f.get(null))).clear();
         } catch (NoSuchFieldException | IllegalAccessException e) {
             //ignore
-            log.debug("Failed to clear cache", e);
+            log.debug("Failed to clear annotation cache", e);
+        }
+    }
+
+    private static void clearBeansIntrospectorCache() {
+        try {
+            Introspector.flushCaches();
+        } catch (Exception e) {
+            //ignore
+            log.debug("Failed to clear java.beans.Introspector cache", e);
         }
     }
 }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -324,7 +324,7 @@ public class QuarkusDevModeTest
         rootLogger.setHandlers(originalRootLoggerHandlers);
         inMemoryLogHandler.clearRecords();
         inMemoryLogHandler.setFilter(null);
-        ClearCache.clearAnnotationCache();
+        ClearCache.clearCaches();
         TestConfigUtil.cleanUp();
     }
 

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -769,7 +769,7 @@ public class QuarkusUnitTest
             if (afterAllCustomizer != null) {
                 afterAllCustomizer.run();
             }
-            ClearCache.clearAnnotationCache();
+            ClearCache.clearCaches();
             TestConfigUtil.cleanUp();
         }
         if (records != null) {


### PR DESCRIPTION
The introspector cache keeps a reference to the class loader and it's one of the reasons for our class loader leaks.
Note that the calls to the Introspector are coming from REST Assured and especially from their Groovy machinery.

This actually makes a big difference when REST Assured is in use.

This is a typical heap dump when running `extensions/opentelemetry/deployment` tests before this patch:

![Screenshot from 2024-07-02 11-45-31](https://github.com/quarkusio/quarkus/assets/1279749/186642f5-bc0f-4169-961c-8eec6bbb59eb)

And after the patch:

![Screenshot from 2024-07-02 11-45-43](https://github.com/quarkusio/quarkus/assets/1279749/8a4a494a-9c90-4d98-ac19-6f41552b02be)
