### PR TITLE
Redis - Improve parameter validation of the hmget command

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/HashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/HashCommands.java
@@ -122,8 +122,8 @@ public interface HashCommands<K, F, V> extends RedisCommands {
      * Group: hash
      * Requires Redis 2.0.0
      *
-     * @param key the key
-     * @param fields the fields
+     * @param key the key must not be {@code null}
+     * @param fields the fields, must not be empty, must not contain {@code null} values
      * @return list of values associated with the given fields, in the same order as they are requested.
      *         If a requested field does not exist, the returned map contains a {@code null} value for that field.
      **/

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHashCommands.java
@@ -82,6 +82,11 @@ class AbstractHashCommands<K, F, V> extends AbstractRedisCommands {
 
     @SafeVarargs
     final Uni<Response> _hmget(K key, F... fields) {
+        nonNull(key, "key");
+        doesNotContainNull(fields, "fields");
+        if (fields.length == 0) {
+            throw new IllegalArgumentException("`fields` must not be empty");
+        }
         RedisCommand cmd = RedisCommand.of(Command.HMGET);
         cmd.put(marshaller.encode(key));
 


### PR DESCRIPTION
Fix #42131
