### PR TITLE
Deprecate class cloning configuration

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -226,6 +226,7 @@ public class TestConfig {
      * most parent first classes it will just cause problems.
      */
     @ConfigItem(defaultValue = "java\\..*")
+    @Deprecated(forRemoval = true)
     String classClonePattern;
 
     /**


### PR DESCRIPTION
In https://github.com/quarkusio/quarkus/pull/17306 the class cloning was made configurable, to make Pact work with Quarkus. With recent versions of Quarkus and the Pact extension, this config is not necessary. Even https://github.com/skattela/pact-workshop-jvm-quarkus, which is older, does not use the config. 

I’ve searched through public codebases, and I do not believe this configuration is widely used. https://github.com/search?q=quarkus.test.class-clone-pattern%3D&type=code shows only 6 usages of quarkus.test.class-clone-pattern in configuration files, all in commented out boilerplate. Searching for the camel case version, CLASS_CLONE_PATTERN= gave no instances: https://github.com/search?q=CLASS_CLONE_PATTERN%3D&type=code
In my searches, I added the equals sign so filter out config documentation and forks of the quarkus repo, which do reference the property name.

Whether we explicitly remove the configurable part of the cloning process (https://github.com/quarkusio/quarkus/pull/41621), or just remove the whole class cloning (https://github.com/quarkusio/quarkus/pull/34681), we should get rid of this unused knob. 