### PR TITLE
Update gitflow-incremental-builder to 4.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
-        <gitflow-incremental-builder.version>4.5.3</gitflow-incremental-builder.version>
+        <gitflow-incremental-builder.version>4.5.4</gitflow-incremental-builder.version>
         <quarkus-platform-bom-plugin.version>0.0.107</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>


### PR DESCRIPTION
Dependabot hasn't picked up 4.5.4 for almost 2 months, hence manually.

https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/releases/tag/v4.5.4

The JGit update should fix an exception on shutdown which I saw just a moment ago in a Quarkus CI build.