### PR TITLE
Add a property to disable liquibase for selected data sources at build time

### DIFF
--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseConfig.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseConfig.java
@@ -16,6 +16,11 @@ import io.quarkus.runtime.annotations.ConfigDocMapKey;
 public class LiquibaseConfig {
 
     /**
+     * Enable liquibase for a specific data source
+     */
+    public boolean active = true;
+
+    /**
      * The change log file
      */
     public String changeLog = DEFAULT_CHANGE_LOG;

--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseCreator.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseCreator.java
@@ -17,22 +17,17 @@ class LiquibaseCreator {
 
     public LiquibaseFactory createLiquibaseFactory(DataSource dataSource, String dataSourceName) {
         LiquibaseConfig config = new LiquibaseConfig();
+        config.active = liquibaseBuildTimeConfig.active;
         config.changeLog = liquibaseBuildTimeConfig.changeLog;
         config.searchPath = liquibaseBuildTimeConfig.searchPath;
         config.changeLogParameters = liquibaseRuntimeConfig.changeLogParameters;
 
-        if (liquibaseRuntimeConfig.labels.isPresent()) {
-            config.labels = liquibaseRuntimeConfig.labels.get();
-        }
-        if (liquibaseRuntimeConfig.contexts.isPresent()) {
-            config.contexts = liquibaseRuntimeConfig.contexts.get();
-        }
-        if (liquibaseRuntimeConfig.databaseChangeLogLockTableName.isPresent()) {
-            config.databaseChangeLogLockTableName = liquibaseRuntimeConfig.databaseChangeLogLockTableName.get();
-        }
-        if (liquibaseRuntimeConfig.databaseChangeLogTableName.isPresent()) {
-            config.databaseChangeLogTableName = liquibaseRuntimeConfig.databaseChangeLogTableName.get();
-        }
+        liquibaseRuntimeConfig.labels.ifPresent(lbls -> config.labels = lbls);
+        liquibaseRuntimeConfig.contexts.ifPresent(ctxs -> config.contexts = ctxs);
+        liquibaseRuntimeConfig.databaseChangeLogLockTableName
+                .ifPresent(name -> config.databaseChangeLogLockTableName = name);
+        liquibaseRuntimeConfig.databaseChangeLogTableName.ifPresent(name -> config.databaseChangeLogTableName = name);
+
         config.password = liquibaseRuntimeConfig.password;
         config.username = liquibaseRuntimeConfig.username;
         config.defaultSchemaName = liquibaseRuntimeConfig.defaultSchemaName;

--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseDataSourceBuildTimeConfig.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseDataSourceBuildTimeConfig.java
@@ -19,10 +19,11 @@ public final class LiquibaseDataSourceBuildTimeConfig {
      *
      * @return {@link LiquibaseDataSourceBuildTimeConfig}
      */
-    public static final LiquibaseDataSourceBuildTimeConfig defaultConfig() {
+    public static LiquibaseDataSourceBuildTimeConfig defaultConfig() {
         LiquibaseDataSourceBuildTimeConfig defaultConfig = new LiquibaseDataSourceBuildTimeConfig();
         defaultConfig.changeLog = DEFAULT_CHANGE_LOG;
         defaultConfig.searchPath = Optional.empty();
+        defaultConfig.active = true;
         return defaultConfig;
     }
 
@@ -31,6 +32,12 @@ public final class LiquibaseDataSourceBuildTimeConfig {
      */
     @ConfigItem(defaultValue = DEFAULT_CHANGE_LOG)
     public String changeLog;
+
+    /**
+     * {@code true} to enable Liquibase for a specific data source, {@code false} otherwise.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean active;
 
     /**
      * The search path for DirectoryResourceAccessor

--- a/integration-tests/liquibase/src/main/resources/application.properties
+++ b/integration-tests/liquibase/src/main/resources/application.properties
@@ -10,6 +10,13 @@ quarkus.datasource.second.username=readonly
 quarkus.datasource.second.password=readonly
 quarkus.datasource.second.jdbc.url=jdbc:h2:mem:second;INIT=RUNSCRIPT FROM 'src/main/resources/db/second/initdb.sql'
 
+# datasource with missing liquibase changeLog
+quarkus.datasource.invalid.db-kind=h2
+quarkus.datasource.invalid.username=readonly
+quarkus.datasource.invalid.password=readonly
+quarkus.datasource.invalid.jdbc.url=jdbc:h2:mem:invalid;DB_CLOSE_DELAY=-1
+
+
 # Liquibase config properties
 quarkus.liquibase.change-log=db/changeLog.xml
 quarkus.liquibase.clean-at-start=true
@@ -23,6 +30,11 @@ quarkus.liquibase.second.password=pass
 quarkus.liquibase.second.change-log=db/second/changeLog.xml
 quarkus.liquibase.second.clean-at-start=false
 quarkus.liquibase.second.migrate-at-start=false
+
+# Config with invalid changeLog path for testing 'active' flag
+# When active the build fails in native mode
+quarkus.liquibase.invalid.change-log=invalid/path/to/changeLog.xml
+quarkus.liquibase.invalid.active=false
 
 # Debug logging
 #quarkus.log.console.level=DEBUG


### PR DESCRIPTION
This PR adds a build time configuration property `quarkus.liquibase.active` and accordingly `quarkus.liquibase."named-data-sources".active`.

It enables users to deactivate liquibase at build time for data sources which don't need migration.

The PR also contains some minor brush ups of existing code.

Are there any documentation tasks, that should be addressed in the context of this PR?

- Fixes: #27437