### PR TITLE
Bump com.h2database:h2 from 2.3.230 to 2.3.232

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -119,7 +119,7 @@
         <httpasync.version>4.1.5</httpasync.version>
         <cronutils.version>9.2.1</cronutils.version>
         <quartz.version>2.3.2</quartz.version>
-        <h2.version>2.3.230</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions -->
+        <h2.version>2.3.232</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions -->
         <postgresql-jdbc.version>42.7.3</postgresql-jdbc.version>
         <mariadb-jdbc.version>3.4.1</mariadb-jdbc.version>
         <mysql-jdbc.version>8.3.0</mysql-jdbc.version>

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/config/DialectVersions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/config/DialectVersions.java
@@ -23,7 +23,7 @@ public final class DialectVersions {
 
         // This must be aligned on the H2 version in the Quarkus BOM
         // This must never be removed
-        public static final String H2 = "2.3.230";
+        public static final String H2 = "2.3.232";
 
         private Defaults() {
         }

--- a/integration-tests/jpa-h2-embedded/src/main/java/io/quarkus/it/jpa/h2/DialectEndpoint.java
+++ b/integration-tests/jpa-h2-embedded/src/main/java/io/quarkus/it/jpa/h2/DialectEndpoint.java
@@ -1,6 +1,9 @@
 package io.quarkus.it.jpa.h2;
 
 import java.io.IOException;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -13,16 +16,27 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 
 import io.quarkus.hibernate.orm.runtime.config.DialectVersions;
 
-@Path("/dialect/version")
+@Path("/dialect/")
 @Produces(MediaType.TEXT_PLAIN)
 public class DialectEndpoint {
     @Inject
     SessionFactory sessionFactory;
+    @Inject
+    DataSource dataSource;
 
     @GET
-    public String test() throws IOException {
+    @Path("version")
+    public String version() throws IOException {
         var version = sessionFactory.unwrap(SessionFactoryImplementor.class).getJdbcServices().getDialect().getVersion();
         return DialectVersions.toString(version);
+    }
+
+    @GET
+    @Path("actual-db-version")
+    public String actualDbVersion() throws IOException, SQLException {
+        try (var conn = dataSource.getConnection()) {
+            return conn.getMetaData().getDatabaseProductVersion();
+        }
     }
 
 }

--- a/integration-tests/jpa-h2-embedded/src/test/java/io/quarkus/it/jpa/h2/DialectTest.java
+++ b/integration-tests/jpa-h2-embedded/src/test/java/io/quarkus/it/jpa/h2/DialectTest.java
@@ -15,11 +15,22 @@ import io.restassured.RestAssured;
 public class DialectTest {
 
     /**
-     * This is important to avoid https://github.com/quarkusio/quarkus/issues/1886
+     * This is important for backwards compatibility reasons:
+     * we want to keep using at least the same version as before by default.
      */
     @Test
     public void version() {
         String version = RestAssured.when().get("/dialect/version").then().extract().body().asString();
+        assertThat(version).startsWith(DialectVersions.Defaults.H2);
+    }
+
+    /**
+     * This is important to avoid https://github.com/quarkusio/quarkus/issues/1886
+     */
+    @Test
+    public void actualDbVersion() {
+        String version = RestAssured.when().get("/dialect/actual-db-version").then().extract().body().asString();
+        // Can't use "equal" as the returned string includes trailing information (build date, ...)
         assertThat(version).startsWith(DialectVersions.Defaults.H2);
     }
 

--- a/integration-tests/jpa-h2/src/main/java/io/quarkus/it/jpa/h2/DialectEndpoint.java
+++ b/integration-tests/jpa-h2/src/main/java/io/quarkus/it/jpa/h2/DialectEndpoint.java
@@ -1,6 +1,9 @@
 package io.quarkus.it.jpa.h2;
 
 import java.io.IOException;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -13,16 +16,27 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 
 import io.quarkus.hibernate.orm.runtime.config.DialectVersions;
 
-@Path("/dialect/version")
+@Path("/dialect/")
 @Produces(MediaType.TEXT_PLAIN)
 public class DialectEndpoint {
     @Inject
     SessionFactory sessionFactory;
+    @Inject
+    DataSource dataSource;
 
     @GET
-    public String test() throws IOException {
+    @Path("version")
+    public String version() throws IOException {
         var version = sessionFactory.unwrap(SessionFactoryImplementor.class).getJdbcServices().getDialect().getVersion();
         return DialectVersions.toString(version);
+    }
+
+    @GET
+    @Path("actual-db-version")
+    public String actualDbVersion() throws IOException, SQLException {
+        try (var conn = dataSource.getConnection()) {
+            return conn.getMetaData().getDatabaseProductVersion();
+        }
     }
 
 }

--- a/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/DialectTest.java
+++ b/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/DialectTest.java
@@ -15,11 +15,22 @@ import io.restassured.RestAssured;
 public class DialectTest {
 
     /**
-     * This is important to avoid https://github.com/quarkusio/quarkus/issues/1886
+     * This is important for backwards compatibility reasons:
+     * we want to keep using at least the same version as before by default.
      */
     @Test
     public void version() {
         String version = RestAssured.when().get("/dialect/version").then().extract().body().asString();
+        assertThat(version).startsWith(DialectVersions.Defaults.H2);
+    }
+
+    /**
+     * This is important to avoid https://github.com/quarkusio/quarkus/issues/1886
+     */
+    @Test
+    public void actualDbVersion() {
+        String version = RestAssured.when().get("/dialect/actual-db-version").then().extract().body().asString();
+        // Can't use "equal" as the returned string includes trailing information (build date, ...)
         assertThat(version).startsWith(DialectVersions.Defaults.H2);
     }
 


### PR DESCRIPTION
Supersedes #42495

Fixes the missing test noticed by @gsmet 