### PR TITLE
Aggressively clear the fields of the QuarkusClassLoader on close

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -511,8 +511,6 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        ensureOpen();
-
         for (ClassLoaderEventListener l : classLoaderEventListeners) {
             l.loadClass(name, this.name);
         }
@@ -529,6 +527,9 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
                 if (c != null) {
                     return c;
                 }
+
+                ensureOpen();
+
                 String resourceName = fromClassNameToResourceName(name);
                 if (state.bannedResources.contains(resourceName)) {
                     throw new ClassNotFoundException(name);
@@ -643,8 +644,6 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
     }
 
     public Class<?> visibleDefineClass(String name, byte[] b, int off, int len) throws ClassFormatError {
-        ensureOpen();
-
         return super.defineClass(name, b, off, len);
     }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -692,6 +692,9 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
                 log.debug("Failed to clean up DB drivers");
             }
         }
+
+        status = STATUS_CLOSED;
+
         closeClassPathElements(elements);
         closeClassPathElements(bannedElements);
         closeClassPathElements(parentFirstElements);
@@ -707,8 +710,6 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         classLoaderEventListeners.clear();
 
         ResourceBundle.clearCache(this);
-
-        status = STATUS_CLOSED;
     }
 
     private static void closeClassPathElements(List<ClassPathElement> classPathElements) {
@@ -730,11 +731,17 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
     }
 
     private void ensureOpen() {
-        if (LOG_ACCESS_TO_CLOSED_CLASS_LOADERS && status == STATUS_CLOSED) {
+        if (status != STATUS_CLOSED) {
+            return;
+        }
+
+        if (LOG_ACCESS_TO_CLOSED_CLASS_LOADERS) {
             // we do not use a logger as it might require some class loading
             System.out.println("Class loader " + this + " has been closed and may not be accessed anymore");
             Thread.dumpStack();
         }
+
+        throw new IllegalStateException("Class loader " + this + " has been closed and may not be accessed anymore");
     }
 
     @Override


### PR DESCRIPTION
We know that the class loaders can leak, for instance due to long lived resources that span the boundaries of a test so we try to limit the effects by clearing the fields from the class loader and especially all the ClassPathElements.

Note that for now, I didn't nullify the parent field that points to the parent CL but I wonder if we should do it.

We also add some logging to debug the lifecycle of the class loader. We can't easily log things in the close() method so things are not as clean as they could be. That's the reason why we are using a system property to enable the logging.

You can log the constructor and close() calls by enabling debug logging for category
`io.quarkus.bootstrap.classloading.QuarkusClassLoader.lifecycle`.

You can log late accesses to closed class loaders by passing `-Dquarkus-log-access-to-closed-class-loaders` to your build command.

This work is related to the class loader leaks work I have been doing for weeks and also to these issues:
- https://github.com/quarkusio/quarkus/issues/41233
- https://github.com/quarkusio/quarkus/issues/41607