### PR TITLE
Change assertions in templated normal test to more realistic ones

### DIFF
--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/TestTemplateCanSeeByteCodeChangesDevModeIT.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/TestTemplateCanSeeByteCodeChangesDevModeIT.java
@@ -59,7 +59,7 @@ public class TestTemplateCanSeeByteCodeChangesDevModeIT extends RunAndCheckMojoT
         // This is a bit brittle when we add tests, but failures are often so catastrophic they're not even reported as failures,
         // so we need to check the pass count explicitly
         Assertions.assertEquals(0, results.getTestsFailed());
-        Assertions.assertEquals(9, results.getTestsPassed());
+        Assertions.assertEquals(8, results.getTestsPassed());
     }
 
 }

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/TestTemplateCanSeeByteCodeChangesTestModeIT.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/TestTemplateCanSeeByteCodeChangesTestModeIT.java
@@ -69,7 +69,7 @@ public class TestTemplateCanSeeByteCodeChangesTestModeIT extends RunAndCheckMojo
         // This is a bit brittle when we add tests, but failures are often so catastrophic they're not even reported as failures,
         // so we need to check the pass count explicitly
         Assertions.assertEquals(0, results.getTestsFailed());
-        Assertions.assertEquals(9, results.getTestsPassed());
+        Assertions.assertEquals(8, results.getTestsPassed());
     }
 
 }

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension-with-bytecode-changes/src/test/java/org/acme/TemplatedNormalTest.java
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension-with-bytecode-changes/src/test/java/org/acme/TemplatedNormalTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 // No QuarkusTest annotation
 
 /**
- * It's likely we would never expect this to work; unit tests which don't have a @QuarkusTest
+ * It's likely we would never expect Quarkus bytecode changes to be visible in this kind of test; unit tests which don't have
  * annotation would not be able to
  * benefit from bytecode manipulations from extensions.
  */
@@ -46,22 +46,8 @@ public class TemplatedNormalTest {
     @TestTemplate
     @ExtendWith(MyContextProvider.class)
     void contextAnnotationCheckingTestTemplate(ExtensionContext context) {
-        Annotation[] contextAnnotations = context.getRequiredTestClass()
-                .getAnnotations();
-        Assertions.assertTrue(Arrays.toString(contextAnnotations)
-                .contains("AnnotationAddedByExtension"),
-                "The JUnit extension context does not see the annotation, only sees " + Arrays.toString(
-                        contextAnnotations));
+        // We don't expect to see the annotations because we don't have a @QuarkusTest annotation, but the basic test should work
+        Assertions.assertEquals(true, true);
     }
 
-    @TestTemplate
-    @ExtendWith(MyContextProvider.class)
-    void executionAnnotationCheckingTestTemplate(ExtensionContext context) {
-        Annotation[] myAnnotations = this.getClass()
-                .getAnnotations();
-        Assertions.assertTrue(Arrays.toString(myAnnotations)
-                .contains("AnnotationAddedByExtension"),
-                "The test execution does not see the annotation, only sees " + Arrays.toString(
-                        myAnnotations));
-    }
 }

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension/src/test/java/org/acme/TemplatedNormalTest.java
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension/src/test/java/org/acme/TemplatedNormalTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 // No QuarkusTest annotation
 
 /**
- * It's likely we would never expect this to work; unit tests which don't have a @QuarkusTest
+ * It's likely we would never expect Quarkus bytecode changes to be visible in this kind of test; unit tests which don't have
+ * a @QuarkusTest
  * annotation would not be able to
  * benefit from bytecode manipulations from extensions.
  */


### PR DESCRIPTION
This is a tiny little change, just pulling some standalone content out of #34681. One of the tests I added a while ago (which is still disabled until #27821 is fixed) checks that even if you don't have a `@QuarkusTest` annotation in your test, you still see instrumented bytecode in your test class. I don't think that's a realistic expectation, so adjusting the test to give it a better change of passing when it is enabled. 