### PR TITLE
Improve the way we register providers for reflection

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveMethodBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveMethodBuildItem.java
@@ -13,8 +13,13 @@ public final class ReflectiveMethodBuildItem extends MultiBuildItem {
     final String declaringClass;
     final String name;
     final String[] params;
+    final boolean queryOnly;
 
     public ReflectiveMethodBuildItem(MethodInfo methodInfo) {
+        this(false, methodInfo);
+    }
+
+    public ReflectiveMethodBuildItem(boolean queryOnly, MethodInfo methodInfo) {
         String[] params = new String[methodInfo.parametersCount()];
         for (int i = 0; i < params.length; ++i) {
             params[i] = methodInfo.parameterType(i).name().toString();
@@ -22,9 +27,14 @@ public final class ReflectiveMethodBuildItem extends MultiBuildItem {
         this.name = methodInfo.name();
         this.params = params;
         this.declaringClass = methodInfo.declaringClass().name().toString();
+        this.queryOnly = queryOnly;
     }
 
     public ReflectiveMethodBuildItem(Method method) {
+        this(false, method);
+    }
+
+    public ReflectiveMethodBuildItem(boolean queryOnly, Method method) {
         this.params = new String[method.getParameterCount()];
         if (method.getParameterCount() > 0) {
             Class<?>[] parameterTypes = method.getParameterTypes();
@@ -34,16 +44,28 @@ public final class ReflectiveMethodBuildItem extends MultiBuildItem {
         }
         this.name = method.getName();
         this.declaringClass = method.getDeclaringClass().getName();
+        this.queryOnly = queryOnly;
     }
 
     public ReflectiveMethodBuildItem(String declaringClass, String name,
             String... params) {
+        this(false, declaringClass, name, params);
+    }
+
+    public ReflectiveMethodBuildItem(boolean queryOnly, String declaringClass, String name,
+            String... params) {
         this.declaringClass = declaringClass;
         this.name = name;
         this.params = params;
+        this.queryOnly = queryOnly;
     }
 
     public ReflectiveMethodBuildItem(String declaringClass, String name,
+            Class<?>... params) {
+        this(false, declaringClass, name, params);
+    }
+
+    public ReflectiveMethodBuildItem(boolean queryOnly, String declaringClass, String name,
             Class<?>... params) {
         this.declaringClass = declaringClass;
         this.name = name;
@@ -51,6 +73,7 @@ public final class ReflectiveMethodBuildItem extends MultiBuildItem {
         for (int i = 0; i < params.length; ++i) {
             this.params[i] = params[i].getName();
         }
+        this.queryOnly = queryOnly;
     }
 
     public String getName() {
@@ -63,6 +86,10 @@ public final class ReflectiveMethodBuildItem extends MultiBuildItem {
 
     public String getDeclaringClass() {
         return declaringClass;
+    }
+
+    public boolean isQueryOnly() {
+        return queryOnly;
     }
 
     @Override


### PR DESCRIPTION
Instead of registering all constructors we only need to register the nullary constructor.

Furthermore, we need to register the `provider()` method for reflective lookup to avoid `MissingReflectionRegistrationError`s at run-time when using `-H:+ThrowMissingRegistrationErrors` or `--exact-reachability-metadata`.

The said constructor and method are accessed in [ServiceLoader#loadProvider and ServiceLoader#findStaticProviderMethod.](https://github.com/openjdk/jdk21u/blob/d6e8788ca888fac7f04751e72202f10fda8cad59/src/java.base/share/classes/java/util/ServiceLoader.java#L848)

Relates to https://github.com/quarkusio/quarkus/issues/41995
