### PR TITLE
Bump apicurio-registry.version from 2.5.10.Final to 2.6.2.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -196,7 +196,7 @@
         <log4j2-api.version>2.23.1</log4j2-api.version>
         <log4j-jboss-logmanager.version>1.3.1.Final</log4j-jboss-logmanager.version>
         <avro.version>1.12.0</avro.version>
-        <apicurio-registry.version>2.5.10.Final</apicurio-registry.version>
+        <apicurio-registry.version>2.6.2.Final</apicurio-registry.version>
         <apicurio-common-rest-client.version>0.1.18.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <testcontainers.version>1.20.1</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
         <docker-java.version>3.4.0</docker-java.version> <!-- must be the version Testcontainers use: https://central.sonatype.com/artifact/org.testcontainers/testcontainers -->


### PR DESCRIPTION
@gsmet here is the upgrade, as promised.