### PR TITLE
Increase default OIDC session-age-extension to minimize chances of dropping expired ID tokens

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1316,12 +1316,34 @@ If you work with a Quarkus OIDC `web-app` application, then the Quarkus OIDC cod
 To use the refresh token, you should carefully configure the session cookie age.
 The session age should be longer than the ID token lifespan and close to or equal to the refresh token lifespan.
 
-You calculate the session age by adding the lifespan value of the current ID token and the values of the `quarkus.oidc.authentication.session-age-extension` and `quarkus.oidc.token.lifespan-grace` properties.
+You calculate the session cookie age by adding the lifespan value of the current ID token and the values of the `quarkus.oidc.authentication.session-age-extension` and `quarkus.oidc.token.lifespan-grace` properties.
 
 [TIP]
 ====
-You use only the `quarkus.oidc.authentication.session-age-extension` property to significantly extend the session lifespan, if required.
 You use the `quarkus.oidc.token.lifespan-grace` property only to consider some small clock skews.
+====
+
+[TIP]
+====
+Use the quarkus.oidc.authentication.session-age-extension property to extend the session lifespan and ensure the application can access expired ID tokens when needed.
+
+By default, the session cookie's max-age property is set to the value of the ID token life span.
+After the session cookie expires and the user attempts to access the application again, the authenticated user is redirected to the OIDC provider to re-authenticate.
+
+However, if `quarkus.oidc.authentication.session-age-extension` is set to a reasonable idle-time duration of several hours, longer than the life-span of an ID token, the expired ID token can still be made available to the application.
+This allows the application to refresh the token or redirect the user to a session expired page, as the session cookie storing the ID token remains available during the current authenticated user's request.
+
+For example, expect a typical user activity to last 30 minutes.
+Therefore, you have configured the OIDC provider to issue ID tokens, which are valid for 30 minutes only.
+However, you would also like to refresh a user's ID token and renew the session after this user returns from a one-hour break.
+In this case, set this property to 90 minutes; otherwise, Quarkus will not be able to detect a session cookie, and the user will be required to re-authenticate.
+
+The important point is that extending the session cookie's age with `quarkus.oidc.authentication.session-age-extension` maximizes the chances of making an expired ID token available to the application.
+This token, associated with the cookie, can then be used for further processing.
+
+It improves a user experience; otherwise, an authenticated user may be surprised to see an immediate re-authentication challenge if the ID token and the session cookie that holds it have expired.
+
+By default, this property will be set to 1 hour if either `quarkus.oidc.token.refresh-expired` or `quarkus.oidc.authentication.session-expired-page` features are enabled since they can only be effective if an expired ID token is available.
 ====
 
 When the current authenticated user returns to the protected Quarkus endpoint and the ID token associated with the session cookie has expired, then, by default, the user is automatically redirected to the OIDC Authorization endpoint to re-authenticate.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -771,15 +771,30 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         Optional<Boolean> userInfoRequired();
 
         /**
-         * Session age extension in minutes.
-         * The user session age property is set to the value of the ID token life-span by default and
-         * the user is redirected to the OIDC provider to re-authenticate once the session has expired.
-         * If this property is set to a nonzero value, then the expired ID token can be refreshed before
-         * the session has expired.
-         * This property is ignored if the `token.refresh-expired` property has not been enabled.
+         * Session cookie max-age extension.
+         *
+         * Session cookie max-age property is set to the value of the ID token life-span by default
+         * and the authenticated user is redirected to the OIDC provider to re-authenticate, after the session cookie has
+         * expired and the user has attempted to access the application again.
+         *
+         * However, if this property is set to a reasonable idle-time duration of several hours,
+         * longer than an ID token life-span, then, even if the ID token has expired,
+         * it can still be made available to the application which may refresh it or redirect the user
+         * to a session expired page, because the session cookie which keeps ID token is still available
+         * during the current authenticated user's request.
+         *
+         * An important point is that extending the session cookie's age with this property
+         * is only about maximizing the chances of making even an expired ID token associated
+         * with this cookie available to the application for further processing.
+         * It improves a user experience, otherwise, an authenticated user may be surprised by seeing an immediate
+         * re-authentication challenge if the ID token has expired together with the session cookie which
+         * holds it.
+         *
+         * By default, this property will be set to 1 hour if either 'quarkus.oidc.token.refresh-expired'
+         * or 'quarkus.oidc.authentication.session-expired-page' features are enabled since they can only
+         * be effective if an expired ID token is available.
          */
-        @WithDefault("5M")
-        Duration sessionAgeExtension();
+        Optional<Duration> sessionAgeExtension();
 
         /**
          * State cookie age in minutes.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
@@ -26,7 +26,7 @@ public final class AuthenticationConfigBuilder {
             Optional<Boolean> addOpenidScope, Map<String, String> extraParams, Optional<List<String>> forwardParams,
             boolean cookieForceSecure, Optional<String> cookieSuffix, String cookiePath, Optional<String> cookiePathHeader,
             Optional<String> cookieDomain, CookieSameSite cookieSameSite, boolean allowMultipleCodeFlows,
-            boolean failOnMissingStateParam, Optional<Boolean> userInfoRequired, Duration sessionAgeExtension,
+            boolean failOnMissingStateParam, Optional<Boolean> userInfoRequired, Optional<Duration> sessionAgeExtension,
             Duration stateCookieAge, boolean javaScriptAutoRedirect, Optional<Boolean> idTokenRequired,
             Optional<Duration> internalIdTokenLifespan, Optional<Boolean> pkceRequired, Optional<String> pkceSecret,
             Optional<String> stateSecret) implements Authentication {
@@ -56,7 +56,7 @@ public final class AuthenticationConfigBuilder {
     private boolean allowMultipleCodeFlows;
     private boolean failOnMissingStateParam;
     private Optional<Boolean> userInfoRequired;
-    private Duration sessionAgeExtension;
+    private Optional<Duration> sessionAgeExtension;
     private Duration stateCookieAge;
     private boolean javaScriptAutoRedirect;
     private Optional<Boolean> idTokenRequired;
@@ -428,7 +428,7 @@ public final class AuthenticationConfigBuilder {
      * @return this builder
      */
     public AuthenticationConfigBuilder sessionAgeExtension(Duration sessionAgeExtension) {
-        this.sessionAgeExtension = Objects.requireNonNull(sessionAgeExtension);
+        this.sessionAgeExtension = Optional.of(sessionAgeExtension);
         return this;
     }
 

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
@@ -152,7 +152,7 @@ public class OidcTenantConfigBuilderTest {
         assertTrue(authentication.allowMultipleCodeFlows());
         assertFalse(authentication.failOnMissingStateParam());
         assertTrue(authentication.userInfoRequired().isEmpty());
-        assertEquals(5, authentication.sessionAgeExtension().toMinutes());
+        assertTrue(authentication.sessionAgeExtension().isEmpty());
         assertEquals(5, authentication.stateCookieAge().toMinutes());
         assertTrue(authentication.javaScriptAutoRedirect());
         assertTrue(authentication.idTokenRequired().isEmpty());
@@ -549,7 +549,7 @@ public class OidcTenantConfigBuilderTest {
         assertFalse(authentication.allowMultipleCodeFlows());
         assertTrue(authentication.failOnMissingStateParam());
         assertTrue(authentication.userInfoRequired().orElseThrow());
-        assertEquals(77, authentication.sessionAgeExtension().toMinutes());
+        assertEquals(77, authentication.sessionAgeExtension().orElseThrow().toMinutes());
         assertEquals(88, authentication.stateCookieAge().toMinutes());
         assertFalse(authentication.javaScriptAutoRedirect());
         assertFalse(authentication.idTokenRequired().orElseThrow());
@@ -1285,7 +1285,7 @@ public class OidcTenantConfigBuilderTest {
         assertFalse(builtFirst.allowMultipleCodeFlows());
         assertTrue(builtFirst.failOnMissingStateParam());
         assertTrue(builtFirst.userInfoRequired().orElseThrow());
-        assertEquals(77, builtFirst.sessionAgeExtension().toMinutes());
+        assertEquals(77, builtFirst.sessionAgeExtension().orElseThrow().toMinutes());
         assertEquals(88, builtFirst.stateCookieAge().toMinutes());
         assertFalse(builtFirst.javaScriptAutoRedirect());
         assertFalse(builtFirst.idTokenRequired().orElseThrow());
@@ -1335,7 +1335,7 @@ public class OidcTenantConfigBuilderTest {
         assertFalse(builtSecond.allowMultipleCodeFlows());
         assertTrue(builtSecond.failOnMissingStateParam());
         assertTrue(builtSecond.userInfoRequired().orElseThrow());
-        assertEquals(77, builtSecond.sessionAgeExtension().toMinutes());
+        assertEquals(77, builtSecond.sessionAgeExtension().orElseThrow().toMinutes());
         assertEquals(88, builtSecond.stateCookieAge().toMinutes());
         assertFalse(builtSecond.javaScriptAutoRedirect());
         assertFalse(builtSecond.idTokenRequired().orElseThrow());

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -699,7 +699,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             }
 
             @Override
-            public Duration sessionAgeExtension() {
+            public Optional<Duration> sessionAgeExtension() {
                 invocationsRecorder.put(ConfigMappingMethods.AUTHENTICATION_SESSION_AGE_EXTENSION, true);
                 return null;
             }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -371,10 +371,10 @@ public class CodeFlowAuthorizationTest {
             Cookie sessionCookie = getSessionCookie(webClient, "code-flow-user-info-github-cached-in-idtoken");
             Date date = sessionCookie.getExpires();
             assertTrue(date.toInstant().getEpochSecond() - issuedAt >= 299 + 300);
-            // This test enables the token refresh, in this case the cookie age is extended by additional 5 mins
+            // This test enables the token refresh, in this case the cookie age is extended by additional 1 hour
             // to minimize the risk of the browser losing immediately after it has expired, for this cookie
             // be returned to Quarkus, analyzed and refreshed
-            assertTrue(date.toInstant().getEpochSecond() - issuedAt <= 299 + 300 + 3);
+            assertTrue(date.toInstant().getEpochSecond() - issuedAt - (60 * 60) <= 299 + 300 + 3);
 
             // This is the initial call to  the token endpoint where the code was exchanged for tokens
             wireMockServer.verify(1,
@@ -397,7 +397,7 @@ public class CodeFlowAuthorizationTest {
             sessionCookie = getSessionCookie(webClient, "code-flow-user-info-github-cached-in-idtoken");
             date = sessionCookie.getExpires();
             assertTrue(date.toInstant().getEpochSecond() - issuedAt >= 305 + 300);
-            assertTrue(date.toInstant().getEpochSecond() - issuedAt <= 305 + 300 + 3);
+            assertTrue(date.toInstant().getEpochSecond() - issuedAt - (60 * 60 * 5) <= 305 + 300 + 3);
 
             // access token must've been refreshed
             wireMockServer.verify(1,


### PR DESCRIPTION
This PR is really only about improving an OIDC authenticated user experience than fixing anything OIDC specific, following several discussions with users, the last one being with @calvernaz a few weeks back related to a difficult to trace issue with #41015.

So, the OIDC session cookie serves the only purpose: keep an ID token (directly in the encrypted form or indirectly via a reference to some custom token state manager's state) and make it available to Quarkus whenever an already authenticated user tries to access Quarkus again, for OIDC be able to analyze this ID token: confirm it is valid, refresh if it has expired or redirect the user to a session expired page in order to explain to the user that the session has expired. 

If the session cookie has expired, then the browser drops it and Quarkus does not know that the current user authenticated and therefore must treat it as a new request and redirects the user to OIDC provider to authenticate.

It leads to a rather poor user experience. For example, imagine you have authenticated to an airline's website, stayed idle for a bit longer that than the session age is, now you click on your order and you see a request to enter name and password at the SSO OIDC provider login page, without any explanation. 

So extending the session cookie's max-age to a few hours by default simply minimizes the chances of the expired ID token being dropped together with its session cookie `container` and thus giving OIDC a chance to do something about this expired ID token - for example, auto-refresh it if the token refresh is allowed, or, redirect the user to a session expired page where a user can be explained the sessin has now expired, and offered a link to re-authenticate.
 
Also, extending the session cookie's max-age does not change the real user session's age, that of the ID token.

Fixes #41130.

I've set to 5 hours by default but it can probably be set to 8 hours or more at a later stage. Users can tune it further as needed, this PR is about trying to help users avoid having to set this property in real prods, since without it, the expired ID token is always lost and users would see re-authentication screens without any hints as to what has happened.

CC @calvernaz