### PR TITLE
Allow extensions to contribute actions to the error page

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ErrorPageAction.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ErrorPageAction.java
@@ -1,0 +1,5 @@
+package io.quarkus.runtime;
+
+public record ErrorPageAction(String name, String url) {
+
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/TemplateHtmlBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/TemplateHtmlBuilder.java
@@ -115,6 +115,7 @@ public class TemplateHtmlBuilder {
             + "<header>\n" +
             "    <div class=\"exception-message\">\n" +
             "        <h2 class=\"container\">%2$s</h2>\n" +
+            "        <div class=\"actions\">%3$s</div>\n" +
             "    </div>\n" +
             "</header>\n" +
             "<div class=\"container content\">\n";
@@ -176,25 +177,37 @@ public class TemplateHtmlBuilder {
     private String baseUrl;
 
     public TemplateHtmlBuilder(String title, String subTitle, String details) {
-        this(null, title, subTitle, details, null, Collections.emptyList());
+        this(null, title, subTitle, details, Collections.emptyList(), null, Collections.emptyList());
     }
 
-    public TemplateHtmlBuilder(String baseUrl, String title, String subTitle, String details) {
-        this(baseUrl, title, subTitle, details, null, Collections.emptyList());
+    public TemplateHtmlBuilder(String title, String subTitle, String details, List<ErrorPageAction> actions) {
+        this(null, title, subTitle, details, actions, null, Collections.emptyList());
     }
 
-    public TemplateHtmlBuilder(String title, String subTitle, String details, String redirect,
+    public TemplateHtmlBuilder(String baseUrl, String title, String subTitle, String details, List<ErrorPageAction> actions) {
+        this(baseUrl, title, subTitle, details, actions, null, Collections.emptyList());
+    }
+
+    public TemplateHtmlBuilder(String title, String subTitle, String details, List<ErrorPageAction> actions, String redirect,
             List<CurrentConfig> config) {
-        this(null, title, subTitle, details, null, Collections.emptyList());
+        this(null, title, subTitle, details, actions, null, Collections.emptyList());
     }
 
-    public TemplateHtmlBuilder(String baseUrl, String title, String subTitle, String details, String redirect,
+    public TemplateHtmlBuilder(String baseUrl, String title, String subTitle, String details, List<ErrorPageAction> actions,
+            String redirect,
             List<CurrentConfig> config) {
         this.baseUrl = baseUrl;
+
         loadCssFile();
+
+        StringBuilder actionLinks = new StringBuilder();
+        for (ErrorPageAction epa : actions) {
+            actionLinks.append(buildLink(epa.name(), epa.url()));
+        }
+
         result = new StringBuilder(String.format(HTML_TEMPLATE_START, escapeHtml(title),
                 subTitle == null || subTitle.isEmpty() ? "" : " - " + escapeHtml(subTitle), CSS));
-        result.append(String.format(HEADER_TEMPLATE, escapeHtml(title), escapeHtml(details)));
+        result.append(String.format(HEADER_TEMPLATE, escapeHtml(title), escapeHtml(details), actionLinks.toString()));
         if (!config.isEmpty()) {
             result.append(String.format(CONFIG_EDITOR_HEAD, redirect));
             for (CurrentConfig i : config) {
@@ -378,5 +391,9 @@ public class TemplateHtmlBuilder {
                 throw new UncheckedIOException(e);
             }
         }
+    }
+
+    private String buildLink(String name, String url) {
+        return "<a href=" + url + ">" + name + "</a>";
     }
 }

--- a/core/runtime/src/main/resources/META-INF/template-html-builder.css
+++ b/core/runtime/src/main/resources/META-INF/template-html-builder.css
@@ -34,6 +34,25 @@ ul {
 .exception-message {
     background: #960031;
     font-size: 1.5rem;
+    display: flex;
+    align-items: center;
+    padding-right: 50px;
+}
+
+.actions {
+    font-size: 1.1rem;
+    display: flex;
+    gap: 10px;
+}
+
+.actions a {
+
+    padding: 1px 6px;
+    border: 1px outset #180011;
+    border-radius: 4px;
+    color: white !important;
+    background-color: #041437;
+    text-decoration: none !important;
 }
 
 h1, h2 {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ErrorPageActionsBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ErrorPageActionsBuildItem.java
@@ -1,0 +1,29 @@
+package io.quarkus.vertx.http.deployment;
+
+import java.util.List;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.runtime.ErrorPageAction;
+
+/**
+ * Allows extensions to contribute an action (button) to the error page
+ */
+public final class ErrorPageActionsBuildItem extends MultiBuildItem {
+    private final List<ErrorPageAction> actions;
+
+    public ErrorPageActionsBuildItem(String name, String url) {
+        this(new ErrorPageAction(name, url));
+    }
+
+    public ErrorPageActionsBuildItem(ErrorPageAction errorPageAction) {
+        this(List.of(errorPageAction));
+    }
+
+    public ErrorPageActionsBuildItem(List<ErrorPageAction> errorPageAction) {
+        this.actions = errorPageAction;
+    }
+
+    public List<ErrorPageAction> getActions() {
+        return actions;
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -54,6 +54,7 @@ import io.quarkus.dev.spi.HotReplacementContext;
 import io.quarkus.netty.runtime.virtual.VirtualAddress;
 import io.quarkus.netty.runtime.virtual.VirtualChannel;
 import io.quarkus.netty.runtime.virtual.VirtualServerChannel;
+import io.quarkus.runtime.ErrorPageAction;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.LiveReloadConfig;
 import io.quarkus.runtime.QuarkusBindException;
@@ -377,7 +378,8 @@ public class VertxHttpRecorder {
             LaunchMode launchMode, BooleanSupplier[] requireBodyHandlerConditions,
             Handler<RoutingContext> bodyHandler,
             GracefulShutdownFilter gracefulShutdownFilter, ShutdownConfig shutdownConfig,
-            Executor executor) {
+            Executor executor,
+            List<ErrorPageAction> actions) {
         HttpConfiguration httpConfiguration = this.httpConfiguration.getValue();
         // install the default route at the end
         Router httpRouteRouter = httpRouterRuntimeValue.getValue();
@@ -415,8 +417,7 @@ public class VertxHttpRecorder {
         applyCompression(httpBuildTimeConfig.enableCompression, httpRouteRouter);
         httpRouteRouter.route().last().failureHandler(
                 new QuarkusErrorHandler(launchMode.isDevOrTest(), decorateStacktrace(launchMode, httpConfiguration),
-                        httpConfiguration.unhandledErrorContentTypeDefault));
-
+                        httpConfiguration.unhandledErrorContentTypeDefault, actions));
         for (BooleanSupplier requireBodyHandlerCondition : requireBodyHandlerConditions) {
             if (requireBodyHandlerCondition.getAsBoolean()) {
                 //if this is set then everything needs the body handler installed
@@ -535,7 +536,7 @@ public class VertxHttpRecorder {
 
             mr.route().last().failureHandler(
                     new QuarkusErrorHandler(launchMode.isDevOrTest(), decorateStacktrace(launchMode, httpConfiguration),
-                            httpConfiguration.unhandledErrorContentTypeDefault));
+                            httpConfiguration.unhandledErrorContentTypeDefault, actions));
 
             mr.route().order(RouteConstants.ROUTE_ORDER_BODY_HANDLER_MANAGEMENT)
                     .handler(createBodyHandlerForManagementInterface());

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ReplacementDebugPage.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ReplacementDebugPage.java
@@ -64,7 +64,7 @@ public class ReplacementDebugPage {
         }
 
         TemplateHtmlBuilder builder = new TemplateHtmlBuilder("Error restarting Quarkus", exception.getClass().getName(),
-                generateHeaderMessage(exception), currentUri, toEdit);
+                generateHeaderMessage(exception), List.of(), currentUri, toEdit);
         builder.stack(exception);
         return builder.toString();
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ResourceNotFoundData.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ResourceNotFoundData.java
@@ -75,7 +75,7 @@ public class ResourceNotFoundData {
 
         List<RouteDescription> combinedRoutes = getCombinedRoutes();
         TemplateHtmlBuilder builder = new TemplateHtmlBuilder(this.baseUrl,
-                HEADING, "", "Resources overview");
+                HEADING, "", "Resources overview", List.of());
 
         builder.resourcesStart(RESOURCE_ENDPOINTS);
 


### PR DESCRIPTION
This will allow extension to contribute actions to the error page. For example, chappie can add a link that will navigate to the Dev UI Screen that can help solve the exception

![image](https://github.com/user-attachments/assets/aa3fe40d-1361-42a7-985d-f39fb606019b)
