### PR TITLE
Fix methos to methods typos

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -593,7 +593,7 @@ Methods annotated with `@OnOpen`, `@OnTextMessage`, `@OnBinaryMessage`, and `@On
 @Inject WebSocketConnection connection;
 ----
 
-NOTE: Note that outside of these methos, the `WebSocketConnection` object is not available. However, it is possible to <<list-open-connections,list all open connections>>.
+NOTE: Note that outside of these methods, the `WebSocketConnection` object is not available. However, it is possible to <<list-open-connections,list all open connections>>.
 
 The connection can be used to send messages to the client, access the path parameters, broadcast messages to all connected clients, etc.
 
@@ -909,7 +909,7 @@ Methods annotated with `@OnOpen`, `@OnTextMessage`, `@OnBinaryMessage`, and `@On
 @Inject WebSocketClientConnection connection;
 ----
 
-NOTE: Note that outside of these methos, the `WebSocketClientConnection` object is not available. However, it is possible to <<list-open-client-connections,list all open client connections>>.
+NOTE: Note that outside of these methods, the `WebSocketClientConnection` object is not available. However, it is possible to <<list-open-client-connections,list all open client connections>>.
 
 The connection can be used to send messages to the client, access the path parameters, etc.
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateData.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateData.java
@@ -18,7 +18,7 @@ import io.quarkus.qute.TemplateData.Container;
  * non-public members, constructors, static initializers, static, synthetic and void methods are always ignored.
  * <p>
  * If the {@link #namespace()} is set to a non-empty value then a namespace resolver is automatically generated to access static
- * fields and methos of the target class.
+ * fields and methods of the target class.
  *
  * @see ValueResolver
  * @see NamespaceResolver
@@ -60,7 +60,7 @@ public @interface TemplateData {
     boolean properties() default false;
 
     /**
-     * If set to a non-empty value then a namespace resolver is automatically generated to access static fields and methos of
+     * If set to a non-empty value then a namespace resolver is automatically generated to access static fields and methods of
      * the target class.
      * <p>
      * By default, the namespace is the FQCN of the target class where dots and dollar signs are replaced by underscores, for


### PR DESCRIPTION
I noticed this in websocket.next docs, but I did a global search for "methos" :). Maybe it's the favorite typo of @mkouba :D