### PR TITLE
WebSockets Next: broadcasting fixes

### DIFF
--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/Endpoints.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/Endpoints.java
@@ -291,7 +291,7 @@ class Endpoints {
                 || throwable instanceof ForbiddenException;
     }
 
-    private static boolean isWebSocketIsClosedFailure(Throwable throwable, WebSocketConnectionBase connection) {
+    static boolean isWebSocketIsClosedFailure(Throwable throwable, WebSocketConnectionBase connection) {
         if (!connection.isClosed()) {
             return false;
         }


### PR DESCRIPTION
- intentionally ignore 'WebSocket is closed' failures
- do not fail fast but collect all failures