### PR TITLE
Fix consistency of SmallRye Health config roots

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/DeprecatedHealthBuildTimeConfig.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/DeprecatedHealthBuildTimeConfig.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.health.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * This class is deprecated, don't add any more properties here.
+ *
+ * When dropping this class please make the properties in {@link SmallRyeHealthBuildTimeConfig} non optional.
+ *
+ * @deprecated Use {@link SmallRyeHealthBuildTimeConfig} instead.
+ */
+@ConfigRoot(name = "health")
+@Deprecated(since = "3.14", forRemoval = true)
+public class DeprecatedHealthBuildTimeConfig {
+
+    /**
+     * Whether extensions published health check should be enabled.
+     *
+     * @deprecated Use {@code quarkus.smallrye-health.extensions.enabled} instead.
+     */
+    @ConfigItem(name = "extensions.enabled", defaultValue = "true")
+    @Deprecated(since = "3.14", forRemoval = true)
+    public boolean extensionsEnabled;
+
+    /**
+     * Whether to include the Liveness and Readiness Health endpoints in the generated OpenAPI document
+     *
+     * @deprecated Use {@code quarkus.smallrye-health.openapi.included} instead.
+     */
+    @ConfigItem(name = "openapi.included", defaultValue = "false")
+    @Deprecated(since = "3.14", forRemoval = true)
+    public boolean openapiIncluded;
+}

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthActive.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthActive.java
@@ -4,9 +4,9 @@ import java.util.function.BooleanSupplier;
 
 public class SmallRyeHealthActive implements BooleanSupplier {
 
-    private final HealthBuildTimeConfig config;
+    private final SmallRyeHealthBuildTimeConfig config;
 
-    SmallRyeHealthActive(HealthBuildTimeConfig config) {
+    SmallRyeHealthActive(SmallRyeHealthBuildTimeConfig config) {
         this.config = config;
     }
 

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthBuildTimeConfig.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthBuildTimeConfig.java
@@ -1,10 +1,12 @@
 package io.quarkus.smallrye.health.deployment;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(name = "health")
-public class HealthBuildTimeConfig {
+@ConfigRoot(name = "smallrye-health")
+public class SmallRyeHealthBuildTimeConfig {
     /**
      * Activate or disable this extension. Disabling this extension means that no health related information is exposed.
      */
@@ -14,12 +16,12 @@ public class HealthBuildTimeConfig {
     /**
      * Whether extensions published health check should be enabled.
      */
-    @ConfigItem(name = "extensions.enabled", defaultValue = "true")
-    public boolean extensionsEnabled;
+    @ConfigItem(name = "extensions.enabled", defaultValueDocumentation = "true")
+    public Optional<Boolean> extensionsEnabled;
 
     /**
      * Whether to include the Liveness and Readiness Health endpoints in the generated OpenAPI document
      */
-    @ConfigItem(name = "openapi.included", defaultValue = "false")
-    public boolean openapiIncluded;
+    @ConfigItem(name = "openapi.included", defaultValueDocumentation = "false")
+    public Optional<Boolean> openapiIncluded;
 }

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -118,14 +118,13 @@ class SmallRyeHealthProcessor {
             "key-files");
 
     static class OpenAPIIncluded implements BooleanSupplier {
-        HealthBuildTimeConfig config;
+        SmallRyeHealthBuildTimeConfig smallryeHealthBuildTimeConfig;
+        DeprecatedHealthBuildTimeConfig deprecatedHealthBuildTimeConfig;
 
         public boolean getAsBoolean() {
-            return config.openapiIncluded;
+            return smallryeHealthBuildTimeConfig.openapiIncluded.orElse(deprecatedHealthBuildTimeConfig.openapiIncluded);
         }
     }
-
-    HealthBuildTimeConfig config;
 
     @BuildStep
     List<HotDeploymentWatchedFileBuildItem> brandingFiles() {
@@ -140,8 +139,11 @@ class SmallRyeHealthProcessor {
 
     @BuildStep
     void healthCheck(BuildProducer<AdditionalBeanBuildItem> buildItemBuildProducer,
-            List<HealthBuildItem> healthBuildItems) {
-        boolean extensionsEnabled = config.extensionsEnabled &&
+            List<HealthBuildItem> healthBuildItems,
+            SmallRyeHealthBuildTimeConfig smallryeHealthBuildTimeConfig,
+            DeprecatedHealthBuildTimeConfig deprecatedHealthBuildTimeConfig) {
+        boolean extensionsEnabled = smallryeHealthBuildTimeConfig.extensionsEnabled
+                .orElse(deprecatedHealthBuildTimeConfig.extensionsEnabled) &&
                 !ConfigProvider.getConfig().getOptionalValue("mp.health.disable-default-procedures", boolean.class)
                         .orElse(false);
         if (extensionsEnabled) {

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/DeactiveHealthWithConfigTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/DeactiveHealthWithConfigTest.java
@@ -15,7 +15,7 @@ class DeactiveHealthWithConfigTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(BasicHealthCheck.class)
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
-            .overrideConfigKey("quarkus.health.enabled", "false");
+            .overrideConfigKey("quarkus.smallrye-health.enabled", "false");
 
     @Test
     void testAdditionalJsonPropertyInclusions() {

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/DeprecatedHealthOpenAPITest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/DeprecatedHealthOpenAPITest.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-class HealthOpenAPITest {
+@Deprecated(since = "3.14", forRemoval = true)
+class DeprecatedHealthOpenAPITest {
 
     private static final String OPEN_API_PATH = "/q/openapi";
 
@@ -17,7 +18,7 @@ class HealthOpenAPITest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(BasicHealthCheck.class, OpenApiRoute.class)
-                    .addAsResource(new StringAsset("quarkus.smallrye-health.openapi.included=true\n"
+                    .addAsResource(new StringAsset("quarkus.health.openapi.included=true\n"
                             + "quarkus.smallrye-openapi.store-schema-directory=target"), "application.properties")
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
 


### PR DESCRIPTION
Some properties were under the `quarkus.health` prefix and some under the `quarkus.smallrye-health` prefix.
I unified everything under `quarkus.smallrye-health` and kept the old properties for backward compatibility (except for the just introduced `enabled`).

Fixes #42382