### PR TITLE
Clarify RedisClientConfig documentation for max-pool-size

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
@@ -81,9 +81,9 @@ public interface RedisClientConfig {
     Optional<String> password();
 
     /**
-     * The maximum size of the connection pool. When working with cluster or sentinel.
-     * <p>
-     * This value should be at least the total number of cluster member (or number of sentinels + 1)
+     * The maximum size of the connection pool.
+     * When working with cluster or sentinel, this value should be at least the total number of cluster members (or
+     * number of sentinels + 1)
      */
     @WithDefault("6")
     int maxPoolSize();


### PR DESCRIPTION
The documentation for max-pool size has a small typo, which could be interpreted as "this value is only respected when using cluster or sentinel mode". This value is also respected in standalone mode though :)