### PR TITLE
Correct indendation in metadata documentation so metadata is actually in the metadata block

### DIFF
--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -64,6 +64,9 @@ And here is the final version of the file included in the runtime JAR augmented 
 ----
 name: "Quarkus REST (formerly RESTEasy Reactive)"
 artifact: "io.quarkus:quarkus-rest:999-SNAPSHOT"
+description: "A Jakarta REST implementation utilizing build time processing and Vert.x.\
+  \ This extension is not compatible with the quarkus-resteasy extension, or any of\
+  \ the extensions that depend on it." <1>
 metadata:
   short-name: "rest"
   keywords:
@@ -84,13 +87,13 @@ metadata:
     artifact: "io.quarkus:quarkus-project-core-extension-codestarts::jar:999-SNAPSHOT"
   config:
   - "quarkus.rest."
-  built-with-quarkus-core: "3.8.5" <1>
-  requires-quarkus-core: "[3.8,)" <2>
-  capabilities: <3>
+  built-with-quarkus-core: "3.8.5" <2>
+  requires-quarkus-core: "[3.8,)" <3>
+  capabilities: <4>
     provides:
     - "io.quarkus.rest"
     - "io.quarkus.resteasy.reactive"
-  extension-dependencies: <4>
+  extension-dependencies: <5>
   - "io.quarkus:quarkus-rest-common"
   - "io.quarkus:quarkus-mutiny"
   - "io.quarkus:quarkus-smallrye-context-propagation"
@@ -100,20 +103,17 @@ metadata:
   - "io.quarkus:quarkus-vertx-http"
   - "io.quarkus:quarkus-core"
   - "io.quarkus:quarkus-jsonp"
-description: "A Jakarta REST implementation utilizing build time processing and Vert.x.\
-  \ This extension is not compatible with the quarkus-resteasy extension, or any of\
-  \ the extensions that depend on it." <5>
-scm-url: "https://github.com/quarkusio/quarkus" <6>
-sponsor: A Sponsoring Organisation <7>
+  scm-url: "https://github.com/quarkusio/quarkus" <6>
+  sponsor: A Sponsoring Organisation <7>
 ----
-
-<1> Quarkus version the extension was built with
-<2> The Quarkus version range this extension requires. Optional, and will be set automatically by using the `built-with-quarkus-core` as the minimum range.
-<3> https://quarkus.io/guides/capabilities[Capabilities] this extension provides
-<4> Direct dependencies on other extensions
-<5> Description that can be displayed to users. In this case, the description was copied from the `pom.xml` of the extension module but it could also be provided in the template file.
+<1> Description that can be displayed to users. In this case, the description was copied from the `pom.xml` of the extension module but it could also be provided in the template file.
+<2> Quarkus version the extension was built with
+<3> The Quarkus version range this extension requires. Optional, and will be set automatically by using the `built-with-quarkus-core` as the minimum range.
+<4> https://quarkus.io/guides/capabilities[Capabilities] this extension provides
+<5> Direct dependencies on other extensions
 <6> The source code repository of this extension. Optional, and will often be set automatically by using the `<scm>` information in the pom. In GitHub Actions builds, it will be inferred from the CI environment. For other GitHub repositories, it can be controlled by setting a `GITHUB_REPOSITORY` environment variable.
 <7> The sponsor(s) of this extension. Optional, and will sometimes be determined automatically from commit history.
+
 
 [[quarkus-extension-properties]]
 == META-INF/quarkus-extension.properties


### PR DESCRIPTION
[rdehuyss](https://github.com/rdehuyss) (thanks!) has pointed out that the metadata documentation shows `scm-url` as a top-level item, when it should be in the metadata. While I was fixing that, I noticed I'd made the same mistake for the sponsor field. 

I've re-ordered the entries so it's harder to make the same mistake *again* for new metadata, and fixed the indentation. 