### PR TITLE
Upgrade to Oracle JDBC driver 23.4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -125,7 +125,7 @@
         <mysql-jdbc.version>8.3.0</mysql-jdbc.version>
         <mssql-jdbc.version>12.6.3.jre11</mssql-jdbc.version>
         <adal4j.version>1.6.7</adal4j.version>
-        <oracle-jdbc.version>23.3.0.23.09</oracle-jdbc.version>
+        <oracle-jdbc.version>23.4.0.24.05</oracle-jdbc.version>
         <derby-jdbc.version>10.16.1.1</derby-jdbc.version>
         <db2-jdbc.version>11.5.8.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/ExtendedCharactersSupport.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/ExtendedCharactersSupport.java
@@ -5,13 +5,12 @@ import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.jdbc.oracle.runtime.OracleInitRecorder;
 
 public final class ExtendedCharactersSupport {
 
     @Record(STATIC_INIT)
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     public void preinitializeCharacterSets(NativeConfig config, OracleInitRecorder recorder) {
         recorder.setupCharSets(config.addAllCharsets());
     }

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -77,15 +77,6 @@ public final class OracleMetadataOverrides {
                 .constructors().build());
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.sql.AnyDataFactory")
                 .constructors().build());
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder("com.sun.rowset.providers.RIOptimisticProvider")
-                        .build());
-        //This is listed in the original metadata, but it doesn't actually exist:
-        //        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.jdbc.logging.annotations.Supports")
-        //                .constructors().methods().build());
-        //This is listed in the original metadata, but it doesn't actually exist:
-        //        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.jdbc.logging.annotations.Feature")
-        //                .constructors().methods().build());
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -12,7 +12,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuil
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.maven.dependency.ArtifactKey;
 
 /**
@@ -36,7 +35,7 @@ import io.quarkus.maven.dependency.ArtifactKey;
  * require it, so this would facilitate the option to revert to the older version in
  * case of problems.
  */
-@BuildSteps(onlyIf = NativeOrNativeSourcesBuild.class)
+@BuildSteps
 public final class OracleMetadataOverrides {
 
     static final String DRIVER_JAR_MATCH_REGEX = "com\\.oracle\\.database\\.jdbc";

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -123,6 +123,15 @@ public final class OracleMetadataOverrides {
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.xa.client.OracleXAHeteroConnection"));
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.T4CXAConnection"));
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.security.o5logon.O5Logon"));
+
+        //These were missing in the original driver, and apparently in its automatic feature definitions as well;
+        //the need was spotted by running the native build: GraalVM will complain about these types having initialized fields
+        //referring to various other types which aren't allowed in a captured heap.
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.diagnostics.Diagnostic"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.replay.driver.FailoverManagerImpl"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.diagnostics.CommonDiagnosable"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.replay.driver.TxnFailoverManagerImpl"));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.diagnostics.OracleDiagnosticsMXBean"));
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
@@ -3,12 +3,18 @@ package io.quarkus.jdbc.oracle.deployment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 /**
  * @author Sanne Grinovero <sanne@hibernate.org>
  */
 public final class OracleNativeImage {
+
+    @BuildStep
+    NativeImageFeatureBuildItem staticNativeImageFeature() {
+        return new NativeImageFeatureBuildItem("oracle.jdbc.nativeimage.NativeImageFeature");
+    }
 
     /**
      * Registers the {@code oracle.jdbc.driver.OracleDriver} so that it can be loaded

--- a/integration-tests/jpa-oracle/src/main/java/io/quarkus/example/jpaoracle/SerializationTestEndpoint.java
+++ b/integration-tests/jpa-oracle/src/main/java/io/quarkus/example/jpaoracle/SerializationTestEndpoint.java
@@ -11,8 +11,11 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 @Path("/jpa-oracle/testserialization")
 @Produces(MediaType.TEXT_PLAIN)
+@RegisterForReflection(targets = { String.class }, serialization = true)
 public class SerializationTestEndpoint {
 
     @GET


### PR DESCRIPTION
Helping @Felk with his PR #41949 , as native-image metadata got a bit tricky to handle.

Needs @tsegismont approval to ensure compatibility with the vert.x oracle pgclient. @DavideD could test this version too in Hibernate Reactive?

