### PR TITLE
Disable external configuration sources parsing in native-mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigBuildSteps.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigBuildSteps.java
@@ -15,6 +15,7 @@ import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.StaticInitConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.runtime.configuration.SystemOnlySourcesConfigBuilder;
 import io.quarkus.runtime.graal.InetRunTime;
@@ -59,6 +60,16 @@ class ConfigBuildSteps {
     void systemOnlySources(BuildProducer<StaticInitConfigBuilderBuildItem> staticInitConfigBuilder,
             BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
         staticInitConfigBuilder.produce(new StaticInitConfigBuilderBuildItem(SystemOnlySourcesConfigBuilder.class.getName()));
+        runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(SystemOnlySourcesConfigBuilder.class.getName()));
+    }
+
+    /**
+     * Disable external configuration sources parsing for native executables since they are not supported see
+     * https://github.com/quarkusio/quarkus/issues/41994
+     */
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void nativeNoSources(BuildProducer<StaticInitConfigBuilderBuildItem> staticInitConfigBuilder,
+            BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
         runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(SystemOnlySourcesConfigBuilder.class.getName()));
     }
 


### PR DESCRIPTION
`SmallryeConfigBuilder` tries to access properties files from various
sources, despite them not being available at run-time nor supported in
native-mode, see https://github.com/quarkusio/quarkus/issues/41994

This patch also avoids getting a `MissingRegistrationError` when using
`-H:+ThrowMissingRegistrationErrors` or `--exact-reachability-metadata`.

Related to https://github.com/quarkusio/quarkus/issues/41994 and
https://github.com/quarkusio/quarkus/issues/41995
