### PR TITLE
Limit external configuration sources parsing in native-mode

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/FileSystemOnlySourcesConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/FileSystemOnlySourcesConfigBuilder.java
@@ -1,0 +1,22 @@
+package io.quarkus.runtime.configuration;
+
+import static io.smallrye.config.PropertiesConfigSourceLoader.inFileSystem;
+
+import java.nio.file.Paths;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class FileSystemOnlySourcesConfigBuilder implements ConfigBuilder {
+    @Override
+    public SmallRyeConfigBuilder configBuilder(final SmallRyeConfigBuilder builder) {
+        return builder.setAddDefaultSources(false).addSystemSources().withSources(
+                inFileSystem(Paths.get(System.getProperty("user.dir"), "config", "application.properties").toUri().toString(),
+                        260, builder.getClassLoader()));
+    }
+
+    @Override
+    public int priority() {
+        return Integer.MAX_VALUE;
+    }
+
+}

--- a/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
+++ b/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
+import io.quarkus.config.yaml.runtime.NativeYamlConfigBuilder;
 import io.quarkus.config.yaml.runtime.YamlConfigBuilder;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -14,6 +15,8 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.StaticInitConfigBuilderBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.smallrye.config.SmallRyeConfig;
 
 public final class ConfigYamlProcessor {
@@ -23,7 +26,7 @@ public final class ConfigYamlProcessor {
         return new FeatureBuildItem(Feature.CONFIG_YAML);
     }
 
-    @BuildStep
+    @BuildStep(onlyIfNot = NativeOrNativeSourcesBuild.class)
     public void yamlConfig(
             BuildProducer<StaticInitConfigBuilderBuildItem> staticInitConfigBuilder,
             BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
@@ -32,12 +35,23 @@ public final class ConfigYamlProcessor {
         runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(YamlConfigBuilder.class));
     }
 
+    /**
+     * Limit external configuration sources parsing for native executables since they are not supported see
+     * https://github.com/quarkusio/quarkus/issues/41994
+     */
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void nativeNoSources(BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
+        runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(NativeYamlConfigBuilder.class));
+    }
+
     @BuildStep
     void watchYamlConfig(BuildProducer<HotDeploymentWatchedFileBuildItem> watchedFiles) {
         List<String> configWatchedFiles = new ArrayList<>();
         String userDir = System.getProperty("user.dir");
 
         // Main files
+        configWatchedFiles.add("META-INF/microprofile-config.yaml");
+        configWatchedFiles.add("META-INF/microprofile-config.yml");
         configWatchedFiles.add("application.yaml");
         configWatchedFiles.add("application.yml");
         configWatchedFiles.add(Paths.get(userDir, "config", "application.yaml").toAbsolutePath().toString());
@@ -57,5 +71,32 @@ public final class ConfigYamlProcessor {
         for (String configWatchedFile : configWatchedFiles) {
             watchedFiles.produce(new HotDeploymentWatchedFileBuildItem(configWatchedFile));
         }
+    }
+
+    /**
+     * Registers configuration files for access at runtime in native-mode. Doesn't use absolute paths.
+     */
+    @BuildStep
+    NativeImageResourceBuildItem nativeYamlConfig() {
+        List<String> configFiles = new ArrayList<>();
+
+        // Main files
+        configFiles.add("META-INF/microprofile-config.yaml");
+        configFiles.add("META-INF/microprofile-config.yml");
+        configFiles.add("application.yaml");
+        configFiles.add("application.yml");
+        configFiles.add(Paths.get("config", "application.yaml").toString());
+        configFiles.add(Paths.get("config", "application.yml").toString());
+
+        // Profiles
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        for (String profile : config.getProfiles()) {
+            configFiles.add(String.format("application-%s.yaml", profile));
+            configFiles.add(String.format("application-%s.yml", profile));
+            configFiles.add(Paths.get("config", String.format("application-%s.yaml", profile)).toString());
+            configFiles.add(Paths.get("config", String.format("application-%s.yml", profile)).toString());
+        }
+
+        return new NativeImageResourceBuildItem(configFiles);
     }
 }

--- a/extensions/config-yaml/runtime/src/main/java/io/quarkus/config/yaml/runtime/NativeYamlConfigBuilder.java
+++ b/extensions/config-yaml/runtime/src/main/java/io/quarkus/config/yaml/runtime/NativeYamlConfigBuilder.java
@@ -1,0 +1,12 @@
+package io.quarkus.config.yaml.runtime;
+
+import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.source.yaml.YamlConfigSourceLoader;
+
+public class NativeYamlConfigBuilder implements ConfigBuilder {
+    @Override
+    public SmallRyeConfigBuilder configBuilder(final SmallRyeConfigBuilder builder) {
+        return builder.withSources(new YamlConfigSourceLoader.InFileSystem());
+    }
+}


### PR DESCRIPTION
`SmallryeConfigBuilder` tries to access properties files from various sources, despite them not being available at run-time nor supported in native-mode, see https://github.com/quarkusio/quarkus/issues/41994

This patch also avoids getting a `MissingRegistrationError` when using `-H:+ThrowMissingRegistrationErrors` or `--exact-reachability-metadata`.

Related to https://github.com/quarkusio/quarkus/issues/41994 and https://github.com/quarkusio/quarkus/issues/41995

Supersedes https://github.com/quarkusio/quarkus/pull/42103