### PR TITLE
Dev UI show non container dev services

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
@@ -20,17 +20,27 @@ import io.quarkus.builder.item.MultiBuildItem;
 public final class DevServicesResultBuildItem extends MultiBuildItem {
 
     private final String name;
+    private final String description;
     private final String containerId;
     private final Map<String, String> config;
 
     public DevServicesResultBuildItem(String name, String containerId, Map<String, String> config) {
+        this(name, null, containerId, config);
+    }
+
+    public DevServicesResultBuildItem(String name, String description, String containerId, Map<String, String> config) {
         this.name = name;
+        this.description = description;
         this.containerId = containerId;
         this.config = config;
     }
 
     public String getName() {
         return name;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
     public String getContainerId() {
@@ -44,6 +54,7 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
     public static class RunningDevService implements Closeable {
 
         private final String name;
+        private final String description;
         private final String containerId;
         private final Map<String, String> config;
         private final Closeable closeable;
@@ -54,12 +65,25 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
             return map;
         }
 
-        public RunningDevService(String name, String containerId, Closeable closeable, String key, String value) {
-            this(name, containerId, closeable, mapOf(key, value));
+        public RunningDevService(String name, String containerId, Closeable closeable, String key,
+                String value) {
+            this(name, null, containerId, closeable, mapOf(key, value));
         }
 
-        public RunningDevService(String name, String containerId, Closeable closeable, Map<String, String> config) {
+        public RunningDevService(String name, String description, String containerId, Closeable closeable, String key,
+                String value) {
+            this(name, description, containerId, closeable, mapOf(key, value));
+        }
+
+        public RunningDevService(String name, String containerId, Closeable closeable,
+                Map<String, String> config) {
+            this(name, null, containerId, closeable, config);
+        }
+
+        public RunningDevService(String name, String description, String containerId, Closeable closeable,
+                Map<String, String> config) {
             this.name = name;
+            this.description = description;
             this.containerId = containerId;
             this.closeable = closeable;
             this.config = Collections.unmodifiableMap(config);
@@ -67,6 +91,10 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
 
         public String getName() {
             return name;
+        }
+
+        public String getDescription() {
+            return description;
         }
 
         public String getContainerId() {
@@ -93,7 +121,7 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
         }
 
         public DevServicesResultBuildItem toBuildItem() {
-            return new DevServicesResultBuildItem(name, containerId, config);
+            return new DevServicesResultBuildItem(name, description, containerId, config);
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServiceDescriptionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/DevServiceDescriptionBuildItem.java
@@ -9,14 +9,22 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 public final class DevServiceDescriptionBuildItem extends MultiBuildItem {
     private String name;
+    private String description;
     private ContainerInfo containerInfo;
     private Map<String, String> configs;
 
     public DevServiceDescriptionBuildItem() {
     }
 
-    public DevServiceDescriptionBuildItem(String name, ContainerInfo containerInfo, Map<String, String> configs) {
+    public DevServiceDescriptionBuildItem(String name, ContainerInfo containerInfo,
+            Map<String, String> configs) {
+        this(name, null, containerInfo, configs);
+    }
+
+    public DevServiceDescriptionBuildItem(String name, String description, ContainerInfo containerInfo,
+            Map<String, String> configs) {
         this.name = name;
+        this.description = description;
         this.containerInfo = containerInfo;
         this.configs = configs instanceof SortedMap ? configs : new TreeMap<>(configs);
     }
@@ -29,6 +37,10 @@ public final class DevServiceDescriptionBuildItem extends MultiBuildItem {
         return name;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
     public ContainerInfo getContainerInfo() {
         return containerInfo;
     }
@@ -39,6 +51,10 @@ public final class DevServiceDescriptionBuildItem extends MultiBuildItem {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public void setContainerInfo(ContainerInfo containerInfo) {

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
@@ -130,7 +130,7 @@ public class DevServicesProcessor {
                 config.remove(key);
             }
             if (!config.isEmpty()) {
-                descriptions.add(new DevServiceDescriptionBuildItem("Additional Dev Services config", null, config));
+                descriptions.add(new DevServiceDescriptionBuildItem("Additional Dev Services config", null, null, config));
             }
         }
         return descriptions;
@@ -151,9 +151,11 @@ public class DevServicesProcessor {
 
     private DevServiceDescriptionBuildItem toDevServiceDescription(DevServicesResultBuildItem buildItem, Container container) {
         if (container == null) {
-            return new DevServiceDescriptionBuildItem(buildItem.getName(), null, buildItem.getConfig());
+            return new DevServiceDescriptionBuildItem(buildItem.getName(), buildItem.getDescription(), null,
+                    buildItem.getConfig());
         } else {
-            return new DevServiceDescriptionBuildItem(buildItem.getName(), toContainerInfo(container), buildItem.getConfig());
+            return new DevServiceDescriptionBuildItem(buildItem.getName(), buildItem.getDescription(),
+                    toContainerInfo(container), buildItem.getConfig());
         }
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
@@ -2,6 +2,8 @@ package io.quarkus.devui.deployment.menu;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -29,19 +31,24 @@ public class DevServicesProcessor {
                 .icon("font-awesome-solid:wand-magic-sparkles")
                 .componentLink("qwc-dev-services.js"));
 
-        List<DevServiceDescriptionBuildItem> combined = new ArrayList<>();
+        Map<String, DevServiceDescriptionBuildItem> combined = new TreeMap<>();
+        addToMap(combined, devServiceDescriptions);
+        addToMap(combined, otherDevServices);
 
-        if (!devServiceDescriptions.isEmpty()) {
-            combined.addAll(devServiceDescriptions);
-        }
-        if (!otherDevServices.isEmpty()) {
-            combined.addAll(otherDevServices);
-        }
-
-        devServicesPages.addBuildTimeData("devServices", combined);
+        devServicesPages.addBuildTimeData("devServices", combined.values());
 
         return devServicesPages;
 
+    }
+
+    private void addToMap(Map<String, DevServiceDescriptionBuildItem> m, List<DevServiceDescriptionBuildItem> list) {
+        if (!list.isEmpty()) {
+            for (DevServiceDescriptionBuildItem i : list) {
+                if (!m.containsKey(i.getName())) {
+                    m.put(i.getName(), i);
+                }
+            }
+        }
     }
 
     private List<DevServiceDescriptionBuildItem> getOtherDevServices(
@@ -49,7 +56,9 @@ public class DevServicesProcessor {
         List<DevServiceDescriptionBuildItem> devServiceDescriptions = new ArrayList<>();
         for (DevServicesResultBuildItem devServicesResultBuildItem : devServicesResultBuildItems) {
             if (devServicesResultBuildItem.getContainerId() == null) {
-                devServiceDescriptions.add(new DevServiceDescriptionBuildItem(devServicesResultBuildItem.getName(), null,
+                devServiceDescriptions.add(new DevServiceDescriptionBuildItem(devServicesResultBuildItem.getName(),
+                        devServicesResultBuildItem.getDescription(),
+                        null,
                         devServicesResultBuildItem.getConfig()));
             }
         }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
@@ -38,6 +38,10 @@ export class QwcDevServices extends observeState(QwcHotReloadElement) {
             padding-left: 10px;
             background: var(--lumo-contrast-5pct);
         }
+    
+        .content {
+            padding: 15px;
+        }
     `;
 
     static properties = {
@@ -71,7 +75,7 @@ export class QwcDevServices extends observeState(QwcHotReloadElement) {
 
     _renderCard(devService){
         return html`<qui-card header="${devService.name}">
-                        <div slot="content">
+                        <div slot="content" class="content">
                             ${this._renderContainerDetails(devService)}
                             ${this._renderConfigDetails(devService)}
                         </div>

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
@@ -42,6 +42,11 @@ export class QwcDevServices extends observeState(QwcHotReloadElement) {
         .content {
             padding: 15px;
         }
+    
+        .description {
+            padding-bottom: 10px;
+            color: var(--lumo-contrast-50pct);
+        }
     `;
 
     static properties = {
@@ -76,10 +81,17 @@ export class QwcDevServices extends observeState(QwcHotReloadElement) {
     _renderCard(devService){
         return html`<qui-card header="${devService.name}">
                         <div slot="content" class="content">
+                            ${this._renderDescription(devService)}
                             ${this._renderContainerDetails(devService)}
                             ${this._renderConfigDetails(devService)}
                         </div>
                     </qui-card>`;
+    }
+
+    _renderDescription(devService){
+        if(devService.description){
+            return html`<div class="description">${devService.description}</div>`;
+        }
     }
 
     _renderContainerDetails(devService){


### PR DESCRIPTION
This PR contains 2 commits:

- Change to the Dev UI Dev Services screen to also show Dev Services that does not use containers
- Change to allow extensions to add a description to a Dev Service definition, and also display that in Dev UI