### PR TITLE
Simplify mailer test setup now that we are Java 17+

### DIFF
--- a/extensions/mailer/deployment/pom.xml
+++ b/extensions/mailer/deployment/pom.xml
@@ -60,42 +60,5 @@
             </plugin>
         </plugins>
     </build>
-    
-    <profiles>
-        <profile>
-            <id>java-17</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-
-            <properties>
-                <maven.compiler.target>17</maven.compiler.target>
-                <maven.compiler.source>17</maven.compiler.source>
-                <maven.compiler.release>17</maven.compiler.release>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>add-java17-directory</id>
-                                <phase>generate-test-sources</phase>
-                                <goals>
-                                    <goal>add-test-source</goal>
-                                </goals>
-                                <configuration>
-                                    <sources>
-                                        <source>src/test/java17</source>
-                                    </sources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateRecordTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateRecordTest.java
@@ -2,6 +2,8 @@ package io.quarkus.mailer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import jakarta.inject.Inject;
+
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -10,7 +12,6 @@ import io.quarkus.mailer.MailTemplate.MailTemplateInstance;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.test.QuarkusUnitTest;
 import io.vertx.ext.mail.MailMessage;
-import jakarta.inject.Inject;
 
 public class MailTemplateRecordTest {
 


### PR DESCRIPTION
Noticed while working on the new extension annotation processor.