### PR TITLE
Generate `docker-compose.yml` from includes

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/codestart.yml
@@ -8,6 +8,7 @@ output-strategy:
   "README.adoc": forbidden
   "readme.adoc": forbidden
   ".gitignore": append
+  "docker-compose-include-*": docker-compose-includes
   "src/main/resources/META-INF/resources/index.html": content-merge
   "src/main/resources/application.yml": smart-config-merge
   "src/main/resources/application.properties": forbidden

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/CodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/CodestartFileStrategyHandler.java
@@ -27,7 +27,8 @@ public interface CodestartFileStrategyHandler {
                     new ForbiddenCodestartFileStrategyHandler(),
                     new SmartConfigMergeCodestartFileStrategyHandler(),
                     new SmartPomMergeCodestartFileStrategyHandler(),
-                    new SmartPackageFileStrategyHandler())
+                    new SmartPackageFileStrategyHandler(),
+                    new DockerComposeCodestartFileStrategyHandler())
             .collect(Collectors.toMap(CodestartFileStrategyHandler::name, Function.identity()));
 
     String name();

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/DockerComposeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/DockerComposeCodestartFileStrategyHandler.java
@@ -1,0 +1,57 @@
+package io.quarkus.devtools.codestarts.core.strategy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.devtools.codestarts.CodestartStructureException;
+import io.quarkus.devtools.codestarts.core.reader.TargetFile;
+
+public class DockerComposeCodestartFileStrategyHandler implements CodestartFileStrategyHandler {
+
+    static final String NAME = "docker-compose-includes";
+
+    final String INCLUDE_LINE_IDENTIFIER = "include:\n";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void process(Path targetDirectory, String relativePath, List<TargetFile> codestartFiles, Map<String, Object> data)
+            throws IOException {
+        List<String> includes = (List<String>) data.getOrDefault(NAME, new ArrayList<String>());
+
+        for (TargetFile targetFile : codestartFiles) {
+            String filename = targetFile.getSourceName();
+            writeFile(targetDirectory.resolve(filename), targetFile.getContent());
+
+            includes.add(filename);
+        }
+        data.put(NAME, includes);
+
+        StringBuilder content = new StringBuilder(INCLUDE_LINE_IDENTIFIER);
+        for (String include : includes) {
+            content.append("  - ").append(include).append("\n");
+        }
+
+        final Path targetPath = targetDirectory.resolve("docker-compose.yml");
+        writeFile(targetPath, content.toString());
+    }
+
+    @Override
+    public void writeFile(final Path targetPath, final String content) throws IOException {
+        if (Files.exists(targetPath) && !Files.readString(targetPath).startsWith(INCLUDE_LINE_IDENTIFIER)) {
+            throw new CodestartStructureException(
+                    "Target file already exists: " + targetPath.toString());
+        }
+
+        Files.writeString(targetPath, content);
+    }
+
+}

--- a/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/core/CodestartProcessorTest.java
+++ b/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/core/CodestartProcessorTest.java
@@ -19,6 +19,7 @@ class CodestartProcessorTest {
         Map<String, String> spec = new HashMap<>();
         spec.put("test/foo.tt", "forbidden");
         spec.put("*", "replace");
+        spec.put("docker-compose-include-test.yml", "docker-compose-includes");
 
         final CodestartProcessor processor = new CodestartProcessor(
                 MessageWriter.info(),
@@ -29,6 +30,8 @@ class CodestartProcessorTest {
 
         assertThat(processor.getSelectedDefaultStrategy()).isEqualTo(CodestartFileStrategyHandler.BY_NAME.get("replace"));
         assertThat(processor.getStrategy("test/foo.tt")).hasValue(CodestartFileStrategyHandler.BY_NAME.get("forbidden"));
+        assertThat(processor.getStrategy("docker-compose-include-test.yml"))
+                .hasValue(CodestartFileStrategyHandler.BY_NAME.get("docker-compose-includes"));
     }
 
     @Test


### PR DESCRIPTION
> According to the discussion https://github.com/quarkusio/quarkus/discussions/42162#discussioncomment-10189387.

A `docker-compose-include-<name>.yml` file in a codestart gets included in a generated `docker-compose.yml` file.

An error is thrown if a codestart already has a `docker-compose.yml` file.

I had some problems due to the file handler running for every codestart. That's why I overwrote the `writeFile` method on the assumption that a codestart's `docker-compse.yml` doesn't include includes.  