### PR TITLE
Enable dev services to be located by in-container java

### DIFF
--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/pom.xml
@@ -31,7 +31,27 @@
     <!-- insert test dependencies here -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
+      <artifactId>quarkus-agroal</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-postgresql</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/main/java/org/acme/Fruit.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/main/java/org/acme/Fruit.java
@@ -1,0 +1,50 @@
+package org.acme;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.QueryHint;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "known_fruits")
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name", hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
+@Cacheable
+public class Fruit {
+
+    @Id
+    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
+    @GeneratedValue(generator = "fruitsSequence")
+    private Integer id;
+
+    @Column(length = 40, unique = true)
+    private String name;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name) {
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/main/java/org/acme/FruitResource.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/main/java/org/acme/FruitResource.java
@@ -1,0 +1,124 @@
+package org.acme;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@Path("fruits")
+@ApplicationScoped
+@Produces("application/json")
+@Consumes("application/json")
+public class FruitResource {
+
+    private static final Logger LOGGER = Logger.getLogger(FruitResource.class.getName());
+
+    @Inject
+    EntityManager entityManager;
+
+    @GET
+    public List<Fruit> get() {
+        return entityManager.createNamedQuery("Fruits.findAll", Fruit.class)
+                .getResultList();
+    }
+
+    @GET
+    @Path("{id}")
+    public Fruit getSingle(Integer id) {
+        Fruit entity = entityManager.find(Fruit.class, id);
+        if (entity == null) {
+            throw new WebApplicationException("Fruit with id of " + id + " does not exist.", 404);
+        }
+        return entity;
+    }
+
+    @POST
+    @Transactional
+    public Response create(Fruit fruit) {
+        if (fruit.getId() != null) {
+            throw new WebApplicationException("Id was invalidly set on request.", 422);
+        }
+
+        entityManager.persist(fruit);
+        return Response.ok(fruit).status(201).build();
+    }
+
+    @PUT
+    @Path("{id}")
+    @Transactional
+    public Fruit update(Integer id, Fruit fruit) {
+        if (fruit.getName() == null) {
+            throw new WebApplicationException("Fruit Name was not set on request.", 422);
+        }
+
+        Fruit entity = entityManager.find(Fruit.class, id);
+
+        if (entity == null) {
+            throw new WebApplicationException("Fruit with id of " + id + " does not exist.", 404);
+        }
+
+        entity.setName(fruit.getName());
+
+        return entity;
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Transactional
+    public Response delete(Integer id) {
+        Fruit entity = entityManager.getReference(Fruit.class, id);
+        if (entity == null) {
+            throw new WebApplicationException("Fruit with id of " + id + " does not exist.", 404);
+        }
+        entityManager.remove(entity);
+        return Response.status(204).build();
+    }
+
+    @Provider
+    public static class ErrorMapper implements ExceptionMapper<Exception> {
+
+        @Inject
+        ObjectMapper objectMapper;
+
+        @Override
+        public Response toResponse(Exception exception) {
+            LOGGER.error("Failed to handle request", exception);
+
+            int code = 500;
+            if (exception instanceof WebApplicationException) {
+                code = ((WebApplicationException) exception).getResponse().getStatus();
+            }
+
+            ObjectNode exceptionJson = objectMapper.createObjectNode();
+            exceptionJson.put("exceptionType", exception.getClass().getName());
+            exceptionJson.put("code", code);
+
+            if (exception.getMessage() != null) {
+                exceptionJson.put("error", exception.getMessage());
+            }
+
+            return Response.status(code)
+                    .entity(exceptionJson)
+                    .build();
+        }
+
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.sql-load-script=import.sql

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/main/resources/import.sql
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/main/resources/import.sql
@@ -1,0 +1,4 @@
+INSERT INTO known_fruits(id, name) VALUES (1, 'Cherry');
+INSERT INTO known_fruits(id, name) VALUES (2, 'Apple');
+INSERT INTO known_fruits(id, name) VALUES (3, 'Banana');
+ALTER SEQUENCE known_fruits_id_seq RESTART WITH 4;

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/test/java/org/acme/FruitsEndpointIT.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/test/java/org/acme/FruitsEndpointIT.java
@@ -1,0 +1,10 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class FruitsEndpointIT extends FruitsEndpointTest {
+
+    // Runs the same tests as the parent class
+
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/test/java/org/acme/FruitsEndpointTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/test/java/org/acme/FruitsEndpointTest.java
@@ -1,0 +1,63 @@
+package org.acme;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.IsNot.not;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class FruitsEndpointTest {
+
+    @Test
+    public void testListAllFruits() {
+        //List all, should have all 3 fruits the database has initially:
+        given()
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("Cherry"),
+                        containsString("Apple"),
+                        containsString("Banana"));
+
+        //Delete the Cherry:
+        given()
+                .when().delete("/fruits/1")
+                .then()
+                .statusCode(204);
+
+        //List all, cherry should be missing now:
+        given()
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        not(containsString("Cherry")),
+                        containsString("Apple"),
+                        containsString("Banana"));
+
+        //Create the Pear:
+        given()
+                .when()
+                .body("{\"name\" : \"Pear\"}")
+                .contentType("application/json")
+                .post("/fruits")
+                .then()
+                .statusCode(201);
+
+        //List all, cherry should be missing now:
+        given()
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .body(
+                        not(containsString("Cherry")),
+                        containsString("Apple"),
+                        containsString("Banana"),
+                        containsString("Pear"));
+    }
+
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/test/java/org/acme/GreetingResourceTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-agent-integration/src/test/java/org/acme/GreetingResourceTest.java
@@ -25,7 +25,6 @@ public class GreetingResourceTest
         given()
             .when().get("/hello/Bob")
             .then()
-            .statusCode(404)
-            .body(is(""));
+            .statusCode(404);
     }
 }


### PR DESCRIPTION
Fixes #41771

* Integration tests need more awareness that native image agent integration tests run Quarkus in container, therefore any dev services need to be tweaked so that the java process in container can locate them.
* Tweaked the existing native image agent test in order to run an ORM/postgresql test that
fails without this fix.
* The switch from `quarkus-resteasy` to `quarkus-rest` causes the existing tests to fail with the 404 body message, so removed the body check. Status code check is enough.