### PR TITLE
Fix Quarkus REST concurrent modification exception when making abstract resource classes inheritors beans

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/InheritanceTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/InheritanceTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.InheritanceAbstractParentImplResource;
+import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.InheritanceAbstractParentResource;
 import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.InheritanceParentResource;
 import io.quarkus.resteasy.reactive.server.test.resource.basic.resource.InheritanceParentResourceImpl;
 import io.quarkus.resteasy.reactive.server.test.simple.PortProviderUtil;
@@ -39,6 +41,8 @@ public class InheritanceTest {
                 public JavaArchive get() {
                     JavaArchive war = ShrinkWrap.create(JavaArchive.class);
                     war.addClass(InheritanceParentResource.class);
+                    war.addClass(InheritanceAbstractParentResource.class);
+                    war.addClass(InheritanceAbstractParentImplResource.class);
                     war.addClasses(PortProviderUtil.class, InheritanceParentResourceImpl.class);
                     return war;
                 }
@@ -66,5 +70,14 @@ public class InheritanceTest {
         Response response = builder.get();
         Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         Assertions.assertEquals(response.readEntity(String.class), "First");
+    }
+
+    @Test
+    public void testAbstractParent() {
+        Builder builder = client.target(generateURL("/inheritance-abstract-parent-test")).request();
+        builder.header("Accept", "text/plain");
+        Response response = builder.get();
+        Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        Assertions.assertEquals(response.readEntity(String.class), "works");
     }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/InheritanceAbstractParentImplResource.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/InheritanceAbstractParentImplResource.java
@@ -1,0 +1,10 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic.resource;
+
+public class InheritanceAbstractParentImplResource extends InheritanceAbstractParentResource {
+
+    @Override
+    public String get() {
+        return "works";
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/InheritanceAbstractParentResource.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/InheritanceAbstractParentResource.java
@@ -1,0 +1,12 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic.resource;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/inheritance-abstract-parent-test")
+public abstract class InheritanceAbstractParentResource {
+
+    @GET
+    public abstract String get();
+
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -263,7 +263,8 @@ public class ResteasyReactiveScanner {
         }
 
         // handle abstract classes
-        scannedResources.values().stream().filter(ClassInfo::isAbstract).forEach(abstractScannedResource -> {
+        var abstractClasses = scannedResources.values().stream().filter(ClassInfo::isAbstract).toList();
+        abstractClasses.forEach(abstractScannedResource -> {
             Collection<ClassInfo> allSubclasses = index.getAllKnownSubclasses(abstractScannedResource.name());
             if (allSubclasses.size() != 1) {
                 return; // don't do anything with this case as it's not evident how it's supposed to be handled


### PR DESCRIPTION
I tested https://github.com/quarkusio/quarkus/pull/41606 when it was https://github.com/quarkusio/quarkus/commit/ee756d68cd62396102d8939a069245e1107cb53c. Later the PR code changed to https://github.com/quarkusio/quarkus/commit/c56532c0fdfddf96f83c5387d0cec857e908bfe7 which leads to `Build step io.quarkus.resteasy.reactive.common.deployment.ResteasyReactiveCommonProcessor#scanResources threw an exception: java.util.ConcurrentModificationException`.