### PR TITLE
[3.8] Use the correct extension names for 3.8

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -79,14 +79,15 @@ endif::no-quarkus-oidc-token-propagation[]
 
 ifdef::no-quarkus-oidc-token-propagation[]
 :create-app-artifact-id: security-openid-connect-client-quickstart
-:create-app-extensions: oidc,rest-client-oidc-filter,rest
+:create-app-extensions: oidc,oidc-client-reactive-filter,resteasy-reactive
+
 include::{includes}/devtools/create-app.adoc[]
 
-It generates a Maven project, importing the `oidc`, `rest-client-oidc-filter`, and `rest` extensions.
+It generates a Maven project, importing the `oidc`, `oidc-client-reactive-filter`, and `resteasy-reactive` extensions.
 
 If you already have your Quarkus project configured, you can add these extensions to your project by running the following command in your project base directory:
 
-:add-extension-extensions: oidc,rest-client-oidc-filter,rest
+:add-extension-extensions: oidc,oidc-client-reactive-filter,resteasy-reactive
 include::{includes}/devtools/extension-add.adoc[]
 endif::no-quarkus-oidc-token-propagation[]
 
@@ -141,7 +142,7 @@ ifdef::no-quarkus-oidc-token-propagation[]
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-implementation("io.quarkus:quarkus-oidc,rest-client-oidc-filter,rest")
+implementation("io.quarkus:quarkus-oidc,oidc-client-reactive-filter,resteasy-reactive")
 ----
 endif::no-quarkus-oidc-token-propagation[]
 


### PR DESCRIPTION
When I cherry-picked PR [#39999](https://github.com/quarkusio/quarkus/pull/39999) to the `3.8` branch in [PR #40887](https://github.com/quarkusio/quarkus/pull/40887), I unintentionally included a few new extension names referenced in the [Migration Guide for 3.9](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9). 

I have reviewed all the security documentation topics to ensure that no additional new extension names have been inadvertently included.