### PR TITLE
Catch exceptions when running checkMissingCommand

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -185,6 +185,11 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
             return Optional.empty();
         } catch (UnmatchedArgumentException e) {
             return Optional.of(args[0]);
+        } catch (Exception e) {
+            // For any other exceptions (e.g. MissingParameterException), we should just ignore.
+            // The problem is not that the command is missing but that the options might not be adequate.
+            // This will be handled by Picocli at a later step.
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
We want to check for the missing commands only, any other error will have to be handled by Picocli later (and thus will properly handle the formatting of the feedback and avoid a stacktrace).

Fixes #41513