### PR TITLE
Configure OTel metrics on observability devservice

### DIFF
--- a/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
+++ b/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
@@ -72,9 +72,9 @@ For Tracing add the `quarkus-opentelemetry` extension to your build file:
 implementation("io.quarkus:quarkus-opentelemetry")
 ----
 
-The `quarkus.otel.exporter.otlp.traces.endpoint` property is automatically set to OTel collector endpoint as seen from the outside of the docker container.
+The `quarkus.otel.exporter.otlp.endpoint` property is automatically set to OTel collector endpoint as seen from the outside of the docker container.
 
-The `quarkus.otel.exporter.otlp.traces.protocol` is set to `http/protobuf`.
+The `quarkus.otel.exporter.otlp.protocol` is set to `http/protobuf`.
 
 === Access Grafana
 
@@ -86,7 +86,7 @@ You will see a log entry like this:
 
 [source, log]
 ----
-[io.qu.ob.de.ObservabilityDevServiceProcessor] (build-35) Dev Service Lgtm started, config: {grafana.endpoint=http://localhost:42797, quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:34711, otel-collector.url=localhost:34711, quarkus.micrometer.export.otlp.url=http://localhost:34711/v1/metrics, quarkus.otel.exporter.otlp.traces.protocol=http/protobuf}
+[io.qu.ob.de.ObservabilityDevServiceProcessor] (build-35) Dev Service Lgtm started, config: {grafana.endpoint=http://localhost:42797, quarkus.otel.exporter.otlp.endpoint=http://localhost:34711, otel-collector.url=localhost:34711, quarkus.micrometer.export.otlp.url=http://localhost:34711/v1/metrics, quarkus.otel.exporter.otlp.protocol=http/protobuf}
 
 ----
 Remember that Grafana is accessible in an ephemeral port, so you need to check the logs to see which port is being used. In this example, the grafana endpoint is `grafana.endpoint=http://localhost:42797`.

--- a/extensions/observability-devservices/testlibs/devresource-lgtm/src/main/java/io/quarkus/observability/devresource/lgtm/LgtmResource.java
+++ b/extensions/observability-devservices/testlibs/devresource-lgtm/src/main/java/io/quarkus/observability/devresource/lgtm/LgtmResource.java
@@ -61,9 +61,9 @@ public class LgtmResource extends ContainerResource<LgtmContainer, LgtmConfig> {
 
         // set relevant properties for Quarkus extensions directly
         if (catalog != null && catalog.hasOpenTelemetry()) {
-            containerConfigs.put("quarkus.otel.exporter.otlp.traces.endpoint",
+            containerConfigs.put("quarkus.otel.exporter.otlp.endpoint",
                     String.format("http://%s:%s", host, container.getOtlpPort()));
-            containerConfigs.put("quarkus.otel.exporter.otlp.traces.protocol", "http/protobuf");
+            containerConfigs.put("quarkus.otel.exporter.otlp.protocol", "http/protobuf");
         }
         if (catalog != null && catalog.hasMicrometerOtlp()) {
             containerConfigs.put("quarkus.micrometer.export.otlp.url",

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmLifecycleTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmLifecycleTest.java
@@ -22,8 +22,8 @@ public class LgtmLifecycleTest extends LgtmTestBase {
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                     "quarkus.micrometer.export.otlp.url", "http://${otel-collector.url}/v1/metrics",
-                    "quarkus.otel.exporter.otlp.traces.protocol", "http/protobuf",
-                    "quarkus.otel.exporter.otlp.traces.endpoint", "http://${otel-collector.url}",
+                    "quarkus.otel.exporter.otlp.protocol", "http/protobuf",
+                    "quarkus.otel.exporter.otlp.endpoint", "http://${otel-collector.url}",
                     "quarkus.observability.dev-resources", "false",
                     "quarkus.observability.enabled", "false");
         }

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesTest.java
@@ -22,8 +22,8 @@ public class LgtmResourcesTest extends LgtmTestBase {
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                     "quarkus.micrometer.export.otlp.url", "http://${otel-collector.url}/v1/metrics",
-                    "quarkus.otel.exporter.otlp.traces.protocol", "http/protobuf",
-                    "quarkus.otel.exporter.otlp.traces.endpoint", "http://${otel-collector.url}",
+                    "quarkus.otel.exporter.otlp.protocol", "http/protobuf",
+                    "quarkus.otel.exporter.otlp.endpoint", "http://${otel-collector.url}",
                     "quarkus.observability.dev-resources", "true",
                     "quarkus.observability.enabled", "false");
         }


### PR DESCRIPTION
This is a follow up of https://github.com/quarkusio/quarkus/pull/41244 in order to support the new OTel metrics and also other future signals.
Made possible by https://github.com/quarkusio/quarkus/pull/41786