### PR TITLE
Docs: Remove additional ) at the end

### DIFF
--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -76,7 +76,7 @@ IMPORTANT: It is not possible to conditionally enable/disable additional beans v
 ----
 @BuildStep
 AdditionalBeanBuildItem additionalBeans() {
-     return new AdditionalBeanBuildItem(SmallRyeHealthReporter.class, HealthServlet.class)); <1>
+     return new AdditionalBeanBuildItem(SmallRyeHealthReporter.class, HealthServlet.class); <1>
 }
 ----
 <1> `AdditionalBeanBuildItem.Builder` can be used for more complex use cases.


### PR DESCRIPTION
While reading the docs I stumbled across additional `)` char before the closing semicolon.
This PR is simply fixing this typo.