### PR TITLE
Rename SA_PASSWORD to MSSQL_SA_PASSWORD as SA_PASSWORD is deprecated

### DIFF
--- a/extensions/reactive-mssql-client/deployment/pom.xml
+++ b/extensions/reactive-mssql-client/deployment/pom.xml
@@ -148,7 +148,7 @@
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
-                                            <SA_PASSWORD>yourStrong(!)Password</SA_PASSWORD>
+                                            <MSSQL_SA_PASSWORD>yourStrong(!)Password</MSSQL_SA_PASSWORD>
                                         </env>
                                         <log>
                                             <prefix>MSSQL:</prefix>

--- a/integration-tests/hibernate-reactive-mssql/pom.xml
+++ b/integration-tests/hibernate-reactive-mssql/pom.xml
@@ -205,7 +205,7 @@
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
-                                            <SA_PASSWORD>yourStrong(!)Password</SA_PASSWORD>
+                                            <MSSQL_SA_PASSWORD>yourStrong(!)Password</MSSQL_SA_PASSWORD>
                                         </env>
                                         <log>
                                             <prefix>MS SQL Server:</prefix>

--- a/integration-tests/jpa-mssql/README.md
+++ b/integration-tests/jpa-mssql/README.md
@@ -25,7 +25,7 @@ you'll probably want to change the authentication password too: `-Dmssqldb.sa-pa
 If you prefer to run the MSSQL Server container via podman, use:
 
 ```
-podman run --rm=true --net=host --memory-swappiness=0 --name mssql_testing -e SA_PASSWORD=yourStrong(!)Password -e ACCEPT_EULA=Y -p 1435:1433 mcr.microsoft.com/mssql/2022-latest
+podman run --rm=true --net=host --memory-swappiness=0 --name mssql_testing -e MSSQL_SA_PASSWORD=yourStrong(!)Password -e ACCEPT_EULA=Y -p 1435:1433 mcr.microsoft.com/mssql/2022-latest
 ```
 
 ## Limitations

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -201,7 +201,7 @@
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
-                                            <SA_PASSWORD>yourStrong(!)Password</SA_PASSWORD>
+                                            <MSSQL_SA_PASSWORD>yourStrong(!)Password</MSSQL_SA_PASSWORD>
                                         </env>
                                         <log>
                                             <prefix>MS SQL Server:</prefix>

--- a/integration-tests/reactive-mssql-client/pom.xml
+++ b/integration-tests/reactive-mssql-client/pom.xml
@@ -167,7 +167,7 @@
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
-                                            <SA_PASSWORD>yourStrong(!)Password</SA_PASSWORD>
+                                            <MSSQL_SA_PASSWORD>yourStrong(!)Password</MSSQL_SA_PASSWORD>
                                         </env>
                                         <log>
                                             <prefix>MSSQL:</prefix>


### PR DESCRIPTION
Updating password env variable for MSSQL as it was deprecated see https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker?view=sql-server-ver16&tabs=cli&pivots=cs1-bash#run-the-container-2