### PR TITLE
Rewrite TLS test for the rest-client and reactive-rest-client

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -115,7 +115,6 @@
         <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
         <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
         <maven-invoker-plugin.version>3.7.0</maven-invoker-plugin.version>
-        <truststore-maven-plugin.version>3.0.0</truststore-maven-plugin.version>
 
         <!-- revapi API check -->
         <revapi-maven-plugin.version>0.14.7</revapi-maven-plugin.version>

--- a/integration-tests/rest-client-reactive/pom.xml
+++ b/integration-tests/rest-client-reactive/pom.xml
@@ -11,15 +11,6 @@
     <artifactId>quarkus-integration-test-rest-client-reactive</artifactId>
     <name>Quarkus - Integration Tests - REST Client Reactive</name>
 
-    <properties>
-        <self-signed.trust-store>${project.build.directory}/self-signed.p12</self-signed.trust-store>
-        <self-signed.trust-store-password>changeit</self-signed.trust-store-password>
-        <wrong-host.trust-store>${project.build.directory}/wrong-host.p12</wrong-host.trust-store>
-        <wrong-host.trust-store-password>changeit</wrong-host.trust-store-password>
-    </properties>
-
-    <!--todo add ssl tests-->
-
     <dependencies>
         <!-- Client dependencies -->
         <dependency>
@@ -82,6 +73,11 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.certs</groupId>
+            <artifactId>smallrye-certificate-generator</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -156,48 +152,6 @@
                         <goals>
                             <goal>build</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>uk.co.automatictester</groupId>
-                <artifactId>truststore-maven-plugin</artifactId>
-                <version>${truststore-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>self-signed-truststore</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>generate-truststore</goal>
-                        </goals>
-                        <configuration>
-                            <truststoreFormat>PKCS12</truststoreFormat>
-                            <truststoreFile>${self-signed.trust-store}</truststoreFile>
-                            <truststorePassword>${self-signed.trust-store-password}</truststorePassword>
-                            <servers>
-                                <server>self-signed.badssl.com:443</server>
-                            </servers>
-                            <trustAllCertificates>true</trustAllCertificates>
-                            <includeCertificates>LEAF</includeCertificates>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>wrong-host-truststore</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>generate-truststore</goal>
-                        </goals>
-                        <configuration>
-                            <truststoreFormat>PKCS12</truststoreFormat>
-                            <truststoreFile>${wrong-host.trust-store}</truststoreFile>
-                            <truststorePassword>${wrong-host.trust-store-password}</truststorePassword>
-                            <servers>
-                                <server>wrong.host.badssl.com:443</server>
-                            </servers>
-                            <trustAllCertificates>true</trustAllCertificates>
-                            <includeCertificates>LEAF</includeCertificates>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/selfsigned/ExternalSelfSignedClient.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/selfsigned/ExternalSelfSignedClient.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@RegisterRestClient(baseUri = "https://self-signed.badssl.com/", configKey = "self-signed")
+@RegisterRestClient(baseUri = "http://not-available", configKey = "self-signed")
 public interface ExternalSelfSignedClient {
 
     @GET

--- a/integration-tests/rest-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive/src/main/resources/application.properties
@@ -5,16 +5,6 @@ correlation/mp-rest/url=${test.url}
 io.quarkus.it.rest.client.main.ParamClient/mp-rest/url=${test.url}
 # global client logging scope
 quarkus.rest-client.logging.scope=request-response
-# Self-Signed client
-quarkus.rest-client.self-signed.trust-store=${self-signed.trust-store}
-quarkus.rest-client.self-signed.trust-store-password=${self-signed.trust-store-password}
-# Wrong Host client (connection accepted, as host verification is turned off)
-quarkus.rest-client.wrong-host.trust-store=${wrong-host.trust-store}
-quarkus.rest-client.wrong-host.trust-store-password=${wrong-host.trust-store-password}
-quarkus.rest-client.wrong-host.verify-host=false
-# Wrong Host client verified (connection rejected, as host verification is turned on by default)
-quarkus.rest-client.wrong-host-rejected.trust-store=${wrong-host.trust-store}
-quarkus.rest-client.wrong-host-rejected.trust-store-password=${wrong-host.trust-store-password}
 
 # speed up build
 quarkus.otel.bsp.schedule.delay=100

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/selfsigned/ExternalSelfSignedTestCase.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/selfsigned/ExternalSelfSignedTestCase.java
@@ -5,9 +5,13 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.it.rest.client.wronghost.BadHostServiceTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@WithTestResource(SelfSignedServiceTestResource.class)
+@WithTestResource(BadHostServiceTestResource.class)
 public class ExternalSelfSignedTestCase {
 
     @Test

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/selfsigned/SelfSignedServiceTestResource.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/selfsigned/SelfSignedServiceTestResource.java
@@ -1,0 +1,58 @@
+package io.quarkus.it.rest.client.selfsigned;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.PfxOptions;
+
+public class SelfSignedServiceTestResource implements QuarkusTestResourceLifecycleManager {
+
+    Vertx vertx = Vertx.vertx();
+
+    @Override
+    public Map<String, String> start() {
+        File file = new File("target/certs");
+        file.mkdirs();
+        // Generate self-signed certificate
+        // We do not use the junit 5 plugin to avoid having to annotate all the tests to make sure the certs are
+        // generated before the tests are run
+        CertificateGenerator generator = new CertificateGenerator(file.toPath(), false);
+        CertificateRequest cr = new CertificateRequest()
+                .withName("self-signed")
+                .withFormat(Format.PKCS12)
+                .withPassword("changeit")
+                .withDuration(Duration.ofDays(2))
+                .withCN("localhost");
+        try {
+            generator.generate(cr);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        HttpServerOptions options = new HttpServerOptions()
+                .setSsl(true)
+                .setKeyCertOptions(new PfxOptions()
+                        .setPath("target/certs/self-signed-keystore.p12")
+                        .setPassword("changeit"));
+        var server = vertx.createHttpServer(options)
+                .requestHandler(req -> req.response().end("OK"))
+                .listen(-2).toCompletionStage().toCompletableFuture().join();
+
+        return Map.of(
+                "quarkus.rest-client.self-signed.url", "https://localhost:" + server.actualPort() + "/",
+                "quarkus.rest-client.self-signed.trust-store", "target/certs/self-signed-truststore.p12",
+                "quarkus.rest-client.self-signed.trust-store-password", "changeit");
+    }
+
+    @Override
+    public void stop() {
+        vertx.close().toCompletionStage().toCompletableFuture().join();
+    }
+}

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/wronghost/BadHostServiceTestResource.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/wronghost/BadHostServiceTestResource.java
@@ -1,0 +1,68 @@
+package io.quarkus.it.rest.client.wronghost;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.PfxOptions;
+
+public class BadHostServiceTestResource implements QuarkusTestResourceLifecycleManager {
+
+    Vertx vertx = Vertx.vertx();
+
+    @Override
+    public Map<String, String> start() {
+        File file = new File("target/certs");
+        file.mkdirs();
+        // Generate self-signed certificate
+        // We do not use the junit 5 plugin to avoid having to annotate all the tests to make sure the certs are
+        // generated before the tests are run
+        CertificateGenerator generator = new CertificateGenerator(file.toPath(), false);
+        CertificateRequest cr = new CertificateRequest()
+                .withName("bad-host")
+                .withFormat(Format.PKCS12)
+                .withPassword("changeit")
+                .withDuration(Duration.ofDays(2))
+                .withCN("bad-host.com")
+                .withSubjectAlternativeName("DNS:bad-host.com");
+        try {
+            generator.generate(cr);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        File f = new File("target/certs/bad-host-keystore.p12");
+        System.out.println(f.getAbsolutePath() + " / " + f.exists());
+        HttpServerOptions options = new HttpServerOptions()
+                .setSsl(true)
+                .setKeyCertOptions(new PfxOptions()
+                        .setPath("target/certs/bad-host-keystore.p12")
+                        .setPassword("changeit"));
+        var server = vertx.createHttpServer(options)
+                .requestHandler(req -> req.response().end("OK"))
+                .listen(-1).toCompletionStage().toCompletableFuture().join();
+
+        return Map.of(
+                // Wrong Host client (connection accepted, as host verification is turned off)
+                "quarkus.rest-client.wrong-host.url", "https://localhost:" + server.actualPort() + "/",
+                "quarkus.rest-client.wrong-host.trust-store", "target/certs/bad-host-truststore.p12",
+                "quarkus.rest-client.wrong-host.trust-store-password", "changeit",
+                "quarkus.rest-client.wrong-host.verify-host", "false",
+
+                // Wrong Host client verified (connection rejected, as host verification is turned on by default)
+                "quarkus.rest-client.wrong-host-rejected.url", "https://localhost:" + server.actualPort() + "/",
+                "quarkus.rest-client.wrong-host-rejected.trust-store", "target/certs/bad-host-truststore.p12",
+                "quarkus.rest-client.wrong-host-rejected.trust-store-password", "changeit");
+    }
+
+    @Override
+    public void stop() {
+        vertx.close().toCompletionStage().toCompletableFuture().join();
+    }
+}

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestCase.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestCase.java
@@ -6,9 +6,13 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.it.rest.client.selfsigned.SelfSignedServiceTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@WithTestResource(SelfSignedServiceTestResource.class)
+@WithTestResource(BadHostServiceTestResource.class)
 public class ExternalWrongHostTestCase {
     @Test
     public void restClient() {

--- a/integration-tests/rest-client/pom.xml
+++ b/integration-tests/rest-client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>quarkus-integration-tests-parent</artifactId>
         <groupId>io.quarkus</groupId>
@@ -12,10 +12,8 @@
     <name>Quarkus - Integration Tests - REST client</name>
 
     <properties>
-        <self-signed.trust-store>${project.build.directory}/self-signed.p12</self-signed.trust-store>
+        <self-signed.trust-store>${project.build.directory}/certs/self-signed-keystore.p12</self-signed.trust-store>
         <self-signed.trust-store-password>changeit</self-signed.trust-store-password>
-        <wrong-host.trust-store>${project.build.directory}/wrong-host.p12</wrong-host.trust-store>
-        <wrong-host.trust-store-password>changeit</wrong-host.trust-store-password>
     </properties>
 
     <dependencies>
@@ -65,6 +63,11 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.certs</groupId>
+            <artifactId>smallrye-certificate-generator</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -142,49 +145,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>uk.co.automatictester</groupId>
-                <artifactId>truststore-maven-plugin</artifactId>
-                <version>${truststore-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>self-signed-truststore</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>generate-truststore</goal>
-                        </goals>
-                        <configuration>
-                            <truststoreFormat>PKCS12</truststoreFormat>
-                            <truststoreFile>${self-signed.trust-store}</truststoreFile>
-                            <truststorePassword>${self-signed.trust-store-password}</truststorePassword>
-                            <servers>
-                                <server>self-signed.badssl.com:443</server>
-                            </servers>
-                            <trustAllCertificates>true</trustAllCertificates>
-                            <includeCertificates>LEAF</includeCertificates>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>wrong-host-truststore</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>generate-truststore</goal>
-                        </goals>
-                        <configuration>
-                            <truststoreFormat>PKCS12</truststoreFormat>
-                            <truststoreFile>${wrong-host.trust-store}</truststoreFile>
-                            <truststorePassword>${wrong-host.trust-store-password}</truststorePassword>
-                            <servers>
-                                <server>wrong.host.badssl.com:443</server>
-                            </servers>
-                            <trustAllCertificates>true</trustAllCertificates>
-                            <includeCertificates>LEAF</includeCertificates>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -193,9 +153,8 @@
                         <!-- force the locale as we want to explicitly test message interpolation -->
                         <user.language>en</user.language>
                         <javax.net.ssl.trustStore>${self-signed.trust-store}</javax.net.ssl.trustStore>
-                        <javax.net.ssl.trustStorePassword>${self-signed.trust-store-password}</javax.net.ssl.trustStorePassword>
-                        <rest-client.trustStore>${wrong-host.trust-store}</rest-client.trustStore>
-                        <rest-client.trustStorePassword>${wrong-host.trust-store-password}</rest-client.trustStorePassword>
+                        <javax.net.ssl.trustStorePassword>${self-signed.trust-store-password}
+                        </javax.net.ssl.trustStorePassword>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -213,8 +172,6 @@
             <!-- add some custom config, the rest comes from parent -->
             <properties>
                 <quarkus.native.enable-https-url-handler>true</quarkus.native.enable-https-url-handler>
-                <quarkus.native.additional-build-args>-J-Djavax.net.ssl.trustStore=${self-signed.trust-store},
-                    -J-Djavax.net.ssl.trustStorePassword=${self-signed.trust-store-password}</quarkus.native.additional-build-args>
             </properties>
             <build>
                 <plugins>
@@ -225,8 +182,6 @@
                             <systemPropertyVariables>
                                 <!-- force the locale as we want to explicitly test message interpolation -->
                                 <user.language>en</user.language>
-                                <rest-client.trustStore>${wrong-host.trust-store}</rest-client.trustStore>
-                                <rest-client.trustStorePassword>${wrong-host.trust-store-password}</rest-client.trustStorePassword>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/integration-tests/rest-client/src/main/java/io/quarkus/it/rest/client/selfsigned/ExternalSelfSignedClient.java
+++ b/integration-tests/rest-client/src/main/java/io/quarkus/it/rest/client/selfsigned/ExternalSelfSignedClient.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@RegisterRestClient(baseUri = "https://self-signed.badssl.com/", configKey = "self-signed")
+@RegisterRestClient(configKey = "self-signed")
 public interface ExternalSelfSignedClient {
 
     @GET

--- a/integration-tests/rest-client/src/main/java/io/quarkus/it/rest/client/selfsigned/ExternalSelfSignedResource.java
+++ b/integration-tests/rest-client/src/main/java/io/quarkus/it/rest/client/selfsigned/ExternalSelfSignedResource.java
@@ -1,9 +1,6 @@
 package io.quarkus.it.rest.client.selfsigned;
 
 import java.io.IOException;
-import java.net.URL;
-
-import javax.net.ssl.HttpsURLConnection;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -28,31 +25,6 @@ public class ExternalSelfSignedResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String perform() throws IOException {
         return String.valueOf(client.invoke().getStatus());
-    }
-
-    @GET
-    @Path("/java")
-    @Produces(MediaType.TEXT_PLAIN)
-    public String invokeJavaURLWithDefaultTruststore() throws IOException {
-        try {
-            return doGetCipher();
-        } catch (IOException e) {
-            // if it fails it might be because the remote service is down, so sleep and try again
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException ignored) {
-            }
-            return doGetCipher();
-        }
-    }
-
-    private String doGetCipher() throws IOException {
-        // this URL provides an always on example of an HTTPS URL utilizing self-signed certificate
-        URL url = new URL("https://self-signed.badssl.com/");
-        HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
-        con.setRequestMethod("GET");
-        con.getResponseCode();
-        return con.getCipherSuite();
     }
 
 }

--- a/integration-tests/rest-client/src/main/java/io/quarkus/it/rest/client/wronghost/WrongHostClient.java
+++ b/integration-tests/rest-client/src/main/java/io/quarkus/it/rest/client/wronghost/WrongHostClient.java
@@ -8,7 +8,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@RegisterRestClient(baseUri = "https://wrong.host.badssl.com/", configKey = "wrong-host")
+@RegisterRestClient(configKey = "wrong-host")
 public interface WrongHostClient {
 
     @GET

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/selfsigned/ExternalSelfSignedTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/selfsigned/ExternalSelfSignedTestCase.java
@@ -1,15 +1,15 @@
 package io.quarkus.it.rest.client.selfsigned;
 
 import static io.restassured.RestAssured.when;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@WithTestResource(SelfSignedServiceTestResource.class)
 public class ExternalSelfSignedTestCase {
 
     @Test
@@ -21,12 +21,4 @@ public class ExternalSelfSignedTestCase {
                 .body(is("200"));
     }
 
-    @Test
-    public void should_accept_self_signed_certs_java_url() {
-        when()
-                .get("/self-signed/java")
-                .then()
-                .statusCode(200)
-                .body(is(not(empty())));
-    }
 }

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/selfsigned/SelfSignedServiceTestResource.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/selfsigned/SelfSignedServiceTestResource.java
@@ -1,0 +1,58 @@
+package io.quarkus.it.rest.client.selfsigned;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.PfxOptions;
+
+public class SelfSignedServiceTestResource implements QuarkusTestResourceLifecycleManager {
+
+    Vertx vertx = Vertx.vertx();
+
+    @Override
+    public Map<String, String> start() {
+        File file = new File("target/certs");
+        file.mkdirs();
+        // Generate self-signed certificate
+        // We do not use the junit 5 plugin to avoid having to annotate all the tests to make sure the certs are
+        // generated before the tests are run
+        CertificateGenerator generator = new CertificateGenerator(file.toPath(), false);
+        CertificateRequest cr = new CertificateRequest()
+                .withName("self-signed")
+                .withFormat(Format.PKCS12)
+                .withPassword("changeit")
+                .withDuration(Duration.ofDays(2))
+                .withCN("localhost");
+        try {
+            generator.generate(cr);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        HttpServerOptions options = new HttpServerOptions()
+                .setSsl(true)
+                .setKeyCertOptions(new PfxOptions()
+                        .setPath("target/certs/self-signed-keystore.p12")
+                        .setPassword("changeit"));
+        var server = vertx.createHttpServer(options)
+                .requestHandler(req -> req.response().end("OK"))
+                .listen(-2).toCompletionStage().toCompletableFuture().join();
+
+        return Map.of(
+                "quarkus.rest-client.self-signed.url", "https://localhost:" + server.actualPort() + "/",
+                "quarkus.rest-client.self-signed.trust-store", "target/certs/self-signed-truststore.p12",
+                "quarkus.rest-client.self-signed.trust-store-password", "changeit");
+    }
+
+    @Override
+    public void stop() {
+        vertx.close().toCompletionStage().toCompletableFuture().join();
+    }
+}

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/BadHostServiceTestResource.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/BadHostServiceTestResource.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.rest.client.trustall;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.PfxOptions;
+
+public class BadHostServiceTestResource implements QuarkusTestResourceLifecycleManager {
+
+    Vertx vertx = Vertx.vertx();
+
+    @Override
+    public Map<String, String> start() {
+        File file = new File("target/certs");
+        file.mkdirs();
+        // Generate self-signed certificate
+        // We do not use the junit 5 plugin to avoid having to annotate all the tests to make sure the certs are
+        // generated before the tests are run
+        CertificateGenerator generator = new CertificateGenerator(file.toPath(), false);
+        CertificateRequest cr = new CertificateRequest()
+                .withName("bad-host")
+                .withFormat(Format.PKCS12)
+                .withPassword("changeit")
+                .withDuration(Duration.ofDays(2))
+                .withCN("bad-host.com")
+                .withSubjectAlternativeName("DNS:bad-host.com");
+        try {
+            generator.generate(cr);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        HttpServerOptions options = new HttpServerOptions()
+                .setSsl(true)
+                .setKeyCertOptions(new PfxOptions()
+                        .setPath("target/certs/bad-host-keystore.p12")
+                        .setPassword("changeit"));
+        var server = vertx.createHttpServer(options)
+                .requestHandler(req -> req.response().end("OK"))
+                .listen(-1).toCompletionStage().toCompletableFuture().join();
+
+        return Map.of("wrong-host/mp-rest/url", "https://localhost:" + server.actualPort() + "/");
+    }
+
+    @Override
+    public void stop() {
+        vertx.close().toCompletionStage().toCompletableFuture().join();
+    }
+}

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestCase.java
@@ -5,13 +5,12 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.it.rest.client.wronghost.ExternalWrongHostTestResourceUsingHostnameVerifier;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@WithTestResource(BadHostServiceTestResource.class)
 @WithTestResource(value = ExternalTlsTrustAllTestResource.class, restrictToAnnotatedClass = false)
-@WithTestResource(ExternalWrongHostTestResourceUsingHostnameVerifier.class)
 public class ExternalTlsTrustAllTestCase {
 
     @Test

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestResource.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestResource.java
@@ -10,9 +10,9 @@ public class ExternalTlsTrustAllTestResource implements QuarkusTestResourceLifec
     @Override
     public Map<String, String> start() {
         Map<String, String> result = new HashMap<>();
-        result.put("wrong-host/mp-rest/trustStore", System.getProperty("rest-client.trustStore"));
-        result.put("wrong-host/mp-rest/trustStorePassword", System.getProperty("rest-client.trustStorePassword"));
-        result.put("quarkus.tls.trust-all", "true");
+        result.put("wrong-host/mp-rest/trustStore", "target/certs/bad-host-truststore.p12");
+        result.put("wrong-host/mp-rest/trustStorePassword", "changeit");
+        result.put("wrong-host/mp-rest/verifyHost", Boolean.FALSE.toString());
         return result;
     }
 

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/BaseExternalWrongHostTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/BaseExternalWrongHostTestCase.java
@@ -22,6 +22,6 @@ public abstract class BaseExternalWrongHostTestCase {
                 .then()
                 .statusCode(200)
                 .body(containsString(
-                        "http_client_requests_seconds_count{clientName=\"wrong.host.badssl.com\",method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"root\"}"));
+                        "http_client_requests_seconds_count{clientName=\"localhost\",method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"root\"}"));
     }
 }

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestResourceUsingHostnameVerifier.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestResourceUsingHostnameVerifier.java
@@ -14,8 +14,8 @@ public class ExternalWrongHostTestResourceUsingHostnameVerifier implements Quark
     @Override
     public Map<String, String> start() {
         Map<String, String> result = new HashMap<>();
-        result.put("wrong-host/mp-rest/trustStore", System.getProperty("rest-client.trustStore"));
-        result.put("wrong-host/mp-rest/trustStorePassword", System.getProperty("rest-client.trustStorePassword"));
+        result.put("wrong-host/mp-rest/trustStore", "target/certs/bad-host-truststore.p12");
+        result.put("wrong-host/mp-rest/trustStorePassword", "changeit");
         result.put("wrong-host/mp-rest/hostnameVerifier", NoopHostnameVerifier.class.getName());
         return result;
     }

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestResourceUsingVerifyHost.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestResourceUsingVerifyHost.java
@@ -13,8 +13,8 @@ public class ExternalWrongHostTestResourceUsingVerifyHost implements QuarkusTest
     @Override
     public Map<String, String> start() {
         Map<String, String> result = new HashMap<>();
-        result.put("wrong-host/mp-rest/trustStore", System.getProperty("rest-client.trustStore"));
-        result.put("wrong-host/mp-rest/trustStorePassword", System.getProperty("rest-client.trustStorePassword"));
+        result.put("wrong-host/mp-rest/trustStore", "target/certs/bad-host-truststore.p12");
+        result.put("wrong-host/mp-rest/trustStorePassword", "changeit");
         result.put("wrong-host/mp-rest/verifyHost", Boolean.FALSE.toString());
         return result;
     }

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingHostnameVerifierTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingHostnameVerifierTestCase.java
@@ -1,9 +1,11 @@
 package io.quarkus.it.rest.client.wronghost;
 
+import io.quarkus.it.rest.client.trustall.BadHostServiceTestResource;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@WithTestResource(BadHostServiceTestResource.class)
 @WithTestResource(ExternalWrongHostTestResourceUsingHostnameVerifier.class)
 public class ExternalWrongHostUsingHostnameVerifierTestCase extends BaseExternalWrongHostTestCase {
 }

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingVerifyHostTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingVerifyHostTestCase.java
@@ -1,9 +1,11 @@
 package io.quarkus.it.rest.client.wronghost;
 
+import io.quarkus.it.rest.client.trustall.BadHostServiceTestResource;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@WithTestResource(BadHostServiceTestResource.class)
 @WithTestResource(ExternalWrongHostTestResourceUsingVerifyHost.class)
 public class ExternalWrongHostUsingVerifyHostTestCase extends BaseExternalWrongHostTestCase {
 }


### PR DESCRIPTION
- Remove the trust store maven plugin which has not be super reliable recently on CI
- Use the cert generator instead
- Make sure the tests are not tainted with a quarkus.tls.trust-all=true
