### PR TITLE
Add one more level of TOC for Qute reference guide

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -10,6 +10,7 @@ include::_attributes.adoc[]
 :numbered:
 :sectnums:
 :sectnumlevels: 4
+:toclevels: 3
 :topics: templating,qute
 :extensions: io.quarkus:quarkus-qute,io.quarkus:quarkus-resteasy-qute,io.quarkus:quarkus-rest-qute
 


### PR DESCRIPTION
Typically, you cannot find User-defined tags in the TOC, which is a bit annoying.
Companion PR: https://github.com/quarkusio/quarkusio.github.io/pull/2067