### PR TITLE
Downgrade .sdkmanrc to mvnd 1.0.0

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 java=17.0.10-tem
-mvnd=1.0.1
+mvnd=1.0.0


### PR DESCRIPTION
mvnd 1.0.1 is not compatible with our build due to: https://github.com/apache/maven-mvnd/issues/1031

Error is that `${maven.multiModuleProjectDirectory}` is not interpolated anymore:

> /home/gsmet/git/quarkus/independent-projects/resteasy-reactive/common/processor/${maven.multiModuleProjectDirectory}/.forbiddenapis/banned-signatures-common.txt