### PR TITLE
Add http root to OIDC back channel logout handlers

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -424,6 +424,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public static class Backchannel {
         /**
          * The relative path of the Back-Channel Logout endpoint at the application.
+         * It must start with the forward slash '/', for example, '/back-channel-logout'.
+         * This value is always resolved relative to 'quarkus.http.root-path'.
          */
         @ConfigItem
         public Optional<String> path = Optional.empty();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -13,6 +13,7 @@ import org.jose4j.jwt.consumer.InvalidJwtException;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.SecurityEvent;
 import io.quarkus.oidc.SecurityEvent.Type;
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.security.spi.runtime.SecurityEventHelper;
 import io.vertx.core.Handler;
@@ -24,6 +25,7 @@ import io.vertx.ext.web.RoutingContext;
 
 public class BackChannelLogoutHandler {
     private static final Logger LOG = Logger.getLogger(BackChannelLogoutHandler.class);
+    private static final String SLASH = "/";
 
     @Inject
     DefaultTenantConfigResolver resolver;
@@ -44,7 +46,8 @@ public class BackChannelLogoutHandler {
 
     private void addRoute(Router router, OidcTenantConfig oidcTenantConfig) {
         if (oidcTenantConfig.isTenantEnabled() && oidcTenantConfig.logout.backchannel.path.isPresent()) {
-            router.route(oidcTenantConfig.logout.backchannel.path.get()).handler(new RouteHandler(oidcTenantConfig));
+            router.route(getRootPath() + oidcTenantConfig.logout.backchannel.path.get())
+                    .handler(new RouteHandler(oidcTenantConfig));
         }
     }
 
@@ -160,7 +163,18 @@ public class BackChannelLogoutHandler {
         private boolean isMatchingTenant(String requestPath, TenantConfigContext tenant) {
             return tenant.oidcConfig.isTenantEnabled()
                     && tenant.oidcConfig.getTenantId().get().equals(oidcTenantConfig.getTenantId().get())
-                    && requestPath.equals(tenant.oidcConfig.logout.backchannel.path.orElse(null));
+                    && requestPath.equals(getRootPath() + tenant.oidcConfig.logout.backchannel.path.orElse(null));
         }
+    }
+
+    private String getRootPath() {
+        // Prepend '/' if it is not present
+        String rootPath = OidcCommonUtils.prependSlash(resolver.getRootPath());
+        // Strip trailing '/' if the length is > 1
+        if (rootPath.length() > 1 && rootPath.endsWith("/")) {
+            rootPath = rootPath.substring(rootPath.length() - 1);
+        }
+        // if it is only '/' then return an empty value
+        return SLASH.equals(rootPath) ? "" : rootPath;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -51,6 +51,7 @@ public class DefaultTenantConfigResolver {
     private final TenantConfigBean tenantConfigBean;
     private final TenantResolver[] staticTenantResolvers;
     private final boolean annotationBasedTenantResolutionEnabled;
+    private final String rootPath;
 
     @Inject
     Instance<TenantConfigResolver> tenantConfigResolver;
@@ -86,6 +87,7 @@ public class DefaultTenantConfigResolver {
         this.staticTenantResolvers = prepareStaticTenantResolvers(tenantConfigBean, rootPath, tenantResolverInstance,
                 resolveTenantsWithIssuer, new DefaultStaticTenantResolver());
         this.annotationBasedTenantResolutionEnabled = Boolean.getBoolean(OidcUtils.ANNOTATION_BASED_TENANT_RESOLUTION_ENABLED);
+        this.rootPath = rootPath;
     }
 
     @PostConstruct
@@ -412,6 +414,10 @@ public class DefaultTenantConfigResolver {
             return tenantConfigBean.getDynamicTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
         }
         return null;
+    }
+
+    public String getRootPath() {
+        return rootPath;
     }
 
     private static final class IssuerBasedTenantResolver implements TenantResolver {


### PR DESCRIPTION
Fixes #42483.

Simple PR to take the http root path into consideration when creating OIDC back channel logout handlers.

Backchannel logout is typically used to logout a user from all the applications, to support a global logout. For example, a user explicitly logs out from one Quarkus application and then the OIDC provider will separately notify all other registered Quarkus services to clear the session when the user attempts to access them.

The existing test code is [here](https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java#L181), and I can confirm it failed initially with this PR before I fixed it to use en empty http root prefix if it is set as `/`, since the back channel logout path also starts from `/`.

To really test that an http root like `/a` is taken account, I'd need to create a new integration test module, which I'm not too keen :-) given the simplicity of the fix. If I add an http root configuration to `integration-tests/oidc-wiremock` where the backchannel test is available, then it would impact a real lot of tests.

Let me know what you think please