### PR TITLE
Enable comments (reasons) in the generated reflect-config.json and improve hierarchical registration tracing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CollectionClassProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CollectionClassProcessor.java
@@ -8,13 +8,13 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 public class CollectionClassProcessor {
     @BuildStep
     ReflectiveClassBuildItem setupCollectionClasses() {
-        return ReflectiveClassBuildItem.builder(ArrayList.class.getName(),
-                HashMap.class.getName(),
-                HashSet.class.getName(),
-                LinkedList.class.getName(),
-                LinkedHashMap.class.getName(),
-                LinkedHashSet.class.getName(),
-                TreeMap.class.getName(),
-                TreeSet.class.getName()).build();
+        return ReflectiveClassBuildItem.builder(ArrayList.class,
+                HashMap.class,
+                HashSet.class,
+                LinkedList.class,
+                LinkedHashMap.class,
+                LinkedHashSet.class,
+                TreeMap.class,
+                TreeSet.class).reason(getClass().getName()).build();
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/SecureRandomProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/SecureRandomProcessor.java
@@ -9,7 +9,9 @@ public class SecureRandomProcessor {
     @BuildStep
     void registerReflectiveMethods(BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods) {
         // Called reflectively through java.security.SecureRandom.SecureRandom()
-        reflectiveMethods.produce(new ReflectiveMethodBuildItem("sun.security.provider.NativePRNG", "<init>",
+        reflectiveMethods.produce(new ReflectiveMethodBuildItem(
+                getClass().getName(),
+                "sun.security.provider.NativePRNG", "<init>",
                 java.security.SecureRandomParameters.class));
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -24,6 +24,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private final boolean weak;
     private final boolean serialization;
     private final boolean unsafeAllocated;
+    private final String reason;
 
     public static Builder builder(Class<?>... classes) {
         String[] classNames = stream(classes)
@@ -43,10 +44,10 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     }
 
     private ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
-            boolean fields, boolean getClasses, boolean weak, boolean serialization,
-            boolean unsafeAllocated, Class<?>... classes) {
+            boolean fields, boolean getClasses, boolean weak, boolean serialization, boolean unsafeAllocated, String reason,
+            Class<?>... classes) {
         this(constructors, queryConstructors, methods, queryMethods, fields, getClasses, weak, serialization,
-                unsafeAllocated, stream(classes).map(Class::getName).toArray(String[]::new));
+                unsafeAllocated, reason, stream(classes).map(Class::getName).toArray(String[]::new));
     }
 
     /**
@@ -64,7 +65,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
      */
     @Deprecated(since = "3.0", forRemoval = true)
     public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, Class<?>... classes) {
-        this(constructors, false, methods, false, fields, false, false, false, false, classes);
+        this(constructors, false, methods, false, fields, false, false, false, false, null, classes);
     }
 
     /**
@@ -118,12 +119,12 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
             boolean fields, boolean weak, boolean serialization,
             boolean unsafeAllocated, String... className) {
         this(constructors, queryConstructors, methods, queryMethods, fields, false, weak, serialization, unsafeAllocated,
-                className);
+                null, className);
     }
 
     ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
             boolean fields, boolean classes, boolean weak, boolean serialization,
-            boolean unsafeAllocated, String... className) {
+            boolean unsafeAllocated, String reason, String... className) {
         for (String i : className) {
             if (i == null) {
                 throw new NullPointerException();
@@ -153,6 +154,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this.weak = weak;
         this.serialization = serialization;
         this.unsafeAllocated = unsafeAllocated;
+        this.reason = reason;
     }
 
     public List<String> getClassNames() {
@@ -204,6 +206,10 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         return unsafeAllocated;
     }
 
+    public String getReason() {
+        return reason;
+    }
+
     public static class Builder {
         private String[] className;
         private boolean constructors = true;
@@ -215,6 +221,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         private boolean weak;
         private boolean serialization;
         private boolean unsafeAllocated;
+        private String reason;
 
         private Builder() {
         }
@@ -341,13 +348,18 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
             return this;
         }
 
+        public Builder reason(String reason) {
+            this.reason = reason;
+            return this;
+        }
+
         public Builder unsafeAllocated() {
             return unsafeAllocated(true);
         }
 
         public ReflectiveClassBuildItem build() {
             return new ReflectiveClassBuildItem(constructors, queryConstructors, methods, queryMethods, fields, classes, weak,
-                    serialization, unsafeAllocated, className);
+                    serialization, unsafeAllocated, reason, className);
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveFieldBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveFieldBuildItem.java
@@ -10,13 +10,24 @@ public final class ReflectiveFieldBuildItem extends MultiBuildItem {
 
     final String declaringClass;
     final String name;
+    final String reason;
 
-    public ReflectiveFieldBuildItem(FieldInfo field) {
+    public ReflectiveFieldBuildItem(String reason, FieldInfo field) {
+        this.reason = reason;
         this.name = field.name();
         this.declaringClass = field.declaringClass().name().toString();
     }
 
+    public ReflectiveFieldBuildItem(FieldInfo field) {
+        this(null, field);
+    }
+
     public ReflectiveFieldBuildItem(Field field) {
+        this(null, field);
+    }
+
+    public ReflectiveFieldBuildItem(String reason, Field field) {
+        this.reason = reason;
         this.name = field.getName();
         this.declaringClass = field.getDeclaringClass().getName();
     }
@@ -27,5 +38,9 @@ public final class ReflectiveFieldBuildItem extends MultiBuildItem {
 
     public String getName() {
         return name;
+    }
+
+    public String getReason() {
+        return reason;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveMethodBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveMethodBuildItem.java
@@ -3,7 +3,6 @@ package io.quarkus.deployment.builditem.nativeimage;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.jboss.jandex.MethodInfo;
 
@@ -58,7 +57,7 @@ public final class ReflectiveMethodBuildItem extends MultiBuildItem {
     }
 
     public ReflectiveMethodBuildItem(boolean queryOnly, String declaringClass, String name,
-                                     String... params) {
+            String... params) {
         this(null, queryOnly, declaringClass, name, params);
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -122,9 +122,10 @@ public class ConfigMappingUtils {
             reflectiveClasses.produce(ReflectiveClassBuildItem.builder(mappingMetadata.getClassName())
                     .reason(ConfigMappingUtils.class.getName())
                     .build());
-            reflectiveMethods
-                    .produce(new ReflectiveMethodBuildItem(mappingMetadata.getClassName(), "getDefaults", new String[0]));
-            reflectiveMethods.produce(new ReflectiveMethodBuildItem(mappingMetadata.getClassName(), "getNames", new String[0]));
+            reflectiveMethods.produce(new ReflectiveMethodBuildItem(ConfigMappingUtils.class.getName(),
+                    mappingMetadata.getClassName(), "getDefaults", new String[0]));
+            reflectiveMethods.produce(new ReflectiveMethodBuildItem(ConfigMappingUtils.class.getName(),
+                    mappingMetadata.getClassName(), "getNames", new String[0]));
 
             configComponentInterfaces.add(mappingMetadata.getInterfaceType());
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -290,7 +290,7 @@ public final class LoggingResourceProcessor {
             if (!discoveredLogComponents.getNameToFilterClass().isEmpty()) {
                 reflectiveClassBuildItemBuildProducer.produce(
                         ReflectiveClassBuildItem.builder(discoveredLogComponents.getNameToFilterClass().values().toArray(
-                                EMPTY_STRING_ARRAY)).build());
+                                EMPTY_STRING_ARRAY)).reason(getClass().getName()).build());
                 serviceProviderBuildItemBuildProducer
                         .produce(ServiceProviderBuildItem.allProvidersFromClassPath(LogFilterFactory.class.getName()));
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -485,6 +485,12 @@ public interface NativeConfig {
     boolean enableDashboardDump();
 
     /**
+     * Include a reasons entries in the generated json configuration files.
+     */
+    @WithDefault("false")
+    boolean includeReasonsInConfigFiles();
+
+    /**
      * Configure native executable compression using UPX.
      */
     Compression compression();

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -157,7 +157,7 @@ public class ConfigGenerationBuildStep {
             method.returnValue(configBuilder);
         }
 
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(builderClassName).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(builderClassName).reason(getClass().getName()).build());
         staticInitConfigBuilder.produce(new StaticInitConfigBuilderBuildItem(builderClassName));
         runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(builderClassName));
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -512,7 +512,7 @@ public class MainClassBuildStep {
      */
     @BuildStep
     ReflectiveClassBuildItem applicationReflection() {
-        return ReflectiveClassBuildItem.builder(Application.APP_CLASS_NAME).build();
+        return ReflectiveClassBuildItem.builder(Application.APP_CLASS_NAME).reason("The generated application class").build();
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
@@ -54,11 +54,13 @@ public class NativeImageReflectConfigStep {
         for (ServiceProviderBuildItem i : serviceProviderBuildItems) {
             for (String provider : i.providers()) {
                 // Register the nullary constructor
-                addReflectiveMethod(reflectiveClasses, new ReflectiveMethodBuildItem("Class registered as provider", provider, "<init>", new String[0]));
+                addReflectiveMethod(reflectiveClasses,
+                        new ReflectiveMethodBuildItem("Class registered as provider", provider, "<init>", new String[0]));
                 // Register public provider() method for lookkup to avoid throwing a MissingReflectionRegistrationError at run time.
                 // See ServiceLoader#loadProvider and ServiceLoader#findStaticProviderMethod.
                 addReflectiveMethod(reflectiveClasses,
-                        new ReflectiveMethodBuildItem("Class registered as provider", true, provider, "provider", new String[0]));
+                        new ReflectiveMethodBuildItem("Class registered as provider", true, provider, "provider",
+                                new String[0]));
             }
         }
 
@@ -233,6 +235,13 @@ public class NativeImageReflectConfigStep {
             reflectiveClasses.put(cl, existing = new ReflectionInfo());
         }
         existing.fieldSet.add(fieldInfo.getName());
+        String reason = fieldInfo.getReason();
+        if (reason != null) {
+            if (existing.reasons == null) {
+                existing.reasons = new HashSet<>();
+            }
+            existing.reasons.add(reason);
+        }
     }
 
     static final class ReflectionInfo {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
@@ -54,11 +54,11 @@ public class NativeImageReflectConfigStep {
         for (ServiceProviderBuildItem i : serviceProviderBuildItems) {
             for (String provider : i.providers()) {
                 // Register the nullary constructor
-                addReflectiveMethod(reflectiveClasses, new ReflectiveMethodBuildItem(provider, "<init>", new String[0]));
+                addReflectiveMethod(reflectiveClasses, new ReflectiveMethodBuildItem("Class registered as provider", provider, "<init>", new String[0]));
                 // Register public provider() method for lookkup to avoid throwing a MissingReflectionRegistrationError at run time.
                 // See ServiceLoader#loadProvider and ServiceLoader#findStaticProviderMethod.
                 addReflectiveMethod(reflectiveClasses,
-                        new ReflectiveMethodBuildItem(true, provider, "provider", new String[0]));
+                        new ReflectiveMethodBuildItem("Class registered as provider", true, provider, "provider", new String[0]));
             }
         }
 
@@ -174,6 +174,13 @@ public class NativeImageReflectConfigStep {
             } else {
                 existing.methodSet.add(methodInfo);
             }
+        }
+        String reason = methodInfo.getReason();
+        if (reason != null) {
+            if (existing.reasons == null) {
+                existing.reasons = new HashSet<>();
+            }
+            existing.reasons.add(reason);
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -136,6 +136,7 @@ public class ReflectiveHierarchyStep {
             Set<DotName> processedReflectiveHierarchies, Map<DotName, Set<String>> unindexedClasses,
             Predicate<ClassInfo> finalFieldsWritable, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             Deque<ReflectiveHierarchyVisitor> visits) {
+        final String newSource = source + " > " + type.name().toString();
         if (type instanceof VoidType ||
                 type instanceof PrimitiveType ||
                 type instanceof UnresolvedTypeVariable ||
@@ -146,20 +147,20 @@ public class ReflectiveHierarchyStep {
                 return;
             }
 
-            addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, source, type.name(),
+            addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, newSource, type.name(),
                     type.name(),
                     processedReflectiveHierarchies, unindexedClasses,
                     finalFieldsWritable, reflectiveClass, visits);
 
             for (ClassInfo subclass : combinedIndexBuildItem.getIndex().getAllKnownSubclasses(type.name())) {
-                addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, source,
+                addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, newSource,
                         subclass.name(),
                         subclass.name(),
                         processedReflectiveHierarchies,
                         unindexedClasses, finalFieldsWritable, reflectiveClass, visits);
             }
             for (ClassInfo subclass : combinedIndexBuildItem.getIndex().getAllKnownImplementors(type.name())) {
-                addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, source,
+                addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, newSource,
                         subclass.name(),
                         subclass.name(),
                         processedReflectiveHierarchies,
@@ -167,13 +168,14 @@ public class ReflectiveHierarchyStep {
             }
         } else if (type instanceof ArrayType) {
             visits.addLast(() -> addReflectiveHierarchy(combinedIndexBuildItem, capabilities,
-                    reflectiveHierarchyBuildItem, source,
+                    reflectiveHierarchyBuildItem, newSource,
                     type.asArrayType().constituent(),
                     processedReflectiveHierarchies,
                     unindexedClasses, finalFieldsWritable, reflectiveClass, visits));
         } else if (type instanceof ParameterizedType) {
             if (!reflectiveHierarchyBuildItem.getIgnoreTypePredicate().test(type.name())) {
-                addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, source, type.name(),
+                addClassTypeHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, newSource,
+                        type.name(),
                         type.name(),
                         processedReflectiveHierarchies,
                         unindexedClasses, finalFieldsWritable, reflectiveClass, visits);
@@ -181,7 +183,8 @@ public class ReflectiveHierarchyStep {
             final ParameterizedType parameterizedType = (ParameterizedType) type;
             for (Type typeArgument : parameterizedType.arguments()) {
                 visits.addLast(
-                        () -> addReflectiveHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem, source,
+                        () -> addReflectiveHierarchy(combinedIndexBuildItem, capabilities, reflectiveHierarchyBuildItem,
+                                newSource,
                                 typeArgument,
                                 processedReflectiveHierarchies,
                                 unindexedClasses, finalFieldsWritable, reflectiveClass, visits));

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -228,6 +228,7 @@ public class ReflectiveHierarchyStep {
                         .fields()
                         .classes()
                         .serialization(reflectiveHierarchyBuildItem.isSerialization())
+                        .reason(source)
                         .build());
 
         processedReflectiveHierarchies.add(name);

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
@@ -226,6 +226,11 @@ public class TestNativeConfig implements NativeConfig {
     }
 
     @Override
+    public boolean includeReasonsInConfigFiles() {
+        return false;
+    }
+
+    @Override
     public Compression compression() {
         return null;
     }

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -86,6 +86,7 @@ public class AmazonLambdaHttpProcessor {
                         APIGatewayV2HTTPEvent.RequestContext.IAM.class,
                         APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT.class,
                         APIGatewayV2HTTPResponse.class, Headers.class, MultiValuedTreeMap.class)
+                        .reason(getClass().getName())
                         .methods().fields().build());
     }
 

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -87,7 +87,9 @@ public class AmazonLambdaHttpProcessor {
                         CognitoAuthorizerClaims.class,
                         ErrorModel.class,
                         Headers.class,
-                        MultiValuedTreeMap.class).methods().fields().build());
+                        MultiValuedTreeMap.class)
+                        .reason(getClass().getName())
+                        .methods().fields().build());
     }
 
     /**

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -142,6 +142,7 @@ public final class AmazonLambdaProcessor {
         additionalBeanBuildItemBuildProducer.produce(builder.build());
         reflectiveClassBuildItemBuildProducer
                 .produce(ReflectiveClassBuildItem.builder(FunctionError.class).methods().fields()
+                        .reason(getClass().getName())
                         .build());
         return ret;
     }
@@ -159,7 +160,9 @@ public final class AmazonLambdaProcessor {
         additionalBeanBuildItemBuildProducer.produce(builder.build());
 
         reflectiveClassBuildItemBuildProducer
-                .produce(ReflectiveClassBuildItem.builder(handlerClass).methods().fields().build());
+                .produce(ReflectiveClassBuildItem.builder(handlerClass).methods().fields()
+                        .reason(getClass().getName())
+                        .build());
 
         // TODO
         // This really isn't good enough.  We should recursively add reflection for all method and field types of the parameter
@@ -172,12 +175,16 @@ public final class AmazonLambdaProcessor {
                 if (!parameterTypes[0].equals(Object.class)) {
                     reflectiveClassBuildItemBuildProducer
                             .produce(ReflectiveClassBuildItem.builder(parameterTypes[0].getName())
+                                    .reason(getClass().getName() + " > " + method.getName() + " first parameter type")
                                     .methods().fields().build());
                     reflectiveClassBuildItemBuildProducer
                             .produce(ReflectiveClassBuildItem.builder(method.getReturnType().getName())
+                                    .reason(getClass().getName() + " > " + method.getName() + " return type")
                                     .methods().fields().build());
-                    reflectiveClassBuildItemBuildProducer.produce(ReflectiveClassBuildItem.builder(DateTime.class)
-                            .methods().fields().build());
+                    reflectiveClassBuildItemBuildProducer
+                            .produce(ReflectiveClassBuildItem.builder(DateTime.class)
+                                    .reason(getClass().getName())
+                                    .methods().fields().build());
                     break;
                 }
             }
@@ -313,7 +320,9 @@ public final class AmazonLambdaProcessor {
             AmazonLambdaStaticRecorder recorder) {
         Set<Class<?>> classes = config.expectedExceptions.map(Set::copyOf).orElseGet(Set::of);
         classes.stream()
-                .map(clazz -> ReflectiveClassBuildItem.builder(clazz).constructors(false).build())
+                .map(clazz -> ReflectiveClassBuildItem.builder(clazz).constructors(false)
+                        .reason(getClass().getName() + " expectedExceptions")
+                        .build())
                 .forEach(registerForReflection::produce);
         recorder.setExpectedExceptionClasses(classes);
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -548,7 +548,7 @@ public class ArcProcessor {
 
             @Override
             public void registerField(FieldInfo fieldInfo) {
-                reflectiveFields.produce(new ReflectiveFieldBuildItem(fieldInfo));
+                reflectiveFields.produce(new ReflectiveFieldBuildItem(getClass().getName(), fieldInfo));
             }
 
             @Override

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -556,7 +556,9 @@ public class ArcProcessor {
                 if (reflectiveBeanClassesNames.contains(beanClassName)) {
                     // Fields should never be registered for client proxies
                     reflectiveClasses
-                            .produce(ReflectiveClassBuildItem.builder(clientProxyName).methods().build());
+                            .produce(ReflectiveClassBuildItem.builder(clientProxyName)
+                                    .reason(getClass().getName())
+                                    .methods().build());
                 }
             }
 
@@ -565,7 +567,9 @@ public class ArcProcessor {
                 if (reflectiveBeanClassesNames.contains(beanClassName)) {
                     // Fields should never be registered for subclasses
                     reflectiveClasses
-                            .produce(ReflectiveClassBuildItem.builder(subclassName).methods().build());
+                            .produce(ReflectiveClassBuildItem.builder(subclassName)
+                                    .reason(getClass().getName())
+                                    .methods().build());
                 }
             }
 
@@ -597,13 +601,17 @@ public class ArcProcessor {
         // Register all qualifiers for reflection to support type-safe resolution at runtime in native image
         for (ClassInfo qualifier : beanProcessor.getBeanDeployment().getQualifiers()) {
             reflectiveClasses
-                    .produce(ReflectiveClassBuildItem.builder(qualifier.name().toString()).methods().build());
+                    .produce(ReflectiveClassBuildItem.builder(qualifier.name().toString())
+                            .reason(getClass().getName())
+                            .methods().build());
         }
 
         // Register all interceptor bindings for reflection so that AnnotationLiteral.equals() works in a native image
         for (ClassInfo binding : beanProcessor.getBeanDeployment().getInterceptorBindings()) {
             reflectiveClasses
-                    .produce(ReflectiveClassBuildItem.builder(binding.name().toString()).methods().build());
+                    .produce(ReflectiveClassBuildItem.builder(binding.name().toString())
+                            .reason(getClass().getName())
+                            .methods().build());
         }
     }
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -538,12 +538,12 @@ public class ArcProcessor {
 
             @Override
             public void registerMethod(String declaringClass, String name, String... params) {
-                reflectiveMethods.produce(new ReflectiveMethodBuildItem(declaringClass, name, params));
+                reflectiveMethods.produce(new ReflectiveMethodBuildItem(getClass().getName(), declaringClass, name, params));
             }
 
             @Override
             public void registerMethod(MethodInfo methodInfo) {
-                reflectiveMethods.produce(new ReflectiveMethodBuildItem(methodInfo));
+                reflectiveMethods.produce(new ReflectiveMethodBuildItem(getClass().getName(), methodInfo));
             }
 
             @Override

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -127,7 +127,9 @@ public class ConfigBuildStep {
             if (type.kind() != Kind.ARRAY) {
                 // Implicit converters are most likely used
                 reflectiveClass
-                        .produce(ReflectiveClassBuildItem.builder(type.name().toString()).methods().build());
+                        .produce(ReflectiveClassBuildItem.builder(type.name().toString()).methods()
+                                .reason(getClass().getName() + " Custom config bean")
+                                .build());
             }
             DotName implClazz = type.kind() == Kind.ARRAY ? DotName.createSimple(ConfigBeanCreator.class.getName())
                     : type.name();
@@ -549,7 +551,9 @@ public class ConfigBuildStep {
         List<String> typeArgumentNames = Collections.emptyList();
 
         if (configProperty.getPropertyType().kind() != Kind.PRIMITIVE) {
-            reflectiveClass.produce(ReflectiveClassBuildItem.builder(typeName).build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(typeName)
+                    .reason(ConfigBuildStep.class.getSimpleName() + " Configuration property")
+                    .build());
         }
 
         if (configProperty.getPropertyType().kind() == Kind.PARAMETERIZED_TYPE) {
@@ -558,7 +562,10 @@ public class ConfigBuildStep {
             for (Type argumentType : argumentTypes) {
                 typeArgumentNames.add(argumentType.name().toString());
                 if (argumentType.kind() != Kind.PRIMITIVE) {
-                    reflectiveClass.produce(ReflectiveClassBuildItem.builder(argumentType.name().toString()).build());
+                    reflectiveClass.produce(ReflectiveClassBuildItem.builder(argumentType.name().toString())
+                            .reason(ConfigBuildStep.class.getSimpleName() + " Configuration property's " + typeName
+                                    + " parameter")
+                            .build());
                 }
             }
         }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
@@ -351,7 +351,7 @@ public class InterceptedStaticMethodsProcessor {
                 chainHandle, methodHandle, bindingsHandle, forwardingFunc);
 
         // Needed when running on native image
-        reflectiveMethods.produce(new ReflectiveMethodBuildItem(method));
+        reflectiveMethods.produce(new ReflectiveMethodBuildItem(getClass().getName(), method));
 
         // Call InterceptedStaticMethods.register()
         init.invokeStaticMethod(INTERCEPTED_STATIC_METHODS_REGISTER, init.load(interceptedStaticMethod.getHash()),

--- a/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
+++ b/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
@@ -42,10 +42,13 @@ public class CaffeineProcessor {
         }
         if (!effectiveImplementorNames.isEmpty()) {
             //Do not force registering any Caffeine classes if we can avoid it: there's a significant chain reaction
-            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(CACHE_LOADER_CLASS_NAME).methods().build());
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(CACHE_LOADER_CLASS_NAME)
+                    .reason(getClass().getName())
+                    .methods().build());
 
-            reflectiveClasses.produce(
-                    ReflectiveClassBuildItem.builder(effectiveImplementorNames.toArray(new String[0])).methods().build());
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(effectiveImplementorNames.toArray(new String[0]))
+                    .reason(getClass().getName())
+                    .methods().build());
         }
     }
 

--- a/extensions/elytron-security-common/deployment/src/main/java/io/quarkus/elytron/security/common/deployment/QuarkusSecurityCommonProcessor.java
+++ b/extensions/elytron-security-common/deployment/src/main/java/io/quarkus/elytron/security/common/deployment/QuarkusSecurityCommonProcessor.java
@@ -40,9 +40,8 @@ public class QuarkusSecurityCommonProcessor {
      */
     @BuildStep
     void services(BuildProducer<ReflectiveClassBuildItem> classes) {
-        String[] allClasses = {
-                "org.wildfly.security.password.impl.PasswordFactorySpiImpl",
-        };
-        classes.produce(ReflectiveClassBuildItem.builder(allClasses).methods().build());
+        classes.produce(ReflectiveClassBuildItem.builder("org.wildfly.security.password.impl.PasswordFactorySpiImpl")
+                .reason(getClass().getName())
+                .methods().build());
     }
 }

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayProcessor.java
@@ -86,7 +86,9 @@ class FlywayProcessor {
     @BuildStep
     void reflection(CombinedIndexBuildItem index, BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyProducer) {
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(ConfigurationExtension.class).fields().methods().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(ConfigurationExtension.class)
+                .reason(getClass().getName())
+                .fields().methods().build());
 
         for (ClassInfo configurationExtension : index.getIndex().getAllKnownImplementors(ConfigurationExtension.class)) {
             var extensionName = configurationExtension.name();

--- a/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionScannerBuildStep.java
+++ b/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionScannerBuildStep.java
@@ -108,8 +108,9 @@ public class FunctionScannerBuildStep {
         }
         Set<ClassInfo> withoutDefaultCtor = new HashSet<>();
         for (ClassInfo clazz : classes) {
-            reflectiveClass.produce(ReflectiveClassBuildItem.builder(clazz.name().toString()).methods()
-                    .fields().build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(clazz.name().toString())
+                    .reason(getClass().getName())
+                    .methods().fields().build());
             if (!clazz.hasNoArgsConstructor()) {
                 withoutDefaultCtor.add(clazz);
             }

--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
@@ -54,14 +54,14 @@ public class GrpcCommonProcessor {
         }
 
         // Built-In providers:
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(DnsNameResolverProvider.class).methods()
+        reflectiveClass.produce(ReflectiveClassBuildItem
+                .builder(DnsNameResolverProvider.class, PickFirstLoadBalancerProvider.class, NettyChannelProvider.class)
+                .methods()
+                .reason(getClass().getName() + " built-in provider")
                 .build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(PickFirstLoadBalancerProvider.class)
-                .methods().build());
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider")
+                .reason(getClass().getName() + " built-in provider")
                 .methods().build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(NettyChannelProvider.class).methods()
-                .build());
     }
 
     @BuildStep

--- a/extensions/hal/deployment/src/main/java/io/quarkus/hal/deployment/HalProcessor.java
+++ b/extensions/hal/deployment/src/main/java/io/quarkus/hal/deployment/HalProcessor.java
@@ -20,7 +20,7 @@ public class HalProcessor {
 
     @BuildStep
     ReflectiveClassBuildItem registerReflection() {
-        return ReflectiveClassBuildItem.builder(HalLink.class).methods().fields().build();
+        return ReflectiveClassBuildItem.builder(HalLink.class).reason(getClass().getName()).methods().fields().build();
     }
 
     @BuildStep

--- a/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
+++ b/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.envers.deployment;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -34,18 +35,20 @@ public final class HibernateEnversProcessor {
     @BuildStep
     public void registerEnversReflections(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             HibernateEnversBuildTimeConfig buildTimeConfig) {
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("org.hibernate.envers.DefaultRevisionEntity").methods()
-                .build());
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder("org.hibernate.envers.DefaultTrackingModifiedEntitiesRevisionEntity")
-                        .methods().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(
+                "org.hibernate.envers.DefaultRevisionEntity",
+                "org.hibernate.envers.DefaultTrackingModifiedEntitiesRevisionEntity")
+                .reason(getClass().getName())
+                .methods().build());
 
+        List<String> classes = new ArrayList<>(buildTimeConfig.persistenceUnits().size() * 2);
         for (HibernateEnversBuildTimeConfigPersistenceUnit pu : buildTimeConfig.persistenceUnits().values()) {
-            pu.revisionListener().ifPresent(
-                    s -> reflectiveClass.produce(ReflectiveClassBuildItem.builder(s).methods().fields().build()));
-            pu.auditStrategy().ifPresent(
-                    s -> reflectiveClass.produce(ReflectiveClassBuildItem.builder(s).methods().fields().build()));
+            pu.revisionListener().ifPresent(classes::add);
+            pu.auditStrategy().ifPresent(classes::add);
         }
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(classes.toArray(new String[0]))
+                .reason("Configured Envers listeners and audit strategies")
+                .methods().fields().build());
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -455,4 +455,11 @@ public final class ClassNames {
             createConstant("java.util.UUID"),
             createConstant("java.lang.Void"));
 
+    public static final DotName HIBERNATE_ORM_PROCESSOR = createConstant(
+            "io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor");
+
+    public static final DotName HIBERNATE_USER_TYPE_PROCESSOR = createConstant(
+            "io.quarkus.hibernate.orm.deployment.HibernateUserTypeProcessor");
+
+    public static final DotName GRAAL_VM_FEATURES = createConstant("io.quarkus.hibernate.orm.deployment.GraalVMFeatures");
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/GraalVMFeatures.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/GraalVMFeatures.java
@@ -25,6 +25,7 @@ public class GraalVMFeatures {
     @BuildStep
     ReflectiveClassBuildItem registerGeneratorClassesForReflections() {
         return ReflectiveClassBuildItem.builder(GENERATORS.stream().map(DotName::toString).toArray(String[]::new))
+                .reason(ClassNames.GRAAL_VM_FEATURES.toString())
                 .build();
     }
 
@@ -34,6 +35,7 @@ public class GraalVMFeatures {
     ReflectiveClassBuildItem registerJdbcArrayTypesForReflection() {
         return ReflectiveClassBuildItem
                 .builder(ClassNames.JDBC_JAVA_TYPES.stream().map(d -> d.toString() + "[]").toArray(String[]::new))
+                .reason(ClassNames.GRAAL_VM_FEATURES.toString())
                 .build();
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -473,6 +473,7 @@ public final class HibernateOrmProcessor {
                 annotationClassNames.add(name.toString());
             }
             reflective.produce(ReflectiveClassBuildItem.builder(annotationClassNames.toArray(new String[0]))
+                    .reason(ClassNames.HIBERNATE_ORM_PROCESSOR.toString())
                     .methods().fields().build());
             for (String annotationClassName : annotationClassNames) {
                 proxyDefinitions.produce(new NativeImageProxyDefinitionBuildItem(annotationClassName));
@@ -744,8 +745,9 @@ public final class HibernateOrmProcessor {
                     .map(a -> a.target().asClass().name().toString())
                     .toArray(String[]::new);
 
-            reflective.produce(
-                    ReflectiveClassBuildItem.builder(metamodel).constructors(false).fields().build());
+            reflective.produce(ReflectiveClassBuildItem.builder(metamodel)
+                    .reason(ClassNames.HIBERNATE_ORM_PROCESSOR.toString())
+                    .constructors(false).fields().build());
         }
     }
 
@@ -769,8 +771,9 @@ public final class HibernateOrmProcessor {
                 .forEach(classes::add);
 
         if (!classes.isEmpty()) {
-            reflective.produce(ReflectiveClassBuildItem.builder(classes.toArray(new String[0])).constructors(false)
-                    .methods().build());
+            reflective.produce(ReflectiveClassBuildItem.builder(classes.toArray(new String[0]))
+                    .reason(ClassNames.HIBERNATE_ORM_PROCESSOR.toString())
+                    .constructors(false).methods().build());
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateUserTypeProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateUserTypeProcessor.java
@@ -43,8 +43,9 @@ public final class HibernateUserTypeProcessor {
         }
 
         if (!userTypes.isEmpty()) {
-            reflectiveClass.produce(
-                    ReflectiveClassBuildItem.builder(userTypes.toArray(new String[] {})).methods().fields().build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(userTypes.toArray(new String[] {}))
+                    .reason(ClassNames.HIBERNATE_USER_TYPE_PROCESSOR.toString())
+                    .methods().fields().build());
         }
     }
 

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -113,7 +113,7 @@ class HibernateSearchElasticsearchProcessor {
                     configuredPersistenceUnits, staticIntegrations, runtimeIntegrations);
         }
 
-        registerReflectionForGson(reflectiveClass);
+        reflectiveClass.produce(registerReflectionForGson());
     }
 
     private static Map<String, Map<String, Set<String>>> collectPersistenceUnitAndBackendAndIndexNamesForSearchExtensions(
@@ -374,9 +374,11 @@ class HibernateSearchElasticsearchProcessor {
         hotDeploymentWatchedFiles.produce(new HotDeploymentWatchedFileBuildItem(classpathFile));
     }
 
-    private void registerReflectionForGson(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+    private ReflectiveClassBuildItem registerReflectionForGson() {
         String[] reflectiveClasses = GsonClasses.typesRequiringReflection().toArray(String[]::new);
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(reflectiveClasses).methods().fields().build());
+        return ReflectiveClassBuildItem.builder(reflectiveClasses)
+                .reason(getClass().getName())
+                .methods().fields().build();
     }
 
     @BuildStep(onlyIfNot = IsNormal.class)

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -35,7 +35,9 @@ class HibernateSearchOutboxPollingProcessor {
         String[] avroTypes = HibernateOrmMapperOutboxPollingClasses.avroTypes().toArray(String[]::new);
         additionalIndexedClasses.produce(new AdditionalIndexedClassesBuildItem(avroTypes));
         String[] hibernateOrmTypes = HibernateOrmMapperOutboxPollingClasses.hibernateOrmTypes().toArray(String[]::new);
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(hibernateOrmTypes).methods().fields().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(hibernateOrmTypes)
+                .reason(getClass().getName())
+                .methods().fields().build());
         for (String className : hibernateOrmTypes) {
             additionalJpaModel.produce(new AdditionalJpaModelBuildItem(className));
         }

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneProcessor.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneProcessor.java
@@ -253,7 +253,9 @@ class HibernateSearchStandaloneProcessor {
 
     private void registerReflectionForGson(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         String[] reflectiveClasses = GsonClasses.typesRequiringReflection().toArray(String[]::new);
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(reflectiveClasses).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(reflectiveClasses)
+                .reason(getClass().getName())
+                .methods().fields().build());
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -309,8 +309,10 @@ class HibernateValidatorProcessor {
                     .map(DotName::createSimple)
                     .forEach(configComponentsInterfacesToRegisterForReflection::add);
         }
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(
-                configComponentsInterfacesToRegisterForReflection.stream().map(DotName::toString).toArray(String[]::new))
+        reflectiveClass.produce(ReflectiveClassBuildItem
+                .builder(configComponentsInterfacesToRegisterForReflection.stream().map(DotName::toString)
+                        .toArray(String[]::new))
+                .reason(getClass().getName())
                 .methods().build());
 
         String builderClassName = HibernateBeanValidationConfigValidator.class.getName() + "Builder";
@@ -634,8 +636,9 @@ class HibernateValidatorProcessor {
         exceptionMapperProducer.produce(new ExceptionMapperBuildItem(ResteasyReactiveViolationExceptionMapper.class.getName(),
                 ValidationException.class.getName(), Priorities.USER + 1, true));
         reflectiveClassProducer.produce(
-                ReflectiveClassBuildItem.builder(ViolationReport.class,
-                        ViolationReport.Violation.class).methods().fields().build());
+                ReflectiveClassBuildItem.builder(ViolationReport.class, ViolationReport.Violation.class)
+                        .reason(getClass().getName())
+                        .methods().fields().build());
     }
 
     // We need to make sure that the standard process of obtaining a ValidationFactory is not followed,

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -504,7 +504,8 @@ class HibernateValidatorProcessor {
                 } else if (annotation.target().kind() == AnnotationTarget.Kind.METHOD) {
                     contributeClass(classNamesToBeValidated, indexView, annotation.target().asMethod().declaringClass().name());
                     // we need to register the method for reflection as it could be a getter
-                    reflectiveMethods.produce(new ReflectiveMethodBuildItem(annotation.target().asMethod()));
+                    reflectiveMethods
+                            .produce(new ReflectiveMethodBuildItem(getClass().getName(), annotation.target().asMethod()));
                     contributeClassMarkedForCascadingValidation(classNamesToBeValidated, indexView, consideredAnnotation,
                             annotation.target().asMethod().returnType());
                     contributeMethodsWithInheritedValidation(methodsWithInheritedValidation, indexView,
@@ -535,7 +536,8 @@ class HibernateValidatorProcessor {
                         }
                     } else if (enclosingTarget.kind() == AnnotationTarget.Kind.METHOD) {
                         contributeClass(classNamesToBeValidated, indexView, enclosingTarget.asMethod().declaringClass().name());
-                        reflectiveMethods.produce(new ReflectiveMethodBuildItem(enclosingTarget.asMethod()));
+                        reflectiveMethods
+                                .produce(new ReflectiveMethodBuildItem(getClass().getName(), enclosingTarget.asMethod()));
                         if (annotation.target().asType().target() != null) {
                             contributeClassMarkedForCascadingValidation(classNamesToBeValidated, indexView,
                                     consideredAnnotation,

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -498,7 +498,7 @@ class HibernateValidatorProcessor {
             for (AnnotationInstance annotation : annotationInstances) {
                 if (annotation.target().kind() == AnnotationTarget.Kind.FIELD) {
                     contributeClass(classNamesToBeValidated, indexView, annotation.target().asField().declaringClass().name());
-                    reflectiveFields.produce(new ReflectiveFieldBuildItem(annotation.target().asField()));
+                    reflectiveFields.produce(new ReflectiveFieldBuildItem(getClass().getName(), annotation.target().asField()));
                     contributeClassMarkedForCascadingValidation(classNamesToBeValidated, indexView, consideredAnnotation,
                             annotation.target().asField().type());
                 } else if (annotation.target().kind() == AnnotationTarget.Kind.METHOD) {
@@ -528,7 +528,7 @@ class HibernateValidatorProcessor {
                     AnnotationTarget enclosingTarget = annotation.target().asType().enclosingTarget();
                     if (enclosingTarget.kind() == AnnotationTarget.Kind.FIELD) {
                         contributeClass(classNamesToBeValidated, indexView, enclosingTarget.asField().declaringClass().name());
-                        reflectiveFields.produce(new ReflectiveFieldBuildItem(enclosingTarget.asField()));
+                        reflectiveFields.produce(new ReflectiveFieldBuildItem(getClass().getName(), enclosingTarget.asField()));
                         if (annotation.target().asType().target() != null) {
                             contributeClassMarkedForCascadingValidation(classNamesToBeValidated, indexView,
                                     consideredAnnotation,

--- a/extensions/infinispan-cache/deployment/src/main/java/io/quarkus/cache/infinispan/deployment/InfinispanCacheProcessor.java
+++ b/extensions/infinispan-cache/deployment/src/main/java/io/quarkus/cache/infinispan/deployment/InfinispanCacheProcessor.java
@@ -46,7 +46,9 @@ public class InfinispanCacheProcessor {
 
     @BuildStep
     void nativeImage(BuildProducer<ReflectiveClassBuildItem> producer) {
-        producer.produce(ReflectiveClassBuildItem.builder(CompositeCacheKey.class).methods(true).build());
+        producer.produce(ReflectiveClassBuildItem.builder(CompositeCacheKey.class)
+                .reason(getClass().getName())
+                .methods(true).build());
     }
 
 }

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
@@ -318,7 +318,7 @@ class InfinispanClientProcessor {
                 "org.wildfly.security.credential.X509CertificateChainPublicCredential"
         };
 
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(elytronClasses).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(elytronClasses).reason(getClass().getName()).build());
         return new InfinispanPropertiesBuildItem(propertiesMap);
     }
 

--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -166,14 +166,17 @@ public class JacksonProcessor {
             if (CLASS.equals(annotationTarget.kind())) {
                 DotName dotName = annotationTarget.asClass().name();
                 if (!ignoredDotNames.contains(dotName)) {
-                    addReflectiveHierarchyClass(dotName, reflectiveHierarchyClass);
+                    addReflectiveHierarchyClass(getClass().getSimpleName() + " annotated with @" + JSON_DESERIALIZE,
+                            dotName, reflectiveHierarchyClass);
                 }
 
                 AnnotationValue annotationValue = deserializeInstance.value("builder");
                 if (null != annotationValue && AnnotationValue.Kind.CLASS.equals(annotationValue.kind())) {
                     DotName builderClassName = annotationValue.asClass().name();
                     if (!BUILDER_VOID.equals(builderClassName)) {
-                        addReflectiveHierarchyClass(builderClassName, reflectiveHierarchyClass);
+                        addReflectiveHierarchyClass(
+                                getClass().getSimpleName() + " @" + JSON_DESERIALIZE + " builder of " + dotName,
+                                builderClassName, reflectiveHierarchyClass);
                     }
                 }
             }
@@ -316,10 +319,10 @@ public class JacksonProcessor {
         additionalBeans.produce(new AdditionalBeanBuildItem(ObjectMapperProducer.class));
     }
 
-    private void addReflectiveHierarchyClass(DotName className,
+    private void addReflectiveHierarchyClass(String reason, DotName className,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyClass) {
         reflectiveHierarchyClass.produce(ReflectiveHierarchyBuildItem.builder(className)
-                .source(getClass().getSimpleName() + " > " + className)
+                .source(reason)
                 .build());
     }
 

--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -273,7 +273,7 @@ public class JacksonProcessor {
         // make sure we register the constructors and methods marked with @JsonCreator for reflection
         for (AnnotationInstance creatorInstance : index.getAnnotations(JSON_CREATOR)) {
             if (METHOD == creatorInstance.target().kind()) {
-                reflectiveMethod.produce(new ReflectiveMethodBuildItem(creatorInstance.target().asMethod()));
+                reflectiveMethod.produce(new ReflectiveMethodBuildItem(getClass().getName(), creatorInstance.target().asMethod()));
             }
         }
 

--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -273,7 +273,8 @@ public class JacksonProcessor {
         // make sure we register the constructors and methods marked with @JsonCreator for reflection
         for (AnnotationInstance creatorInstance : index.getAnnotations(JSON_CREATOR)) {
             if (METHOD == creatorInstance.target().kind()) {
-                reflectiveMethod.produce(new ReflectiveMethodBuildItem(getClass().getName(), creatorInstance.target().asMethod()));
+                reflectiveMethod
+                        .produce(new ReflectiveMethodBuildItem(getClass().getName(), creatorInstance.target().asMethod()));
             }
         }
 

--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -134,12 +134,15 @@ public class JacksonProcessor {
                         "com.fasterxml.jackson.databind.ser.std.SqlTimeSerializer",
                         "com.fasterxml.jackson.databind.deser.std.DateDeserializers$SqlDateDeserializer",
                         "com.fasterxml.jackson.databind.deser.std.DateDeserializers$TimestampDeserializer",
-                        "com.fasterxml.jackson.annotation.SimpleObjectIdResolver").methods().build());
+                        "com.fasterxml.jackson.annotation.SimpleObjectIdResolver")
+                        .reason(getClass().getName())
+                        .methods().build());
         reflectiveClass.produce(
                 ReflectiveClassBuildItem.builder(
                         "com.fasterxml.jackson.databind.ser.std.ClassSerializer",
                         "com.fasterxml.jackson.databind.ext.CoreXMLSerializers",
                         "com.fasterxml.jackson.databind.ext.CoreXMLDeserializers")
+                        .reason(getClass().getName())
                         .constructors()
                         .build());
 
@@ -148,6 +151,7 @@ public class JacksonProcessor {
                         && x.getArtifactId().equals("jackson-module-jaxb-annotations"))) {
             reflectiveClass.produce(
                     ReflectiveClassBuildItem.builder("com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector")
+                            .reason(getClass().getName())
                             .methods().build());
         }
 
@@ -183,18 +187,23 @@ public class JacksonProcessor {
             AnnotationValue usingValue = deserializeInstance.value("using");
             if (usingValue != null) {
                 // the Deserializers are constructed internally by Jackson using a no-args constructor
-                reflectiveClass.produce(ReflectiveClassBuildItem.builder(usingValue.asClass().name().toString()).build());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(usingValue.asClass().name().toString())
+                        .reason(getClass().getName() + " @" + JSON_DESERIALIZE + " using")
+                        .build());
             }
             AnnotationValue keyUsingValue = deserializeInstance.value("keyUsing");
             if (keyUsingValue != null) {
                 // the Deserializers are constructed internally by Jackson using a no-args constructor
-                reflectiveClass.produce(ReflectiveClassBuildItem.builder(keyUsingValue.asClass().name().toString()).build());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(keyUsingValue.asClass().name().toString())
+                        .reason(getClass().getName() + " @" + JSON_DESERIALIZE + " keyUsing")
+                        .build());
             }
             AnnotationValue contentUsingValue = deserializeInstance.value("contentUsing");
             if (contentUsingValue != null) {
                 // the Deserializers are constructed internally by Jackson using a no-args constructor
-                reflectiveClass
-                        .produce(ReflectiveClassBuildItem.builder(contentUsingValue.asClass().name().toString()).build());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(contentUsingValue.asClass().name().toString())
+                        .reason(getClass().getName() + " @" + JSON_DESERIALIZE + " contentUsing")
+                        .build());
             }
         }
 
@@ -203,30 +212,39 @@ public class JacksonProcessor {
             AnnotationValue usingValue = serializeInstance.value("using");
             if (usingValue != null) {
                 // the Serializers are constructed internally by Jackson using a no-args constructor
-                reflectiveClass.produce(ReflectiveClassBuildItem.builder(usingValue.asClass().name().toString()).build());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(usingValue.asClass().name().toString())
+                        .reason(getClass().getName() + " @" + JSON_SERIALIZE + " using")
+                        .build());
             }
             AnnotationValue keyUsingValue = serializeInstance.value("keyUsing");
             if (keyUsingValue != null) {
                 // the Deserializers are constructed internally by Jackson using a no-args constructor
-                reflectiveClass.produce(ReflectiveClassBuildItem.builder(keyUsingValue.asClass().name().toString()).build());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(keyUsingValue.asClass().name().toString())
+                        .reason(getClass().getName() + " @" + JSON_SERIALIZE + " keyUsing")
+                        .build());
             }
             AnnotationValue contentUsingValue = serializeInstance.value("contentUsing");
             if (contentUsingValue != null) {
                 // the Deserializers are constructed internally by Jackson using a no-args constructor
                 reflectiveClass
-                        .produce(ReflectiveClassBuildItem.builder(contentUsingValue.asClass().name().toString()).build());
+                        .produce(ReflectiveClassBuildItem.builder(contentUsingValue.asClass().name().toString())
+                                .reason(getClass().getName() + " @" + JSON_SERIALIZE + " contentUsing")
+                                .build());
             }
             AnnotationValue nullsUsingValue = serializeInstance.value("nullsUsing");
             if (nullsUsingValue != null) {
                 // the Deserializers are constructed internally by Jackson using a no-args constructor
                 reflectiveClass
-                        .produce(ReflectiveClassBuildItem.builder(nullsUsingValue.asClass().name().toString()).build());
+                        .produce(ReflectiveClassBuildItem.builder(nullsUsingValue.asClass().name().toString())
+                                .reason(getClass().getName() + " @" + JSON_SERIALIZE + " nullsUsing")
+                                .build());
             }
         }
 
         for (AnnotationInstance creatorInstance : index.getAnnotations(JSON_AUTO_DETECT)) {
             if (creatorInstance.target().kind() == CLASS) {
                 reflectiveClass.produce(ReflectiveClassBuildItem.builder(creatorInstance.target().asClass().name().toString())
+                        .reason(getClass().getName() + " annotated with @" + JSON_AUTO_DETECT)
                         .methods().fields().build());
             }
         }
@@ -242,10 +260,12 @@ public class JacksonProcessor {
                 // Add the type-id-resolver class
                 reflectiveClass
                         .produce(ReflectiveClassBuildItem.builder(value.asClass().name().toString()).methods().fields()
+                                .reason(getClass().getName() + " @" + JSON_TYPE_ID_RESOLVER + " value")
                                 .build());
                 if (resolverInstance.target().kind() == CLASS) {
                     // Add the whole hierarchy of the annotated class
-                    addReflectiveHierarchyClass(resolverInstance.target().asClass().name(), reflectiveHierarchyClass);
+                    addReflectiveHierarchyClass(getClass().getSimpleName() + " annotated with @" + JSON_TYPE_ID_RESOLVER,
+                            resolverInstance.target().asClass().name(), reflectiveHierarchyClass);
                 }
             }
         }
@@ -262,6 +282,7 @@ public class JacksonProcessor {
             AnnotationValue strategyValue = jsonNamingInstance.value("value");
             if (strategyValue != null) {
                 reflectiveClass.produce(ReflectiveClassBuildItem.builder(strategyValue.asClass().name().toString())
+                        .reason(getClass().getName() + " @" + JSON_NAMING + " value")
                         .methods().fields().build());
             }
         }
@@ -272,15 +293,18 @@ public class JacksonProcessor {
             AnnotationValue resolverValue = jsonIdentityInfoInstance.value("resolver");
             if (generatorValue != null) {
                 reflectiveClass.produce(ReflectiveClassBuildItem.builder(generatorValue.asClass().name().toString())
+                        .reason(getClass().getName() + " @" + JSON_IDENTITY_INFO + " generator")
                         .methods().fields().build());
             }
             if (resolverValue != null) {
                 reflectiveClass.produce(ReflectiveClassBuildItem.builder(resolverValue.asClass().name().toString())
+                        .reason(getClass().getName() + " @" + JSON_IDENTITY_INFO + " resolver")
                         .methods().fields().build());
             } else {
                 // Registering since SimpleObjectIdResolver is the default value of @JsonIdentityInfo.resolver
-                reflectiveClass.produce(
-                        ReflectiveClassBuildItem.builder(SimpleObjectIdResolver.class).methods().fields().build());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(SimpleObjectIdResolver.class)
+                        .reason(getClass().getName() + " @" + JSON_IDENTITY_INFO + " resolver default value")
+                        .methods().fields().build());
             }
         }
 
@@ -300,6 +324,7 @@ public class JacksonProcessor {
         }
         if (!subTypeTypesNames.isEmpty()) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(subTypeTypesNames.toArray(EMPTY_STRING))
+                    .reason(getClass().getName() + " @" + JSON_SUBTYPES + " value")
                     .methods().fields().build());
         }
 
@@ -312,7 +337,9 @@ public class JacksonProcessor {
             }
         }
         if (!namingTypesNames.isEmpty()) {
-            reflectiveClass.produce(ReflectiveClassBuildItem.builder(namingTypesNames.toArray(EMPTY_STRING)).build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(namingTypesNames.toArray(EMPTY_STRING))
+                    .reason(getClass().getName() + " @" + JACKSON_NAMING + " value")
+                    .build());
         }
 
         // this needs to be registered manually since the runtime module is not indexed by Jandex
@@ -443,7 +470,9 @@ public class JacksonProcessor {
             }
             ClassInfo mixinClassInfo = instance.target().asClass();
             String mixinClassName = mixinClassInfo.name().toString();
-            reflectiveClass.produce(ReflectiveClassBuildItem.builder(mixinClassName).methods().fields().build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(mixinClassName)
+                    .reason(getClass().getName() + " annotated with @" + JACKSON_MIXIN)
+                    .methods().fields().build());
             try {
                 Type[] targetTypes = instance.value().asClassArray();
                 if ((targetTypes == null) || targetTypes.length == 0) {
@@ -452,8 +481,9 @@ public class JacksonProcessor {
                 Class<?> mixinClass = Thread.currentThread().getContextClassLoader().loadClass(mixinClassName);
                 for (Type targetType : targetTypes) {
                     String targetClassName = targetType.name().toString();
-                    reflectiveClass
-                            .produce(ReflectiveClassBuildItem.builder(targetClassName).methods().fields().build());
+                    reflectiveClass.produce(ReflectiveClassBuildItem.builder(targetClassName)
+                            .reason(getClass().getName() + " @" + JACKSON_MIXIN + " value of " + mixinClassName)
+                            .methods().fields().build());
                     mixinsMap.put(Thread.currentThread().getContextClassLoader().loadClass(targetClassName),
                             mixinClass);
                 }

--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -240,7 +240,9 @@ public class JaxbProcessor {
             if (xmlSchemaInstance.target().kind() == Kind.CLASS) {
                 String className = xmlSchemaInstance.target().asClass().name().toString();
 
-                reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).build());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(className)
+                        .reason(getClass().getName() + " annotated with @" + XML_SCHEMA)
+                        .build());
             }
         }
 
@@ -248,17 +250,22 @@ public class JaxbProcessor {
         for (AnnotationInstance xmlJavaTypeAdapterInstance : index.getAnnotations(XML_JAVA_TYPE_ADAPTER)) {
             reflectiveClass.produce(
                     ReflectiveClassBuildItem.builder(xmlJavaTypeAdapterInstance.value().asClass().name().toString())
+                            .reason(getClass().getName() + " @" + XML_JAVA_TYPE_ADAPTER + " value")
                             .methods().fields().build());
         }
 
         if (!index.getAnnotations(XML_ANY_ELEMENT).isEmpty()) {
-            addReflectiveClass(reflectiveClass, false, false, "jakarta.xml.bind.annotation.W3CDomHandler");
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder("jakarta.xml.bind.annotation.W3CDomHandler")
+                    .reason(getClass().getName() + " @" + XML_ANY_ELEMENT + " annotation present")
+                    .build());
         }
 
         JAXB_ANNOTATIONS.stream()
                 .map(Class::getName)
                 .forEach(className -> {
-                    addReflectiveClass(reflectiveClass, true, false, className);
+                    reflectiveClass.produce(ReflectiveClassBuildItem.builder(className)
+                            .reason(getClass().getName() + " JAXB annotation")
+                            .methods().build());
                 });
 
         // Register @XmlSeeAlso
@@ -268,7 +275,9 @@ public class JaxbProcessor {
             AnnotationValue value = xmlSeeAlsoAnn.value();
             Type[] types = value.asClassArray();
             for (Type t : types) {
-                addReflectiveClass(reflectiveClass, false, false, t.name().toString());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(t.name().toString())
+                        .reason(getClass().getName() + " @" + XML_SEE_ALSO + " value")
+                        .build());
             }
         }
         // Register Native proxy definitions
@@ -296,11 +305,14 @@ public class JaxbProcessor {
             BuildProducer<ServiceProviderBuildItem> providerItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle) {
-        addReflectiveClass(reflectiveClass, true, false, "org.glassfish.jaxb.runtime.v2.ContextFactory");
-        addReflectiveClass(reflectiveClass, true, false, "com.sun.xml.internal.stream.XMLInputFactoryImpl");
-        addReflectiveClass(reflectiveClass, true, false, "com.sun.xml.internal.stream.XMLOutputFactoryImpl");
-        addReflectiveClass(reflectiveClass, true, false, "com.sun.org.apache.xpath.internal.functions.FuncNot");
-        addReflectiveClass(reflectiveClass, true, false, "com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl");
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(
+                "org.glassfish.jaxb.runtime.v2.ContextFactory",
+                "com.sun.xml.internal.stream.XMLInputFactoryImpl",
+                "com.sun.xml.internal.stream.XMLOutputFactoryImpl",
+                "com.sun.org.apache.xpath.internal.functions.FuncNot",
+                "com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl")
+                .reason(getClass().getName())
+                .methods().build());
 
         addResourceBundle(resourceBundle, "jakarta.xml.bind.Messages");
         addResourceBundle(resourceBundle, "jakarta.xml.bind.helpers.Messages");
@@ -310,7 +322,9 @@ public class JaxbProcessor {
 
         JAXB_REFLECTIVE_CLASSES.stream()
                 .map(Class::getName)
-                .forEach(className -> addReflectiveClass(reflectiveClass, true, false, className));
+                .forEach(className -> reflectiveClass.produce(ReflectiveClassBuildItem.builder(className)
+                        .reason(getClass().getName() + " JAXB reflective class")
+                        .methods().build()));
 
         providerItem
                 .produce(new ServiceProviderBuildItem(JAXBContext.class.getName(),
@@ -390,6 +404,7 @@ public class JaxbProcessor {
 
             resource.produce(new NativeImageResourceBuildItem(path));
 
+            ArrayList<Class> classes = new ArrayList<>();
             for (String line : Files.readAllLines(p)) {
                 line = line.trim();
                 if (!line.isEmpty() && !line.startsWith("#")) {
@@ -398,11 +413,14 @@ public class JaxbProcessor {
                     classesToBeBound.add(clazz);
 
                     while (cl != Object.class) {
-                        reflectiveClass.produce(ReflectiveClassBuildItem.builder(cl).methods().fields().build());
+                        classes.add(cl);
                         cl = cl.getSuperclass();
                     }
                 }
             }
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(classes.toArray(new Class[0]))
+                    .reason(getClass().getName() + " jaxb.index file " + path)
+                    .methods().fields().build());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -430,11 +448,6 @@ public class JaxbProcessor {
         } catch (IOException e) {
             throw new IOError(e);
         }
-    }
-
-    private void addReflectiveClass(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, boolean methods, boolean fields,
-            String... className) {
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods(methods).fields(fields).build());
     }
 
     private void addResourceBundle(BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle, String bundle) {

--- a/extensions/jdbc/jdbc-db2/deployment/src/main/java/io/quarkus/jdbc/db2/deployment/JDBCDB2Processor.java
+++ b/extensions/jdbc/jdbc-db2/deployment/src/main/java/io/quarkus/jdbc/db2/deployment/JDBCDB2Processor.java
@@ -70,18 +70,23 @@ public class JDBCDB2Processor {
         //any JDBC driver being configured explicitly through its configuration.
         //We register it for the sake of people not using Agroal,
         //for example when the driver is used with OpenTelemetry JDBC instrumentation.
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(DB2_DRIVER_CLASS).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(DB2_DRIVER_CLASS)
+                .reason(getClass().getName() + " DB2 JDBC driver classes")
+                .build());
 
         // register resource bundles for reflection (they are apparently classes...)
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(Resources.class).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ResourceKeys.class).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(SqljResources.class).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(T2uResourceKeys.class).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(T2uResources.class).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(T2zResourceKeys.class).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(T2zResources.class).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(T4ResourceKeys.class).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(T4Resources.class).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(
+                Resources.class,
+                ResourceKeys.class,
+                SqljResources.class,
+                T2uResourceKeys.class,
+                T2uResources.class,
+                T2zResourceKeys.class,
+                T2zResources.class,
+                T4ResourceKeys.class,
+                T4Resources.class)
+                .reason(getClass().getName() + " DB2 JDBC driver classes")
+                .build());
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/PostgreSQLJDBCReflections.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/PostgreSQLJDBCReflections.java
@@ -39,7 +39,7 @@ public final class PostgreSQLJDBCReflections {
                 // so let's not include it:
                 // "org.postgresql.jdbc.PgResultSet.NullObject"
         };
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(pgObjectClasses).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(pgObjectClasses).reason(getClass().getName()).build());
 
         // Needed when quarkus.datasource.jdbc.transactions=xa for the setting of the username and password
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("org.postgresql.ds.common.BaseDataSource").constructors(false)

--- a/extensions/jsonb/deployment/src/main/java/io/quarkus/jsonb/deployment/JsonbProcessor.java
+++ b/extensions/jsonb/deployment/src/main/java/io/quarkus/jsonb/deployment/JsonbProcessor.java
@@ -92,7 +92,9 @@ public class JsonbProcessor {
                 ReflectiveClassBuildItem.builder("java.lang.String").build());
 
         // Necessary for Yasson versions using MethodHandles (2.0+)
-        reflectiveMethod.produce(new ReflectiveMethodBuildItem("jdk.internal.misc.Unsafe", "putReference", Object.class,
+        reflectiveMethod.produce(new ReflectiveMethodBuildItem(
+                getClass().getName(),
+                "jdk.internal.misc.Unsafe", "putReference", Object.class,
                 long.class, Object.class));
     }
 

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -238,10 +238,14 @@ public class KafkaProcessor {
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(OAuthBearerSaslClient.class,
                 OAuthBearerSaslClient.OAuthBearerSaslClientFactory.class,
                 OAuthBearerToken.class,
-                OAuthBearerRefreshingLogin.class).build());
+                OAuthBearerRefreshingLogin.class)
+                .reason(getClass().getName() + " OAuthBearerSaslClient classes")
+                .build());
 
         for (Class<?> i : BUILT_INS) {
-            reflectiveClass.produce(ReflectiveClassBuildItem.builder(i.getName()).build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(i.getName())
+                    .reason(getClass().getName() + " (de)serialization built-ins")
+                    .build());
             collectSubclasses(toRegister, indexBuildItem, i);
         }
 
@@ -250,7 +254,9 @@ public class KafkaProcessor {
         // So, enable the Jackson support unconditionally.
         reflectiveClass.produce(
                 ReflectiveClassBuildItem.builder(ObjectMapperSerializer.class,
-                        ObjectMapperDeserializer.class).build());
+                        ObjectMapperDeserializer.class)
+                        .reason(getClass().getName() + " Jackson support")
+                        .build());
         collectSubclasses(toRegister, indexBuildItem, ObjectMapperSerializer.class);
         collectSubclasses(toRegister, indexBuildItem, ObjectMapperDeserializer.class);
 
@@ -260,24 +266,26 @@ public class KafkaProcessor {
         if (capabilities.isPresent(Capability.JSONB)) {
             reflectiveClass.produce(
                     ReflectiveClassBuildItem.builder(JsonbSerializer.class, JsonbDeserializer.class)
+                            .reason(getClass().getName() + " " + Capability.JSONB + " support")
                             .build());
             collectSubclasses(toRegister, indexBuildItem, JsonbSerializer.class);
             collectSubclasses(toRegister, indexBuildItem, JsonbDeserializer.class);
         }
 
         for (DotName s : toRegister) {
-            reflectiveClass.produce(ReflectiveClassBuildItem.builder(s.toString()).build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(s.toString())
+                    .reason(getClass().getName() + " Jackson and " + Capability.JSONB + " support")
+                    .build());
         }
 
         // built in partitioner and partition assignors
-        reflectiveClass.produce(
-                ReflectiveClassBuildItem.builder(DefaultPartitioner.class.getName()).build());
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(RangeAssignor.class.getName()).build());
-        reflectiveClass.produce(
-                ReflectiveClassBuildItem.builder(RoundRobinAssignor.class.getName()).build());
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(StickyAssignor.class.getName()).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(
+                DefaultPartitioner.class,
+                RangeAssignor.class,
+                RoundRobinAssignor.class,
+                StickyAssignor.class)
+                .reason(getClass().getName() + " built-in partitioner and partition assignors")
+                .build());
 
         handleAvro(reflectiveClass, proxies, serviceProviders, sslNativeSupport, capabilities);
 
@@ -290,7 +298,9 @@ public class KafkaProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageResourceBuildItem> nativeLibs) {
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("org.xerial.snappy.SnappyInputStream",
-                "org.xerial.snappy.SnappyOutputStream").methods().fields().build());
+                "org.xerial.snappy.SnappyOutputStream")
+                .reason(getClass().getName() + " snappy support")
+                .methods().fields().build());
 
         String root = "org/xerial/snappy/native/";
         // add linux64 native lib when targeting containers
@@ -342,23 +352,21 @@ public class KafkaProcessor {
 
         // --- Apicurio Registry 1.x ---
         if (QuarkusClassLoader.isClassPresentAtRuntime("io.apicurio.registry.utils.serde.AvroKafkaDeserializer")) {
-            reflectiveClass.produce(
-                    ReflectiveClassBuildItem.builder("io.apicurio.registry.utils.serde.AvroKafkaDeserializer",
-                            "io.apicurio.registry.utils.serde.AvroKafkaSerializer").methods()
-                            .build());
-
-            reflectiveClass.produce(ReflectiveClassBuildItem
-                    .builder("io.apicurio.registry.utils.serde.avro.DefaultAvroDatumProvider",
-                            "io.apicurio.registry.utils.serde.avro.ReflectAvroDatumProvider",
-                            "io.apicurio.registry.utils.serde.strategy.AutoRegisterIdStrategy",
-                            "io.apicurio.registry.utils.serde.strategy.CachedSchemaIdStrategy",
-                            "io.apicurio.registry.utils.serde.strategy.FindBySchemaIdStrategy",
-                            "io.apicurio.registry.utils.serde.strategy.FindLatestIdStrategy",
-                            "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy",
-                            "io.apicurio.registry.utils.serde.strategy.RecordIdStrategy",
-                            "io.apicurio.registry.utils.serde.strategy.SimpleTopicIdStrategy",
-                            "io.apicurio.registry.utils.serde.strategy.TopicIdStrategy",
-                            "io.apicurio.registry.utils.serde.strategy.TopicRecordIdStrategy")
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(
+                    "io.apicurio.registry.utils.serde.AvroKafkaDeserializer",
+                    "io.apicurio.registry.utils.serde.AvroKafkaSerializer",
+                    "io.apicurio.registry.utils.serde.avro.DefaultAvroDatumProvider",
+                    "io.apicurio.registry.utils.serde.avro.ReflectAvroDatumProvider",
+                    "io.apicurio.registry.utils.serde.strategy.AutoRegisterIdStrategy",
+                    "io.apicurio.registry.utils.serde.strategy.CachedSchemaIdStrategy",
+                    "io.apicurio.registry.utils.serde.strategy.FindBySchemaIdStrategy",
+                    "io.apicurio.registry.utils.serde.strategy.FindLatestIdStrategy",
+                    "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy",
+                    "io.apicurio.registry.utils.serde.strategy.RecordIdStrategy",
+                    "io.apicurio.registry.utils.serde.strategy.SimpleTopicIdStrategy",
+                    "io.apicurio.registry.utils.serde.strategy.TopicIdStrategy",
+                    "io.apicurio.registry.utils.serde.strategy.TopicRecordIdStrategy")
+                    .reason(getClass().getName() + " apicurio registry 1.x support")
                     .methods().build());
 
             // Apicurio uses dynamic proxies, register them
@@ -395,14 +403,13 @@ public class KafkaProcessor {
             BuildProducer<ReflectiveClassConditionBuildItem> reflectiveClassCondition,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport) {
 
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(AbstractLogin.DefaultLoginCallbackHandler.class)
-                        .build());
         reflectiveClass.produce(
-                ReflectiveClassBuildItem.builder(SaslClientCallbackHandler.class).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(DefaultLogin.class).build());
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(ScramSaslClient.ScramSaslClientFactory.class)
+                ReflectiveClassBuildItem.builder(
+                        AbstractLogin.DefaultLoginCallbackHandler.class,
+                        SaslClientCallbackHandler.class,
+                        DefaultLogin.class,
+                        ScramSaslClient.ScramSaslClientFactory.class)
+                        .reason(getClass().getName() + " sasl support")
                         .build());
 
         // Enable SSL support if kafka.security.protocol is set to something other than PLAINTEXT, which is the default
@@ -413,12 +420,16 @@ public class KafkaProcessor {
 
         for (ClassInfo loginModule : index.getIndex().getAllKnownImplementors(LOGIN_MODULE)) {
             reflectiveClass.produce(
-                    ReflectiveClassBuildItem.builder(loginModule.name().toString()).build());
+                    ReflectiveClassBuildItem.builder(loginModule.name().toString())
+                            .reason(getClass().getName() + " sasl support " + LOGIN_MODULE + " known implementors")
+                            .build());
         }
         // Kafka oauth login internally iterates over all ServiceLoader available LoginModule's
         registerJDKLoginModules(reflectiveClass);
         for (ClassInfo authenticateCallbackHandler : index.getIndex().getAllKnownImplementors(AUTHENTICATE_CALLBACK_HANDLER)) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(authenticateCallbackHandler.name().toString())
+                    .reason(getClass().getName() + " sasl support " + AUTHENTICATE_CALLBACK_HANDLER
+                            + " known implementors")
                     .build());
         }
         // Add a condition for the optional authenticate callback handler
@@ -432,20 +443,15 @@ public class KafkaProcessor {
 
     private void registerJDKLoginModules(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         // jdk.security.auth module provided LoginModule's
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.sun.security.auth.module.Krb5LoginModule")
-                .build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.sun.security.auth.module.UnixLoginModule")
-                .build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.sun.security.auth.module.JndiLoginModule")
-                .build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.sun.security.auth.module.KeyStoreLoginModule")
-                .build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.sun.security.auth.module.LdapLoginModule")
-                .build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.sun.security.auth.module.NTLoginModule")
-                .build());
-        // java.management module provided LoginModule's
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.sun.jmx.remote.security.FileLoginModule")
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(
+                "com.sun.security.auth.module.Krb5LoginModule",
+                "com.sun.security.auth.module.UnixLoginModule",
+                "com.sun.security.auth.module.JndiLoginModule",
+                "com.sun.security.auth.module.KeyStoreLoginModule",
+                "com.sun.security.auth.module.LdapLoginModule",
+                "com.sun.security.auth.module.NTLoginModule",
+                "com.sun.jmx.remote.security.FileLoginModule")
+                .reason(getClass().getName() + " jdk.security.auth module provided LoginModule's")
                 .build());
     }
 

--- a/extensions/keycloak-admin-rest-client/deployment/src/main/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientReactiveProcessor.java
+++ b/extensions/keycloak-admin-rest-client/deployment/src/main/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientReactiveProcessor.java
@@ -44,6 +44,7 @@ public class KeycloakAdminClientReactiveProcessor {
                 StringListMapDeserializer.class,
                 StringOrArrayDeserializer.class,
                 StringOrArraySerializer.class)
+                .reason(getClass().getName())
                 .methods().build());
         reflectiveHierarchyProducer.produce(
                 new ReflectiveHierarchyIgnoreWarningBuildItem(new ReflectiveHierarchyIgnoreWarningBuildItem.DotNameExclusion(

--- a/extensions/keycloak-admin-resteasy-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientProcessor.java
+++ b/extensions/keycloak-admin-resteasy-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientProcessor.java
@@ -44,6 +44,7 @@ public class KeycloakAdminClientProcessor {
                 StringListMapDeserializer.class,
                 StringOrArrayDeserializer.class,
                 StringOrArraySerializer.class)
+                .reason(getClass().getName())
                 .methods().build();
     }
 

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -166,6 +166,7 @@ public class KubernetesClientProcessor {
         if (!withFieldsRegistration.isEmpty()) {
             reflectiveClasses.produce(ReflectiveClassBuildItem
                     .builder(withFieldsRegistration.toArray(EMPTY_STRINGS_ARRAY))
+                    .reason(getClass().getName())
                     .weak().methods().fields()
                     .build());
         }
@@ -184,7 +185,9 @@ public class KubernetesClientProcessor {
                 .map(c -> c.name().toString())
                 .filter(s -> s.startsWith("io.fabric8.kubernetes"))
                 .toArray(String[]::new);
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(deserializerClasses).methods().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(deserializerClasses)
+                .reason(getClass().getName())
+                .methods().build());
 
         final String[] serializerClasses = fullIndex
                 .getAllKnownSubclasses(DotName.createSimple("com.fasterxml.jackson.databind.JsonSerializer"))
@@ -192,23 +195,31 @@ public class KubernetesClientProcessor {
                 .map(c -> c.name().toString())
                 .filter(s -> s.startsWith("io.fabric8.kubernetes"))
                 .toArray(String[]::new);
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(serializerClasses).methods().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(serializerClasses)
+                .reason(getClass().getName())
+                .methods().build());
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(KubernetesClientImpl.class, DefaultKubernetesClient.class, VersionInfo.class)
+                        .reason(getClass().getName())
                         .methods().fields().build());
         reflectiveClasses.produce(ReflectiveClassBuildItem
-                .builder(AnyType.class, IntOrString.class, KubernetesDeserializer.class).methods().build());
+                .builder(AnyType.class, IntOrString.class, KubernetesDeserializer.class)
+                .reason(getClass().getName())
+                .methods().build());
 
         // exec credentials support
         reflectiveClasses
                 .produce(ReflectiveClassBuildItem.builder(Config.ExecCredential.class,
                         Config.ExecCredentialSpec.class,
-                        Config.ExecCredentialStatus.class).methods().fields().build());
+                        Config.ExecCredentialStatus.class)
+                        .reason(getClass().getName())
+                        .methods().fields().build());
         // OpenID support
         reflectiveClasses
                 .produce(ReflectiveClassBuildItem.builder(OpenIDConnectionUtils.OpenIdConfiguration.class,
                         OpenIDConnectionUtils.OAuthToken.class)
+                        .reason(getClass().getName())
                         .methods().fields().build());
 
         if (log.isDebugEnabled()) {

--- a/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
+++ b/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
@@ -119,6 +119,7 @@ class LiquibaseMongodbProcessor {
                 .builder(combinedIndex.getIndex().getAllKnownSubclasses(AbstractPluginFactory.class).stream()
                         .map(classInfo -> classInfo.name().toString())
                         .toArray(String[]::new))
+                .reason(getClass().getName())
                 .constructors().build());
 
         reflective.produce(ReflectiveClassBuildItem.builder(
@@ -162,6 +163,7 @@ class LiquibaseMongodbProcessor {
         }
         reflective.produce(
                 ReflectiveClassBuildItem.builder(classesMarkedWithDatabaseChangeProperty.toArray(new String[0]))
+                        .reason(getClass().getName())
                         .constructors().methods().fields().build());
 
         resource.produce(
@@ -201,9 +203,9 @@ class LiquibaseMongodbProcessor {
             }
             services.produce(new ServiceProviderBuildItem(serviceClassName, implementations.toArray(new String[0])));
 
-            reflective.produce(ReflectiveClassBuildItem.builder(
-                    implementations.toArray(new String[0]))
-                    .constructors().methods().fields(shouldRegisterFieldForReflection).build());
+            reflective.produce(
+                    ReflectiveClassBuildItem.builder(implementations.toArray(new String[0])).reason(getClass().getName())
+                            .constructors().methods().fields(shouldRegisterFieldForReflection).build());
         } catch (IOException ex) {
             throw new IllegalStateException(ex);
         }

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -127,12 +127,14 @@ class LiquibaseProcessor {
 
         reflective.produce(ReflectiveClassBuildItem
                 .builder(liquibase.change.AbstractSQLChange.class, liquibase.database.jvm.JdbcConnection.class).methods()
+                .reason(getClass().getName())
                 .build());
 
         reflective.produce(ReflectiveClassBuildItem
                 .builder(combinedIndex.getIndex().getAllKnownSubclasses(AbstractPluginFactory.class).stream()
                         .map(classInfo -> classInfo.name().toString())
                         .toArray(String[]::new))
+                .reason(getClass().getName())
                 .constructors().build());
 
         reflective.produce(ReflectiveClassBuildItem.builder(
@@ -140,6 +142,7 @@ class LiquibaseProcessor {
                 liquibase.database.LiquibaseTableNamesFactory.class.getName(),
                 liquibase.configuration.ConfiguredValueModifierFactory.class.getName(),
                 liquibase.changelog.FastCheckService.class.getName())
+                .reason(getClass().getName())
                 .constructors().build());
 
         reflective.produce(ReflectiveClassBuildItem.builder(
@@ -154,14 +157,18 @@ class LiquibaseProcessor {
                 liquibase.sql.visitor.ReplaceSqlVisitor.class.getName(),
                 liquibase.sql.visitor.AppendSqlVisitor.class.getName(),
                 liquibase.sql.visitor.RegExpReplaceSqlVisitor.class.getName())
+                .reason(getClass().getName())
                 .constructors().methods().fields().build());
 
         reflective.produce(ReflectiveClassBuildItem.builder(
                 liquibase.change.ConstraintsConfig.class.getName())
+                .reason(getClass().getName())
                 .fields().build());
 
         // liquibase seems to instantiate these types reflectively...
-        reflective.produce(ReflectiveClassBuildItem.builder(ConcurrentHashMap.class, ArrayList.class).build());
+        reflective.produce(ReflectiveClassBuildItem.builder(ConcurrentHashMap.class, ArrayList.class)
+                .reason(getClass().getName())
+                .build());
 
         // register classes marked with @DatabaseChangeProperty for reflection
         Set<String> classesMarkedWithDatabaseChangeProperty = new HashSet<>();
@@ -175,6 +182,7 @@ class LiquibaseProcessor {
         }
         reflective.produce(
                 ReflectiveClassBuildItem.builder(classesMarkedWithDatabaseChangeProperty.toArray(new String[0]))
+                        .reason(getClass().getName())
                         .constructors().methods().fields().build());
 
         Collection<String> dataSourceNames = jdbcDataSourceBuildItems.stream()
@@ -188,6 +196,7 @@ class LiquibaseProcessor {
         consumeService(liquibase.precondition.Precondition.class.getName(), (serviceClassName, implementations) -> {
             services.produce(new ServiceProviderBuildItem(serviceClassName, implementations.toArray(new String[0])));
             reflective.produce(ReflectiveClassBuildItem.builder(implementations.toArray(new String[0]))
+                    .reason(getClass().getName())
                     .constructors().methods().fields().build());
         });
 
@@ -197,7 +206,9 @@ class LiquibaseProcessor {
                     .filter(commandStepPredicate(capabilities))
                     .toArray(String[]::new);
             services.produce(new ServiceProviderBuildItem(serviceClassName, filteredImpls));
-            reflective.produce(ReflectiveClassBuildItem.builder(filteredImpls).constructors().build());
+            reflective.produce(ReflectiveClassBuildItem.builder(filteredImpls)
+                    .reason(getClass().getName())
+                    .constructors().build());
             for (String implementation : filteredImpls) {
                 runtimeInitialized.produce(new RuntimeInitializedClassBuildItem(implementation));
             }

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -243,7 +243,7 @@ public class MicrometerProcessor {
             }
         }
 
-        return ReflectiveClassBuildItem.builder(classes.toArray(new String[0])).build();
+        return ReflectiveClassBuildItem.builder(classes.toArray(new String[0])).reason(getClass().getName()).build();
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -188,13 +188,21 @@ public class MongoClientProcessor {
         reflectiveClassNames.addAll(contextProviders.getContextProviderClassNames());
 
         List<ReflectiveClassBuildItem> reflectiveClass = reflectiveClassNames.stream()
-                .map(s -> ReflectiveClassBuildItem.builder(s).methods().build())
+                .map(s -> ReflectiveClassBuildItem.builder(s)
+                        .reason(getClass().getName())
+                        .methods().build())
                 .collect(Collectors.toCollection(ArrayList::new));
         // ChangeStreamDocument needs to be registered for reflection with its fields.
-        reflectiveClass.add(ReflectiveClassBuildItem.builder(ChangeStreamDocument.class).methods().fields().build());
-        reflectiveClass.add(ReflectiveClassBuildItem.builder(UpdateDescription.class).methods().build());
+        reflectiveClass.add(ReflectiveClassBuildItem.builder(ChangeStreamDocument.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
+        reflectiveClass.add(ReflectiveClassBuildItem.builder(UpdateDescription.class)
+                .reason(getClass().getName())
+                .methods().build());
         // ObjectId is often used on identifier, so we also register it
-        reflectiveClass.add(ReflectiveClassBuildItem.builder(ObjectId.class).methods().fields().build());
+        reflectiveClass.add(ReflectiveClassBuildItem.builder(ObjectId.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
         return reflectiveClass;
     }
 

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -137,7 +137,9 @@ class NarayanaJtaProcessor {
                 JTATransactionLogXAResourceOrphanFilter.class,
                 JTANodeNameXAResourceOrphanFilter.class,
                 JTAActionStatusServiceXAResourceOrphanFilter.class,
-                ExpiredTransactionStatusManagerScanner.class).build());
+                ExpiredTransactionStatusManagerScanner.class)
+                .reason(getClass().getName())
+                .build());
 
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder();
         builder.addBeanClass(TransactionalInterceptorSupports.class);

--- a/extensions/narayana-stm/deployment/src/main/java/io/quarkus/narayana/stm/deployment/NarayanaSTMProcessor.java
+++ b/extensions/narayana-stm/deployment/src/main/java/io/quarkus/narayana/stm/deployment/NarayanaSTMProcessor.java
@@ -98,7 +98,9 @@ class NarayanaSTMProcessor {
 
         String[] classNames = proxies.toArray(new String[0]);
 
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(classNames).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(classNames)
+                .reason(getClass().getName())
+                .methods().fields().build());
 
         return new NativeImageProxyDefinitionBuildItem(classNames);
     }

--- a/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
+++ b/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
@@ -42,8 +42,9 @@ public class OidcClientFilterBuildStep {
             BuildProducer<RestClientAnnotationProviderBuildItem> restAnnotationProvider) {
 
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(OidcClientRequestFilter.class));
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(OidcClientRequestFilter.class).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(OidcClientRequestFilter.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
         final Set<String> namedFilterClientClasses = namedOidcClientFilterBuildItem.namedFilterClientClasses;
 
         // register default request filter provider against the rest of the clients (client != namedFilterClientClasses)
@@ -111,6 +112,7 @@ public class OidcClientFilterBuildStep {
 
                 // register for reflection
                 reflectiveClass.produce(ReflectiveClassBuildItem.builder(generatedProvider).methods()
+                        .reason(getClass().getName())
                         .fields().serialization(true).build());
 
                 // register named request filter provider against Rest client

--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -75,7 +75,8 @@ public class OidcClientReactiveFilterBuildStep {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(OidcClientRequestReactiveFilter.class));
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(OidcClientRequestReactiveFilter.class.getName()));
-        reflectiveClass.produce(
-                ReflectiveClassBuildItem.builder(OidcClientRequestReactiveFilter.class).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(OidcClientRequestReactiveFilter.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
     }
 }

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/AccessTokenRequestFilterGenerator.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/AccessTokenRequestFilterGenerator.java
@@ -67,7 +67,9 @@ public final class AccessTokenRequestFilterGenerator {
                     }
                     unremovableBeansProducer.produce(UnremovableBeanBuildItem.beanClassNames(className));
                     reflectiveClassProducer
-                            .produce(ReflectiveClassBuildItem.builder(className).methods().fields().constructors().build());
+                            .produce(ReflectiveClassBuildItem.builder(className)
+                                    .reason(getClass().getName())
+                                    .methods().fields().constructors().build());
                     return className;
                 });
     }

--- a/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
@@ -60,8 +60,9 @@ public class OidcTokenPropagationReactiveBuildStep {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(AccessTokenRequestReactiveFilter.class));
-        reflectiveClass.produce(
-                ReflectiveClassBuildItem.builder(AccessTokenRequestReactiveFilter.class).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(AccessTokenRequestReactiveFilter.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(AccessTokenRequestReactiveFilter.class.getName()));
     }

--- a/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
+++ b/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
@@ -49,9 +49,9 @@ public class OidcTokenPropagationBuildStep {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(AccessTokenRequestFilter.class));
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(JsonWebTokenRequestFilter.class));
         reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(AccessTokenRequestFilter.class).methods().fields().build());
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(JsonWebTokenRequestFilter.class).methods().fields().build());
+                .produce(ReflectiveClassBuildItem.builder(AccessTokenRequestFilter.class, JsonWebTokenRequestFilter.class)
+                        .reason(getClass().getName())
+                        .methods().fields().build());
 
         if (config.registerFilter()) {
             Class<?> filterClass = config.jsonWebToken() ? JsonWebTokenRequestFilter.class : AccessTokenRequestFilter.class;

--- a/extensions/openshift-client/deployment/src/main/java/io/quarkus/openshift/client/deployment/OpenShiftClientProcessor.java
+++ b/extensions/openshift-client/deployment/src/main/java/io/quarkus/openshift/client/deployment/OpenShiftClientProcessor.java
@@ -41,7 +41,9 @@ public class OpenShiftClientProcessor {
                 .map(c -> c.name().toString())
                 .filter(s -> s.startsWith("io.fabric8.openshift"))
                 .toArray(String[]::new);
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(deserializerClasses).methods().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(deserializerClasses)
+                .reason(getClass().getName())
+                .methods().build());
 
         final String[] serializerClasses = combinedIndexBuildItem.getIndex()
                 .getAllKnownSubclasses(DotName.createSimple("com.fasterxml.jackson.databind.JsonSerializer"))
@@ -49,14 +51,13 @@ public class OpenShiftClientProcessor {
                 .map(c -> c.name().toString())
                 .filter(s -> s.startsWith("io.fabric8.openshift"))
                 .toArray(String[]::new);
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(serializerClasses).methods().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(serializerClasses)
+                .reason(getClass().getName())
+                .methods().build());
 
-        reflectiveClasses
-                .produce(ReflectiveClassBuildItem.builder(OpenShiftClientImpl.class.getName()).methods().fields()
-                        .build());
-        reflectiveClasses
-                .produce(ReflectiveClassBuildItem.builder(DefaultOpenShiftClient.class.getName()).methods().fields()
-                        .build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(OpenShiftClientImpl.class, DefaultOpenShiftClient.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
     }
 
     @BuildStep

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -186,8 +186,9 @@ public class OpenTelemetryProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         resource.produce(new NativeImageResourceBuildItem(
                 "META-INF/services/io.opentelemetry.context.ContextStorageProvider"));
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(QuarkusContextStorage.class).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(QuarkusContextStorage.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
     }
 
     @BuildStep

--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -166,37 +166,39 @@ public class QuartzProcessor {
                     JobDataMap.class,
                     DirtyFlagMap.class,
                     StringKeyDirtyFlagMap.class,
-                    HashMap.class).serialization(true).build());
+                    HashMap.class)
+                    .reason(getClass().getName())
+                    .serialization(true).build());
         }
 
+        reflectiveClasses.add(ReflectiveClassBuildItem.builder(SimpleThreadPool.class, SimpleInstanceIdGenerator.class)
+                .reason(getClass().getName())
+                .methods().build());
         reflectiveClasses
-                .add(ReflectiveClassBuildItem.builder(SimpleThreadPool.class.getName()).methods().build());
-        reflectiveClasses.add(ReflectiveClassBuildItem.builder(SimpleInstanceIdGenerator.class.getName()).methods()
-                .build());
-        reflectiveClasses.add(ReflectiveClassBuildItem.builder(CascadingClassLoadHelper.class.getName())
-                .build());
-        reflectiveClasses.add(ReflectiveClassBuildItem.builder(config.storeType.clazz).methods().fields().build());
-        reflectiveClasses
-                .add(ReflectiveClassBuildItem.builder(InitThreadContextClassLoadHelper.class)
+                .add(ReflectiveClassBuildItem.builder(CascadingClassLoadHelper.class, InitThreadContextClassLoadHelper.class)
+                        .reason(getClass().getName())
                         .build());
+        reflectiveClasses.add(ReflectiveClassBuildItem.builder(config.storeType.clazz)
+                .reason(getClass().getName())
+                .methods().fields().build());
 
         if (config.storeType.isDbStore()) {
-            reflectiveClasses
-                    .add(ReflectiveClassBuildItem.builder(JobStoreSupport.class.getName()).methods().build());
-            reflectiveClasses
-                    .add(ReflectiveClassBuildItem.builder(Connection.class.getName()).methods().fields().build());
-            reflectiveClasses
-                    .add(ReflectiveClassBuildItem.builder(AbstractTrigger.class.getName()).methods().build());
-            reflectiveClasses.add(
-                    ReflectiveClassBuildItem.builder(SimpleTriggerImpl.class.getName()).methods().build());
-            reflectiveClasses
-                    .add(ReflectiveClassBuildItem.builder(driverDialect.getDriver().get()).methods().build());
-            reflectiveClasses
-                    .add(ReflectiveClassBuildItem.builder("io.quarkus.quartz.runtime.QuartzSchedulerImpl$InvokerJob")
-                            .methods().fields().build());
-            reflectiveClasses
-                    .add(ReflectiveClassBuildItem.builder(QuarkusQuartzConnectionPoolProvider.class.getName()).methods()
-                            .build());
+            reflectiveClasses.add(ReflectiveClassBuildItem.builder(
+                    JobStoreSupport.class,
+                    AbstractTrigger.class,
+                    SimpleTriggerImpl.class,
+                    QuarkusQuartzConnectionPoolProvider.class)
+                    .reason(getClass().getName())
+                    .methods().build());
+            reflectiveClasses.add(ReflectiveClassBuildItem.builder(Connection.class)
+                    .reason(getClass().getName()).methods()
+                    .fields().build());
+            reflectiveClasses.add(ReflectiveClassBuildItem.builder(driverDialect.getDriver().get())
+                    .reason(getClass().getName())
+                    .methods().build());
+            reflectiveClasses.add(ReflectiveClassBuildItem.builder("io.quarkus.quartz.runtime.QuartzSchedulerImpl$InvokerJob")
+                    .reason(getClass().getName())
+                    .methods().fields().build());
         }
 
         reflectiveClasses
@@ -220,7 +222,9 @@ public class QuartzProcessor {
             } catch (ClassNotFoundException e) {
                 throw new IllegalArgumentException(e);
             }
-            reflectiveClasses.add(ReflectiveClassBuildItem.builder(props.clazz).methods().build());
+            reflectiveClasses.add(ReflectiveClassBuildItem.builder(props.clazz)
+                    .reason(getClass().getName())
+                    .methods().build());
         }
         return reflectiveClasses;
     }

--- a/extensions/redis-cache/deployment/src/main/java/io/quarkus/cache/redis/deployment/RedisCacheProcessor.java
+++ b/extensions/redis-cache/deployment/src/main/java/io/quarkus/cache/redis/deployment/RedisCacheProcessor.java
@@ -62,7 +62,9 @@ public class RedisCacheProcessor {
 
     @BuildStep
     void nativeImage(BuildProducer<ReflectiveClassBuildItem> producer) {
-        producer.produce(ReflectiveClassBuildItem.builder(CompositeCacheKey.class).methods(true).build());
+        producer.produce(ReflectiveClassBuildItem.builder(CompositeCacheKey.class)
+                .reason(getClass().getName())
+                .methods().build());
     }
 
     @BuildStep

--- a/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -113,7 +113,9 @@ public class ResteasyCommonProcessor {
 
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(ServletConfigSource.class,
                 ServletContextConfigSource.class,
-                FilterConfigSource.class).build());
+                FilterConfigSource.class)
+                .reason(getClass().getName())
+                .build());
     }
 
     @BuildStep
@@ -240,6 +242,7 @@ public class ResteasyCommonProcessor {
             // This abstract one is also accessed directly via reflection
             reflectiveClass.produce(
                     ReflectiveClassBuildItem.builder("org.jboss.resteasy.plugins.providers.jsonb.AbstractJsonBindingProvider")
+                            .reason(getClass().getName())
                             .methods().fields().build());
         }
 

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -755,7 +755,9 @@ public class ResteasyServerCommonProcessor {
         // special case: our config providers
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(ServletConfigSource.class,
                 ServletContextConfigSource.class,
-                FilterConfigSource.class).build());
+                FilterConfigSource.class)
+                .reason(ResteasyServerCommonProcessor.class.getSimpleName())
+                .build());
     }
 
     private static void generateDefaultConstructors(BuildProducer<BytecodeTransformerBuildItem> transformers,

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -252,8 +252,9 @@ public class JaxrsClientReactiveProcessor {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(StorkClientRequestFilter.class));
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(StorkClientRequestFilter.class.getName()));
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(StorkClientRequestFilter.class).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(StorkClientRequestFilter.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
     }
 
     @BuildStep
@@ -296,6 +297,7 @@ public class JaxrsClientReactiveProcessor {
         }
         reflectiveClassBuildItemBuildProducer.produce(ReflectiveClassBuildItem
                 .builder(scannedParameterContainers.stream().map(DotName::toString).distinct().toArray(String[]::new))
+                .reason(getClass().getName())
                 .methods().fields().build());
 
         if (resourceScanningResultBuildItem.isEmpty()
@@ -426,6 +428,7 @@ public class JaxrsClientReactiveProcessor {
             recorder.registerReader(serialisers, additionalReader.getEntityClass(), reader);
             reflectiveClassBuildItemBuildProducer
                     .produce(ReflectiveClassBuildItem.builder(readerClass)
+                            .reason(getClass().getName())
                             .build());
         }
 
@@ -438,6 +441,7 @@ public class JaxrsClientReactiveProcessor {
             recorder.registerWriter(serialisers, entry.getEntityClass(), writer);
             reflectiveClassBuildItemBuildProducer
                     .produce(ReflectiveClassBuildItem.builder(writerClass)
+                            .reason(getClass().getName())
                             .build());
         }
 

--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -364,10 +364,8 @@ class RestClientReactiveProcessor {
                 .getOptionalValue(ENABLE_COMPRESSION, Boolean.class)
                 .orElse(false);
         if (enableCompression) {
-            reflectiveClasses.produce(ReflectiveClassBuildItem
-                    .builder(ClientGZIPDecodingInterceptor.class)
-                    .serialization(false)
-                    .build());
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(ClientGZIPDecodingInterceptor.class)
+                    .reason(getClass().getName()).build());
         }
     }
 
@@ -401,9 +399,8 @@ class RestClientReactiveProcessor {
                 filterClassNames.add(filterClassName.toString());
             }
         }
-        reflectiveClasses.produce(ReflectiveClassBuildItem
-                .builder(filterClassNames.toArray(new String[0]))
-                .constructors(true)
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(filterClassNames.toArray(new String[0]))
+                .reason(getClass().getName())
                 .build());
     }
 
@@ -695,7 +692,8 @@ class RestClientReactiveProcessor {
             }
             result.put(classResult.interfaceName, classResult);
             reflectiveClassesProducer.produce(ReflectiveClassBuildItem.builder(classResult.generatedClassName)
-                    .serialization(false).build());
+                    .reason(getClass().getName())
+                    .build());
         }
         return result;
     }
@@ -720,7 +718,8 @@ class RestClientReactiveProcessor {
             } else if (existing == null || existing.priority < classResult.priority) {
                 result.put(classResult.interfaceName, classResult);
                 reflectiveClasses.produce(ReflectiveClassBuildItem.builder(classResult.generatedClassName)
-                        .serialization(false).build());
+                        .reason(getClass().getName())
+                        .build());
             }
         }
         return result;
@@ -746,7 +745,8 @@ class RestClientReactiveProcessor {
             }
             result.put(classResult.interfaceName, classResult);
             reflectiveClasses.produce(ReflectiveClassBuildItem.builder(classResult.generatedClassName)
-                    .serialization(false).build());
+                    .reason(getClass().getName())
+                    .build());
         }
         return result;
     }

--- a/extensions/resteasy-reactive/rest-csrf/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveBuildStep.java
+++ b/extensions/resteasy-reactive/rest-csrf/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveBuildStep.java
@@ -19,8 +19,9 @@ public class CsrfReactiveBuildStep {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(CsrfRequestResponseReactiveFilter.class));
-        reflectiveClass.produce(
-                ReflectiveClassBuildItem.builder(CsrfRequestResponseReactiveFilter.class).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(CsrfRequestResponseReactiveFilter.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(CsrfTokenParameterProvider.class));
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(CsrfRequestResponseReactiveFilter.class.getName()));

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -229,7 +229,7 @@ public class ResteasyReactiveJacksonProcessor {
 
     @BuildStep
     void reflection(BuildProducer<ReflectiveClassBuildItem> producer) {
-        producer.produce(ReflectiveClassBuildItem.builder(Cookie.class).methods().build());
+        producer.produce(ReflectiveClassBuildItem.builder(Cookie.class).reason(getClass().getName()).methods().build());
     }
 
     @Record(ExecutionTime.STATIC_INIT)
@@ -283,6 +283,7 @@ public class ResteasyReactiveJacksonProcessor {
                     }
                     reflectiveClassProducer.produce(
                             ReflectiveClassBuildItem.builder(biFunctionType.name().toString())
+                                    .reason(getClass().getName())
                                     .build());
                     recorder.recordCustomSerialization(getTargetId(instance.target()), biFunctionType.name().toString());
                 }
@@ -309,6 +310,7 @@ public class ResteasyReactiveJacksonProcessor {
                     }
                     reflectiveClassProducer.produce(
                             ReflectiveClassBuildItem.builder(biFunctionType.name().toString())
+                                    .reason(getClass().getName())
                                     .build());
                     recorder.recordCustomDeserialization(getTargetId(instance.target()), biFunctionType.name().toString());
                 }
@@ -319,7 +321,9 @@ public class ResteasyReactiveJacksonProcessor {
             jacksonFeatures.add(JacksonFeatureBuildItem.Feature.CUSTOM_SERIALIZATION);
             String className = bi.getCustomSerializationProvider().getName();
             reflectiveClassProducer.produce(
-                    ReflectiveClassBuildItem.builder(className).build());
+                    ReflectiveClassBuildItem.builder(className)
+                            .reason(getClass().getName())
+                            .build());
             recorder.recordCustomSerialization(getMethodId(bi.getMethodInfo(), bi.getDeclaringClassInfo()), className);
         }
 

--- a/extensions/resteasy-reactive/rest-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/ResteasyReactiveJsonbProcessor.java
+++ b/extensions/resteasy-reactive/rest-jsonb/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/deployment/ResteasyReactiveJsonbProcessor.java
@@ -34,6 +34,6 @@ public class ResteasyReactiveJsonbProcessor {
 
     @BuildStep
     void reflection(BuildProducer<ReflectiveClassBuildItem> producer) {
-        producer.produce(ReflectiveClassBuildItem.builder(Cookie.class).methods().build());
+        producer.produce(ReflectiveClassBuildItem.builder(Cookie.class).reason(getClass().getName()).methods().build());
     }
 }

--- a/extensions/resteasy-reactive/rest-kotlin-serialization-common/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/deployment/KotlinSerializationCommonProcessor.java
+++ b/extensions/resteasy-reactive/rest-kotlin-serialization-common/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/deployment/KotlinSerializationCommonProcessor.java
@@ -46,9 +46,11 @@ public class KotlinSerializationCommonProcessor {
         }
         // the companion classes need to be registered for reflection so Kotlin can construct them and invoke methods reflectively
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(supportClassNames.toArray(EMPTY_ARRAY))
+                .reason(getClass().getName())
                 .methods().build());
         // the serializable classes need to be registered for reflection, so they can be constructed and also Kotlin can determine the companion field at runtime
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(serializableClassNames.toArray(EMPTY_ARRAY))
+                .reason(getClass().getName())
                 .fields().build());
     }
 

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -382,9 +382,8 @@ public class ResteasyReactiveProcessor {
             Map<String, String> generationResult = ServerExceptionMapperGenerator.generatePerClassMapper(methodInfo,
                     classOutput,
                     Set.of(HTTP_SERVER_REQUEST, HTTP_SERVER_RESPONSE, ROUTING_CONTEXT), Set.of(Unremovable.class.getName()));
-            reflectiveClass.produce(
-                    ReflectiveClassBuildItem.builder(generationResult.values().toArray(
-                            EMPTY_STRING_ARRAY)).build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(generationResult.values().toArray(EMPTY_STRING_ARRAY))
+                    .reason(getClass().getName()).build());
             Map<String, String> classMappers;
             DotName classDotName = methodInfo.declaringClass().name();
             if (resultingMappers.containsKey(classDotName)) {
@@ -998,6 +997,7 @@ public class ResteasyReactiveProcessor {
         if (!dateTimeFormatterProviderClassNames.isEmpty()) {
             reflectiveClass
                     .produce(ReflectiveClassBuildItem.builder(dateTimeFormatterProviderClassNames.toArray(EMPTY_STRING_ARRAY))
+                            .reason(getClass().getName())
                             .serialization(false).build());
         }
     }
@@ -1188,6 +1188,7 @@ public class ResteasyReactiveProcessor {
         if (serializersRequireResourceReflection) {
             producer.produce(ReflectiveClassBuildItem
                     .builder(resourceClasses.stream().map(ResourceClass::getClassName).toArray(String[]::new))
+                    .reason(getClass().getName())
                     .constructors(false).methods().build());
         }
     }

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -570,7 +570,7 @@ public class ResteasyReactiveProcessor {
                                                 QuarkusResteasyReactiveDotNames.IGNORE_FIELD_FOR_REFLECTION_PREDICATE)
                                         .ignoreMethodPredicate(
                                                 QuarkusResteasyReactiveDotNames.IGNORE_METHOD_FOR_REFLECTION_PREDICATE)
-                                        .source(source)
+                                        .source(source + " > " + method.returnType().name().toString())
                                         .build());
                             }
 
@@ -587,7 +587,7 @@ public class ResteasyReactiveProcessor {
                                                     QuarkusResteasyReactiveDotNames.IGNORE_FIELD_FOR_REFLECTION_PREDICATE)
                                             .ignoreMethodPredicate(
                                                     QuarkusResteasyReactiveDotNames.IGNORE_METHOD_FOR_REFLECTION_PREDICATE)
-                                            .source(source)
+                                            .source(source + " > " + parameterType.name().toString())
                                             .build());
                                 }
                                 if (parameterType.name().equals(FILE)) {

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -148,7 +148,7 @@ public class SmallRyeFaultToleranceProcessor {
                 clazz.methods()
                         .stream()
                         .filter(it -> fallbackMethod.equals(it.name()))
-                        .forEach(it -> reflectiveMethod.produce(new ReflectiveMethodBuildItem(it)));
+                        .forEach(it -> reflectiveMethod.produce(new ReflectiveMethodBuildItem(getClass().getName(), it)));
 
                 DotName superClass = clazz.superName();
                 if (superClass != null && !DotNames.OBJECT.equals(superClass)) {

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -281,7 +281,8 @@ public class SmallRyeFaultToleranceProcessor {
         for (String exceptionConfig : exceptionConfigs) {
             Optional<String[]> exceptionNames = config.getOptionalValue(exceptionConfig, String[].class);
             if (exceptionNames.isPresent()) {
-                reflectiveClass.produce(ReflectiveClassBuildItem.builder(exceptionNames.get()).build());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(exceptionNames.get())
+                        .reason(getClass().getName()).build());
             }
         }
 
@@ -309,7 +310,8 @@ public class SmallRyeFaultToleranceProcessor {
                     Optional<String[]> exceptionNames = config.getOptionalValue(beanClass.name().toString()
                             + "/" + exceptionConfig, String[].class);
                     if (exceptionNames.isPresent()) {
-                        reflectiveClass.produce(ReflectiveClassBuildItem.builder(exceptionNames.get()).build());
+                        reflectiveClass.produce(ReflectiveClassBuildItem.builder(exceptionNames.get())
+                                .reason(getClass().getName()).build());
                     }
                 }
 
@@ -334,7 +336,8 @@ public class SmallRyeFaultToleranceProcessor {
                             Optional<String[]> exceptionNames = config.getOptionalValue(beanClass.name().toString()
                                     + "/" + method.name() + "/" + exceptionConfig, String[].class);
                             if (exceptionNames.isPresent()) {
-                                reflectiveClass.produce(ReflectiveClassBuildItem.builder(exceptionNames.get()).build());
+                                reflectiveClass.produce(ReflectiveClassBuildItem.builder(exceptionNames.get())
+                                        .reason(getClass().getName()).build());
                             }
                         }
 

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -329,11 +329,14 @@ public class SmallRyeGraphQLProcessor {
 
         // Make sure the complex object from the application can work in native mode
         reflectiveClassProducer
-                .produce(ReflectiveClassBuildItem.builder(getSchemaJavaClasses(schema)).methods().fields().build());
+                .produce(ReflectiveClassBuildItem.builder(getSchemaJavaClasses(schema))
+                        .reason(getClass().getName())
+                        .methods().fields().build());
 
         // Make sure the GraphQL Java classes needed for introspection can work in native mode
-        reflectiveClassProducer
-                .produce(ReflectiveClassBuildItem.builder(getGraphQLJavaClasses()).methods().fields().build());
+        reflectiveClassProducer.produce(ReflectiveClassBuildItem.builder(getGraphQLJavaClasses())
+                .reason(getClass().getName())
+                .methods().fields().build());
     }
 
     private void registerExtraScalarsInSchema(List<ExtraScalar> extraScalars) {

--- a/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/build/deployment/SmallRyeJwtBuildProcessor.java
+++ b/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/build/deployment/SmallRyeJwtBuildProcessor.java
@@ -23,10 +23,10 @@ class SmallRyeJwtBuildProcessor {
     @BuildStep
     void addClassesForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
         reflectiveClasses
-                .produce(ReflectiveClassBuildItem.builder(SignatureAlgorithm.class).methods().fields().build());
-        reflectiveClasses
-                .produce(ReflectiveClassBuildItem.builder(KeyEncryptionAlgorithm.class).methods().fields().build());
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(JwtProviderImpl.class).methods().fields().build());
+                .produce(ReflectiveClassBuildItem
+                        .builder(SignatureAlgorithm.class, KeyEncryptionAlgorithm.class, JwtProviderImpl.class)
+                        .reason(getClass().getName())
+                        .methods().fields().build());
     }
 
     /**

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -115,10 +115,9 @@ class SmallRyeJwtProcessor {
         removable.addBeanClass(Claim.class);
         additionalBeans.produce(removable.build());
 
-        reflectiveClasses
-                .produce(ReflectiveClassBuildItem.builder(SignatureAlgorithm.class).methods().fields().build());
-        reflectiveClasses
-                .produce(ReflectiveClassBuildItem.builder(KeyEncryptionAlgorithm.class).methods().fields().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(SignatureAlgorithm.class, KeyEncryptionAlgorithm.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
     }
 
     /**

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -288,9 +288,9 @@ public class SmallRyeMetricsProcessor {
             }
         }
         if (!classNames.isEmpty()) {
-            reflectiveClass.produce(
-                    ReflectiveClassBuildItem.builder(classNames.toArray(new String[0]))
-                            .methods(true).constructors(true).build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(classNames.toArray(new String[0]))
+                    .reason(getClass().getName())
+                    .methods(true).build());
         }
     }
 

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -270,7 +270,8 @@ public class SmallRyeOpenApiProcessor {
                 .supplier(recorder.createUserDefinedRuntimeFilters(userDefinedRuntimeFilters))
                 .done());
 
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(userDefinedRuntimeFilters.toArray(new String[] {})).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(userDefinedRuntimeFilters.toArray(new String[] {}))
+                .reason(getClass().getName()).build());
     }
 
     @BuildStep

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -71,7 +71,9 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
     @BuildStep
     public void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<AdditionalBeanBuildItem> additionalBean) {
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ProcessingState.class).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ProcessingState.class)
+                .reason(getClass().getName())
+                .methods().fields().build());
         additionalBean.produce(AdditionalBeanBuildItem.unremovableOf(KafkaConfigCustomizer.class));
     }
 
@@ -133,7 +135,9 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
         if (hasStateStoreConfig(REDIS_STATE_STORE, ConfigProvider.getConfig())) {
             Optional<String> checkpointStateType = getConnectorProperty("checkpoint.state-type", ConfigProvider.getConfig());
             checkpointStateType.ifPresent(
-                    s -> reflectiveClass.produce(ReflectiveClassBuildItem.builder(s).methods().fields().build()));
+                    s -> reflectiveClass.produce(ReflectiveClassBuildItem.builder(s)
+                            .reason(getClass().getName())
+                            .methods().fields().build()));
             if (capabilities.isPresent(Capability.REDIS_CLIENT)) {
                 additionalBean.produce(new AdditionalBeanBuildItem(RedisStateStore.Factory.class));
                 additionalBean.produce(new AdditionalBeanBuildItem(DatabindProcessingStateCodec.Factory.class));
@@ -873,7 +877,9 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
                 LOGGER.infof("Generating Jackson deserializer for type %s", type.name().toString());
                 // Deserializers are access by reflection.
                 reflection.produce(
-                        ReflectiveClassBuildItem.builder(clazz).methods().build());
+                        ReflectiveClassBuildItem.builder(clazz)
+                                .reason(getClass().getName())
+                                .methods().build());
                 alreadyGeneratedDeserializers.put(type.toString(), result);
                 // if the channel has a DLQ config generate a serializer as well
                 if (hasDLQConfig(channelName, discovery.getConfig())) {
@@ -910,7 +916,9 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
                 LOGGER.infof("Generating Jackson serializer for type %s", type.name().toString());
                 // Serializers are access by reflection.
                 reflection.produce(
-                        ReflectiveClassBuildItem.builder(clazz).methods().build());
+                        ReflectiveClassBuildItem.builder(clazz)
+                                .reason(getClass().getName())
+                                .methods().build());
                 result = Result.of(clazz);
                 alreadyGeneratedSerializers.put(type.toString(), result);
             }
@@ -1022,7 +1030,9 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
 
     void produceReflectiveClass(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, Type type) {
         reflectiveClass.produce(
-                ReflectiveClassBuildItem.builder(type.name().toString()).methods().fields().build());
+                ReflectiveClassBuildItem.builder(type.name().toString())
+                        .reason(getClass().getName())
+                        .methods().fields().build());
     }
 
     // visible for testing

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ClassConfigurationPropertiesUtil.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ClassConfigurationPropertiesUtil.java
@@ -305,7 +305,7 @@ final class ClassConfigurationPropertiesUtil {
                                 continue;
                             }
                             if (method.parameterType(0).name().equals(DotNames.STRING)) {
-                                reflectiveMethods.produce(new ReflectiveMethodBuildItem(method));
+                                reflectiveMethods.produce(new ReflectiveMethodBuildItem(getClass().getName(), method));
                                 break;
                             }
                         }

--- a/extensions/spring-cloud-config-client/deployment/src/main/java/io/quarkus/spring/cloud/config/client/SpringCloudConfigProcessor.java
+++ b/extensions/spring-cloud-config-client/deployment/src/main/java/io/quarkus/spring/cloud/config/client/SpringCloudConfigProcessor.java
@@ -24,7 +24,9 @@ public class SpringCloudConfigProcessor {
 
     @BuildStep
     public void registerForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(Response.class, Response.PropertySource.class).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(Response.class, Response.PropertySource.class)
+                .reason(getClass().getName())
+                .build());
     }
 
     @BuildStep

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -450,8 +450,7 @@ class VertxHttpProcessor {
         boolean startVirtual = requireVirtual.isPresent() || httpBuildTimeConfig.virtual;
         if (startVirtual) {
             reflectiveClass
-                    .produce(ReflectiveClassBuildItem.builder(VirtualServerChannel.class)
-                            .build());
+                    .produce(ReflectiveClassBuildItem.builder(VirtualServerChannel.class).reason(getClass().getName()).build());
         }
         boolean startSocket = requireSocket.isPresent() ||
                 ((!startVirtual || launchMode.getLaunchMode() != LaunchMode.NORMAL)

--- a/extensions/websockets/client/deployment/src/main/java/io/quarkus/websockets/client/deployment/WebsocketClientProcessor.java
+++ b/extensions/websockets/client/deployment/src/main/java/io/quarkus/websockets/client/deployment/WebsocketClientProcessor.java
@@ -120,8 +120,9 @@ public class WebsocketClientProcessor {
             annotated.add(i.className);
         }
         reflection.produce(
-                ReflectiveClassBuildItem.builder(annotated.toArray(new String[annotated.size()])).methods()
-                        .build());
+                ReflectiveClassBuildItem.builder(annotated.toArray(new String[annotated.size()]))
+                        .reason(getClass().getName())
+                        .methods().build());
 
         registerCodersForReflection(reflection, index.getAnnotations(CLIENT_ENDPOINT));
 


### PR DESCRIPTION
Starting with GraalVM / Mandrel for JDK 23 (24.1) the `*-config.json` files will be deprecated. Instead `reachability-metadata.json` will be used which will also allow us to include some comments regarding the configuration (see https://github.com/oracle/graal/pull/9048)

This PR sets the foundations for supporting this by adding a `reasons` entry to the `reflect-config.json` file that Quarkus generates. This will hopefully enable us and our users to get a better understanding on why some elements are being registered for reflective access (i.e. what Quarkus extension/part is responsible for the registration). It also improves the tracing done in hierarchical class registrations (so that users can see the whole trace leading to a class being registered).

Note that since `*config.json` don't officially support this `reasons` entry, a warning is printed during compilation time. As a results this is an opt-in feature, one needs to pass `-Dquarkus.native.include-reasons-in-config-files`, at least for the time being.

FWIW the result looks like this:

```json
  {
    "reasons": [
      "io.quarkus.elytron.security.common.deployment.QuarkusSecurityCommonProcessor"
    ],
    "allDeclaredConstructors": true,
    "name": "org.wildfly.security.password.impl.PasswordFactorySpiImpl",
    "allDeclaredMethods": true
  },
  {
    "allDeclaredConstructors": true,
    "name": "io.quarkus.vertx.mdc.provider.LateBoundMDCProvider",
    "allDeclaredMethods": true,
    "allDeclaredFields": true
  },
  {
    "reasons": [
      "The generated application class"
    ],
    "allDeclaredConstructors": true,
    "name": "io.quarkus.runner.ApplicationImpl"
  },
  {
    "reasons": [
      "io.quarkus.hibernate.validator.deployment.HibernateValidatorProcessor"
    ],
    "allDeclaredConstructors": true,
    "name": "io.quarkus.hibernate.validator.runtime.jaxrs.ViolationReport",
    "allDeclaredMethods": true,
    "allDeclaredFields": true
  },
```

