### PR TITLE
Support Quarkus REST endpoint security annotations placed on endpoint implementations

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/AbstractImplMethodSecuredTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/AbstractImplMethodSecuredTest.java
@@ -1,0 +1,411 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SecurityAnnotation.METHOD_ROLES_ALLOWED;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SecurityAnnotation.NONE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SecurityAnnotation.PATH_SEPARATOR;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.FIRST_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.MULTIPLE_INHERITANCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SECOND_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SECURED_SUB_RESOURCE_ENDPOINT_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.THIRD_INTERFACE;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+/**
+ * Tests that implementation method is always secured when a standard security annotation is on a class
+ * or on a class method or when additional method security (like the default JAX-RS security) is in place.
+ */
+public abstract class AbstractImplMethodSecuredTest {
+
+    protected static QuarkusUnitTest getRunner() {
+        return getRunner("");
+    }
+
+    protected static QuarkusUnitTest getRunner(String applicationProperties) {
+        return new QuarkusUnitTest()
+                .withApplicationRoot((jar) -> jar
+                        .addPackage("io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation")
+                        .addPackage("io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed")
+                        .addPackage("io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall")
+                        .addPackage("io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall")
+                        .addPackage("io.quarkus.resteasy.reactive.server.test.security.inheritance.multiple.pathonbase")
+                        .addClasses(TestIdentityProvider.class, TestIdentityController.class, SecurityAnnotation.class,
+                                SubPaths.class, JsonObjectReader.class)
+                        .addAsResource(new StringAsset(applicationProperties + System.lineSeparator()),
+                                "application.properties"));
+    }
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    protected boolean denyAllUnannotated() {
+        return false;
+    }
+
+    protected String roleRequiredForUnannotatedEndpoint() {
+        return null;
+    }
+
+    private void assertPath(String basePath, Object securityAnnotationObj, String classSecurityOn) {
+        assertPath(basePath, toSecurityAnnotation(securityAnnotationObj), classSecurityOn);
+    }
+
+    private void assertSecuredSubResourcePath(String basePath) {
+
+        // sub resource locator is not secured, e.g. @Path("sub") public SubResource subResource() { ... }
+        var path = NONE.assemblePath(basePath) + SECURED_SUB_RESOURCE_ENDPOINT_PATH;
+        var methodSubPath = NONE.methodSubPath(basePath) + SECURED_SUB_RESOURCE_ENDPOINT_PATH;
+
+        boolean defJaxRsSecurity = denyAllUnannotated() || roleRequiredForUnannotatedEndpoint() != null;
+        final SecurityAnnotation securityAnnotation;
+        if (defJaxRsSecurity) {
+            // subresource locator is not secured, therefore default JAX-RS security wins
+            securityAnnotation = NONE;
+        } else {
+            // sub resource endpoint itself has RolesAllowed, e.g. @RolesAllowed @Path("endpoint") String endpoint() { ... }
+            securityAnnotation = METHOD_ROLES_ALLOWED;
+        }
+
+        assertPath(path, methodSubPath, securityAnnotation);
+    }
+
+    private void assertPath(String basePath, SecurityAnnotation securityAnnotation, String classSecurityOn) {
+        var path = securityAnnotation.assemblePath(basePath, classSecurityOn);
+        var methodSubPath = securityAnnotation.methodSubPath(basePath, classSecurityOn);
+        assertPath(path, methodSubPath, securityAnnotation);
+    }
+
+    private void assertPath(String basePath, SecurityAnnotation securityAnnotation) {
+        var path = securityAnnotation.assemblePath(basePath);
+        var methodSubPath = securityAnnotation.methodSubPath(basePath);
+        assertPath(path, methodSubPath, securityAnnotation);
+    }
+
+    private void assertPath(String path, String methodSubPath, SecurityAnnotation securityAnnotation) {
+        var invalidPayload = "}{\"simple\": \"obj\"}";
+        var validPayload = "{\"simple\": \"obj\"}";
+
+        boolean defJaxRsSecurity = denyAllUnannotated() || roleRequiredForUnannotatedEndpoint() != null;
+        boolean endpointSecuredWithDefJaxRsSec = defJaxRsSecurity && !securityAnnotation.hasSecurityAnnotation();
+        boolean endpointSecured = endpointSecuredWithDefJaxRsSec || securityAnnotation.endpointSecured();
+
+        // test anonymous - for secured endpoints: unauthenticated
+        if (endpointSecured) {
+            given().contentType(ContentType.JSON).body(invalidPayload).post(path).then().statusCode(401);
+        } else {
+            given().contentType(ContentType.JSON).body(validPayload).post(path).then().statusCode(200).body(is(methodSubPath));
+        }
+
+        // test user - for secured endpoints: unauthorized
+        if (endpointSecured) {
+            given().contentType(ContentType.JSON).body(invalidPayload).auth().preemptive().basic("user", "user").post(path)
+                    .then().statusCode(403);
+        } else {
+            given().contentType(ContentType.JSON).body(validPayload).auth().preemptive().basic("user", "user").post(path).then()
+                    .statusCode(200).body(is(methodSubPath));
+        }
+
+        // test admin - for secured endpoints: authorized
+        boolean denyAccess = securityAnnotation.denyAll() || (endpointSecuredWithDefJaxRsSec && denyAllUnannotated());
+        if (denyAccess) {
+            given().contentType(ContentType.JSON).body(invalidPayload).auth().preemptive().basic("admin", "admin").post(path)
+                    .then().statusCode(403);
+        } else {
+            given().contentType(ContentType.JSON).body(invalidPayload).auth().preemptive().basic("admin", "admin").post(path)
+                    .then().statusCode(500);
+            given().contentType(ContentType.JSON).body(validPayload).auth().preemptive().basic("admin", "admin").post(path)
+                    .then().statusCode(200).body(is(methodSubPath));
+        }
+    }
+
+    private static void assertNotFound(String basePath) {
+        var path = NONE.assembleNotFoundPath(basePath);
+        // this assures that not-tested scenarios are simply not supported by RESTEasy
+        // should this assertion fail, we need to assure implementation method is secured
+        given().contentType(ContentType.JSON).body("{\"simple\": \"obj\"}").post(path).then().statusCode(404);
+    }
+
+    private static SecurityAnnotation toSecurityAnnotation(Object securityAnnotationObj) {
+        // we use Object due to @EnumSource class loading problems
+        return SecurityAnnotation.valueOf(securityAnnotationObj.toString());
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnInterface_ImplOnBaseResource_ImplMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_INTERFACE + PATH_SEPARATOR + CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE
+                + IMPL_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_BASE);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnResource_ImplOnBaseResource_ImplMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE
+                + IMPL_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_BASE);
+    }
+
+    @Test
+    public void test_ClassPathOnParentResource_ImplOnBaseResource_ImplMetWithPath() {
+        var resourceSubPath = CLASS_PATH_ON_PARENT_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE
+                + IMPL_METHOD_WITH_PATH;
+        assertNotFound(resourceSubPath);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnInterface_ImplOnBaseResource_InterfaceMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_INTERFACE + PATH_SEPARATOR + CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE
+                + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_BASE);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnResource_ImplOnBaseResource_InterfaceMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE
+                + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_BASE);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnParentResource_ImplOnBaseResource_InterfaceMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_PARENT_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE
+                + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_BASE);
+    }
+
+    @Test
+    public void test_ClassPathOnInterface_ImplOnBaseResource_ParentMetWithPath() {
+        var resourceSubPath = CLASS_PATH_ON_INTERFACE + PATH_SEPARATOR + CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE
+                + PARENT_METHOD_WITH_PATH;
+        assertNotFound(resourceSubPath);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnResource_ImplOnBaseResource_ParentMetWithPath(Object securityAnnotationObj) {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        var resourceSubPath = CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE
+                + PARENT_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_BASE);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnParentResource_ImplOnBaseResource_ParentMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_PARENT_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE
+                + PARENT_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_BASE);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface(Object securityAnnotationObj) {
+        // test subresource locator defined on an interface
+        // @Path("i")
+        // public interface I {
+        //    @Path("sub")
+        //    @RolesAllowed("admin")
+        //    default SubResource subResource() {
+        //      return new SubResource();
+        //    }
+        // }
+
+        var resourceSubPath = CLASS_PATH_ON_INTERFACE + PATH_SEPARATOR + CLASS_PATH_ON_INTERFACE
+                + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_INTERFACE);
+    }
+
+    @Test
+    public void test_ClassPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_SecurityInsideSub() {
+        // HINT: test security is inside sub resource on an endpoint method
+        var resourceSubPath = CLASS_PATH_ON_INTERFACE + PATH_SEPARATOR + CLASS_PATH_ON_INTERFACE
+                + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE;
+        assertSecuredSubResourcePath(resourceSubPath);
+        assertSecuredSubResourcePath(resourceSubPath);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnInterface_SubDeclaredOnInterface_SubImplOnParent(Object securityAnnotationObj) {
+        // HINT: test security for '@Path("sub") SubResource subResource' but not inside endpoints 'SubResource' itself
+        var resourceSubPath = CLASS_PATH_ON_INTERFACE + PATH_SEPARATOR + CLASS_PATH_ON_INTERFACE
+                + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_PARENT);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnResource_SubDeclaredOnBase_SubImplOnBase(Object securityAnnotationObj) {
+        // HINT: test security for '@Path("sub") SubResource subResource' but not inside endpoints 'SubResource' itself
+        var resourceSubPath = CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_RESOURCE
+                + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_BASE);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnParentResource_SubDeclaredOnParent_SubImplOnParent(Object securityAnnotationObj) {
+        // HINT: test security for '@Path("sub") SubResource subResource' but not inside endpoints 'SubResource' itself
+        var resourceSubPath = CLASS_PATH_ON_PARENT_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_PARENT_RESOURCE
+                + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_PARENT);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnParentResource_SubDeclaredOnParent_SubImplOnBase(Object securityAnnotationObj) {
+        // HINT: test security for '@Path("sub") SubResource subResource' but not inside endpoints 'SubResource' itself
+        var resourceSubPath = CLASS_PATH_ON_PARENT_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_PARENT_RESOURCE
+                + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_BASE);
+    }
+
+    @Test
+    public void test_ClassPathOnInterface_ImplOnParentResource_ImplMetWithPath() {
+        var resourceSubPath = CLASS_PATH_ON_INTERFACE + PATH_SEPARATOR + CLASS_PATH_ON_INTERFACE
+                + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH;
+        assertNotFound(resourceSubPath);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnResource_ImplOnParentResource_ImplMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT
+                + IMPL_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_PARENT);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnParentResource_ImplOnParentResource_ImplMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_PARENT_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT
+                + IMPL_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_PARENT);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnInterface_ImplOnParentResource_InterfaceMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_INTERFACE + PATH_SEPARATOR + CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT
+                + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_PARENT);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnResource_ImplOnParentResource_InterfaceMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT
+                + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_PARENT);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnParentResource_ImplOnParentResource_InterfaceMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_PARENT_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT
+                + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_PARENT);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnInterface_ImplOnInterface_ImplMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_INTERFACE + PATH_SEPARATOR + CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE
+                + IMPL_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_INTERFACE);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnResource_ImplOnInterface_ImplMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE
+                + IMPL_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_INTERFACE);
+    }
+
+    @EnumSource(SecurityAnnotation.class)
+    @ParameterizedTest
+    public void test_ClassPathOnParentResource_ImplOnInterface_ImplMetWithPath(Object securityAnnotationObj) {
+        var resourceSubPath = CLASS_PATH_ON_PARENT_RESOURCE + PATH_SEPARATOR + CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE
+                + IMPL_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, securityAnnotationObj, CLASS_SECURITY_ON_INTERFACE);
+    }
+
+    @Test
+    public void test_MultipleInheritance_ClassPathOnBase_ImplOnBase_ImplWithPath() {
+        var resourceSubPath = MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + MULTIPLE_INHERITANCE
+                + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, METHOD_ROLES_ALLOWED);
+        assertPath(resourceSubPath, NONE);
+    }
+
+    @Test
+    public void test_MultipleInheritance_ClassPathOnBase_ImplOnBase_FirstInterface_InterfaceMethodWithPath() {
+        var resourceSubPath = MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + MULTIPLE_INHERITANCE
+                + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + SECOND_INTERFACE + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, METHOD_ROLES_ALLOWED);
+        assertPath(resourceSubPath, NONE);
+    }
+
+    @Test
+    public void test_MultipleInheritance_ClassPathOnBase_ImplOnBase_SecondInterface_InterfaceMethodWithPath() {
+        var resourceSubPath = MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + MULTIPLE_INHERITANCE
+                + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + FIRST_INTERFACE + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, METHOD_ROLES_ALLOWED);
+        assertPath(resourceSubPath, NONE);
+    }
+
+    @Test
+    public void test_MultipleInheritance_ClassPathOnBase_ImplOnBase_ThirdInterface_InterfaceMethodWithPath() {
+        var resourceSubPath = MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + MULTIPLE_INHERITANCE
+                + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, METHOD_ROLES_ALLOWED);
+        assertPath(resourceSubPath, NONE);
+    }
+
+    @Test
+    public void test_MultipleInheritance_ClassPathOnBase_ImplOnInterface_ThirdInterface_InterfaceMethodWithPath() {
+        var resourceSubPath = MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + PATH_SEPARATOR + MULTIPLE_INHERITANCE
+                + CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH;
+        assertPath(resourceSubPath, METHOD_ROLES_ALLOWED);
+        assertPath(resourceSubPath, NONE);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/DefaultJaxRsDenyAllImplMethodSecuredTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/DefaultJaxRsDenyAllImplMethodSecuredTest.java
@@ -1,0 +1,16 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultJaxRsDenyAllImplMethodSecuredTest extends AbstractImplMethodSecuredTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = getRunner("quarkus.security.jaxrs.deny-unannotated-endpoints=true");
+
+    @Override
+    protected boolean denyAllUnannotated() {
+        return true;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/DefaultJaxRsRolesAllowedImplMethodSecuredTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/DefaultJaxRsRolesAllowedImplMethodSecuredTest.java
@@ -1,0 +1,16 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultJaxRsRolesAllowedImplMethodSecuredTest extends AbstractImplMethodSecuredTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = getRunner("quarkus.security.jaxrs.default-roles-allowed=admin");
+
+    @Override
+    protected String roleRequiredForUnannotatedEndpoint() {
+        return "admin";
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/ImplMethodSecuredTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/ImplMethodSecuredTest.java
@@ -1,0 +1,12 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ImplMethodSecuredTest extends AbstractImplMethodSecuredTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = getRunner();
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/JsonObjectReader.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/JsonObjectReader.java
@@ -1,0 +1,56 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+
+import io.vertx.core.json.JsonObject;
+
+@Provider
+@Consumes(MediaType.APPLICATION_JSON)
+public class JsonObjectReader implements ServerMessageBodyReader<JsonObject> {
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo lazyMethod, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public JsonObject readFrom(Class<JsonObject> type, Type genericType, MediaType mediaType, ServerRequestContext context)
+            throws WebApplicationException, IOException {
+        return readFrom(context.getInputStream());
+    }
+
+    @Override
+    public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public JsonObject readFrom(Class<JsonObject> aClass, Type type, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> multivaluedMap, InputStream inputStream)
+            throws IOException, WebApplicationException {
+        return readFrom(inputStream);
+    }
+
+    private JsonObject readFrom(InputStream inputStream) {
+        try {
+            String json = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            return new JsonObject(json);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to parse JsonObject.", e);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/SecurityAnnotation.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/SecurityAnnotation.java
@@ -1,0 +1,77 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance;
+
+import jakarta.ws.rs.Path;
+
+public enum SecurityAnnotation {
+    NONE(SubPaths.NO_SECURITY_ANNOTATION, false, null, false),
+    METHOD_ROLES_ALLOWED(SubPaths.METHOD_ROLES_ALLOWED, false, "admin", false),
+    METHOD_DENY_ALL(SubPaths.METHOD_DENY_ALL, true, null, false),
+    METHOD_PERMIT_ALL(SubPaths.METHOD_PERMIT_ALL, false, null, false),
+    CLASS_ROLES_ALLOWED(SubPaths.CLASS_ROLES_ALLOWED, false, "admin", true),
+    CLASS_DENY_ALL(SubPaths.CLASS_DENY_ALL, true, null, true),
+    CLASS_PERMIT_ALL(SubPaths.CLASS_PERMIT_ALL, false, null, true),
+    CLASS_PERMIT_ALL_METHOD_PERMIT_ALL(SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL, false, null, true),
+    // class is annotated with the @DenyAll, but method level annotation must have priority, therefore we set denyAll=false
+    CLASS_DENY_ALL_METHOD_ROLES_ALLOWED(SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED, false, "admin", true),
+    CLASS_DENY_ALL_METHOD_PERMIT_ALL(SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL, false, null, true);
+
+    static final String PATH_SEPARATOR = "/";
+
+    private final SubPaths.SubPath subPath;
+    private final String allowedRole;
+    private final boolean isClassSecurityAnnotation;
+    private final boolean denyAll;
+
+    SecurityAnnotation(SubPaths.SubPath subPath, boolean denyAll, String allowedRole, boolean isClassSecurityAnnotation) {
+        this.subPath = subPath;
+        this.denyAll = denyAll;
+        this.allowedRole = allowedRole;
+        this.isClassSecurityAnnotation = isClassSecurityAnnotation;
+    }
+
+    private String toSecurityAnnInfix(String classSecurityOn) {
+        return isClassSecurityAnnotation ? classSecurityOn : "";
+    }
+
+    boolean hasSecurityAnnotation() {
+        return this != NONE;
+    }
+
+    boolean denyAll() {
+        return denyAll;
+    }
+
+    boolean endpointSecured() {
+        return denyAll || allowedRole != null;
+    }
+
+    /**
+     * @param basePath path common for all {@link this} annotations
+     * @param classSecurityOn whether class-level annotation is on interface, parent or base
+     * @return request path
+     */
+    String assemblePath(String basePath, String classSecurityOn) {
+        return subPath.classSubPathPrefix() + toSecurityAnnInfix(classSecurityOn) + basePath + subPath.methodSubPath();
+    }
+
+    String assemblePath(String basePath) {
+        return subPath.classSubPathPrefix() + basePath + subPath.methodSubPath();
+    }
+
+    String assembleNotFoundPath(String basePath) {
+        return subPath.classSubPathPrefix() + basePath;
+    }
+
+    /**
+     * @return endpoint method-level {@link Path#value()}
+     */
+    String methodSubPath(String basePath, String classSecurityOn) {
+        var path = assemblePath(basePath, classSecurityOn);
+        return path.substring(path.indexOf(PATH_SEPARATOR, 1) + 1);
+    }
+
+    String methodSubPath(String basePath) {
+        var path = assemblePath(basePath);
+        return path.substring(path.indexOf(PATH_SEPARATOR, 1) + 1);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/SubPaths.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/SubPaths.java
@@ -1,0 +1,88 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance;
+
+public interface SubPaths {
+
+    record SubPath(String classSubPathPrefix, String methodSubPath) {
+    }
+
+    String CLASS_PATH_ON_INTERFACE = "class-path-on-interface";
+    String CLASS_PATH_ON_RESOURCE = "class-path-on-resource";
+    String CLASS_PATH_ON_PARENT_RESOURCE = "class-path-on-parent-resource";
+
+    String CLASS_SECURITY_ON_BASE = "class-security-on-base-";
+    String CLASS_SECURITY_ON_PARENT = "class-security-on-parent-";
+    String CLASS_SECURITY_ON_INTERFACE = "class-security-on-interface-";
+
+    String IMPL_ON_BASE = "/impl-on-base-resource";
+    String IMPL_ON_PARENT = "/impl-on-parent-resource";
+    /**
+     * Interface that sits on the top of a resource class hierarchy.
+     */
+    String IMPL_ON_INTERFACE = "/impl-on-interface";
+    String SUB_DECLARED_ON = "/sub-resource-declared-on-";
+
+    /**
+     * Following 3 constants refer to where method like {@code @Path("sub") SubResource subResource} with JAX-RS
+     * sub-resource declaring annotations are declared.
+     */
+    String SUB_DECLARED_ON_INTERFACE = SUB_DECLARED_ON + "interface";
+    String SUB_DECLARED_ON_BASE = SUB_DECLARED_ON + "base";
+    String SUB_DECLARED_ON_PARENT = SUB_DECLARED_ON + "parent";
+
+    String SECURED_SUB_RESOURCE_ENDPOINT_PATH = "/secured";
+
+    /**
+     * Following 3 constants refer to where method like {@code @Override SubResource subResource() { return new SubResource();
+     * }}
+     * is implemented. That is whether actually invoked sub-resource endpoint is placed on a base, parent or an interface.
+     */
+    String SUB_IMPL_ON_BASE = "/sub-impl-on-base";
+    String SUB_IMPL_ON_PARENT = "/sub-impl-on-parent";
+    String SUB_IMPL_ON_INTERFACE = "/sub-impl-on-interface";
+
+    String IMPL_METHOD_WITH_PATH = "/impl-met-with-path";
+    String PARENT_METHOD_WITH_PATH = "/parent-met-with-path";
+    String INTERFACE_METHOD_WITH_PATH = "/interface-met-with-path";
+
+    String CLASS_NO_ANNOTATION_PREFIX = "/class-no-annotation-";
+    String CLASS_ROLES_ALLOWED_PREFIX = "/class-roles-allowed-";
+    String CLASS_DENY_ALL_PREFIX = "/class-deny-all-";
+    String CLASS_PERMIT_ALL_PREFIX = "/class-permit-all-";
+
+    String NO_SECURITY_ANNOTATION_PATH = "/no-security-annotation";
+    String METHOD_ROLES_ALLOWED_PATH = "/method-roles-allowed";
+    String METHOD_DENY_ALL_PATH = "/method-deny-all";
+    String METHOD_PERMIT_ALL_PATH = "/method-permit-all";
+    String CLASS_ROLES_ALLOWED_PATH = "/class-roles-allowed";
+    String CLASS_DENY_ALL_PATH = "/class-deny-all";
+    String CLASS_PERMIT_ALL_PATH = "/class-permit-all";
+    String CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH = "/class-deny-all-method-roles-allowed";
+    String CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH = "/class-deny-all-method-permit-all";
+    String CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH = "/class-permit-all-method-permit-all";
+
+    String MULTIPLE_INHERITANCE = "multiple-inheritance-";
+
+    /**
+     * Interface implemented by a base/parent resource.
+     */
+    String FIRST_INTERFACE = "/first-interface";
+    /**
+     * Interface that extends {@link #FIRST_INTERFACE}.
+     */
+    String SECOND_INTERFACE = "/second-interface";
+    /**
+     * Interface that extends {@link #SECOND_INTERFACE}.
+     */
+    String THIRD_INTERFACE = "/third-interface";
+
+    SubPath NO_SECURITY_ANNOTATION = new SubPath(CLASS_NO_ANNOTATION_PREFIX, NO_SECURITY_ANNOTATION_PATH);
+    SubPath METHOD_ROLES_ALLOWED = new SubPath(CLASS_NO_ANNOTATION_PREFIX, METHOD_ROLES_ALLOWED_PATH);
+    SubPath METHOD_DENY_ALL = new SubPath(CLASS_NO_ANNOTATION_PREFIX, METHOD_DENY_ALL_PATH);
+    SubPath METHOD_PERMIT_ALL = new SubPath(CLASS_NO_ANNOTATION_PREFIX, METHOD_PERMIT_ALL_PATH);
+    SubPath CLASS_ROLES_ALLOWED = new SubPath(CLASS_ROLES_ALLOWED_PREFIX, CLASS_ROLES_ALLOWED_PATH);
+    SubPath CLASS_DENY_ALL = new SubPath(CLASS_DENY_ALL_PREFIX, CLASS_DENY_ALL_PATH);
+    SubPath CLASS_PERMIT_ALL = new SubPath(CLASS_PERMIT_ALL_PREFIX, CLASS_PERMIT_ALL_PATH);
+    SubPath CLASS_DENY_ALL_METHOD_ROLES_ALLOWED = new SubPath(CLASS_DENY_ALL_PREFIX, CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH);
+    SubPath CLASS_DENY_ALL_METHOD_PERMIT_ALL = new SubPath(CLASS_DENY_ALL_PREFIX, CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH);
+    SubPath CLASS_PERMIT_ALL_METHOD_PERMIT_ALL = new SubPath(CLASS_PERMIT_ALL_PREFIX, CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH);
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithPath_OnBase_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithPath_OnBase_SecurityOnParent.java
@@ -1,0 +1,17 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_DENY_ALL_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_RESOURCE)
+public class ClassDenyAllBaseResourceWithPath_OnBase_SecurityOnParent
+        extends ClassDenyAllParentResourceWithoutPath_PathOnBase_SecurityOnParent {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithPath_SecurityOnBase.java
@@ -1,0 +1,106 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@DenyAll
+@Path(CLASS_DENY_ALL_PREFIX + CLASS_SECURITY_ON_BASE + CLASS_PATH_ON_RESOURCE)
+public class ClassDenyAllBaseResourceWithPath_SecurityOnBase extends ClassDenyAllParentResourceWithoutPath_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_ClassDenyAllPath(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_ClassDenyAllMethodPermitAllPath(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_ClassDenyAllMethodRolesAllowedPath(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_PATH)
+    public ClassDenyAllSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_ClassDenyAll() {
+        return new ClassDenyAllSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_PATH);
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    public ClassDenyAllSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_ClassDenyAllMethodPermitAll() {
+        return new ClassDenyAllSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    public ClassDenyAllSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_ClassDenyAllMethodRolesAllowed() {
+        return new ClassDenyAllSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithPath_SecurityOnInterface.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_DENY_ALL_PREFIX + CLASS_SECURITY_ON_INTERFACE + CLASS_PATH_ON_RESOURCE)
+public class ClassDenyAllBaseResourceWithPath_SecurityOnInterface
+        extends ClassDenyAllParentResourceWithoutPath_SecurityOnInterface {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathExtParentRes_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathExtParentRes_SecurityOnBase.java
@@ -1,0 +1,81 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+
+import io.vertx.core.json.JsonObject;
+
+@DenyAll
+public class ClassDenyAllBaseResourceWithoutPathExtParentRes_SecurityOnBase
+        extends ClassDenyAllParentResourceWithPath_SecurityOnBase {
+
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(
+            JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH
+                + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH
+                + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH
+                + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Override
+    public ClassDenyAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassDenyAll() {
+        return new ClassDenyAllSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_PATH);
+    }
+
+    @PermitAll
+    @Override
+    public ClassDenyAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassDenyAllMethodPermitAll() {
+        return new ClassDenyAllSubResourceWithoutPath(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE
+                + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public ClassDenyAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassDenyAllMethodRolesAllowed() {
+        return new ClassDenyAllSubResourceWithoutPath(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE
+                + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathExtParentRes_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathExtParentRes_SecurityOnInterface.java
@@ -1,0 +1,5 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+public class ClassDenyAllBaseResourceWithoutPathExtParentRes_SecurityOnInterface
+        extends ClassDenyAllParentResourceWithPath_SecurityOnInterface {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathExtParentRes_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathExtParentRes_SecurityOnParent.java
@@ -1,0 +1,6 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+public class ClassDenyAllBaseResourceWithoutPathExtParentRes_SecurityOnParent
+        extends ClassDenyAllParentResourceWithPath_SecurityOnParent {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathImplInterface_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathImplInterface_SecurityOnBase.java
@@ -1,0 +1,76 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+
+import io.vertx.core.json.JsonObject;
+
+@DenyAll
+public class ClassDenyAllBaseResourceWithoutPathImplInterface_SecurityOnBase
+        implements ClassDenyAllInterfaceWithPath_SecurityOnBase {
+
+    @Override
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassDenyAll() {
+        return new ClassDenyAllSubResourceWithoutPath(
+                CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_PATH);
+    }
+
+    @PermitAll
+    @Override
+    public ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassDenyAllMethodPermitAll() {
+        return new ClassDenyAllSubResourceWithoutPath(
+                CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassDenyAllMethodRolesAllowed() {
+        return new ClassDenyAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathImplInterface_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPathImplInterface_SecurityOnInterface.java
@@ -1,0 +1,6 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+// must always be here as interface needs an implementing class, otherwise is ignored
+public class ClassDenyAllBaseResourceWithoutPathImplInterface_SecurityOnInterface
+        implements ClassDenyAllInterfaceWithPath_SecurityOnInterface {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllBaseResourceWithoutPath_SecurityOnParent.java
@@ -1,0 +1,5 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+public class ClassDenyAllBaseResourceWithoutPath_SecurityOnParent
+        extends ClassDenyAllParentResourceWithoutPath_SecurityOnParent {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithPath_SecurityOnBase.java
@@ -1,0 +1,61 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_DENY_ALL_PREFIX + CLASS_SECURITY_ON_BASE + CLASS_PATH_ON_INTERFACE)
+public interface ClassDenyAllInterfaceWithPath_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array);
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_PATH)
+    ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassDenyAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassDenyAllMethodPermitAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassDenyAllMethodRolesAllowed();
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithPath_SecurityOnInterface.java
@@ -1,0 +1,72 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_INTERFACE;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@DenyAll
+@Path(CLASS_DENY_ALL_PREFIX + CLASS_SECURITY_ON_INTERFACE + CLASS_PATH_ON_INTERFACE)
+public interface ClassDenyAllInterfaceWithPath_SecurityOnInterface {
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + CLASS_DENY_ALL_PATH)
+    default ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_ClassDenyAll() {
+        return new ClassDenyAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_INTERFACE + CLASS_DENY_ALL_PATH);
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    default ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_ClassDenyAllMethodPermitAll() {
+        return new ClassDenyAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_INTERFACE + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE
+            + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    default ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_ClassDenyAllMethodRolesAllowed() {
+        return new ClassDenyAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_INTERFACE + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH);
+    }
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithPath_SecurityOnParent.java
@@ -1,0 +1,50 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_DENY_ALL_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_INTERFACE)
+public interface ClassDenyAllInterfaceWithPath_SecurityOnParent {
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT + CLASS_DENY_ALL_PATH)
+    ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassDenyAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT
+            + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassDenyAllMethodPermitAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT
+            + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassDenyAllMethodRolesAllowed();
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_PathOnParent_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_PathOnParent_SecurityOnInterface.java
@@ -1,0 +1,44 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@DenyAll
+public interface ClassDenyAllInterfaceWithoutPath_PathOnParent_SecurityOnInterface {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH
+                + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_ClassDenyAllMethodRolesAllowed(
+            JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH
+                + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_PathOnParent_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_PathOnParent_SecurityOnParent.java
@@ -1,0 +1,30 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassDenyAllInterfaceWithoutPath_PathOnParent_SecurityOnParent {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH
+            + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_SecurityOnBase.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassDenyAllInterfaceWithoutPath_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_SecurityOnInterface.java
@@ -1,0 +1,41 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@DenyAll
+public interface ClassDenyAllInterfaceWithoutPath_SecurityOnInterface {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllInterfaceWithoutPath_SecurityOnParent.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassDenyAllInterfaceWithoutPath_SecurityOnParent {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceInterface_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceInterface_SecurityOnBase.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassDenyAllParentResourceInterface_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithPath_SecurityOnBase.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_DENY_ALL_PREFIX + CLASS_SECURITY_ON_BASE + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class ClassDenyAllParentResourceWithPath_SecurityOnBase
+        implements ClassDenyAllParentResourceInterface_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassDenyAllMethodPermitAll(
+            JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassDenyAllMethodRolesAllowed(
+            JsonObject array);
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + CLASS_DENY_ALL_PATH)
+    public abstract ClassDenyAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassDenyAll();
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE
+            + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    public abstract ClassDenyAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassDenyAllMethodPermitAll();
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE
+            + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    public abstract ClassDenyAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassDenyAllMethodRolesAllowed();
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithPath_SecurityOnInterface.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_DENY_ALL_PREFIX + CLASS_SECURITY_ON_INTERFACE + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class ClassDenyAllParentResourceWithPath_SecurityOnInterface
+        implements ClassDenyAllInterfaceWithoutPath_PathOnParent_SecurityOnInterface {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithPath_SecurityOnParent.java
@@ -1,0 +1,97 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@DenyAll
+@Path(CLASS_DENY_ALL_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class ClassDenyAllParentResourceWithPath_SecurityOnParent
+        implements ClassDenyAllInterfaceWithoutPath_PathOnParent_SecurityOnParent {
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + CLASS_DENY_ALL_PATH)
+    public ClassDenyAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParent_ClassDenyAll() {
+        return new ClassDenyAllSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + CLASS_DENY_ALL_PATH);
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT
+            + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    public ClassDenyAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParent_ClassDenyAllMethodPermitAll() {
+        return new ClassDenyAllSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT
+                        + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT
+            + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    public ClassDenyAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParent_ClassDenyAllMethodRolesAllowed() {
+        return new ClassDenyAllSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT
+                        + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH);
+    }
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH
+                + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH
+                + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(
+            JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH
+                + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithoutPath_PathOnBase_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithoutPath_PathOnBase_SecurityOnParent.java
@@ -1,0 +1,59 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@DenyAll
+public abstract class ClassDenyAllParentResourceWithoutPath_PathOnBase_SecurityOnParent
+        implements ClassDenyAllInterfaceWithoutPath_SecurityOnParent {
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithoutPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithoutPath_SecurityOnBase.java
@@ -1,0 +1,32 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public abstract class ClassDenyAllParentResourceWithoutPath_SecurityOnBase
+        implements ClassDenyAllInterfaceWithoutPath_SecurityOnBase {
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassDenyAll(JsonObject array);
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassDenyAllMethodPermitAll(
+            JsonObject array);
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassDenyAllMethodRolesAllowed(
+            JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithoutPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithoutPath_SecurityOnInterface.java
@@ -1,0 +1,6 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+public abstract class ClassDenyAllParentResourceWithoutPath_SecurityOnInterface
+        implements ClassDenyAllInterfaceWithoutPath_SecurityOnInterface {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithoutPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllParentResourceWithoutPath_SecurityOnParent.java
@@ -1,0 +1,58 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+
+import io.vertx.core.json.JsonObject;
+
+@DenyAll
+public abstract class ClassDenyAllParentResourceWithoutPath_SecurityOnParent
+        implements ClassDenyAllInterfaceWithPath_SecurityOnParent {
+
+    @Override
+    public ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassDenyAll() {
+        return new ClassDenyAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_PARENT + CLASS_DENY_ALL_PATH);
+    }
+
+    @PermitAll
+    @Override
+    public ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassDenyAllMethodPermitAll() {
+        return new ClassDenyAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_PARENT + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public ClassDenyAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassDenyAllMethodRolesAllowed() {
+        return new ClassDenyAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_PARENT + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH);
+    }
+
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassDenyAllMethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_DENY_ALL_METHOD_ROLES_ALLOWED_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllSubResourceWithoutPath.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classdenyall/ClassDenyAllSubResourceWithoutPath.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classdenyall;
+
+import jakarta.ws.rs.POST;
+
+import io.vertx.core.json.JsonObject;
+
+public class ClassDenyAllSubResourceWithoutPath {
+
+    private final String subResourcePath;
+
+    public ClassDenyAllSubResourceWithoutPath(String subResourcePath) {
+        this.subResourcePath = subResourcePath;
+    }
+
+    @POST
+    public String post(JsonObject array) {
+        return subResourcePath;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithPath_SecurityOnBase.java
@@ -1,0 +1,77 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@PermitAll
+@Path(CLASS_PERMIT_ALL_PREFIX + CLASS_SECURITY_ON_BASE + CLASS_PATH_ON_RESOURCE)
+public class ClassPermitAllBaseResourceWithPath_SecurityOnBase extends ClassPermitAllParentResourceWithoutPath_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_ClassPermitAllPath(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_ClassPermitAllMethodPermitAllPath(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_PATH)
+    public ClassPermitAllSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_ClassPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_PATH);
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    public ClassPermitAllSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_ClassPermitAllMethodPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithPath_SecurityOnInterface.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_PERMIT_ALL_PREFIX + CLASS_SECURITY_ON_INTERFACE + CLASS_PATH_ON_RESOURCE)
+public class ClassPermitAllBaseResourceWithPath_SecurityOnInterface
+        extends ClassPermitAllParentResourceWithoutPath_SecurityOnInterface {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathExtParentRes_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathExtParentRes_SecurityOnBase.java
@@ -1,0 +1,55 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.PermitAll;
+
+import io.vertx.core.json.JsonObject;
+
+@PermitAll
+public class ClassPermitAllBaseResourceWithoutPathExtParentRes_SecurityOnBase
+        extends ClassPermitAllParentResourceWithPath_SecurityOnBase {
+
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH
+                + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public ClassPermitAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_PATH);
+    }
+
+    @PermitAll
+    @Override
+    public ClassPermitAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassPermitAllMethodPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT
+                + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathExtParentRes_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathExtParentRes_SecurityOnInterface.java
@@ -1,0 +1,5 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+public class ClassPermitAllBaseResourceWithoutPathExtParentRes_SecurityOnInterface
+        extends ClassPermitAllParentResourceWithPath_SecurityOnInterface {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathExtParentRes_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathExtParentRes_SecurityOnParent.java
@@ -1,0 +1,5 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+public class ClassPermitAllBaseResourceWithoutPathExtParentRes_SecurityOnParent
+        extends ClassPermitAllParentResourceWithPath_SecurityOnParent {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathImplInterface_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathImplInterface_SecurityOnBase.java
@@ -1,0 +1,54 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.PermitAll;
+
+import io.vertx.core.json.JsonObject;
+
+@PermitAll
+public class ClassPermitAllBaseResourceWithoutPathImplInterface_SecurityOnBase
+        implements ClassPermitAllInterfaceWithPath_SecurityOnBase {
+
+    @Override
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_PATH);
+    }
+
+    @PermitAll
+    @Override
+    public ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassPermitAllMethodPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathImplInterface_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPathImplInterface_SecurityOnInterface.java
@@ -1,0 +1,6 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+// must always be here as interface needs an implementing class, otherwise is ignored
+public class ClassPermitAllBaseResourceWithoutPathImplInterface_SecurityOnInterface
+        implements ClassPermitAllInterfaceWithPath_SecurityOnInterface {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPath_OnBase_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPath_OnBase_SecurityOnParent.java
@@ -1,0 +1,17 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_PERMIT_ALL_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_RESOURCE)
+public class ClassPermitAllBaseResourceWithoutPath_OnBase_SecurityOnParent
+        extends ClassPermitAllParentResourceWithoutPath_PathOnBase_SecurityOnParent {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllBaseResourceWithoutPath_SecurityOnParent.java
@@ -1,0 +1,5 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+public class ClassPermitAllBaseResourceWithoutPath_SecurityOnParent
+        extends ClassPermitAllParentResourceWithoutPath_SecurityOnParent {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithPath_SecurityOnBase.java
@@ -1,0 +1,48 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_PERMIT_ALL_PREFIX + CLASS_SECURITY_ON_BASE + CLASS_PATH_ON_INTERFACE)
+public interface ClassPermitAllInterfaceWithPath_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array);
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_PATH)
+    ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassPermitAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassPermitAllMethodPermitAll();
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithPath_SecurityOnInterface.java
@@ -1,0 +1,54 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_INTERFACE;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@PermitAll
+@Path(CLASS_PERMIT_ALL_PREFIX + CLASS_SECURITY_ON_INTERFACE + CLASS_PATH_ON_INTERFACE)
+public interface ClassPermitAllInterfaceWithPath_SecurityOnInterface {
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + CLASS_PERMIT_ALL_PATH)
+    default ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_ClassPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_INTERFACE + CLASS_PERMIT_ALL_PATH);
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    default ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_ClassPermitAllMethodPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_INTERFACE + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithPath_SecurityOnParent.java
@@ -1,0 +1,41 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_PERMIT_ALL_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_INTERFACE)
+public interface ClassPermitAllInterfaceWithPath_SecurityOnParent {
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT + CLASS_PERMIT_ALL_PATH)
+    ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassPermitAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT
+            + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassPermitAllMethodPermitAll();
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_PathOnParent_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_PathOnParent_SecurityOnInterface.java
@@ -1,0 +1,32 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@PermitAll
+public interface ClassPermitAllInterfaceWithoutPath_PathOnParent_SecurityOnInterface {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_ClassPermitAllMethodPermitAll(
+            JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH
+                + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_PathOnParent_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_PathOnParent_SecurityOnParent.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassPermitAllInterfaceWithoutPath_PathOnParent_SecurityOnParent {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_SecurityOnBase.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassPermitAllInterfaceWithoutPath_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_SecurityOnInterface.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@PermitAll
+public interface ClassPermitAllInterfaceWithoutPath_SecurityOnInterface {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllInterfaceWithoutPath_SecurityOnParent.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassPermitAllInterfaceWithoutPath_SecurityOnParent {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceInterface_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceInterface_SecurityOnBase.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassPermitAllParentResourceInterface_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithPath_SecurityOnBase.java
@@ -1,0 +1,41 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_PERMIT_ALL_PREFIX + CLASS_SECURITY_ON_BASE + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class ClassPermitAllParentResourceWithPath_SecurityOnBase
+        implements ClassPermitAllParentResourceInterface_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassPermitAllMethodPermitAll(
+            JsonObject array);
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_PATH)
+    public abstract ClassPermitAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassPermitAll();
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    public abstract ClassPermitAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBase_ClassPermitAllMethodPermitAll();
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithPath_SecurityOnInterface.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_PERMIT_ALL_PREFIX + CLASS_SECURITY_ON_INTERFACE + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class ClassPermitAllParentResourceWithPath_SecurityOnInterface
+        implements ClassPermitAllInterfaceWithoutPath_PathOnParent_SecurityOnInterface {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithPath_SecurityOnParent.java
@@ -1,0 +1,69 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@PermitAll
+@Path(CLASS_PERMIT_ALL_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class ClassPermitAllParentResourceWithPath_SecurityOnParent
+        implements ClassPermitAllInterfaceWithoutPath_PathOnParent_SecurityOnParent {
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + CLASS_PERMIT_ALL_PATH)
+    public ClassPermitAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParent_ClassPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + CLASS_PERMIT_ALL_PATH);
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT
+            + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    public ClassPermitAllSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParent_ClassPermitAllMethodPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT
+                + SUB_IMPL_ON_PARENT + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(
+            JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH
+                + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithoutPath_PathOnBase_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithoutPath_PathOnBase_SecurityOnParent.java
@@ -1,0 +1,42 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@PermitAll
+public abstract class ClassPermitAllParentResourceWithoutPath_PathOnBase_SecurityOnParent
+        implements ClassPermitAllInterfaceWithoutPath_SecurityOnParent {
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithoutPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithoutPath_SecurityOnBase.java
@@ -1,0 +1,26 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public abstract class ClassPermitAllParentResourceWithoutPath_SecurityOnBase
+        implements ClassPermitAllInterfaceWithoutPath_SecurityOnBase {
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassPermitAll(JsonObject array);
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassPermitAllMethodPermitAll(
+            JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithoutPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithoutPath_SecurityOnInterface.java
@@ -1,0 +1,6 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+public abstract class ClassPermitAllParentResourceWithoutPath_SecurityOnInterface
+        implements ClassPermitAllInterfaceWithoutPath_SecurityOnInterface {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithoutPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllParentResourceWithoutPath_SecurityOnParent.java
@@ -1,0 +1,42 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.annotation.security.PermitAll;
+
+import io.vertx.core.json.JsonObject;
+
+@PermitAll
+public abstract class ClassPermitAllParentResourceWithoutPath_SecurityOnParent
+        implements ClassPermitAllInterfaceWithPath_SecurityOnParent {
+
+    @Override
+    public ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_PARENT + CLASS_PERMIT_ALL_PATH);
+    }
+
+    @PermitAll
+    @Override
+    public ClassPermitAllSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassPermitAllMethodPermitAll() {
+        return new ClassPermitAllSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_PARENT + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH);
+    }
+
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassPermitAllMethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_PERMIT_ALL_METHOD_PERMIT_ALL_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllSubResourceWithoutPath.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classpermitall/ClassPermitAllSubResourceWithoutPath.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classpermitall;
+
+import jakarta.ws.rs.POST;
+
+import io.vertx.core.json.JsonObject;
+
+public class ClassPermitAllSubResourceWithoutPath {
+
+    private final String subResourcePath;
+
+    public ClassPermitAllSubResourceWithoutPath(String subResourcePath) {
+        this.subResourcePath = subResourcePath;
+    }
+
+    @POST
+    public String post(JsonObject array) {
+        return subResourcePath;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithPath_SecurityOnBase.java
@@ -1,0 +1,51 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@RolesAllowed("admin")
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_BASE + CLASS_PATH_ON_RESOURCE)
+public class ClassRolesAllowedBaseResourceWithPath_SecurityOnBase
+        extends ClassRolesAllowedParentResourceWithoutPath_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_ClassRolesAllowedPath(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_ROLES_ALLOWED_PATH)
+    public ClassRolesAllowedSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_ClassRolesAllowed() {
+        return new ClassRolesAllowedSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + CLASS_ROLES_ALLOWED_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithPath_SecurityOnInterface.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_INTERFACE + CLASS_PATH_ON_RESOURCE)
+public class ClassRolesAllowedBaseResourceWithPath_SecurityOnInterface
+        extends ClassRolesAllowedParentResourceWithoutPath_SecurityOnInterface {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithPath_SecurityOnParent.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_RESOURCE)
+public class ClassRolesAllowedBaseResourceWithPath_SecurityOnParent
+        extends ClassRolesAllowedParentResourceWithoutPath_SecurityOnParent {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathExtParentRes_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathExtParentRes_SecurityOnBase.java
@@ -1,0 +1,34 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import io.vertx.core.json.JsonObject;
+
+@RolesAllowed("admin")
+public class ClassRolesAllowedBaseResourceWithoutPathExtParentRes_SecurityOnBase
+        extends ClassRolesAllowedParentResourceWithPath_SecurityOnBase {
+
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public ClassRolesAllowedSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_ClassRolesAllowed() {
+        return new ClassRolesAllowedSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + CLASS_ROLES_ALLOWED_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathExtParentRes_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathExtParentRes_SecurityOnInterface.java
@@ -1,0 +1,5 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+public class ClassRolesAllowedBaseResourceWithoutPathExtParentRes_SecurityOnInterface
+        extends ClassRolesAllowedParentResourceWithPath_SecurityOnInterface {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathExtParentRes_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathExtParentRes_SecurityOnParent.java
@@ -1,0 +1,6 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+public class ClassRolesAllowedBaseResourceWithoutPathExtParentRes_SecurityOnParent
+        extends ClassRolesAllowedParentResourceWithPath_SecurityOnParent {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathImplInterface_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathImplInterface_SecurityOnBase.java
@@ -1,0 +1,35 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import io.vertx.core.json.JsonObject;
+
+@RolesAllowed("admin")
+public class ClassRolesAllowedBaseResourceWithoutPathImplInterface_SecurityOnBase
+        implements ClassRolesAllowedInterfaceWithPath_SecurityOnBase {
+
+    @Override
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public ClassRolesAllowedSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassRolesAllowed() {
+        return new ClassRolesAllowedSubResourceWithoutPath(
+                CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                        + SUB_IMPL_ON_BASE + CLASS_ROLES_ALLOWED_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathImplInterface_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPathImplInterface_SecurityOnInterface.java
@@ -1,0 +1,6 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+// must always be here as interface needs an implementing class, otherwise is ignored
+public class ClassRolesAllowedBaseResourceWithoutPathImplInterface_SecurityOnInterface
+        implements ClassRolesAllowedInterfaceWithPath_SecurityOnInterface {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPath_OnBase_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPath_OnBase_SecurityOnParent.java
@@ -1,0 +1,17 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_RESOURCE)
+public class ClassRolesAllowedBaseResourceWithoutPath_OnBase_SecurityOnParent
+        extends ClassRolesAllowedParentResourceWithoutPath_PathOnBase_SecurityOnParent {
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPath_OnInterface_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedBaseResourceWithoutPath_OnInterface_SecurityOnParent.java
@@ -1,0 +1,6 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+public class ClassRolesAllowedBaseResourceWithoutPath_OnInterface_SecurityOnParent
+        extends ClassRolesAllowedParentResourceWithoutPath_PathOnInterface_SecurityOnParent {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithPath_SecurityOnBase.java
@@ -1,0 +1,36 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_BASE + CLASS_PATH_ON_INTERFACE)
+public interface ClassRolesAllowedInterfaceWithPath_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_ClassRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array);
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + CLASS_ROLES_ALLOWED_PATH)
+    ClassRolesAllowedSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_ClassRolesAllowed();
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithPath_SecurityOnInterface.java
@@ -1,0 +1,40 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_INTERFACE;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@RolesAllowed("admin")
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_INTERFACE + CLASS_PATH_ON_INTERFACE)
+public interface ClassRolesAllowedInterfaceWithPath_SecurityOnInterface {
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + CLASS_ROLES_ALLOWED_PATH)
+    default ClassRolesAllowedSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_ClassRolesAllowed() {
+        return new ClassRolesAllowedSubResourceWithoutPath(
+                CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                        + SUB_IMPL_ON_INTERFACE + CLASS_ROLES_ALLOWED_PATH);
+    }
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithPath_SecurityOnParent.java
@@ -1,0 +1,32 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_INTERFACE)
+public interface ClassRolesAllowedInterfaceWithPath_SecurityOnParent {
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT + CLASS_ROLES_ALLOWED_PATH)
+    ClassRolesAllowedSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassRolesAllowed();
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_PathOnParent_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_PathOnParent_SecurityOnInterface.java
@@ -1,0 +1,23 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@RolesAllowed("admin")
+public interface ClassRolesAllowedInterfaceWithoutPath_PathOnParent_SecurityOnInterface {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_PathOnParent_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_PathOnParent_SecurityOnParent.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassRolesAllowedInterfaceWithoutPath_PathOnParent_SecurityOnParent {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_SecurityOnBase.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassRolesAllowedInterfaceWithoutPath_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_SecurityOnInterface.java
@@ -1,0 +1,23 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@RolesAllowed("admin")
+public interface ClassRolesAllowedInterfaceWithoutPath_SecurityOnInterface {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedInterfaceWithoutPath_SecurityOnParent.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassRolesAllowedInterfaceWithoutPath_SecurityOnParent {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceInterface_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceInterface_SecurityOnBase.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface ClassRolesAllowedParentResourceInterface_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithPath_SecurityOnBase.java
@@ -1,0 +1,32 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_BASE + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class ClassRolesAllowedParentResourceWithPath_SecurityOnBase
+        implements ClassRolesAllowedParentResourceInterface_SecurityOnBase {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_ClassRolesAllowed(JsonObject array);
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + CLASS_ROLES_ALLOWED_PATH)
+    public abstract ClassRolesAllowedSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_ClassRolesAllowed();
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithPath_SecurityOnInterface.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_INTERFACE;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_INTERFACE + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class ClassRolesAllowedParentResourceWithPath_SecurityOnInterface
+        implements ClassRolesAllowedInterfaceWithoutPath_PathOnParent_SecurityOnInterface {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithPath_SecurityOnParent.java
@@ -1,0 +1,45 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_SECURITY_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@RolesAllowed("admin")
+@Path(CLASS_ROLES_ALLOWED_PREFIX + CLASS_SECURITY_ON_PARENT + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class ClassRolesAllowedParentResourceWithPath_SecurityOnParent
+        implements ClassRolesAllowedInterfaceWithoutPath_PathOnParent_SecurityOnParent {
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + CLASS_ROLES_ALLOWED_PATH)
+    public ClassRolesAllowedSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParentResource_ClassRolesAllowed() {
+        return new ClassRolesAllowedSubResourceWithoutPath(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT
+                + SUB_IMPL_ON_PARENT + CLASS_ROLES_ALLOWED_PATH);
+    }
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_PathOnBase_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_PathOnBase_SecurityOnParent.java
@@ -1,0 +1,23 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@RolesAllowed("admin")
+public abstract class ClassRolesAllowedParentResourceWithoutPath_PathOnBase_SecurityOnParent {
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_PathOnInterface_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_PathOnInterface_SecurityOnParent.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import io.vertx.core.json.JsonObject;
+
+@RolesAllowed("admin")
+public abstract class ClassRolesAllowedParentResourceWithoutPath_PathOnInterface_SecurityOnParent
+        implements ClassRolesAllowedInterfaceWithPath_SecurityOnParent {
+
+    @Override
+    public ClassRolesAllowedSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_ClassRolesAllowed() {
+        return new ClassRolesAllowedSubResourceWithoutPath(
+                CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                        + SUB_IMPL_ON_PARENT + CLASS_ROLES_ALLOWED_PATH);
+    }
+
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_SecurityOnBase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_SecurityOnBase.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public abstract class ClassRolesAllowedParentResourceWithoutPath_SecurityOnBase
+        implements ClassRolesAllowedInterfaceWithoutPath_SecurityOnBase {
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_ClassRolesAllowed(JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_SecurityOnInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_SecurityOnInterface.java
@@ -1,0 +1,6 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+public abstract class ClassRolesAllowedParentResourceWithoutPath_SecurityOnInterface
+        implements ClassRolesAllowedInterfaceWithoutPath_SecurityOnInterface {
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_SecurityOnParent.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedParentResourceWithoutPath_SecurityOnParent.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import io.vertx.core.json.JsonObject;
+
+@RolesAllowed("admin")
+public abstract class ClassRolesAllowedParentResourceWithoutPath_SecurityOnParent
+        implements ClassRolesAllowedInterfaceWithoutPath_SecurityOnParent {
+
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_ClassRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + CLASS_ROLES_ALLOWED_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedSubResourceWithoutPath.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/classrolesallowed/ClassRolesAllowedSubResourceWithoutPath.java
@@ -1,0 +1,20 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.classrolesallowed;
+
+import jakarta.ws.rs.POST;
+
+import io.vertx.core.json.JsonObject;
+
+public class ClassRolesAllowedSubResourceWithoutPath {
+
+    private final String subResourcePath;
+
+    public ClassRolesAllowedSubResourceWithoutPath(String subResourcePath) {
+        this.subResourcePath = subResourcePath;
+    }
+
+    @POST
+    public String post(JsonObject array) {
+        return subResourcePath;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/multiple/pathonbase/BaseResource.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/multiple/pathonbase/BaseResource.java
@@ -1,0 +1,83 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.multiple.pathonbase;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_NO_ANNOTATION_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.FIRST_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.MULTIPLE_INHERITANCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SECOND_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.THIRD_INTERFACE;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+@Path(CLASS_NO_ANNOTATION_PREFIX + MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE)
+public class BaseResource implements BaseResource_First_Interface {
+
+    @POST
+    @RolesAllowed("admin")
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    public String multipleInheritance_ClassPathOnBase_ImplOnBase_ImplWithPath_MethodRolesAllowed(JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH
+                + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @POST
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    public String multipleInheritance_ClassPathOnBase_ImplOnBase_ImplWithPath_NoAnnotation(JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH
+                + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String multipleInheritance_ClassPathOnBase_ImplOnBase_FirstInterface_InterfaceMethodWithPath_MethodRolesAllowed(
+            JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + FIRST_INTERFACE + INTERFACE_METHOD_WITH_PATH
+                + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String multipleInheritance_ClassPathOnBase_ImplOnBase_FirstInterface_InterfaceMethodWithPath_NoAnnotation(
+            JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + FIRST_INTERFACE + INTERFACE_METHOD_WITH_PATH
+                + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String multipleInheritance_ClassPathOnBase_ImplOnBase_SecondInterface_InterfaceMethodWithPath_MethodRolesAllowed(
+            JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + SECOND_INTERFACE + INTERFACE_METHOD_WITH_PATH
+                + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String multipleInheritance_ClassPathOnBase_ImplOnBase_SecondInterface_InterfaceMethodWithPath_NoAnnotation(
+            JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + SECOND_INTERFACE + INTERFACE_METHOD_WITH_PATH
+                + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String multipleInheritance_ClassPathOnBase_ImplOnBase_ThirdInterface_InterfaceMethodWithPath_MethodRolesAllowed(
+            JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH
+                + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String multipleInheritance_ClassPathOnBase_ImplOnBase_ThirdInterface_InterfaceMethodWithPath_NoAnnotation(
+            JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH
+                + NO_SECURITY_ANNOTATION_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/multiple/pathonbase/BaseResource_First_Interface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/multiple/pathonbase/BaseResource_First_Interface.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.multiple.pathonbase;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.FIRST_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.MULTIPLE_INHERITANCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface BaseResource_First_Interface
+        extends BaseResource_Second_Interface {
+
+    @POST
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + FIRST_INTERFACE + INTERFACE_METHOD_WITH_PATH
+            + METHOD_ROLES_ALLOWED_PATH)
+    String multipleInheritance_ClassPathOnBase_ImplOnBase_FirstInterface_InterfaceMethodWithPath_MethodRolesAllowed(
+            JsonObject array);
+
+    @POST
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + FIRST_INTERFACE + INTERFACE_METHOD_WITH_PATH
+            + NO_SECURITY_ANNOTATION_PATH)
+    String multipleInheritance_ClassPathOnBase_ImplOnBase_FirstInterface_InterfaceMethodWithPath_NoAnnotation(
+            JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/multiple/pathonbase/BaseResource_Second_Interface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/multiple/pathonbase/BaseResource_Second_Interface.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.multiple.pathonbase;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.MULTIPLE_INHERITANCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SECOND_INTERFACE;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface BaseResource_Second_Interface
+        extends BaseResource_Third_Interface {
+
+    @POST
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + SECOND_INTERFACE + INTERFACE_METHOD_WITH_PATH
+            + METHOD_ROLES_ALLOWED_PATH)
+    String multipleInheritance_ClassPathOnBase_ImplOnBase_SecondInterface_InterfaceMethodWithPath_MethodRolesAllowed(
+            JsonObject array);
+
+    @POST
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + SECOND_INTERFACE + INTERFACE_METHOD_WITH_PATH
+            + NO_SECURITY_ANNOTATION_PATH)
+    String multipleInheritance_ClassPathOnBase_ImplOnBase_SecondInterface_InterfaceMethodWithPath_NoAnnotation(
+            JsonObject array);
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/multiple/pathonbase/BaseResource_Third_Interface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/multiple/pathonbase/BaseResource_Third_Interface.java
@@ -1,0 +1,50 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.multiple.pathonbase;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.MULTIPLE_INHERITANCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.THIRD_INTERFACE;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface BaseResource_Third_Interface {
+
+    @POST
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH
+            + METHOD_ROLES_ALLOWED_PATH)
+    String multipleInheritance_ClassPathOnBase_ImplOnBase_ThirdInterface_InterfaceMethodWithPath_MethodRolesAllowed(
+            JsonObject array);
+
+    @POST
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH
+            + NO_SECURITY_ANNOTATION_PATH)
+    String multipleInheritance_ClassPathOnBase_ImplOnBase_ThirdInterface_InterfaceMethodWithPath_NoAnnotation(
+            JsonObject array);
+
+    @RolesAllowed("admin")
+    @POST
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH
+            + METHOD_ROLES_ALLOWED_PATH)
+    default String multipleInheritance_ClassPathOnBase_ImplOnInterface_ThirdInterface_InterfaceMethodWithPath_MethodRolesAllowed(
+            JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH
+                + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @POST
+    @Path(MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH
+            + NO_SECURITY_ANNOTATION_PATH)
+    default String multipleInheritance_ClassPathOnBase_ImplOnInterface_ThirdInterface_InterfaceMethodWithPath_NoAnnotation(
+            JsonObject array) {
+        return MULTIPLE_INHERITANCE + CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + THIRD_INTERFACE + INTERFACE_METHOD_WITH_PATH
+                + NO_SECURITY_ANNOTATION_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationBaseResourceWithPath.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationBaseResourceWithPath.java
@@ -1,0 +1,132 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_NO_ANNOTATION_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_NO_ANNOTATION_PREFIX + CLASS_PATH_ON_RESOURCE)
+public class NoAnnotationBaseResourceWithPath extends NoAnnotationParentResourceWithoutPath {
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    @POST
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_NoAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @Override
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    @POST
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    @POST
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    @POST
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_RolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_DenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_PermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_RolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_DenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_PermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + NO_SECURITY_ANNOTATION_PATH)
+    public NoAnnotationSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_NoSecurityAnnotation() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + NO_SECURITY_ANNOTATION_PATH);
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + METHOD_PERMIT_ALL_PATH)
+    public NoAnnotationSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_MethodPermitAll() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + METHOD_PERMIT_ALL_PATH);
+    }
+
+    @DenyAll
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + METHOD_DENY_ALL_PATH)
+    public NoAnnotationSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_MethodDenyAll() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + METHOD_DENY_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + METHOD_ROLES_ALLOWED_PATH)
+    public NoAnnotationSubResourceWithoutPath classPathOnResource_SubDeclaredOnBase_SubImplOnBase_MethodRolesAllowed() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_RESOURCE + SUB_DECLARED_ON_BASE + SUB_IMPL_ON_BASE + METHOD_ROLES_ALLOWED_PATH);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationBaseResourceWithoutPathExtParentRes.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationBaseResourceWithoutPathExtParentRes.java
@@ -1,0 +1,105 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_NO_ANNOTATION_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public class NoAnnotationBaseResourceWithoutPathExtParentRes extends NoAnnotationParentResourceWithPath {
+
+    @Override
+    @Path(CLASS_NO_ANNOTATION_PREFIX + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    @POST
+    public String get_ClassPathOnParentResource_ImplOnBase_ImplMethodWithPath_NoAnnotation(JsonObject array) {
+        return CLASS_NO_ANNOTATION_PREFIX + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_NoAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_NoSecurityAnnotation() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + NO_SECURITY_ANNOTATION_PATH);
+    }
+
+    @PermitAll
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_MethodPermitAll() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + METHOD_PERMIT_ALL_PATH);
+    }
+
+    @DenyAll
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_MethodDenyAll() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + METHOD_DENY_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_MethodRolesAllowed() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + METHOD_ROLES_ALLOWED_PATH);
+    }
+
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationBaseResourceWithoutPathImplInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationBaseResourceWithoutPathImplInterface.java
@@ -1,0 +1,110 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public class NoAnnotationBaseResourceWithoutPathImplInterface extends NoAnnotationParentResourceWithoutPathImplInterface {
+
+    @Override
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_NoAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Override
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    public String classPathOnInterface_ImplOnBase_ImplMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_NoAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_NoSecurityAnnotation() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_BASE + NO_SECURITY_ANNOTATION_PATH);
+    }
+
+    @PermitAll
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_MethodPermitAll() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_BASE + METHOD_PERMIT_ALL_PATH);
+    }
+
+    @DenyAll
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_MethodDenyAll() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_BASE + METHOD_DENY_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_MethodRolesAllowed() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_BASE + METHOD_ROLES_ALLOWED_PATH);
+    }
+
+    @Override
+    public String classPathOnInterface_ImplOnBase_ParentMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        throw new IllegalStateException("RESTEasy didn't support this endpoint in past");
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationInterfaceWithPath.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationInterfaceWithPath.java
@@ -1,0 +1,152 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_NO_ANNOTATION_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_NO_ANNOTATION_PREFIX + CLASS_PATH_ON_INTERFACE)
+public interface NoAnnotationInterfaceWithPath {
+
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_NoAnnotation(JsonObject array);
+
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_MethodRolesAllowed(JsonObject array);
+
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_MethodDenyAll(JsonObject array);
+
+    String classPathOnInterface_ImplOnBase_ImplMethodWithPath_MethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_NoAnnotation(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_MethodDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnBase_InterfaceMethodWithPath_MethodPermitAll(JsonObject array);
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + NO_SECURITY_ANNOTATION_PATH)
+    default NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_NoSecurityAnnotation() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_INTERFACE + NO_SECURITY_ANNOTATION_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + METHOD_ROLES_ALLOWED_PATH)
+    default NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_MethodRolesAllowed() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_INTERFACE + METHOD_ROLES_ALLOWED_PATH);
+    }
+
+    @DenyAll
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + METHOD_DENY_ALL_PATH)
+    default NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_MethodDenyAll() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + METHOD_DENY_ALL_PATH);
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + METHOD_PERMIT_ALL_PATH)
+    default NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnInterface_MethodPermitAll() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_INTERFACE + METHOD_PERMIT_ALL_PATH);
+    }
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + NO_SECURITY_ANNOTATION_PATH)
+    NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_NoSecurityAnnotation();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + METHOD_PERMIT_ALL_PATH)
+    NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_MethodPermitAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + METHOD_DENY_ALL_PATH)
+    NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_MethodDenyAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_BASE + METHOD_ROLES_ALLOWED_PATH)
+    NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnBase_MethodRolesAllowed();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT + NO_SECURITY_ANNOTATION_PATH)
+    NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_NoSecurityAnnotation();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT + METHOD_PERMIT_ALL_PATH)
+    NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_MethodPermitAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT + METHOD_DENY_ALL_PATH)
+    NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_MethodDenyAll();
+
+    @Path(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE + SUB_IMPL_ON_PARENT + METHOD_ROLES_ALLOWED_PATH)
+    NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_MethodRolesAllowed();
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_NoSecurityAnnotation(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_MethodDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_MethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @DenyAll
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    default String classPathOnInterface_ImplOnInterface_ImplMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationInterfaceWithoutPath.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationInterfaceWithoutPath.java
@@ -1,0 +1,83 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface NoAnnotationInterfaceWithoutPath {
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_NoSecurityAnnotation(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_RolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_DenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    String classPathOnResource_ImplOnBase_InterfaceMethodWithPath_PermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_NoAnnotation(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_MethodDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_MethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @DenyAll
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @POST
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    default String classPathOnResource_ImplOnInterface_ImplMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationParentResourceInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationParentResourceInterface.java
@@ -1,0 +1,82 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public interface NoAnnotationParentResourceInterface {
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_NoSecurityAnnotation(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_MethodDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    String classPathOnParentResource_ImplOnBase_InterfaceMethodWithPath_MethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_NoSecurityAnnotation(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_MethodPermitAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_MethodDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @PermitAll
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @DenyAll
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    default String classPathOnParentResource_ImplOnInterface_ImplMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_INTERFACE + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationParentResourceWithPath.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationParentResourceWithPath.java
@@ -1,0 +1,142 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_NO_ANNOTATION_PREFIX;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_PARENT_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonObject;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path(CLASS_NO_ANNOTATION_PREFIX + CLASS_PATH_ON_PARENT_RESOURCE)
+public abstract class NoAnnotationParentResourceWithPath implements NoAnnotationParentResourceInterface {
+
+    public String get_ClassPathOnParentResource_ImplOnBase_ImplMethodWithPath_NoAnnotation(JsonObject array) {
+        throw new IllegalStateException("Implementation should had been invoked");
+    }
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_NoAnnotation(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_MethodRolesAllowed(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_MethodDenyAll(JsonObject array);
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    public abstract String classPathOnParentResource_ImplOnBase_ParentMethodWithPath_MethodPermitAll(JsonObject array);
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + NO_SECURITY_ANNOTATION_PATH)
+    public NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParentResource_NoSecurityAnnotation() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT
+                + SUB_IMPL_ON_PARENT + NO_SECURITY_ANNOTATION_PATH);
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + METHOD_PERMIT_ALL_PATH)
+    public NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParentResource_MethodPermitAll() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + METHOD_PERMIT_ALL_PATH);
+    }
+
+    @DenyAll
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + METHOD_DENY_ALL_PATH)
+    public NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParentResource_MethodDenyAll() {
+        return new NoAnnotationSubResourceWithoutPath(
+                CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + METHOD_DENY_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_PARENT + METHOD_ROLES_ALLOWED_PATH)
+    public NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnParentResource_MethodRolesAllowed() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT
+                + SUB_IMPL_ON_PARENT + METHOD_ROLES_ALLOWED_PATH);
+    }
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + NO_SECURITY_ANNOTATION_PATH)
+    public abstract NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_NoSecurityAnnotation();
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + METHOD_PERMIT_ALL_PATH)
+    public abstract NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_MethodPermitAll();
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + METHOD_DENY_ALL_PATH)
+    public abstract NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_MethodDenyAll();
+
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + SUB_DECLARED_ON_PARENT + SUB_IMPL_ON_BASE + METHOD_ROLES_ALLOWED_PATH)
+    public abstract NoAnnotationSubResourceWithoutPath classPathOnParentResource_SubDeclaredOnParent_SubImplOnBaseResource_MethodRolesAllowed();
+
+    @POST
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @POST
+    @PermitAll
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @POST
+    @DenyAll
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @POST
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    public String classPathOnParentResource_ImplOnParent_ImplMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnParentResource_ImplOnParent_InterfaceMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_PARENT_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationParentResourceWithoutPath.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationParentResourceWithoutPath.java
@@ -1,0 +1,95 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_RESOURCE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public abstract class NoAnnotationParentResourceWithoutPath implements NoAnnotationInterfaceWithoutPath {
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_NoSecurityAnnotation(JsonObject array);
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_RolesAllowed(JsonObject array);
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_DenyAll(JsonObject array);
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    @POST
+    public abstract String test_ClassPathOnResource_ImplOnBase_ParentMethodWithPath_PermitAll(JsonObject array);
+
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Path(CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH)
+    @POST
+    public String test_ClassPathOnResource_ImplOnParent_ImplMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_NoAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+
+    @DenyAll
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnResource_ImplOnParent_InterfaceMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_RESOURCE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    public String get_ClassPathOnResource_ImplOnBase_ImplMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        // hint: purpose of this method is to ensure that existence of overridden parent method
+        //   has no effect on a secured method (like: correct secured resource method is identified)
+        throw new IllegalStateException("Implementation should be used");
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationParentResourceWithoutPathImplInterface.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationParentResourceWithoutPathImplInterface.java
@@ -1,0 +1,85 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.CLASS_PATH_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_BASE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.IMPL_ON_PARENT;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.INTERFACE_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_DENY_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_PERMIT_ALL_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.METHOD_ROLES_ALLOWED_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.NO_SECURITY_ANNOTATION_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.PARENT_METHOD_WITH_PATH;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_DECLARED_ON_INTERFACE;
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SUB_IMPL_ON_PARENT;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public abstract class NoAnnotationParentResourceWithoutPathImplInterface implements NoAnnotationInterfaceWithPath {
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_BASE + PARENT_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    public abstract String classPathOnInterface_ImplOnBase_ParentMethodWithPath_NoSecurityAnnotation(JsonObject array);
+
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_NoSecurityAnnotation() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_PARENT + NO_SECURITY_ANNOTATION_PATH);
+    }
+
+    @PermitAll
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_MethodPermitAll() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_PARENT + METHOD_PERMIT_ALL_PATH);
+    }
+
+    @DenyAll
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_MethodDenyAll() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_PARENT + METHOD_DENY_ALL_PATH);
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public NoAnnotationSubResourceWithoutPath classPathOnInterface_SubDeclaredOnInterface_SubImplOnParent_MethodRolesAllowed() {
+        return new NoAnnotationSubResourceWithoutPath(CLASS_PATH_ON_INTERFACE + SUB_DECLARED_ON_INTERFACE
+                + SUB_IMPL_ON_PARENT + METHOD_ROLES_ALLOWED_PATH);
+    }
+
+    @POST
+    @Path(CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH)
+    public String classPathOnInterface_ImplOnParent_ImplMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + IMPL_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_NoSecurityAnnotation(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + NO_SECURITY_ANNOTATION_PATH;
+    }
+
+    @DenyAll
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_MethodDenyAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_DENY_ALL_PATH;
+    }
+
+    @PermitAll
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_MethodPermitAll(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_PERMIT_ALL_PATH;
+    }
+
+    @RolesAllowed("admin")
+    @Override
+    public String classPathOnInterface_ImplOnParent_InterfaceMethodWithPath_MethodRolesAllowed(JsonObject array) {
+        return CLASS_PATH_ON_INTERFACE + IMPL_ON_PARENT + INTERFACE_METHOD_WITH_PATH + METHOD_ROLES_ALLOWED_PATH;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationSubResourceWithoutPath.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/inheritance/noclassannotation/NoAnnotationSubResourceWithoutPath.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.reactive.server.test.security.inheritance.noclassannotation;
+
+import static io.quarkus.resteasy.reactive.server.test.security.inheritance.SubPaths.SECURED_SUB_RESOURCE_ENDPOINT_PATH;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.vertx.core.json.JsonObject;
+
+public class NoAnnotationSubResourceWithoutPath {
+
+    private final String subResourcePath;
+
+    public NoAnnotationSubResourceWithoutPath(String subResourcePath) {
+        this.subResourcePath = subResourcePath;
+    }
+
+    @POST
+    public String post(JsonObject array) {
+        return subResourcePath;
+    }
+
+    @RolesAllowed("admin")
+    @Path(SECURED_SUB_RESOURCE_ENDPOINT_PATH)
+    @POST
+    public String securedPost(JsonObject array) {
+        return subResourcePath + SECURED_SUB_RESOURCE_ENDPOINT_PATH;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/ResourceMethodDescription.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/ResourceMethodDescription.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.reactive.server.runtime.security;
+
+import org.jboss.resteasy.reactive.server.model.ServerResourceMethod;
+
+import io.quarkus.security.spi.runtime.MethodDescription;
+
+/**
+ * @param invokedMethodDesc description of actually invoked method (method on which CDI interceptors are applied)
+ * @param fallbackMethodDesc description that we used in the past; not null when different to {@code invokedMethodDesc}
+ */
+record ResourceMethodDescription(MethodDescription invokedMethodDesc, MethodDescription fallbackMethodDesc) {
+
+    static ResourceMethodDescription of(ServerResourceMethod method) {
+        return new ResourceMethodDescription(
+                createMethodDescription(method, method.getActualDeclaringClassName()),
+                createMethodDescription(method, method.getClassDeclMethodThatHasJaxRsEndpointDefiningAnn()));
+    }
+
+    private static MethodDescription createMethodDescription(ServerResourceMethod method, String clazz) {
+        if (clazz == null) {
+            return null;
+        }
+        String[] paramTypes = new String[method.getParameters().length];
+        for (int i = 0; i < method.getParameters().length; i++) {
+            paramTypes[i] = method.getParameters()[i].declaredUnresolvedType;
+        }
+
+        return new MethodDescription(clazz, method.getName(), paramTypes);
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/EagerSecurityInterceptorBindingBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/EagerSecurityInterceptorBindingBuildItem.java
@@ -27,6 +27,11 @@ public final class EagerSecurityInterceptorBindingBuildItem extends MultiBuildIt
     private final DotName[] annotationBindings;
     private final Function<String, Consumer<RoutingContext>> interceptorCreator;
     private final Map<String, String> bindingToValue;
+    /**
+     * If this interceptor is always accompanied by {@link io.quarkus.security.spi.runtime.SecurityCheck}.
+     * For example, we know that endpoint annotated with {@link HttpAuthenticationMechanism} is always secured.
+     */
+    private final boolean requiresSecurityCheck;
 
     /**
      *
@@ -38,6 +43,7 @@ public final class EagerSecurityInterceptorBindingBuildItem extends MultiBuildIt
         this.annotationBindings = interceptorBindings;
         this.interceptorCreator = interceptorCreator;
         this.bindingToValue = Map.of();
+        this.requiresSecurityCheck = false;
     }
 
     EagerSecurityInterceptorBindingBuildItem(Function<String, Consumer<RoutingContext>> interceptorCreator,
@@ -45,6 +51,7 @@ public final class EagerSecurityInterceptorBindingBuildItem extends MultiBuildIt
         this.annotationBindings = interceptorBindings;
         this.interceptorCreator = interceptorCreator;
         this.bindingToValue = bindingToValue;
+        this.requiresSecurityCheck = true;
     }
 
     public DotName[] getAnnotationBindings() {
@@ -72,5 +79,9 @@ public final class EagerSecurityInterceptorBindingBuildItem extends MultiBuildIt
         } else {
             return target.asClass().name().toString();
         }
+    }
+
+    boolean requiresSecurityCheck() {
+        return requiresSecurityCheck;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
@@ -19,6 +19,7 @@ public class ServerResourceMethod extends ResourceMethod {
     private List<HandlerChainCustomizer> handlerChainCustomizers = new ArrayList<>();
     private ParameterExtractor customerParameterExtractor;
     private String actualDeclaringClassName;
+    private String classDeclMethodThatHasJaxRsEndpointDefiningAnn;
 
     public ServerResourceMethod() {
     }
@@ -78,5 +79,26 @@ public class ServerResourceMethod extends ResourceMethod {
 
     public void setActualDeclaringClassName(String actualDeclaringClassName) {
         this.actualDeclaringClassName = actualDeclaringClassName;
+    }
+
+    /**
+     * Returns a declaring class name of a resource method annotated with Jakarta REST endpoint defining annotations.
+     * This class can be different to {@link #getActualDeclaringClassName()} when this method is overridden on subclasses,
+     * or when method-level {@link jakarta.ws.rs.Path} is defined on non-default interface method.
+     *
+     * @return declaring class name if different to {@link #getActualDeclaringClassName()} or null
+     */
+    public String getClassDeclMethodThatHasJaxRsEndpointDefiningAnn() {
+        return classDeclMethodThatHasJaxRsEndpointDefiningAnn;
+    }
+
+    /**
+     * Sets a declaring class name of a resource method annotated with Jakarta REST endpoint defining annotations.
+     * Should only be set when the name is different to {@link #getActualDeclaringClassName()}.
+     *
+     * @param classDeclMethodThatHasJaxRsEndpointDefiningAnn class name
+     */
+    public void setClassDeclMethodThatHasJaxRsEndpointDefiningAnn(String classDeclMethodThatHasJaxRsEndpointDefiningAnn) {
+        this.classDeclMethodThatHasJaxRsEndpointDefiningAnn = classDeclMethodThatHasJaxRsEndpointDefiningAnn;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveResourceInfo.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveResourceInfo.java
@@ -132,6 +132,11 @@ public class ResteasyReactiveResourceInfo implements ResourceInfo {
         return methodId;
     }
 
+    /**
+     * @return declaring class of a method that returns endpoint response
+     * @deprecated if you need the method, please open an issue so that we can document and test your use case
+     */
+    @Deprecated
     public String getActualDeclaringClassName() {
         return actualDeclaringClassName;
     }


### PR DESCRIPTION
follow-up for the #41564

This PR aims to assure that when a security annotation is placed on a method that is actually invoked (returns endpoint response), than security is applied. Also, that when the security is applied, then default JAX-RS security is not applied as requested in the #39964. Extra tests comparing to #41564 are to assert endpoint implementation is identified for supported scenarios (tested scenarios). CDI interceptors that are backup for eager checks here are untouched by this PR, as well as all existing tests.