### PR TITLE
toplevel class can't have static

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -821,7 +821,7 @@ Let’s consider the following client endpoint:
 [source, java]
 ----
 @WebSocketClient(path = "/endpoint/{name}")
-public static class ClientEndpoint {
+public class ClientEndpoint {
 
     @OnTextMessage
     void onMessage(@PathParam String name, String message, WebSocketClientConnection connection) {


### PR DESCRIPTION
if pasting the code into toplevel class you end up with error so removing it from the client endpoint