### PR TITLE
Fix augmentors called multiple times for each identity provider

### DIFF
--- a/extensions/security/runtime/pom.xml
+++ b/extensions/security/runtime/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusIdentityProviderManagerImpl.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusIdentityProviderManagerImpl.java
@@ -127,6 +127,9 @@ public class QuarkusIdentityProviderManagerImpl implements IdentityProviderManag
                         return handleProvider(pos + 1, providers, request);
                     }
                 });
+        if (pos > 0) {
+            return cs;
+        }
         return cs.onItem().transformToUni(new Function<SecurityIdentity, Uni<? extends SecurityIdentity>>() {
             @Override
             public Uni<? extends SecurityIdentity> apply(SecurityIdentity securityIdentity) {


### PR DESCRIPTION
Fixes #42600.

When multiple `IdentityProvider` are present and they return a `nullitem`  the SecurityIdentityAugmentors will be called once per IdentityProvider  that where called.

It is caused by the Uni transforming the SecurityIdentity for each called `IdentityProvider`.