### PR TITLE
Handle new format of used_classes_* reports in GraalVM for JDK 24

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/nativeimage/ClassInclusionReport.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/nativeimage/ClassInclusionReport.java
@@ -37,7 +37,10 @@ public final class ClassInclusionReport {
         TreeSet<String> set = new TreeSet<>();
         try (Scanner scanner = new Scanner(usedClassesReport.toFile())) {
             while (scanner.hasNextLine()) {
-                set.add(scanner.nextLine());
+                // Starting with GraalVM for JDK 24 the format of the report has changed prefixing each line with
+                // the class loader name and a colon. We need to strip that part.
+                String[] line = scanner.nextLine().split(":");
+                set.add(line[line.length - 1]);
             }
         } catch (FileNotFoundException e) {
             throw new RuntimeException("Could not load used classes report", e);


### PR DESCRIPTION
Starting with GraalVM for JDK 24 the format of the report has changed
prefixing each line with the class loader name and a colon, e.g.:

GraalVM for JDK 22 (and 23 which is not released yet):
```
org.postgresql.jdbc.PgSQLXML
```

GraalVM for JDK 24:
```
com.oracle.svm.hosted.NativeImageClassLoader:org.postgresql.jdbc.PgSQLXML
```

See https://github.com/oracle/graal/commit/1d769c7ffe3fec32a6738ba96d803bf06cf9f444#diff-01f83a129b979abfb9acd79deb25f1db51df940f9d4ca968c301cd9718bf627bR347

Closes https://github.com/quarkusio/quarkus/issues/41917
