### PR TITLE
Enable Liquibase includeAll in Native Image

### DIFF
--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/NativeImageResourceAccessor.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/NativeImageResourceAccessor.java
@@ -1,0 +1,63 @@
+package io.quarkus.liquibase.runtime;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+import liquibase.resource.AbstractPathResourceAccessor;
+import liquibase.resource.PathResource;
+import liquibase.resource.Resource;
+
+public class NativeImageResourceAccessor extends AbstractPathResourceAccessor {
+    private static final URI NATIVE_IMAGE_FILESYSTEM_URI = URI.create("resource:/");
+    private static final Logger log = Logger.getLogger(NativeImageResourceAccessor.class);
+
+    private final FileSystem fileSystem;
+
+    public NativeImageResourceAccessor() {
+        FileSystem fs;
+        try {
+            fs = FileSystems.newFileSystem(
+                    NATIVE_IMAGE_FILESYSTEM_URI,
+                    Collections.singletonMap("create", "true"));
+            log.debug("Creating new filesystem for native image");
+        } catch (FileSystemAlreadyExistsException ex) {
+            fs = FileSystems.getFileSystem(NATIVE_IMAGE_FILESYSTEM_URI);
+            log.debug("Native image file system already exists", ex);
+        } catch (IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+        fileSystem = fs;
+    }
+
+    @Override
+    protected Path getRootPath() {
+        return fileSystem.getPath("/");
+    }
+
+    @Override
+    protected Resource createResource(Path file, String pathToAdd) {
+        return new PathResource(pathToAdd, file);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public List<String> describeLocations() {
+        return Collections.singletonList(fileSystem.toString());
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + " (" + getRootPath() + ") (" + fileSystem.toString() + ")";
+    }
+}

--- a/integration-tests/liquibase/src/main/resources/db/xml/changeLog.xml
+++ b/integration-tests/liquibase/src/main/resources/db/xml/changeLog.xml
@@ -10,7 +10,5 @@
 
     <include relativeToChangelogFile="true" file="create-views.xml" />
 
-    <!-- errorIfMissingOrEmpty to avoid hard error in native,
-         see also: LiquibaseFunctionalityNativeIT.isIncludeAllExpectedToWork() -->
-    <includeAll relativeToChangelogFile="true" path="includeAll" errorIfMissingOrEmpty="false" />
+    <includeAll relativeToChangelogFile="true" path="includeAll" />
 </databaseChangeLog>

--- a/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityNativeIT.java
+++ b/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityNativeIT.java
@@ -4,11 +4,4 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 public class LiquibaseFunctionalityNativeIT extends LiquibaseFunctionalityTest {
-
-    // see: https://github.com/quarkusio/quarkus/issues/16292
-    // if this is ever resolved, make sure to remove errorIfMissingOrEmpty="false" from includeAll in changeLog.xml
-    @Override
-    protected boolean isIncludeAllExpectedToWork() {
-        return false;
-    }
 }

--- a/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityPMT.java
+++ b/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityPMT.java
@@ -28,7 +28,7 @@ public class LiquibaseFunctionalityPMT {
 
     @Test
     public void test() {
-        LiquibaseFunctionalityTest.doTestLiquibaseQuarkusFunctionality(true);
+        LiquibaseFunctionalityTest.doTestLiquibaseQuarkusFunctionality();
     }
 
     @AfterEach

--- a/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityTest.java
+++ b/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityTest.java
@@ -15,7 +15,7 @@ public class LiquibaseFunctionalityTest {
     @Test
     @DisplayName("Migrates a schema correctly using integrated instance")
     public void testLiquibaseQuarkusFunctionality() {
-        doTestLiquibaseQuarkusFunctionality(isIncludeAllExpectedToWork());
+        doTestLiquibaseQuarkusFunctionality();
     }
 
     @Test
@@ -25,21 +25,17 @@ public class LiquibaseFunctionalityTest {
                 "ADMIN"));
     }
 
-    static void doTestLiquibaseQuarkusFunctionality(boolean isIncludeAllExpectedToWork) {
+    static void doTestLiquibaseQuarkusFunctionality() {
         when()
                 .get("/liquibase/update")
                 .then()
                 .body(is(
                         "create-tables-1,test-1,create-view-inline,create-view-file-abs,create-view-file-rel,"
-                                + (isIncludeAllExpectedToWork ? "includeAll-1,includeAll-2," : "")
+                                + ("includeAll-1,includeAll-2,")
                                 + "json-create-tables-1,json-test-1,"
                                 + "sql-create-tables-1,sql-test-1,"
                                 + "yaml-create-tables-1,yaml-test-1,"
                                 + "00000000000000,00000000000001,00000000000002,"
                                 + "1613578374533-1,1613578374533-2,1613578374533-3"));
-    }
-
-    protected boolean isIncludeAllExpectedToWork() {
-        return true;
     }
 }


### PR DESCRIPTION
Fixes #16292

This patch creates a `FileSystem` in the native image to enable access to the Liquibase changelog resources.