### PR TITLE
Enhance CONTRIBUTING - Add windows option to enable longpaths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,6 +233,7 @@ If you have not done so on this machine, you need to:
     * macOS: Use the `Disk Utility.app` to check. It also allows you to create a case-sensitive volume to store your code projects. See this [blog entry](https://karnsonline.com/case-sensitive-apfs/) for more.
     * Windows: [Enable case sensitive file names per directory](https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity)
 * Install Git and configure your GitHub access
+  * Windows: enable longpaths: `git config --global core.longpaths true`
 * Install Java SDK 17+ (OpenJDK recommended)
 * Install [GraalVM](https://quarkus.io/guides/building-native-image)
 * Install platform C developer tools:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,9 @@ If you have not done so on this machine, you need to:
     * macOS: Use the `Disk Utility.app` to check. It also allows you to create a case-sensitive volume to store your code projects. See this [blog entry](https://karnsonline.com/case-sensitive-apfs/) for more.
     * Windows: [Enable case sensitive file names per directory](https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity)
 * Install Git and configure your GitHub access
-  * Windows: enable longpaths: `git config --global core.longpaths true`
+  * Windows: 
+    * enable longpaths: `git config --global core.longpaths true`
+    * avoid CRLF breaks: `git config --global core.autocrlf false`      
 * Install Java SDK 17+ (OpenJDK recommended)
 * Install [GraalVM](https://quarkus.io/guides/building-native-image)
 * Install platform C developer tools:


### PR DESCRIPTION
fix maven build avoiding Filename too long error on Windows