### PR TITLE
Add missing extension annotation processor to Spring Boot Properties extension

### DIFF
--- a/extensions/spring-boot-properties/runtime/pom.xml
+++ b/extensions/spring-boot-properties/runtime/pom.xml
@@ -39,6 +39,18 @@
                     </excludedArtifacts>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <!--- @SpringBootConfigProperties needs to be part of the index -->
             <plugin>
                 <groupId>io.smallrye</groupId>


### PR DESCRIPTION
While not strictly necessary for this extension, this is good practice to have it enabled for all extensions.

Noticed while working on the new annotation processor.