### PR TITLE
Include the run attempt in the build-reports file name

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -221,7 +221,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-Initial JDK 17 Build"
+          name: "build-reports-${{ github.run_attempt }}-Initial JDK 17 Build"
           path: |
             build-reports.zip
           retention-days: 7
@@ -413,7 +413,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-JVM Tests - JDK ${{matrix.java.name}}"
+          name: "build-reports-${{ github.run_attempt }}-JVM Tests - JDK ${{matrix.java.name}}"
           path: |
             build-reports.zip
           retention-days: 7
@@ -525,7 +525,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-Maven Tests - JDK ${{matrix.java.name}}"
+          name: "build-reports-${{ github.run_attempt }}-Maven Tests - JDK ${{matrix.java.name}}"
           path: |
             build-reports.zip
           retention-days: 7
@@ -613,7 +613,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-Gradle Tests - JDK ${{matrix.java.name}}"
+          name: "build-reports-${{ github.run_attempt }}-Gradle Tests - JDK ${{matrix.java.name}}"
           path: |
             build-reports.zip
           retention-days: 7
@@ -707,7 +707,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-Devtools Tests - JDK ${{matrix.java.name}}"
+          name: "build-reports-${{ github.run_attempt }}-Devtools Tests - JDK ${{matrix.java.name}}"
           path: |
             build-reports.zip
           retention-days: 7
@@ -801,7 +801,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-Kubernetes Tests - JDK ${{matrix.java.name}}"
+          name: "build-reports-${{ github.run_attempt }}-Kubernetes Tests - JDK ${{matrix.java.name}}"
           path: |
             build-reports.zip
           retention-days: 7
@@ -887,7 +887,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-Quickstarts Compilation - JDK ${{matrix.java.name}}"
+          name: "build-reports-${{ github.run_attempt }}-Quickstarts Compilation - JDK ${{matrix.java.name}}"
           path: |
             build-reports.zip
           retention-days: 7
@@ -962,7 +962,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-Virtual Thread Support Tests Native - ${{matrix.category}}"
+          name: "build-reports-${{ github.run_attempt }}-Virtual Thread Support Tests Native - ${{matrix.category}}"
           path: |
             build-reports.zip
           retention-days: 7
@@ -1045,7 +1045,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-MicroProfile TCKs Tests"
+          name: "build-reports-${{ github.run_attempt }}-MicroProfile TCKs Tests"
           path: |
             build-reports.zip
           retention-days: 7
@@ -1161,7 +1161,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "build-reports-Native Tests - ${{matrix.category}}"
+          name: "build-reports-${{ github.run_attempt }}-Native Tests - ${{matrix.category}}"
           path: |
             build-reports.zip
           retention-days: 7


### PR DESCRIPTION
When we have multiple attempts of a given workflow run (for instance, when we manually rerun it), only the first build-reports artifacts are saved as artifacts are immutable.

Thus we keep generating the report based on the artifacts of the first run, which is incorrect and confusing.

This should be backported to all supported branches as handling the transition is not exactly easy.

Will merge it myself as I need to coordinate the merge with a deployment of the new build reporter in the bot and the action.