### PR TITLE
Upgrade Oracle JDBC driver to 23.4.0.24.05

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -125,7 +125,7 @@
         <mysql-jdbc.version>8.3.0</mysql-jdbc.version>
         <mssql-jdbc.version>12.6.3.jre11</mssql-jdbc.version>
         <adal4j.version>1.6.7</adal4j.version>
-        <oracle-jdbc.version>23.3.0.23.09</oracle-jdbc.version>
+        <oracle-jdbc.version>23.4.0.24.05</oracle-jdbc.version>
         <derby-jdbc.version>10.16.1.1</derby-jdbc.version>
         <db2-jdbc.version>11.5.8.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>


### PR DESCRIPTION
I'm not entirely sure if it's okay to just do this, @Sanne might know since he did all the OJDBC updates so far.

This isn't a high priority for me, but it's nice if it finds its way into Quarkus eventually since it fixes https://github.com/quarkusio/quarkus/issues/35070 (current workaround is an exclusion to manually upgrade to OJDBC 23.4)