### PR TITLE
mtls-certificates: Fail on transport, not network level (wrong port)

### DIFF
--- a/integration-tests/mtls-certificates/src/main/resources/application.properties
+++ b/integration-tests/mtls-certificates/src/main/resources/application.properties
@@ -4,5 +4,4 @@ quarkus.http.ssl.certificate.trust-store-file=server-truststore.p12
 quarkus.http.ssl.certificate.trust-store-password=password
 quarkus.http.ssl.client-auth=REQUIRED
 quarkus.http.auth.certificate-role-properties=cn-role-mappings.txt
-quarkus.native.additional-build-args=-H:IncludeResources=.*\\.p12,-H:IncludeResources=.*\\.txt
-
+quarkus.native.resources.includes=*.p12,*.txt


### PR DESCRIPTION
fixes #40553

The test had been reporting a false negative in HotSpot mode by expecting ConnectException. That exception was not caused by a failed handshake, it was caused by the test trying to talk to the server on a wrong port.

In Native mode, the test framework had the port correct, so it talked to the server and got the correct SSLHandshakeException.

From JDK doc:

> java.net.ConnectException
> Signals that an error occurred while attempting to connect a socket to a remote address and port.
> Typically, the connection was refused remotely (e. g., no process is listening on the remote address/ port).

> javax.net.ssl.SSLHandshakeException
> Indicates that the client and server could not negotiate the desired level of security.
> The connection is no longer usable.

It makes no sense to test a connection refused error on a port nobody listens on. The correct test is to try to trigger a handshake exception while talking to the actual server.
