### PR TITLE
Make flyway and jdbc driver extensions work without any other required dependencies

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1033,6 +1033,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-oracle</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-oracle-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-liquibase</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1073,6 +1073,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-db2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-db2-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-liquibase</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1043,6 +1043,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-mysql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-mysql-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-liquibase</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1053,6 +1053,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-mssql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-mssql-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-liquibase</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1063,6 +1063,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-derby</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-flyway-derby-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-liquibase</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -618,6 +618,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-flyway-mysql</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-funqy-amazon-lambda</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -592,46 +592,7 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-flyway-postgresql</artifactId>
-                    <version>${project.version}</version>
-                    <type>pom</type>
-                    <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-flyway-oracle</artifactId>
-                    <version>${project.version}</version>
-                    <type>pom</type>
-                    <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-flyway-mysql</artifactId>
-                    <version>${project.version}</version>
-                    <type>pom</type>
-                    <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-flyway-mssql</artifactId>
+                    <artifactId>quarkus-flyway-db2</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>
@@ -657,7 +618,46 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-flyway-db2</artifactId>
+                    <artifactId>quarkus-flyway-mssql</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-flyway-mysql</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-flyway-oracle</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-flyway-postgresql</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -657,6 +657,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-flyway-db2</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-funqy-amazon-lambda</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -605,6 +605,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-flyway-oracle</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-funqy-amazon-lambda</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -631,6 +631,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-flyway-mssql</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-funqy-amazon-lambda</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -644,6 +644,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-flyway-derby</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-funqy-amazon-lambda</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -656,6 +656,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-derby-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-funqy-amazon-lambda-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -630,6 +630,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-mysql-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-funqy-amazon-lambda-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -604,46 +604,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway-postgresql-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway-oracle-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway-mysql-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway-mssql-deployment</artifactId>
+            <artifactId>quarkus-flyway-db2-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -669,7 +630,46 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway-db2-deployment</artifactId>
+            <artifactId>quarkus-flyway-mssql-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-mysql-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-oracle-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-postgresql-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -669,6 +669,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-db2-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-funqy-amazon-lambda-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -643,6 +643,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-mssql-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-funqy-amazon-lambda-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -617,6 +617,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-oracle-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-funqy-amazon-lambda-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/extensions/flyway-db2/deployment/pom.xml
+++ b/extensions/flyway-db2/deployment/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-db2-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-db2-deployment</artifactId>
+    <name>Quarkus - Flyway - DB2 - Deployment</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-db2 are on the classpath</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-db2</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/flyway-db2/pom.xml
+++ b/extensions/flyway-db2/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-db2-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Quarkus - Flyway - DB2</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/flyway-db2/runtime/pom.xml
+++ b/extensions/flyway-db2/runtime/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-db2-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-db2</artifactId>
+    <name>Quarkus - Flyway - DB2 - Runtime</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-db2 are on the classpath</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-db2</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <dependencyCondition>
+                                <artifact>io.quarkus:quarkus-flyway</artifact>
+                            </dependencyCondition>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/flyway-db2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/flyway-db2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,5 @@
+name: Quarkus Flyway DB2
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+description: Conditional extension added when Flyway and DB2 extensions are present
+metadata:
+  unlisted: true

--- a/extensions/flyway-derby/deployment/pom.xml
+++ b/extensions/flyway-derby/deployment/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-derby-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-derby-deployment</artifactId>
+    <name>Quarkus - Flyway - Derby - Deployment</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-derby are on the classpath</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-derby</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/flyway-derby/pom.xml
+++ b/extensions/flyway-derby/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-derby-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Quarkus - Flyway - Derby</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/flyway-derby/runtime/pom.xml
+++ b/extensions/flyway-derby/runtime/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-derby-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-derby</artifactId>
+    <name>Quarkus - Flyway - Derby - Runtime</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-derby are on the classpath</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-derby</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <dependencyCondition>
+                                <artifact>io.quarkus:quarkus-flyway</artifact>
+                            </dependencyCondition>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/flyway-derby/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/flyway-derby/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,5 @@
+name: Quarkus Flyway Derby
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+description: Conditional extension added when Flyway and Derby extensions are present
+metadata:
+  unlisted: true

--- a/extensions/flyway-mssql/deployment/pom.xml
+++ b/extensions/flyway-mssql/deployment/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-mssql-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-mssql-deployment</artifactId>
+    <name>Quarkus - Flyway - MSSQL - Deployment</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-mssql are on the classpath</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-mssql</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/flyway-mssql/pom.xml
+++ b/extensions/flyway-mssql/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-mssql-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Quarkus - Flyway - MSSQL</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/flyway-mssql/runtime/pom.xml
+++ b/extensions/flyway-mssql/runtime/pom.xml
@@ -2,49 +2,32 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <parent>
-        <artifactId>quarkus-jdbc-mssql-parent</artifactId>
         <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-mssql-parent</artifactId>
         <version>999-SNAPSHOT</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-jdbc-mssql</artifactId>
-    <name>Quarkus - JDBC - MSSQL - Runtime</name>
-    <description>Connect to the Microsoft SQL Server database via JDBC</description>
+    <artifactId>quarkus-flyway-mssql</artifactId>
+    <name>Quarkus - Flyway - MSSQL - Runtime</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-mssql are on the classpath</description>
 
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
+            <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>mssql-jdbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>nativeimage</artifactId>
+            <artifactId>quarkus-flyway</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-kubernetes-service-binding</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway-mssql</artifactId>
-            <optional>true</optional>  <!-- conditional dependency -->
-        </dependency>
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-sqlserver</artifactId>
         </dependency>
     </dependencies>
 
@@ -53,11 +36,20 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
-                <configuration>
-                    <parentFirstArtifacts>
-                        <parentFirstArtifact>com.microsoft.sqlserver:mssql-jdbc</parentFirstArtifact>
-                    </parentFirstArtifacts>
-                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <dependencyCondition>
+                                <artifact>io.quarkus:quarkus-flyway</artifact>
+                            </dependencyCondition>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -73,5 +65,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/extensions/flyway-mssql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/flyway-mssql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,5 @@
+name: Quarkus Flyway MSSQL
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+description: Conditional extension added when Flyway and MSSQL extensions are present
+metadata:
+  unlisted: true

--- a/extensions/flyway-mysql/deployment/pom.xml
+++ b/extensions/flyway-mysql/deployment/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-mysql-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-mysql-deployment</artifactId>
+    <name>Quarkus - Flyway - MySQL - Deployment</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-mysql are on the classpath</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-mysql</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/flyway-mysql/pom.xml
+++ b/extensions/flyway-mysql/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-mysql-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Quarkus - Flyway - MySQL</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/flyway-mysql/runtime/pom.xml
+++ b/extensions/flyway-mysql/runtime/pom.xml
@@ -2,44 +2,32 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <parent>
-        <artifactId>quarkus-jdbc-mysql-parent</artifactId>
         <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-mysql-parent</artifactId>
         <version>999-SNAPSHOT</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-jdbc-mysql</artifactId>
-    <name>Quarkus - JDBC - MySQL - Runtime</name>
-    <description>Connect to the MySQL database via JDBC</description>
+    <artifactId>quarkus-flyway-mysql</artifactId>
+    <name>Quarkus - Flyway - MySQL - Runtime</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-mysql are on the classpath</description>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
+            <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>nativeimage</artifactId>
+            <artifactId>quarkus-flyway</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-kubernetes-service-binding</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway-mysql</artifactId>
-            <optional>true</optional>  <!-- conditional dependency -->
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
         </dependency>
     </dependencies>
 
@@ -48,11 +36,20 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
-                <configuration>
-                    <parentFirstArtifacts>
-                        <parentFirstArtifact>com.mysql:mysql-connector-j</parentFirstArtifact>
-                    </parentFirstArtifacts>
-                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <dependencyCondition>
+                                <artifact>io.quarkus:quarkus-flyway</artifact>
+                            </dependencyCondition>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -68,5 +65,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/extensions/flyway-mysql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/flyway-mysql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,5 @@
+name: Quarkus Flyway MySQL
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+description: Conditional extension added when Flyway and MySQL extensions are present
+metadata:
+  unlisted: true

--- a/extensions/flyway-oracle/deployment/pom.xml
+++ b/extensions/flyway-oracle/deployment/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-oracle-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-oracle-deployment</artifactId>
+    <name>Quarkus - Flyway - Oracle - Deployment</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-oracle are on the classpath</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-oracle</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/flyway-oracle/pom.xml
+++ b/extensions/flyway-oracle/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-flyway-oracle-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Quarkus - Flyway - Oracle</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/flyway-oracle/runtime/pom.xml
+++ b/extensions/flyway-oracle/runtime/pom.xml
@@ -2,48 +2,32 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <parent>
-        <artifactId>quarkus-jdbc-oracle-parent</artifactId>
         <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-flyway-oracle-parent</artifactId>
         <version>999-SNAPSHOT</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-jdbc-oracle</artifactId>
-    <name>Quarkus - JDBC - Oracle - Runtime</name>
-    <description>Connect to the Oracle database via JDBC</description>
+    <artifactId>quarkus-flyway-oracle</artifactId>
+    <name>Quarkus - Flyway - Oracle - Runtime</name>
+    <description>This extension is added by Quarkus automatically when quarkus-flyway and quarkus-jdbc-oracle are on the classpath</description>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
+            <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc11</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle.database.nls</groupId>
-            <artifactId>orai18n</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>nativeimage</artifactId>
+            <artifactId>quarkus-flyway</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-kubernetes-service-binding</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway-oracle</artifactId>
-            <optional>true</optional>  <!-- conditional dependency -->
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-oracle</artifactId>
         </dependency>
     </dependencies>
 
@@ -52,11 +36,20 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
-                <configuration>
-                    <capabilities>
-                        <provides>io.quarkus.jdbc.oracle</provides>
-                    </capabilities>
-                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <dependencyCondition>
+                                <artifact>io.quarkus:quarkus-flyway</artifact>
+                            </dependencyCondition>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -72,5 +65,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/extensions/flyway-oracle/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/flyway-oracle/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,5 @@
+name: Quarkus Flyway Oracle
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+description: Conditional extension added when Flyway and Oracle extensions are present
+metadata:
+  unlisted: true

--- a/extensions/jdbc/jdbc-db2/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-db2/deployment/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-db2-deployment</artifactId>
+            <optional>true</optional>  <!-- conditional dependency -->
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-db2</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jdbc/jdbc-db2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-db2/runtime/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>quarkus-kubernetes-service-binding</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-db2</artifactId>
+            <optional>true</optional>  <!-- conditional dependency -->
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jdbc/jdbc-derby/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-derby/deployment/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-derby-deployment</artifactId>
+            <optional>true</optional>  <!-- conditional dependency -->
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-derby</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jdbc/jdbc-derby/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-derby/runtime/pom.xml
@@ -26,6 +26,11 @@
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-derby</artifactId>
+            <optional>true</optional>  <!-- conditional dependency -->
+        </dependency>
         <!-- Required for JTA and to reference JDBC drivers by name.
              See https://db.apache.org/derby/releases/release-10.15.1.3.cgi#Note%20for%20DERBY-6945
              "the derbytools.jar library is now required [...] when using Derby DataSources, and when directly referencing the JDBC drivers" -->

--- a/extensions/jdbc/jdbc-mssql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/deployment/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-mssql-deployment</artifactId>
+            <optional>true</optional>  <!-- conditional dependency -->
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-mssql</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jdbc/jdbc-mysql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mysql/deployment/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-mysql-deployment</artifactId>
+            <optional>true</optional>  <!-- conditional dependency -->
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-mysql</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jdbc/jdbc-oracle/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-oracle/deployment/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway-oracle-deployment</artifactId>
+            <optional>true</optional>  <!-- conditional dependency -->
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-oracle</artifactId>
         </dependency>
         <dependency>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -192,6 +192,7 @@
         <module>flyway-mysql</module>
         <module>flyway-mssql</module>
         <module>flyway-derby</module>
+        <module>flyway-db2</module>
         <module>liquibase</module>
         <module>liquibase-mongodb</module>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -188,6 +188,7 @@
         <!-- Database migrations -->
         <module>flyway</module>
         <module>flyway-postgresql</module>
+        <module>flyway-oracle</module>
         <module>liquibase</module>
         <module>liquibase-mongodb</module>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -189,6 +189,7 @@
         <module>flyway</module>
         <module>flyway-postgresql</module>
         <module>flyway-oracle</module>
+        <module>flyway-mysql</module>
         <module>liquibase</module>
         <module>liquibase-mongodb</module>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -191,6 +191,7 @@
         <module>flyway-oracle</module>
         <module>flyway-mysql</module>
         <module>flyway-mssql</module>
+        <module>flyway-derby</module>
         <module>liquibase</module>
         <module>liquibase-mongodb</module>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -190,6 +190,7 @@
         <module>flyway-postgresql</module>
         <module>flyway-oracle</module>
         <module>flyway-mysql</module>
+        <module>flyway-mssql</module>
         <module>liquibase</module>
         <module>liquibase-mongodb</module>
 


### PR DESCRIPTION
- Closes: #41580
- Based on: #41583

JDBC drivers covered:

1. Oracle
2. MySQL
3. MSSQL (SQL Server)
4. Derby
5. DB2

cc/ @geoand 