### PR TITLE
Trigger docs build on processor changes

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches-ignore:
       - 'dependabot/**'
-      - 'jakarta-rewrite'
       - '3.0'
     paths:
+      - 'core/processor/**'
       - 'docs/src/main/asciidoc/**'
       - '.github/workflows/doc-build.yml'
   pull_request:


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/41979 caused an NPE in certain cases processing the configuration documentation, which the CI did not catch because the main PR build skips the docs, and the separate doc workflow does not trigger on changes to the annotation processor.