### PR TITLE
Fix `QuarkusMainLauncher` not returning exit code

### DIFF
--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/ExitCodeCommand.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/ExitCodeCommand.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.picocli;
+
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "exitcode", versionProvider = DynamicVersionProvider.class)
+public class ExitCodeCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = "--code")
+    int exitCode;
+
+    @Override
+    public Integer call() {
+        return exitCode;
+    }
+}

--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/TopTestCommand.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/TopTestCommand.java
@@ -5,6 +5,7 @@ import picocli.CommandLine;
 
 @TopCommand
 @CommandLine.Command(name = "test", mixinStandardHelpOptions = true, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n", subcommands = {
+        ExitCodeCommand.class,
         CommandUsedAsParent.class,
         CompletionReflectionCommand.class,
         DefaultValueProviderCommand.class,

--- a/integration-tests/picocli-native/src/test/java/io/quarkus/it/picocli/PicocliTest.java
+++ b/integration-tests/picocli-native/src/test/java/io/quarkus/it/picocli/PicocliTest.java
@@ -22,6 +22,16 @@ public class PicocliTest {
     private String value;
 
     @Test
+    public void testExitCode(QuarkusMainLauncher launcher) {
+        LaunchResult result = launcher.launch("exitcode", "--code", Integer.toString(42));
+        assertThat(result.exitCode()).isEqualTo(42);
+        result = launcher.launch("exitcode", "--code", Integer.toString(0));
+        assertThat(result.exitCode()).isEqualTo(0);
+        result = launcher.launch("exitcode", "--code", Integer.toString(2));
+        assertThat(result.exitCode()).isEqualTo(2);
+    }
+
+    @Test
     @Launch({ "test-command", "-f", "test.txt", "-f", "test2.txt", "-f", "test3.txt", "-s", "ERROR", "-h", "SOCKS=5.5.5.5",
             "-p", "privateValue", "pos1", "pos2" })
     public void testBasicReflection(LaunchResult result) throws UnknownHostException {

--- a/integration-tests/picocli/src/main/java/io/quarkus/it/picocli/ExitCodeCommand.java
+++ b/integration-tests/picocli/src/main/java/io/quarkus/it/picocli/ExitCodeCommand.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.picocli;
+
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "exitcode")
+public class ExitCodeCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = "--code")
+    int exitCode;
+
+    @Override
+    public Integer call() {
+        return exitCode;
+    }
+}

--- a/integration-tests/picocli/src/test/java/io/quarkus/it/picocli/TestExitCode.java
+++ b/integration-tests/picocli/src/test/java/io/quarkus/it/picocli/TestExitCode.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.picocli;
+
+import static io.quarkus.it.picocli.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class TestExitCode {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("hello-app", ExitCodeCommand.class)
+            .setCommandLineParameters("--code", "42");
+
+    @Test
+    public void simpleTest() {
+        assertThat(config.getExitCode()).isEqualTo(42);
+    }
+}


### PR DESCRIPTION
`QuarkusMainLauncher` always returns `0`, because `currentApplication` is set to `null` in `io.quarkus.runtime.ApplicationLifecycleManager#run(io.quarkus.runtime.Application, java.lang.Class<? extends io.quarkus.runtime.QuarkusApplication>, java.util.function.BiConsumer<java.lang.Integer,java.lang.Throwable>, java.lang.String...)`.

This change introduces a new callback to `ApplicationLifecycleManager` used by `StartupActionImpl` to know whether the application was actually started or not.

- Fixes: #42250