### PR TITLE
Update SmallRye Config to 3.10.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -48,7 +48,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>3.1.2</microprofile-openapi.version>
         <smallrye-common.version>2.8.0</smallrye-common.version>
-        <smallrye-config.version>3.9.1</smallrye-config.version>
+        <smallrye-config.version>3.10.0</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>3.13.0</smallrye-open-api.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -101,7 +101,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.QuarkusConfigFactory;
 import io.quarkus.runtime.util.HashUtil;
-import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.SmallRyeConfig;
 
 /**
@@ -172,7 +172,7 @@ public final class ExtensionLoader {
 
         // this has to be an identity hash map else the recorder will get angry
         Map<Object, FieldDescriptor> rootFields = new IdentityHashMap<>();
-        Map<Object, ConfigClassWithPrefix> mappingClasses = new IdentityHashMap<>();
+        Map<Object, ConfigClass> mappingClasses = new IdentityHashMap<>();
         for (Map.Entry<Class<?>, Object> entry : proxies.entrySet()) {
             // ConfigRoot
             RootDefinition root = readResult.getAllRootsByClass().get(entry.getKey());
@@ -182,7 +182,7 @@ public final class ExtensionLoader {
             }
 
             // ConfigMapping
-            ConfigClassWithPrefix mapping = readResult.getAllMappings().get(entry.getKey());
+            ConfigClass mapping = readResult.getAllMappings().get(entry.getKey());
             if (mapping != null) {
                 mappingClasses.put(entry.getValue(), mapping);
                 continue;
@@ -210,7 +210,7 @@ public final class ExtensionLoader {
                 ObjectLoader mappingLoader = new ObjectLoader() {
                     @Override
                     public ResultHandle load(final BytecodeCreator body, final Object obj, final boolean staticInit) {
-                        ConfigClassWithPrefix mapping = mappingClasses.get(obj);
+                        ConfigClass mapping = mappingClasses.get(obj);
                         MethodDescriptor getConfig = MethodDescriptor.ofMethod(ConfigProvider.class, "getConfig", Config.class);
                         ResultHandle config = body.invokeStaticMethod(getConfig);
                         MethodDescriptor getMapping = MethodDescriptor.ofMethod(SmallRyeConfig.class, "getConfigMapping",

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ConfigMappingBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ConfigMappingBuildItem.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.runtime.annotations.StaticInitSafe;
-import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 
 public final class ConfigMappingBuildItem extends MultiBuildItem {
     private final Class<?> configClass;
@@ -27,8 +27,8 @@ public final class ConfigMappingBuildItem extends MultiBuildItem {
         return configClass.isAnnotationPresent(StaticInitSafe.class);
     }
 
-    public ConfigClassWithPrefix toConfigClassWithPrefix() {
-        return new ConfigClassWithPrefix(configClass, prefix);
+    public ConfigClass toConfigClass() {
+        return new ConfigClass(configClass, prefix);
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -1,9 +1,8 @@
 package io.quarkus.deployment.configuration;
 
-import static io.smallrye.config.ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix;
+import static io.smallrye.config.ConfigMappings.ConfigClass.configClass;
 import static org.jboss.jandex.AnnotationTarget.Kind.CLASS;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -35,7 +34,7 @@ import io.smallrye.config.ConfigMappingInterface.MapProperty;
 import io.smallrye.config.ConfigMappingInterface.Property;
 import io.smallrye.config.ConfigMappingLoader;
 import io.smallrye.config.ConfigMappingMetadata;
-import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 
 public class ConfigMappingUtils {
 
@@ -64,7 +63,7 @@ public class ConfigMappingUtils {
             Class<?> configClass = toClass(target.asClass().name());
             String prefix = Optional.ofNullable(annotationPrefix).map(AnnotationValue::asString).orElse("");
             Kind configClassKind = getConfigClassType(instance);
-            processConfigClass(configClassWithPrefix(configClass, prefix), configClassKind, true, combinedIndex,
+            processConfigClass(configClass(configClass, prefix), configClassKind, true, combinedIndex,
                     generatedClasses, reflectiveClasses, reflectiveMethods, configClasses, additionalConstrainedClasses);
         }
     }
@@ -81,7 +80,7 @@ public class ConfigMappingUtils {
     }
 
     public static void processExtensionConfigMapping(
-            ConfigClassWithPrefix configClass,
+            ConfigClass configClass,
             CombinedIndexBuildItem combinedIndex,
             BuildProducer<GeneratedClassBuildItem> generatedClasses,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
@@ -94,7 +93,7 @@ public class ConfigMappingUtils {
     }
 
     private static void processConfigClass(
-            ConfigClassWithPrefix configClassWithPrefix,
+            ConfigClass configClassWithPrefix,
             Kind configClassKind,
             boolean isApplicationClass,
             CombinedIndexBuildItem combinedIndex,
@@ -143,7 +142,6 @@ public class ConfigMappingUtils {
 
         ConfigMappingInterface mapping = ConfigMappingLoader.getConfigMapping(configClass);
         for (Property property : mapping.getProperties()) {
-            Class<?> returnType = property.getMethod().getReturnType();
             String reason = ConfigMappingUtils.class.getSimpleName() + " Required to process property "
                     + property.getPropertyName();
 
@@ -218,15 +216,6 @@ public class ConfigMappingUtils {
         } else {
             return Kind.PROPERTIES;
         }
-    }
-
-    private static List<Class<?>> getHierarchy(Class<?> mapping) {
-        List<Class<?>> interfaces = new ArrayList<>();
-        for (Class<?> i : mapping.getInterfaces()) {
-            interfaces.add(i);
-            interfaces.addAll(getHierarchy(i));
-        }
-        return interfaces;
     }
 
     private static Set<Type> collectTypes(CombinedIndexBuildItem combinedIndex, Class<?> configClass) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -64,7 +64,7 @@ import io.quarkus.runtime.configuration.NameIterator;
 import io.quarkus.runtime.configuration.PropertiesUtil;
 import io.quarkus.runtime.configuration.QuarkusConfigFactory;
 import io.smallrye.config.ConfigMappings;
-import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.Converters;
 import io.smallrye.config.KeyMap;
 import io.smallrye.config.SmallRyeConfig;
@@ -1198,13 +1198,13 @@ public final class RunTimeConfigurationGenerator {
 
         private void generateUnknownFilter() {
             Set<String> names = new HashSet<>();
-            for (ConfigClassWithPrefix buildTimeMapping : buildTimeConfigResult.getBuildTimeMappings()) {
+            for (ConfigClass buildTimeMapping : buildTimeConfigResult.getBuildTimeMappings()) {
                 names.addAll(ConfigMappings.getProperties(buildTimeMapping).keySet());
             }
-            for (ConfigClassWithPrefix staticConfigMapping : buildTimeConfigResult.getBuildTimeRunTimeMappings()) {
+            for (ConfigClass staticConfigMapping : buildTimeConfigResult.getBuildTimeRunTimeMappings()) {
                 names.addAll(ConfigMappings.getProperties(staticConfigMapping).keySet());
             }
-            for (ConfigClassWithPrefix runtimeConfigMapping : buildTimeConfigResult.getRunTimeMappings()) {
+            for (ConfigClass runtimeConfigMapping : buildTimeConfigResult.getRunTimeMappings()) {
                 names.addAll(ConfigMappings.getProperties(runtimeConfigMapping).keySet());
             }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigDescriptionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigDescriptionBuildStep.java
@@ -35,7 +35,7 @@ import io.smallrye.config.ConfigMappingInterface.LeafProperty;
 import io.smallrye.config.ConfigMappingInterface.PrimitiveProperty;
 import io.smallrye.config.ConfigMappingInterface.Property;
 import io.smallrye.config.ConfigMappings;
-import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 
 public class ConfigDescriptionBuildStep {
 
@@ -120,9 +120,9 @@ public class ConfigDescriptionBuildStep {
         }
     }
 
-    private void processMappings(List<ConfigClassWithPrefix> mappings, List<ConfigDescriptionBuildItem> descriptionBuildItems,
+    private void processMappings(List<ConfigClass> mappings, List<ConfigDescriptionBuildItem> descriptionBuildItems,
             Properties javaDocProperties, ConfigPhase configPhase) {
-        for (ConfigClassWithPrefix mapping : mappings) {
+        for (ConfigClass mapping : mappings) {
             Map<String, Property> properties = ConfigMappings.getProperties(mapping);
             for (Map.Entry<String, Property> entry : properties.entrySet()) {
                 String propertyName = entry.getKey();

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -88,7 +88,7 @@ import io.quarkus.runtime.configuration.RuntimeConfigBuilder;
 import io.quarkus.runtime.configuration.RuntimeOverrideConfigSource;
 import io.quarkus.runtime.configuration.RuntimeOverrideConfigSourceBuilder;
 import io.quarkus.runtime.configuration.StaticInitConfigBuilder;
-import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.ConfigSourceFactory;
 import io.smallrye.config.ConfigSourceInterceptor;
 import io.smallrye.config.ConfigSourceInterceptorFactory;
@@ -184,14 +184,14 @@ public class ConfigGenerationBuildStep {
         processConfigMapping(combinedIndex, generatedClasses, reflectiveClasses, reflectiveMethods, configClasses,
                 additionalConstrainedClasses);
 
-        List<ConfigClassWithPrefix> buildTimeRunTimeMappings = configItem.getReadResult().getBuildTimeRunTimeMappings();
-        for (ConfigClassWithPrefix buildTimeRunTimeMapping : buildTimeRunTimeMappings) {
+        List<ConfigClass> buildTimeRunTimeMappings = configItem.getReadResult().getBuildTimeRunTimeMappings();
+        for (ConfigClass buildTimeRunTimeMapping : buildTimeRunTimeMappings) {
             processExtensionConfigMapping(buildTimeRunTimeMapping, combinedIndex, generatedClasses, reflectiveClasses,
                     reflectiveMethods, configClasses, additionalConstrainedClasses);
         }
 
-        List<ConfigClassWithPrefix> runTimeMappings = configItem.getReadResult().getRunTimeMappings();
-        for (ConfigClassWithPrefix runTimeMapping : runTimeMappings) {
+        List<ConfigClass> runTimeMappings = configItem.getReadResult().getRunTimeMappings();
+        for (ConfigClass runTimeMapping : runTimeMappings) {
             processExtensionConfigMapping(runTimeMapping, combinedIndex, generatedClasses, reflectiveClasses, reflectiveMethods,
                     configClasses, additionalConstrainedClasses);
         }
@@ -239,7 +239,7 @@ public class ConfigGenerationBuildStep {
         Set<String> configCustomizers = discoverService(SmallRyeConfigBuilderCustomizer.class, reflectiveClass);
 
         // For Static Init Config
-        Set<ConfigClassWithPrefix> staticMappings = new HashSet<>();
+        Set<ConfigClass> staticMappings = new HashSet<>();
         staticMappings.addAll(staticSafeConfigMappings(configMappings));
         staticMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
         Set<String> staticCustomizers = new HashSet<>(staticSafeServices(configCustomizers));
@@ -261,7 +261,7 @@ public class ConfigGenerationBuildStep {
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(CONFIG_STATIC_NAME).build());
 
         // For RunTime Config
-        Set<ConfigClassWithPrefix> runTimeMappings = new HashSet<>();
+        Set<ConfigClass> runTimeMappings = new HashSet<>();
         runTimeMappings.addAll(runtimeConfigMappings(configMappings));
         runTimeMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
         runTimeMappings.addAll(configItem.getReadResult().getRunTimeMappings());
@@ -569,7 +569,7 @@ public class ConfigGenerationBuildStep {
             Set<String> configSourceFactories,
             Set<String> secretKeyHandlers,
             Set<String> secretKeyHandlerFactories,
-            Set<ConfigClassWithPrefix> mappings,
+            Set<ConfigClass> mappings,
             Set<String> configCustomizers,
             Set<String> configBuilders) {
 
@@ -630,7 +630,7 @@ public class ConfigGenerationBuildStep {
                         method.newInstance(MethodDescriptor.ofConstructor(secretKeyHandlerFactory)));
             }
 
-            for (ConfigClassWithPrefix mapping : mappings) {
+            for (ConfigClass mapping : mappings) {
                 method.invokeStaticMethod(WITH_MAPPING, configBuilder, method.load(mapping.getKlass().getName()),
                         method.load(mapping.getPrefix()));
             }
@@ -704,16 +704,16 @@ public class ConfigGenerationBuildStep {
         return staticSafe;
     }
 
-    private static Set<ConfigClassWithPrefix> staticSafeConfigMappings(List<ConfigMappingBuildItem> configMappings) {
+    private static Set<ConfigClass> staticSafeConfigMappings(List<ConfigMappingBuildItem> configMappings) {
         return configMappings.stream()
                 .filter(ConfigMappingBuildItem::isStaticInitSafe)
-                .map(ConfigMappingBuildItem::toConfigClassWithPrefix)
+                .map(ConfigMappingBuildItem::toConfigClass)
                 .collect(toSet());
     }
 
-    private static Set<ConfigClassWithPrefix> runtimeConfigMappings(List<ConfigMappingBuildItem> configMappings) {
+    private static Set<ConfigClass> runtimeConfigMappings(List<ConfigMappingBuildItem> configMappings) {
         return configMappings.stream()
-                .map(ConfigMappingBuildItem::toConfigClassWithPrefix)
+                .map(ConfigMappingBuildItem::toConfigClass)
                 .collect(toSet());
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
@@ -9,6 +9,8 @@ import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
 
 import io.smallrye.common.constraint.Assert;
+import io.smallrye.config.ConfigMappingInterface;
+import io.smallrye.config.ConfigMappingLoader;
 import io.smallrye.config.ConfigMappingMetadata;
 
 /**
@@ -22,7 +24,7 @@ final class Substitutions {
         private static volatile ConfigProviderResolver instance;
     }
 
-    @TargetClass(className = "io.smallrye.config.ConfigMappingLoader")
+    @TargetClass(ConfigMappingLoader.class)
     static final class Target_ConfigMappingLoader {
         @Substitute
         static Class<?> loadClass(final Class<?> parent, final ConfigMappingMetadata configMappingMetadata) {
@@ -39,7 +41,7 @@ final class Substitutions {
         }
     }
 
-    @TargetClass(className = "io.smallrye.config.ConfigMappingInterface")
+    @TargetClass(ConfigMappingInterface.class)
     static final class Target_ConfigMappingInterface {
         @Alias
         static ClassValue<Target_ConfigMappingInterface> cv = null;
@@ -62,7 +64,7 @@ final class Substitutions {
         }
     }
 
-    @TargetClass(className = "io.smallrye.config.ConfigMappingClass")
+    @TargetClass(value = ConfigMappingLoader.class, innerClass = "ConfigMappingClass")
     static final class Target_ConfigMappingClass {
         @Alias
         static ClassValue<Target_ConfigMappingClass> cv = null;

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -7,7 +7,7 @@ import static io.quarkus.deployment.builditem.ConfigClassBuildItem.Kind.MAPPING;
 import static io.quarkus.deployment.builditem.ConfigClassBuildItem.Kind.PROPERTIES;
 import static io.quarkus.deployment.configuration.ConfigMappingUtils.CONFIG_MAPPING_NAME;
 import static io.quarkus.deployment.configuration.ConfigMappingUtils.processConfigClasses;
-import static io.smallrye.config.ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix;
+import static io.smallrye.config.ConfigMappings.ConfigClass.configClass;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.eclipse.microprofile.config.inject.ConfigProperties.UNCONFIGURED_PREFIX;
@@ -75,7 +75,7 @@ import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.hibernate.validator.spi.AdditionalConstrainedClassBuildItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
-import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.inject.ConfigProducer;
 
 /**
@@ -497,13 +497,13 @@ public class ConfigBuildStep {
 
         // TODO - Register ConfigProperties during build time
         context.registerNonDefaultConstructor(
-                ConfigClassWithPrefix.class.getDeclaredConstructor(Class.class, String.class),
-                configClassWithPrefix -> Stream.of(configClassWithPrefix.getKlass(), configClassWithPrefix.getPrefix())
+                ConfigClass.class.getDeclaredConstructor(Class.class, String.class),
+                configClass -> Stream.of(configClass.getKlass(), configClass.getPrefix())
                         .collect(toList()));
 
         recorder.registerConfigProperties(
                 configProperties.stream()
-                        .map(p -> configClassWithPrefix(p.getConfigClass(), p.getPrefix()))
+                        .map(p -> configClass(p.getConfigClass(), p.getPrefix()))
                         .collect(toSet()));
     }
 

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/IndexedPropertiesInjectionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/IndexedPropertiesInjectionTest.java
@@ -59,7 +59,7 @@ public class IndexedPropertiesInjectionTest {
         assertEquals(Stream.of(new ConvertedValue("out")).collect(Collectors.toList()), indexedBean.getConverted());
         assertEquals(Stream.of("a", "b", "c").collect(Collectors.toList()), indexedBean.getDefaults());
         assertEquals(Stream.of("e", "f").collect(Collectors.toList()), indexedBean.getOverrideDefaults());
-        assertEquals(Stream.of("a", "b", "c").collect(Collectors.toList()), indexedBean.getComma());
+        assertEquals(Stream.of("a", "b").collect(Collectors.toList()), indexedBean.getComma());
     }
 
     @Test

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigRecorder.java
@@ -18,7 +18,7 @@ import io.quarkus.runtime.annotations.RecordableConstructor;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.config.ConfigMappings;
-import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.ConfigValidationException;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.inject.ConfigProducerUtil;
@@ -75,7 +75,7 @@ public class ConfigRecorder {
         }
     }
 
-    public void registerConfigProperties(final Set<ConfigClassWithPrefix> configClasses) {
+    public void registerConfigProperties(final Set<ConfigClass> configClasses) {
         try {
             SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig();
             ConfigMappings.registerConfigProperties(config, configClasses);

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.component;
 
 import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
+import static io.smallrye.config.ConfigMappings.ConfigClass.configClass;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -120,7 +121,7 @@ import io.quarkus.arc.processor.Types;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.test.InjectMock;
 import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
@@ -440,11 +441,11 @@ public class QuarkusComponentTestExtension
                             new QuarkusComponentTestConfigSource(configuration.configProperties,
                                     configuration.configSourceOrdinal));
             @SuppressWarnings("unchecked")
-            Set<ConfigClassWithPrefix> configMappings = store(context).get(KEY_CONFIG_MAPPINGS, Set.class);
+            Set<ConfigClass> configMappings = store(context).get(KEY_CONFIG_MAPPINGS, Set.class);
             if (configMappings != null) {
                 // Register the mappings found during bean discovery
-                for (ConfigClassWithPrefix mapping : configMappings) {
-                    configBuilder.withMapping(mapping.getKlass(), mapping.getPrefix());
+                for (ConfigClass mapping : configMappings) {
+                    configBuilder.withMapping(mapping);
                 }
             }
             if (configuration.configBuilderCustomizer != null) {
@@ -789,7 +790,7 @@ public class QuarkusComponentTestExtension
                     }
 
                     if (!prefixToConfigMappings.isEmpty()) {
-                        Set<ConfigClassWithPrefix> configMappings = new HashSet<>();
+                        Set<ConfigClass> configMappings = new HashSet<>();
                         for (Entry<String, Set<String>> e : prefixToConfigMappings.entrySet()) {
                             for (String mapping : e.getValue()) {
                                 DotName mappingName = DotName.createSimple(mapping);
@@ -799,8 +800,7 @@ public class QuarkusComponentTestExtension
                                         .param("mappingClass", mapping)
                                         .param("prefix", e.getKey())
                                         .done();
-                                configMappings.add(ConfigClassWithPrefix
-                                        .configClassWithPrefix(ConfigMappingBeanCreator.tryLoad(mapping), e.getKey()));
+                                configMappings.add(configClass(ConfigMappingBeanCreator.tryLoad(mapping), e.getKey()));
                             }
                         }
                         store(extensionContext).put(KEY_CONFIG_MAPPINGS, configMappings);


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.10.0</h2>
    <ul>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1242">#1242</a> Bump version.curator from 5.7.0 to 5.7.1</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1240">#1240</a> Bump kotlin.version from 2.0.20 to 2.0.21</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1239">#1239</a> Add @ConfigMapping beanStyleGetter to enable / disable bean style getter names matching with configuration names</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1237">#1237</a> Bump org.ow2.asm:asm from 9.7 to 9.7.1</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1236">#1236</a> Rename ConfigClassWithPrefix to ConfigClass and use it in SmallRyeConfigBuilder</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1235">#1235</a> Bump version.smallrye.testing from 2.3.0 to 2.3.1</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1234">#1234</a> Bump io.smallrye.common:smallrye-common-bom from 2.4.0 to 2.7.0</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1231">#1231</a> Slight optimization when looking up System properties</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1229">#1229</a> Bump io.fabric8:docker-maven-plugin from 0.45.0 to 0.45.1</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1226">#1226</a> Move local classes to inner to reduce the number of classes in the main package</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1224">#1224</a> Remove constructor arguments from examples</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1223">#1223</a> Fix docs of interceptor service registration</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1222">#1222</a> Bump io.smallrye:smallrye-parent from 45 to 46</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1220">#1220</a> Support a fixed list of Map keys statically @WithKeys</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1218">#1218</a> Bump org.yaml:snakeyaml from 2.2 to 2.3</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1217">#1217</a> Cache profile prefixes</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1216">#1216</a> Avoid expensive exception and log when getValues fails lookup for indexed properties and fallbacks to comma</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1215">#1215</a> Check if profile file resources are in the location ClassLoader</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1214">#1214</a> Internal cleanup of AbstractLocationConfigSourceLoader</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1213">#1213</a> Reduce allocations of iterateNames</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1212">#1212</a> Improve mappings documentation</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1211">#1211</a> Avoid using string concatenation to forge impl name</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1210">#1210</a> Bump kotlin.version from 2.0.0 to 2.0.20</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1209">#1209</a> ConfigValue name consistent with PropertiesConfigSource</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1204">#1204</a> Search for indexed property names before flattened comma separated value name when loading Collections for CDI injection</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1203">#1203</a> Remove the generation of a comma separated value name for Collections in the YamlConfigSource</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1202">#1202</a> Search for indexed property names before flattened comma separated value name when loading Collections</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1201">#1201</a> Drop support for full YAML content in parent property names</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1200">#1200</a> Bump io.fabric8:docker-maven-plugin from 0.44.0 to 0.45.0</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1198">#1198</a> Update sample ordinal in custom.md</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1195">#1195</a> Bump zipp from 3.15.0 to 3.19.1 in /documentation</li>
    </ul>
</blockquote>

Quarkus:
- Fixes #42070
- Fixes #42580 


Breaking Changes:
- Search for indexed property names before flattened comma separated value name when loading Collections
- Remove the generation of a comma separated value name for Collections in the YamlConfigSource