### PR TITLE
Add more log messages to show how OIDC client checks and refreshes tokens

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
@@ -2,27 +2,37 @@ package io.quarkus.oidc.client;
 
 import java.time.Duration;
 
+import org.jboss.logging.Logger;
+
 import io.vertx.core.json.JsonObject;
 
 /**
  * Access and Refresh tokens returned from a token grant request
  */
 public class Tokens {
+    private static final Logger LOG = Logger.getLogger(Tokens.class);
+
     final private String accessToken;
     final private Long accessTokenExpiresAt;
     final private Long refreshTokenTimeSkew;
     final private String refreshToken;
     final Long refreshTokenExpiresAt;
     final private JsonObject grantResponse;
+    final private String clientId;
 
     public Tokens(String accessToken, Long accessTokenExpiresAt, Duration refreshTokenTimeSkewDuration, String refreshToken,
-            Long refreshTokenExpiresAt, JsonObject grantResponse) {
+            Long refreshTokenExpiresAt, JsonObject grantResponse, String clientId) {
         this.accessToken = accessToken;
         this.accessTokenExpiresAt = accessTokenExpiresAt;
         this.refreshTokenTimeSkew = refreshTokenTimeSkewDuration == null ? null : refreshTokenTimeSkewDuration.getSeconds();
         this.refreshToken = refreshToken;
         this.refreshTokenExpiresAt = refreshTokenExpiresAt;
         this.grantResponse = grantResponse;
+        this.clientId = clientId;
+    }
+
+    public String getClientId() {
+        return clientId;
     }
 
     public String getAccessToken() {
@@ -46,11 +56,11 @@ public class Tokens {
     }
 
     public boolean isAccessTokenExpired() {
-        return isExpired(accessTokenExpiresAt);
+        return isExpired(accessTokenExpiresAt, true);
     }
 
     public boolean isRefreshTokenExpired() {
-        return isExpired(refreshTokenExpiresAt);
+        return isExpired(refreshTokenExpiresAt, false);
     }
 
     public boolean isAccessTokenWithinRefreshInterval() {
@@ -58,14 +68,40 @@ public class Tokens {
             return false;
         }
         final long nowSecs = System.currentTimeMillis() / 1000;
-        return nowSecs + refreshTokenTimeSkew > accessTokenExpiresAt;
+        final boolean proactiveRefresh = nowSecs + refreshTokenTimeSkew > accessTokenExpiresAt;
+
+        if (proactiveRefresh) {
+            LOG.debugf(
+                    "Access token is still valid but must be refreshed by client %s because it will expire in about %d seconds"
+                            + " which is less than the refresh token time skew %d",
+                    clientId, accessTokenExpiresAt - nowSecs, refreshTokenTimeSkew);
+        }
+
+        return proactiveRefresh;
     }
 
-    private static boolean isExpired(Long expiresAt) {
+    private boolean isExpired(Long expiresAt, boolean accessToken) {
         if (expiresAt == null) {
             return false;
         }
         final long nowSecs = System.currentTimeMillis() / 1000;
-        return nowSecs > expiresAt;
+        final boolean expired = nowSecs > expiresAt;
+
+        if (expired) {
+            if (accessToken) {
+                LOG.debugf("Access token has expired and must be refreshed by client %s", clientId);
+            } else {
+                LOG.debugf("Refresh token for client %s has expired", clientId);
+            }
+        } else {
+            final long expiresIn = expiresAt - nowSecs;
+            if (accessToken) {
+                LOG.tracef("Access token for client %s is valid but will expire in about %d seconds", clientId, expiresIn);
+            } else {
+                LOG.tracef("Refresh token for client %s is valid but will expire in about %d seconds", clientId, expiresIn);
+            }
+        }
+
+        return expired;
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -220,7 +220,7 @@ public class OidcClientImpl implements OidcClient {
                     json.getValue(oidcConfig.grant.refreshExpiresInProperty));
 
             return new Tokens(accessToken, accessTokenExpiresAt, oidcConfig.refreshTokenTimeSkew.orElse(null), refreshToken,
-                    refreshTokenExpiresAt, json);
+                    refreshTokenExpiresAt, json, oidcConfig.clientId.orElse(DEFAULT_OIDC_CLIENT_ID));
         } else {
             String errorMessage = resp.bodyAsString();
             LOG.debugf("%s OidcClient has failed to complete the %s grant request:  status: %d, error message: %s",


### PR DESCRIPTION
Closes #41461.

In #41461, OidcClient works as expected but it took @spirostz a lot of effort to confirm it was the case.

As agreed in #41461, I'm adding more log messages to the OIDC client code to make it easier to users to trace if a given access token is still valid, if yes, when it will expire, when the proactive refresh is going to be enforced, etc.

Also, untangled a bit the code which uses `forceNewTokens` and the refresh token checks in one complex condition, it should be easier to read it now.

I thought I'd use `debug` for most of the new messages as they won't happen frequently, but `trace` for the one which informs the user when the token will expire but still valid as the access token is valid most of the time and it can overflow the system with the high concurrency