### PR TITLE
Prevents potential NPE while closing resource

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -154,8 +154,9 @@ public class JarResource implements ClassLoadingResource {
             // The jarfile has been already used and it's going to be removed from the cache,
             // so the future must be already completed
             var ref = futureRef.getNow(null);
-            assert (ref != null);
-            ref.close(this);
+            if (ref != null) {
+                ref.close(this);
+            }
         }
     }
 


### PR DESCRIPTION
This prevents the following error from happening:

```
05:39:30 ERROR traceId=73a9ac0f0a387cf75ed794edd87e8576, parentId=, spanId=e48aff7d010659dd, sampled=true [io.qu.ve.ht.ru.QuarkusErrorHandler] (executor-thread-1) HTTP Request to /api/villains failed, error id: 315533e1-7ce0-4312-af88-2e1403e1cd4e-1: java.lang.NullPointerException: Cannot invoke "io.quarkus.bootstrap.runner.JarFileReference.close(io.quarkus.bootstrap.runner.JarResource)" because "ref" is null
	at io.quarkus.bootstrap.runner.JarResource.close(JarResource.java:158)
	at io.quarkus.bootstrap.runner.JarResource.resetInternalCaches(JarResource.java:165)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.accessingResource(RunnerClassLoader.java:192)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:104)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:71)
	at io.vertx.core.http.impl.Http1xServerRequest.eventHandler(Http1xServerRequest.java:110)
	at io.vertx.core.http.impl.Http1xServerRequest.handler(Http1xServerRequest.java:314)
	at io.quarkus.vertx.http.runtime.ResumingRequestWrapper.handler(ResumingRequestWrapper.java:20)
```

- Introduced in https://github.com/quarkusio/quarkus/pull/40942
- See https://github.com/quarkusio/quarkus-super-heroes/actions/runs/10002970451/job/27649141577