### PR TITLE
Extend reflection configuration for SmallRye FT

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -17,6 +17,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private final List<String> className;
     private final boolean methods;
     private final boolean queryMethods;
+    private final boolean queryPublicMethods;
     private final boolean fields;
     private final boolean classes;
     private final boolean constructors;
@@ -46,7 +47,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
             boolean fields, boolean getClasses, boolean weak, boolean serialization, boolean unsafeAllocated, String reason,
             Class<?>... classes) {
-        this(constructors, queryConstructors, methods, queryMethods, fields, getClasses, weak, serialization,
+        this(constructors, queryConstructors, methods, queryMethods, false, fields, getClasses, weak, serialization,
                 unsafeAllocated, reason, stream(classes).map(Class::getName).toArray(String[]::new));
     }
 
@@ -118,12 +119,12 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
             boolean fields, boolean weak, boolean serialization,
             boolean unsafeAllocated, String... className) {
-        this(constructors, queryConstructors, methods, queryMethods, fields, false, weak, serialization, unsafeAllocated,
+        this(constructors, queryConstructors, methods, queryMethods, false, fields, false, weak, serialization, unsafeAllocated,
                 null, className);
     }
 
     ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
-            boolean fields, boolean classes, boolean weak, boolean serialization,
+            boolean queryPublicMethods, boolean fields, boolean classes, boolean weak, boolean serialization,
             boolean unsafeAllocated, String reason, String... className) {
         for (String i : className) {
             if (i == null) {
@@ -140,6 +141,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         } else {
             this.queryMethods = queryMethods;
         }
+        this.queryPublicMethods = queryPublicMethods;
         this.fields = fields;
         this.classes = classes;
         this.constructors = constructors;
@@ -167,6 +169,10 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
     public boolean isQueryMethods() {
         return queryMethods;
+    }
+
+    public boolean isQueryPublicMethods() {
+        return queryPublicMethods;
     }
 
     public boolean isFields() {
@@ -216,6 +222,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         private boolean queryConstructors;
         private boolean methods;
         private boolean queryMethods;
+        private boolean queryPublicMethods;
         private boolean fields;
         private boolean classes;
         private boolean weak;
@@ -282,6 +289,20 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
         public Builder queryMethods() {
             return queryMethods(true);
+        }
+
+        /**
+         * Configures whether declared methods should be registered for reflection, for query purposes only,
+         * i.e. {@link Class#getMethods()}. Setting this enables getting all declared methods for the class but
+         * does not allow invoking them reflectively.
+         */
+        public Builder queryPublicMethods(boolean queryPublicMethods) {
+            this.queryPublicMethods = queryPublicMethods;
+            return this;
+        }
+
+        public Builder queryPublicMethods() {
+            return queryPublicMethods(true);
         }
 
         /**
@@ -358,8 +379,8 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         }
 
         public ReflectiveClassBuildItem build() {
-            return new ReflectiveClassBuildItem(constructors, queryConstructors, methods, queryMethods, fields, classes, weak,
-                    serialization, unsafeAllocated, reason, className);
+            return new ReflectiveClassBuildItem(constructors, queryConstructors, methods, queryMethods, queryPublicMethods,
+                    fields, classes, weak, serialization, unsafeAllocated, reason, className);
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
@@ -107,6 +107,9 @@ public class NativeImageReflectConfigStep {
                     extractToJsonArray(info.queriedMethodSet, queriedMethodsArray);
                 }
             }
+            if (info.queryPublicMethods) {
+                json.put("queryAllPublicMethods", true);
+            }
             if (!methodsArray.isEmpty()) {
                 json.put("methods", methodsArray);
             }
@@ -206,6 +209,9 @@ public class NativeImageReflectConfigStep {
                 if (classBuildItem.isQueryMethods()) {
                     existing.queryMethods = true;
                 }
+                if (classBuildItem.isQueryPublicMethods()) {
+                    existing.queryPublicMethods = true;
+                }
                 if (classBuildItem.isFields()) {
                     existing.fields = true;
                 }
@@ -249,6 +255,7 @@ public class NativeImageReflectConfigStep {
         boolean queryConstructors;
         boolean methods;
         boolean queryMethods;
+        boolean queryPublicMethods;
         boolean fields;
         boolean classes;
         boolean serialization;
@@ -266,6 +273,7 @@ public class NativeImageReflectConfigStep {
         private ReflectionInfo(ReflectiveClassBuildItem classBuildItem, String typeReachable) {
             this.methods = classBuildItem.isMethods();
             this.queryMethods = classBuildItem.isQueryMethods();
+            this.queryPublicMethods = classBuildItem.isQueryPublicMethods();
             this.fields = classBuildItem.isFields();
             this.classes = classBuildItem.isClasses();
             this.typeReachable = typeReachable;

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -54,7 +54,9 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo.ClassOutput;
@@ -273,5 +275,21 @@ class VertxProcessor {
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException("Unable to load type: " + name, e);
         }
+    }
+
+    @BuildStep
+    void registerNativeImageResources(BuildProducer<NativeImageResourceBuildItem> resources) {
+        // Accessed by io.vertx.core.impl.VertxBuilder.<init>
+        resources.produce(new NativeImageResourceBuildItem("META-INF/services/io.vertx.core.spi.VertxServiceProvider"));
+        // Accessed by io.vertx.core.impl.VertxImpl.<init>
+        resources.produce(new NativeImageResourceBuildItem("META-INF/services/io.vertx.core.spi.VerticleFactory"));
+    }
+
+    @BuildStep
+    void registerReflectivelyAccessedMethods(BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods) {
+        // Accessed by io.vertx.core.impl.VertxImpl.<init>
+        reflectiveMethods.produce(new ReflectiveMethodBuildItem("java.lang.Thread$Builder$OfVirtual", "name",
+                String.class, long.class));
+        reflectiveMethods.produce(new ReflectiveMethodBuildItem("java.lang.Thread$Builder", "factory", new Class[0]));
     }
 }


### PR DESCRIPTION
Doesn't seem to fix any functionality issues but prevents
`MissingRegistrationErrors` from being thrown when
`ThrowMissingRegistrationErrors` is enabled.

Related to https://github.com/quarkusio/quarkus/issues/41995
