### PR TITLE
Bump Micrometer to 1.13

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -36,8 +36,8 @@
         <opentelemetry-alpha.version>2.5.0-alpha</opentelemetry-alpha.version>
         <opentelemetry-semconv.version>1.25.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>5.3.1</quarkus-http.version>
-        <micrometer.version>1.12.5</micrometer.version><!-- keep in sync with hdrhistogram -->
-        <hdrhistogram.version>2.1.12</hdrhistogram.version><!-- keep in sync with micrometer -->
+        <micrometer.version>1.13.3</micrometer.version><!-- keep in sync with hdrhistogram -->
+        <hdrhistogram.version>2.2.2</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>
         <graphql-java.version>22.1</graphql-java.version> <!-- keep in sync with smallrye-graphql -->
         <microprofile-config-api.version>3.1</microprofile-config-api.version>

--- a/docs/src/main/asciidoc/telemetry-micrometer-tutorial.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-tutorial.adoc
@@ -40,6 +40,8 @@ include::{includes}/devtools/create-app.adoc[]
 This command generates a Maven project, that imports the `micrometer-registry-prometheus` extension as a dependency.
 This extension will load the core `micrometer` extension as well as additional library dependencies required to support prometheus.
 
+NOTE: To maintain backwards compatibility, the extension uses the Prometheus client v0.x from Micrometer 1.13+, instead of their default v1.x client.
+
 == Create a REST endpoint
 
 Let's first add a simple endpoint that calculates prime numbers.

--- a/extensions/micrometer-registry-prometheus/deployment/pom.xml
+++ b/extensions/micrometer-registry-prometheus/deployment/pom.xml
@@ -27,7 +27,7 @@
 
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
         </dependency>
 
     </dependencies>

--- a/extensions/micrometer-registry-prometheus/runtime/pom.xml
+++ b/extensions/micrometer-registry-prometheus/runtime/pom.xml
@@ -32,7 +32,7 @@
 
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
         </dependency>
 
     </dependencies>

--- a/extensions/micrometer/deployment/pom.xml
+++ b/extensions/micrometer/deployment/pom.xml
@@ -63,7 +63,7 @@
 
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -37,6 +37,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.metrics.MetricsFactoryConsumerBuildItem;
@@ -207,8 +208,18 @@ public class MicrometerProcessor {
             MicrometerConfig config,
             List<MicrometerRegistryProviderBuildItem> providerClassItems,
             List<MetricsFactoryConsumerBuildItem> metricsFactoryConsumerBuildItems,
-            List<MicrometerRegistryProviderBuildItem> providerClasses,
-            ShutdownContextBuildItem shutdownContextBuildItem) {
+            ShutdownContextBuildItem shutdownContextBuildItem,
+            BuildProducer<SystemPropertyBuildItem> systemProperty) {
+
+        // Avoid users from receiving:
+        // [io.mic.cor.ins.com.CompositeMeterRegistry] (main) A MeterFilter is being configured after a Meter has been
+        // registered to this registry...
+        // It's unavoidable because of how Quarkus startup works and users cannot do anything about it.
+        // see: https://github.com/micrometer-metrics/micrometer/issues/4920#issuecomment-2298348202
+        systemProperty.produce(
+                new SystemPropertyBuildItem(
+                        "quarkus.log.category.\"io.micrometer.core.instrument.composite.CompositeMeterRegistry\".level",
+                        "ERROR"));
 
         Set<Class<? extends MeterRegistry>> typeClasses = new HashSet<>();
         for (MicrometerRegistryProviderBuildItem item : providerClassItems) {

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
@@ -14,7 +14,9 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,12 +24,13 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
 import io.micrometer.core.instrument.binder.netty4.NettyEventExecutorMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.EventLoopGroup;
@@ -53,8 +56,17 @@ public class NettyMetricsTest {
     @Any
     Instance<MeterBinder> binders;
 
-    @Inject
-    MeterRegistry registry;
+    final static SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeAll
+    static void setRegistry() {
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll()
+    static void removeRegistry() {
+        Metrics.removeRegistry(registry);
+    }
 
     @Inject
     Vertx vertx;

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RedisClientMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RedisClientMetricsTest.java
@@ -6,15 +6,18 @@ import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.test.QuarkusUnitTest;
 import io.vertx.redis.client.Command;
@@ -27,14 +30,23 @@ public class RedisClientMetricsTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest();
 
+    final static SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeAll
+    static void setRegistry() {
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll()
+    static void removeRegistry() {
+        Metrics.removeRegistry(registry);
+    }
+
     @Inject
     RedisDataSource ds;
 
     @Inject
     Redis redis;
-
-    @Inject
-    MeterRegistry registry;
 
     @Test
     void testCommands() {

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsLoadBalancerFailTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsLoadBalancerFailTest.java
@@ -8,6 +8,8 @@ import java.util.concurrent.TimeUnit;
 import jakarta.inject.Inject;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -15,9 +17,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.micrometer.runtime.binder.stork.StorkObservationCollectorBean;
 import io.quarkus.micrometer.test.GreetingResource;
 import io.quarkus.micrometer.test.MockServiceSelectorConfiguration;
@@ -50,8 +53,17 @@ public class StorkMetricsLoadBalancerFailTest {
                             MockServiceSelectorProviderLoader.class, GreetingResource.class,
                             GreetingResource.GreetingRestClient.class, Util.class));
 
-    @Inject
-    MeterRegistry registry;
+    final static SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeAll
+    static void setRegistry() {
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll()
+    static void removeRegistry() {
+        Metrics.removeRegistry(registry);
+    }
 
     @Inject
     MockServiceSelectorProvider provider;
@@ -91,15 +103,25 @@ public class StorkMetricsLoadBalancerFailTest {
     }
 
     private void assertStorkMetricsInMicrometerRegistry(String serviceName) {
-        Counter instanceCounter = registry.counter("stork.service-discovery.instances.count", "service-name", serviceName);
-        Timer serviceDiscoveryDuration = registry.timer("stork.service-discovery.duration", "service-name", serviceName);
-        Timer serviceSelectionDuration = registry.timer("stork.service-selection.duration", "service-name", serviceName);
-        Counter serviceDiscoveryFailures = registry.counter("stork.service-discovery.failures", "service-name", serviceName);
-        Counter loadBalancerFailures = registry.counter("stork.service-selection.failures", "service-name", serviceName);
+        Counter instanceCounter = registry.find("stork.service-discovery.instances.count").tag("service-name", serviceName)
+                .counter();
+        Timer serviceDiscoveryDuration = registry.find("stork.service-discovery.duration").tag("service-name", serviceName)
+                .timer();
+        Timer serviceSelectionDuration = registry.find("stork.service-selection.duration").tag("service-name", serviceName)
+                .timer();
+        Counter serviceDiscoveryFailures = registry.find("stork.service-discovery.failures").tag("service-name", serviceName)
+                .counter();
+        Counter loadBalancerFailures = registry.find("stork.service-selection.failures").tag("service-name", serviceName)
+                .counter();
 
         Util.assertTags(Tag.of("service-name", serviceName), instanceCounter, serviceDiscoveryDuration,
                 serviceSelectionDuration);
 
+        Assertions.assertThat(instanceCounter).isNotNull();
+        Assertions.assertThat(serviceDiscoveryDuration).isNotNull();
+        Assertions.assertThat(serviceSelectionDuration).isNotNull();
+        Assertions.assertThat(serviceDiscoveryFailures).isNotNull();
+        Assertions.assertThat(loadBalancerFailures).isNotNull();
         Assertions.assertThat(instanceCounter.count()).isEqualTo(1);
         Assertions.assertThat(loadBalancerFailures.count()).isEqualTo(1);
         Assertions.assertThat(serviceDiscoveryFailures.count()).isEqualTo(0);

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsServiceDiscoveryFailTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsServiceDiscoveryFailTest.java
@@ -2,13 +2,14 @@
 package io.quarkus.micrometer.deployment.binder;
 
 import static io.restassured.RestAssured.when;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -16,9 +17,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.micrometer.runtime.binder.stork.StorkObservationCollectorBean;
 import io.quarkus.micrometer.test.GreetingResource;
 import io.quarkus.micrometer.test.MockServiceDiscoveryConfiguration;
@@ -48,8 +50,17 @@ public class StorkMetricsServiceDiscoveryFailTest {
                             MockServiceDiscoveryProviderLoader.class, GreetingResource.class,
                             GreetingResource.GreetingRestClient.class, Util.class));
 
-    @Inject
-    MeterRegistry registry;
+    final static SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeAll
+    static void setRegistry() {
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll()
+    static void removeRegistry() {
+        Metrics.removeRegistry(registry);
+    }
 
     @Inject
     MockServiceDiscoveryProvider provider;
@@ -73,15 +84,25 @@ public class StorkMetricsServiceDiscoveryFailTest {
     }
 
     private void assertStorkMetricsInMicrometerRegistry(String serviceName) {
-        Counter instanceCounter = registry.counter("stork.service-discovery.instances.count", "service-name", serviceName);
-        Timer serviceDiscoveryDuration = registry.timer("stork.service-discovery.duration", "service-name", serviceName);
-        Timer serviceSelectionDuration = registry.timer("stork.service-selection.duration", "service-name", serviceName);
-        Counter serviceDiscoveryFailures = registry.counter("stork.service-discovery.failures", "service-name", serviceName);
-        Counter loadBalancerFailures = registry.counter("stork.service-selection.failures", "service-name", serviceName);
+        Counter instanceCounter = registry.find("stork.service-discovery.instances.count").tags("service-name", serviceName)
+                .counter();
+        Timer serviceDiscoveryDuration = registry.find("stork.service-discovery.duration").tags("service-name", serviceName)
+                .timer();
+        Timer serviceSelectionDuration = registry.find("stork.service-selection.duration").tags("service-name", serviceName)
+                .timer();
+        Counter serviceDiscoveryFailures = registry.find("stork.service-discovery.failures").tags("service-name", serviceName)
+                .counter();
+        Counter loadBalancerFailures = registry.find("stork.service-selection.failures").tags("service-name", serviceName)
+                .counter();
 
         Util.assertTags(Tag.of("service-name", serviceName), instanceCounter, serviceDiscoveryDuration,
                 serviceSelectionDuration);
 
+        Assertions.assertThat(instanceCounter).isNotNull();
+        Assertions.assertThat(serviceDiscoveryDuration).isNotNull();
+        Assertions.assertThat(serviceSelectionDuration).isNotNull();
+        Assertions.assertThat(serviceDiscoveryFailures).isNotNull();
+        Assertions.assertThat(loadBalancerFailures).isNotNull();
         Assertions.assertThat(instanceCounter.count()).isEqualTo(0);
         Assertions.assertThat(loadBalancerFailures.count()).isEqualTo(0);
         Assertions.assertThat(serviceDiscoveryFailures.count()).isEqualTo(1);

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/StorkMetricsTest.java
@@ -5,18 +5,19 @@ import static io.restassured.RestAssured.when;
 
 import java.util.concurrent.TimeUnit;
 
-import jakarta.inject.Inject;
-
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.micrometer.runtime.binder.stork.StorkObservationCollectorBean;
 import io.quarkus.micrometer.test.GreetingResource;
 import io.quarkus.micrometer.test.PingPongResource;
@@ -37,15 +38,25 @@ public class StorkMetricsTest {
             .overrideConfigKey("quarkus.stork.greeting-service.service-discovery.type", "static")
             .overrideConfigKey("quarkus.stork.greeting-service.service-discovery.address-list", "${test.url}")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.log.category.\"io.micrometer.core.instrument\".level", "DEBUG")
             .withApplicationRoot((jar) -> jar
                     .addClasses(PingPongResource.class, PingPongResource.PingPongRestClient.class, GreetingResource.class,
                             GreetingResource.GreetingRestClient.class, Util.class));
 
-    @Inject
-    MeterRegistry registry;
+    final static SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeAll
+    static void setRegistry() {
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll()
+    static void removeRegistry() {
+        Metrics.removeRegistry(registry);
+    }
 
     @Test
-    public void shouldGetStorkMetricsForTwoServicesWhenEverythingSucceded() {
+    public void shouldGetStorkMetricsForTwoServicesWhenEverythingSucceeded() {
         when().get("/ping/one").then().statusCode(200);
         when().get("greeting/hola").then().statusCode(200);
 
@@ -61,15 +72,25 @@ public class StorkMetricsTest {
 
     private void assertStorkMetricsInMicrometerRegistry(String serviceName) {
 
-        Counter instanceCounter = registry.counter("stork.service-discovery.instances.count", "service-name", serviceName);
-        Timer serviceDiscoveryDuration = registry.timer("stork.service-discovery.duration", "service-name", serviceName);
-        Timer serviceSelectionDuration = registry.timer("stork.service-selection.duration", "service-name", serviceName);
-        Counter serviceDiscoveryFailures = registry.counter("stork.service-discovery.failures", "service-name", serviceName);
-        Counter loadBalancerFailures = registry.counter("stork.service-selection.failures", "service-name", serviceName);
+        Counter instanceCounter = registry.find("stork.service-discovery.instances.count").tags("service-name", serviceName)
+                .counter();
+        Timer serviceDiscoveryDuration = registry.find("stork.service-discovery.duration").tags("service-name", serviceName)
+                .timer();
+        Timer serviceSelectionDuration = registry.find("stork.service-selection.duration").tags("service-name", serviceName)
+                .timer();
+        Counter serviceDiscoveryFailures = registry.find("stork.service-discovery.failures").tags("service-name", serviceName)
+                .counter();
+        Counter loadBalancerFailures = registry.find("stork.service-selection.failures").tags("service-name", serviceName)
+                .counter();
 
         Util.assertTags(Tag.of("service-name", serviceName), instanceCounter, serviceDiscoveryDuration,
                 serviceSelectionDuration);
 
+        Assertions.assertThat(instanceCounter).isNotNull();
+        Assertions.assertThat(serviceDiscoveryDuration).isNotNull();
+        Assertions.assertThat(serviceSelectionDuration).isNotNull();
+        Assertions.assertThat(serviceDiscoveryFailures).isNotNull();
+        Assertions.assertThat(loadBalancerFailures).isNotNull();
         Assertions.assertThat(instanceCounter.count()).isEqualTo(1);
         Assertions.assertThat(serviceDiscoveryDuration.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
         Assertions.assertThat(serviceSelectionDuration.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxEventBusMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxEventBusMetricsTest.java
@@ -2,12 +2,15 @@ package io.quarkus.micrometer.deployment.binder;
 
 import jakarta.inject.Inject;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.Search;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.test.QuarkusUnitTest;
 import io.vertx.mutiny.core.Vertx;
 
@@ -19,11 +22,23 @@ public class VertxEventBusMetricsTest {
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
             .withEmptyApplication();
 
+    final static SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeAll
+    static void setRegistry() {
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll()
+    static void removeRegistry() {
+        Metrics.removeRegistry(registry);
+    }
+
     @Inject
     Vertx vertx;
 
     private Search getMeter(String name, String address) {
-        return Metrics.globalRegistry.find(name).tags("address", address);
+        return registry.find(name).tags("address", address);
     }
 
     @Test

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxHttpClientMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxHttpClientMetricsTest.java
@@ -10,12 +10,15 @@ import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.Search;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.micrometer.test.Util;
 import io.quarkus.test.QuarkusUnitTest;
 import io.vertx.core.http.HttpClientOptions;
@@ -38,6 +41,18 @@ public class VertxHttpClientMetricsTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(App.class, HttpClient.class, WsClient.class, Util.class));
 
+    final static SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeAll
+    static void setRegistry() {
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll()
+    static void removeRegistry() {
+        Metrics.removeRegistry(registry);
+    }
+
     @Inject
     HttpClient client;
 
@@ -48,7 +63,7 @@ public class VertxHttpClientMetricsTest {
     WsClient ws;
 
     private Search getMeter(String name) {
-        return Metrics.globalRegistry.find(name);
+        return registry.find(name);
     }
 
     @Test
@@ -59,7 +74,7 @@ public class VertxHttpClientMetricsTest {
         // If the WS test runs before, some data was already written
         double sizeBefore = 0;
         if (getMeter("http.client.bytes.written").summary() != null) {
-            sizeBefore = Metrics.globalRegistry.find("http.client.bytes.written")
+            sizeBefore = registry.find("http.client.bytes.written")
                     .tag("clientName", "my-client")
                     .summary().totalAmount();
         }
@@ -74,10 +89,10 @@ public class VertxHttpClientMetricsTest {
             double expectedBytesWritten = sizeBefore + 5;
             await().untilAsserted(
                     () -> Assertions.assertEquals(expectedBytesWritten,
-                            Metrics.globalRegistry.find("http.client.bytes.written")
+                            registry.find("http.client.bytes.written")
                                     .tag("clientName", "my-client").summary().totalAmount()));
             await().untilAsserted(() -> Assertions.assertEquals(7,
-                    Metrics.globalRegistry.find("http.client.bytes.read")
+                    registry.find("http.client.bytes.read")
                             .tag("clientName", "my-client").summary().totalAmount()));
 
             await().until(() -> getMeter("http.client.requests").timer().totalTime(TimeUnit.NANOSECONDS) > 0);
@@ -86,15 +101,15 @@ public class VertxHttpClientMetricsTest {
                 return getMeter("http.client.requests").timer().count() == 1;
             });
 
-            Assertions.assertEquals(1, Metrics.globalRegistry.find("http.client.requests")
+            Assertions.assertEquals(1, registry.find("http.client.requests")
                     .tag("uri", "root")
                     .tag("outcome", "SUCCESS").timers().size(),
-                    Util.foundClientRequests(Metrics.globalRegistry, "/ with tag outcome=SUCCESS."));
+                    Util.foundClientRequests(registry, "/ with tag outcome=SUCCESS."));
 
             // Queue
-            Assertions.assertEquals(2, Metrics.globalRegistry.find("http.client.queue.delay")
+            Assertions.assertEquals(2, registry.find("http.client.queue.delay")
                     .tag("clientName", "my-client").timer().count());
-            Assertions.assertTrue(Metrics.globalRegistry.find("http.client.queue.delay")
+            Assertions.assertTrue(registry.find("http.client.queue.delay")
                     .tag("clientName", "my-client").timer().totalTime(TimeUnit.NANOSECONDS) > 0);
 
             await().until(() -> getMeter("http.client.queue.size").gauge().value() == 0.0);

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxTcpMetricsNoClientMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/VertxTcpMetricsNoClientMetricsTest.java
@@ -9,12 +9,15 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.Search;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.test.QuarkusUnitTest;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.net.NetSocket;
@@ -34,8 +37,20 @@ public class VertxTcpMetricsNoClientMetricsTest {
     @Inject
     NetServer server;
 
+    final static SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeAll
+    static void setRegistry() {
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll()
+    static void removeRegistry() {
+        Metrics.removeRegistry(registry);
+    }
+
     private Search getMeter(String name) {
-        return Metrics.globalRegistry.find(name);
+        return registry.find(name);
     }
 
     @Test

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -49,7 +49,7 @@
 
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerRecorder.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerRecorder.java
@@ -29,6 +29,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.quarkus.arc.Arc;
 import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
@@ -56,10 +57,12 @@ public class MicrometerRecorder {
 
     @StaticInit
     public RuntimeValue<MeterRegistry> createRootRegistry(MicrometerConfig config, String qUri, String httpUri) {
-        factory = new MicrometerMetricsFactory(config, Metrics.globalRegistry);
+
+        CompositeMeterRegistry globalRegistry = Metrics.globalRegistry;
+        factory = new MicrometerMetricsFactory(config, globalRegistry);
         nonApplicationUri = qUri;
         httpRootUri = httpUri;
-        return new RuntimeValue<>(Metrics.globalRegistry);
+        return new RuntimeValue<>(globalRegistry);
     }
 
     @RuntimeInit

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/HttpInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/HttpInstrumenterVertxTracer.java
@@ -297,8 +297,12 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
                 final HttpRequest httpRequest,
                 final HttpResponse httpResponse,
                 final Throwable error) {
-            attributes.put(HTTP_REQUEST_BODY_SIZE, getContentLength(httpRequest.headers()));
-            attributes.put(HTTP_RESPONSE_BODY_SIZE, getContentLength(httpResponse.headers()));
+            if (httpRequest != null) {
+                attributes.put(HTTP_REQUEST_BODY_SIZE, getContentLength(httpRequest.headers()));
+            }
+            if (httpResponse != null) {
+                attributes.put(HTTP_RESPONSE_BODY_SIZE, getContentLength(httpResponse.headers()));
+            }
         }
 
         private static Long getContentLength(final MultiMap headers) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ExtendedQuarkusVertxHttpMetrics.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ExtendedQuarkusVertxHttpMetrics.java
@@ -22,6 +22,7 @@ public interface ExtendedQuarkusVertxHttpMetrics {
 
         @Override
         public void initialize(int maxConnections, AtomicInteger current) {
+            // no-op
         }
     };
 


### PR DESCRIPTION
This will use the deprecated simple prometheus client for v0.x, not the new prometheus client 1.x.
Beware of the dependency change. Instead of `micrometer-registry-prometheus`, now use:
```xml
<dependency>
    <groupId>io.micrometer</groupId>
    <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
</dependency>
```

This means this bum is backwards compatible with the previous code.

Tests  should always use the SimpleMeterRegistry:
```java
    final static SimpleMeterRegistry registry = new SimpleMeterRegistry();

    @BeforeAll
    static void setRegistry() {
        Metrics.addRegistry(registry);
    }

    @AfterAll()
    static void removeRegistry() {
        Metrics.removeRegistry(registry);
    }
```
Will also fix https://github.com/quarkusio/quarkus/issues/42578

We will suppress these log warnings:
[io.mic.cor.ins.com.CompositeMeterRegistry] (main) A MeterFilter is being configured after a Meter has been
registered to this registry...
It's unavoidable because of how Quarkus startup works and users cannot do anything about it.
see: https://github.com/micrometer-metrics/micrometer/issues/4920#issuecomment-2298348202
