### PR TITLE
Don't convert WebApplicationException in REST Client when produced by a custom mapper

### DIFF
--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/MicroProfileRestClientResponseFilter.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/MicroProfileRestClientResponseFilter.java
@@ -1,5 +1,7 @@
 package io.quarkus.rest.client.reactive.runtime;
 
+import static org.jboss.resteasy.reactive.client.impl.RestClientRequestContext.INVOKED_EXCEPTION_MAPPER_CLASS_NAME_PROP;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +53,7 @@ public class MicroProfileRestClientResponseFilter implements ClientResponseFilte
                     } else {
                         throwable = exceptionMapper.toThrowable(response);
                     }
+                    requestContext.setProperty(INVOKED_EXCEPTION_MAPPER_CLASS_NAME_PROP, exceptionMapper.getClass().getName());
                     if (throwable != null) {
                         throw new UnwrappableException(throwable);
                     }


### PR DESCRIPTION
The idea is that if a user has opted to create an exception, we should always honor it - even if it's a WebApplicationException

- Fixes: #42275