### PR TITLE
Make mvnd 1.X work and require Maven 3.9.6 to build Quarkus

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dmaven.multiModuleProjectDirectory=${session.rootDirectory}

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -73,7 +73,7 @@
         <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
 
         <!-- maven-enforcer-plugin -->
-        <maven.min.version>3.8.6</maven.min.version>
+        <maven.min.version>3.9.6</maven.min.version>
         <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
         <insecure.repositories>ERROR</insecure.repositories>
 

--- a/integration-tests/gradle/update-dependencies.sh
+++ b/integration-tests/gradle/update-dependencies.sh
@@ -87,7 +87,7 @@ echo ''
 echo 'Sanity check...'
 echo ''
 # sanity check; make sure nothing stupid was added like non-existing deps
-mvn -Dscan=false dependency:resolve validate -Dsilent -q -f "${PRG_PATH}" $*
+${PRG_PATH}/../../mvnw -Dscan=false dependency:resolve validate -Dsilent -q -f "${PRG_PATH}" $*
 
 # CI only: verify that no pom.xml was touched (if changes are found, committer forgot to run script or to add changes)
 if [ "${CI:-}" == true ] && [ $(git status -s -u no '*pom.xml' | wc -l) -ne 0 ]

--- a/tcks/resteasy-reactive/update-dependencies.sh
+++ b/tcks/resteasy-reactive/update-dependencies.sh
@@ -90,7 +90,7 @@ echo ''
 echo 'Sanity check...'
 echo ''
 # sanity check; make sure nothing stupid was added like non-existing deps
-mvn -Dscan=false dependency:resolve validate -Dsilent -q -f "${PRG_PATH}" $*
+${PRG_PATH}/../../mvnw -Dscan=false dependency:resolve validate -Dsilent -q -f "${PRG_PATH}" $*
 
 # CI only: verify that no pom.xml was touched (if changes are found, committer forgot to run script or to add changes)
 if [ "${CI:-}" == true ] && [ $(git status -s -u no '*pom.xml' | wc -l) -ne 0 ]

--- a/update-extension-dependencies.sh
+++ b/update-extension-dependencies.sh
@@ -14,7 +14,7 @@ then
   echo ''
   echo 'Building bom-descriptor-json...'
   echo ''
-  mvn -q -e -Dscan=false clean package -f "${PRG_PATH}/devtools/bom-descriptor-json" -Denforcer.skip $*
+  ./mvnw -q -e -Dscan=false clean package -f "${PRG_PATH}/devtools/bom-descriptor-json" -Denforcer.skip $*
 else
   read -n1 -p 'Build the entire project with relocations? [y/n] ' ANSWER
   echo ''
@@ -23,7 +23,7 @@ else
     echo ''
     echo 'Building entire project with relocations...'
     echo ''
-    mvn -q -e -Dscan=false -Dquickly -Dno-test-modules -Prelocations -T0.8C -f "${PRG_PATH}" $*
+    ./mvnw -q -e -Dscan=false -Dquickly -Dno-test-modules -Prelocations -T0.8C -f "${PRG_PATH}" $*
   else
     echo ''
     echo 'Aborted!'
@@ -112,7 +112,7 @@ echo ''
 echo 'Sanity check...'
 echo ''
 # sanity check; make sure nothing stupid was added like non-existing deps
-mvn -Dscan=false dependency:resolve validate -Dsilent -q -f "${PRG_PATH}" -pl devtools/bom-descriptor-json,docs $*
+./mvnw -Dscan=false dependency:resolve validate -Dsilent -q -f "${PRG_PATH}" -pl devtools/bom-descriptor-json,docs $*
 
 # CI only: verify that no pom.xml was touched (if changes are found, committer forgot to run script or to add changes)
 if [ "${CI:-}" == true ] && [ $(git status -s -u no '*pom.xml' | wc -l) -ne 0 ]


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/41323

Supersedes https://github.com/quarkusio/quarkus/pull/41628

This is a bit of a hack. But it works.

The codebase has a lot of references to `maven.multiModuleProjectDirectory` not sure if everything does work. But for futureproofness this should be changed, I think.

Occurences;
- core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
- docs/src/main/asciidoc/maven-tooling.adoc
- docs/src/main/asciidoc/tests-with-coverage.adoc
- independent-projects/parent/pom.xml
- independent-projects/resteasy-reactive/pom.xml
- tcks/resteasy-reactive/pom.xml
- Some places in the maven wrapper.

cc @gsmet 