### PR TITLE
Add guidelines about runtime footprint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,7 @@ is followed for every pull request.
   can be used temporarily during the review process but things should be squashed at the end to have meaningful commits.
   We use merge commits so the GitHub Merge button cannot do that for us. If you don't know how to do that, just ask in
   your pull request, we will be happy to help!
+* Please limit the use of lambdas and streams as much as possible in code that executes at runtime, in order to minimize runtime footprint.
 
 ### Continuous Integration
 


### PR DESCRIPTION
I took some of the arguments about avoiding lambdas from comments in #30777, #39942, #41467, and #42179.

I hope this helps communicating the established convention and/or loose policy.