### PR TITLE
Make singleResultOptional throw jakarta exceptions

### DIFF
--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -337,7 +337,10 @@ public class CommonPanacheQueryImpl<Entity> {
     public <T extends Entity> Optional<T> singleResultOptional() {
         SelectionQuery hibernateQuery = createQuery();
         try (NonThrowingCloseable c = applyFilters()) {
-            return hibernateQuery.uniqueResultOptional();
+            // Yes, there's a much nicer hibernateQuery.uniqueResultOptional() BUT
+            //  it throws org.hibernate.NonUniqueResultException instead of a jakarta.persistence.NonUniqueResultException
+            //  and at this point changing it would be a breaking change >_<
+            return Optional.ofNullable((T) hibernateQuery.getSingleResultOrNull());
         }
     }
 

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
@@ -1860,4 +1860,41 @@ public class TestEndpoint {
         Assertions.assertEquals(1, Person.delete("\r\n  \n\ndelete\nfrom\n Person2\nwhere\nname = ?1", "foo"));
         return "OK";
     }
+
+    @GET
+    @Path("42416")
+    public String testBug42416() {
+        createSomeEntities42416();
+        runSomeTests42416();
+        return "OK";
+    }
+
+    @Transactional
+    public void createSomeEntities42416() {
+        Fruit.deleteAll();
+        Fruit f = new Fruit("apple", "red");
+        f.persist();
+
+        Fruit f2 = new Fruit("apple", "yellow");
+        f2.persist();
+    }
+
+    @Transactional
+    public void runSomeTests42416() {
+        try {
+            Fruit.find("where name = ?1", "apple").singleResult();
+        } catch (jakarta.persistence.NonUniqueResultException e) {
+            // all good let's continue
+        }
+        try {
+            Fruit.find("where name = ?1", "not-a-fruit").singleResult();
+        } catch (jakarta.persistence.NoResultException e) {
+            // all good let's continue
+        }
+        try {
+            Fruit.find("where name = ?1", "apple").singleResultOptional();
+        } catch (jakarta.persistence.NonUniqueResultException e) {
+            // all good let's continue
+        }
+    }
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/PanacheFunctionalityTest.java
@@ -258,4 +258,9 @@ public class PanacheFunctionalityTest {
     public void testBug31117() {
         RestAssured.when().get("/test/31117").then().body(is("OK"));
     }
+
+    @Test
+    public void testBug42416() {
+        RestAssured.when().get("/test/42416").then().body(is("OK"));
+    }
 }


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/42416 (probably)

`singleResult()` seems unaffected, while the `singleResultOptional` one is throwing hibernate exceptions .. `getSingleResultOrNull` also throws jakarta exceptions, so this probably will do the trick ... 