### PR TITLE
WebSockets Next client: support string params for connector.baseUri()

### DIFF
--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/BasicConnectorTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/BasicConnectorTest.java
@@ -47,7 +47,7 @@ public class BasicConnectorTest {
     @Test
     void testClient() throws InterruptedException {
 
-        assertThrows(NullPointerException.class, () -> connector.baseUri(null));
+        assertThrows(IllegalArgumentException.class, () -> connector.baseUri("foo\\"));
         assertThrows(NullPointerException.class, () -> connector.path(null));
         assertThrows(NullPointerException.class, () -> connector.addHeader(null, "foo"));
         assertThrows(NullPointerException.class, () -> connector.addHeader("foo", null));

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientAutoPingIntervalTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/ClientAutoPingIntervalTest.java
@@ -37,7 +37,7 @@ public class ClientAutoPingIntervalTest {
 
     @Test
     public void testPingPong() throws InterruptedException, ExecutionException {
-        connector.baseUri(uri).connectAndAwait();
+        connector.baseUri(uri.toString()).connectAndAwait();
         // Ping messages are sent automatically
         assertTrue(ClientEndpoint.PONG.await(5, TimeUnit.SECONDS));
     }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
@@ -40,6 +40,16 @@ public interface BasicWebSocketConnector {
     BasicWebSocketConnector baseUri(URI uri);
 
     /**
+     * Set the base URI.
+     *
+     * @param baseUri
+     * @return self
+     */
+    default BasicWebSocketConnector baseUri(String baseUri) {
+        return baseUri(URI.create(baseUri));
+    }
+
+    /**
      * Set the path that should be appended to the path of the URI set by {@link #baseUri(URI)}.
      * <p>
      * The path may contain path parameters as defined by {@link WebSocketClient#path()}. In this case, the

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnector.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnector.java
@@ -28,6 +28,16 @@ public interface WebSocketConnector<CLIENT> {
     WebSocketConnector<CLIENT> baseUri(URI baseUri);
 
     /**
+     * Set the base URI.
+     *
+     * @param baseUri
+     * @return self
+     */
+    default WebSocketConnector<CLIENT> baseUri(String baseUri) {
+        return baseUri(URI.create(baseUri));
+    }
+
+    /**
      * Set the path param.
      * <p>
      * The value is encoded using {@link URLEncoder#encode(String, java.nio.charset.Charset)} before it's used to build the


### PR DESCRIPTION
- resolves #42182