### PR TITLE
Avoid virtual thread pinning in RestClientsConfig

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/VirtualThreadSupport.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/VirtualThreadSupport.java
@@ -19,7 +19,7 @@ public class VirtualThreadSupport {
         }
     }
 
-    static boolean isVirtualThread() {
+    public static boolean isVirtualThread() {
         if (virtualMh == null) {
             return false;
         }
@@ -30,11 +30,11 @@ public class VirtualThreadSupport {
         }
     }
 
-    static int majorVersionFromJavaSpecificationVersion() {
+    private static int majorVersionFromJavaSpecificationVersion() {
         return majorVersion(System.getProperty("java.specification.version", "17"));
     }
 
-    static int majorVersion(String javaSpecVersion) {
+    private static int majorVersion(String javaSpecVersion) {
         String[] components = javaSpecVersion.split("\\.");
         int[] version = new int[components.length];
 


### PR DESCRIPTION
This is a fix for the virtual thread pinning problem reported [here](https://github.com/quarkusio/quarkus/issues/41313
).

As reported by @radcortez [here](https://github.com/quarkusio/quarkus/issues/41313#issuecomment-2225925541) the more structural fix there would be removing the implicit CDI dependency thus completely getting rid of the `ConcurrentHashMap`. However, as he also confirmed, a rewriting of the REST Client configuration could take a while, so I followed @franz1981's [suggestion](https://github.com/quarkusio/quarkus/issues/41313#issuecomment-2230517219) and fixed at least the symptom simply avoiding to call the `computeIfAbsent` method from a virtual thread.