### PR TITLE
Manage opentelemetry-semconv-incubating

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6443,16 +6443,6 @@
                 <groupId>io.opentelemetry.semconv</groupId>
                 <artifactId>opentelemetry-semconv</artifactId>
                 <version>${opentelemetry-semconv.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.opentelemetry</groupId>
-                        <artifactId>opentelemetry-bom</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.opentelemetry</groupId>
-                        <artifactId>opentelemetry-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry.semconv</groupId>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6454,6 +6454,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.semconv</groupId>
+                <artifactId>opentelemetry-semconv-incubating</artifactId>
+                <version>${opentelemetry-semconv.version}</version>
+            </dependency>
 
             <!-- JDK Flight Recorder -->
             <dependency>


### PR DESCRIPTION
Needed to avoid convergence conflicts in Quarkus CXF - see 

```
Error: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce) on project quarkus-cxf-integration-tracing-opentelemetry: 
Error:  Rule 1: org.apache.maven.enforcer.rules.dependency.DependencyConvergence failed with message:
Error:  Failed while enforcing releasability.
Error:  
Error:  Dependency convergence error for io.opentelemetry.semconv:opentelemetry-semconv-incubating:jar:1.26.0-alpha paths to dependency are:
Error:  +-io.quarkiverse.cxf:quarkus-cxf-integration-tracing-opentelemetry:jar:3.13.1-SNAPSHOT
Error:    +-org.apache.cxf:cxf-integration-tracing-opentelemetry:jar:4.0.5:compile
Error:      +-io.opentelemetry.semconv:opentelemetry-semconv-incubating:jar:1.26.0-alpha:compile
Error:  and
Error:  +-io.quarkiverse.cxf:quarkus-cxf-integration-tracing-opentelemetry:jar:3.13.1-SNAPSHOT
Error:    +-io.quarkus:quarkus-opentelemetry:jar:3.13.0:compile
Error:      +-io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations-support:jar:2.5.0-alpha:compile
Error:        +-io.opentelemetry.semconv:opentelemetry-semconv-incubating:jar:1.25.0-alpha:compile
Error:  -> [Help 1]
```