### PR TITLE
Allow streaming data in deployment classpath methods in Dev UI

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -1035,7 +1035,7 @@ this._observer.cancel(); //<2>
 
 https://github.com/phillip-kruger/quarkus-jokes/blob/main/deployment/src/main/resources/dev-ui/qwc-jokes-web-components.js[Example code]
 
-==== JsonRpc against the deployment classpath
+=== JsonRpc against the deployment classpath
 
 In certain cases you might need to execute methods and/or get data against the deployment classpath. This also happens over JsonRPC communication, but in this case you do not create a JsonRPC Service in the runtime module,
 you can just supply the code to be run in a supplier in the deployment module. To do this you will produce a `BuildTimeActionBuildItem`, example:
@@ -1064,9 +1064,11 @@ you can just supply the code to be run in a supplier in the deployment module. T
 ----
 <1> Return or use a BuildProducer to create a `BuildTimeActionBuildItem`
 <2> `BuildTimeActionBuildItem` is automatically scoped with your extension namespace
-<3> The method name (that can be called from js in the same way as any json-rpc service) is `generateManifests`
+<3> Here we add an action, that is the same as a request-response method. The method name (that can be called from js in the same way as any json-rpc service) is `generateManifests`. 
 
-===== Dev UI Log
+You can also return a `CompletableFuture`/`CompletionStage` as an action, and if you want to stream data you need to use `addSubscription` (rather than `addAction`) and return a `Flow.Publisher`.
+
+=== Dev UI Log
 
 When running a local application using the `999-SNAPSHOT` version, the Dev UI will show a `Dev UI` Log in the footer. This is useful for debugging all JSON RPC messages flowing between the browser and the Quarkus app.
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -207,6 +207,7 @@ public class BuildTimeContentProcessor {
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
 
         List<String> methodNames = new ArrayList<>();
+        List<String> subscriptionNames = new ArrayList<>();
         for (BuildTimeActionBuildItem actions : buildTimeActions) {
             String extensionPathName = actions.getExtensionPathName(curateOutcomeBuildItem);
             for (BuildTimeAction bta : actions.getActions()) {
@@ -214,9 +215,14 @@ public class BuildTimeContentProcessor {
                 DevConsoleManager.register(fullName, bta.getAction());
                 methodNames.add(fullName);
             }
+            for (BuildTimeAction bts : actions.getSubscriptions()) {
+                String fullName = extensionPathName + "." + bts.getMethodName();
+                DevConsoleManager.register(fullName, bts.getAction());
+                subscriptionNames.add(fullName);
+            }
         }
 
-        return new DeploymentMethodBuildItem(methodNames);
+        return new DeploymentMethodBuildItem(methodNames, subscriptionNames);
     }
 
     private Map<String, Object> getBuildTimeDataForPage(AbstractPageBuildItem pageBuildItem) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DeploymentMethodBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DeploymentMethodBuildItem.java
@@ -10,9 +10,11 @@ import io.quarkus.builder.item.SimpleBuildItem;
 public final class DeploymentMethodBuildItem extends SimpleBuildItem {
 
     private final List<String> methods;
+    private final List<String> subscriptions;
 
-    public DeploymentMethodBuildItem(List<String> methods) {
+    public DeploymentMethodBuildItem(List<String> methods, List<String> subscriptions) {
         this.methods = methods;
+        this.subscriptions = subscriptions;
     }
 
     public List<String> getMethods() {
@@ -21,5 +23,13 @@ public final class DeploymentMethodBuildItem extends SimpleBuildItem {
 
     public boolean hasMethods() {
         return this.methods != null && !this.methods.isEmpty();
+    }
+
+    public List<String> getSubscriptions() {
+        return this.subscriptions;
+    }
+
+    public boolean hasSubscriptions() {
+        return this.subscriptions != null && !this.subscriptions.isEmpty();
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -379,6 +379,10 @@ public class DevUIProcessor {
             requestResponseMethods.addAll(deploymentMethodBuildItem.getMethods());
         }
 
+        if (deploymentMethodBuildItem.hasSubscriptions()) {
+            subscriptionMethods.addAll(deploymentMethodBuildItem.getSubscriptions());
+        }
+
         if (!extensionMethodsMap.isEmpty()) {
             jsonRPCMethodsProvider.produce(new JsonRPCRuntimeMethodsBuildItem(extensionMethodsMap));
         }
@@ -409,7 +413,8 @@ public class DevUIProcessor {
 
             DevConsoleManager.setGlobal(DevUIRecorder.DEV_MANAGER_GLOBALS_JSON_MAPPER_FACTORY,
                     JsonMapper.Factory.deploymentLinker().createLinkData(new DevUIDatabindCodec.Factory()));
-            recorder.createJsonRpcRouter(beanContainer.getValue(), extensionMethodsMap, deploymentMethodBuildItem.getMethods());
+            recorder.createJsonRpcRouter(beanContainer.getValue(), extensionMethodsMap, deploymentMethodBuildItem.getMethods(),
+                    deploymentMethodBuildItem.getSubscriptions());
         }
     }
 

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
@@ -13,6 +13,7 @@ import io.quarkus.devui.spi.AbstractDevUIBuildItem;
 public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
 
     private final List<BuildTimeAction> actions = new ArrayList<>();
+    private final List<BuildTimeAction> subscriptions = new ArrayList<>();
 
     public BuildTimeActionBuildItem() {
         super();
@@ -33,5 +34,18 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
 
     public List<BuildTimeAction> getActions() {
         return actions;
+    }
+
+    public void addSubscription(BuildTimeAction buildTimeAction) {
+        this.subscriptions.add(buildTimeAction);
+    }
+
+    public <T> void addSubscription(String methodName,
+            Function<Map<String, String>, T> action) {
+        this.addSubscription(new BuildTimeAction(methodName, action));
+    }
+
+    public List<BuildTimeAction> getSubscriptions() {
+        return subscriptions;
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
@@ -46,10 +46,11 @@ public class DevUIRecorder {
 
     public void createJsonRpcRouter(BeanContainer beanContainer,
             Map<String, Map<JsonRpcMethodName, JsonRpcMethod>> extensionMethodsMap,
-            List<String> deploymentMethods) {
+            List<String> deploymentMethods,
+            List<String> deploymentSubscriptions) {
         JsonRpcRouter jsonRpcRouter = beanContainer.beanInstance(JsonRpcRouter.class);
         jsonRpcRouter.populateJsonRPCRuntimeMethods(extensionMethodsMap);
-        jsonRpcRouter.setJsonRPCDeploymentMethods(deploymentMethods);
+        jsonRpcRouter.setJsonRPCDeploymentActions(deploymentMethods, deploymentSubscriptions);
         jsonRpcRouter.initializeCodec(createJsonMapper());
     }
 


### PR DESCRIPTION
This allows extension developers to use Flow.publisher returns in Build time action methods in Dev UI. Allowing streaming data from the deployment classpath.