### PR TITLE
Fix build error caused by content in datasource guide

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -547,7 +547,7 @@ All <<extensions-and-database-drivers-reference,supported JDBC drivers do>>,
 but <<other-databases,other JDBC drivers>> might not.
 . Make sure your database server is configured to enable XA.
 . Enable XA support explicitly for each relevant datasource by setting
-<<quarkus-agroal_quarkus-datasource-jdbc-transactions,`quarkus.datasource[.optional name].jdbc.transactions`>> to `xa`.
+<<quarkus-agroal_quarkus-datasource-jdbc-transactions,`quarkus.datasource[.optional name\].jdbc.transactions`>> to `xa`.
 
 Using XA, a rollback in one datasource will trigger a rollback in every other datasource enrolled in the transaction.
 


### PR DESCRIPTION
In community `main`, line 550 in `/asciidoc/datasource.adoc` is:

```
<<quarkus-agroal_quarkus-datasource-jdbc-transactions,`quarkus.datasource[.optional name].jdbc.transactions`>> to `xa
```
In the syncrhonization PR, it causes the following preview build failure, 
```
Transforming the AsciiDoc content to DocBook XML... [31m[1mOpening and ending tag mismatch: literal line 566 and link, line 566, column 66[0m [31m[1mUnable to parse the AsciiDoc built DocBook XML[0m
```
In this PR, the previously mentioned line 550 has been transformed into:
```
xref:quarkus-agroal_quarkus-datasource-jdbc-transactions[`quarkus.datasource[.optional name].jdbc.transactions`] to `xa`.
```
If you inspect line 556 in the master.adoc file for this PR, https://jenkins.dxp.redhat.com/job/CCS/job/ccs-mr-preview/80313/artifact/pantheon/configure-data-sources/build/en-US/master.xml/*view*/, that same line renders as follows:
```
 <link linkend="quarkus-agroal_quarkus-datasource-jdbc-transactions"><literal>quarkus.datasource[.optional name</link>.jdbc.transactions</literal>] to <literal>xa</literal>.</simpara> </listitem>
```
In other words, the right bracket in `name]` terminates the `<link>` element prematurely. Instead, the right bracket in `</literal>]` should close that `<link>` element. 

I have confirmed that escaping the right bracket in `name]` solves the issue, as shown in the following example:

```
xref:quarkus-agroal_quarkus-datasource-jdbc-transactions[`quarkus.datasource[.optional name\].jdbc.transactions`] 
```
 