### PR TITLE
Remove .env file generated during tests

### DIFF
--- a/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/SelfSignedGenerationTest.java
+++ b/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/SelfSignedGenerationTest.java
@@ -4,10 +4,20 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SelfSignedGenerationTest {
+
+    @AfterAll
+    static void cleanup() {
+        // File generated during the generation.
+        File file = new File(".env");
+        if (file.isFile()) {
+            file.delete();
+        }
+    }
 
     @Test
     public void testSelfSignedGeneration() throws Exception {


### PR DESCRIPTION
One unit tests from the TLS CLI is generating a .env file during its execution. This commit removes the file after the execution of the test.
