### PR TITLE
Removed missed deprecated `@QuarkusTestResource` from docs

### DIFF
--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -639,14 +639,14 @@ To set the desired port MongoDB will listen to when it is launched, the followin
 
 [source,java]
 ----
-@QuarkusTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = MongoTestResource.PORT, value = "27017"))
+@WithTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = MongoTestResource.PORT, value = "27017"))
 ----
 
 To set the desired MongoDB version that will be launched, the following code should be used:
 
 [source,java]
 ----
-@QuarkusTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = MongoTestResource.VERSION, value = "V5_0"))
+@WithTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = MongoTestResource.VERSION, value = "V5_0"))
 ----
 
 The string value used can be any of one of the `de.flapdoodle.embed.mongo.distribution.Version` or `de.flapdoodle.embed.mongo.distribution.Version.Main` enums.

--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -45,7 +45,7 @@ which configures our REST client to connect to an SSL REST service.
 For the purposes of this guide, we also need to remove the configuration that starts the embedded WireMock server that stubs REST client responses so the tests actually propagate calls to the https://stage.code.quarkus.io/api. Update the test file `src/test/java/org/acme/rest/client/ExtensionsResourceTest.java` and remove the line:
 [source,java]
 ----
-@QuarkusTestResource(WireMockExtensions.class)
+@WithTestResource(WireMockExtensions.class)
 ----
 from the `ExtensionsResourceTest` class.
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ResourceArg.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ResourceArg.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Uses to define arguments of for {@code QuarkusTestResource}
+ * Uses to define arguments for {@code WithTestResource}
  *
  * see {@link WithTestResource#initArgs()}
  */


### PR DESCRIPTION
As `QuarkusTestResource` was deprecated in 3.13.0 there was still some leftovers in docs/javadocs. This should remove all of them. 

Note that `native-and-ssl.adoc` that stated 

```
Update the test file `src/test/java/org/acme/rest/client/ExtensionsResourceTest.java` and remove the line:

@QuarkusTestResource(WireMockExtensions.class)
```

So probably https://github.com/quarkusio/quarkus-quickstarts/pull/1435 should go first for docs be valid.

Tested these changes localy