### PR TITLE
[Maven 4] Replace ${maven.multiModuleProjectDirectory} with ${session.rootDirectory}

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--Dmaven.multiModuleProjectDirectory=${session.rootDirectory}

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -141,7 +141,7 @@
         <platform.quarkus.native.builder-image>mandrel</platform.quarkus.native.builder-image>
 
         <script.extension>sh</script.extension>
-        <docker-prune.location>${maven.multiModuleProjectDirectory}/.github/docker-prune.${script.extension}</docker-prune.location>
+        <docker-prune.location>${session.rootDirectory}/.github/docker-prune.${script.extension}</docker-prune.location>
 
         <surefire.argLine.additional></surefire.argLine.additional>
         <failsafe.argLine.additional>${surefire.argLine.additional}</failsafe.argLine.additional>
@@ -616,7 +616,7 @@
                                 <!-- if the used Java version is too new, don't fail, just do nothing: -->
                                 <failOnUnsupportedJava>false</failOnUnsupportedJava>
                                 <signaturesFiles>
-                                    <signaturesFile>${maven.multiModuleProjectDirectory}/.forbiddenapis/banned-signatures-common.txt</signaturesFile>
+                                    <signaturesFile>${session.rootDirectory}/.forbiddenapis/banned-signatures-common.txt</signaturesFile>
                                 </signaturesFiles>
                                 <failOnMissingClasses>false</failOnMissingClasses>
                                 <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -238,7 +238,7 @@
                         <configuration>
                             <signaturesFiles>
                                 <signaturesFile>./banned-signatures.txt</signaturesFile>
-                                <signaturesFile>${maven.multiModuleProjectDirectory}/.forbiddenapis/banned-signatures-common.txt</signaturesFile>
+                                <signaturesFile>${session.rootDirectory}/.forbiddenapis/banned-signatures-common.txt</signaturesFile>
                             </signaturesFiles>
                         </configuration>
                     </execution>

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -1038,13 +1038,17 @@ These system properties above could be added to, e.g., a `surefire` and/or `fail
 ==== Top-level vs Multi-module project directory
 
 In Maven there appears to be a notion of the top-level project (that is exposed as a project property `${session.topLevelProject.basedir.absolutePath}`)
-and the multi-module project directory (that is available as property `${maven.multiModuleProjectDirectory}`). These directories might not always match!
+and the multi-module project directory (that is available as property `${session.rootDirectory}`). These directories might not always match!
 
-IMPORTANT: `maven.multiModuleProjectDirectory` is meant to be consulted by the Maven code itself and not something to be relied upon by user code. So, if you find it useful, use it at your own risk!
+The `${session.rootDirectory}` is defined as:
 
-The `${maven.multiModuleProjectDirectory}` will be resolved to the first directory that contains `.mvn` directory as its child going up the workspace file system tree
-starting from the current directory (or the one specified with the `-f` argument) from which the `mvn` command was launched. If the `.mvn` directory was not found, however,
-the `${maven.multiModuleProjectDirectory}` will be pointing to the directory from which the `mvn` command was launched (or the one targeted with the `-f` argument).
+[quote]
+____
+The project's directory or parent directory containing a `.mvn` subdirectory or a `pom.xml` flagged with the `root="true"` attribute.
+____
+
+The resolution starts from the current directory (or the one specified with the `-f` argument) from which the `mvn` command was launched.
+In multi-module projects, it is the vetted way to reference the root of your multi-module project.
 
 The `${session.topLevelProject.basedir.absolutePath}` will be pointing either to the directory from which the `mvn` command was launched or to the directory targeted with
 the `-f` argument, if it was specified.

--- a/docs/src/main/asciidoc/tests-with-coverage.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage.adoc
@@ -183,9 +183,9 @@ specifying a `data-file` or `report-location` will assume the path as is. Here i
   <artifactId>maven-surefire-plugin</artifactId>
   <configuration>
     <systemPropertyVariables>
-      <quarkus.jacoco.data-file>${maven.multiModuleProjectDirectory}/target/jacoco.exec</quarkus.jacoco.data-file>
+      <quarkus.jacoco.data-file>${session.rootDirectory}/target/jacoco.exec</quarkus.jacoco.data-file>
       <quarkus.jacoco.reuse-data-file>true</quarkus.jacoco.reuse-data-file>
-      <quarkus.jacoco.report-location>${maven.multiModuleProjectDirectory}/target/coverage</quarkus.jacoco.report-location>
+      <quarkus.jacoco.report-location>${session.rootDirectory}/target/coverage</quarkus.jacoco.report-location>
     </systemPropertyVariables>
   </configuration>
 </plugin

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -484,7 +484,7 @@
                                     <outputDirectory>${project.build.directory}/classes/META-INF</outputDirectory>
                                     <resources>
                                         <resource>
-                                            <directory>${maven.multiModuleProjectDirectory}</directory>
+                                            <directory>${session.rootDirectory}</directory>
                                             <filtering>false</filtering>
                                             <includes>
                                                 <include>LICENSE</include>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -491,7 +491,7 @@
                                 <!-- if the used Java version is too new, don't fail, just do nothing: -->
                                 <failOnUnsupportedJava>false</failOnUnsupportedJava>
                                 <signaturesFiles>
-                                    <signaturesFile>${maven.multiModuleProjectDirectory}/.forbiddenapis/banned-signatures-common.txt</signaturesFile>
+                                    <signaturesFile>${session.rootDirectory}/.forbiddenapis/banned-signatures-common.txt</signaturesFile>
                                 </signaturesFiles>
                                 <failOnMissingClasses>false</failOnMissingClasses>
                                 <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>

--- a/tcks/resteasy-reactive/pom.xml
+++ b/tcks/resteasy-reactive/pom.xml
@@ -72,7 +72,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${maven.multiModuleProjectDirectory}/mvnw</executable>
+                            <executable>${session.rootDirectory}/mvnw</executable>
                             <commandlineArgs>-e -B --settings ${session.request.userSettingsFile.path} clean install ${resteasy-reactive-testsuite.mvn.args} -Dquarkus.platform.version=${project.version} -Dquarkus-plugin.version=${project.version}</commandlineArgs>
                             <skip>${resteasy-reactive-testsuite.test.skip}</skip>
                         </configuration>


### PR DESCRIPTION
This will be when we migrate to Maven 4.
While Maven 3.9.2 also introduces ${session.rootDirectory}, it is not usable in POM files, only in the Maven config itself.

/cc @aloubyansky for your awareness.

Fixes #42430