### PR TITLE
Avoid deprecated quarkus.test.disable-console-input in test framewok

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ContinuousTestingTestUtils.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ContinuousTestingTestUtils.java
@@ -49,7 +49,7 @@ public class ContinuousTestingTestUtils {
     }
 
     public static String appProperties(String... props) {
-        return "quarkus.test.continuous-testing=enabled\nquarkus.test.display-test-output=true\nquarkus.console.basic=true\nquarkus.test.disable-console-input=true\n"
+        return "quarkus.test.continuous-testing=enabled\nquarkus.test.display-test-output=true\nquarkus.console.basic=true\nquarkus.console.disable-input=true\n"
                 + String.join("\n", Arrays.asList(props));
     }
 

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/continuoustesting/ContinuousTestingMavenTestUtils.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/continuoustesting/ContinuousTestingMavenTestUtils.java
@@ -69,7 +69,7 @@ public class ContinuousTestingMavenTestUtils {
     }
 
     public static String appProperties(String... props) {
-        return "quarkus.test.continuous-testing=enabled\nquarkus.test.display-test-output=true\nquarkus.console.basic=true\nquarkus.test.disable-console-input=true\n"
+        return "quarkus.test.continuous-testing=enabled\nquarkus.test.display-test-output=true\nquarkus.console.basic=true\nquarkus.console.disable-input=true\n"
                 + String.join("\n", Arrays.asList(props));
     }
 


### PR DESCRIPTION
It has been replaced by quarkus.console.disable-input.

Noticed while working on another PR.