### PR TITLE
fixes the showmore issue to allow users to select text

### DIFF
--- a/docs/src/main/asciidoc/javascript/config.js
+++ b/docs/src/main/asciidoc/javascript/config.js
@@ -26,7 +26,7 @@ if(tables){
                 const collapsibleSpan = decoration.children.item(1);
                 const descDiv = td.firstElementChild.querySelector(".description");
                 const collapsibleHandler = makeCollapsibleHandler(descDiv, td, row, collapsibleSpan, iconDecoration);
-                row.addEventListener('click', collapsibleHandler);
+                decoration.addEventListener('click', collapsibleHandler);
             }
         }
 

--- a/docs/src/main/asciidoc/stylesheet/config.css
+++ b/docs/src/main/asciidoc/stylesheet/config.css
@@ -80,9 +80,8 @@ table.configuration-reference.tableblock .description-collapsed {
 table.configuration-reference.tableblock .description-decoration {
   height: 10px;
   margin: 0px;
-  padding: 0px;
+  padding: 0px 0px .75rem 0px;
   text-align: center;
-
   cursor: pointer;
 }
 
@@ -100,7 +99,6 @@ table.configuration-reference.tableblock a.link-collapsible i.fa {
 }
 
 table.configuration-reference.tableblock tr.row-collapsible td {
-  cursor: pointer;
 }
 
 table.configuration-reference.tableblock td.tableblock > .content > :last-child {


### PR DESCRIPTION
worked with @ebullient to sort out the Javascript to remove the trigger from the entire row and only make it actionable on the "show more/show less" link. This will allow users to select the copy in the TD instead of closing.

Fix https://github.com/quarkusio/quarkusio.github.io/issues/2044
