### PR TITLE
Use the root path for OpenContainerPathTree#getRoots()

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
@@ -93,7 +93,7 @@ public abstract class OpenContainerPathTree extends PathTreeWithManifest impleme
 
     @Override
     public Collection<Path> getRoots() {
-        return List.of(getContainerPath());
+        return List.of(getRootPath());
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
@@ -83,8 +83,7 @@ public interface PathTree {
     /**
      * The roots of the path tree.
      * <p>
-     * Note that for archives, it will return the path to the archive itself,
-     * not a path that you can browse.
+     * Note that you shouldn't use these roots for browsing except if the PathTree is open.
      *
      * @return roots of the path tree
      */


### PR DESCRIPTION
The container path is the path of the container (could be a directory or an archive and shouldn't be used for browsing.
The root path is the path of the root. In the case of an archive, it's actually a ZipPath, which can be used to browse the archive.

Fixes #42571
Follows up #42492