### PR TITLE
QuarkusTestProfile overrides in a high ordinal application.properties

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -77,9 +77,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
             prepareResult = null;
         }
         if (prepareResult == null) {
-            final LinkedBlockingDeque<Runnable> shutdownTasks = new LinkedBlockingDeque<>();
-            PrepareResult result = createAugmentor(extensionContext, profile, shutdownTasks);
-            prepareResult = result;
+            LinkedBlockingDeque<Runnable> shutdownTasks = new LinkedBlockingDeque<>();
+            prepareResult = createAugmentor(extensionContext, profile, shutdownTasks);
         }
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -205,12 +205,12 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         }
         hangTimeout = new DurationConverter().convert(time);
         hangTaskKey = hangDetectionExecutor.schedule(hangDetectionTask, hangTimeout.toMillis(), TimeUnit.MILLISECONDS);
-
         quarkusTestProfile = profile;
+
+        LinkedBlockingDeque<Runnable> shutdownTasks = new LinkedBlockingDeque<>();
         Class<?> requiredTestClass = context.getRequiredTestClass();
         Closeable testResourceManager = null;
         try {
-            final LinkedBlockingDeque<Runnable> shutdownTasks = new LinkedBlockingDeque<>();
             PrepareResult result = createAugmentor(context, profile, shutdownTasks);
             AugmentAction augmentAction = result.augmentAction;
             QuarkusTestProfile profileInstance = result.profileInstance;
@@ -298,8 +298,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                     }
                 }
             };
-            ExtensionState state = new ExtensionState(testResourceManager, shutdownTask);
-            return state;
+            return new ExtensionState(testResourceManager, shutdownTask);
         } catch (Throwable e) {
             if (!InitialConfigurator.DELAYED_HANDLER.isActivated()) {
                 activateLogging();
@@ -313,6 +312,16 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                 }
             } catch (Exception ex) {
                 effectiveException.addSuppressed(determineEffectiveException(ex));
+            }
+
+            while (!shutdownTasks.isEmpty()) {
+                shutdownTasks.pop().run();
+            }
+
+            try {
+                TestClassIndexer.removeIndex(requiredTestClass);
+            } catch (Exception ignored) {
+
             }
 
             throw effectiveException;


### PR DESCRIPTION
- Fixes #27996

This sets the `QuarkusTestProfile` config overrides as a high ordinal `application.properties`, available as an additional resource to the Quarkus test application. This should solve a couple of issues:

- Test config overrides are now properly isolated
- ~~The test config now overrides sources higher than `System`~~ (this is not possible now, without additional changes out of scope of the issue / PR). System properties are being mutated to pass around configuration, and it shouldn't. We need to fix that first.