### PR TITLE
Load Testcontainers parent first and start the containers with the Platform CL as the TCCL

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -217,6 +217,15 @@
 
                         <!-- Make use of byteman frictionless -->
                         <parentFirstArtifact>org.jboss.byteman:byteman</parentFirstArtifact>
+
+                        <!--
+                          Testcontainers support: Testcontainers start a lot of threads that are long lived,
+                          leaking class loaders like crazy.
+                        -->
+                        <parentFirstArtifact>org.testcontainers:testcontainers</parentFirstArtifact>
+                        <parentFirstArtifact>com.github.docker-java:docker-java-api</parentFirstArtifact>
+                        <parentFirstArtifact>com.github.docker-java:docker-java-transport-zerodep</parentFirstArtifact>
+                        <parentFirstArtifact>org.rnorth.duct-tape:duct-tape</parentFirstArtifact>
                     </parentFirstArtifacts>
                     <runnerParentFirstArtifacts>
                         <runnerParentFirstArtifact>org.graalvm.sdk:nativeimage</runnerParentFirstArtifact>
@@ -257,6 +266,15 @@
                         <runnerParentFirstArtifact>io.github.crac:org-crac</runnerParentFirstArtifact>
                         <!-- Make use of byteman frictionless -->
                         <runnerParentFirstArtifact>org.jboss.byteman:byteman</runnerParentFirstArtifact>
+
+                        <!--
+                          Testcontainers support: Testcontainers start a lot of threads that are long lived,
+                          leaking class loaders like crazy.
+                        -->
+                        <runnerParentFirstArtifact>org.testcontainers:testcontainers</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>com.github.docker-java:docker-java-api</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>com.github.docker-java:docker-java-transport-zerodep</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.rnorth.duct-tape:duct-tape</runnerParentFirstArtifact>
                     </runnerParentFirstArtifacts>
                     <excludedArtifacts>
                         <excludedArtifact>io.smallrye:smallrye-config</excludedArtifact>

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -13,6 +13,7 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.Db2Container;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
@@ -65,7 +66,7 @@ public class DB2DevServicesProcessor {
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
-                container.start();
+                QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
                 LOG.info("Dev Services for IBM Db2 started.");
 

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -13,6 +13,7 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
@@ -74,7 +75,7 @@ public class MariaDBDevServicesProcessor {
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
-                container.start();
+                QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
                 LOG.info("Dev Services for MariaDB started.");
 

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -11,6 +11,7 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
@@ -66,7 +67,7 @@ public class MSSQLDevServicesProcessor {
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
 
-                container.start();
+                QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
                 LOG.info("Dev Services for Microsoft SQL Server started.");
 

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -13,6 +13,7 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
@@ -74,7 +75,7 @@ public class MySQLDevServicesProcessor {
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
 
-                container.start();
+                QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
                 LOG.info("Dev Services for MySQL started.");
 

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -13,6 +13,7 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
@@ -80,7 +81,7 @@ public class OracleDevServicesProcessor {
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
 
-                container.start();
+                QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
                 LOG.info("Dev Services for Oracle started.");
 

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -16,6 +16,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
@@ -77,7 +78,7 @@ public class PostgresqlDevServicesProcessor {
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
 
-                container.start();
+                QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
                 LOG.info("Dev Services for PostgreSQL started.");
 

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -17,6 +17,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
@@ -208,7 +209,8 @@ public class DevServicesElasticsearchProcessor {
 
             container.withReuse(config.reuse);
 
-            container.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(container::start);
+
             return new DevServicesResultBuildItem.RunningDevService(Feature.ELASTICSEARCH_REST_CLIENT_COMMON.getName(),
                     container.getContainerId(),
                     new ContainerShutdownCloseable(container, "Elasticsearch"),

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -20,6 +20,7 @@ import org.infinispan.server.test.core.InfinispanContainer;
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.BindMode;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -212,7 +213,7 @@ public class InfinispanDevServiceProcessor {
                     useSharedNetwork);
             timeout.ifPresent(infinispanContainer::withStartupTimeout);
             infinispanContainer.withEnv(devServicesConfig.containerEnv);
-            infinispanContainer.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(infinispanContainer::start);
 
             return getRunningDevService(clientName, infinispanContainer.getContainerId(), infinispanContainer::close,
                     infinispanContainer.getHost() + ":" + infinispanContainer.getPort(),

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -41,6 +41,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.fabric8.kubernetes.client.Config;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -229,7 +230,7 @@ public class DevServicesKubernetesProcessor {
 
             container.withEnv(config.containerEnv);
 
-            container.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
             KubeConfig kubeConfig = KubeConfigUtils.parseKubeConfig(container.getKubeconfig());
 

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -21,6 +21,7 @@ import org.testcontainers.utility.DockerImageName;
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.message.BasicNameValuePair;
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.net.URLEncodedUtils;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -188,7 +189,7 @@ public class DevServicesMongoProcessor {
             }
             timeout.ifPresent(mongoDBContainer::withStartupTimeout);
             mongoDBContainer.withEnv(capturedProperties.containerEnv);
-            mongoDBContainer.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(mongoDBContainer::start);
 
             final String effectiveUrl = getEffectiveUrl(configPrefix, mongoDBContainer.getEffectiveHost(),
                     mongoDBContainer.getEffectivePort(), capturedProperties);

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -42,6 +42,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -379,7 +380,7 @@ public class KeycloakDevServicesProcessor {
 
             timeout.ifPresent(oidcContainer::withStartupTimeout);
             oidcContainer.withEnv(capturedDevServicesConfiguration.containerEnv);
-            oidcContainer.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(oidcContainer::start);
 
             String internalUrl = startURL(oidcContainer.getHost(), oidcContainer.getPort(), oidcContainer.keycloakX);
             String hostUrl = oidcContainer.useSharedNetwork

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -18,6 +18,7 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -181,7 +182,7 @@ public class DevServicesRedisProcessor {
                     launchMode == DEVELOPMENT ? devServicesConfig.serviceName() : null, useSharedNetwork);
             timeout.ifPresent(redisContainer::withStartupTimeout);
             redisContainer.withEnv(devServicesConfig.containerEnv());
-            redisContainer.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(redisContainer::start);
             String redisHost = REDIS_SCHEME + redisContainer.getHost() + ":" + redisContainer.getPort();
             return new RunningDevService(Feature.REDIS_CLIENT.getName(), redisContainer.getContainerId(),
                     redisContainer::close, configPrefix + RedisConfig.HOSTS_CONFIG_NAME, redisHost);

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
@@ -13,6 +13,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.apicurio.registry.devservice.ApicurioRegistryBuildTimeConfig.ApicurioRegistryDevServicesBuildTimeConfig;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -182,7 +183,7 @@ public class DevServicesApicurioRegistryProcessor {
                             useSharedNetwork);
                     timeout.ifPresent(container::withStartupTimeout);
                     container.withEnv(config.containerEnv);
-                    container.start();
+                    QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
                     return new RunningDevService(Feature.APICURIO_REGISTRY_AVRO.getName(), container.getContainerId(),
                             container::close, getRegistryUrlConfigs(container.getUrl()));

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -16,6 +16,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -190,7 +191,7 @@ public class AmqpDevServicesProcessor {
 
             timeout.ifPresent(container::withStartupTimeout);
             container.withEnv(config.containerEnv);
-            container.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
             return getRunningService(container.getContainerId(), container::close, container.getEffectiveHost(),
                     container.getPort(), container.getMappedPort());

--- a/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
@@ -164,7 +164,7 @@ public class MqttDevServicesProcessor {
             // Starting the broker
             timeout.ifPresent(container::withStartupTimeout);
             container.withEnv(config.containerEnv);
-            container.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(container::start);
             return getRunningDevService(
                     container.getContainerId(),
                     container::close,

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesProcessor.java
@@ -14,6 +14,7 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -175,7 +176,7 @@ public class PulsarDevServicesProcessor {
                 container.withPort(config.fixedExposedPort);
             }
             timeout.ifPresent(container::withStartupTimeout);
-            container.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(container::start);
 
             return getRunningService(container.getContainerId(), container::close, container.getPulsarBrokerUrl(),
                     container.getHttpServiceUrl());

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
@@ -191,7 +191,7 @@ public class RabbitMQDevServicesProcessor {
             // Starting the broker
             timeout.ifPresent(container::withStartupTimeout);
             container.withEnv(config.containerEnv);
-            container.start();
+            QuarkusClassLoader.runWithPlatformClassLoader(container::start);
             return getRunningDevService(container.getContainerId(), container::close, container.getHost(),
                     container.getPort(), container.getHttpPort(), container.getAdminUsername(), container.getAdminPassword());
         };

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -95,6 +95,16 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         return false;
     }
 
+    public static void runWithPlatformClassLoader(Runnable runnable) {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(PLATFORM_CLASS_LOADER);
+            runnable.run();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
     private final String name;
     private final List<ClassPathElement> elements;
     private final ConcurrentMap<ClassPathElement, ProtectionDomain> protectionDomains = new ConcurrentHashMap<>();

--- a/test-framework/common/pom.xml
+++ b/test-framework/common/pom.xml
@@ -34,6 +34,21 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <!-- This makes Testcontainers part of the test classpath, allowing us to load it parent first -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
+        </dependency>
         <!-- Needed for RestAssured -->
         <dependency>
             <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
> [!NOTE]
> This PR is part of a coordinated effort to address the OOM reported in https://github.com/quarkusio/quarkus/issues/42471:
> - https://github.com/quarkusio/quarkus/pull/42492
> - https://github.com/quarkusio/quarkus/pull/42525
> - https://github.com/quarkusio/quarkus/pull/42560

This is the last piece of the puzzle to make https://github.com/quarkusio/quarkus/issues/42471 actually pass.

TBH, I'm not exactly excited about adding testcontainers always but for now that's the only solution I could find.

There are two aspects to it:
- Start the containers with the TCCL set to the Platform CL to avoid having the TCCL of the threads being a `QuarkusClassLoader`
- Load Testcontainers base classes parent first: some are long lived so we need to avoid loading them with the `QuarkusClassLoader`

The problem with the latter is that we then need to make testcontainers a dependency of `quarkus-test-common` so that it appears in the test classpath.

There might be a better way to do it in the future with the work @holly-cummins has started but that's how it is for now (and I'm not entirely sure Holly's work would be enough to solve this as we would basically need to figure out that testcontainers is around and add it to a base class loader that would be shared across all the tests - it might be possible but I haven't looked at Holly's work yet).

The problem with Testcontainers is that there are some long lived threads that are kept around and our class loaders leak in two ways:
- by being the CL of some classes that are kept around
- by being the TCCL of some Testcontainers thread (Testcontainers itself, the Ryuk reaper thread and a ducttape thread)

Thus why this work is in two parts.

Class loader of a long lived class:

![Screenshot from 2024-08-16 17-00-37](https://github.com/user-attachments/assets/fa50ae71-4308-4b52-a8ba-06a00e2e10e3)


TCCL of thread:

![Screenshot from 2024-08-16 17-02-57](https://github.com/user-attachments/assets/7ba7f3ff-e3b8-462f-a5cf-01dc5ca781a8)

