### PR TITLE
Support APT processors in Gradle quarkusdev

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -497,6 +497,12 @@ public abstract class QuarkusDev extends QuarkusTask {
         builder.sourceJavaVersion(javaPluginExtension.getSourceCompatibility().toString());
         builder.targetJavaVersion(javaPluginExtension.getTargetCompatibility().toString());
 
+        final SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+
+        builder.annotationProcessorPaths(mainSourceSet.getAnnotationProcessorPath().getFiles());
+        // builder.annotationProcessors(SOME);
+
         for (CompilerOption compilerOptions : compilerOptions.getCompilerOptions()) {
             builder.compilerOptions(compilerOptions.getName(), compilerOptions.getArgs());
         }
@@ -628,6 +634,8 @@ public abstract class QuarkusDev extends QuarkusTask {
         }
         Path classesDir = classesDirs.isEmpty() ? null
                 : QuarkusGradleUtils.mergeClassesDirs(classesDirs, project.getWorkspaceModule().getBuildDir(), root, false);
+        Path generatedSourcesPath = sources.getSourceDirs().isEmpty() ? null
+                : sources.getSourceDirs().iterator().next().getAptSourcesDir();
 
         final Set<Path> resourcesSrcDirs = new LinkedHashSet<>();
         // resourcesSrcDir may exist but if it's empty the resources output dir won't be created
@@ -660,6 +668,7 @@ public abstract class QuarkusDev extends QuarkusTask {
                 .setName(project.getArtifactId())
                 .setProjectDirectory(project.getWorkspaceModule().getModuleDir().getAbsolutePath())
                 .setSourcePaths(PathList.from(sourcePaths))
+                .setGeneratedSourcesPath(generatedSourcesPath != null ? generatedSourcesPath.toString() : null)
                 .setClassesPath(classesDir.toString())
                 .setResourcePaths(PathList.from(resourcesSrcDirs))
                 .setResourcesOutputPath(resourcesOutputPath)

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
@@ -22,6 +22,11 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
+    compileOnly "org.hibernate.orm:hibernate-jpamodelgen"
+    compileOnly enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen"
+    annotationProcessor enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
 }

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/gradle.properties
@@ -3,4 +3,4 @@
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformGroupId=io.quarkus
 org.gradle.logging.level=INFO
-lombokVersion=1.18.12
+lombokVersion=1.18.34

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/src/main/java/io/playground/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/src/main/java/io/playground/HelloResource.java
@@ -17,4 +17,11 @@ public class HelloResource {
     public String hello() {
         return "hello " + myData.getMessage();
     }
+
+    @Path("jpa")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String jpa() {
+        return MyEntity_.FIELD;
+    }
 }

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/src/main/java/io/playground/MyEntity.java
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/src/main/java/io/playground/MyEntity.java
@@ -1,0 +1,11 @@
+package io.playground;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.Entity;
+
+@Entity
+public class MyEntity {
+	public String field;
+	@Id
+	public String id;
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/CompileOnlyDependencyDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/CompileOnlyDependencyDevModeTest.java
@@ -2,13 +2,11 @@ package io.quarkus.gradle.devmode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.Disabled;
 
 import com.google.common.collect.ImmutableMap;
 
-@Disabled
 public class CompileOnlyDependencyDevModeTest extends QuarkusDevGradleTestBase {
 
     @Override
@@ -24,6 +22,15 @@ public class CompileOnlyDependencyDevModeTest extends QuarkusDevGradleTestBase {
     protected void testDevMode() throws Exception {
 
         assertThat(getHttpResponse("/hello", 2, TimeUnit.MINUTES)).contains("hello lombok");
+        assertThat(getHttpResponse("/hello/jpa", 2, TimeUnit.MINUTES)).isEqualTo("field");
+
+        // make sure annotations go to the right place
+        File testDir = getProjectDir();
+        File entityMetamodelSourceFile = new File(testDir,
+                "build/generated/sources/annotationProcessor/java/main/io/playground/MyEntity_.java");
+        assertThat(entityMetamodelSourceFile).exists().content().contains("FIELD");
+        File entityMetamodelClassFile = new File(testDir, "build/classes/java/main/io/playground/MyEntity_.class");
+        assertThat(entityMetamodelClassFile).exists();
 
         replace("src/main/java/io/playground/MyData.java",
                 ImmutableMap.of("private String other;", "private final String other;"));
@@ -34,6 +41,18 @@ public class CompileOnlyDependencyDevModeTest extends QuarkusDevGradleTestBase {
                 ImmutableMap.of("return \"hello \" + myData.getMessage();",
                         "return \"hello \" + myData.getMessage() + myData.getOther();"));
 
+        // Edit the entity to change the field name
+        replace("src/main/java/io/playground/MyEntity.java", ImmutableMap.of("String field;", "String field2;"));
+
+        // Edit the "Hello" message for the new field.
+        replace("src/main/java/io/playground/HelloResource.java", ImmutableMap.of("return MyEntity_.FIELD;",
+                "return MyEntity_.FIELD2;"));
+
         assertUpdatedResponseContains("/hello", "hello lombok!", 5, TimeUnit.MINUTES);
+        assertUpdatedResponseContains("/hello/jpa", "field2", 5, TimeUnit.MINUTES);
+
+        // make sure annotations go to the right place
+        assertThat(entityMetamodelSourceFile).exists().content().contains("FIELD2");
+        assertThat(entityMetamodelClassFile).exists();
     }
 }


### PR DESCRIPTION
- Support passing the APT processor paths to our dev mode so that it runs APT processors during hot reload
- Support passing the proper gradle output path for APT so annotation-generated source files end up in the proper place

- Fixes #38228