### PR TITLE
Module `java.security.jgss` should export `sun.security.jgss`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -788,6 +788,7 @@ public class NativeImageBuildStep {
                  * control its actual inclusion which will depend on the usual analysis.
                  */
                 nativeImageArgs.add("-J--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED");
+                nativeImageArgs.add("-J--add-exports=java.security.jgss/sun.security.jgss=ALL-UNNAMED");
 
                 //address https://github.com/quarkusio/quarkus-quickstarts/issues/993
                 nativeImageArgs.add("-J--add-opens=java.base/java.text=ALL-UNNAMED");


### PR DESCRIPTION
This enables using `sun.security.jgss.SunProvider` (in module `java.security.jgss`) which is required in `quarkus-kerberos`.

- See https://github.com/quarkiverse/quarkus-kerberos/pull/121#issuecomment-2223373515