### PR TITLE
Codestart modularize Dockerfiles

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-copy.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-copy.include.qute
@@ -1,0 +1,11 @@
+
+{#if type == 'jvm'}
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=185 {buildtool.build-dir}/quarkus-app/lib/ /deployments/lib/
+COPY --chown=185 {buildtool.build-dir}/quarkus-app/*.jar /deployments/
+COPY --chown=185 {buildtool.build-dir}/quarkus-app/app/ /deployments/app/
+COPY --chown=185 {buildtool.build-dir}/quarkus-app/quarkus/ /deployments/quarkus/
+{#else}
+COPY {buildtool.build-dir}/lib/* /deployments/lib/
+COPY {buildtool.build-dir}/*-runner.jar /deployments/quarkus-run.jar
+{/if}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-entrypoint.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-entrypoint.include.qute
@@ -1,0 +1,2 @@
+
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-env.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-env.include.qute
@@ -1,0 +1,11 @@
+
+
+ENV LANGUAGE='en_US:en'
+
+EXPOSE 8080
+USER 185
+{#if java.version == '11'}
+ENV AB_JOLOKIA_OFF=""
+{/if}
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-from.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-from.include.qute
@@ -1,0 +1,5 @@
+{#if dockerfile.jvm.from}
+FROM {dockerfile.jvm.from}
+{#else}
+FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.20
+{/if}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-header.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-jar-header.include.qute
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# {#insert quarkusbuild /}
+# {buildtool.cli} {cmd}
 #
 # Then, build the image with:
 #
@@ -77,22 +77,3 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-{#if dockerfile.jvm.from}
-FROM {dockerfile.jvm.from}
-{#else}
-FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.20
-{/if}
-
-ENV LANGUAGE='en_US:en'
-
-{#insert copy /}
-
-EXPOSE 8080
-USER 185
-{#if java.version == '11'}
-ENV AB_JOLOKIA_OFF=""
-{/if}
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
-
-ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-native-body.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-native-body.include.qute
@@ -1,0 +1,12 @@
+
+
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root {buildtool.build-dir}/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-native-from.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-native-from.include.qute
@@ -1,0 +1,1 @@
+FROM {image}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-native-header.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-native-header.include.qute
@@ -1,0 +1,21 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
+{#if type == 'native-micro'}
+# It uses a micro base image, tuned for Quarkus native executables.
+# It reduces the size of the resulting container image.
+# Check https://quarkus.io/guides/quarkus-runtime-base-image for further information about this image.
+{/if}
+#
+# Before building the container image run:
+#
+# {buildtool.cli} {buildtool.cmd.package-native}
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.{type} -t quarkus/{project.artifact-id} .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}
+#
+###

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.jvm
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.jvm
@@ -1,11 +1,6 @@
-{#include Dockerfile-layout type='jvm'}
-    {#quarkusbuild}{buildtool.cli} {buildtool.cmd.package}{/quarkusbuild}
-    {#copy}
-# We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=185 {buildtool.build-dir}/quarkus-app/lib/ /deployments/lib/
-COPY --chown=185 {buildtool.build-dir}/quarkus-app/*.jar /deployments/
-COPY --chown=185 {buildtool.build-dir}/quarkus-app/app/ /deployments/app/
-COPY --chown=185 {buildtool.build-dir}/quarkus-app/quarkus/ /deployments/quarkus/
-    {/copy}
-{/include}
+{#include Dockerfile-jar-header type='jvm' cmd=buildtool.cmd.package /}
+{#include Dockerfile-jar-from /}
+{#include Dockerfile-jar-env /}
+{#include Dockerfile-jar-copy type='jvm' /}
+{#include Dockerfile-jar-entrypoint /}
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.legacy-jar
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.legacy-jar
@@ -1,7 +1,5 @@
-{#include Dockerfile-layout type='legacy-jar'}
-    {#quarkusbuild}{buildtool.cli} {buildtool.cmd.package-legacy-jar}{/quarkusbuild}
-    {#copy}
-COPY {buildtool.build-dir}/lib/* /deployments/lib/
-COPY {buildtool.build-dir}/*-runner.jar /deployments/quarkus-run.jar
-    {/copy}
-{/include}
+{#include Dockerfile-jar-header type='legacy-jar' cmd=buildtool.cmd.package-legacy-jar /}
+{#include Dockerfile-jar-from /}
+{#include Dockerfile-jar-env /}
+{#include Dockerfile-jar-copy type='legacy-jar' /}
+{#include Dockerfile-jar-entrypoint /}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native
@@ -1,27 +1,4 @@
-####
-# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
-#
-# Before building the container image run:
-#
-# {buildtool.cli} {buildtool.cmd.package-native}
-#
-# Then, build the image with:
-#
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/{project.artifact-id} .
-#
-# Then run the container using:
-#
-# docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}
-#
-###
-FROM {dockerfile.native.from}
-WORKDIR /work/
-RUN chown 1001 /work \
-    && chmod "g+rwX" /work \
-    && chown 1001:root /work
-COPY --chown=1001:root {buildtool.build-dir}/*-runner /work/application
+{#include Dockerfile-native-header type='native' /}
+{#include Dockerfile-native-from image=dockerfile.native.from /}
+{#include Dockerfile-native-body /}
 
-EXPOSE 8080
-USER 1001
-
-ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-micro
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-micro
@@ -1,30 +1,3 @@
-####
-# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
-# It uses a micro base image, tuned for Quarkus native executables.
-# It reduces the size of the resulting container image.
-# Check https://quarkus.io/guides/quarkus-runtime-base-image for further information about this image.
-#
-# Before building the container image run:
-#
-# {buildtool.cli} {buildtool.cmd.package-native}
-#
-# Then, build the image with:
-#
-# docker build -f src/main/docker/Dockerfile.native-micro -t quarkus/{project.artifact-id} .
-#
-# Then run the container using:
-#
-# docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}
-#
-###
-FROM {dockerfile.native-micro.from}
-WORKDIR /work/
-RUN chown 1001 /work \
-    && chmod "g+rwX" /work \
-    && chown 1001:root /work
-COPY --chown=1001:root {buildtool.build-dir}/*-runner /work/application
-
-EXPOSE 8080
-USER 1001
-
-ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
+{#include Dockerfile-native-header type='native-micro' /}
+{#include Dockerfile-native-from image=dockerfile.native-micro.from /}
+{#include Dockerfile-native-body /}


### PR DESCRIPTION
Modularize Dockerfiles so that custom base codestarts can override specific parts, without having to override the entire resource.
for instance if we want to change just the `FROM` for jvm, we do not have to replace the entire `Dockerfile-layout.include.qute`. doing so would prevent us to pick up changes in other parts we are not interested in (for instance the header) as the quarkus core project moves on.

see this [zulip discussion](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/custom.20create.20app.20scaffolding/near/462772206)