### PR TITLE
Remove quarkus-panache-common from docs

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -90,37 +90,6 @@ If you don't want to generate a new project, add the dependency in your build fi
 implementation("io.quarkus:quarkus-mongodb-panache")
 ----
 
-[NOTE]
-====
-If your project is already configured to use other annotation processors, you will need to additionally add the Panache annotation processor:
-
-[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
-.pom.xml
-----
-<plugin>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>${compiler-plugin.version}</version>
-    <configuration>
-        <parameters>${maven.compiler.parameters}</parameters>
-        <annotationProcessorPaths>
-            <!-- Your existing annotation processor(s)... -->
-            <path>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-panache-common</artifactId>
-                <version>${quarkus.platform.version}</version>
-            </path>
-        </annotationProcessorPaths>
-    </configuration>
-</plugin>
-----
-
-[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
-.build.gradle
-----
-annotationProcessor("io.quarkus:quarkus-panache-common")
-----
-====
-
 == Setting up and configuring MongoDB with Panache
 
 To get started:


### PR DESCRIPTION
Fixes Update docs to reflect Panache annotation processor removed for Hibernate ORM/Hibernate Reactive/MongoDB #42531
Backport to 3.9?