### PR TITLE
Create a lossy index of resource -> ClassPathElement mapping

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -340,7 +340,7 @@ public class CodeGenerator {
             final QuarkusClassLoader.Builder configClBuilder = QuarkusClassLoader.builder("CodeGenerator Config ClassLoader",
                     deploymentClassLoader, false);
             if (!allowedConfigServices.isEmpty()) {
-                configClBuilder.addElement(new MemoryClassPathElement(allowedConfigServices, true));
+                configClBuilder.addNormalPriorityElement(new MemoryClassPathElement(allowedConfigServices, true));
             }
             if (!bannedConfigServices.isEmpty()) {
                 configClBuilder.addBannedElement(new MemoryClassPathElement(bannedConfigServices, true));

--- a/core/deployment/src/main/java/io/quarkus/deployment/GeneratedClassGizmoAdaptor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/GeneratedClassGizmoAdaptor.java
@@ -1,17 +1,13 @@
 package io.quarkus.deployment;
 
-import static io.quarkus.commons.classloading.ClassLoaderHelper.fromClassNameToResourceName;
-
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import io.quarkus.bootstrap.BootstrapDebug;
-import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
@@ -75,12 +71,7 @@ public class GeneratedClassGizmoAdaptor implements ClassOutput {
     }
 
     public static boolean isApplicationClass(String className) {
-        QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread()
-                .getContextClassLoader();
-        //if the class file is present in this (and not the parent) CL then it is an application class
-        List<ClassPathElement> res = cl
-                .getElementsWithResource(fromClassNameToResourceName(className), true);
-        return !res.isEmpty();
+        return QuarkusClassLoader.isApplicationClass(className);
     }
 
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -30,14 +30,12 @@ import io.quarkus.bootstrap.app.ClassChangeInformation;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.app.StartupAction;
-import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildStep;
-import io.quarkus.commons.classloading.ClassLoaderHelper;
 import io.quarkus.deployment.builditem.ApplicationClassPredicateBuildItem;
 import io.quarkus.deployment.console.ConsoleCommand;
 import io.quarkus.deployment.console.ConsoleStateManager;
@@ -478,14 +476,8 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                     //we need to make sure all hot reloadable classes are application classes
                     context.produce(new ApplicationClassPredicateBuildItem(new Predicate<String>() {
                         @Override
-                        public boolean test(String s) {
-                            QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread()
-                                    .getContextClassLoader();
-                            String resourceName = ClassLoaderHelper.fromClassNameToResourceName(s);
-                            //if the class file is present in this (and not the parent) CL then it is an application class
-                            List<ClassPathElement> res = cl
-                                    .getElementsWithResource(resourceName, true);
-                            return !res.isEmpty();
+                        public boolean test(String className) {
+                            return QuarkusClassLoader.isApplicationClass(className);
                         }
                     }));
                 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -652,7 +652,7 @@ public class JunitTestRunner {
             //this is a lot more complex
             //we need to transform the classes to make the tracing magic work
             QuarkusClassLoader deploymentClassLoader = (QuarkusClassLoader) Thread.currentThread().getContextClassLoader();
-            Set<String> classesToTransform = new HashSet<>(deploymentClassLoader.getLocalClassNames());
+            Set<String> classesToTransform = new HashSet<>(deploymentClassLoader.getReloadableClassNames());
             Map<String, byte[]> transformedClasses = new HashMap<>();
             for (String i : classesToTransform) {
                 try {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -221,7 +221,7 @@ public class TestSupport implements TestController {
                                             + curatedApplication.getClassLoaderNameSuffix(),
                                             getClass().getClassLoader().getParent(), false);
                                 }
-                                clBuilder.addElement(ClassPathElement.fromDependency(d));
+                                clBuilder.addNormalPriorityElement(ClassPathElement.fromDependency(d));
                             }
                         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -25,7 +25,6 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
-import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.IsNormal;
@@ -155,13 +154,8 @@ public class TestTracingProcessor {
         return null;
     }
 
-    public boolean isAppClass(String theClassName) {
-        QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread()
-                .getContextClassLoader();
-        //if the class file is present in this (and not the parent) CL then it is an application class
-        List<ClassPathElement> res = cl
-                .getElementsWithResource(theClassName.replace(".", "/") + ".class", true);
-        return !res.isEmpty();
+    public boolean isAppClass(String className) {
+        return QuarkusClassLoader.isApplicationClass(className);
     }
 
     public static class TracingClassVisitor extends ClassVisitor {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
@@ -87,6 +87,11 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
     }
 
     @Override
+    public boolean providesLocalResources() {
+        return false;
+    }
+
+    @Override
     public Collection<Path> getRoots() {
         return List.of(archive);
     }
@@ -238,6 +243,11 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
             super(ArchivePathTree.this.pathFilter, ArchivePathTree.this);
             this.fs = fs;
             this.rootPath = fs.getPath("/");
+        }
+
+        @Override
+        public boolean providesLocalResources() {
+            return false;
         }
 
         @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
@@ -87,8 +87,8 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
     }
 
     @Override
-    public boolean providesLocalResources() {
-        return false;
+    public boolean isArchiveOrigin() {
+        return true;
     }
 
     @Override
@@ -246,8 +246,8 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         }
 
         @Override
-        public boolean providesLocalResources() {
-            return false;
+        public boolean isArchiveOrigin() {
+            return true;
         }
 
         @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
@@ -37,8 +37,8 @@ public class DirectoryPathTree extends OpenContainerPathTree implements Serializ
     }
 
     @Override
-    public boolean providesLocalResources() {
-        return true;
+    public boolean isArchiveOrigin() {
+        return false;
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
@@ -37,6 +37,11 @@ public class DirectoryPathTree extends OpenContainerPathTree implements Serializ
     }
 
     @Override
+    public boolean providesLocalResources() {
+        return true;
+    }
+
+    @Override
     protected Path getRootPath() {
         return dir;
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
@@ -16,6 +16,11 @@ public class EmptyPathTree implements OpenPathTree {
     }
 
     @Override
+    public boolean providesLocalResources() {
+        return false;
+    }
+
+    @Override
     public Collection<Path> getRoots() {
         return Collections.emptyList();
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
@@ -16,7 +16,7 @@ public class EmptyPathTree implements OpenPathTree {
     }
 
     @Override
-    public boolean providesLocalResources() {
+    public boolean isArchiveOrigin() {
         return false;
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
@@ -23,8 +23,8 @@ class FilePathTree implements OpenPathTree {
     }
 
     @Override
-    public boolean providesLocalResources() {
-        return true;
+    public boolean isArchiveOrigin() {
+        return false;
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
@@ -23,6 +23,11 @@ class FilePathTree implements OpenPathTree {
     }
 
     @Override
+    public boolean providesLocalResources() {
+        return true;
+    }
+
+    @Override
     public Collection<Path> getRoots() {
         return Collections.singletonList(file);
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
@@ -18,8 +18,8 @@ public class FilteredPathTree implements PathTree {
     }
 
     @Override
-    public boolean providesLocalResources() {
-        return original.providesLocalResources();
+    public boolean isArchiveOrigin() {
+        return original.isArchiveOrigin();
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
@@ -18,6 +18,11 @@ public class FilteredPathTree implements PathTree {
     }
 
     @Override
+    public boolean providesLocalResources() {
+        return original.providesLocalResources();
+    }
+
+    @Override
     public Collection<Path> getRoots() {
         return original.getRoots();
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
@@ -26,17 +26,17 @@ public class MultiRootPathTree implements OpenPathTree {
     }
 
     /**
-     * If at least one of the PathTrees contains local resources, we return true.
+     * If at least one of the PathTrees is not an archive, we return false.
      */
     @Override
-    public boolean providesLocalResources() {
+    public boolean isArchiveOrigin() {
         for (PathTree tree : trees) {
-            if (tree.providesLocalResources()) {
-                return true;
+            if (!tree.isArchiveOrigin()) {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
@@ -25,6 +25,20 @@ public class MultiRootPathTree implements OpenPathTree {
         roots = tmp;
     }
 
+    /**
+     * If at least one of the PathTrees contains local resources, we return true.
+     */
+    @Override
+    public boolean providesLocalResources() {
+        for (PathTree tree : trees) {
+            if (tree.providesLocalResources()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     @Override
     public Collection<Path> getRoots() {
         return roots;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
@@ -81,6 +81,13 @@ public interface PathTree {
     }
 
     /**
+     * Whether the PathTree provides local resources.
+     * <p>
+     * For instance a directory or a file provides local resources. A jar does not.
+     */
+    boolean providesLocalResources();
+
+    /**
      * The roots of the path tree.
      * <p>
      * Note that you shouldn't use these roots for browsing except if the PathTree is open.

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
@@ -81,11 +81,11 @@ public interface PathTree {
     }
 
     /**
-     * Whether the PathTree provides local resources.
+     * Whether the content of this tree comes from an archive or not.
      * <p>
-     * For instance a directory or a file provides local resources. A jar does not.
+     * This is useful for instance when you want to determine if the resources can be updated in dev mode.
      */
-    boolean providesLocalResources();
+    boolean isArchiveOrigin();
 
     /**
      * The roots of the path tree.

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
@@ -123,8 +123,8 @@ class SharedArchivePathTree extends ArchivePathTree {
         }
 
         @Override
-        public boolean providesLocalResources() {
-            return delegate.providesLocalResources();
+        public boolean isArchiveOrigin() {
+            return delegate.isArchiveOrigin();
         }
 
         @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
@@ -123,6 +123,11 @@ class SharedArchivePathTree extends ArchivePathTree {
         }
 
         @Override
+        public boolean providesLocalResources() {
+            return delegate.providesLocalResources();
+        }
+
+        @Override
         public PathTree getOriginalTree() {
             return delegate.getOriginalTree();
         }

--- a/independent-projects/bootstrap/classloader-commons/src/main/java/io/quarkus/commons/classloading/ClassLoaderHelper.java
+++ b/independent-projects/bootstrap/classloader-commons/src/main/java/io/quarkus/commons/classloading/ClassLoaderHelper.java
@@ -6,6 +6,8 @@ public final class ClassLoaderHelper {
     private static final String JDK_INTERNAL = "jdk.internal.";
     private static final String SUN_MISC = "sun.misc.";
 
+    private static final String CLASS_SUFFIX = ".class";
+
     private ClassLoaderHelper() {
         //Not meant to be instantiated
     }
@@ -19,7 +21,23 @@ public final class ClassLoaderHelper {
      */
     public static String fromClassNameToResourceName(final String className) {
         //Important: avoid indy!
-        return className.replace('.', '/').concat(".class");
+        return className.replace('.', '/').concat(CLASS_SUFFIX);
+    }
+
+    /**
+     * Helper method to convert a resource name into the corresponding class name:
+     * replace all "/" with "." and remove the ".class" postfix.
+     *
+     * @param resourceName
+     * @return the name of the respective class
+     */
+    public static String fromResourceNameToClassName(final String resourceName) {
+        if (!resourceName.endsWith(CLASS_SUFFIX)) {
+            throw new IllegalArgumentException(
+                    String.format("%s is not a valid resource name as it doesn't end with .class", resourceName));
+        }
+
+        return resourceName.substring(0, resourceName.length() - CLASS_SUFFIX.length()).replace('/', '.');
     }
 
     public static boolean isInJdkPackage(String name) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -496,8 +496,8 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         }
 
         @Override
-        public boolean providesLocalResources() {
-            return delegate.providesLocalResources();
+        public boolean containsReloadableResources() {
+            return delegate.containsReloadableResources();
         }
 
         @Override

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -183,10 +183,12 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             //we always load this from the parent if it is available, as this acts as a bridge between the running
             //app and the dev mode code
             builder.addParentFirstElement(element);
+            builder.addNormalPriorityElement(element);
         } else if (dep.isFlagSet(DependencyFlags.CLASSLOADER_LESSER_PRIORITY)) {
             builder.addLesserPriorityElement(element);
+        } else {
+            builder.addNormalPriorityElement(element);
         }
-        builder.addElement(element);
     }
 
     public synchronized QuarkusClassLoader getOrCreateAugmentClassLoader() {
@@ -212,7 +214,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             }
 
             for (Path i : quarkusBootstrap.getAdditionalDeploymentArchives()) {
-                builder.addElement(ClassPathElement.fromPath(i, false));
+                builder.addNormalPriorityElement(ClassPathElement.fromPath(i, false));
             }
             Map<String, byte[]> banned = new HashMap<>();
             for (Collection<String> i : configuredClassLoading.getRemovedResources().values()) {
@@ -256,7 +258,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                 //there is no need to restart so there is no need for an additional CL
 
                 for (Path root : quarkusBootstrap.getApplicationRoot()) {
-                    builder.addElement(ClassPathElement.fromPath(root, true));
+                    builder.addNormalPriorityElement(ClassPathElement.fromPath(root, true));
                 }
             } else {
                 for (Path root : quarkusBootstrap.getApplicationRoot()) {
@@ -269,7 +271,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             for (AdditionalDependency i : quarkusBootstrap.getAdditionalApplicationArchives()) {
                 if (!i.isHotReloadable()) {
                     for (Path root : i.getResolvedPaths()) {
-                        builder.addElement(ClassPathElement.fromPath(root, true));
+                        builder.addNormalPriorityElement(ClassPathElement.fromPath(root, true));
                     }
                 } else {
                     for (Path root : i.getResolvedPaths()) {
@@ -339,7 +341,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                 .setAggregateParentResources(true);
 
         for (Path root : quarkusBootstrap.getApplicationRoot()) {
-            builder.addElement(ClassPathElement.fromPath(root, true));
+            builder.addNormalPriorityElement(ClassPathElement.fromPath(root, true));
         }
 
         builder.setResettableElement(new MemoryClassPathElement(Collections.emptyMap(), false));
@@ -347,7 +349,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         //additional user class path elements first
         for (AdditionalDependency i : quarkusBootstrap.getAdditionalApplicationArchives()) {
             for (Path root : i.getResolvedPaths()) {
-                builder.addElement(ClassPathElement.fromPath(root, true));
+                builder.addNormalPriorityElement(ClassPathElement.fromPath(root, true));
             }
         }
         for (ResolvedDependency dependency : appModel.getDependencies()) {
@@ -361,7 +363,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             }
         }
         for (Path root : configuredClassLoading.getAdditionalClasspathElements()) {
-            builder.addElement(ClassPathElement.fromPath(root, true));
+            builder.addNormalPriorityElement(ClassPathElement.fromPath(root, true));
         }
         return builder.build();
     }
@@ -387,15 +389,15 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                 .setAggregateParentResources(true);
         builder.setTransformedClasses(transformedClasses);
 
-        builder.addElement(new MemoryClassPathElement(resources, true));
+        builder.addNormalPriorityElement(new MemoryClassPathElement(resources, true));
         for (Path root : quarkusBootstrap.getApplicationRoot()) {
-            builder.addElement(ClassPathElement.fromPath(root, true));
+            builder.addNormalPriorityElement(ClassPathElement.fromPath(root, true));
         }
 
         for (AdditionalDependency i : getQuarkusBootstrap().getAdditionalApplicationArchives()) {
             if (i.isHotReloadable()) {
                 for (Path root : i.getResolvedPaths()) {
-                    builder.addElement(ClassPathElement.fromPath(root, true));
+                    builder.addNormalPriorityElement(ClassPathElement.fromPath(root, true));
                 }
             }
         }
@@ -410,7 +412,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             }
         }
         for (Path root : configuredClassLoading.getAdditionalClasspathElements()) {
-            builder.addElement(ClassPathElement.fromPath(root, true));
+            builder.addNormalPriorityElement(ClassPathElement.fromPath(root, true));
         }
         return builder.build();
     }
@@ -491,6 +493,11 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         @Override
         public Set<String> getProvidedResources() {
             return delegate.getProvidedResources().stream().filter(s -> s.endsWith(".class")).collect(Collectors.toSet());
+        }
+
+        @Override
+        public boolean providesLocalResources() {
+            return delegate.providesLocalResources();
         }
 
         @Override

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
@@ -74,9 +74,9 @@ public interface ClassPathElement extends Closeable {
     Set<String> getProvidedResources();
 
     /**
-     * Whether this class path element contains local resources.
+     * Whether this class path element contains resources that can be reloaded in dev mode.
      */
-    boolean providesLocalResources();
+    boolean containsReloadableResources();
 
     /**
      *
@@ -133,7 +133,7 @@ public interface ClassPathElement extends Closeable {
         }
 
         @Override
-        public boolean providesLocalResources() {
+        public boolean containsReloadableResources() {
             return false;
         }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
@@ -3,7 +3,6 @@ package io.quarkus.bootstrap.classloading;
 import java.io.Closeable;
 import java.nio.file.Path;
 import java.security.ProtectionDomain;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -75,6 +74,11 @@ public interface ClassPathElement extends Closeable {
     Set<String> getProvidedResources();
 
     /**
+     * Whether this class path element contains local resources.
+     */
+    boolean providesLocalResources();
+
+    /**
      *
      * @return The protection domain that should be used to define classes from this element
      */
@@ -102,6 +106,7 @@ public interface ClassPathElement extends Closeable {
     }
 
     static ClassPathElement EMPTY = new ClassPathElement() {
+
         @Override
         public Path getRoot() {
             return null;
@@ -124,7 +129,12 @@ public interface ClassPathElement extends Closeable {
 
         @Override
         public Set<String> getProvidedResources() {
-            return Collections.emptySet();
+            return Set.of();
+        }
+
+        @Override
+        public boolean providesLocalResources() {
+            return false;
         }
 
         @Override

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathResourceIndex.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathResourceIndex.java
@@ -63,25 +63,25 @@ public class ClassPathResourceIndex {
     private final Map<String, ClassPathElement[]> resourceMapping;
     private final Map<String, ClassPathElement> transformedClasses;
 
-    private final Set<String> localClasses;
+    private final Set<String> relodableClasses;
     private final Set<String> parentFirstResources;
     private final Set<String> bannedResources;
 
     private ClassPathResourceIndex(Map<String, ClassPathElement[]> resourceMapping,
             Map<String, ClassPathElement> transformedClasses,
-            Set<String> localClasses,
+            Set<String> reloadableClasses,
             Set<String> parentFirstResources,
             Set<String> bannedResources) {
         this.resourceMapping = resourceMapping.isEmpty() ? Map.of() : Collections.unmodifiableMap(resourceMapping);
         this.transformedClasses = transformedClasses.isEmpty() ? Map.of() : transformedClasses;
-        this.localClasses = localClasses.isEmpty() ? Set.of() : Collections.unmodifiableSet(localClasses);
+        this.relodableClasses = reloadableClasses.isEmpty() ? Set.of() : Collections.unmodifiableSet(reloadableClasses);
         this.parentFirstResources = parentFirstResources.isEmpty() ? Set.of()
                 : Collections.unmodifiableSet(parentFirstResources);
         this.bannedResources = bannedResources.isEmpty() ? Set.of() : Collections.unmodifiableSet(bannedResources);
     }
 
-    public Set<String> getLocalClassResourceNames() {
-        return localClasses;
+    public Set<String> getReloadableClasses() {
+        return relodableClasses;
     }
 
     public boolean isParentFirst(String resource) {
@@ -199,7 +199,7 @@ public class ClassPathResourceIndex {
         private final Map<String, ClassPathElement> transformedClasses = new HashMap<>();
         private final Map<String, List<ClassPathElement>> resourceMapping = new HashMap<>();
 
-        private final Set<String> localClasses = new HashSet<>();
+        private final Set<String> reloadableClasses = new HashSet<>();
         private final Set<String> parentFirstResources = new HashSet<>();
         private final Set<String> bannedResources = new HashSet<>();
 
@@ -215,8 +215,8 @@ public class ClassPathResourceIndex {
         }
 
         public void addResourceMapping(ClassPathElement classPathElement, String resource) {
-            if (classPathElement.providesLocalResources() && resource.endsWith(CLASS_SUFFIX)) {
-                localClasses.add(resource);
+            if (classPathElement.containsReloadableResources() && resource.endsWith(CLASS_SUFFIX)) {
+                reloadableClasses.add(resource);
             }
 
             ClassPathElement transformedClassClassPathElement = transformedClassCandidates.get(resource);
@@ -255,7 +255,7 @@ public class ClassPathResourceIndex {
             }
 
             return new ClassPathResourceIndex(compactedResourceMapping, transformedClasses,
-                    localClasses, parentFirstResources, bannedResources);
+                    reloadableClasses, parentFirstResources, bannedResources);
         }
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathResourceIndex.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathResourceIndex.java
@@ -152,6 +152,10 @@ public class ClassPathResourceIndex {
      * Probably something we will have to tweak for corner cases but let's try to keep it fast.
      */
     static String getResourceKey(String resource) {
+        if (resource.isEmpty()) {
+            return resource;
+        }
+
         // we don't really care about this part, it can be slower
         if (resource.startsWith(META_INF_MAVEN)) {
             return META_INF_MAVEN;

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathResourceIndex.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathResourceIndex.java
@@ -1,0 +1,261 @@
+package io.quarkus.bootstrap.classloading;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * We used to have a full index of the resources present in the classpath stored in ClassLoaderState of QuarkusClassLoader.
+ * <p>
+ * However it could lead to some major memory consumption, the index being more than 13 MB on real-life projects.
+ * This was a problem especially since we also keep a list of the resources in each ClassPathElement.
+ * <p>
+ * Going through the whole list of ClassPathElements for each lookup is not a good option so we choose an intermediary approach
+ * of having a lossy index referencing the start of the resource path to reduce the number of ClassPathElements to go through.
+ * This index still returns exact references as we check the ClassPathElements themselves for the presence of the resource.
+ * <p>
+ * In the particular example above, we went down to less than 3 MB for the index, storing ~600 entries instead of 86000+ in the
+ * mapping.
+ * <p>
+ * We try to be clever as to how we build the resource key to reduce the number of misses. It might need further tuning in the
+ * future.
+ * <p>
+ * The general idea is to have this index:
+ * <ul>
+ * <li>store a mapping between the prefix of the resource and the {@code ClassPathElement}s that contain resources starting with
+ * this prefix.</li>
+ * <li>generate a prefix that is smart: we want to reduce the size of the index but we also want to reduce the impact on
+ * performances (e.g. for {@code io.quarkus}, we keep one more segment, for versioned classes, we keep 3 more, we make sure
+ * {@code META-INF/services/} files are fully indexed...)</li>
+ * <li>store some additional information such as the transformed classes, banned resources, the classes that are considered
+ * "local" to this class loader (excluding the jars). For these elements, the information is NOT lossy.</li>
+ * </ul>
+ * When interrogating the index, we get the candidate {@code ClassPathElement}s and we then check if the resource is actually in
+ * a given {@code ClassPathElement} before actually considering it.
+ * <p>
+ * In most cases, the information that is in the index is that a resource with this prefix is in these {@code ClassPathElement}
+ * but it might not be the precise resource we are looking for.
+ */
+public class ClassPathResourceIndex {
+
+    private static final String IO_QUARKUS = "io/quarkus/";
+    private static final String META_INF_MAVEN = "META-INF/maven/";
+    private static final String META_INF_SERVICES = "META-INF/services/";
+    private static final String META_INF_VERSIONS = "META-INF/versions/";
+
+    private static final int MAX_SEGMENTS_DEFAULT = 3;
+    private static final int MAX_SEGMENTS_IO_QUARKUS = 4;
+    // let's go with default max segments + 3 for the META-INF/versions/<version> part
+    private static final int MAX_SEGMENTS_META_INF_VERSIONS = MAX_SEGMENTS_DEFAULT + 3;
+
+    /**
+     * This map is mapped by prefixes.
+     */
+    private final Map<String, ClassPathElement[]> resourceMapping;
+    private final Map<String, ClassPathElement> transformedClasses;
+
+    private final Set<String> localClasses;
+    private final Set<String> parentFirstResources;
+    private final Set<String> bannedResources;
+
+    private ClassPathResourceIndex(Map<String, ClassPathElement[]> resourceMapping,
+            Map<String, ClassPathElement> transformedClasses,
+            Set<String> localClasses,
+            Set<String> parentFirstResources,
+            Set<String> bannedResources) {
+        this.resourceMapping = resourceMapping.isEmpty() ? Map.of() : Collections.unmodifiableMap(resourceMapping);
+        this.transformedClasses = transformedClasses.isEmpty() ? Map.of() : transformedClasses;
+        this.localClasses = localClasses.isEmpty() ? Set.of() : Collections.unmodifiableSet(localClasses);
+        this.parentFirstResources = parentFirstResources.isEmpty() ? Set.of()
+                : Collections.unmodifiableSet(parentFirstResources);
+        this.bannedResources = bannedResources.isEmpty() ? Set.of() : Collections.unmodifiableSet(bannedResources);
+    }
+
+    public Set<String> getLocalClassResourceNames() {
+        return localClasses;
+    }
+
+    public boolean isParentFirst(String resource) {
+        return parentFirstResources.contains(resource);
+    }
+
+    public boolean isBanned(String resource) {
+        return bannedResources.contains(resource);
+    }
+
+    // it's tempting to use an Optional here but let's avoid the additional allocation
+    public ClassPathElement getFirstClassPathElement(String resource) {
+        ClassPathElement transformedClassClassPathElement = transformedClasses.get(resource);
+        if (transformedClassClassPathElement != null) {
+            return transformedClassClassPathElement;
+        }
+
+        ClassPathElement[] candidates = resourceMapping.get(getResourceKey(resource));
+        if (candidates == null) {
+            return null;
+        }
+
+        for (int i = 0; i < candidates.length; i++) {
+            if (candidates[i].getProvidedResources().contains(resource)) {
+                return candidates[i];
+            }
+        }
+
+        return null;
+    }
+
+    public List<ClassPathElement> getClassPathElements(String resource) {
+        ClassPathElement transformedClassClassPathElement = transformedClasses.get(resource);
+        if (transformedClassClassPathElement != null) {
+            return List.of(transformedClassClassPathElement);
+        }
+
+        ClassPathElement[] candidates = resourceMapping.get(getResourceKey(resource));
+        if (candidates == null) {
+            return List.of();
+        }
+
+        if (candidates.length == 1) {
+            if (candidates[0].getProvidedResources().contains(resource)) {
+                return List.of(candidates[0]);
+            }
+
+            return List.of();
+        }
+
+        List<ClassPathElement> classPathElements = new ArrayList<>(candidates.length);
+        for (int i = 0; i < candidates.length; i++) {
+            if (candidates[i].getProvidedResources().contains(resource)) {
+                classPathElements.add(candidates[i]);
+            }
+        }
+        return classPathElements;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns a key that tries to find a good compromise between reducing the size of the index and providing good
+     * performances.
+     * <p>
+     * Probably something we will have to tweak for corner cases but let's try to keep it fast.
+     */
+    private static String getResourceKey(String resource) {
+        // we don't really care about this part, it can be slower
+        if (resource.startsWith(META_INF_MAVEN)) {
+            return META_INF_MAVEN;
+        }
+        if (resource.startsWith(META_INF_SERVICES)) {
+            // for services, we want to reference the full path
+            return resource;
+        }
+        StringBuilder prefix = new StringBuilder();
+
+        int maxSegments;
+        if (resource.startsWith(IO_QUARKUS)) {
+            maxSegments = MAX_SEGMENTS_IO_QUARKUS;
+        } else if (resource.startsWith(META_INF_VERSIONS)) {
+            maxSegments = MAX_SEGMENTS_META_INF_VERSIONS;
+        } else {
+            maxSegments = MAX_SEGMENTS_DEFAULT;
+        }
+
+        char[] charArray = resource.toCharArray();
+        int segmentCount = 0;
+        for (char c : charArray) {
+            if (c == '/') {
+                segmentCount++;
+                if (segmentCount == maxSegments) {
+                    return prefix.toString();
+                }
+            }
+            prefix.append(c);
+        }
+
+        // let's drop the file name if we haven't truncated anything and we detect it's a file
+        if (segmentCount > 0 && segmentCount < maxSegments) {
+            int lastSlash = prefix.lastIndexOf("/");
+            if (prefix.substring(lastSlash).contains(".")) {
+                prefix.setLength(lastSlash);
+            }
+        }
+
+        return prefix.toString();
+    }
+
+    public static class Builder {
+
+        private static final String CLASS_SUFFIX = ".class";
+
+        private final Map<String, ClassPathElement> transformedClassCandidates = new HashMap<>();
+        private final Map<String, ClassPathElement> transformedClasses = new HashMap<>();
+        private final Map<String, List<ClassPathElement>> resourceMapping = new HashMap<>();
+
+        private final Set<String> localClasses = new HashSet<>();
+        private final Set<String> parentFirstResources = new HashSet<>();
+        private final Set<String> bannedResources = new HashSet<>();
+
+        public void scanClassPathElement(ClassPathElement classPathElement,
+                BiConsumer<ClassPathElement, String> consumer) {
+            for (String resource : classPathElement.getProvidedResources()) {
+                consumer.accept(classPathElement, resource);
+            }
+        }
+
+        public void addTranformedClassCandidate(ClassPathElement classPathElement, String resource) {
+            transformedClassCandidates.put(resource, classPathElement);
+        }
+
+        public void addResourceMapping(ClassPathElement classPathElement, String resource) {
+            if (classPathElement.providesLocalResources() && resource.endsWith(CLASS_SUFFIX)) {
+                localClasses.add(resource);
+            }
+
+            ClassPathElement transformedClassClassPathElement = transformedClassCandidates.get(resource);
+            if (transformedClassClassPathElement != null) {
+                transformedClasses.put(resource, transformedClassClassPathElement);
+                return;
+            }
+
+            String resourcePrefix = getResourceKey(resource);
+
+            List<ClassPathElement> classPathElements = resourceMapping.get(resourcePrefix);
+            if (classPathElements == null) {
+                // default initial capacity of 10 is way too large
+                classPathElements = new ArrayList<>(2);
+                resourceMapping.put(resourcePrefix, classPathElements);
+            }
+
+            if (!classPathElements.contains(classPathElement)) {
+                classPathElements.add(classPathElement);
+            }
+        }
+
+        public void addParentFirstResource(ClassPathElement classPathElement, String resource) {
+            parentFirstResources.add(resource);
+        }
+
+        public void addBannedResource(ClassPathElement classPathElement, String resource) {
+            bannedResources.add(resource);
+        }
+
+        public ClassPathResourceIndex build() {
+            Map<String, ClassPathElement[]> compactedResourceMapping = new HashMap<>(resourceMapping.size());
+            for (Entry<String, List<ClassPathElement>> resourceMappingEntry : resourceMapping.entrySet()) {
+                compactedResourceMapping.put(resourceMappingEntry.getKey(),
+                        resourceMappingEntry.getValue().toArray(new ClassPathElement[resourceMappingEntry.getValue().size()]));
+            }
+
+            return new ClassPathResourceIndex(compactedResourceMapping, transformedClasses,
+                    localClasses, parentFirstResources, bannedResources);
+        }
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/FilteredClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/FilteredClassPathElement.java
@@ -14,12 +14,15 @@ import io.quarkus.paths.OpenPathTree;
 
 public class FilteredClassPathElement implements ClassPathElement {
 
-    final ClassPathElement delegate;
-    final Set<String> removed;
+    private final ClassPathElement delegate;
+    private final Set<String> removed;
+    private final Set<String> resources;
 
     public FilteredClassPathElement(ClassPathElement delegate, Collection<String> removed) {
         this.delegate = delegate;
         this.removed = new HashSet<>(removed);
+        this.resources = new HashSet<>(delegate.getProvidedResources());
+        this.resources.removeAll(this.removed);
     }
 
     @Override
@@ -52,9 +55,12 @@ public class FilteredClassPathElement implements ClassPathElement {
 
     @Override
     public Set<String> getProvidedResources() {
-        Set<String> ret = new HashSet<>(delegate.getProvidedResources());
-        ret.removeAll(removed);
-        return ret;
+        return resources;
+    }
+
+    @Override
+    public boolean providesLocalResources() {
+        return delegate.providesLocalResources();
     }
 
     @Override

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/FilteredClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/FilteredClassPathElement.java
@@ -59,8 +59,8 @@ public class FilteredClassPathElement implements ClassPathElement {
     }
 
     @Override
-    public boolean providesLocalResources() {
-        return delegate.providesLocalResources();
+    public boolean containsReloadableResources() {
+        return delegate.containsReloadableResources();
     }
 
     @Override

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/MemoryClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/MemoryClassPathElement.java
@@ -114,6 +114,11 @@ public class MemoryClassPathElement extends AbstractClassPathElement {
     }
 
     @Override
+    public boolean providesLocalResources() {
+        return true;
+    }
+
+    @Override
     public ProtectionDomain getProtectionDomain() {
         // we used to include the class bytes in the ProtectionDomain
         // but it is not a good idea

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/MemoryClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/MemoryClassPathElement.java
@@ -114,7 +114,7 @@ public class MemoryClassPathElement extends AbstractClassPathElement {
     }
 
     @Override
-    public boolean providesLocalResources() {
+    public boolean containsReloadableResources() {
         return true;
     }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
@@ -176,6 +176,11 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
     }
 
     @Override
+    public boolean providesLocalResources() {
+        return pathTree.providesLocalResources();
+    }
+
+    @Override
     protected ManifestAttributes readManifest() {
         return apply(OpenPathTree::getManifestAttributes);
     }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
@@ -176,8 +176,8 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
     }
 
     @Override
-    public boolean providesLocalResources() {
-        return pathTree.providesLocalResources();
+    public boolean containsReloadableResources() {
+        return !pathTree.isArchiveOrigin();
     }
 
     @Override

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -605,15 +605,21 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
     public List<ClassPathElement> getElementsWithResource(String name, boolean localOnly) {
         ensureOpen(name);
 
+        boolean parentFirst = parentFirst(name, getClassPathResourceIndex());
+
         List<ClassPathElement> ret = new ArrayList<>();
-        if (parent instanceof QuarkusClassLoader && !localOnly) {
+
+        if (parentFirst && !localOnly && parent instanceof QuarkusClassLoader) {
             ret.addAll(((QuarkusClassLoader) parent).getElementsWithResource(name));
         }
+
         List<ClassPathElement> classPathElements = getClassPathResourceIndex().getClassPathElements(name);
-        if (classPathElements.isEmpty()) {
-            return ret;
-        }
         ret.addAll(classPathElements);
+
+        if (!parentFirst && !localOnly && parent instanceof QuarkusClassLoader) {
+            ret.addAll(((QuarkusClassLoader) parent).getElementsWithResource(name));
+        }
+
         return ret;
     }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -614,11 +614,11 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         return ret;
     }
 
-    public Set<String> getLocalClassNames() {
+    public Set<String> getReloadableClassNames() {
         ensureOpen();
 
         Set<String> ret = new HashSet<>();
-        for (String resourceName : getClassPathResourceIndex().getLocalClassResourceNames()) {
+        for (String resourceName : getClassPathResourceIndex().getReloadableClasses()) {
             ret.add(ClassLoaderHelper.fromResourceNameToClassName(resourceName));
         }
         return ret;

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -270,15 +270,6 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
                     }
                 }
             }
-        } else if (name.isEmpty()) {
-            for (int i = 0; i < normalPriorityElements.size(); i++) {
-                List<ClassPathResource> resList = normalPriorityElements.get(i).getResources("");
-                for (var res : resList) {
-                    if (res != null) {
-                        resources.add(res.getUrl());
-                    }
-                }
-            }
         }
         if (!banned) {
             if ((resources.isEmpty() && !parentAlreadyFoundResources) || aggregateParentResources) {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingInterruptTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingInterruptTestCase.java
@@ -24,7 +24,7 @@ public class ClassLoadingInterruptTestCase {
             jar.as(ExplodedExporter.class).exportExploded(path.toFile(), "tmp");
 
             ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
-                    .addElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
+                    .addNormalPriorityElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
                     .build();
             Class<?> c = cl.loadClass(InterruptClass.class.getName());
             Assertions.assertNotEquals(c, InterruptClass.class);

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingPathTreeResourceUrlTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingPathTreeResourceUrlTestCase.java
@@ -37,7 +37,7 @@ public class ClassLoadingPathTreeResourceUrlTestCase {
             jar.as(ExplodedExporter.class).exportExploded(path.toFile(), "tmp");
 
             ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
-                    .addElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
+                    .addNormalPriorityElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
                     .build();
             URL res = cl.getResource("a.txt");
             Assertions.assertNotNull(res);
@@ -75,7 +75,7 @@ public class ClassLoadingPathTreeResourceUrlTestCase {
         try {
             jar.as(ExplodedExporter.class).exportExploded(tmpDir.toFile(), "tmpcltest");
             final ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
-                    .addElement(ClassPathElement.fromPath(tmpDir.resolve("tmpcltest"), true))
+                    .addNormalPriorityElement(ClassPathElement.fromPath(tmpDir.resolve("tmpcltest"), true))
                     .build();
 
             try (final InputStream is = cl.getResourceAsStream("b/")) {
@@ -103,7 +103,7 @@ public class ClassLoadingPathTreeResourceUrlTestCase {
             jar.as(ZipExporter.class).exportTo(path.toFile(), true);
 
             ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
-                    .addElement(ClassPathElement.fromPath(path, true))
+                    .addNormalPriorityElement(ClassPathElement.fromPath(path, true))
                     .build();
             URL res = cl.getResource("a.txt");
             Assertions.assertNotNull(res);

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingResourceUrlTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/ClassLoadingResourceUrlTestCase.java
@@ -42,7 +42,7 @@ public class ClassLoadingResourceUrlTestCase {
             jar.as(ExplodedExporter.class).exportExploded(path.toFile(), "tmp");
 
             ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
-                    .addElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
+                    .addNormalPriorityElement(ClassPathElement.fromPath(path.resolve("tmp"), true))
                     .build();
             URL res = cl.getResource("a.txt");
             Assertions.assertNotNull(res);
@@ -80,7 +80,7 @@ public class ClassLoadingResourceUrlTestCase {
         try {
             jar.as(ExplodedExporter.class).exportExploded(tmpDir.toFile(), "tmpcltest");
             final ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
-                    .addElement(ClassPathElement.fromPath(tmpDir.resolve("tmpcltest"), true))
+                    .addNormalPriorityElement(ClassPathElement.fromPath(tmpDir.resolve("tmpcltest"), true))
                     .build();
 
             try (final InputStream is = cl.getResourceAsStream("b/")) {
@@ -108,7 +108,7 @@ public class ClassLoadingResourceUrlTestCase {
             jar.as(ZipExporter.class).exportTo(path.toFile(), true);
 
             ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
-                    .addElement(ClassPathElement.fromPath(path, true))
+                    .addNormalPriorityElement(ClassPathElement.fromPath(path, true))
                     .build();
             URL res = cl.getResource("a.txt");
             Assertions.assertNotNull(res);
@@ -135,7 +135,7 @@ public class ClassLoadingResourceUrlTestCase {
         Thread.sleep(2);
 
         ClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
-                .addElement(
+                .addNormalPriorityElement(
                         new MemoryClassPathElement(Collections.singletonMap("a.txt", "hello".getBytes(StandardCharsets.UTF_8)),
                                 true))
                 .build();

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/MultiReleaseJarTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloader/MultiReleaseJarTestCase.java
@@ -52,7 +52,7 @@ public class MultiReleaseJarTestCase {
     @Test
     public void shouldLoadMultiReleaseJarOnJDK9Plus() throws IOException {
         try (QuarkusClassLoader cl = QuarkusClassLoader.builder("test", getClass().getClassLoader(), false)
-                .addElement(ClassPathElement.fromPath(jarPath, true))
+                .addNormalPriorityElement(ClassPathElement.fromPath(jarPath, true))
                 .build()) {
             URL resource = cl.getResource("foo.txt");
             assertNotNull(resource, "foo.txt was not found in generated JAR");

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloading/ClassPathResourceIndexTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/classloading/ClassPathResourceIndexTestCase.java
@@ -1,0 +1,24 @@
+package io.quarkus.bootstrap.classloading;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class ClassPathResourceIndexTestCase {
+
+    @Test
+    public void testGetResourceKey() {
+        assertEquals("io/quarkus/core/deployment",
+                ClassPathResourceIndex.getResourceKey("io/quarkus/core/deployment/MyClass.class"));
+        assertEquals("io/quarkus/core/deployment",
+                ClassPathResourceIndex.getResourceKey("io/quarkus/core/deployment/package/MyClass.class"));
+        assertEquals("org/apache/commons",
+                ClassPathResourceIndex.getResourceKey("org/apache/commons/codec/MyClass.class"));
+        assertEquals("test.properties", ClassPathResourceIndex.getResourceKey("test.properties"));
+        assertEquals("META-INF/maven/", ClassPathResourceIndex.getResourceKey("META-INF/maven/commons-codec/file.properties"));
+        assertEquals("io/quarkus", ClassPathResourceIndex.getResourceKey("io/quarkus/MyClass.class"));
+        assertEquals("META-INF/services/my-service", ClassPathResourceIndex.getResourceKey("META-INF/services/my-service"));
+        assertEquals("META-INF/versions/17/io/quarkus/core",
+                ClassPathResourceIndex.getResourceKey("META-INF/versions/17/io/quarkus/core/deployment"));
+    }
+}

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -595,13 +595,8 @@ public class QuarkusUnitTest
                                 //we need to make sure all hot reloadable classes are application classes
                                 context.produce(new ApplicationClassPredicateBuildItem(new Predicate<String>() {
                                     @Override
-                                    public boolean test(String s) {
-                                        QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread()
-                                                .getContextClassLoader();
-                                        //if the class file is present in this (and not the parent) CL then it is an application class
-                                        List<ClassPathElement> res = cl
-                                                .getElementsWithResource(s.replace(".", "/") + ".class", true);
-                                        return !res.isEmpty();
+                                    public boolean test(String className) {
+                                        return QuarkusClassLoader.isApplicationClass(className);
                                     }
                                 }));
                             }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -70,7 +70,6 @@ import org.opentest4j.TestAbortedException;
 import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.app.StartupAction;
-import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.builder.BuildChainBuilder;
@@ -1244,13 +1243,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                             //we need to make sure all hot reloadable classes are application classes
                             context.produce(new ApplicationClassPredicateBuildItem(new Predicate<String>() {
                                 @Override
-                                public boolean test(String s) {
-                                    QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread()
-                                            .getContextClassLoader();
-                                    //if the class file is present in this (and not the parent) CL then it is an application class
-                                    List<ClassPathElement> res = cl
-                                            .getElementsWithResource(s.replace(".", "/") + ".class", true);
-                                    return !res.isEmpty();
+                                public boolean test(String className) {
+                                    return QuarkusClassLoader.isApplicationClass(className);
                                 }
                             }));
                         }


### PR DESCRIPTION
> [!NOTE]
> This PR is part of a coordinated effort to address the OOM reported in https://github.com/quarkusio/quarkus/issues/42471:
> - https://github.com/quarkusio/quarkus/pull/42492
> - https://github.com/quarkusio/quarkus/pull/42525
> - https://github.com/quarkusio/quarkus/pull/42560

The size of the `ClassLoaderState` of the `QuarkusClassLoader` can be extremely problematic (I have seen it regularly at 10+ MB in the various heap dumps I studied these past months).

I made a first attempt at fixing it a few months ago but wasn't really happy with the approach. I approached the problem differently here.

The idea of this patch is to have a lossy index instead and try to find a good compromise between speed and memory usage.
And that's the only compromise we make as each `ClassPathElement` has a comprehensive index of what it contains so we can narrow down the candidates using the lossy index and then fully check the few ``ClassPathElement``s candidates.

I personally think it makes things a bit more readable too but YMMV.

This is related to issue https://github.com/quarkusio/quarkus/issues/42471 .

In this particular example:
- the old `state` is 13 MB+
- the new index is less than 3 MB

So we end up with 10 less MB per `QuarkusClassLoader` in this case (obviously this will depend on the number of classes in your app).

As for speed, I made a few tests and things are not noticeably slower when starting an application in dev mode from what I could see. I made the implementation of `ClassPathResourceIndex#getResourceKey()` faster in a follow up commit.

One thing that I noticed (but it's preexisting) is that I saw this call appear a few times in the flamegraph:
https://github.com/quarkusio/quarkus/blob/main/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java#L105-L107

When calling this from the CL we could bypass this check as we know the resource is there. But I'm not sure how to make it evolve from an API perspective. /cc @aloubyansky 

This is better reviewed commit per commit as I added a few more things.

Situation before this patch:

![Screenshot from 2024-08-16 14-17-17](https://github.com/user-attachments/assets/61f5a72b-79d5-414b-a31a-c4e4b63f4b63)

Situation after this patch:

![Screenshot from 2024-08-16 14-15-55](https://github.com/user-attachments/assets/e435d853-475c-4874-92a7-339907cc8c3e)
