### PR TITLE
Introduce `@UnwrapException` for Quarkus REST

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -2271,6 +2271,40 @@ By default, methods annotated with `@ServerExceptionMapper` do **not** run CDI i
 Users however can opt into interceptors by adding the corresponding annotations to the method.
 ====
 
+[TIP]
+====
+When mapping an exception to a `@ServerExceptionMapper` method, the cause of the exception normally does not come into play.
+
+However, some exception types in Java only serve as wrappers for other exceptions. Often, checked exceptions are wrapped into `RuntimeException` just to not have them declared in method `throws` parameters.
+Working with `CompletionStage` for example, will require `CompletionException`. There are many such exception types that are just wrappers around the real cause of the exception.
+
+If you wish to make sure your exception mapper is called for your exception type even when it is wrapped by one of those wrapper exceptions, you can use `@UnwrapException` on the exception wrapper type:
+
+[source,java]
+----
+public class MyExceptionWrapper extends RuntimeException {
+    public MyExceptionWrapper(Exception cause) {
+        super(cause);
+    }
+}
+----
+
+If you don't control that exception wrapper type, you can place the annotation on any class and specify the exception wrapper types it applies to as annotation parameter:
+
+[source,java]
+----
+@UnwrapException({CompletionException.class, RuntimeException.class})
+public class Mapper {
+
+    @ServerExceptionMapper
+    public Response handleMyException(MyException x) {
+        // ...
+    }
+
+}
+----
+====
+
 [NOTE]
 ====
 Εxception mappers defined in REST endpoint classes will only be called if the  exception is thrown in the same class. If you want to define global exception mappers,

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/UnwrapExceptionTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/UnwrapExceptionTest.java
@@ -1,0 +1,155 @@
+package io.quarkus.resteasy.reactive.server.test.customexceptions;
+
+import static io.quarkus.resteasy.reactive.server.test.ExceptionUtil.removeStackTrace;
+import static io.restassured.RestAssured.when;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.resteasy.reactive.server.UnwrapException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.test.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UnwrapExceptionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(FirstException.class, SecondException.class, ThirdException.class,
+                                    FourthException.class, FifthException.class, SixthException.class,
+                                    Mappers.class, Resource.class, ExceptionUtil.class);
+                }
+            });
+
+    @Test
+    public void testWrapperWithUnmappedException() {
+        when().get("/hello/iaeInSecond")
+                .then().statusCode(500);
+    }
+
+    @Test
+    public void testMappedExceptionWithoutUnwrappedWrapper() {
+        when().get("/hello/iseInFirst")
+                .then().statusCode(500);
+
+        when().get("/hello/iseInThird")
+                .then().statusCode(500);
+
+        when().get("/hello/iseInSixth")
+                .then().statusCode(500);
+    }
+
+    @Test
+    public void testWrapperWithMappedException() {
+        when().get("/hello/iseInSecond")
+                .then().statusCode(900);
+
+        when().get("/hello/iseInFourth")
+                .then().statusCode(900);
+
+        when().get("/hello/iseInFifth")
+                .then().statusCode(900);
+    }
+
+    @Path("hello")
+    public static class Resource {
+
+        @Path("iseInFirst")
+        public String throwsISEAsCauseOfFirstException() {
+            throw removeStackTrace(new FirstException(removeStackTrace(new IllegalStateException("dummy"))));
+        }
+
+        @Path("iseInSecond")
+        public String throwsISEAsCauseOfSecondException() {
+            throw removeStackTrace(new SecondException(removeStackTrace(new IllegalStateException("dummy"))));
+        }
+
+        @Path("iaeInSecond")
+        public String throwsIAEAsCauseOfSecondException() {
+            throw removeStackTrace(new SecondException(removeStackTrace(new IllegalArgumentException("dummy"))));
+        }
+
+        @Path("iseInThird")
+        public String throwsISEAsCauseOfThirdException() throws ThirdException {
+            throw removeStackTrace(new ThirdException(removeStackTrace(new IllegalStateException("dummy"))));
+        }
+
+        @Path("iseInFourth")
+        public String throwsISEAsCauseOfFourthException() throws FourthException {
+            throw removeStackTrace(new FourthException(removeStackTrace(new IllegalStateException("dummy"))));
+        }
+
+        @Path("iseInFifth")
+        public String throwsISEAsCauseOfFifthException() {
+            throw removeStackTrace(new FifthException(removeStackTrace(new IllegalStateException("dummy"))));
+        }
+
+        @Path("iseInSixth")
+        public String throwsISEAsCauseOfSixthException() {
+            throw removeStackTrace(new SixthException(removeStackTrace(new IllegalStateException("dummy"))));
+        }
+    }
+
+    @UnwrapException({ FourthException.class, FifthException.class })
+    public static class Mappers {
+
+        @ServerExceptionMapper
+        public Response handleIllegalStateException(IllegalStateException e) {
+            return Response.status(900).build();
+        }
+    }
+
+    public static class FirstException extends RuntimeException {
+
+        public FirstException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    @UnwrapException
+    public static class SecondException extends FirstException {
+
+        public SecondException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class ThirdException extends Exception {
+
+        public ThirdException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class FourthException extends SecondException {
+
+        public FourthException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class FifthException extends RuntimeException {
+
+        public FifthException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class SixthException extends RuntimeException {
+
+        public SixthException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/UnwrappedExceptionBuildItem.java
+++ b/extensions/resteasy-reactive/rest/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/UnwrappedExceptionBuildItem.java
@@ -3,18 +3,32 @@ package io.quarkus.resteasy.reactive.server.spi;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * When an Exception of this type is thrown and no {@code jakarta.ws.rs.ext.ExceptionMapper} exists,
+ * When an {@link Exception} of this type is thrown and no {@code jakarta.ws.rs.ext.ExceptionMapper} exists,
  * then RESTEasy Reactive will attempt to locate an {@code ExceptionMapper} for the cause of the Exception.
  */
 public final class UnwrappedExceptionBuildItem extends MultiBuildItem {
 
-    private final Class<? extends Throwable> throwableClass;
+    private final String throwableClassName;
 
-    public UnwrappedExceptionBuildItem(Class<? extends Throwable> throwableClass) {
-        this.throwableClass = throwableClass;
+    public UnwrappedExceptionBuildItem(String throwableClassName) {
+        this.throwableClassName = throwableClassName;
     }
 
+    public UnwrappedExceptionBuildItem(Class<? extends Throwable> throwableClassName) {
+        this.throwableClassName = throwableClassName.getName();
+    }
+
+    @Deprecated(forRemoval = true)
     public Class<? extends Throwable> getThrowableClass() {
-        return throwableClass;
+        try {
+            return (Class<? extends Throwable>) Class.forName(throwableClassName, false,
+                    Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getThrowableClassName() {
+        return throwableClassName;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerExceptionMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerExceptionMapper.java
@@ -41,6 +41,8 @@ import jakarta.ws.rs.core.UriInfo;
  * <p>
  * The return type of the method must be either be of type {@code Response}, {@code Uni<Response>}, {@code RestResponse} or
  * {@code Uni<RestResponse>}.
+ * <p>
+ * See also {@link UnwrapException}
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/UnwrapException.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/UnwrapException.java
@@ -1,0 +1,23 @@
+package org.jboss.resteasy.reactive.server;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to configure that an exception (or exceptions) should be unwrapped during exception handling.
+ * <p>
+ * Unwrapping means that when an {@link Exception} of the configured type is thrown and no
+ * {@code jakarta.ws.rs.ext.ExceptionMapper} exists,
+ * then RESTEasy Reactive will attempt to locate an {@code ExceptionMapper} for the cause of the Exception.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface UnwrapException {
+
+    /**
+     * If this is not set, the value is assumed to be the exception class where the annotation is placed
+     */
+    Class<? extends Exception>[] value() default {};
+}


### PR DESCRIPTION
This allows users to configure exceptions
whose cause will be checked against exception mappers.

This capability already existed in Quarkus REST and was used to map some internal exceptions, but with the new annotation users can opt into the feature for whatever exceptions make sense for their use case.

- Closes: #42089