### PR TITLE
Initialize graphql.util.IdGenerator at runtime

### DIFF
--- a/extensions/vertx-graphql/deployment/src/main/java/io/quarkus/vertx/graphql/deployment/VertxGraphqlProcessor.java
+++ b/extensions/vertx-graphql/deployment/src/main/java/io/quarkus/vertx/graphql/deployment/VertxGraphqlProcessor.java
@@ -103,4 +103,9 @@ class VertxGraphqlProcessor {
     private static boolean doNotIncludeVertxGraphqlUi(LaunchModeBuildItem launchMode, VertxGraphqlConfig config) {
         return !launchMode.getLaunchMode().isDevOrTest() && !config.ui.alwaysInclude;
     }
+
+    @BuildStep
+    void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses) {
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem("graphql.util.IdGenerator"));
+    }
 }


### PR DESCRIPTION
Fixes the native mode problem introduced in https://github.com/quarkusio/quarkus/pull/41822