### PR TITLE
Quartz - fix job refire behavior, improve dep. bean job scenario

### DIFF
--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DependentBeanJobTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DependentBeanJobTest.java
@@ -86,10 +86,10 @@ public class DependentBeanJobTest {
 
     @Test
     public void testDependentBeanJobWithRefire() throws SchedulerException, InterruptedException {
-        // 5 one-off jobs should trigger construction/execution/destruction 10 times in total
-        CountDownLatch execLatch = service.initExecuteLatch(10);
-        CountDownLatch constructLatch = service.initConstructLatch(10);
-        CountDownLatch destroyedLatch = service.initDestroyedLatch(10);
+        // 5 one-off jobs should trigger construction/execution/destruction 5 times in total
+        CountDownLatch execLatch = service.initExecuteLatch(5);
+        CountDownLatch constructLatch = service.initConstructLatch(5);
+        CountDownLatch destroyedLatch = service.initDestroyedLatch(5);
         for (int i = 0; i < 5; i++) {
             Trigger trigger = TriggerBuilder.newTrigger()
                     .withIdentity("myTrigger" + i, "myRefiringGroup")
@@ -104,10 +104,10 @@ public class DependentBeanJobTest {
         assertTrue(constructLatch.await(2, TimeUnit.SECONDS), "Latch count: " + constructLatch.getCount());
         assertTrue(destroyedLatch.await(2, TimeUnit.SECONDS), "Latch count: " + destroyedLatch.getCount());
 
-        // repeating job triggering three times; we expect six beans to exist for that due to refires
-        execLatch = service.initExecuteLatch(6);
-        constructLatch = service.initConstructLatch(6);
-        destroyedLatch = service.initDestroyedLatch(6);
+        // repeating job triggering three times; re-fires should NOT recreate the bean instance
+        execLatch = service.initExecuteLatch(3);
+        constructLatch = service.initConstructLatch(3);
+        destroyedLatch = service.initDestroyedLatch(3);
         JobDetail job = JobBuilder.newJob(RefiringJob.class)
                 .withIdentity("myRepeatingJob", "myRefiringGroup")
                 .build();

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/InterruptableJobTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/InterruptableJobTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -40,6 +41,7 @@ public class InterruptableJobTest {
 
     static final CountDownLatch INTERRUPT_LATCH = new CountDownLatch(1);
     static final CountDownLatch EXECUTE_LATCH = new CountDownLatch(1);
+    static Integer initCounter = 0;
 
     static final CountDownLatch NON_INTERRUPTABLE_EXECUTE_LATCH = new CountDownLatch(1);
     static final CountDownLatch NON_INTERRUPTABLE_HOLD_LATCH = new CountDownLatch(1);
@@ -66,7 +68,9 @@ public class InterruptableJobTest {
             throw new RuntimeException(e);
         }
 
-        assertTrue(INTERRUPT_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(INTERRUPT_LATCH.await(3, TimeUnit.SECONDS));
+        // asserts that a single dep. scoped bean instance was used for both, execute() and interrupt() methods
+        assertTrue(initCounter == 1);
     }
 
     @Test
@@ -101,6 +105,11 @@ public class InterruptableJobTest {
 
     @ApplicationScoped
     static class MyJob implements InterruptableJob {
+
+        @PostConstruct
+        public void postConstruct() {
+            initCounter++;
+        }
 
         @Override
         public void execute(JobExecutionContext context) {

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/CdiAwareJob.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/CdiAwareJob.java
@@ -28,10 +28,14 @@ class CdiAwareJob implements InterruptableJob {
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         Instance.Handle<? extends Job> handle = jobInstance.getHandle();
+        boolean refire = false;
         try {
             handle.get().execute(context);
+        } catch (JobExecutionException e) {
+            refire = e.refireImmediately();
+            throw e;
         } finally {
-            if (handle.getBean().getScope().equals(Dependent.class)) {
+            if (refire != true && handle.getBean().getScope().equals(Dependent.class)) {
                 handle.destroy();
             }
         }

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -1246,7 +1246,7 @@ public class QuartzSchedulerImpl implements QuartzScheduler {
             Instance<? extends Job> instance = jobs.select(jobClass);
             if (instance.isResolvable()) {
                 // This is a job backed by a CDI bean
-                return jobWithSpanWrapper(new CdiAwareJob(instance));
+                return jobWithSpanWrapper(new CdiAwareJob(instance.getHandle()));
             }
             // Instantiate a plain job class
             return jobWithSpanWrapper(super.newJob(bundle, Scheduler));


### PR DESCRIPTION
Follows up on https://github.com/quarkusio/quarkus/pull/42072 and superseeds https://github.com/quarkusio/quarkus/pull/42096
Related to https://github.com/quarkusio/quarkus/issues/42034

First commit fixes a case that we discussed with @mkouba over on Zulip which is that job re-fires (via `JobExecutionException`) should *not* spawn new bean instance but instead reuse existing one.
The other commit is a fix that makes sure we use the same bean instance for both, `execute()` and `interrupt()` methods.

@ilia1243 FYI, this is a follow up on the discussion from last week; hopefully this no longer has the same shortcomings :)