### PR TITLE
Accept signed OIDC UserInfo

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -477,7 +477,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                 resolvedContext.oidcConfig.token.isSubjectRequired(), nonce));
             } catch (Throwable t) {
                 if (t.getCause() instanceof UnresolvableKeyException) {
-                    LOG.debug("No matching JWK key is found, refreshing and repeating the verification");
+                    LOG.debug("No matching JWK key is found, refreshing and repeating the token verification");
                     return refreshJwksAndVerifyTokenUni(resolvedContext, token, enforceAudienceVerification,
                             resolvedContext.oidcConfig.token.isSubjectRequired(), nonce);
                 } else {

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -123,7 +123,7 @@ quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.application-type=hybri
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.authorization-path=/
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.token-path=access_token_refreshed
-quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.user-info-path=protocol/openid-connect/userinfo
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.user-info-path=protocol/openid-connect/signeduserinfo
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.jwks-path=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.code-grant.extra-params.extra-param=extra-param-value
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.code-grant.headers.X-Custom=XCustomHeaderValue
@@ -233,6 +233,8 @@ quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".level=TRACE
+quarkus.log.file.enable=true
+quarkus.log.file.format=%C - %s%n
 
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated


### PR DESCRIPTION
Fixes #42341.

Quarkus OIDC may request UserInfo from the OIDC provider, in addition to a signed ID token in the JWT format.
Typically, UserInfo  is returned as a plain JSON.

However, the OIDC spec also allows returning signed UserInfo, i.e, as a JWT token:

https://openid.net/specs/openid-connect-core-1_0.html#UserInfo

To handle signed UserInfo, Quarkus needs to verify it like any other JWT token, and then get the UserInfo JSON out of this token.

So this PR does a simple enough fix to do it to meet this spec requirement:

* If a UserInfo response media type is `application/jwt` then a signed UserInfo JWT is expected and it goes through the same verification process that a regular JWT token such as IdToken is goes through. The only reason there is a bit of a copy and paste there is that with regular JWT tokens some requirements like enforcing the audience verification may be optional, while with the signed UserInfo it is required, while things like nonce and sub claims are not required.
* Once the JWT is verified, `UserInfo` is initialized with the secured JSON
* Updated one of the OIDC wiremock tests to return a signed UserInfo and to check the log to confirm that indeed it was the case, the signed UserInfo form only exists during the response from the OIDC server to Quarkus OIDC, so it is tricky to confirm it otherwise