### PR TITLE
Remove dead links in podman documentation

### DIFF
--- a/docs/src/main/asciidoc/podman.adoc
+++ b/docs/src/main/asciidoc/podman.adoc
@@ -22,12 +22,7 @@ The Homebrew package manager on Mac (*brew*) *should not be used to install Podm
 
 On Linux, Podman is integrated as part of the operating system, and installed through the system's packager manager. As with Mac, and Windows, Podman Desktop can also be installed to supplement the Podman CLI. However, on Linux, Podman Desktop acts as a client to the native Podman integration, and does not manage the underlying Podman installation.
 
-See https://podman-desktop.io/downloads/ for the latest version of Podman Desktop or pick the version that suits your operating system from the list below:
-
-- https://podman-desktop.io/macos/[MacOS]
-- https://podman-desktop.io/windows/[Windows]
-- https://podman-desktop.io/linux/[Linux]
-
+See https://podman-desktop.io/downloads/ for the latest version of Podman Desktop.
 
 Additionally, if you are using Linux, see the Podman https://podman.io/docs/installation#installing-on-linux[Linux installation documentation] for instructions installing Podman to your specific Linux distribution.
 


### PR DESCRIPTION
https://quarkus.io/guides/podman has several dead links on it. Google SEO penalises pages for dead links, which might be why if you search for 'quarkus podman' our guide page is sixth in the list. It looks like what's happened is that the podman site has removed the platform specific landing pages, such as https://podman-desktop.io/macos/.

There are platform-specific one-liners like `brew install podman-desktop` listed on the podman-desktop page which I think it would be nice to include instead of the platform-specific pages, but if we did that we'd need to rephrase the warning about brew at the top of our page. So I'll leave it for now.