### PR TITLE
Do not try to create temp directory in test archives

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -176,7 +176,15 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
             }
 
             // Creates a temporary application.properties file for the test with a high ordinal (build and runtime)
-            Path tempDirectory = Files.createTempDirectory(testClassLocation, requiredTestClass.getSimpleName());
+            // Note that in the case of the Quarkus Platform, the testClassLocation is actually a jar so we can't
+            // create a temp directory in it.
+            Path tempDirectory;
+            if (Files.isDirectory(testClassLocation) && Files.isWritable(testClassLocation)) {
+                tempDirectory = Files.createTempDirectory(testClassLocation, requiredTestClass.getSimpleName());
+            } else {
+                tempDirectory = Files.createTempDirectory(requiredTestClass.getSimpleName());
+            }
+
             Path propertiesFile = tempDirectory.resolve("application.properties");
             Files.createFile(propertiesFile);
             Properties properties = new Properties();


### PR DESCRIPTION
When dealing with test archives, such as in the Platform, we shouldn't try to create a temp directory in the archive.

Related to the failure described here:
https://github.com/quarkusio/quarkus-platform/pull/1255#issuecomment-2288766644

This needs to be in 3.14.0 final as it's breaking the platform testing.