### PR TITLE
Encode URL in OIDC cookie

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -4,6 +4,8 @@ import static io.quarkus.oidc.runtime.OidcIdentityProvider.NEW_AUTHENTICATION;
 import static io.quarkus.oidc.runtime.OidcIdentityProvider.REFRESH_TOKEN_GRANT_RESPONSE;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
@@ -940,7 +942,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             Authentication authentication = configContext.oidcConfig.authentication;
             boolean pkceRequired = authentication.pkceRequired.orElse(false);
             if (!pkceRequired && !authentication.nonceRequired) {
-                bean.setRestorePath(parsedStateCookieValue[1]);
+                bean.setRestorePath(URLDecoder.decode(parsedStateCookieValue[1], StandardCharsets.UTF_8));
                 return bean;
             }
 
@@ -1177,7 +1179,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                 throw new AuthenticationCompletionException(ex);
             }
         } else {
-            return extraStateValue.getRestorePath();
+            return URLEncoder.encode(extraStateValue.getRestorePath(), StandardCharsets.UTF_8);
         }
 
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -4,8 +4,6 @@ import static io.quarkus.oidc.runtime.OidcIdentityProvider.NEW_AUTHENTICATION;
 import static io.quarkus.oidc.runtime.OidcIdentityProvider.REFRESH_TOKEN_GRANT_RESPONSE;
 
 import java.net.URI;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
@@ -71,7 +69,6 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     static final String EQ = "=";
     static final String COOKIE_DELIM = "|";
     static final Pattern COOKIE_PATTERN = Pattern.compile("\\" + COOKIE_DELIM);
-    static final String STATE_COOKIE_RESTORE_PATH = "restore-path";
     static final Uni<Void> VOID_UNI = Uni.createFrom().voidItem();
     static final String NO_OIDC_COOKIES_AVAILABLE = "no_oidc_cookies";
 
@@ -940,13 +937,16 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         if (parsedStateCookieValue.length == 2) {
             CodeAuthenticationStateBean bean = new CodeAuthenticationStateBean();
             Authentication authentication = configContext.oidcConfig.authentication;
+
             boolean pkceRequired = authentication.pkceRequired.orElse(false);
             if (!pkceRequired && !authentication.nonceRequired) {
-                bean.setRestorePath(URLDecoder.decode(parsedStateCookieValue[1], StandardCharsets.UTF_8));
+                JsonObject json = new JsonObject(OidcUtils.base64UrlDecode(parsedStateCookieValue[1]));
+                bean.setRestorePath(json.getString(OidcUtils.STATE_COOKIE_RESTORE_PATH));
                 return bean;
             }
 
             JsonObject json = null;
+
             try {
                 json = OidcUtils.decryptJson(parsedStateCookieValue[1], configContext.getStateEncryptionKey());
             } catch (Exception ex) {
@@ -954,7 +954,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                         configContext.oidcConfig.tenantId.get());
                 throw new AuthenticationCompletionException(ex);
             }
-            bean.setRestorePath(json.getString(STATE_COOKIE_RESTORE_PATH));
+            bean.setRestorePath(json.getString(OidcUtils.STATE_COOKIE_RESTORE_PATH));
             bean.setCodeVerifier(json.getString(OidcConstants.PKCE_CODE_VERIFIER));
             bean.setNonce(json.getString(OidcConstants.NONCE));
             return bean;
@@ -1161,8 +1161,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     }
 
     private String encodeExtraStateValue(CodeAuthenticationStateBean extraStateValue, TenantConfigContext configContext) {
+        JsonObject json = new JsonObject();
+
         if (extraStateValue.getCodeVerifier() != null || extraStateValue.getNonce() != null) {
-            JsonObject json = new JsonObject();
             if (extraStateValue.getCodeVerifier() != null) {
                 json.put(OidcConstants.PKCE_CODE_VERIFIER, extraStateValue.getCodeVerifier());
             }
@@ -1170,7 +1171,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                 json.put(OidcConstants.NONCE, extraStateValue.getNonce());
             }
             if (extraStateValue.getRestorePath() != null) {
-                json.put(STATE_COOKIE_RESTORE_PATH, extraStateValue.getRestorePath());
+                json.put(OidcUtils.STATE_COOKIE_RESTORE_PATH, extraStateValue.getRestorePath());
             }
             try {
                 return OidcUtils.encryptJson(json, configContext.getStateEncryptionKey());
@@ -1179,7 +1180,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                 throw new AuthenticationCompletionException(ex);
             }
         } else {
-            return URLEncoder.encode(extraStateValue.getRestorePath(), StandardCharsets.UTF_8);
+            json.put(OidcUtils.STATE_COOKIE_RESTORE_PATH, extraStateValue.getRestorePath());
+
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(json.encode().getBytes(StandardCharsets.UTF_8));
         }
 
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -75,6 +75,7 @@ import io.vertx.ext.web.RoutingContext;
 public final class OidcUtils {
     private static final Logger LOG = Logger.getLogger(OidcUtils.class);
 
+    public static final String STATE_COOKIE_RESTORE_PATH = "restore-path";
     public static final String CONFIG_METADATA_ATTRIBUTE = "configuration-metadata";
     public static final String USER_INFO_ATTRIBUTE = "userinfo";
     public static final String INTROSPECTION_ATTRIBUTE = "introspection";
@@ -252,7 +253,7 @@ public final class OidcUtils {
         }
     }
 
-    private static String base64UrlDecode(String encodedContent) {
+    public static String base64UrlDecode(String encodedContent) {
         return new String(Base64.getUrlDecoder().decode(encodedContent), StandardCharsets.UTF_8);
     }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -173,7 +173,7 @@ quarkus.oidc.tenant-split-tokens.token-state-manager.encryption-secret=eUk1p7UB3
 quarkus.oidc.tenant-split-tokens.application-type=web-app
 quarkus.oidc.tenant-split-tokens.authentication.cookie-same-site=strict
 
-quarkus.http.auth.permission.roles1.paths=/index.html
+quarkus.http.auth.permission.roles1.paths=/index.html,/index.html;/checktterer
 quarkus.http.auth.permission.roles1.policy=authenticated
 
 quarkus.http.auth.permission.logout.paths=/tenant-logout

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
@@ -1561,12 +1562,12 @@ public class CodeFlowTest {
 
     private String getStateCookieSavedPath(WebClient webClient, String tenantId) {
         String[] parts = getStateCookie(webClient, tenantId).getValue().split("\\|");
-        return parts.length == 2 ? parts[1] : null;
+        return parts.length == 2 ? URLDecoder.decode(parts[1], StandardCharsets.UTF_8) : null;
     }
 
     private String getStateCookieSavedPath(Cookie stateCookie) {
         String[] parts = stateCookie.getValue().split("\\|");
-        return parts.length == 2 ? parts[1] : null;
+        return parts.length == 2 ? URLDecoder.decode(parts[1], StandardCharsets.UTF_8) : null;
     }
 
     private Cookie getSessionCookie(WebClient webClient, String tenantId) {


### PR DESCRIPTION
Fix #31802

This will need some serious testing and I would appreciate if either @sberyozkin or @michalvavrik could test it. Be careful, you need to test it in this very specific configuration where the cookie is not saved as JSON.

I'm especially not entirely sure if the thing needs decoding on the way back.

See the issue for details.