### PR TITLE
Update to latest Snowdrop Buildpack Platform Impl

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -213,7 +213,7 @@
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>9.41.1</strimzi-oauth.nimbus.version>
         <jose4j.version>0.9.6</jose4j.version>
-        <java-buildpack-client.version>0.0.6</java-buildpack-client.version>
+        <java-buildpack-client.version>0.0.12</java-buildpack-client.version>
         <org-crac.version>0.1.3</org-crac.version>
         <sshd-common.version>2.12.1</sshd-common.version>
         <mime4j.version>0.8.11</mime4j.version>

--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
@@ -14,14 +14,20 @@ public class BuildpackConfig {
     /**
      * The buildpacks builder image to use when building the project in jvm mode.
      */
-    @ConfigItem
-    public Optional<String> jvmBuilderImage;
+    @ConfigItem(defaultValue = "paketocommunity/builder-ubi-base:latest")
+    public String jvmBuilderImage;
 
     /**
-     * The buildpacks builder image to use when building the project in jvm mode.
+     * The buildpacks builder image to use when building the project in native mode.
      */
     @ConfigItem
     public Optional<String> nativeBuilderImage;
+
+    /**
+     * Should the builder image be 'trusted' (use creator lifecycle)
+     */
+    @ConfigItem
+    public Optional<Boolean> trustBuilderImage;
 
     /**
      * Environment key/values to pass to buildpacks.
@@ -39,16 +45,29 @@ public class BuildpackConfig {
     public Optional<String> runImage;
 
     /**
-     * Max pull timeout for builder/run images, in seconds
+     * Initial pull timeout for builder/run images, in seconds
      */
     @ConfigItem(defaultValue = "300")
     public Integer pullTimeoutSeconds;
 
     /**
+     * Increase pull timeout for builder/run images after failure, in seconds
+     */
+    @ConfigItem(defaultValue = "15")
+    public Integer pullTimeoutIncreaseSeconds;
+
+    /**
+     * How many times to retry an image pull after a failure
+     */
+    @ConfigItem(defaultValue = "3")
+    public Integer pullRetryCount;
+
+    /**
      * DOCKER_HOST value to use.
      *
-     * If not set, the env var DOCKER_HOST is used, if that is not set
-     * the value `unix:///var/run/docker.sock' (or 'npipe:///./pipe/docker_engine' for windows) is used.
+     * If not set, the env var DOCKER_HOST is used, if that is not set the platform will look for
+     * 'npipe:///./pipe/docker_engine' for windows, and `unix:///var/run/docker.sock' then
+     * `unix:///var/run/podman.sock` then `unix:///var/run/user/<uid>/podman/podman.sock` for linux
      */
     @ConfigItem
     public Optional<String> dockerHost;


### PR DESCRIPTION
Significant update to the buildpack platform implementation used by the buildpack container image extension. 

Updates from snowdrop lib 0.0.6 to 0.0.10 bringing support for builder images using image extensions, and updating the default builder to be the paketo ubi builder image. Also contains updates for podman compatibility, image pull retry, and various other minor fixes. 

- Fixes: #41899 
- Fixes: #37777 
- Fixes: #23883 
- Fixes: #23559 
