### PR TITLE
Actually upgrade Vert.x to 4.5.9 in the BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -113,7 +113,7 @@
         <wildfly-elytron.version>2.5.0.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.1.4.SP1</jboss-marshalling.version>
         <jboss-threads.version>3.6.1.Final</jboss-threads.version>
-        <vertx.version>4.5.8</vertx.version>
+        <vertx.version>4.5.9</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>


### PR DESCRIPTION
This is a followup of #41955 where updating the BOM was forgotten.