### PR TITLE
Register `sun.security.provider.NativePRNG#<init>` for reflection

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/SecureRandomProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/SecureRandomProcessor.java
@@ -1,0 +1,16 @@
+package io.quarkus.deployment;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
+
+public class SecureRandomProcessor {
+
+    @BuildStep
+    void registerReflectiveMethods(BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods) {
+        // Called reflectively through java.security.SecureRandom.SecureRandom()
+        reflectiveMethods.produce(new ReflectiveMethodBuildItem("sun.security.provider.NativePRNG", "<init>",
+                java.security.SecureRandomParameters.class));
+    }
+
+}


### PR DESCRIPTION
When instantiating a `SecureRandom` [the constructor reflectively looks for
the `NativePRNG` constructor and invokes it](https://github.com/openjdk/jdk21u/blob/d6e8788ca888fac7f04751e72202f10fda8cad59/src/java.base/share/classes/java/security/SecureRandom.java#L225).

Although the lookup succeeds without the explicit registration, it's
better to explicitly request it. This also prevents getting a
`MissingRegistrationError` when using
`-H:+ThrowMissingRegistrationErrors` or `--exact-reachability-metadata`.

Relates to https://github.com/quarkusio/quarkus/issues/41995
