### PR TITLE
Remove deprecated cloning pattern config which isn't really useful anymore

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -222,17 +222,6 @@ public interface TestConfig {
     TestType type();
 
     /**
-     * If a class matches this pattern then it will be cloned into the Quarkus ClassLoader even if it
-     * is in a parent first artifact.
-     * <p>
-     * This is important for collections which can contain objects from the Quarkus ClassLoader, but for
-     * most parent first classes it will just cause problems.
-     */
-    @WithDefault("java\\..*")
-    @Deprecated(forRemoval = true)
-    String classClonePattern();
-
-    /**
      * If this is true then only the tests from the main application module will be run (i.e. the module that is currently
      * running mvn quarkus:dev).
      * <p>

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ParameterResolverTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ParameterResolverTest.java
@@ -45,7 +45,7 @@ public class ParameterResolverTest {
 
     @Test
     @ExtendWith(ParameterResolverTest.ListWithNonSerializableParameterResolver.class)
-    public void testSerializableParameterResolverFallbackToXStream(List<NonSerializable> list) {
+    public void testSerializableParameterResolverFallback(List<NonSerializable> list) {
         assertEquals("foo", list.get(0).value);
         assertEquals("bar", list.get(1).value);
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/NewSerializingDeepClone.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/NewSerializingDeepClone.java
@@ -5,7 +5,6 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 import org.jboss.marshalling.cloner.ClassCloner;
 import org.jboss.marshalling.cloner.ClonerConfiguration;
@@ -20,7 +19,6 @@ import io.quarkus.bootstrap.app.RunningQuarkusApplication;
  */
 public final class NewSerializingDeepClone implements DeepClone {
     private final ObjectCloner cloner;
-    private static Pattern clonePattern;
     private RunningQuarkusApplication runningQuarkusApplication;
 
     public NewSerializingDeepClone(final ClassLoader sourceLoader, final ClassLoader targetLoader) {
@@ -56,7 +54,7 @@ public final class NewSerializingDeepClone implements DeepClone {
                     Class<?> theClassWeCareAbout = original.getClass();
 
                     // Short-circuit the checks if we've been configured to clone this
-                    if (!clonePattern.matcher(theClassWeCareAbout.getName()).matches()) {
+                    if (!theClassWeCareAbout.getName().startsWith("java.")) {
 
                         if (theClassWeCareAbout.isPrimitive()) {
                             // avoid copying things that do not need to be copied
@@ -140,9 +138,6 @@ public final class NewSerializingDeepClone implements DeepClone {
     @Override
     public void setRunningQuarkusApplication(RunningQuarkusApplication runningQuarkusApplication) {
         this.runningQuarkusApplication = runningQuarkusApplication;
-        String patternString = runningQuarkusApplication.getConfigValue("quarkus.test.class-clone-pattern", String.class)
-                .orElse("java\\..*");
-        clonePattern = Pattern.compile(patternString);
     }
 
 }


### PR DESCRIPTION
*Comment from July*: We should merge this a couple of releases after https://github.com/quarkusio/quarkus/pull/41623, so perhaps November 2024.

#40601 dropped support for the class-clone-pattern configuration, but didn’t remove the documentation. The configuration wasn’t really needed anymore, since #40601 cloned almost everything. 

My amendment of #40601 to work around the “do not clone everything” problem clones less, and does reintroduce have the support for configuring the cloning. However, I think even in this scenario, the config is not useful. The config was introduced as part https://github.com/quarkusio/quarkus/pull/17306, to make Pact work, but I've run the Pact tests against a local quarkus build and Pact works fine without the config. 

I’ve searched through public codebases, and I do not believe this configuration is widely used. https://github.com/search?q=quarkus.test.class-clone-pattern%3D&type=code shows only 6 usages of `quarkus.test.class-clone-pattern` in configuration files, all in commented out boilerplate. Searching for the camel case version, `CLASS_CLONE_PATTERN=` gave no instances: https://github.com/search?q=CLASS_CLONE_PATTERN%3D&type=code
In my searches, I added the equals sign so filter out config documentation and forks of the quarkus repo, which do reference the property name. 

The default value of the configuration is `java.*`, so removing the config does mean we no longer attempt to clone `java.*` classes. I don’t see any benefit in doing that cloning, but be aware this (sort of) is a functional change. 

