### PR TITLE
Upgrade opentelemetry-semconv to 1.26.0-alpha

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -34,7 +34,7 @@
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <opentelemetry-alpha.version>2.5.0-alpha</opentelemetry-alpha.version>
-        <opentelemetry-semconv.version>1.25.0-alpha</opentelemetry-semconv.version>
+        <opentelemetry-semconv.version>1.26.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>5.3.1</quarkus-http.version>
         <micrometer.version>1.12.5</micrometer.version><!-- keep in sync with hdrhistogram -->
         <hdrhistogram.version>2.1.12</hdrhistogram.version><!-- keep in sync with micrometer -->


### PR DESCRIPTION
Sending this upgrade as proposed by @gsmet around here https://github.com/quarkusio/quarkus/pull/42459#issuecomment-2301375580

This upgrade is motivated by https://github.com/quarkiverse/quarkus-cxf/issues/1465 .