### PR TITLE
Bump agroal.version from 2.4 to 2.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -100,7 +100,7 @@
         <!-- See root POM for hibernate-orm.version, hibernate-reactive.version, hibernate-validator.version,
              hibernate-search.version, antlr.version, bytebuddy.version, hibernate-commons-annotations.version -->
         <narayana.version>7.0.2.Final</narayana.version>
-        <agroal.version>2.4</agroal.version>
+        <agroal.version>2.5</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
         <elasticsearch-opensource-components.version>8.14.3</elasticsearch-opensource-components.version>
         <rxjava.version>2.2.21</rxjava.version>

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/FlushOnCloseDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/FlushOnCloseDataSourceConfigTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.agroal.test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -59,11 +57,8 @@ class FlushOnCloseDataSourceConfigTest {
         }
 
         try (Connection connection = defaultDataSource.getConnection()) {
-            assertEquals("1", connection.getClientInfo("ClientUser"));
-            try (Connection conn2 = defaultDataSource.getConnection()) {
-                // new connection should not contain any mark ClientUser
-                assertNull(conn2.getClientInfo("ClientUser"));
-            }
+            // new connection should not contain any mark ClientUser
+            assertNull(connection.getClientInfo("ClientUser"));
         }
     }
 
@@ -81,13 +76,7 @@ class FlushOnCloseDataSourceConfigTest {
 
         @Override
         public void onConnectionReturn(Connection connection) {
-            try {
-                // Connection marked "ClientUser:2" must not return to the pool.
-                assertNotEquals("2", connection.getClientInfo("ClientUser"));
-                LOGGER.info("connection returned ClientUser:" + connection.getClientInfo("ClientUser"));
-            } catch (SQLException e) {
-                Assertions.fail(e);
-            }
+            Assertions.fail("unexpected connection return");
         }
     }
 }


### PR DESCRIPTION
Bumps `agroal.version` from 2.4 to 2.5.

Updates `io.agroal:agroal-api` from 2.4 to 2.5
- [Commits](https://github.com/agroal/agroal/compare/2.4...2.5)

Updates `io.agroal:agroal-narayana` from 2.4 to 2.5
- [Commits](https://github.com/agroal/agroal/compare/2.4...2.5)

Updates `io.agroal:agroal-pool` from 2.4 to 2.5
- [Commits](https://github.com/agroal/agroal/compare/2.4...2.5)

---
updated-dependencies:
- dependency-name: io.agroal:agroal-api dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: io.agroal:agroal-narayana dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: io.agroal:agroal-pool dependency-type: direct:production update-type: version-update:semver-minor ...