### PR TITLE
Show qualified name with generics

### DIFF
--- a/docs/src/main/java/io/quarkus/docs/generation/QuarkusBuildItemDoc.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/QuarkusBuildItemDoc.java
@@ -198,7 +198,8 @@ public class QuarkusBuildItemDoc {
             if (field.isStatic()) {
                 continue;
             }
-            sb.append("`").append(field.getType().getName()).append(" ").append(field.getName()).append("` :: ");
+            sb.append("`").append(field.getType().getQualifiedNameWithGenerics()).append(" ").append(field.getName())
+                    .append("` :: ");
             sb.append("+++").append(javadocToHTML(getJavaDoc(field))).append("+++");
             sb.append("\n");
         }


### PR DESCRIPTION
- This ensures that generics are shown in the Build Items page

![Screenshot 2024-07-15 at 16 49 02](https://github.com/user-attachments/assets/f2bf1c27-591d-4b47-8c31-35a6dd865112)
