### PR TITLE
Condition the new config doc sections of the extension template

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/pom.tpl.qute.xml
@@ -55,6 +55,7 @@
                     </execution>
                 </executions>
             </plugin>
+            {#if quarkus.version.or(quarkus.bom.version).compareVersionTo("3.14") >= 0}
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-config-doc-maven-plugin</artifactId>
@@ -63,6 +64,7 @@
                     <targetDirectory>$\{project.basedir}/modules/ROOT/pages/includes/</targetDirectory>
                 </configuration>
             </plugin>
+            {/if}
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
@@ -75,6 +77,13 @@
                         <configuration>
                             <outputDirectory>$\{project.basedir}/modules/ROOT/pages/includes/</outputDirectory>
                             <resources>
+                                {#if quarkus.version.or(quarkus.bom.version).compareVersionTo("3.14") < 0}
+                                <resource>
+                                    <directory>$\{project.basedir}/../target/asciidoc/generated/config/</directory>
+                                    <include>{namespace.id}{extension.id}.adoc</include>
+                                    <filtering>false</filtering>
+                                </resource>
+                                {/if}
                                 <resource>
                                     <directory>$\{project.basedir}/templates/includes</directory>
                                     <include>attributes.adoc</include>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/pom.tpl.qute.xml
@@ -8,6 +8,7 @@
         <developerConnection>scm:git:git@github.com:quarkiverse/quarkus-{extension.id}.git</developerConnection>
         <url>https://github.com/quarkiverse/quarkus-{extension.id}</url>
     </scm>
+    {#if quarkus.version.or(quarkus.bom.version).compareVersionTo("3.14") >= 0}
     <build>
         <pluginManagement>
             <plugins>
@@ -19,6 +20,7 @@
             </plugins>
         </pluginManagement>
     </build>
+    {/if}
     <profiles>
         <profile>
             <id>it</id>

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateExtensionMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateExtensionMojoIT.java
@@ -93,7 +93,7 @@ public class CreateExtensionMojoIT extends QuarkusPlatformAwareMojoTestBase {
         Properties properties = new Properties();
         properties.put("groupId", "io.quarkiverse.my-quarkiverse-ext");
         properties.put("extensionId", "my-quarkiverse-ext");
-        properties.put("quarkusVersion", "2.10.5.Final");
+        properties.put("quarkusVersion", "3.14.0");
         properties.put("extensionName", "My Quarkiverse extension");
         properties.put("extensionDescription", "My Quarkiverse extension description");
         properties.put("withCodestart", "true");
@@ -136,7 +136,7 @@ public class CreateExtensionMojoIT extends QuarkusPlatformAwareMojoTestBase {
         properties.put("groupId", "io.standalone");
         properties.put("extensionId", "my-own-ext");
         properties.put("namespaceId", "my-org-");
-        properties.put("quarkusVersion", "2.10.5.Final");
+        properties.put("quarkusVersion", "3.14.0");
         InvocationResult result = setup(properties);
 
         assertThat(result.getExitCode()).isZero();

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>2.10.5.Final</quarkus.version>
+        <quarkus.version>3.14.0</quarkus.version>
     </properties>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateStandaloneExtension/my-org-my-own-ext_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateStandaloneExtension/my-org-my-own-ext_pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>2.10.5.Final</quarkus.version>
+        <quarkus.version>3.14.0</quarkus.version>
         <surefire-plugin.version>3.3.1</surefire-plugin.version>
     </properties>
 


### PR DESCRIPTION
When creating projects or extensions, the codestarts from the tooling version are always used even for older versions so we need to be careful about it.

Fixes #42649