### PR TITLE
Use generated hostname when shared network is enabled

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -313,5 +313,10 @@ public class DevServicesMongoProcessor {
                 return super.getReplicaSetUrl(databaseName);
             }
         }
+
+        @Override
+        public String getHost() {
+            return useSharedNetwork ? hostName : super.getHost();
+        }
     }
 }


### PR DESCRIPTION
When using MongoDB DevService and Jib container build, the generated connection-string to run integration tests points to localhost, ex: ` QUARKUS_MONGODB_CONNECTION_STRING=mongodb://localhost:63109/test`. The container will fail to start since `localhost` is not the correct host for the MongoDB service. Instead, the shared network hostname should be used.