### PR TITLE
Using safe Integer comparison

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToKnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToKnativeConfig.java
@@ -29,7 +29,7 @@ public class AddPortToKnativeConfig extends Configurator<KnativeConfigFluent<?>>
      */
     private boolean hasPort(KnativeConfigFluent<?> config) {
         for (Port p : config.buildPorts()) {
-            if (p.getContainerPort() == port.getContainerPort()) {
+            if (Objects.equals(p.getContainerPort(), port.getContainerPort())) {
                 return true;
             }
         }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToKubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToKubernetesConfig.java
@@ -29,7 +29,7 @@ public class AddPortToKubernetesConfig extends Configurator<KubernetesConfigFlue
      */
     private boolean hasPort(KubernetesConfigFluent<?> config) {
         for (Port p : config.buildPorts()) {
-            if (p.getContainerPort() == port.getContainerPort()) {
+            if (Objects.equals(p.getContainerPort(), port.getContainerPort())) {
                 return true;
             }
         }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToOpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToOpenshiftConfig.java
@@ -29,7 +29,7 @@ public class AddPortToOpenshiftConfig extends Configurator<OpenshiftConfigFluent
      */
     private boolean hasPort(OpenshiftConfigFluent<?> config) {
         for (Port p : config.buildPorts()) {
-            if (p.getContainerPort() == port.getContainerPort()) {
+            if (Objects.equals(p.getContainerPort(), port.getContainerPort())) {
                 return true;
             }
         }


### PR DESCRIPTION
This compares using `Objects.equals` to avoid NPEs and comparing references instead of values 