### PR TITLE
Clear com.sun.naming.internal.ResourceManager#propertiesCache

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -440,7 +440,8 @@
                         </systemPropertyVariables>
                         <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
                         <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
-                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional}</argLine>
+                        <!-- the add-opens is here to allow to clear the propertiesCache in com.sun.naming.internal.ResourceManager -->
+                        <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional} --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/extensions/jaxb/deployment/pom.xml
+++ b/extensions/jaxb/deployment/pom.xml
@@ -11,6 +11,9 @@
 
     <artifactId>quarkus-jaxb-deployment</artifactId>
     <name>Quarkus - JAXB - Deployment</name>
+    <properties>
+        <surefire.argLine.additional>-Duser.language=en</surefire.argLine.additional>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -50,13 +53,6 @@
                             <version>${project.version}</version>
                         </path>
                     </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-Duser.language=en</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ClearCache.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ClearCache.java
@@ -13,17 +13,26 @@ public class ClearCache {
 
     public static void clearCaches() {
         clearAnnotationCache();
+        clearResourceManagerPropertiesCache();
         clearBeansIntrospectorCache();
     }
 
     private static void clearAnnotationCache() {
+        clearMap(AnnotationUtils.class, "repeatableAnnotationContainerCache");
+    }
+
+    /**
+     * This will only be effective if the tests are launched with --add-opens java.naming/com.sun.naming.internal=ALL-UNNAMED,
+     * which is the case in the Quarkus codebase where memory usage is actually an issue.
+     * <p>
+     * While not mandatory, this actually helps so enabling it only in the Quarkus codebase has actual value.
+     */
+    private static void clearResourceManagerPropertiesCache() {
         try {
-            Field f = AnnotationUtils.class.getDeclaredField("repeatableAnnotationContainerCache");
-            f.setAccessible(true);
-            ((Map) (f.get(null))).clear();
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            //ignore
-            log.debug("Failed to clear annotation cache", e);
+            clearMap(Class.forName("com.sun.naming.internal.ResourceManager"), "propertiesCache");
+        } catch (ClassNotFoundException e) {
+            // ignore
+            log.debug("Unable to load com.sun.naming.internal.ResourceManager", e);
         }
     }
 
@@ -31,8 +40,19 @@ public class ClearCache {
         try {
             Introspector.flushCaches();
         } catch (Exception e) {
-            //ignore
+            // ignore
             log.debug("Failed to clear java.beans.Introspector cache", e);
+        }
+    }
+
+    private static void clearMap(Class<?> clazz, String mapField) {
+        try {
+            Field f = clazz.getDeclaredField(mapField);
+            f.setAccessible(true);
+            ((Map) (f.get(null))).clear();
+        } catch (Exception e) {
+            // ignore
+            log.debugf(e, "Failed to clear cache for %s#%s cache", clazz.getName(), mapField);
         }
     }
 }


### PR DESCRIPTION
This is only effective if the class is made accessible, which we make in our code.
I noticed this a few times in my heap dumps and I noticed this was also handled in some other frameworks (until the switch to Java 9 that made the --add-opens mandatory).
I think dealing with it in our codebase is a good idea from a sustainability point of view.