### PR TITLE
Update content for support of quarkus-oidc-token-propagation-(reactive) extensions

### DIFF
--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -402,14 +402,12 @@ For example, it can be a public endpoint or be protected with mTLS.
 In this scenario, you do not need to protect your Quarkus endpoint by using the Quarkus OpenID Connect adapter.
 ====
 
-ifndef::no-quarkus-oidc-token-propagation[]
 The `quarkus-resteasy-client-oidc-token-propagation` extension requires the `quarkus-oidc` extension.
 It provides Jakarta REST `TokenCredentialRequestFilter`, which sets the OpenID Connect Bearer token or Authorization Code Flow access token as the `Bearer` scheme value of the HTTP `Authorization` header.
 This filter can be registered with MicroProfile REST client implementations injected into the current Quarkus endpoint, which must be protected by using the Quarkus OIDC adapter.
 This filter can propagate the access token to the downstream services.
 
 For more information, see the xref:security-openid-connect-client.adoc[OpenID Connect client and token propagation quickstart] and xref:security-openid-connect-client-reference.adoc[OpenID Connect (OIDC) and OAuth2 client and filters reference] guides.
-endif::no-quarkus-oidc-token-propagation[]
 
 
 [[smallrye-jwt-authentication]]

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -16,10 +16,7 @@ This includes the following:
 
  - Using `quarkus-oidc-client`, `quarkus-rest-client-oidc-filter` and `quarkus-resteasy-client-oidc-filter` extensions to acquire and refresh access tokens from OpenID Connect and OAuth 2.0 compliant Authorization Servers such as link:https://www.keycloak.org[Keycloak].
 
-ifndef::no-quarkus-oidc-token-propagation[]
-
  - Using `quarkus-rest-client-oidc-token-propagation` and `quarkus-resteasy-client-oidc-token-propagation` extensions to propagate the current `Bearer` or `Authorization Code Flow` access tokens.
-endif::no-quarkus-oidc-token-propagation[]
 
 The access tokens managed by these extensions can be used as HTTP Authorization Bearer tokens to access the remote services.
 
@@ -1106,7 +1103,6 @@ public class OidcRequestCustomizer implements OidcRequestFilter {
 }
 ----
 
-ifndef::no-quarkus-oidc-token-propagation-reactive[]
 [[token-propagation-reactive]]
 == Token Propagation Reactive
 
@@ -1182,9 +1178,7 @@ quarkus.oidc-token-propagation.exchange-token=true
 ----
 
 `AccessTokenRequestReactiveFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.oidc-token-propagation-reactive.client-name` configuration property or with the `io.quarkus.oidc.token.propagation.AccessToken#exchangeTokenClient` annotation attribute.
-endif::no-quarkus-oidc-token-propagation-reactive[]
 
-ifndef::no-quarkus-oidc-token-propagation[]
 [[token-propagation]]
 == Token Propagation
 
@@ -1199,7 +1193,6 @@ However, the direct end-to-end Bearer token propagation should be avoided. For e
 Additionally, a complex application might need to exchange or update the tokens before propagating them. For example, the access context might be different when `Service A` is accessing `Service B`. In this case, `Service A` might be granted a narrow or completely different set of scopes to access `Service B`.
 
 The following sections show how `AccessTokenRequestFilter` and `JsonWebTokenRequestFilter` can help.
-endif::no-quarkus-oidc-token-propagation[]
 
 === RestClient AccessTokenRequestFilter
 
@@ -1341,7 +1334,6 @@ As mentioned, use `AccessTokenRequestFilter` if you work with Keycloak or an Ope
 You can generate the tokens as described in xref:security-oidc-bearer-token-authentication.adoc#bearer-token-integration-testing[OpenID Connect Bearer Token Integration testing] section.
 Prepare the REST test endpoints. You can have the test front-end endpoint, which uses the injected MP REST client with a registered token propagation filter, call the downstream endpoint. For example, see the `integration-tests/resteasy-client-oidc-token-propagation` in the `main` Quarkus repository.
 
-ifndef::no-quarkus-oidc-token-propagation[]
 [[reactive-token-propagation]]
 == Token Propagation Reactive
 
@@ -1359,7 +1351,6 @@ The `quarkus-rest-client-resteasy-client-oidc-token-propagation` extension provi
 
 The `quarkus-rest-client-resteasy-client-oidc-token-propagation` extension (as opposed to the non-reactive `quarkus-resteasy-client-oidc-token-propagation` extension) does not currently support the exchanging or resigning of the tokens before the propagation.
 However, these features might be added in the future.
-endif::no-quarkus-oidc-token-propagation[]
 
 ifndef::no-quarkus-oidc-client-graphql[]
 [[quarkus-oidc-client-graphql]]
@@ -1426,11 +1417,9 @@ endif::no-quarkus-oidc-client-graphql[]
 
 include::{generated-dir}/config/quarkus-oidc-client.adoc[opts=optional, leveloffset=+1]
 
-ifndef::no-quarkus-oidc-token-propagation-reactive[]
 === OIDC token propagation
 
 include::{generated-dir}/config/quarkus-oidc-token-propagation-reactive.adoc[opts=optional, leveloffset=+1]
-endif::no-quarkus-oidc-token-propagation-reactive[]
 
 == References
 

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -68,7 +68,6 @@ The solution is in the `security-openid-connect-client-quickstart` link:{quickst
 First, you need a new project.
 Create a new project with the following command:
 
-ifndef::no-quarkus-oidc-token-propagation[]
 :create-app-artifact-id: security-openid-connect-client-quickstart
 :create-app-extensions: oidc,rest-client-oidc-filter,rest-client-oidc-token-propagation,rest
 include::{includes}/devtools/create-app.adoc[]
@@ -79,24 +78,9 @@ If you already have your Quarkus project configured, you can add these extension
 
 :add-extension-extensions: oidc,rest-client-oidc-filter,rest-client-oidc-token-propagation,rest
 include::{includes}/devtools/extension-add.adoc[]
-endif::no-quarkus-oidc-token-propagation[]
-
-ifdef::no-quarkus-oidc-token-propagation[]
-:create-app-artifact-id: security-openid-connect-client-quickstart
-:create-app-extensions: oidc,rest-client-oidc-filter,rest
-include::{includes}/devtools/create-app.adoc[]
-
-It generates a Maven project, importing the `oidc`, `rest-client-oidc-filter`, and `rest` extensions.
-
-If you already have your Quarkus project configured, you can add these extensions to your project by running the following command in your project base directory:
-
-:add-extension-extensions: oidc,rest-client-oidc-filter,rest
-include::{includes}/devtools/extension-add.adoc[]
-endif::no-quarkus-oidc-token-propagation[]
 
 It adds the following extensions to your build file:
 
-ifndef::no-quarkus-oidc-token-propagation[]
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
 ----
@@ -123,32 +107,6 @@ ifndef::no-quarkus-oidc-token-propagation[]
 ----
 implementation("io.quarkus:quarkus-oidc,rest-client-oidc-filter,rest-client-oidc-token-propagation,rest")
 ----
-endif::no-quarkus-oidc-token-propagation[]
-
-ifdef::no-quarkus-oidc-token-propagation[]
-[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
-.pom.xml
-----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-oidc</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-rest-client-oidc-filter</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-rest</artifactId>
-</dependency>
-----
-
-[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
-.build.gradle
-----
-implementation("io.quarkus:quarkus-oidc,rest-client-oidc-filter,rest")
-----
-endif::no-quarkus-oidc-token-propagation[]
 
 == Writing the application
 
@@ -201,9 +159,7 @@ Next, add the following REST clients:
 
 1. `RestClientWithOidcClientFilter`, which uses an OIDC client filter provided by the `quarkus-rest-client-oidc-filter` extension to get and propagate an access token.
 2. `RestClientWithTokenHeaderParam`, which accepts a token already acquired by the programmatically created OidcClient as an HTTP `Authorization` header value.
-ifndef::no-quarkus-oidc-token-propagation[]
 3. `RestClientWithTokenPropagationFilter`, which uses an OIDC token propagation filter provided by the `quarkus-rest-client-oidc-token-propagation` extension to get and propagate an access token.
-endif::no-quarkus-oidc-token-propagation[]
 
 Add the `RestClientWithOidcClientFilter` REST client:
 
@@ -270,7 +226,6 @@ public interface RestClientWithTokenHeaderParam {
 ----
 <1> `RestClientWithTokenHeaderParam` REST client expects that the tokens will be passed to it as HTTP `Authorization` header values.
 
-ifndef::no-quarkus-oidc-token-propagation[]
 Add the `RestClientWithTokenPropagationFilter` REST client:
 
 [source,java]
@@ -308,7 +263,6 @@ public interface RestClientWithTokenPropagationFilter {
 
 IMPORTANT: Do not use the `RestClientWithOidcClientFilter` and `RestClientWithTokenPropagationFilter` interfaces in the same REST client because they can conflict, leading to issues.
 For example, the OIDC client filter can override the token from the OIDC token propagation filter, or the propagation filter might not work correctly if it attempts to propagate a token when none is available, expecting the OIDC client filter to obtain a new token instead.
-endif::no-quarkus-oidc-token-propagation[]
 
 
 Also, add `OidcClientCreator` to create an OIDC client programmatically at startup. `OidcClientCreator` supports `RestClientWithTokenHeaderParam` REST client calls:


### PR DESCRIPTION
The quarkus-oidc-token-propagation and quarkus-oidc-token-propagation-reactive extensions have [tech preview status in 3.8](https://code.quarkus.redhat.com/?S=com.redhat.quarkus.platform%3A3.8&extension-search=origin:platform%20quarkus-oidc-token-propagation) and later.

Therefore, this PR removes `ifndef` conditionals to ensure that content indicating support for those extensions is visible. Additionally, it removes `ifdef` conditionals along with the non-support content they contain.