### PR TITLE
Bump Elasticsearch/OpenSearch version used for tests/devservices to 8.15/2.16

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -70,7 +70,7 @@
         <volume.access.modifier>:Z</volume.access.modifier>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>8.13.2</elasticsearch-server.version>
+        <elasticsearch-server.version>8.15.0</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -75,7 +75,7 @@
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
-        <opensearch-server.version>2.13.0</opensearch-server.version>
+        <opensearch-server.version>2.16.0</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
         <opensearch.protocol>http</opensearch.protocol>
         <junit-pioneer.version>2.2.0</junit-pioneer.version>

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -823,7 +823,7 @@ as shown below.
 
 [source,properties]
 ----
-quarkus.hibernate-search-orm.elasticsearch.version=opensearch:2.13
+quarkus.hibernate-search-orm.elasticsearch.version=opensearch:2.16
 ----
 
 All other configuration options and APIs are exactly the same as with Elasticsearch.

--- a/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
@@ -741,7 +741,7 @@ as shown below.
 
 [source,properties]
 ----
-quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:2.13
+quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:2.16
 ----
 
 All other configuration options and APIs are exactly the same as with Elasticsearch.

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -238,7 +238,7 @@ public class DevServicesElasticsearchProcessor {
         // Disable disk-based shard allocation thresholds:
         // in a single-node setup they just don't make sense,
         // and lead to problems on large disks with little space left.
-        // See https://www.elastic.co/guide/en/elasticsearch/reference/8.13/modules-cluster.html#disk-based-shard-allocation
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
         container.addEnv("cluster.routing.allocation.disk.threshold_enabled", "false");
         container.addEnv("ES_JAVA_OPTS", config.javaOpts);
         return container;

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -238,7 +238,7 @@ public class DevServicesElasticsearchProcessor {
         // Disable disk-based shard allocation thresholds:
         // in a single-node setup they just don't make sense,
         // and lead to problems on large disks with little space left.
-        // See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cluster.html#disk-based-shard-allocation
         container.addEnv("cluster.routing.allocation.disk.threshold_enabled", "false");
         container.addEnv("ES_JAVA_OPTS", config.javaOpts);
         return container;

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
@@ -17,11 +17,11 @@ quarkus.hibernate-orm."namedpu".database.generation=drop-and-create
 
 # Hibernate Search is inactive for the default PU
 quarkus.hibernate-search-orm.active=false
-quarkus.hibernate-search-orm.elasticsearch.version=8.13
+quarkus.hibernate-search-orm.elasticsearch.version=8.15
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 
 # ... but it's (implicitly) active for a named PU
-quarkus.hibernate-search-orm."namedpu".elasticsearch.version=8.13
+quarkus.hibernate-search-orm."namedpu".elasticsearch.version=8.15
 quarkus.hibernate-search-orm."namedpu".elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm."namedpu".schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
@@ -7,6 +7,6 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-search-orm.active=false
-quarkus.hibernate-search-orm.elasticsearch.version=8.13
+quarkus.hibernate-search-orm.elasticsearch.version=8.15
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
@@ -6,6 +6,6 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=8.13
+quarkus.hibernate-search-orm.elasticsearch.version=8.15
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -3,7 +3,7 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=8.13
+quarkus.hibernate-search-orm.elasticsearch.version=8.15
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-orm.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-orm.schema-management.strategy=none

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
@@ -2,6 +2,6 @@
 quarkus.devservices.enabled=false
 
 quarkus.hibernate-search-standalone.active=false
-quarkus.hibernate-search-standalone.elasticsearch.version=8.13
+quarkus.hibernate-search-standalone.elasticsearch.version=8.15
 quarkus.hibernate-search-standalone.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-standalone.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui.properties
@@ -1,6 +1,6 @@
 # We already start Elasticsearch with Maven
 quarkus.devservices.enabled=false
 
-quarkus.hibernate-search-standalone.elasticsearch.version=8.13
+quarkus.hibernate-search-standalone.elasticsearch.version=8.15
 quarkus.hibernate-search-standalone.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-standalone.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -1,4 +1,4 @@
-quarkus.hibernate-search-standalone.elasticsearch.version=8.13
+quarkus.hibernate-search-standalone.elasticsearch.version=8.15
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-standalone.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-standalone.schema-management.strategy=none

--- a/integration-tests/elasticsearch-java-client/pom.xml
+++ b/integration-tests/elasticsearch-java-client/pom.xml
@@ -170,7 +170,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/elasticsearch-java-client/pom.xml
+++ b/integration-tests/elasticsearch-java-client/pom.xml
@@ -170,7 +170,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.13/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -170,7 +170,7 @@
                       <!-- Disable disk-based shard allocation thresholds:
                            in a single-node setup they just don't make sense,
                            and lead to problems on large disks with little space left.
-                           See https://www.elastic.co/guide/en/elasticsearch/reference/8.13/modules-cluster.html#disk-based-shard-allocation
+                           See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
                        -->
                       <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                       <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -170,7 +170,7 @@
                       <!-- Disable disk-based shard allocation thresholds:
                            in a single-node setup they just don't make sense,
                            and lead to problems on large disks with little space left.
-                           See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
+                           See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cluster.html#disk-based-shard-allocation
                        -->
                       <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                       <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
@@ -211,7 +211,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
@@ -211,7 +211,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.13/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
@@ -227,7 +227,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.13/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
@@ -227,7 +227,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -189,7 +189,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.13/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -189,7 +189,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -38,7 +38,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.13"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.15"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.13");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.15");
         }
 
         @Override

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
@@ -38,7 +38,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.13"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.16"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.13");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.16");
         }
 
         @Override

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -38,7 +38,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "8.13"));
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "8.15"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "8.13");
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "8.15");
         }
 
         @Override

--- a/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
@@ -38,7 +38,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:2.13"));
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:2.16"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-opensearch/src/test/java/io/quarkus/it/hibernate/search/standalone/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:2.13");
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "opensearch:2.16");
         }
 
         @Override

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -162,7 +162,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.13/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -162,7 +162,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.15/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->


### PR DESCRIPTION
this is an updated version of Yoann's PR https://github.com/quarkusio/quarkus/pull/41507 (can't rebase it 😕) where the versions are bumped to 2.16 and 8.15 

There's also a migration note in the original PR.