### PR TITLE
Enable io.netty.allocator.disableCacheFinalizersForFastThreadLocalThreads

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -80,6 +80,11 @@ class NettyProcessor {
     }
 
     @BuildStep
+    public SystemPropertyBuildItem disableFinalizers() {
+        return new SystemPropertyBuildItem("io.netty.allocator.disableCacheFinalizersForFastThreadLocalThreads", "true");
+    }
+
+    @BuildStep
     NativeImageConfigBuildItem build(
             NettyBuildTimeConfig config,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,


### PR DESCRIPTION
This is going to be useful once
https://github.com/netty/netty/pull/14155 lands in Quarkus.

Created as draft until it's get merged in Netty and incorporated in Quarkus.

Fixes #41607