### PR TITLE
Upgrade to Mutiny 2.6.2 and the Vert.x Mutiny bindings 3.13.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -61,7 +61,7 @@
         <smallrye-context-propagation.version>2.1.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.13.1</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.13.2</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.22.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.6.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
@@ -138,7 +138,7 @@
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>
-        <mutiny.version>2.6.1</mutiny.version>
+        <mutiny.version>2.6.2</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
         <kafka3.version>3.7.1</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -47,7 +47,7 @@
         <version.gizmo>1.8.0</version.gizmo>
         <version.jandex>3.2.0</version.jandex>
         <version.jboss-logging>3.6.0.Final</version.jboss-logging>
-        <version.mutiny>2.6.1</version.mutiny>
+        <version.mutiny>2.6.2</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
         <!-- test versions -->
         <version.assertj>3.26.3</version.assertj>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -43,7 +43,7 @@
         <version.jandex>3.2.0</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>
         <version.jboss-logging>3.6.0.Final</version.jboss-logging>
-        <version.smallrye-mutiny>2.6.1</version.smallrye-mutiny>
+        <version.smallrye-mutiny>2.6.2</version.smallrye-mutiny>
     </properties>
 
     <modules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -56,7 +56,7 @@
         <gizmo.version>1.8.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
-        <mutiny.version>2.6.1</mutiny.version>
+        <mutiny.version>2.6.2</mutiny.version>
         <smallrye-common.version>2.5.0</smallrye-common.version>
         <vertx.version>4.5.8</vertx.version>
         <rest-assured.version>5.5.0</rest-assured.version>
@@ -67,7 +67,7 @@
         <yasson.version>3.0.3</yasson.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
         <awaitility.version>4.2.1</awaitility.version>
-        <smallrye-mutiny-vertx-core.version>3.13.1</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>3.13.2</smallrye-mutiny-vertx-core.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <mockito.version>5.12.0</mockito.version>
         <mutiny-zero.version>1.1.0</mutiny-zero.version>


### PR DESCRIPTION
Upgrade to:

- Mutiny 2.6.2, and
- Vert.x Mutiny bindings 3.13.2.