### PR TITLE
Fix config encryption CLI command in guide

### DIFF
--- a/docs/src/main/asciidoc/config-secrets.adoc
+++ b/docs/src/main/asciidoc/config-secrets.adoc
@@ -33,7 +33,7 @@ Use the Quarkus CLI command to add a new encrypted value or encrypt an existent 
 ****
 [source, bash]
 ----
-quarkus config set --encrypt --name=my.secret --value=1234
+quarkus config set --encrypt my.secret 1234
 ----
 
 _For more information about how to install the Quarkus CLI and use it, please refer to xref:cli-tooling.adoc[the Quarkus CLI guide]._


### PR DESCRIPTION
The config command in the Quarkus CLI changed.

```
quarkus config set --help                                 

Sets a configuration in application.properties

Usage: quarkus config set [-ehk] [--verbose] NAME [VALUE]

      NAME        Configuration name
      [VALUE]     Configuration value
Options:
  -e, --errors    Print more context on errors and exceptions.
      --verbose   Verbose mode.
  -h, --help      Display this help message.
  -k, --encrypt   Encrypt the configuration value
```