### PR TITLE
Remove the extra new-line in Keycloak logs

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -538,7 +538,7 @@ public class KeycloakDevServicesProcessor {
 
             if (showLogs) {
                 super.withLogConsumer(t -> {
-                    LOG.info("Keycloak: " + t.getUtf8String());
+                    LOG.info("Keycloak: " + t.getUtf8StringWithoutLineEnding());
                 });
             }
 


### PR DESCRIPTION
This removes the extra new-lines in Keycloak logs:

```
2024-07-17 15:53:10,501 [] INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (docker-java-stream-2143640242) Keycloak: 2024-07-17 12:53:10,499 INFO  [org.infinispan.CONTAINER] (ForkJoinPool.commonPool-worker-1) ISPN000556: Starting user marshaller 'org.infinispan.jboss.marshalling.core.JBossUserMarshaller'

2024-07-17 15:53:10,796 [] INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (docker-java-stream-2143640242) Keycloak: 2024-07-17 12:53:10,795 INFO  [org.infinispan.CLUSTER] (ForkJoinPool.commonPool-worker-1) ISPN000088: Unable to use any JGroups configuration mechanisms provided in properties {}. Using default JGroups configuration!

2024-07-17 15:53:10,932 [] INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (docker-java-stream-2143640242) Keycloak: 2024-07-17 12:53:10,931 INFO  [org.infinispan.CLUSTER] (ForkJoinPool.commonPool-worker-1) ISPN000078: Starting JGroups channel `ISPN`

2024-07-17 15:53:10,934 [] INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (docker-java-stream-2143640242) Keycloak: 2024-07-17 12:53:10,933 INFO  [org.jgroups.JChannel] (ForkJoinPool.commonPool-worker-1) local_addr: c987c7a3-5120-4e7b-af5a-77a0be46151b, name: cec76865ba70-21198

2024-07-17 15:53:10,940 [] INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (docker-java-stream-2143640242) Keycloak: 2024-07-17 12:53:10,939 WARN  [org.jgroups.protocols.UDP] (ForkJoinPool.commonPool-worker-1) JGRP000015: the send buffer of socket MulticastSocket was set to 1MB, but the OS only allocated 212.99KB

2024-07-17 15:53:10,941 [] INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (docker-java-stream-2143640242) Keycloak: 2024-07-17 12:53:10,940 WARN  [org.jgroups.protocols.UDP] (ForkJoinPool.commonPool-worker-1) JGRP000015: the receive buffer of socket MulticastSocket was set to 20MB, but the OS only allocated 212.99KB

2024-07-17 15:53:10,942 [] INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (docker-java-stream-2143640242) Keycloak: 2024-07-17 12:53:10,940 WARN  [org.jgroups.protocols.UDP] (ForkJoinPool.commonPool-worker-1) JGRP000015: the send buffer of socket MulticastSocket was set to 1MB, but the OS only allocated 212.99KB

2024-07-17 15:53:10,942 [] INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (docker-java-stream-2143640242) Keycloak: 2024-07-17 12:53:10,940 WARN  [org.jgroups.protocols.UDP] (ForkJoinPool.commonPool-worker-1) JGRP000015: the receive buffer of socket MulticastSocket was set to 25MB, but the OS only allocated 212.99KB

2024-07-17 15:53:10,951 [] INFO  [io.qua.oid.dep.dev.key.KeycloakDevServicesProcessor] (docker-java-stream-2143640242) Keycloak: 2024-07-17 12:53:10,950 INFO  [org.jgroups.protocols.FD_SOCK2] (ForkJoinPool.commonPool-worker-1) server listening on *.21069
```