### PR TITLE
For NOTE and TIP, use admonition syntax instead of ID syntax

### DIFF
--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -682,7 +682,7 @@ The observers can be either synchronous or asynchronous.
 * `io.quarkus.oidc.SecurityEvent`
 * `io.quarkus.vertx.http.runtime.security.FormAuthenticationEvent`
 
-[[TIP]]
+[TIP]
 For more information about security events specific to the Quarkus OpenID Connect extension, please see
 the xref:security-oidc-code-flow-authentication.adoc#listen-to-authentication-events[Listening to important authentication events]
 section of the OIDC code flow mechanism for protecting web applications guide.

--- a/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
@@ -689,7 +689,7 @@ quarkus.oidc.auth-server-url=https://dev-3ve0cgn7.us.auth0.com
 
 which is all what is needed for the OIDC `service` application to fetch Auth0 public verification keys and use them to verify Auth0 access tokens in JWT format.
 
-[[NOTE]]
+[NOTE]
 ====
 In this tutorial you have already configured the OIDC `hybrid` application which can handle both authorization code and bearer token authentication flows. In production you will run microservices as separate servers but for the sake of simplicity `ApiEchoService` will not have to be started as a second server with its own configuration containing `quarkus.oidc.auth-server-url=https://dev-3ve0cgn7.us.auth0.com` only, and therefore the current configuration which already has the Auth0 dev tenant address configured will be reused.
 


### PR DESCRIPTION
These two admonitions were using ID syntax by mistake, which made them disappear. I updated them to use admonition syntax instead.