### PR TITLE
Fix NPE when calling a ClientResponseFilter

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSetResponseEntityRestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSetResponseEntityRestHandler.java
@@ -24,7 +24,7 @@ public class ClientSetResponseEntityRestHandler implements ClientRestHandler {
 
     @Override
     public void handle(RestClientRequestContext context) throws Exception {
-        ClientRequestContextImpl requestContext = context.getClientRequestContext();
+        ClientRequestContextImpl requestContext = context.getOrCreateClientRequestContext();
         if (context.isCheckSuccessfulFamily()) {
             StatusType effectiveResponseStatus = determineEffectiveResponseStatus(context, requestContext);
             if (Response.Status.Family.familyOf(effectiveResponseStatus.getStatusCode()) != Response.Status.Family.SUCCESSFUL) {


### PR DESCRIPTION
When using the resteasy-reactive-client to make http calls, an NPE is thrown when using a custom filter and exception mapper. Here's the code to reproduce this:
```
private Configuration buildHttpConfig() {
    ConfigurationImpl configuration = new ConfigurationImpl(RuntimeType.CLIENT);
    configuration.property(QuarkusRestClientProperties.CONNECTION_TTL, 7);
    configuration.property(QuarkusRestClientProperties.CONNECTION_POOL_SIZE, 21);
    configuration.property(QuarkusRestClientProperties.KEEP_ALIVE_ENABLED, true);
    configuration.property(QuarkusRestClientProperties.MAX_REDIRECTS, 10);
    return configuration;
}

// Code in test service
ClientBuilder clientBuilder = ClientBuilder.newBuilder();
List<ResponseExceptionMapper<?>> exceptionMappers = Collections.singletonList(new DefaultMicroprofileRestClientExceptionMapper());
Client httpClient = clientBuilder.withConfig(buildHttpConfig())
                .register(new MicroProfileRestClientResponseFilter(exceptionMappers)).build();
try {
    String res = httpClient.target("http://httpbin.org/status/418").request().get(String.class);
    System.out.println(res);
} catch (Exception e) {
    if (e instanceof WebApplicationException webApplicationException) {
        String entity = webApplicationException.getResponse().readEntity(String.class);
        System.out.println(e.getMessage() + " entity " + entity);
    }
    e.printStackTrace();
}
```
Here's the stacktrace of the exception:
```
jakarta.ws.rs.ProcessingException: java.lang.NullPointerException: Cannot invoke "org.jboss.resteasy.reactive.client.impl.ClientRequestContextImpl.getRestClientRequestContext()" because "requestContext" is null
        at org.jboss.resteasy.reactive.client.handlers.ClientResponseFilterRestHandler.handle(ClientResponseFilterRestHandler.java:25)
        at org.jboss.resteasy.reactive.client.handlers.ClientResponseFilterRestHandler.handle(ClientResponseFilterRestHandler.java:10)
        at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.invokeHandler(AbstractResteasyReactiveContext.java:231)
        at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
        at org.jboss.resteasy.reactive.client.impl.RestClientRequestContext$1.lambda$execute$0(RestClientRequestContext.java:314)
        at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:279)
        at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:261)
        at io.vertx.core.impl.ContextInternal.lambda$runOnContext$0(ContextInternal.java:59)
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:566)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NullPointerException: Cannot invoke "org.jboss.resteasy.reactive.client.impl.ClientRequestContextImpl.getRestClientRequestContext()" because "requestContext" is null
        at io.quarkus.rest.client.reactive.runtime.MicroProfileRestClientResponseFilter.filter(MicroProfileRestClientResponseFilter.java:38)
        at org.jboss.resteasy.reactive.client.handlers.ClientResponseFilterRestHandler.handle(ClientResponseFilterRestHandler.java:21)
        ... 15 more
```
This happens in Quarkus 3.11.0 and also tested in latest 3.12.1. When making the change in this PR, compiling and using the generated snapshot, I'm able to read the response as expected.