### PR TITLE
Use @ConfigMapping in Elasticsearch client deployment module

### DIFF
--- a/extensions/elasticsearch-rest-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/deployment/ElasticsearchBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/deployment/ElasticsearchBuildTimeConfig.java
@@ -1,14 +1,18 @@
 package io.quarkus.elasticsearch.restclient.lowlevel.deployment;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
-@ConfigRoot(name = "elasticsearch", phase = ConfigPhase.BUILD_TIME)
-public class ElasticsearchBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.elasticsearch")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface ElasticsearchBuildTimeConfig {
     /**
      * Whether a health check is published in case the smallrye-health extension is present.
      */
-    @ConfigItem(name = "health.enabled", defaultValue = "true")
-    public boolean healthEnabled;
+    @WithName("health.enabled")
+    @WithDefault("true")
+    boolean healthEnabled();
 }

--- a/extensions/elasticsearch-rest-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/deployment/ElasticsearchLowLevelClientProcessor.java
+++ b/extensions/elasticsearch-rest-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/deployment/ElasticsearchLowLevelClientProcessor.java
@@ -41,7 +41,7 @@ class ElasticsearchLowLevelClientProcessor {
     @BuildStep
     HealthBuildItem addHealthCheck(ElasticsearchBuildTimeConfig buildTimeConfig) {
         return new HealthBuildItem("io.quarkus.elasticsearch.restclient.lowlevel.runtime.health.ElasticsearchHealthCheck",
-                buildTimeConfig.healthEnabled);
+                buildTimeConfig.healthEnabled());
     }
 
     @BuildStep


### PR DESCRIPTION
We are already using @ConfigMapping in the runtime module so let's try to be consistent.
Not strictly necessary for the new annotation processor as the rule is per module but still good cleanup.