### PR TITLE
Allow finer tuning of shared network usage by Keycloak DevServices

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -195,8 +195,10 @@ public class KeycloakDevServicesProcessor {
         try {
             List<String> errors = new ArrayList<>();
 
+            boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
+                    devServicesSharedNetworkBuildItem);
             RunningDevService newDevService = startContainer(dockerStatusBuildItem, keycloakBuildItemBuildProducer,
-                    !devServicesSharedNetworkBuildItem.isEmpty(),
+                    useSharedNetwork,
                     devServicesConfig.timeout,
                     errors);
             if (newDevService == null) {


### PR DESCRIPTION
This PR follows up #39899 and is related to the issues encountered here: microcks/microcks-quarkus#48 and there: microcks/microcks-quarkus#49.

At the moment Keycloak OIDC DevServices systematically use the shared network if it exists - leading to inconsistencies if a shared network has been initialized for other needs (see discussion #38398).

Like we did for the database-related DevServices in #39899, we should be more subtle and clearly determine if joining a shared network is required (by the user, by integration test) so that DevServices can only join on purpose.

Signed-off-by: Laurent Broudoux <laurent.broudoux@gmail.com>