### PR TITLE
Suppress unused warning in RestClientMetricsFilter

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/RestClientMetricsFilter.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/RestClientMetricsFilter.java
@@ -21,6 +21,7 @@ import io.quarkus.arc.Unremovable;
  */
 @Unremovable
 @Provider
+@SuppressWarnings("unused") // this is used by io.quarkus.micrometer.deployment.binder.HttpBinderProcessor
 public class RestClientMetricsFilter implements ClientRequestFilter, ClientResponseFilter {
 
     private final static String REQUEST_METRIC_PROPERTY = "restClientMetrics";


### PR DESCRIPTION
This came to my attention while looking at https://github.com/quarkiverse/quarkus-langchain4j/issues/731