### PR TITLE
Set the correct length of parameters when constructing the Redis arguments

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/QueryArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/QueryArgs.java
@@ -545,7 +545,7 @@ public class QueryArgs implements RedisCommandExtraArguments {
 
         if (!params.isEmpty() || !byteArrayParams.isEmpty()) {
             list.add("PARAMS");
-            list.add(Integer.toString(params.size() + byteArrayParams.size()));
+            list.add(Integer.toString((params.size() + byteArrayParams.size()) * 2));
             for (Map.Entry<String, byte[]> entry : byteArrayParams.entrySet()) {
                 list.add(entry.getKey());
                 list.add(entry.getValue());


### PR DESCRIPTION
Currently the arguments when constructing the PARAMS part of a redis query are incorrect.

`queryArgs.param("key", "value")` currently results in:
```
PARAMS 1 key value
```

However, this change would correct it to construct:
```
PARAMS 2 key value
```

I believe the unit tests happen to be passing by pure chance as they are constructing something similar to this at the moment:
```
PARAMS 2 blob blob_data DIALECT 2
```
