### PR TITLE
Use <parameters>true</parameters> instead of <compilerArgs><arg>-parameters</arg></compilerArgs>

### DIFF
--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -219,9 +219,7 @@ Your extension is a multi-module project. So let's start by checking out the par
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${compiler-plugin.version}</version>
           <configuration>
-            <compilerArgs>
-              <arg>-parameters</arg><!--5-->
-            </compilerArgs>
+            <parameters>true</parameters>
           </configuration>
         </plugin>
       </plugins>
@@ -234,7 +232,6 @@ Your extension is a multi-module project. So let's start by checking out the par
 <2> Quarkus requires a recent version of the Maven compiler plugin supporting the annotationProcessorPaths configuration.
 <3> The `quarkus-bom` aligns your dependencies with those used by Quarkus during the augmentation phase.
 <4> Quarkus requires these configs to run tests properly.
-<5> Setting the `parameters` flag this way works around https://issues.apache.org/jira/browse/MCOMPILER-413[MCOMPILER-413].
 
 ==== The Deployment module
 

--- a/extensions/tls-registry/cli/pom.xml
+++ b/extensions/tls-registry/cli/pom.xml
@@ -37,9 +37,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
@@ -113,9 +113,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>$\{compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 {/if}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -152,9 +152,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>$\{compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <!-- Run the tests in JVM mode -->

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
@@ -63,9 +63,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
@@ -78,9 +78,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
@@ -92,9 +92,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/hibernate-orm-compatibility-5.6/database-generator/pom.xml
+++ b/integration-tests/hibernate-orm-compatibility-5.6/database-generator/pom.xml
@@ -67,9 +67,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/expected/new-extension-current-directory-project/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/expected/new-extension-current-directory-project/pom.xml
@@ -42,9 +42,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
             </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/expected/new-extension-project/my-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/expected/new-extension-project/my-ext/pom.xml
@@ -42,9 +42,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
             </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/pom.xml
@@ -67,9 +67,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>\${compiler-plugin.version}</version>
           <configuration>
-            <compilerArgs>
-              <arg>-parameters</arg>
-            </compilerArgs>
+            <parameters>true</parameters>
           </configuration>
         </plugin>
         <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/config-tracking/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/config-tracking/pom.xml
@@ -59,9 +59,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
     </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-codestart/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-codestart/pom.xml
@@ -41,9 +41,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>\${compiler-plugin.version}</version>
           <configuration>
-            <compilerArgs>
-              <arg>-parameters</arg>
-            </compilerArgs>
+            <parameters>true</parameters>
           </configuration>
         </plugin>
       </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/extension/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/extension/pom.xml
@@ -26,9 +26,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>\${compiler-plugin.version}</version>
           <configuration>
-            <compilerArgs>
-              <arg>-parameters</arg>
-            </compilerArgs>
+            <parameters>true</parameters>
           </configuration>
         </plugin>
       </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/resources/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/resources/pom.xml
@@ -14,9 +14,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
     </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/runner/pom.xml
@@ -47,9 +47,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/service-loader/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/service-loader/pom.xml
@@ -14,9 +14,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
     </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/subatomic-provider/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/subatomic-provider/pom.xml
@@ -21,9 +21,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
     </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/supersonic-provider/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/supersonic-provider/pom.xml
@@ -21,9 +21,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
     </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-test-with-no-main/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-test-with-no-main/pom.xml
@@ -66,9 +66,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>\${compiler-plugin.version}</version>
           <configuration>
-            <compilerArgs>
-              <arg>-parameters</arg>
-            </compilerArgs>
+            <parameters>true</parameters>
           </configuration>
         </plugin>
       </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/external-reloadable-artifacts/app/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/external-reloadable-artifacts/app/pom.xml
@@ -51,9 +51,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>\${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/external-reloadable-artifacts/external-lib/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/external-reloadable-artifacts/external-lib/pom.xml
@@ -21,9 +21,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>\${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/ignore-entries-uber-jar/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/ignore-entries-uber-jar/pom.xml
@@ -45,9 +45,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/modules-in-profiles/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/modules-in-profiles/pom.xml
@@ -29,9 +29,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>\${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/module-1/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/module-1/pom.xml
@@ -19,9 +19,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/module-2/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/module-2/pom.xml
@@ -19,9 +19,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode/pom.xml
@@ -65,9 +65,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multijar-module/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multijar-module/pom.xml
@@ -35,9 +35,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-classpath/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-classpath/pom.xml
@@ -33,9 +33,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-revision-prop/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-revision-prop/pom.xml
@@ -33,9 +33,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-root-no-src/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-root-no-src/pom.xml
@@ -32,9 +32,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/pom.xml
@@ -32,9 +32,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/pom.xml
@@ -50,9 +50,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-image-app/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-image-app/pom.xml
@@ -39,9 +39,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/no-resource-root/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/no-resource-root/pom.xml
@@ -40,9 +40,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/pom-in-target-dir/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/pom-in-target-dir/pom.xml
@@ -81,9 +81,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
     </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/pom.xml
@@ -33,9 +33,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/property-expansion/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/property-expansion/pom.xml
@@ -60,9 +60,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/property-overrides/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/property-overrides/pom.xml
@@ -33,9 +33,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/proto-gen/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/proto-gen/pom.xml
@@ -54,9 +54,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/quarkus-index-dependencies-groupid/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/quarkus-index-dependencies-groupid/pom.xml
@@ -30,9 +30,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/quarkus-index-dependencies/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/quarkus-index-dependencies/pom.xml
@@ -30,9 +30,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/quarkus.package.output-directory/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/quarkus.package.output-directory/pom.xml
@@ -51,9 +51,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/reactive-routes/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/reactive-routes/pom.xml
@@ -65,9 +65,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>\${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/pom.xml
@@ -30,9 +30,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/pom.xml
@@ -68,9 +68,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-module-dependency/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-module-dependency/pom.xml
@@ -33,9 +33,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>\${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/module-a/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/module-a/pom.xml
@@ -20,9 +20,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
     </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/module-b/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/module-b/pom.xml
@@ -14,9 +14,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
     </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/runner/pom.xml
@@ -47,9 +47,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-source-sets/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-source-sets/pom.xml
@@ -131,9 +131,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
         <executions>
           <execution>

--- a/integration-tests/maven/src/test/resources-filtered/projects/uberjar-check/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/uberjar-check/pom.xml
@@ -58,9 +58,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/uberjar-maven-plugin-config/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/uberjar-maven-plugin-config/pom.xml
@@ -53,9 +53,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
@@ -57,9 +57,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
             </plugins>

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateStandaloneExtension/my-org-my-own-ext_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateStandaloneExtension/my-org-my-own-ext_pom.xml
@@ -68,9 +68,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
             </plugins>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/pom.xml
@@ -71,9 +71,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-parameter-injection/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-parameter-injection/pom.xml
@@ -69,9 +69,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension-with-bytecode-changes/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension-with-bytecode-changes/pom.xml
@@ -71,9 +71,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension/pom.xml
@@ -71,9 +71,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>\${compiler-plugin.version}</version>
         <configuration>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>

--- a/integration-tests/virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/pom.xml
@@ -137,9 +137,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.compiler.plugin}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Since https://issues.apache.org/jira/browse/MCOMPILER-413 has been fixed with ~~maven~~ maven-compiler-plugin version `3.9.0`, we no longer need this workaround.