### PR TITLE
Avoid mixing @ConfigMapping and legacy @ConfigRoot in OIDC token propagation

### DIFF
--- a/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
+++ b/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
@@ -92,7 +92,7 @@ public class OidcTokenPropagationBuildStep {
         OidcTokenPropagationBuildTimeConfig config;
 
         public boolean getAsBoolean() {
-            return config.enabled;
+            return config.enabled();
         }
     }
 
@@ -100,7 +100,7 @@ public class OidcTokenPropagationBuildStep {
         OidcTokenPropagationBuildTimeConfig config;
 
         public boolean getAsBoolean() {
-            return config.enabledDuringAuthentication;
+            return config.enabledDuringAuthentication();
         }
     }
 }

--- a/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/runtime/OidcTokenPropagationBuildTimeConfig.java
+++ b/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/runtime/OidcTokenPropagationBuildTimeConfig.java
@@ -1,18 +1,22 @@
 package io.quarkus.oidc.token.propagation.runtime;
 
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 /**
  * Build time configuration for OIDC Token Propagation.
  */
-@ConfigRoot(name = "resteasy-client-oidc-token-propagation")
-public class OidcTokenPropagationBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.resteasy-client-oidc-token-propagation")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface OidcTokenPropagationBuildTimeConfig {
+
     /**
      * If the OIDC Token Propagation is enabled.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enabled;
+    @WithDefault("true")
+    boolean enabled();
 
     /**
      * Whether the token propagation is enabled during the `SecurityIdentity` augmentation.
@@ -25,6 +29,6 @@ public class OidcTokenPropagationBuildTimeConfig {
      *
      * @asciidoclet
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enabledDuringAuthentication;
+    @WithDefault("false")
+    boolean enabledDuringAuthentication();
 }


### PR DESCRIPTION
This is going to be a problem with the new extension annotation processor.

@michalvavrik could you have a look? I find it odd we are mixing the two approaches, especially since you are very thorough. Did you have a reason to keep the old `@ConfigRoot` pattern for the build time config? Maybe there was a limitation that got lifted? I ran the module tests and the module ITs and it was going fine.

@radcortez for sanity check