### PR TITLE
Updates to reflect current extension names and configuration roots

### DIFF
--- a/docs/src/main/asciidoc/security-csrf-prevention.adoc
+++ b/docs/src/main/asciidoc/security-csrf-prevention.adoc
@@ -126,8 +126,8 @@ At this stage no additional configuration is needed - by default the CSRF form f
 
 [source,properties]
 ----
-quarkus.csrf-reactive.form-field-name=csrftoken
-quarkus.csrf-reactive.cookie-name=csrftoken
+quarkus.rest-csrf.form-field-name=csrftoken
+quarkus.rest-csrf.cookie-name=csrftoken
 ----
 
 == Sign CSRF token
@@ -136,7 +136,7 @@ You can get `HMAC` signatures created for the generated CSRF tokens and have the
 
 [source,properties]
 ----
-quarkus.csrf-reactive.token-signature-key=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+quarkus.rest-csrf.token-signature-key=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 ----
 
 [[csrf-request-header]]
@@ -151,18 +151,18 @@ If HTML `form` tags are not used and you need to pass CSRF token as a header, th
 ----
 <1> This expression is used to inject a CSRF token header and token. This token will be verified by the CSRF filter against a CSRF cookie.
 
-Default header name is `X-CSRF-TOKEN`, you can customize it with `quarkus.csrf-reactive.token-header-name`, for example:
+Default header name is `X-CSRF-TOKEN`, you can customize it with `quarkus.rest-csrf.token-header-name`, for example:
 
 [source,properties]
 ----
-quarkus.csrf-reactive.token-header-name=CUSTOM-X-CSRF-TOKEN
+quarkus.rest-csrf.token-header-name=CUSTOM-X-CSRF-TOKEN
 ----
 
 If you need to access the CSRF cookie from JavaScript in order to pass its value as a header, use `{inject:csrf.cookieName}` and `{inject:csrf.headerName}` to inject the cookie name which has to be read as a CSRF header value and allow accessing this cookie:
 
 [source,properties]
 ----
-quarkus.csrf-reactive.cookie-http-only=false
+quarkus.rest-csrf.cookie-http-only=false
 ----
 
 == Cross-origin resource sharing
@@ -255,11 +255,11 @@ As you can see a CSRF token verification will be required at the `/service/user`
 [source,properties]
 ----
 # Verify CSRF token only for the `/service/user` path, ignore other paths such as `/service/users`
-quarkus.csrf-reactive.create-token-path=/service/user
+quarkus.rest-csrf.create-token-path=/service/user
 
 # If `/service/user` path accepts not only `application/x-www-form-urlencoded` payloads but also other ones such as JSON then allow them
 # Setting this property is not necessary when the token is submitted as a header value
-quarkus.csrf-reactive.require-form-url-encoded=false
+quarkus.rest-csrf.require-form-url-encoded=false
 ----
 
 == Verify CSRF token in the application code
@@ -316,7 +316,7 @@ Also disable the token verification in the filter:
 
 [source,properties]
 ----
-quarkus.csrf-reactive.verify-token=false
+quarkus.rest-csrf.verify-token=false
 ----
 
 [[csrf-reactive-configuration-reference]]

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -1155,7 +1155,7 @@ quarkus.oidc-client.credentials.secret=secret
 quarkus.oidc-client.grant.type=exchange
 quarkus.oidc-client.grant-options.exchange.audience=quarkus-app-exchange
 
-quarkus.oidc-token-propagation.exchange-token=true <1>
+quarkus.resteasy-client-oidc-token-propagation.exchange-token=true <1>
 ----
 <1> Please note that the `exchange-token` configuration property is ignored when the OidcClient name is set with the `io.quarkus.oidc.token.propagation.AccessToken#exchangeTokenClient` annotation attribute.
 
@@ -1173,10 +1173,10 @@ quarkus.oidc-client.grant.type=jwt
 quarkus.oidc-client.grant-options.jwt.requested_token_use=on_behalf_of
 quarkus.oidc-client.scopes=https://graph.microsoft.com/user.read,offline_access
 
-quarkus.oidc-token-propagation.exchange-token=true
+quarkus.resteasy-client-oidc-token-propagation.exchange-token=true
 ----
 
-`AccessTokenRequestReactiveFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.oidc-token-propagation-reactive.client-name` configuration property or with the `io.quarkus.oidc.token.propagation.AccessToken#exchangeTokenClient` annotation attribute.
+`AccessTokenRequestReactiveFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.rest-client-oidc-token-propagation.client-name` configuration property or with the `io.quarkus.oidc.token.propagation.AccessToken#exchangeTokenClient` annotation attribute.
 
 [[token-propagation]]
 == Token Propagation
@@ -1231,7 +1231,7 @@ public interface ProtectedResourceService {
 }
 ----
 
-Alternatively, `AccessTokenRequestFilter` can be registered automatically with all MP Rest or Jakarta REST clients if the `quarkus.oidc-token-propagation.register-filter` property is set to `true` and `quarkus.oidc-token-propagation.json-web-token` property is set to `false` (which is a default value).
+Alternatively, `AccessTokenRequestFilter` can be registered automatically with all MP Rest or Jakarta REST clients if the `quarkus.resteasy-client-oidc-token-propagation.register-filter` property is set to `true` and `quarkus.resteasy-client-oidc-token-propagation.json-web-token` property is set to `false` (which is a default value).
 
 ==== Exchange token before propagation
 
@@ -1245,7 +1245,7 @@ quarkus.oidc-client.credentials.secret=secret
 quarkus.oidc-client.grant.type=exchange
 quarkus.oidc-client.grant-options.exchange.audience=quarkus-app-exchange
 
-quarkus.oidc-token-propagation.exchange-token=true
+quarkus.resteasy-client-oidc-token-propagation.exchange-token=true
 ----
 
 If you work with providers such as `Azure` that link:https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow#example[require using] link:https://www.rfc-editor.org/rfc/rfc7523#section-2.1[JWT bearer token grant] to exchange the current token, then you can configure `AccessTokenRequestFilter` to exchange the token like this:
@@ -1260,12 +1260,12 @@ quarkus.oidc-client.grant.type=jwt
 quarkus.oidc-client.grant-options.jwt.requested_token_use=on_behalf_of
 quarkus.oidc-client.scopes=https://graph.microsoft.com/user.read,offline_access
 
-quarkus.oidc-token-propagation.exchange-token=true
+quarkus.resteasy-client-oidc-token-propagation.exchange-token=true
 ----
 
 Note `AccessTokenRequestFilter` will use `OidcClient` to exchange the current token, and you can use `quarkus.oidc-client.grant-options.exchange` to set the additional exchange properties expected by your OpenID Connect Provider.
 
-`AccessTokenRequestFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.oidc-token-propagation.client-name` configuration property.
+`AccessTokenRequestFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.resteasy-client-oidc-token-propagation.client-name` configuration property.
 
 === RestClient JsonWebTokenRequestFilter
 
@@ -1307,7 +1307,7 @@ public interface ProtectedResourceService {
 }
 ----
 
-Alternatively, `JsonWebTokenRequestFilter` can be registered automatically with all MicroProfile REST or Jakarta REST clients if both `quarkus.oidc-token-propagation.register-filter` and `quarkus.resteasy-client-oidc-token-propagation.json-web-token` properties are set to `true`.
+Alternatively, `JsonWebTokenRequestFilter` can be registered automatically with all MicroProfile REST or Jakarta REST clients if both `quarkus.resteasy-client-oidc-token-propagation.register-filter` and `quarkus.resteasy-client-oidc-token-propagation.json-web-token` properties are set to `true`.
 
 ==== Update token before propagation
 


### PR DESCRIPTION
Updates to ensure the conditionals and content reflect the changes described in [RESTEasy Reactive extensions renamed to Quarkus REST](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9#resteasy-reactive-extensions-renamed-to-quarkus-rest-gear-white_check_mark)