### PR TITLE
Build Succeeds, when Reusing an Artifact with Enabled Compression

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
@@ -10,10 +10,12 @@ public final class NativeImageBuildItem extends SimpleBuildItem {
 
     private final Path path;
     private final GraalVMVersion graalVMVersion;
+    private final boolean reused;
 
-    public NativeImageBuildItem(Path path, GraalVMVersion graalVMVersion) {
+    public NativeImageBuildItem(Path path, GraalVMVersion graalVMVersion, boolean reused) {
         this.path = path;
         this.graalVMVersion = graalVMVersion;
+        this.reused = reused;
     }
 
     public Path getPath() {
@@ -22,6 +24,10 @@ public final class NativeImageBuildItem extends SimpleBuildItem {
 
     public GraalVMVersion getGraalVMInfo() {
         return graalVMVersion;
+    }
+
+    public boolean isReused() {
+        return reused;
     }
 
     public static class GraalVMVersion {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -209,7 +209,8 @@ public class NativeImageBuildStep {
         if (nativeConfig.reuseExisting()) {
             if (Files.exists(finalExecutablePath)) {
                 return new NativeImageBuildItem(finalExecutablePath,
-                        NativeImageBuildItem.GraalVMVersion.unknown());
+                        NativeImageBuildItem.GraalVMVersion.unknown(),
+                        true);
             }
         }
 
@@ -297,7 +298,8 @@ public class NativeImageBuildStep {
                     new NativeImageBuildItem.GraalVMVersion(graalVMVersion.fullVersion,
                             graalVMVersion.getVersionAsString(),
                             graalVMVersion.javaVersion.feature(),
-                            graalVMVersion.distribution.name()));
+                            graalVMVersion.distribution.name()),
+                    false);
         } catch (ImageGenerationFailureException e) {
             throw e;
         } catch (Exception e) {


### PR DESCRIPTION
Fix #41373 

The `NativeImageBuildItem` tracks now, if the executable was created or reused.
The `UpxCompressionBuildStep` skips compression, when the executable is reused.

Any change to the compression settings between builds, while reusing an existing artifact, will have no effect.