### PR TITLE
Bump kubernetes-client-bom from 6.13.0 to 6.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Properties below are set in this file because they are used
              in the BOM as well as other POMs (build-parent/pom.xml, docs/pom.xml, ...) -->
         <jacoco.version>0.8.12</jacoco.version>
-        <kubernetes-client.version>6.13.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.13.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.4.0</rest-assured.version>
         <hibernate-orm.version>6.5.2.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->


### PR DESCRIPTION
Kubernetes Client 6.13.1 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.13.1

~Might fix #39934 since generated model classes now contain the same annotations on fields and getter methods.~

/cc @metacosm @galderz @shawkins 

- Fixes: #41625