### PR TITLE
Add an important note about the START_TLS configuration requiring tls set to false

### DIFF
--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -418,6 +418,8 @@ quarkus.mailer.start-tls=REQUIRED
 quarkus.mailer.trust-all=true
 ----
 
+IMPORTANT: To use `START_TLS`, make sure you set `tls` to `false` and `start-tls` to `REQUIRED` or `OPTIONAL`.
+
 === Configuring SSL/TLS
 
 To establish a TLS connection, you need to configure a _named_ configuration using the xref:./tls-registry-reference.adoc[TLS registry]:


### PR DESCRIPTION
This is a change introduced with the TLS registry. The previous configuration was ambiguous.


Fix https://github.com/quarkusio/quarkus/issues/42050.

Breaking change also documented in https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.12