### PR TITLE
Add ability to always require a socket

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RequireSocketHttpBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RequireSocketHttpBuildItem.java
@@ -1,0 +1,13 @@
+package io.quarkus.vertx.http.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Marker class that can be used to force the socket to open even when using virtual HTTP.
+ *
+ * There are some use cases that may want to handle both real and virtual HTTP requests, such as mapping incoming
+ * gRPC requests onto JAX-RS handlers.
+ */
+public final class RequireSocketHttpBuildItem extends SimpleBuildItem {
+    public static final RequireSocketHttpBuildItem MARKER = new RequireSocketHttpBuildItem();
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -442,6 +442,7 @@ class VertxHttpProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             HttpBuildTimeConfig httpBuildTimeConfig,
             Optional<RequireVirtualHttpBuildItem> requireVirtual,
+            Optional<RequireSocketHttpBuildItem> requireSocket,
             EventLoopCountBuildItem eventLoopCount,
             List<WebsocketSubProtocolsBuildItem> websocketSubProtocols,
             Capabilities capabilities,
@@ -452,8 +453,9 @@ class VertxHttpProcessor {
                     .produce(ReflectiveClassBuildItem.builder(VirtualServerChannel.class)
                             .build());
         }
-        boolean startSocket = (!startVirtual || launchMode.getLaunchMode() != LaunchMode.NORMAL)
-                && (requireVirtual.isEmpty() || !requireVirtual.get().isAlwaysVirtual());
+        boolean startSocket = requireSocket.isPresent() ||
+                ((!startVirtual || launchMode.getLaunchMode() != LaunchMode.NORMAL)
+                        && (requireVirtual.isEmpty() || !requireVirtual.get().isAlwaysVirtual()));
         recorder.startServer(vertx.getVertx(), shutdown,
                 launchMode.getLaunchMode(), startVirtual, startSocket,
                 eventLoopCount.getEventLoopCount(),


### PR DESCRIPTION
I have a use case the combines both virtual dispatch and standard HTTP, this lets extensions support both.