### PR TITLE
Doc for parameter quarkus.native.add-all-charsets

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -122,7 +122,7 @@ public interface NativeConfig {
     String fileEncoding();
 
     /**
-     * If all character sets should be added to the native image. This increases image size
+     * If all character sets should be added to the native image (Different from GraalVM option : -H:+AddAllCharsets; this flag enables quarkus extensions to do some specific work). This increases image size
      */
     @WithDefault("false")
     boolean addAllCharsets();

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -122,7 +122,12 @@ public interface NativeConfig {
     String fileEncoding();
 
     /**
-     * If all character sets should be added to the native image (Different from GraalVM option : -H:+AddAllCharsets; this flag enables quarkus extensions to do some specific work). This increases image size
+     * If all character sets should be added to the native executable.
+     * <p>
+     * Note that some extensions (e.g. the Oracle JDBC driver) also take this setting into account to enable support for all
+     * charsets at the extension level.
+     * <p>
+     * This increases image size.
      */
     @WithDefault("false")
     boolean addAllCharsets();


### PR DESCRIPTION


Proposed documentation for quarkus.native.add-all-charsets parameter from :

`If all character sets should be added to the native image. This increases image size`

To something like :

`If all character sets should be added to the native image (Different from GraalVM option : -H:+AddAllCharsets; this flag enables quarkus extensions to do some specific work). This increases image size`

In brief : we spent a lot of time finding out this options was fixing our issue with oracle connection from native image.

More informations on issue :  https://github.com/quarkusio/quarkus/issues/41876