### PR TITLE
Allow user defined dev services for any image

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -774,6 +774,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devservices</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-devservices-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/ClasspathResourceMappingConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/ClasspathResourceMappingConfig.java
@@ -1,0 +1,24 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Optional;
+
+import org.testcontainers.containers.BindMode;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface ClasspathResourceMappingConfig {
+
+    /**
+     * The value for the container path
+     */
+    Optional<String> containerPath();
+
+    /**
+     * The Bind mode of the volume
+     */
+    @WithDefault("READ_ONLY")
+    BindMode bindMode();
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/ClasspathResourceMappingsConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/ClasspathResourceMappingsConfig.java
@@ -1,0 +1,21 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigGroup
+public interface ClasspathResourceMappingsConfig {
+
+    /**
+     * Classpath Resource Mappings
+     */
+    @ConfigDocMapKey("resource-path")
+    @WithParentName
+    @WithDefaults
+    Map<String, ClasspathResourceMappingConfig> classpathResourceMapping();
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/DevServiceConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/DevServiceConfig.java
@@ -1,0 +1,98 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.net.URL;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface DevServiceConfig {
+
+    /**
+     * Whether this dev service should be enabled
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * The image to use
+     */
+    Optional<String> imageName();
+
+    /**
+     * The container port. If not provided no port will be mapped
+     */
+    OptionalInt containerPort();
+
+    /**
+     * The port that the contain port should be mapped to. If not provided a random port will be used
+     */
+    OptionalInt mappedPort();
+
+    /**
+     * The version to use
+     */
+    @WithDefault("latest")
+    String version();
+
+    /**
+     * The url the service started on. Might be nothing
+     */
+    Optional<URL> url();
+
+    /**
+     * If the network should be SHARED
+     */
+    @WithDefault("true")
+    boolean sharedNetwork();
+
+    /**
+     * If the container should be reused
+     */
+    Optional<Boolean> reuse();
+
+    /**
+     * Access to the host
+     */
+    @WithDefault("false")
+    boolean accessToHost();
+
+    /**
+     * Capture log
+     */
+    @WithDefault("false")
+    boolean captureLog();
+
+    /**
+     * Wait for
+     */
+    @ConfigDocSection
+    WaitForConfig waitFor();
+
+    /**
+     * Labels
+     */
+    @ConfigDocSection
+    LabelsConfig label();
+
+    /**
+     * Env vars
+     */
+    @ConfigDocSection
+    EnvVarsConfig env();
+
+    /**
+     * File System bindings
+     */
+    @ConfigDocSection
+    FileSystemBindsConfig fileSystemBindings();
+
+    /**
+     * Classpath Resource mappings
+     */
+    @ConfigDocSection
+    ClasspathResourceMappingsConfig classpathResourceMappings();
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/DevServicesConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/DevServicesConfig.java
@@ -1,0 +1,24 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigMapping(prefix = "quarkus.devservices")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface DevServicesConfig {
+
+    /**
+     * DevServices Images.
+     */
+    @ConfigDocMapKey("service-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, DevServiceConfig> devservice();
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/DevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/DevServicesProcessor.java
@@ -1,0 +1,215 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+public class DevServicesProcessor {
+
+    private static final Logger log = Logger.getLogger(DevServicesProcessor.class);
+
+    @BuildStep
+    public void createContainers(BuildProducer<DevServicesResultBuildItem> devServicesResultProducer,
+            DevServicesConfig devServicesConfig) {
+
+        Map<String, DevServiceConfig> devservices = devServicesConfig.devservice();
+        if (devservices != null && !devservices.isEmpty()) {
+            Set<Map.Entry<String, DevServiceConfig>> devservicesSet = devservices.entrySet();
+            for (Map.Entry<String, DevServiceConfig> devservice : devservicesSet) {
+                String name = devservice.getKey();
+                DevServiceConfig devServiceConfig = devservice.getValue();
+                createContainer(devServicesResultProducer, name, devServiceConfig);
+            }
+        }
+    }
+
+    private void createContainer(BuildProducer<DevServicesResultBuildItem> devServicesResultProducer, String name,
+            DevServiceConfig config) {
+        if (config.enabled() && config.imageName().isPresent()) {
+            DockerImageName dockerImageName = DockerImageName
+                    .parse(config.imageName().get());
+
+            AnyContainer container = new AnyContainer(dockerImageName, config.containerPort(), config.mappedPort(),
+                    config.sharedNetwork());
+            Map<String, String> props = new HashMap<>();
+
+            // Reuse
+            // If not provided, and the mapped port is configured, we want reuse true as a default, else false
+            if (config.reuse().isPresent()) {
+                container = container.withReuse(config.reuse().get());
+            } else if (config.mappedPort().isPresent()) {
+                container = container.withReuse(true);
+            } else {
+                container = container.withReuse(false);
+            }
+
+            // Access to host
+            container = container.withAccessToHost(config.accessToHost());
+
+            // Labels
+            container = container.withLabel("quarkus-dev-services", name);
+            Map<String, LabelConfig> labels = config.label().labels();
+            if (labels != null && !labels.isEmpty()) {
+                Set<Map.Entry<String, LabelConfig>> labelsSet = labels.entrySet();
+                for (Map.Entry<String, LabelConfig> label : labelsSet) {
+                    String labelName = label.getKey();
+                    LabelConfig labelConfig = label.getValue();
+                    if (labelConfig.value().isPresent()) {
+                        String labelValue = labelConfig.value().get();
+                        container = container.withLabel(labelName, labelValue);
+                    }
+                }
+            }
+
+            // Env vars
+            Map<String, EnvValueConfig> envvars = config.env().vars();
+            if (envvars != null && !envvars.isEmpty()) {
+                Set<Map.Entry<String, EnvValueConfig>> envvarsSet = envvars.entrySet();
+                for (Map.Entry<String, EnvValueConfig> envvar : envvarsSet) {
+                    String envName = envvar.getKey();
+                    EnvValueConfig envValueConfig = envvar.getValue();
+                    if (envValueConfig.value().isPresent()) {
+                        String envVal = envValueConfig.value().get();
+                        container = container.withEnv(envName, envVal);
+                    }
+                }
+            }
+
+            // File System bindings
+            Map<String, FileSystemBindConfig> fileSystemBindings = config.fileSystemBindings().fileSystemBind();
+            if (fileSystemBindings != null && !fileSystemBindings.isEmpty()) {
+                Set<Map.Entry<String, FileSystemBindConfig>> fileSystemBindingsSet = fileSystemBindings.entrySet();
+                for (Map.Entry<String, FileSystemBindConfig> fileSystemBinding : fileSystemBindingsSet) {
+                    String hostPath = getAbsoluteHostPath(fileSystemBinding.getKey());
+                    FileSystemBindConfig fileSystemBindConfig = fileSystemBinding.getValue();
+                    if (fileSystemBindConfig.containerPath().isPresent()) {
+                        String containerPath = fileSystemBindConfig.containerPath().get();
+                        container = container.withFileSystemBind(hostPath, containerPath, fileSystemBindConfig.bindMode());
+                    }
+                }
+            }
+
+            // Classpath Resource Mapping
+            Map<String, ClasspathResourceMappingConfig> classpathResourceMappings = config.classpathResourceMappings()
+                    .classpathResourceMapping();
+            if (classpathResourceMappings != null && !classpathResourceMappings.isEmpty()) {
+                Set<Map.Entry<String, ClasspathResourceMappingConfig>> classpathResourceMappingsSet = classpathResourceMappings
+                        .entrySet();
+                for (Map.Entry<String, ClasspathResourceMappingConfig> classpathResourceMapping : classpathResourceMappingsSet) {
+                    String resourcePath = classpathResourceMapping.getKey();
+                    ClasspathResourceMappingConfig classpathResourceMappingConfig = classpathResourceMapping.getValue();
+                    if (classpathResourceMappingConfig.containerPath().isPresent()) {
+                        String containerPath = classpathResourceMappingConfig.containerPath().get();
+                        container = container.withClasspathResourceMapping(resourcePath, containerPath,
+                                classpathResourceMappingConfig.bindMode());
+                    }
+                }
+            }
+
+            // Wait for (TODO: Expand http options ?)
+            WaitForConfig waitFor = config.waitFor();
+            if (waitFor.defaultWaitStrategy().isPresent() && waitFor.defaultWaitStrategy().get()) {
+                container = container.waitingFor(Wait.defaultWaitStrategy());
+            }
+            if (waitFor.healthcheck().isPresent() && waitFor.healthcheck().get()) {
+                container = container.waitingFor(Wait.forHealthcheck());
+            }
+            if (waitFor.http().isPresent()) {
+                container = container.waitingFor(Wait.forHttp(waitFor.http().get()).forStatusCode(200));
+            }
+            if (waitFor.https().isPresent()) {
+                container = container.waitingFor(Wait.forHttps(waitFor.https().get()).forStatusCode(200));
+            }
+            if (waitFor.listeningPort().isPresent() && waitFor.listeningPort().get()) {
+                container = container.waitingFor(Wait.forListeningPort());
+            }
+            if (waitFor.listeningPorts().isPresent()) {
+                int[] a = Arrays.stream(waitFor.listeningPorts().get()).mapToInt(Integer::intValue).toArray();
+                container = container.waitingFor(Wait.forListeningPorts(a));
+            }
+            if (waitFor.logMessage().isPresent()) {
+                container = container.waitingFor(
+                        Wait.forLogMessage(waitFor.logMessage().get(), waitFor.logMessageTimes()));
+            }
+            if (waitFor.successfulCommand().isPresent()) {
+                container = container.waitingFor(Wait.forSuccessfulCommand(waitFor.successfulCommand().get()));
+            }
+
+            // Log
+            if (config.captureLog()) {
+                container = container.withLogConsumer(new JbossContainerLogConsumer(log).withPrefix(name));
+            }
+
+            container.start();
+
+            if (container.getPort() != null) {
+                String baseUrl = "http://" + container.getHost() + ":" + container.getPort();
+                props.put("quarkus.devservices." + name + ".url", baseUrl);
+            }
+            devServicesResultProducer
+                    .produce(new DevServicesResultBuildItem.RunningDevService(name, container.getContainerId(),
+                            container::close, props)
+                            .toBuildItem());
+        }
+    }
+
+    private String getAbsoluteHostPath(String hostPath) {
+        if (hostPath.startsWith("/")) {
+            return hostPath;
+        } else if (hostPath.startsWith("./")) {
+            hostPath = hostPath.substring(2);
+        }
+        String userDir = System.getProperty("user.dir");
+        return userDir + "/" + hostPath;
+
+    }
+
+    private static class AnyContainer extends GenericContainer<AnyContainer> {
+        final OptionalInt containerPort;
+        final boolean sharedNetwork;
+
+        public AnyContainer(DockerImageName image, OptionalInt containerPort, OptionalInt mappedPort,
+                boolean sharedNetwork) {
+            super(image);
+            this.containerPort = containerPort;
+            this.sharedNetwork = sharedNetwork;
+            if (this.containerPort.isPresent() && mappedPort.isPresent()) {
+                super.addFixedExposedPort(mappedPort.getAsInt(), this.containerPort.getAsInt());
+            }
+        }
+
+        @Override
+        protected void configure() {
+            if (this.sharedNetwork) {
+                withNetwork(Network.SHARED);
+            }
+            if (this.containerPort.isPresent()) {
+                addExposedPorts(containerPort.getAsInt());
+            }
+        }
+
+        public Integer getPort() {
+            if (this.containerPort.isPresent()) {
+                return this.getMappedPort(containerPort.getAsInt());
+            }
+            return null;
+        }
+    }
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/EnvValueConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/EnvValueConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface EnvValueConfig {
+
+    /**
+     * The value for the env var
+     */
+    Optional<String> value();
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/EnvVarsConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/EnvVarsConfig.java
@@ -1,0 +1,21 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigGroup
+public interface EnvVarsConfig {
+
+    /**
+     * env vars
+     */
+    @ConfigDocMapKey("vars")
+    @WithParentName
+    @WithDefaults
+    Map<String, EnvValueConfig> vars();
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/FileSystemBindConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/FileSystemBindConfig.java
@@ -1,0 +1,24 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Optional;
+
+import org.testcontainers.containers.BindMode;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface FileSystemBindConfig {
+
+    /**
+     * The value for the container path
+     */
+    Optional<String> containerPath();
+
+    /**
+     * The Bind mode of the volume
+     */
+    @WithDefault("READ_ONLY")
+    BindMode bindMode();
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/FileSystemBindsConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/FileSystemBindsConfig.java
@@ -1,0 +1,21 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigGroup
+public interface FileSystemBindsConfig {
+
+    /**
+     * File System Binds
+     */
+    @ConfigDocMapKey("host-path")
+    @WithParentName
+    @WithDefaults
+    Map<String, FileSystemBindConfig> fileSystemBind();
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/JbossContainerLogConsumer.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/JbossContainerLogConsumer.java
@@ -1,0 +1,86 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
+import org.testcontainers.containers.output.BaseConsumer;
+import org.testcontainers.containers.output.OutputFrame;
+
+public class JbossContainerLogConsumer extends BaseConsumer<JbossContainerLogConsumer> {
+
+    private final Logger logger;
+
+    private final Map<String, String> mdc = new HashMap<>();
+
+    private boolean separateOutputStreams;
+
+    private String prefix = "";
+
+    public JbossContainerLogConsumer(Logger logger) {
+        this(logger, false);
+    }
+
+    public JbossContainerLogConsumer(Logger logger, boolean separateOutputStreams) {
+        this.logger = logger;
+        this.separateOutputStreams = separateOutputStreams;
+    }
+
+    public JbossContainerLogConsumer withPrefix(String prefix) {
+        this.prefix = "[" + prefix + "] ";
+        return this;
+    }
+
+    public JbossContainerLogConsumer withMdc(String key, String value) {
+        mdc.put(key, value);
+        return this;
+    }
+
+    public JbossContainerLogConsumer withMdc(Map<String, String> mdc) {
+        this.mdc.putAll(mdc);
+        return this;
+    }
+
+    public JbossContainerLogConsumer withSeparateOutputStreams() {
+        this.separateOutputStreams = true;
+        return this;
+    }
+
+    @Override
+    public void accept(OutputFrame outputFrame) {
+        final OutputFrame.OutputType outputType = outputFrame.getType();
+        final String utf8String = outputFrame.getUtf8StringWithoutLineEnding();
+
+        final Map<String, Object> originalMdc = MDC.getMap();
+        MDC.clear();
+        MDC.getMap().putAll(mdc);
+        try {
+            switch (outputType) {
+                case END:
+                    break;
+                case STDOUT:
+                    if (separateOutputStreams) {
+                        logger.infof("%s%s", prefix.isEmpty() ? "" : (prefix + ": "), utf8String);
+                    } else {
+                        logger.infof("%s%s: %s", prefix, outputType, utf8String);
+                    }
+                    break;
+                case STDERR:
+                    if (separateOutputStreams) {
+                        logger.errorf("%s%s", prefix.isEmpty() ? "" : (prefix + ": "), utf8String);
+                    } else {
+                        logger.infof("%s%s: %s", prefix, outputType, utf8String);
+                    }
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unexpected outputType " + outputType);
+            }
+        } finally {
+            MDC.clear();
+            if (originalMdc != null) {
+                MDC.getMap().putAll(originalMdc);
+            }
+        }
+    }
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/LabelConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/LabelConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface LabelConfig {
+
+    /**
+     * The value for the label
+     */
+    Optional<String> value();
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/LabelsConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/LabelsConfig.java
@@ -1,0 +1,21 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigGroup
+public interface LabelsConfig {
+
+    /**
+     * labels
+     */
+    @ConfigDocMapKey("labels")
+    @WithParentName
+    @WithDefaults
+    Map<String, LabelConfig> labels();
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/WaitForConfig.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/any/WaitForConfig.java
@@ -1,0 +1,57 @@
+package io.quarkus.devservices.deployment.any;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface WaitForConfig {
+
+    /**
+     * defaultWaitStrategy
+     */
+    Optional<Boolean> defaultWaitStrategy();
+
+    /**
+     * forHealthcheck
+     */
+    Optional<Boolean> healthcheck();
+
+    /**
+     * forHttp
+     */
+    Optional<String> http();
+
+    /**
+     * forHttps
+     */
+    Optional<String> https();
+
+    /**
+     * forListeningPort
+     */
+    Optional<Boolean> listeningPort();
+
+    /**
+     * forListeningPorts
+     */
+    Optional<Integer[]> listeningPorts();
+
+    /**
+     * forLogMessage
+     */
+    Optional<String> logMessage();
+
+    /**
+     * forLogMessage times
+     */
+    @WithDefault("1")
+    int logMessageTimes();
+
+    /**
+     * forSuccessfulCommand
+     */
+    Optional<String> successfulCommand();
+
+}

--- a/extensions/devservices/pom.xml
+++ b/extensions/devservices/pom.xml
@@ -27,6 +27,7 @@
         <module>db2</module>
         <module>oracle</module>
         <module>common</module>
+        <module>runtime</module>
         <module>deployment</module>
     </modules>
 

--- a/extensions/devservices/runtime/pom.xml
+++ b/extensions/devservices/runtime/pom.xml
@@ -6,33 +6,30 @@
         <artifactId>quarkus-devservices-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-devservices-deployment</artifactId>
-    <name>Quarkus - DevServices - Deployment</name>
-
+    <artifactId>quarkus-devservices</artifactId>
+    <name>Quarkus - DevServices - Runtime</name>
+    
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devservices</artifactId>
-            <version>${project.version}</version>
+            <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devservices-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core-deployment</artifactId>
+            <artifactId>quarkus-core</artifactId>
         </dependency>
     </dependencies>
+    
     <build>
         <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
@@ -46,6 +43,9 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <compilerArgs>
+                                <arg>-AlegacyConfigRoot=true</arg>
+                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/devservices/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/devservices/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+name: Dev Services
+description: Any devservice via config
+metadata:
+  short-name: "DevServices"
+  keywords:
+  - dev services
+  categories:
+  - "miscellaneous"
+  status: "stable"
+  config:
+  - "quarkus.devservices."


### PR DESCRIPTION
This PR propose an enhanced Dev Services to also allow user defined services for any container image. This is useful when users have multiple microservices of their own that can now be started up by a Quarkus app that depends on it. 

Here is an example where I have an app with the following config to start up 3 dev services with my Quarkus app (nginx, httpd and hello-world):

```
# Any container
quarkus.devservices."nginx".image-name=nginx
quarkus.devservices."nginx".container-port=80
quarkus.devservices."nginx".mapped-port=7070
quarkus.devservices."nginx".capture-log=true
quarkus.devservices."nginx".classpath-resource-mappings."nginx.conf".container-path=/etc/nginx/nginx.conf
quarkus.devservices."nginx".file-system-bindings."/tmp/nginx".container-path=/usr/share/nginx/html
quarkus.devservices."nginx".label."by".value=Phillip Kruger
quarkus.devservices."nginx".wait-for.http=/

quarkus.devservices."httpd".image-name=httpd
quarkus.devservices."httpd".container-port=80

quarkus.devservices."hello-world".image-name=hello-world
```

The hello world and httpd is just there to test the minimal config needed and to test multiple user defined dev services.

If you look at the nginx config you can see this is a bit more configured, and actually serve static pages from /tmp/http. It also captures the log:

```
2024-08-16 20:58:25,022 INFO  [org.tes.DockerClientFactory] (build-31) Checking the system...
2024-08-16 20:58:25,022 INFO  [org.tes.DockerClientFactory] (build-31) ✔︎ Docker server version should be at least 1.6.0
2024-08-16 20:58:25,150 INFO  [tc.nginx:latest] (build-31) Creating container for image: nginx:latest
2024-08-16 20:58:25,516 WARN  [org.tes.con.ContainerDef] (build-31) Unable to mount a file from test host into a running container. This may be a misconfiguration or limitation of your Docker environment. Some features might not work.
2024-08-16 20:58:25,619 INFO  [tc.nginx:latest] (build-31) Container nginx:latest is starting: 4ea2432e1c040da40f72b64406d54fe7f3e45858552ad2e5b20c6dda0ea22e95
2024-08-16 20:58:25,664 INFO  [io.qua.dat.dep.dev.DevServicesDatasourceProcessor] (build-33) Dev Services for default datasource (postgresql) started - container ID is b5e085c43f7f
2024-08-16 20:58:25,778 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
2024-08-16 20:58:25,778 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
2024-08-16 20:58:25,779 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
2024-08-16 20:58:25,780 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
2024-08-16 20:58:25,780 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
2024-08-16 20:58:25,781 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
2024-08-16 20:58:25,782 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
2024-08-16 20:58:25,782 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
2024-08-16 20:58:25,783 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: /docker-entrypoint.sh: Configuration complete; ready for start up
2024-08-16 20:58:25,876 INFO  [org.tes.con.wai.str.HttpWaitStrategy] (build-31) /nifty_austin: Waiting for 60 seconds for URL: http://localhost:7070/ (where port 7070 maps to container port 80)
2024-08-16 20:58:25,882 INFO  [io.qua.dev.dep.any.DevServicesProcessor] (docker-java-stream--1341124604) [nginx] STDOUT: 10.89.24.2 - - [16/Aug/2024:10:58:25 +0000] "GET / HTTP/1.1" 200 305 "-" "Java/21.0.4"
2024-08-16 20:58:25,884 INFO  [tc.nginx:latest] (build-31) Container nginx:latest started in PT0.733859172S
2024-08-16 20:58:25,891 INFO  [tc.hello-world:latest] (build-31) Creating container for image: hello-world:latest
2024-08-16 20:58:25,919 INFO  [tc.hello-world:latest] (build-31) Container hello-world:latest is starting: 4f6c3b9e02b99482e1dce288ca061e00359cf967647e41d01a0bf2920c6a043a
2024-08-16 20:58:26,120 INFO  [tc.hello-world:latest] (build-31) Container hello-world:latest started in PT0.22915224S
2024-08-16 20:58:26,125 INFO  [tc.httpd:latest] (build-31) Creating container for image: httpd:latest
2024-08-16 20:58:26,152 INFO  [tc.httpd:latest] (build-31) Container httpd:latest is starting: 75ae69387255a606635d03430514a39923755f59607a3f7063ec281ef52c10ac
2024-08-16 20:58:26,445 INFO  [tc.httpd:latest] (build-31) Container httpd:latest started in PT0.319468388S
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2024-08-16 20:58:27,433 INFO  [io.und.websockets] (Quarkus Main Thread) UT026003: Adding annotated server endpoint class io.quarkus.sample.audit.AuditLogSocket for path /audit

2024-08-16 20:58:28,516 INFO  [io.quarkus] (Quarkus Main Thread) todo-backend 1.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 4.847s. Listening on: http://localhost:8080
2024-08-16 20:58:28,518 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
2024-08-16 20:58:28,518 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [agroal, cdi, hibernate-orm, hibernate-orm-panache, hibernate-validator, jdbc-postgresql, narayana-jta, rest, rest-jsonb, smallrye-context-propagation, smallrye-graphql, smallrye-health, smallrye-metrics, smallrye-openapi, swagger-ui, vertx, web-dependency-locator, websockets, websockets-client]
```

![nginx](https://github.com/user-attachments/assets/324b2f7a-c946-400a-9134-80fe6a6fba34)

The user defined dev services will also show up in Dev UI:

![any_dev_services](https://github.com/user-attachments/assets/e3aa3afa-6158-428a-b63f-f25abe78b9ef)

For a user to use this, just add :

```
<dependency>
          <groupId>io.quarkus</groupId>
          <artifactId>quarkus-devservices</artifactId>
</dependency>
```
