### PR TITLE
Fix spring-data-jpa `@Modifying(flushAutomatically = true)`

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/ModifyingQueryWithFlushAndClearTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/ModifyingQueryWithFlushAndClearTest.java
@@ -33,6 +33,7 @@ public class ModifyingQueryWithFlushAndClearTest {
     public void setUp() {
         final User user = getUser("JOHN");
         user.setLoginCounter(0);
+        user.getLoginEvents().clear();
         repo.save(user);
     }
 
@@ -69,8 +70,9 @@ public class ModifyingQueryWithFlushAndClearTest {
 
         final User verifyUser = getUser("JOHN");
         // processLoginEvents did not see the new login event
+        assertThat(verifyUser.getLoginEvents()).hasSize(1);
         final boolean allProcessed = verifyUser.getLoginEvents().stream()
-                .allMatch(loginEvent -> loginEvent.isProcessed());
+                .allMatch(LoginEvent::isProcessed);
         assertThat(allProcessed).describedAs("all LoginEvents are marked as processed").isFalse();
     }
 
@@ -83,8 +85,9 @@ public class ModifyingQueryWithFlushAndClearTest {
         repo.processLoginEventsPlainAutoClearAndFlush();
 
         final User verifyUser = getUser("JOHN");
+        assertThat(verifyUser.getLoginEvents()).hasSize(1);
         final boolean allProcessed = verifyUser.getLoginEvents().stream()
-                .allMatch(loginEvent -> loginEvent.isProcessed());
+                .allMatch(LoginEvent::isProcessed);
         assertThat(allProcessed).describedAs("all LoginEvents are marked as processed").isTrue();
     }
 

--- a/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/RepositorySupport.java
+++ b/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/RepositorySupport.java
@@ -78,6 +78,6 @@ public final class RepositorySupport {
     }
 
     public static void flush(Class<?> clazz) {
-        Panache.getSession(clazz).clear();
+        Panache.getSession(clazz).flush();
     }
 }


### PR DESCRIPTION
Issue spotted by @dreab8: https://github.com/quarkusio/quarkus/issues/42322#issuecomment-2273531397

This broke in 3.13.0.CR1 via [6f859d4](https://github.com/quarkusio/quarkus/commit/6f859d4accc336690f7a3653723c8cfec407aed9#diff-25c83264c299e026d3b9b0236d4e392a250417367492a79c2dd0ceed0d7cc999R51) (/cc @yrodiere, no fingerpointing - just to make sure I'm not missing anything)

The test didn't catch it because `allMatch` returns `true` for an empty collection. See also: https://stackoverflow.com/a/30223378