### PR TITLE
Rename suggested extensions in "Consider adding ..." warning messages

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/QuarkusClientEndpointIndexer.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/QuarkusClientEndpointIndexer.java
@@ -69,7 +69,7 @@ public class QuarkusClientEndpointIndexer extends ClientEndpointIndexer {
     protected void logMissingJsonWarning(MethodInfo info) {
         LOGGER.warnf("Quarkus detected the use of JSON in REST Client method '" + info.declaringClass().name() + "#"
                 + info.name()
-                + "' but no JSON extension has been added. Consider adding 'quarkus-rest-client-reactive-jackson' (recommended) or 'quarkus-rest-client-reactive-jsonb'.");
+                + "' but no JSON extension has been added. Consider adding 'quarkus-rest-client-jackson' (recommended) or 'quarkus-rest-client-jsonb'.");
     }
 
     @Override

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/spi/JsonMissingMessageBodyReaderErrorMessageContextualizer.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/spi/JsonMissingMessageBodyReaderErrorMessageContextualizer.java
@@ -9,7 +9,7 @@ public class JsonMissingMessageBodyReaderErrorMessageContextualizer implements
     @Override
     public String provideContextMessage(Input input) {
         if ((input.mediaType() != null) && input.mediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)) {
-            return "Consider adding one the 'quarkus-rest-client-reactive-jackson' or 'quarkus-rest-client-reactive-jsonb' extensions";
+            return "Consider adding one the 'quarkus-rest-client-jackson' or 'quarkus-rest-client-jsonb' extensions";
         }
         return null;
     }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/spi/XmlMissingMessageBodyReaderErrorMessageContextualizer.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/spi/XmlMissingMessageBodyReaderErrorMessageContextualizer.java
@@ -9,7 +9,7 @@ public class XmlMissingMessageBodyReaderErrorMessageContextualizer implements
     @Override
     public String provideContextMessage(Input input) {
         if ((input.mediaType() != null) && input.mediaType().isCompatible(MediaType.APPLICATION_XML_TYPE)) {
-            return "Consider adding the 'quarkus-rest-client-reactive-jaxb' extension";
+            return "Consider adding the 'quarkus-rest-client-jaxb' extension";
         }
         return null;
     }


### PR DESCRIPTION
When suggesting to install missing extensions, some error messages from [quarkus-rest-client](https://quarkus.io/extensions/io.quarkus/quarkus-rest-client/) and [quarkus-rest-client-jaxrs](https://quarkus.io/extensions/io.quarkus/quarkus-rest-client-jaxrs/) still use the old names, predating the [Big Reactive Rename](https://quarkus.io/blog/quarkus-3-9-1-released/) in [3.9](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9):

- quarkus-rest-client-reactive-jackson
- quarkus-rest-client-reactive-jsonb
- quarkus-rest-client-reactive-jaxb

This uses the new names in the "Consider adding ..." error messages from the contextualizers.