### PR TITLE
Downgrade commons-lang3 to 3.14.0 to avoid entropy issues

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -94,7 +94,7 @@
         <gizmo.version>1.8.0</gizmo.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <commons-lang3.version>3.16.0</commons-lang3.version>
+        <commons-lang3.version>3.14.0</commons-lang3.version>
         <commons-codec.version>1.17.1</commons-codec.version>
         <classmate.version>1.7.0</classmate.version>
         <!-- See root POM for hibernate-orm.version, hibernate-reactive.version, hibernate-validator.version,


### PR DESCRIPTION
Details: https://github.com/quarkusio/quarkus/pull/41962#issuecomment-2293614340

Draft until it's clear whether or not this is the right way to go for now.
If not, then there should at least be a hint in the migration guide (I think).