### PR TITLE
Upgrade mariadb-java-client to 3.4.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -121,7 +121,7 @@
         <quartz.version>2.3.2</quartz.version>
         <h2.version>2.2.224</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions -->
         <postgresql-jdbc.version>42.7.3</postgresql-jdbc.version>
-        <mariadb-jdbc.version>3.4.0</mariadb-jdbc.version>
+        <mariadb-jdbc.version>3.4.1</mariadb-jdbc.version>
         <mysql-jdbc.version>8.3.0</mysql-jdbc.version>
         <mssql-jdbc.version>12.8.0.jre11</mssql-jdbc.version>
         <adal4j.version>1.6.7</adal4j.version>

--- a/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/graal/SendPamAuthPacket_Substitutions.java
+++ b/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/graal/SendPamAuthPacket_Substitutions.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 
 import org.mariadb.jdbc.Configuration;
+import org.mariadb.jdbc.HostAddress;
 import org.mariadb.jdbc.client.Context;
 import org.mariadb.jdbc.client.ReadableByteBuf;
 import org.mariadb.jdbc.client.socket.Reader;
@@ -16,7 +17,7 @@ import com.oracle.svm.core.annotate.TargetClass;
 public final class SendPamAuthPacket_Substitutions {
 
     @Substitute
-    public void initialize(String authenticationData, byte[] seed, Configuration conf) {
+    public void initialize(String authenticationData, byte[] seed, Configuration conf, HostAddress hostAddress) {
         throw new UnsupportedOperationException("Authentication strategy 'dialog' is not supported in GraalVM");
     }
 


### PR DESCRIPTION
Adjusts GraalVM substitution to allow the upgrade.