### PR TITLE
Cross-reference CDI FAQ and Gizmo in extension docs

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1462,7 +1462,9 @@ class MyDevModeProcessor {
 <3> The other build step will only be executed in dev mode.
 
 [id='bytecode-recording']
-=== Bytecode Recording
+=== Generating Bytecode
+
+==== Bytecode Recording
 
 One of the main outputs of the build process is recorded bytecode. This bytecode actually sets up the runtime environment. For example, in order to start Undertow, the resulting application will have some bytecode that directly registers all
 Servlet instances and then starts Undertow.
@@ -1556,12 +1558,8 @@ However, this method should not be needed in most use cases because directly loa
 Therefore, this method is deprecated.
 Nonetheless, there are some use cases where this method comes in handy, such as referring to classes that were generated in previous build steps using `GeneratedClassBuildItem`.
 
-==== Runtime Classpath check
 
-Extensions often need a way to determine whether a given class is part of the application's runtime classpath.
-The proper way for an extension to perform this check is to use `io.quarkus.bootstrap.classloading.QuarkusClassLoader.isClassPresentAtRuntime`.
-
-==== Printing step execution time
+===== Printing step execution time
 
 At times, it can be useful to know how the exact time each startup task (which is the result of each bytecode recording) takes when the application is run.
 The simplest way to determine this information is to launch the Quarkus application with the `-Dquarkus.debug.print-startup-times=true` system property.
@@ -1581,10 +1579,22 @@ Build step VertxHttpProcessor.openSocket completed in: 93ms
 Build step ShutdownListenerBuildStep.setupShutdown completed in: 1ms
 ----
 
+==== Using Gizmo
+
+In some scenarios, more significant manipulation of bytecode may be needed.
+If bytecode recording isn't sufficient, link:https://github.com/quarkusio/gizmo/blob/main/USAGE.adoc[Gizmo] is a convenient alternative to ASM, with a higher-level API.
+
+==== Runtime Classpath check
+
+Extensions often need a way to determine whether a given class is part of the application's runtime classpath.
+The proper way for an extension to perform this check is to use `io.quarkus.bootstrap.classloading.QuarkusClassLoader.isClassPresentAtRuntime`.
+
 ////
 TODO: config integration
 ////
 === Contexts and Dependency Injection
+
+The xref:cdi-integration.adoc[CDI integration guide] has more detail on common CDI-related use cases, and example code for solutions.
 
 ==== Extension Points
 


### PR DESCRIPTION
The CDI integration guide is a really useful resource for extension authors, but I didn’t know about it until @mkouba told me about it on zulip. It’s not well-linked from the writing extensions guide.

We also don't talk much about Gizmo, but I think there's now an acceptance that in many scenarios extension authors will use Gizmo rather than bytecode recording. So I've rearranged the headings a bit, and put in the best Gizmo link I have. 