### PR TITLE
Support additional recipe artifacts in quarkus update

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -173,6 +173,9 @@ public class GradleRunner implements BuildSystemRunner {
         if (rewrite.updateRecipesVersion != null) {
             args.add("--updateRecipesVersion=" + rewrite.updateRecipesVersion);
         }
+        if (rewrite.additionalUpdateRecipeCoords != null) {
+            args.add("--additionalUpdateRecipeCoords=" + rewrite.additionalUpdateRecipeCoords);
+        }
         if (rewrite.noRewrite) {
             args.add("--noRewrite");
         }

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -176,6 +176,9 @@ public class MavenRunner implements BuildSystemRunner {
         if (rewrite.updateRecipesVersion != null) {
             args.add("-DupdateRecipesVersion=" + rewrite.updateRecipesVersion);
         }
+        if (rewrite.additionalUpdateRecipeCoords != null) {
+            args.add("-DadditionalUpdateRecipeCoords" + rewrite.additionalUpdateRecipeCoords);
+        }
         if (rewrite.dryRun) {
             args.add("-DrewriteDryRun");
         }

--- a/devtools/cli/src/main/java/io/quarkus/cli/update/RewriteGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/update/RewriteGroup.java
@@ -20,4 +20,8 @@ public class RewriteGroup {
             "--rewrite-plugin-version" }, description = "Use a custom OpenRewrite plugin version.")
     public String pluginVersion;
 
+    @CommandLine.Option(order = 4, names = {
+            "--additional-update-recipe-coords" }, description = "Specify an additional list of artifacts to retrieve recipes from.")
+    public String additionalUpdateRecipeCoords;
+
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -29,6 +29,7 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
     private String rewritePluginVersion = null;
 
     private String rewriteUpdateRecipesVersion = null;
+    private String rewriteAdditionalUpdateRecipeCoords = null;
 
     @Input
     @Optional
@@ -89,6 +90,18 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
     @Input
     @Optional
+    public String getRewriteAdditionalUpdateRecipeCoords() {
+        return rewriteAdditionalUpdateRecipeCoords;
+    }
+
+    @Option(description = " The additional artifacts to retrieve recipes from.", option = "additionalUpdateRecipeCoords")
+    public QuarkusUpdate setRewriteAdditionalUpdateRecipeCoords(String rewriteAdditionalUpdateRecipeCoords) {
+        this.rewriteAdditionalUpdateRecipeCoords = rewriteAdditionalUpdateRecipeCoords;
+        return this;
+    }
+
+    @Input
+    @Optional
     public String getTargetStreamId() {
         return targetStreamId;
     }
@@ -142,6 +155,9 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
         invoker.targetCatalog(targetCatalog);
         if (rewriteUpdateRecipesVersion != null) {
             invoker.rewriteUpdateRecipesVersion(rewriteUpdateRecipesVersion);
+        }
+        if (rewriteAdditionalUpdateRecipeCoords != null) {
+            invoker.rewriteAdditionalUpdateRecipeCoords(rewriteAdditionalUpdateRecipeCoords);
         }
         if (rewritePluginVersion != null) {
             invoker.rewritePluginVersion(rewritePluginVersion);

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -66,6 +66,12 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
     private String rewriteUpdateRecipesVersion;
 
     /**
+     * The list of artifacts containing rewrite recipes
+     */
+    @Parameter(property = "additionalUpdateRecipeCoords", required = false)
+    private String rewriteAdditionalUpdateRecipeCoords;
+
+    /**
      * Target stream (e.g: 2.0)
      */
     @Parameter(property = "stream", required = false)
@@ -115,6 +121,9 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
         }
         if (rewriteUpdateRecipesVersion != null) {
             invoker.rewriteUpdateRecipesVersion(rewriteUpdateRecipesVersion);
+        }
+        if (rewriteAdditionalUpdateRecipeCoords != null) {
+            invoker.rewriteAdditionalUpdateRecipeCoords(rewriteAdditionalUpdateRecipeCoords);
         }
         invoker.rewriteDryRun(rewriteDryRun);
         invoker.noRewrite(noRewrite);

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/UpdateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/UpdateProject.java
@@ -25,6 +25,7 @@ public class UpdateProject {
     public static final String TARGET_PLATFORM_VERSION = "quarkus.update-project.target-platform-version";
     public static final String REWRITE_PLUGIN_VERSION = "quarkus.update-project.rewrite.plugin-version";
     public static final String REWRITE_UPDATE_RECIPES_VERSION = "quarkus.update-project.rewrite.update-recipes-version";
+    public static final String REWRITE_ADDITIONAL_UPDATE_RECIPE_COORDS = "quarkus.update-project.rewrite.additional-update-recipe-coords";
     public static final String REWRITE_DRY_RUN = "quarkus.update-project.rewrite.dry-run";
 
     private final QuarkusCommandInvocation invocation;
@@ -61,6 +62,11 @@ public class UpdateProject {
     public UpdateProject rewriteUpdateRecipesVersion(String rewriteUpdateRecipesVersion) {
         invocation.setValue(REWRITE_UPDATE_RECIPES_VERSION,
                 requireNonNull(rewriteUpdateRecipesVersion, "rewriteUpdateRecipesVersion is required"));
+        return this;
+    }
+
+    public UpdateProject rewriteAdditionalUpdateRecipeCoords(String rewriteAdditionalUpdateRecipeCoords) {
+        invocation.setValue(REWRITE_ADDITIONAL_UPDATE_RECIPE_COORDS, rewriteAdditionalUpdateRecipeCoords);
         return this;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -117,9 +117,13 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                     final String updateRecipesVersion = invocation.getValue(
                             UpdateProject.REWRITE_UPDATE_RECIPES_VERSION,
                             QuarkusUpdatesRepository.DEFAULT_UPDATE_RECIPES_VERSION);
+                    final String additionalUpdateRecipeCoords = invocation.getValue(
+                            UpdateProject.REWRITE_ADDITIONAL_UPDATE_RECIPE_COORDS,
+                            null);
                     final FetchResult fetchResult = QuarkusUpdates.createRecipe(invocation.log(),
                             recipe,
-                            QuarkusProjectHelper.artifactResolver(), buildTool, updateRecipesVersion, request);
+                            QuarkusProjectHelper.artifactResolver(), buildTool, updateRecipesVersion,
+                            additionalUpdateRecipeCoords, request);
                     invocation.log().info("OpenRewrite recipe generated: %s", recipe);
 
                     String rewritePluginVersion = invocation.getValue(UpdateProject.REWRITE_PLUGIN_VERSION,

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateCommand.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateCommand.java
@@ -65,7 +65,9 @@ public class QuarkusUpdateCommand {
         executeCommand(baseDir, getMavenUpdateCommand(mvnBinary, rewritePluginVersion, recipesGAV, recipe, dryRun), log);
 
         // format the sources
-        executeCommand(baseDir, getMavenProcessSourcesCommand(mvnBinary), log);
+        if (!dryRun) {
+            executeCommand(baseDir, getMavenProcessSourcesCommand(mvnBinary), log);
+        }
     }
 
     private static void runGradleUpdate(MessageWriter log, Path baseDir, String rewritePluginVersion, String recipesGAV,

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
@@ -22,11 +22,12 @@ public final class QuarkusUpdates {
     }
 
     public static FetchResult createRecipe(MessageWriter log, Path target, MavenArtifactResolver artifactResolver,
-            BuildTool buildTool, String updateRecipesVersion,
+            BuildTool buildTool, String updateRecipesVersion, String additionalUpdateRecipeCoords,
             ProjectUpdateRequest request)
             throws IOException {
         final FetchResult result = QuarkusUpdatesRepository.fetchRecipes(log, artifactResolver, buildTool,
                 updateRecipesVersion,
+                additionalUpdateRecipeCoords,
                 request.currentVersion,
                 request.targetVersion,
                 request.projectExtensionsUpdateInfo


### PR DESCRIPTION
This is adding support for a `updateRecipeArtifactCoordinates` property in maven/gradle/cli for quarkus update, which allows to specify several artifacts containing update recipes.

this as been tested so far with `mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:update -N -DupdateRecipeArtifactCoordinates=org.acme:quarkusupdate:1.0.0-SNAPSHOT,io.quarkus:quarkus-update-recipes:LATEST -DrewriteDryRun=true` 

with a `3.12.yaml` recipe file in module `org.acme:quarkusupdate` containing:
```
---
type: [specs.openrewrite.org/v1beta/recipe](http://specs.openrewrite.org/v1beta/recipe)
name: add property foo
recipeList:
  - org.openrewrite.maven.AddProperty:
      key: foo
      value: bar
      preserveExistingValue: true
```

when running against a `3.8.5` project, this produces the following build log:
```
[INFO] Running recipe(s)...
[WARNING] These recipes would make changes to pom.xml:
[WARNING]     io.quarkus.openrewrite.Quarkus
[WARNING]         org.openrewrite.maven.UpgradeDependencyVersion: {groupId=io.quarkus.platform, artifactId=quarkus-bom, newVersion=3.12.0}
[WARNING]         io.quarkus.updates.core.quarkus39.Relocations
[WARNING]             org.openrewrite.java.dependencies.ChangeDependency: {oldGroupId=io.quarkus, oldArtifactId=quarkus-resteasy-reactive, newArtifactId=quarkus-rest}
[WARNING]         add property foo
[WARNING]             org.openrewrite.maven.AddProperty: {key=foo, value=bar, preserveExistingValue=true}
[WARNING]         io.quarkus.updates.core.quarkus310.UpdateConfigPackagePom
[WARNING]             io.quarkus.updates.core.quarkus310.AdjustPackageProperty
[WARNING] Patch file available:
[WARNING]     /Users/vsevel/dev/tmp/quarkusupdate/target/rewrite/rewrite.patch
[WARNING] Estimate time saved: 5m
[WARNING] Run 'mvn rewrite:run' to apply the recipes.
```

and the diff looks like:
```
% cat /Users/vsevel/dev/tmp/quarkusupdate/target/rewrite/rewrite.patch
diff --git a/pom.xml b/pom.xml
index 8560607..ffffd24 100644
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,13 @@ org.openrewrite.config.CompositeRecipe
   <version>1.0.2-SNAPSHOT</version>
   <properties>
     <compiler-plugin.version>3.13.0</compiler-plugin.version>
+    <foo>bar</foo>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.8.5</quarkus.platform.version>
+    <quarkus.platform.version>3.12.0</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.2.5</surefire-plugin.version>
   </properties>
@@ -34,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-rest</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -114,7 +115,8 @@
       </activation>
       <properties>
         <skipITs>false</skipITs>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
+        <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
       </properties>
     </profile>
   </profiles>

```

gradle support has not been done yet.
this has not been rebased onto the other PR (wondering if we really need to).
some logging has been added for debugging purposes, but will be removed before merge.
this is created as a draft to get some early feedback from @ia3andy 