### PR TITLE
Fix native issue with @Providers when only the REST Client exists

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -311,6 +311,10 @@ class RestClientReactiveProcessor {
                                     int.class),
                             constructor.getThis(), constructor.loadClassFromTCCL(providerDotName.toString()),
                             constructor.load(priority));
+
+                    // when the server is not included, providers are not automatically registered for reflection,
+                    // so we need to always do it for the client to be on the safe side
+                    reflectiveClassesProducer.produce(ReflectiveClassBuildItem.builder(providerDotName.toString()).build());
                 }
             }
 


### PR DESCRIPTION
When the server part of Quarkus REST is not included, prior to this change, user's @Provider classes were not registered for reflection

Relates to: https://github.com/quarkiverse/quarkus-langchain4j/issues/722