### PR TITLE
Handle GraalVM EA versions and update GraalVM version mapping

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -15,6 +15,7 @@ public final class GraalVM {
     // Implements version parsing after https://github.com/oracle/graal/pull/6302
     static final class VersionParseHelper {
 
+        private static final String EA_BUILD_PREFIX = "-ea";
         private static final String JVMCI_BUILD_PREFIX = "jvmci-";
         private static final String MANDREL_VERS_PREFIX = "Mandrel-";
 
@@ -103,11 +104,10 @@ public final class GraalVM {
             if (vendorVersion == null) {
                 return null;
             }
-            int idx = vendorVersion.indexOf(LIBERICA_NIK_VERS_PREFIX);
-            if (idx < 0) {
+            final String version = buildVersion(vendorVersion, LIBERICA_NIK_VERS_PREFIX);
+            if (version == null) {
                 return null;
             }
-            String version = vendorVersion.substring(idx + LIBERICA_NIK_VERS_PREFIX.length());
             return matchVersion(version);
         }
 
@@ -122,11 +122,10 @@ public final class GraalVM {
             if (vendorVersion == null) {
                 return null;
             }
-            int idx = vendorVersion.indexOf(MANDREL_VERS_PREFIX);
-            if (idx < 0) {
+            final String version = buildVersion(vendorVersion, MANDREL_VERS_PREFIX);
+            if (version == null) {
                 return null;
             }
-            String version = vendorVersion.substring(idx + MANDREL_VERS_PREFIX.length());
             return matchVersion(version);
         }
 
@@ -142,17 +141,27 @@ public final class GraalVM {
             if (buildInfo == null) {
                 return null;
             }
-            int idx = buildInfo.indexOf(JVMCI_BUILD_PREFIX);
-            if (idx < 0) {
-                return null;
+            String version = buildVersion(buildInfo, JVMCI_BUILD_PREFIX);
+            if (version == null) {
+                version = buildVersion(buildInfo, EA_BUILD_PREFIX);
+                if (version == null) {
+                    return null;
+                }
             }
-            String version = buildInfo.substring(idx + JVMCI_BUILD_PREFIX.length());
             Matcher versMatcher = VERSION_PATTERN.matcher(version);
             if (versMatcher.find()) {
                 return matchVersion(version);
             } else {
                 return GRAAL_MAPPING.get(jdkFeature);
             }
+        }
+
+        private static String buildVersion(String buildInfo, String buildPrefix) {
+            int idx = buildInfo.indexOf(buildPrefix);
+            if (idx < 0) {
+                return null;
+            }
+            return buildInfo.substring(idx + buildPrefix.length());
         }
     }
 
@@ -161,8 +170,8 @@ public final class GraalVM {
     // https://github.com/quarkusio/quarkus/issues/34161
     private static final Map<Integer, String> GRAAL_MAPPING = Map.of(22, "24.0",
             23, "24.1",
-            24, "25.0",
-            25, "25.1");
+            24, "24.2",
+            25, "25.0");
 
     public static final class Version implements Comparable<Version> {
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -166,6 +166,19 @@ public class GraalVMTest {
     }
 
     @Test
+    public void testGraalVMEA24DevVersionParser() {
+        final Version graalVMEA24Dev = Version.of(Stream.of(("native-image 24-ea 2025-03-18\n"
+                + "OpenJDK Runtime Environment Oracle GraalVM 24-dev.ea+10.1 (build 24-ea+10-1076)\n"
+                + "OpenJDK 64-Bit Server VM Oracle GraalVM 24-dev.ea+10.1 (build 24-ea+10-1076, mixed mode, sharing)")
+                .split("\\n")));
+        assertThat(graalVMEA24Dev.distribution.name()).isEqualTo("GRAALVM");
+        assertThat(graalVMEA24Dev.getVersionAsString()).isEqualTo("24.2-dev");
+        assertThat(graalVMEA24Dev.javaVersion.toString()).isEqualTo("24-ea+10-1076");
+        assertThat(graalVMEA24Dev.javaVersion.feature()).isEqualTo(24);
+        assertThat(graalVMEA24Dev.javaVersion.update()).isEqualTo(0);
+    }
+
+    @Test
     public void testGraalVMVersionsOlderThan() {
         assertOlderThan("GraalVM Version 19.3.6 CE", "GraalVM Version 20.2.0 (Java Version 11.0.9)");
         assertOlderThan("GraalVM Version 20.0.0 (Java Version 11.0.7)", "GraalVM Version 20.1.0 (Java Version 11.0.8)");


### PR DESCRIPTION
Fixes #42516 42516

* EA versions can result from quick builds running `mx build` on substratevm and using labs JDK EA builds.
* Update GraalVM version mapping according to Christian Wimmer's latest information. He indicated that upcoming JDK 24 will be GraalVM 24.2, and then by JDK 25 version numbers will lineup.

@jerboaa Can you review this too? I can't seem to add you as reviewer.