### PR TITLE
Upload build stats to collector using ubuntu

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1184,7 +1184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.native_matrix) }}
-    runs-on: ${{matrix.os-name}}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Using windows seems uneccessary and also results in failures due to curl
returning exit code 43 (see https://github.com/quarkusio/quarkus/actions/runs/10140736665/job/28040962008)
