### PR TITLE
Add backcompatibility for DevResource::config method

### DIFF
--- a/extensions/observability-devservices/testlibs/devresource-common/src/main/java/io/quarkus/observability/devresource/DevResourceLifecycleManager.java
+++ b/extensions/observability-devservices/testlibs/devresource-common/src/main/java/io/quarkus/observability/devresource/DevResourceLifecycleManager.java
@@ -38,7 +38,9 @@ public interface DevResourceLifecycleManager<T extends ContainerConfig> extends 
      * @param catalog observability catalog. If OpenTelemetry or Micrometer are enabled.
      * @return module's config
      */
-    T config(ModulesConfiguration configuration, ExtensionsCatalog catalog);
+    default T config(ModulesConfiguration configuration, ExtensionsCatalog catalog) {
+        return config(configuration);
+    }
 
     /**
      * Should we enable / start this dev resource.


### PR DESCRIPTION
Let the new method still call the old method by default -- if there are some existing impls out there.
As this is a simple fix on how not to break old things.