### PR TITLE
Bump `quarkiverse-parent` from 16 to 17

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
@@ -86,7 +86,7 @@ public class CreateExtension {
 
     public static final String DEFAULT_QUARKIVERSE_PARENT_GROUP_ID = "io.quarkiverse";
     public static final String DEFAULT_QUARKIVERSE_PARENT_ARTIFACT_ID = "quarkiverse-parent";
-    public static final String DEFAULT_QUARKIVERSE_PARENT_VERSION = "16";
+    public static final String DEFAULT_QUARKIVERSE_PARENT_VERSION = "17";
     public static final String DEFAULT_QUARKIVERSE_NAMESPACE_ID = "quarkus-";
     public static final String DEFAULT_QUARKIVERSE_GUIDE_URL = "https://quarkiverse.github.io/quarkiverse-docs/%s/dev/";
 

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse</groupId>
         <artifactId>quarkiverse-parent</artifactId>
-        <version>16</version>
+        <version>17</version>
     </parent>
     <groupId>io.quarkiverse.my-quarkiverse-ext</groupId>
     <artifactId>quarkus-my-quarkiverse-ext-parent</artifactId>


### PR DESCRIPTION
## What's Changed
* Bump org.asciidoctor:asciidoctor-maven-plugin from 2.2.5 to 2.2.6 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/130
* Bump org.asciidoctor:asciidoctor-maven-plugin from 2.2.6 to 3.0.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/131
* Bump org.apache.maven.plugins:maven-gpg-plugin from 3.1.0 to 3.2.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/132
* Bump org.asciidoctor:asciidoctorj from 2.5.11 to 2.5.12 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/133
* Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.0 to 3.2.1 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/134
* Bump org.apache.maven.plugins:maven-compiler-plugin from 3.12.1 to 3.13.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/135
* Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.1 to 3.2.2 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/136
* Bump org.apache.maven.plugins:maven-source-plugin from 3.3.0 to 3.3.1 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/137
* Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.2 to 3.2.3 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/138
* Bump org.apache.maven.plugins:maven-jar-plugin from 3.3.0 to 3.4.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/139
* Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.3 to 3.2.4 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/140
* Bump org.apache.maven.plugins:maven-jar-plugin from 3.4.0 to 3.4.1 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/141
* Bump org.apache.maven.plugins:maven-deploy-plugin from 3.1.1 to 3.1.2 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/142
* Bump org.asciidoctor:asciidoctorj from 2.5.12 to 2.5.13 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/144
* Bump org.codehaus.mojo:build-helper-maven-plugin from 3.5.0 to 3.6.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/143
* Bump org.sonatype.plugins:nexus-staging-maven-plugin from 1.6.13 to 1.7.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/145
* Bump net.revelc.code:impsort-maven-plugin from 1.9.0 to 1.10.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/146
* Bump net.revelc.code.formatter:formatter-maven-plugin from 2.23.0 to 2.24.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/147
* Bump org.apache.maven.plugins:maven-enforcer-plugin from 3.4.1 to 3.5.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/148
* Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.6.3 to 3.7.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/149
* Revert "Bump net.revelc.code.formatter:formatter-maven-plugin from 2.23.0 to 2.24.0" by @gastaldi in https://github.com/quarkiverse/quarkiverse-parent/pull/150
* Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.5 to 3.3.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/152
* Bump org.apache.maven.plugins:maven-failsafe-plugin from 3.2.5 to 3.3.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/153
* Bump org.apache.maven.plugins:maven-release-plugin from 3.0.1 to 3.1.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/155
* Bump org.apache.maven.plugins:maven-clean-plugin from 3.3.2 to 3.4.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/156
* Bump org.apache.maven.plugins:maven-jar-plugin from 3.4.1 to 3.4.2 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/157
* Bump net.revelc.code:impsort-maven-plugin from 1.10.0 to 1.11.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/158
* Bump org.apache.maven.plugins:maven-failsafe-plugin from 3.3.0 to 3.3.1 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/159
* Bump org.apache.maven.plugins:maven-surefire-plugin from 3.3.0 to 3.3.1 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/160
* Bump org.apache.maven.plugins:maven-release-plugin from 3.1.0 to 3.1.1 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/161
* Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.7.0 to 3.8.0 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/162
* Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.4 to 3.2.5 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/163
* Bump net.revelc.code.formatter:formatter-maven-plugin from 2.23.0 to 2.24.1 by @dependabot in https://github.com/quarkiverse/quarkiverse-parent/pull/164
* Release 17 by @gastaldi in https://github.com/quarkiverse/quarkiverse-parent/pull/154


**Full Changelog**: https://github.com/quarkiverse/quarkiverse-parent/compare/16...17