### PR TITLE
DevUI: Allow regex for defined allowed hosts

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
@@ -26,6 +26,7 @@ public class DevUIConfig {
      * More hosts allowed for Dev UI
      *
      * Comma separated list of valid URLs, e.g.: www.quarkus.io, myhost.com
+     * (This can also be a regex)
      * By default localhost and 127.0.0.1 will always be allowed
      */
     @ConfigItem


### PR DESCRIPTION
Fix comment in https://github.com/quarkusio/quarkus/pull/40979#issuecomment-2293669897

@slallemand please can you test if this solve your issue. 

Here is an example usage. Let's say you want to match all subdomains in foo.bar (so http://*.foo.bar) you will use `^([a-zA-Z0-9-]+\.)*foo\.bar(/.*)?$`

Let me know