### PR TITLE
Reorganize Hibernate Search management config

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -65,7 +65,6 @@ import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElas
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.ElasticsearchIndexBuildTimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRecorder;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
-import io.quarkus.hibernate.search.orm.elasticsearch.runtime.management.HibernateSearchManagementConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
@@ -441,10 +440,12 @@ class HibernateSearchElasticsearchProcessor {
     @BuildStep(onlyIf = HibernateSearchManagementEnabled.class)
     void createManagementRoutes(BuildProducer<RouteBuildItem> routes,
             HibernateSearchElasticsearchRecorder recorder,
-            HibernateSearchManagementConfig managementConfig) {
+            HibernateSearchElasticsearchBuildTimeConfig hibernateSearchElasticsearchBuildTimeConfig) {
+
+        String managementRootPath = hibernateSearchElasticsearchBuildTimeConfig.management().rootPath();
 
         routes.produce(RouteBuildItem.newManagementRoute(
-                managementConfig.rootPath() + (managementConfig.rootPath().endsWith("/") ? "" : "/") + "reindex")
+                managementRootPath + (managementRootPath.endsWith("/") ? "" : "/") + "reindex")
                 .withRoutePathConfigKey("quarkus.hibernate-search-orm.management.root-path")
                 .withRequestHandler(recorder.managementHandler())
                 .displayOnNotFoundPage()

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchEnabled.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchEnabled.java
@@ -10,7 +10,7 @@ import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElas
  */
 public class HibernateSearchEnabled implements BooleanSupplier {
 
-    private final HibernateSearchElasticsearchBuildTimeConfig config;
+    protected final HibernateSearchElasticsearchBuildTimeConfig config;
 
     HibernateSearchEnabled(HibernateSearchElasticsearchBuildTimeConfig config) {
         this.config = config;

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchManagementEnabled.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchManagementEnabled.java
@@ -1,7 +1,6 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
 
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfig;
-import io.quarkus.hibernate.search.orm.elasticsearch.runtime.management.HibernateSearchManagementConfig;
 
 /**
  * Supplier that can be used to only run build steps
@@ -9,17 +8,13 @@ import io.quarkus.hibernate.search.orm.elasticsearch.runtime.management.Hibernat
  */
 public class HibernateSearchManagementEnabled extends HibernateSearchEnabled {
 
-    private final HibernateSearchManagementConfig config;
-
-    HibernateSearchManagementEnabled(HibernateSearchElasticsearchBuildTimeConfig config,
-            HibernateSearchManagementConfig managementConfig) {
+    HibernateSearchManagementEnabled(HibernateSearchElasticsearchBuildTimeConfig config) {
         super(config);
-        this.config = managementConfig;
     }
 
     @Override
     public boolean getAsBoolean() {
-        return super.getAsBoolean() && config.enabled();
+        return super.getAsBoolean() && config.management().enabled();
     }
 
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -35,4 +36,9 @@ public interface HibernateSearchElasticsearchBuildTimeConfig {
     @ConfigDocMapKey("persistence-unit-name")
     Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> persistenceUnits();
 
+    /**
+     * Management interface.
+     */
+    @ConfigDocSection
+    HibernateSearchElasticsearchBuildTimeConfigManagement management();
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigManagement.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigManagement.java
@@ -1,13 +1,10 @@
-package io.quarkus.hibernate.search.orm.elasticsearch.runtime.management;
+package io.quarkus.hibernate.search.orm.elasticsearch.runtime;
 
-import io.quarkus.runtime.annotations.ConfigPhase;
-import io.quarkus.runtime.annotations.ConfigRoot;
-import io.smallrye.config.ConfigMapping;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
-@ConfigMapping(prefix = "quarkus.hibernate-search-orm.management")
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public interface HibernateSearchManagementConfig {
+@ConfigGroup
+public interface HibernateSearchElasticsearchBuildTimeConfigManagement {
 
     /**
      * Root path for reindexing endpoints.

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneEnabled.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneEnabled.java
@@ -10,7 +10,7 @@ import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSea
  */
 public class HibernateSearchStandaloneEnabled implements BooleanSupplier {
 
-    private final HibernateSearchStandaloneBuildTimeConfig config;
+    protected final HibernateSearchStandaloneBuildTimeConfig config;
 
     HibernateSearchStandaloneEnabled(HibernateSearchStandaloneBuildTimeConfig config) {
         this.config = config;

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneManagementEnabled.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneManagementEnabled.java
@@ -1,7 +1,6 @@
 package io.quarkus.hibernate.search.standalone.elasticsearch.deployment;
 
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneBuildTimeConfig;
-import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.management.HibernateSearchStandaloneManagementConfig;
 
 /**
  * Supplier that can be used to only run build steps
@@ -9,17 +8,13 @@ import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.management.H
  */
 public class HibernateSearchStandaloneManagementEnabled extends HibernateSearchStandaloneEnabled {
 
-    private final HibernateSearchStandaloneManagementConfig config;
-
-    HibernateSearchStandaloneManagementEnabled(HibernateSearchStandaloneBuildTimeConfig config,
-            HibernateSearchStandaloneManagementConfig managementConfig) {
+    HibernateSearchStandaloneManagementEnabled(HibernateSearchStandaloneBuildTimeConfig config) {
         super(config);
-        this.config = managementConfig;
     }
 
     @Override
     public boolean getAsBoolean() {
-        return super.getAsBoolean() && config.enabled();
+        return super.getAsBoolean() && config.management().enabled();
     }
 
 }

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneProcessor.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/HibernateSearchStandaloneProcessor.java
@@ -63,7 +63,6 @@ import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSea
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneBuildTimeConfig.ElasticsearchIndexBuildTimeConfig;
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRecorder;
 import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.HibernateSearchStandaloneRuntimeConfig;
-import io.quarkus.hibernate.search.standalone.elasticsearch.runtime.management.HibernateSearchStandaloneManagementConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
@@ -370,10 +369,12 @@ class HibernateSearchStandaloneProcessor {
     @BuildStep(onlyIf = HibernateSearchStandaloneManagementEnabled.class)
     void createManagementRoutes(BuildProducer<RouteBuildItem> routes,
             HibernateSearchStandaloneRecorder recorder,
-            HibernateSearchStandaloneManagementConfig managementConfig) {
+            HibernateSearchStandaloneBuildTimeConfig hibernateSearchStandaloneBuildTimeConfig) {
+
+        String managementRootPath = hibernateSearchStandaloneBuildTimeConfig.management().rootPath();
 
         routes.produce(RouteBuildItem.newManagementRoute(
-                managementConfig.rootPath() + (managementConfig.rootPath().endsWith("/") ? "" : "/") + "reindex")
+                managementRootPath + (managementRootPath.endsWith("/") ? "" : "/") + "reindex")
                 .withRoutePathConfigKey("quarkus.hibernate-search-standalone.management.root-path")
                 .withRequestHandler(recorder.managementHandler())
                 .displayOnNotFoundPage()

--- a/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/HibernateSearchStandaloneBuildTimeConfig.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/HibernateSearchStandaloneBuildTimeConfig.java
@@ -69,6 +69,12 @@ public interface HibernateSearchStandaloneBuildTimeConfig {
     Optional<String> backgroundFailureHandler();
 
     /**
+     * Management interface.
+     */
+    @ConfigDocSection
+    HibernateSearchStandaloneBuildTimeConfigManagement management();
+
+    /**
      * Configuration related to the mapping.
      */
     MappingConfig mapping();

--- a/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/HibernateSearchStandaloneBuildTimeConfigManagement.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/runtime/HibernateSearchStandaloneBuildTimeConfigManagement.java
@@ -1,13 +1,10 @@
-package io.quarkus.hibernate.search.standalone.elasticsearch.runtime.management;
+package io.quarkus.hibernate.search.standalone.elasticsearch.runtime;
 
-import io.quarkus.runtime.annotations.ConfigPhase;
-import io.quarkus.runtime.annotations.ConfigRoot;
-import io.smallrye.config.ConfigMapping;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
-@ConfigMapping(prefix = "quarkus.hibernate-search-standalone.management")
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public interface HibernateSearchStandaloneManagementConfig {
+@ConfigGroup
+public interface HibernateSearchStandaloneBuildTimeConfigManagement {
 
     /**
      * Root path for reindexing endpoints.


### PR DESCRIPTION
While it's working fine with the new annotation processor, the config is not ordered the same and it's better displayed as a section. Also it looks a bit odd to have a specific root just for that.

@marko-bekhta FYI I discussed it with Yoann before his PTO and he agreed it was odd.