### PR TITLE
Fix missing volume access modifier in Reactive MySQL client tests

### DIFF
--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -214,7 +214,7 @@
                                                     ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
                                                 </volume>
                                                 <volume>
-                                                    ${project.basedir}/src/test/resources/setup.sql:/docker-entrypoint-initdb.d/setup.sql
+                                                    ${project.basedir}/src/test/resources/setup.sql:/docker-entrypoint-initdb.d/setup.sql${volume.access.modifier}
                                                 </volume>
                                             </bind>
                                         </volumes>


### PR DESCRIPTION
Without this, you can't run the tests locally on Linux -- at least I can't, using Podman on Fedora 40.

I think CI uses a MySQL service and/or Docker, which is why it's not impacted.