### PR TITLE
resources, not resource for path

### DIFF
--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -31,7 +31,7 @@ The solution is located in the `qute-quickstart` link:{quickstarts-tree-url}/qut
 
 If you want to serve your templates via http:
 
-1. The Qute Web extension allows you to directly serve via http templates located in `src/main/resource/templates/pub/`. In that case you don't need any Java code to "plug" the template, for example, the template `src/main/resource/templates/pub/foo.html` will be served from the paths `/foo` and `/foo.html` by default.
+1. The Qute Web extension allows you to directly serve via http templates located in `src/main/resources/templates/pub/`. In that case you don't need any Java code to "plug" the template, for example, the template `src/main/resources/templates/pub/foo.html` will be served from the paths `/foo` and `/foo.html` by default.
 2. For finer control, you can combine it with Quarkus REST to control how your template will be served. All files located in the `src/main/resources/templates` directory and its subdirectories are registered as templates and can be injected in a REST resource.
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
@@ -63,7 +63,7 @@ Let's start with a Hello World template:
 ----
 <1> `{http:param('name', 'Quarkus')}` is an expression that is evaluated when the template is rendered (Quarkus is the default value).
 
-NOTE: Templates located in the `pub` directory are served via HTTP. Automatically, no controllers needed. For example, the template src/main/resource/templates/pub/foo.html will be served from the paths /foo and /foo.html by default.
+NOTE: Templates located in the `pub` directory are served via HTTP. Automatically, no controllers needed. For example, the template src/main/resources/templates/pub/foo.html will be served from the paths /foo and /foo.html by default.
 
 If your application is running, you can open your browser and hit:  http://localhost:8080/hello?name=Martin
 

--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -27,11 +27,11 @@ Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {q
 The solution is located in the `qute-quickstart` link:{quickstarts-tree-url}/qute-quickstart[directory].
 
 [[serving-templates]]
-== Serving Qute templates via http
+== Serving Qute templates via HTTP
 
-If you want to serve your templates via http:
+If you want to serve your templates via HTTP:
 
-1. The Qute Web extension allows you to directly serve via http templates located in `src/main/resources/templates/pub/`. In that case you don't need any Java code to "plug" the template, for example, the template `src/main/resources/templates/pub/foo.html` will be served from the paths `/foo` and `/foo.html` by default.
+1. The Qute Web extension allows you to directly serve via HTTP templates located in `src/main/resources/templates/pub/`. In that case you don't need any Java code to "plug" the template, for example, the template `src/main/resources/templates/pub/foo.html` will be served from the paths `/foo` and `/foo.html` by default.
 2. For finer control, you can combine it with Quarkus REST to control how your template will be served. All files located in the `src/main/resources/templates` directory and its subdirectories are registered as templates and can be injected in a REST resource.
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
@@ -49,7 +49,7 @@ If you want to serve your templates via http:
 implementation("io.quarkiverse.qute.web:quarkus-qute-web")
 ----
 
-NOTE: The Qute Web extension while using the quarkiverse group-id, it is still part of the Quarkus platform.
+NOTE: The Qute Web extension, while hosted in the Quarkiverse, is part of the Quarkus Platform and its version is defined in the Quarkus Platform BOM.
 
 [[hello-qute-web]]
 === Serving Hello World with Qute
@@ -63,9 +63,9 @@ Let's start with a Hello World template:
 ----
 <1> `{http:param('name', 'Quarkus')}` is an expression that is evaluated when the template is rendered (Quarkus is the default value).
 
-NOTE: Templates located in the `pub` directory are served via HTTP. Automatically, no controllers needed. For example, the template src/main/resources/templates/pub/foo.html will be served from the paths /foo and /foo.html by default.
+NOTE: Templates located in the `pub` directory are served via HTTP. This behavior is built-in, no controllers are needed. For example, the template `src/main/resources/templates/pub/foo.html` will be served from the paths `/foo` and `/foo.html` by default.
 
-If your application is running, you can open your browser and hit:  http://localhost:8080/hello?name=Martin
+If your application is running, you can open your browser and hit: http://localhost:8080/hello?name=Martin
 
 For more information about Qute Web options, see the https://docs.quarkiverse.io/quarkus-qute-web/dev/index.html[Qute Web guide].
 


### PR DESCRIPTION
noticed the docs uses /resource/ where /resources/ is expected (at least according to rest of docs)

cc @ia3andy @mkouba 