### PR TITLE
Option to try all OIDC JWK keys as fallback

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -505,7 +505,6 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
     @ConfigGroup
     public static class Jwks {
-
         /**
          * If JWK verification keys should be fetched at the moment a connection to the OIDC provider
          * is initialized.
@@ -539,6 +538,13 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem
         public Optional<Duration> cleanUpTimerInterval = Optional.empty();
 
+        /**
+         * In case there is no key identifier ('kid') or certificate thumbprints ('x5t', 'x5t#S256') specified in the JOSE
+         * header and no key could be determined, check all available keys matching the token algorithm ('alg') header value.
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean tryAll = false;
+
         public int getCacheSize() {
             return cacheSize;
         }
@@ -569,6 +575,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setResolveEarly(boolean resolveEarly) {
             this.resolveEarly = resolveEarly;
+        }
+
+        public boolean isTryAll() {
+            return tryAll;
+        }
+
+        public void setTryAll(boolean fallbackToTryAll) {
+            this.tryAll = fallbackToTryAll;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DynamicVerificationKeyResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DynamicVerificationKeyResolver.java
@@ -32,10 +32,12 @@ public class DynamicVerificationKeyResolver {
 
     private final OidcProviderClient client;
     private final MemoryCache<Key> cache;
+    private final boolean tryAll;
     final CertChainPublicKeyResolver chainResolverFallback;
 
     public DynamicVerificationKeyResolver(OidcProviderClient client, OidcTenantConfig config) {
         this.client = client;
+        this.tryAll = config.jwks.tryAll;
         this.cache = new MemoryCache<Key>(client.getVertx(), config.jwks.cleanUpTimerInterval,
                 config.jwks.cacheTimeToLive, config.jwks.cacheSize);
         if (config.certificateChain.trustStoreFile.isPresent()) {
@@ -114,6 +116,12 @@ public class DynamicVerificationKeyResolver {
                         if (newKey == null && kid == null && thumbprint == null) {
                             newKey = jwks.getKeyWithoutKeyIdAndThumbprint("RSA");
                         }
+
+                        //                        if (newKey == null && tryAll && kid == null && thumbprint == null) {
+                        //                            LOG.debug("JWK is not available, neither 'kid' nor 'x5t#S256' nor 'x5t' token headers are set,"
+                        //                                    + " falling back to trying all available keys");
+                        //                            newKey = jwks.findKeyInAllKeys(jws); // there is nothing to check the signature for in this method
+                        //                        }
 
                         if (newKey == null && chainResolverFallback != null) {
                             return getChainResolver();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -489,6 +489,12 @@ public class OidcProvider implements Closeable {
                 }
             }
 
+            if (key == null && oidcConfig.jwks.tryAll && kid == null && thumbprint == null) {
+                LOG.debug("JWK is not available, neither 'kid' nor 'x5t#S256' nor 'x5t' token headers are set,"
+                        + " falling back to trying all available keys");
+                key = jwks.findKeyInAllKeys(jws);
+            }
+
             if (key == null && chainResolverFallback != null) {
                 LOG.debug("JWK is not available, neither 'kid' nor 'x5t#S256' nor 'x5t' token headers are set,"
                         + " falling back to the certificate chain resolver");


### PR DESCRIPTION
Instead of changing more logic to check multiple keys as fallback, which would mean bigger changes and also negatively impact performance, I added the option to specify a specific key as a fallback key in case no key could be determined.

- Fixes: #41931