### PR TITLE
Extract macros in docs to avoid breaking regexes

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -117,7 +117,14 @@ ifndef::no-quarkus-oidc-token-propagation[]
     <artifactId>quarkus-rest</artifactId>
 </dependency>
 ----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-oidc,rest-client-oidc-filter,rest-client-oidc-token-propagation,rest")
+----
 endif::no-quarkus-oidc-token-propagation[]
+
 ifdef::no-quarkus-oidc-token-propagation[]
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
@@ -135,16 +142,7 @@ ifdef::no-quarkus-oidc-token-propagation[]
     <artifactId>quarkus-rest</artifactId>
 </dependency>
 ----
-endif::no-quarkus-oidc-token-propagation[]
 
-ifndef::no-quarkus-oidc-token-propagation[]
-[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
-.build.gradle
-----
-implementation("io.quarkus:quarkus-oidc,rest-client-oidc-filter,rest-client-oidc-token-propagation,rest")
-----
-endif::no-quarkus-oidc-token-propagation[]
-ifdef::no-quarkus-oidc-token-propagation[]
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----


### PR DESCRIPTION
...  for downstream transformation

Avoid placing `ifndef`/`ifdef` in the middle of Maven/Gradle snippets
