### PR TITLE
[3.8] Remove conditionalization from Wiremock section

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc
@@ -887,7 +887,6 @@ Open a browser, access http://localhost:8080/hello and get the name displayed in
 
 To confirm the permission is correctly enforced, change it to `echo.name`: `@PermissionsAllowed("echo.name")`. Clear the browser cache, access http://localhost:8080/hello again and you will get `403` reported by `ApiEchoService`. Now revert it back to `@PermissionsAllowed("echo:name")`.
 
-ifndef::no-deprecated-test-resource[]
 == Integration testing
 
 You have already used OIDC DevUI SPA to login to Auth0 and test the Quarkus endpoint with the access token, updating the endpoint code along the way.
@@ -1036,7 +1035,6 @@ image::auth0-test-success.png[Auth0 test success]
 By the way, if you like, you can run the tests in Continuous mode directly from DevUI:
 
 image::auth0-continuous-testing.png[Auth0 Continuous testing]
-endif::no-deprecated-test-resource[]
 
 [[production-mode]]
 == Production mode

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -469,7 +469,6 @@ testImplementation("io.rest-assured:rest-assured")
 testImplementation("io.quarkus:quarkus-junit5")
 ----
 
-ifndef::no-deprecated-test-resource[]
 [[bearer-token-integration-testing-wiremock]]
 ==== WireMock
 
@@ -590,7 +589,6 @@ public class CustomOidcWireMockStubTest {
     }
 }
 ----
-endif::no-deprecated-test-resource[]
 
 [[integration-testing-oidc-test-client]]
 === `OidcTestClient`
@@ -606,7 +604,6 @@ For example, you have the following configuration:
 %test.quarkus.oidc.credentials.secret=secret
 ----
 
-ifndef::no-deprecated-test-resource[]
 To start, add the same dependency, `quarkus-test-oidc-server`, as described in the <<bearer-token-integration-testing-wiremock>> section.
 
 Next, write the test code as follows:
@@ -658,7 +655,6 @@ This test code acquires a token by using a `password` grant from the test `Auth0
 For a test like this to work, the test `Auth0` application must have the `password` grant enabled.
 This example code also shows how to pass additional parameters.
 For `Auth0`, these are the `audience` and `scope` parameters.
-endif::no-deprecated-test-resource[]
 
 [[bearer-token-integration-testing-keycloak-devservices]]
 ==== Dev Services for Keycloak
@@ -872,13 +868,11 @@ quarkus.oidc.public-key=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlivFI8qB4D0y
 smallrye.jwt.sign.key.location=/privateKey.pem
 ----
 
-ifndef::no-deprecated-test-resource[]
 To generate JWT tokens, copy `privateKey.pem` from the `integration-tests/oidc-tenancy` in the `main` Quarkus repository and use a test code similar to the one in the preceding <<bearer-token-integration-testing-wiremock>> section.
 You can use your own test keys, if preferred.
 
 This approach provides limited coverage compared to the WireMock approach.
 For example, the remote communication code is not covered.
-endif::no-deprecated-test-resource[]
 
 [[bearer-token-integration-testing-security-annotation]]
 ==== TestSecurity annotation

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1524,7 +1524,6 @@ testImplementation("net.sourceforge.htmlunit:htmlunit")
 testImplementation("io.quarkus:quarkus-junit5")
 ----
 
-ifndef::no-deprecated-test-resource[]
 [[code-flow-integration-testing-wiremock]]
 === Wiremock
 
@@ -1611,7 +1610,6 @@ The user `admin` has the `user` and `admin` roles by default - it can be customi
 Additionally, `OidcWiremockTestResource` sets the token issuer and audience to `https://service.example.com`,  which can be customized with `quarkus.test.oidc.token.issuer` and `quarkus.test.oidc.token.audience` system properties.
 
 `OidcWiremockTestResource` can be used to emulate all OIDC providers.
-endif::no-deprecated-test-resource[]
 
 [[code-flow-integration-testing-keycloak-devservices]]
 === Dev Services for Keycloak
@@ -1638,7 +1636,6 @@ If a custom realm file has to be imported into Keycloak before running the tests
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 ----
 
-ifndef::no-deprecated-test-resource[]
 Finally, write a test code the same way as it is described in the <<code-flow-integration-testing-wiremock,Wiremock>> section.
 The only difference is that `@QuarkusTestResource` is no longer needed:
 
@@ -1648,7 +1645,6 @@ The only difference is that `@QuarkusTestResource` is no longer needed:
 public class CodeFlowAuthorizationTest {
 }
 ----
-endif::no-deprecated-test-resource[]
 
 ifndef::no-deprecated-test-resource[]
 [[code-flow-integration-testing-keycloak]]

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -765,7 +765,6 @@ Start by adding the following dependencies to your test project:
 </dependency>
 ----
 
-ifndef::no-deprecated-test-resource[]
 [[oidc-client-ref-integration-testing-wiremock]]
 ==== Wiremock
 
@@ -855,7 +854,6 @@ quarkus.oidc-client.grant-options.password.password=alice
 ----
 
 And finally, write the test code. Given the Wiremock-based resource above, the first test invocation should return the `access_token_1` access token, which will expire in 4 seconds. Use `awaitility` to wait for about 5 seconds, and now the next test invocation should return the `access_token_2` access token, which confirms the expired `access_token_1` access token has been refreshed.
-endif::no-deprecated-test-resource[]
 
 ==== Keycloak
 


### PR DESCRIPTION
Cherry Picked from 8da86974033584c2458f598352c19f3fd4309c4c
xref: https://github.com/quarkusio/quarkus/pull/41977

Remove :no-deprecated-test-resource[] conditionalization from Wiremock and OidcTestClient content in response to review comments such as:

https://github.com/quarkusio/quarkus/pull/41834#discussion_r1682451967
https://github.com/quarkusio/quarkus/pull/41834#discussion_r1682454188
https://github.com/quarkusio/quarkus/pull/41834#discussion_r1682468588
https://github.com/quarkusio/quarkus/pull/41834#discussion_r1682470960

When all PRs are approved, we should be able to synch and publish the Security Guides for RHBQ 3.8.