### PR TITLE
[3.8] Upgrade to opentelemetry-semconv.version 1.26.0-alpha to make CXF 4.0.5 happy

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -33,7 +33,7 @@
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
         <opentelemetry.version>1.32.0</opentelemetry.version>
         <opentelemetry-alpha.version>1.32.0-alpha</opentelemetry-alpha.version>
-        <opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version> <!-- keep in sync with opentelemetry-java-instrumentation in the alpha bom-->
+        <opentelemetry-semconv.version>1.26.0-alpha</opentelemetry-semconv.version><!-- Override the version managed in opentelemetry-instrumentation-bom-alpha to make CXF 4.0.5 happy https://github.com/quarkiverse/quarkus-cxf/issues/1465 -->
         <quarkus-http.version>5.2.3</quarkus-http.version>
         <micrometer.version>1.12.2</micrometer.version><!-- keep in sync with hdrhistogram -->
         <hdrhistogram.version>2.1.12</hdrhistogram.version><!-- keep in sync with micrometer -->
@@ -256,7 +256,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
              <!-- Dev UI -->
             <dependency>
                 <groupId>io.quarkus</groupId>
@@ -265,7 +265,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
             <!-- External BOMs -->
 
             <!-- Smallrye Common dependencies, imported as a BOM -->


### PR DESCRIPTION
https://github.com/quarkiverse/quarkus-cxf/issues/1465