### PR TITLE
 Use recognized status for apicurio json schema

### DIFF
--- a/extensions/schema-registry/apicurio/json-schema/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/schema-registry/apicurio/json-schema/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,4 +9,4 @@ metadata:
   guide: ""
   categories:
   - "serialization"
-  status: "draft"
+  status: "experimental"


### PR DESCRIPTION
"draft" was used as status which is not a recognized stated.

Updating to "experimental" as that's what we document in https://quarkus.io/guides/writing-extensions and similar.

But I don't know if that is the true state.