### PR TITLE
Distinguish non-instantiable build items

### DIFF
--- a/docs/src/main/asciidoc/all-builditems.adoc
+++ b/docs/src/main/asciidoc/all-builditems.adoc
@@ -11,6 +11,8 @@ include::_attributes.adoc[]
 :categories: writing-extensions
 :summary: Explore all the BuildItems you can consume/produce in your extensions.
 
-Here you can find a list of Build Items and the extension that provides them:
+Here you can find a list of Build Items and the extension that provides them.
+
+icon:building[title=Non-instantiatable Build Item] Build item can't be instantiated directly, but can be extended/inherited from
 
 include::{generated-dir}/config/quarkus-all-build-items.adoc[opts=optional]

--- a/docs/src/main/java/io/quarkus/docs/generation/QuarkusBuildItemDoc.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/QuarkusBuildItemDoc.java
@@ -186,10 +186,14 @@ public class QuarkusBuildItemDoc {
         String className = source.getQualifiedName();
         String attributes = buildAttributes(source);
         String description = getJavaDoc(source);
+        String baseBuildItemText = source.isAbstract()
+                ? "icon:building[title=Non-instantiatable Build Item (can be inherited from)]"
+                : "";
 
         String linkToClass = String.format("%s[`%s`, window=\"_blank\"]", link, className);
 
-        out.println(String.format("\n\na|%s\n[.description]\n--\n%s\n-- a|%s",
+        out.println(String.format("\n\na|%s %s\n[.description]\n--\n%s\n-- a|%s",
+                baseBuildItemText,
                 linkToClass,
                 javadocToAsciidoc(description),
                 attributes));


### PR DESCRIPTION
In the all-builditems docs, use an icon/hover to distinguish non-instantiable build items. These can be extended by other build items, so documenting them is good.

This came from https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/ContainerRuntime-.2C.20PodmanRuntime-.20and.20DockerStatusBuild.2E.2E.2E

cc: @holly-cummins @gastaldi @turing85 