### PR TITLE
Revert "Make sure the TestResourceManager is closed before the CL is closed"

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -1,6 +1,5 @@
 package io.quarkus.bootstrap.app;
 
-import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -31,7 +30,5 @@ public interface StartupAction {
      * Runs the application by running the main method of the main class, and runs it to completion
      */
     int runMainClassBlocking(String... args) throws Exception;
-
-    void addRuntimeCloseTask(Closeable closeTask);
 
 }


### PR DESCRIPTION
This reverts commit 313e10e644deeb8a0418252873e9cba28bf771df.

Maybe related to https://github.com/quarkusio/quarkus/discussions/42298 .

We still need to fix this issue but probably in another way if it actually fixes the reported issue.