### PR TITLE
Improve exception handling when application fails to start

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -201,6 +201,9 @@ public class ApplicationLifecycleManager {
                 } else if (rootCause instanceof PreventFurtherStepsException
                         && !StringUtil.isNullOrEmpty(rootCause.getMessage())) {
                     System.err.println(rootCause.getMessage());
+                } else if (!currentApplication.isStarted()) {
+                    System.err.println("Failed to start application");
+                    e.printStackTrace();
                 } else {
                     applicationLogger.errorv(e, "Failed to start application");
                     ensureConsoleLogsDrained();


### PR DESCRIPTION
Prevent the usage of the logger when the application has not started
regardless of the cause since it's most likely not configured yet.

Closes https://github.com/quarkusio/quarkus/issues/42084
