### PR TITLE
Vertx HTTP: execute custom logic when HTTP server is started

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -498,6 +498,27 @@ public class MyCustomizer implements HttpServerOptionsCustomizer {
 <1> By making the class a managed bean, Quarkus will take the customizer into account when it starts the Vert.x servers
 <2> In this case, we only care about customizing the HTTP server, so we just override the `customizeHttpServer` method, but users should be aware that `HttpServerOptionsCustomizer` allows configuring the HTTPS and Domain Socket servers as well
 
+
+== How to execute logic when HTTP server started
+
+In order to execute some custom action when the HTTP server is started you'll need to declare an _asynchronous_ CDI observer method. 
+Quarkus _asynchronously_ fires CDI events of types `io.quarkus.vertx.http.HttpServerStart`, `io.quarkus.vertx.http.HttpsServerStart` and `io.quarkus.vertx.http.DomainSocketServerStart` when the corresponding HTTP server starts listening on the configured host and port.
+
+.`HttpServerStart` example
+[source,java]
+----
+@ApplicationScoped
+public class MyListener {
+
+   void httpStarted(@ObservesAsync HttpServerStart start) { <1>
+      // ...notified when the HTTP server starts listening
+   }
+}
+----
+<1> An asynchronous `HttpServerStart` observer method may be declared by annotating an `HttpServerStart` parameter with `@jakarta.enterprise.event.ObservesAsync`.
+
+NOTE: It's not possible to use the `StartupEvent` for this particular use case because this CDI event is fired before the HTTP server is started.
+
 [[reverse-proxy]]
 == Running behind a reverse proxy
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/start/HttpServerStartEventsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/start/HttpServerStartEventsTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.vertx.http.start;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.ObservesAsync;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.HttpServerStart;
+import io.quarkus.vertx.http.HttpsServerStart;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+public class HttpServerStartEventsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(MyListener.class)
+                    .addAsResource(new File("target/certs/ssl-test-keystore.jks"), "server-keystore.jks"))
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-file", "server-keystore.jks")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-password", "secret");
+
+    @Test
+    public void test() throws InterruptedException {
+        assertTrue(MyListener.HTTP.await(5, TimeUnit.SECONDS));
+        assertTrue(MyListener.HTTPS.await(5, TimeUnit.SECONDS));
+        // httpsStarted() is static
+        assertEquals(1, MyListener.COUNTER.get());
+    }
+
+    @Dependent
+    public static class MyListener {
+
+        static final AtomicInteger COUNTER = new AtomicInteger();
+        static final CountDownLatch HTTP = new CountDownLatch(1);
+        static final CountDownLatch HTTPS = new CountDownLatch(1);
+
+        void httpStarted(@ObservesAsync HttpServerStart start) {
+            assertNotNull(start.options());
+            HTTP.countDown();
+        }
+
+        static void httpsStarted(@ObservesAsync HttpsServerStart start) {
+            assertNotNull(start.options());
+            HTTPS.countDown();
+        }
+
+        @PreDestroy
+        void destroy() {
+            COUNTER.incrementAndGet();
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/DomainSocketServerStart.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/DomainSocketServerStart.java
@@ -1,0 +1,21 @@
+package io.quarkus.vertx.http;
+
+import io.vertx.core.http.HttpServerOptions;
+
+/**
+ * Quarkus fires a CDI event of this type asynchronously when the domain socket server starts listening
+ * on the configured host and port.
+ *
+ * <pre>
+ * &#064;ApplicationScoped
+ * public class MyListener {
+ *
+ *     void domainSocketStarted(&#064;ObservesAsync DomainSocketServerStart start) {
+ *         // ...notified when the domain socket server starts listening
+ *     }
+ * }
+ * </pre>
+ */
+public record DomainSocketServerStart(HttpServerOptions options) {
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/HttpServerStart.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/HttpServerStart.java
@@ -1,0 +1,21 @@
+package io.quarkus.vertx.http;
+
+import io.vertx.core.http.HttpServerOptions;
+
+/**
+ * Quarkus fires a CDI event of this type asynchronously when the HTTP server starts listening
+ * on the configured host and port.
+ *
+ * <pre>
+ * &#064;ApplicationScoped
+ * public class MyListener {
+ *
+ *     void httpStarted(&#064;ObservesAsync HttpServerStart start) {
+ *         // ...notified when the HTTP server starts listening
+ *     }
+ * }
+ * </pre>
+ */
+public record HttpServerStart(HttpServerOptions options) {
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/HttpsServerStart.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/HttpsServerStart.java
@@ -1,0 +1,21 @@
+package io.quarkus.vertx.http;
+
+import io.vertx.core.http.HttpServerOptions;
+
+/**
+ * Quarkus fires a CDI event of this type asynchronously when the HTTPS server starts listening
+ * on the configured host and port.
+ *
+ * <pre>
+ * &#064;ApplicationScoped
+ * public class MyListener {
+ *
+ *     void httpsStarted(&#064;ObservesAsync HttpsServerStart start) {
+ *         // ...notified when the HTTPS server starts listening
+ *     }
+ * }
+ * </pre>
+ */
+public record HttpsServerStart(HttpServerOptions options) {
+
+}


### PR DESCRIPTION
- resolves #42366

IMPL. NOTE: I chose CDI async events because it's "safer" compared to `@Observes` which always blocks the current thread. `@ObservesAsync` offloads the logic to the default blocking executor (worker thread in case of `quarkus-vertx`). I mean, we could mention this in the docs, even in javadoc, but that does not prevent users from executing "creative" code in those observers. `@ObservesAsync` should mitigate the risk a little ;-).