### PR TITLE
Upgrade mongodb-client to 5.1.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -167,7 +167,7 @@
         <liquibase-mongodb.version>4.29.0</liquibase-mongodb.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
-        <mongo-client.version>4.11.1</mongo-client.version>
+        <mongo-client.version>5.1.3</mongo-client.version>
         <mongo-crypt.version>1.11.0</mongo-crypt.version>
         <proton-j.version>0.34.1</proton-j.version>
         <javaparser.version>3.26.1</javaparser.version>

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/FindOptions.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/FindOptions.java
@@ -21,7 +21,6 @@ public class FindOptions {
     private Bson projection;
     private Bson sort;
     private boolean noCursorTimeout;
-    private boolean oplogReplay;
     private boolean partial;
     private CursorType cursorType;
     private Collation collation;
@@ -134,17 +133,6 @@ public class FindOptions {
      */
     public FindOptions noCursorTimeout(boolean noCursorTimeout) {
         this.noCursorTimeout = noCursorTimeout;
-        return this;
-    }
-
-    /**
-     * Users should not set this under normal circumstances.
-     *
-     * @param oplogReplay if oplog replay is enabled
-     * @return this
-     */
-    public FindOptions oplogReplay(boolean oplogReplay) {
-        this.oplogReplay = oplogReplay;
         return this;
     }
 
@@ -293,9 +281,6 @@ public class FindOptions {
         }
         if (noCursorTimeout) {
             publisher = publisher.noCursorTimeout(true);
-        }
-        if (oplogReplay) {
-            publisher = publisher.oplogReplay(true);
         }
         if (partial) {
             publisher = publisher.partial(true);

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/MapReduceOptions.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/MapReduceOptions.java
@@ -25,8 +25,6 @@ public class MapReduceOptions {
     private long maxTime;
     private MapReduceAction action;
     private String databaseName;
-    private boolean sharded;
-    private boolean nonAtomic;
     private boolean bypassDocumentValidation;
     private Collation collation;
 
@@ -160,30 +158,6 @@ public class MapReduceOptions {
     }
 
     /**
-     * Sets if the output database is sharded
-     *
-     * @param sharded if the output database is sharded
-     * @return this
-     */
-    public MapReduceOptions sharded(boolean sharded) {
-        this.sharded = sharded;
-        return this;
-    }
-
-    /**
-     * Sets if the post-processing step will prevent MongoDB from locking the database.
-     * <p>
-     * Valid only with the {@code MapReduceAction.MERGE} or {@code MapReduceAction.REDUCE} actions.
-     *
-     * @param nonAtomic if the post-processing step will prevent MongoDB from locking the database.
-     * @return this
-     */
-    public MapReduceOptions nonAtomic(boolean nonAtomic) {
-        this.nonAtomic = nonAtomic;
-        return this;
-    }
-
-    /**
      * Sets the bypass document level validation flag.
      *
      * <p>
@@ -246,8 +220,6 @@ public class MapReduceOptions {
         if (databaseName != null) {
             publisher = publisher.databaseName(databaseName);
         }
-        publisher = publisher.sharded(sharded);
-        publisher = publisher.nonAtomic(nonAtomic);
         publisher = publisher.bypassDocumentValidation(bypassDocumentValidation);
         if (collation != null) {
             publisher = publisher.collation(collation);

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/metrics/MongoMetricsConnectionPoolListener.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/metrics/MongoMetricsConnectionPoolListener.java
@@ -8,13 +8,12 @@ import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.Tag;
 
 import com.mongodb.connection.ServerId;
-import com.mongodb.event.ConnectionAddedEvent;
 import com.mongodb.event.ConnectionCheckedInEvent;
 import com.mongodb.event.ConnectionCheckedOutEvent;
-import com.mongodb.event.ConnectionPoolClosedEvent;
+import com.mongodb.event.ConnectionClosedEvent;
+import com.mongodb.event.ConnectionCreatedEvent;
+import com.mongodb.event.ConnectionPoolCreatedEvent;
 import com.mongodb.event.ConnectionPoolListener;
-import com.mongodb.event.ConnectionPoolOpenedEvent;
-import com.mongodb.event.ConnectionRemovedEvent;
 
 import io.smallrye.metrics.MetricRegistries;
 
@@ -23,15 +22,11 @@ public class MongoMetricsConnectionPoolListener implements ConnectionPoolListene
     private final static String CHECKED_OUT_COUNT_NAME = "mongodb.connection-pool.checked-out-count";
 
     @Override
-    public void connectionPoolOpened(ConnectionPoolOpenedEvent event) {
+    public void connectionPoolCreated(ConnectionPoolCreatedEvent event) {
         Tag[] tags = createTags(event.getServerId());
 
         registerGauge(SIZE_NAME, "the current size of the pool, including idle and and in-use members", tags);
         registerGauge(CHECKED_OUT_COUNT_NAME, "the current count of connections that are currently in use", tags);
-    }
-
-    @Override
-    public void connectionPoolClosed(ConnectionPoolClosedEvent event) {
     }
 
     @Override
@@ -57,7 +52,7 @@ public class MongoMetricsConnectionPoolListener implements ConnectionPoolListene
     }
 
     @Override
-    public void connectionAdded(ConnectionAddedEvent event) {
+    public void connectionCreated(ConnectionCreatedEvent event) {
 
         MetricID metricID = createMetricID(SIZE_NAME, event.getConnectionId().getServerId());
 
@@ -69,7 +64,7 @@ public class MongoMetricsConnectionPoolListener implements ConnectionPoolListene
     }
 
     @Override
-    public void connectionRemoved(ConnectionRemovedEvent event) {
+    public void connectionClosed(ConnectionClosedEvent event) {
 
         MetricID metricID = createMetricID(SIZE_NAME, event.getConnectionId().getServerId());
 


### PR DESCRIPTION
The extension compiles now, and the integration test runs successfully.

The following changes were necessary:
- changed/removed access to deprecated and removed classes/methods
- adjusted graalvm substitutions

There were a couple of deprecations, that were ignored for too long and the corresponding classes/methods were removed in this or an earlier version of the mongoldb java client.

I believe there is still some work to do with the extension, because there are still more than 30 deprecation warnings during compilation.