### PR TITLE
Allow to specify a custom quarkus udpate recipes artifact

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -170,11 +170,11 @@ public class GradleRunner implements BuildSystemRunner {
         if (rewrite.pluginVersion != null) {
             args.add("--rewritePluginVersion=" + rewrite.pluginVersion);
         }
-        if (rewrite.updateRecipesVersion != null) {
-            args.add("--updateRecipesVersion=" + rewrite.updateRecipesVersion);
+        if (rewrite.quarkusUpdateRecipes != null) {
+            args.add("--quarkusUpdateRecipes=" + rewrite.quarkusUpdateRecipes);
         }
-        if (rewrite.additionalUpdateRecipeCoords != null) {
-            args.add("--additionalUpdateRecipeCoords=" + rewrite.additionalUpdateRecipeCoords);
+        if (rewrite.additionalUpdateRecipes != null) {
+            args.add("--additionalUpdateRecipes=" + rewrite.additionalUpdateRecipes);
         }
         if (rewrite.noRewrite) {
             args.add("--noRewrite");

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -173,11 +173,11 @@ public class MavenRunner implements BuildSystemRunner {
         if (rewrite.pluginVersion != null) {
             args.add("-DrewritePluginVersion=" + rewrite.pluginVersion);
         }
-        if (rewrite.updateRecipesVersion != null) {
-            args.add("-DupdateRecipesVersion=" + rewrite.updateRecipesVersion);
+        if (rewrite.quarkusUpdateRecipes != null) {
+            args.add("-DquarkusUpdateRecipes=" + rewrite.quarkusUpdateRecipes);
         }
-        if (rewrite.additionalUpdateRecipeCoords != null) {
-            args.add("-DadditionalUpdateRecipeCoords" + rewrite.additionalUpdateRecipeCoords);
+        if (rewrite.additionalUpdateRecipes != null) {
+            args.add("-DadditionalUpdateRecipes" + rewrite.additionalUpdateRecipes);
         }
         if (rewrite.dryRun) {
             args.add("-DrewriteDryRun");

--- a/devtools/cli/src/main/java/io/quarkus/cli/update/RewriteGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/update/RewriteGroup.java
@@ -13,15 +13,15 @@ public class RewriteGroup {
     public boolean dryRun = false;
 
     @CommandLine.Option(order = 2, names = {
-            "--update-recipes-version" }, description = "Use a custom io.quarkus:quarkus-update-recipes version. This artifact contains the base recipes used by this tool to update a project.")
-    public String updateRecipesVersion;
+            "--quarkus-update-recipes" }, description = "Use custom io.quarkus:quarkus-update-recipes:LATEST artifact (GAV) or just provide the version. This artifact should contain the base Quarkus update recipes to update a project.")
+    public String quarkusUpdateRecipes;
 
     @CommandLine.Option(order = 3, names = {
             "--rewrite-plugin-version" }, description = "Use a custom OpenRewrite plugin version.")
     public String pluginVersion;
 
     @CommandLine.Option(order = 4, names = {
-            "--additional-update-recipe-coords" }, description = "Specify an additional list of artifacts to retrieve recipes from.")
-    public String additionalUpdateRecipeCoords;
+            "--additional-update-recipes" }, description = "Specify a list of additional artifacts (GAV) containing rewrite recipes.")
+    public String additionalUpdateRecipes;
 
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -28,8 +28,8 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
     private String rewritePluginVersion = null;
 
-    private String rewriteUpdateRecipesVersion = null;
-    private String rewriteAdditionalUpdateRecipeCoords = null;
+    private String rewriteQuarkusUpdateRecipes = null;
+    private String rewriteAdditionalUpdateRecipes = null;
 
     @Input
     @Optional
@@ -78,25 +78,25 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
     @Input
     @Optional
-    public String getRewriteUpdateRecipesVersion() {
-        return rewriteUpdateRecipesVersion;
+    public String getRewriteQuarkusUpdateRecipes() {
+        return rewriteQuarkusUpdateRecipes;
     }
 
-    @Option(description = " The io.quarkus:quarkus-update-recipes version. This artifact contains the base recipes used by this tool to update a project.", option = "updateRecipesVersion")
-    public QuarkusUpdate setRewriteUpdateRecipesVersion(String rewriteUpdateRecipesVersion) {
-        this.rewriteUpdateRecipesVersion = rewriteUpdateRecipesVersion;
+    @Option(description = "Use a custom io.quarkus:quarkus-update-recipes:LATEST artifact (GAV) or just provide the version. This artifact should contain the base Quarkus update recipes to update a project.", option = "quarkusUpdateRecipes")
+    public QuarkusUpdate setRewriteQuarkusUpdateRecipes(String rewriteQuarkusUpdateRecipes) {
+        this.rewriteQuarkusUpdateRecipes = rewriteQuarkusUpdateRecipes;
         return this;
     }
 
     @Input
     @Optional
-    public String getRewriteAdditionalUpdateRecipeCoords() {
-        return rewriteAdditionalUpdateRecipeCoords;
+    public String getRewriteAdditionalUpdateRecipes() {
+        return rewriteAdditionalUpdateRecipes;
     }
 
-    @Option(description = " The additional artifacts to retrieve recipes from.", option = "additionalUpdateRecipeCoords")
-    public QuarkusUpdate setRewriteAdditionalUpdateRecipeCoords(String rewriteAdditionalUpdateRecipeCoords) {
-        this.rewriteAdditionalUpdateRecipeCoords = rewriteAdditionalUpdateRecipeCoords;
+    @Option(description = "Specify a list of additional artifacts (GAV) containing rewrite recipes.", option = "additionalUpdateRecipes")
+    public QuarkusUpdate setRewriteAdditionalUpdateRecipes(String rewriteAdditionalUpdateRecipes) {
+        this.rewriteAdditionalUpdateRecipes = rewriteAdditionalUpdateRecipes;
         return this;
     }
 
@@ -153,11 +153,11 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
         final UpdateProject invoker = new UpdateProject(quarkusProject);
         invoker.targetCatalog(targetCatalog);
-        if (rewriteUpdateRecipesVersion != null) {
-            invoker.rewriteUpdateRecipesVersion(rewriteUpdateRecipesVersion);
+        if (rewriteQuarkusUpdateRecipes != null) {
+            invoker.rewriteQuarkusUpdateRecipes(rewriteQuarkusUpdateRecipes);
         }
-        if (rewriteAdditionalUpdateRecipeCoords != null) {
-            invoker.rewriteAdditionalUpdateRecipeCoords(rewriteAdditionalUpdateRecipeCoords);
+        if (rewriteAdditionalUpdateRecipes != null) {
+            invoker.rewriteAdditionalUpdateRecipes(rewriteAdditionalUpdateRecipes);
         }
         if (rewritePluginVersion != null) {
             invoker.rewritePluginVersion(rewritePluginVersion);

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -59,17 +59,18 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
     private Boolean rewriteDryRun;
 
     /**
-     * The io.quarkus:quarkus-update-recipes version. This artifact contains the base recipes used by this tool to update a
-     * project.
+     * Use custom io.quarkus:quarkus-update-recipes:LATEST coords (GAV) or just provide the version. This artifact should
+     * contain the
+     * base Quarkus update recipes to update a project.
      */
-    @Parameter(property = "updateRecipesVersion", required = false)
-    private String rewriteUpdateRecipesVersion;
+    @Parameter(property = "quarkusUpdateRecipes", required = false)
+    private String rewriteQuarkusUpdateRecipes;
 
     /**
-     * The list of artifacts containing rewrite recipes
+     * Specify a list of additional artifacts (GAV) containing rewrite recipes
      */
-    @Parameter(property = "additionalUpdateRecipeCoords", required = false)
-    private String rewriteAdditionalUpdateRecipeCoords;
+    @Parameter(property = "additionalUpdateRecipes", required = false)
+    private String rewriteAdditionalUpdateRecipes;
 
     /**
      * Target stream (e.g: 2.0)
@@ -119,11 +120,11 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
         if (rewritePluginVersion != null) {
             invoker.rewritePluginVersion(rewritePluginVersion);
         }
-        if (rewriteUpdateRecipesVersion != null) {
-            invoker.rewriteUpdateRecipesVersion(rewriteUpdateRecipesVersion);
+        if (rewriteQuarkusUpdateRecipes != null) {
+            invoker.rewriteQuarkusUpdateRecipes(rewriteQuarkusUpdateRecipes);
         }
-        if (rewriteAdditionalUpdateRecipeCoords != null) {
-            invoker.rewriteAdditionalUpdateRecipeCoords(rewriteAdditionalUpdateRecipeCoords);
+        if (rewriteAdditionalUpdateRecipes != null) {
+            invoker.rewriteAdditionalUpdateRecipes(rewriteAdditionalUpdateRecipes);
         }
         invoker.rewriteDryRun(rewriteDryRun);
         invoker.noRewrite(noRewrite);

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/UpdateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/UpdateProject.java
@@ -24,8 +24,8 @@ public class UpdateProject {
     public static final String NO_REWRITE = "quarkus.update-project.rewrite.disabled";
     public static final String TARGET_PLATFORM_VERSION = "quarkus.update-project.target-platform-version";
     public static final String REWRITE_PLUGIN_VERSION = "quarkus.update-project.rewrite.plugin-version";
-    public static final String REWRITE_UPDATE_RECIPES_VERSION = "quarkus.update-project.rewrite.update-recipes-version";
-    public static final String REWRITE_ADDITIONAL_UPDATE_RECIPE_COORDS = "quarkus.update-project.rewrite.additional-update-recipe-coords";
+    public static final String REWRITE_QUARKUS_UPDATE_RECIPES = "quarkus.update-project.rewrite.quarkus-update-recipes";
+    public static final String REWRITE_ADDITIONAL_UPDATE_RECIPES = "quarkus.update-project.rewrite.additional-update-recipes";
     public static final String REWRITE_DRY_RUN = "quarkus.update-project.rewrite.dry-run";
 
     private final QuarkusCommandInvocation invocation;
@@ -59,14 +59,14 @@ public class UpdateProject {
         return this;
     }
 
-    public UpdateProject rewriteUpdateRecipesVersion(String rewriteUpdateRecipesVersion) {
-        invocation.setValue(REWRITE_UPDATE_RECIPES_VERSION,
-                requireNonNull(rewriteUpdateRecipesVersion, "rewriteUpdateRecipesVersion is required"));
+    public UpdateProject rewriteQuarkusUpdateRecipes(String rewriteQuarkusUpdateRecipes) {
+        invocation.setValue(REWRITE_QUARKUS_UPDATE_RECIPES,
+                requireNonNull(rewriteQuarkusUpdateRecipes, "rewriteQuarkusUpdateRecipes is required"));
         return this;
     }
 
-    public UpdateProject rewriteAdditionalUpdateRecipeCoords(String rewriteAdditionalUpdateRecipeCoords) {
-        invocation.setValue(REWRITE_ADDITIONAL_UPDATE_RECIPE_COORDS, rewriteAdditionalUpdateRecipeCoords);
+    public UpdateProject rewriteAdditionalUpdateRecipes(String rewriteAdditionalUpdateRecipes) {
+        invocation.setValue(REWRITE_ADDITIONAL_UPDATE_RECIPES, rewriteAdditionalUpdateRecipes);
         return this;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -114,16 +114,15 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                 Path recipe = null;
                 try {
                     recipe = Files.createTempFile("quarkus-project-recipe-", ".yaml");
-                    final String updateRecipesVersion = invocation.getValue(
-                            UpdateProject.REWRITE_UPDATE_RECIPES_VERSION,
+                    final String quarkusUpdateRecipes = invocation.getValue(
+                            UpdateProject.REWRITE_QUARKUS_UPDATE_RECIPES,
                             QuarkusUpdatesRepository.DEFAULT_UPDATE_RECIPES_VERSION);
-                    final String additionalUpdateRecipeCoords = invocation.getValue(
-                            UpdateProject.REWRITE_ADDITIONAL_UPDATE_RECIPE_COORDS,
+                    final String additionalUpdateRecipes = invocation.getValue(
+                            UpdateProject.REWRITE_ADDITIONAL_UPDATE_RECIPES,
                             null);
-                    final FetchResult fetchResult = QuarkusUpdates.createRecipe(invocation.log(),
-                            recipe,
-                            QuarkusProjectHelper.artifactResolver(), buildTool, updateRecipesVersion,
-                            additionalUpdateRecipeCoords, request);
+                    final FetchResult fetchResult = QuarkusUpdates.createRecipe(invocation.log(), recipe,
+                            QuarkusProjectHelper.artifactResolver(), buildTool, quarkusUpdateRecipes,
+                            additionalUpdateRecipes, request);
                     invocation.log().info("OpenRewrite recipe generated: %s", recipe);
 
                     String rewritePluginVersion = invocation.getValue(UpdateProject.REWRITE_PLUGIN_VERSION,

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
@@ -22,12 +22,15 @@ public final class QuarkusUpdates {
     }
 
     public static FetchResult createRecipe(MessageWriter log, Path target, MavenArtifactResolver artifactResolver,
-            BuildTool buildTool, String updateRecipesVersion, String additionalUpdateRecipeCoords,
+            BuildTool buildTool, String quarkusUpdateRecipes, String additionalUpdateRecipes,
             ProjectUpdateRequest request)
             throws IOException {
-        final FetchResult result = QuarkusUpdatesRepository.fetchRecipes(log, artifactResolver, buildTool,
-                updateRecipesVersion,
-                additionalUpdateRecipeCoords,
+        final FetchResult result = QuarkusUpdatesRepository.fetchRecipes(
+                log,
+                artifactResolver,
+                buildTool,
+                quarkusUpdateRecipes,
+                additionalUpdateRecipes,
                 request.currentVersion,
                 request.targetVersion,
                 request.projectExtensionsUpdateInfo

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdatesRepository.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdatesRepository.java
@@ -4,15 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -33,7 +25,7 @@ public final class QuarkusUpdatesRepository {
     private QuarkusUpdatesRepository() {
     }
 
-    private static final String QUARKUS_RECIPE_GA = "io.quarkus:quarkus-update-recipes";
+    private static final String QUARKUS_UPDATE_RECIPES_GA = "io.quarkus:quarkus-update-recipes";
     public static final String DEFAULT_UPDATE_RECIPES_VERSION = "LATEST";
 
     public static final String DEFAULT_MAVEN_REWRITE_PLUGIN_VERSION = "4.46.0";
@@ -42,14 +34,15 @@ public final class QuarkusUpdatesRepository {
     public static final String PROP_REWRITE_GRADLE_PLUGIN_VERSION = "rewrite-gradle-plugin-version";
 
     public static FetchResult fetchRecipes(MessageWriter log, MavenArtifactResolver artifactResolver,
-            BuildTool buildTool,
-            String recipeVersion, String additionalUpdateRecipeCoords, String currentVersion,
+            BuildTool buildTool, String quarkusUpdateRecipes, String additionalUpdateRecipes, String currentVersion,
             String targetVersion, List<ExtensionUpdateInfo> topExtensionDependency) {
 
         List<String> gavs = new ArrayList<>();
-        gavs.add(QUARKUS_RECIPE_GA + ":" + recipeVersion);
-        if (additionalUpdateRecipeCoords != null) {
-            gavs.addAll(Arrays.stream(additionalUpdateRecipeCoords.split(",")).map(String::strip).toList());
+
+        gavs.add(quarkusUpdateRecipes.contains(":") ? quarkusUpdateRecipes
+                : QUARKUS_UPDATE_RECIPES_GA + ":" + quarkusUpdateRecipes);
+        if (additionalUpdateRecipes != null) {
+            gavs.addAll(Arrays.stream(additionalUpdateRecipes.split(",")).map(String::strip).toList());
         }
 
         List<String> artifacts = new ArrayList<>();


### PR DESCRIPTION
- `updateRecipesVersion` becomes `quarkusUpdateRecipes` in all the tooling
- it's still possible to specify only the version

cc @gsmet @vsevel 