### PR TITLE
[3.8] Upgrade jboss-logmanager dependency

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -167,7 +167,7 @@
         <dekorate.version>4.1.2</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <jboss-logmanager.version>3.0.4.Final</jboss-logmanager.version>
+        <jboss-logmanager.version>3.0.6.Final</jboss-logmanager.version>
         <flyway.version>9.22.3</flyway.version>
         <yasson.version>3.0.3</yasson.version>
         <!-- liquibase-mongodb is not released everytime with liquibase anymore, but the two versions need to be compatible -->

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -64,7 +64,7 @@
         <guava.failureaccess.version>1.0.1</guava.failureaccess.version><!-- keep in sync with guava.version -->
         <j2objc.annotations.version>2.8</j2objc.annotations.version><!-- keep in sync with guava.version -->
         <shrinkwrap-depchain.version>1.2.6</shrinkwrap-depchain.version>
-        <jboss-logmanager.version>3.0.4.Final</jboss-logmanager.version>
+        <jboss-logmanager.version>3.0.6.Final</jboss-logmanager.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <slf4j-api.version>2.0.6</slf4j-api.version>
         <graal-sdk.version>23.1.0</graal-sdk.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -51,7 +51,7 @@
         <maven.version>3.9.6</maven.version>
         <assertj.version>3.25.1</assertj.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>
-        <jboss-logmanager.version>3.0.4.Final</jboss-logmanager.version>
+        <jboss-logmanager.version>3.0.6.Final</jboss-logmanager.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <gizmo.version>1.7.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>


### PR DESCRIPTION
Closes #42043

Bumps [org.jboss.logmanager:jboss-logmanager](https://github.com/jboss-logging/jboss-logmanager) from 3.0.4.Final to 3.0.6.Final.
- [Release notes](https://github.com/jboss-logging/jboss-logmanager/releases)
- [Commits](https://github.com/jboss-logging/jboss-logmanager/compare/3.0.4.Final...3.0.6.Final)

---
updated-dependencies:
- dependency-name: org.jboss.logmanager:jboss-logmanager dependency-type: direct:production update-type: version-update:semver-patch ...