### PR TITLE
Reduce overhead of REST Client config handling

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import jakarta.enterprise.inject.CreationException;
 
@@ -327,11 +328,21 @@ public class RestClientsConfig {
         if (configKey == null) {
             return RestClientConfig.EMPTY;
         }
-        return configs.computeIfAbsent(configKey, RestClientConfig::load);
+        return configs.computeIfAbsent(configKey, new Function<>() {
+            @Override
+            public RestClientConfig apply(String configKey) {
+                return RestClientConfig.load(configKey);
+            }
+        });
     }
 
     public RestClientConfig getClientConfig(Class<?> clientInterface) {
-        return configs.computeIfAbsent(clientInterface.getName(), name -> RestClientConfig.load(clientInterface));
+        return configs.computeIfAbsent(clientInterface.getName(), new Function<>() {
+            @Override
+            public RestClientConfig apply(String interfaceName) {
+                return RestClientConfig.load(clientInterface);
+            }
+        });
     }
 
     public void putClientConfig(String configKey, RestClientConfig clientConfig) {

--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientConfigNotationTest.java
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientConfigNotationTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Iterators;
 import io.quarkus.restclient.config.RestClientConfig;
 import io.quarkus.restclient.config.RestClientsConfig;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.common.AbstractConfigSource;
 
 public class RestClientConfigNotationTest {
@@ -41,6 +42,7 @@ public class RestClientConfigNotationTest {
     })
     public void testInterfaceConfiguration(final String urlPropertyName) {
         TestConfigSource.urlPropertyName = urlPropertyName;
+        refreshPropertyNames();
 
         RestClientsConfig configRoot = new RestClientsConfig();
         RestClientConfig clientConfig = configRoot.getClientConfig(EchoClient.class);
@@ -55,10 +57,17 @@ public class RestClientConfigNotationTest {
     })
     public void testConfigKeyConfiguration(final String urlPropertyName) {
         TestConfigSource.urlPropertyName = urlPropertyName;
+        refreshPropertyNames();
+
         RestClientsConfig configRoot = new RestClientsConfig();
         RestClientConfig clientConfig = configRoot.getClientConfig("echo-client");
 
         verifyConfig(clientConfig, urlPropertyName);
+    }
+
+    private void refreshPropertyNames() {
+        SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig();
+        config.getLatestPropertyNames();
     }
 
     private void verifyConfig(final RestClientConfig clientConfig, final String urlPropertyName) {

--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/VaultScenarioRestClientConfigTest.java
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/VaultScenarioRestClientConfigTest.java
@@ -59,7 +59,7 @@ public class VaultScenarioRestClientConfigTest {
 
         @Override
         public Set<String> getPropertyNames() {
-            return Collections.emptySet();
+            return Set.of("quarkus.rest-client.\"io.quarkus.restclient.configuration.EchoClient\".url");
         }
 
         @Override


### PR DESCRIPTION
The idea here is to reduce the lookups to Smallrye Config while also reducing object creation when those lookups are necessary

- Relates to: #42092