### PR TITLE
Add OIDC clientName property

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -52,6 +52,15 @@ public class OidcCommonConfig {
     public Optional<String> clientId = Optional.empty();
 
     /**
+     * The client name of the application. It is meant to represent a human readable description of the application which you
+     * may provide when an application (client) is registered in an OpenId Connect provider's dashboard.
+     * For example, you can set this property to have more informative log messages which record an activity of the given
+     * client.
+     */
+    @ConfigItem
+    public Optional<String> clientName = Optional.empty();
+
+    /**
      * The duration to attempt the initial connection to an OIDC server.
      * For example, setting the duration to `20S` allows 10 retries, each 2 seconds apart.
      * This property is only effective when the initial OIDC connection is created.
@@ -734,6 +743,14 @@ public class OidcCommonConfig {
 
     public void setClientId(String clientId) {
         this.clientId = Optional.of(clientId);
+    }
+
+    public Optional<String> getClientName() {
+        return clientName;
+    }
+
+    public void setClientName(String clientName) {
+        this.clientName = Optional.of(clientName);
     }
 
     public Credentials getCredentials() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -611,7 +611,10 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     }
 
     public Uni<ChallengeData> getChallengeInternal(RoutingContext context, TenantConfigContext configContext) {
-        LOG.debugf("Starting an authentication challenge for tenant %s", configContext.oidcConfig.tenantId.get());
+        LOG.debugf("Starting an authentication challenge for tenant %s.", configContext.oidcConfig.tenantId.get());
+        if (configContext.oidcConfig.clientName.isPresent()) {
+            LOG.debugf(" Client name: %s", configContext.oidcConfig.clientName.get());
+        }
 
         OidcTenantConfig sessionCookieConfig = configContext.oidcConfig;
         String sessionTenantIdSetByCookie = context.get(OidcUtils.TENANT_ID_SET_BY_SESSION_COOKIE);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -258,7 +258,10 @@ public class OidcProvider implements Closeable {
                 detail = details.get(0).getErrorMessage();
             }
             if (oidcConfig.clientId.isPresent()) {
-                LOG.debugf("Verification of the token issued to client %s has failed: %s", oidcConfig.clientId.get(), detail);
+                LOG.debugf("Verification of the token issued to client %s has failed: %s.", oidcConfig.clientId.get(), detail);
+                if (oidcConfig.clientName.isPresent()) {
+                    LOG.debugf(" Client name: %s", oidcConfig.clientName.get());
+                }
             } else {
                 LOG.debugf("Token verification has failed: %s", detail);
             }


### PR DESCRIPTION
This simple PR adds an optional OIDC client name property.

If set, it is expected to provide a nice, human readable description of the registered client/application.
Typically, with social providers or Keycloak, when we register applications, `Description` is what this client name property represents.

As far as an immediate impact on Quarkus OIDC is concerned, it is only about logging a client name in a couple of places for now, if it is set. Users can also access it when creating Qute templates for creating HTMLs for interacting with users.

It is also relevant for the OIDC Dynamic client registration work which is underway now (see the `client_name` in https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata and https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationRequest), so when the OIDC client is registered automatically, Quarkus will set `quarkus.oidc.client-name` itself, etc

CC @calvernaz