### PR TITLE
Update security docs

### DIFF
--- a/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
@@ -43,7 +43,7 @@ quarkus.http.auth.basic=true
 +
 [source,properties]
 ----
-security.users.embedded.enabled=true
+quarkus.security.users.embedded.enabled=true
 ----
 
 .. You can also configure the required user credentials, user name, secret, and roles.

--- a/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
@@ -79,12 +79,16 @@ The instructions in this example tutorial use a PostgreSQL database for the iden
 You can create a new Maven project with the Security Jakarta Persistence extension or add the extension to an existing Maven project.
 You can use either Hibernate ORM or Hibernate Reactive.
 
+==== Creating new Maven project
+
 * To create a new Maven project with the Jakarta Persistence extension, complete one of the following steps:
 ** To create the Maven project with Hibernate ORM, use the following command:
 
 :create-app-artifact-id: security-jpa-quickstart
 :create-app-extensions: security-jpa,jdbc-postgresql,rest,hibernate-orm-panache
 include::{includes}/devtools/create-app.adoc[]
+
+==== Adding Jakarta Persistence extension to existing project
 
 * To add the Jakarta Persistence extension to an existing Maven project, complete one of the following steps:
 
@@ -415,7 +419,7 @@ In this scenario, `Dev Services for PostgreSQL` launches and configures a `Postg
 %prod.quarkus.datasource.db-kind=postgresql
 %prod.quarkus.datasource.username=quarkus
 %prod.quarkus.datasource.password=quarkus
-%prod.quarkus.datasource.jdbc.url=jdbc:postgresql:elytron_security_jpa
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 ----
@@ -505,7 +509,7 @@ Dev Services for PostgreSQL supports testing while you develop by providing a se
 [source,bash]
 ----
 docker run --rm=true --name security-getting-started -e POSTGRES_USER=quarkus \
-           -e POSTGRES_PASSWORD=quarkus -e POSTGRES_DB=elytron_security_jpa \
+           -e POSTGRES_PASSWORD=quarkus -e POSTGRES_DB=quarkus \
            -p 5432:5432 postgres:14.1
 ----
 === Compile and run the application

--- a/docs/src/main/asciidoc/security-proactive-authentication.adoc
+++ b/docs/src/main/asciidoc/security-proactive-authentication.adoc
@@ -108,7 +108,9 @@ package io.quarkus.it.keycloak;
 
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 


### PR DESCRIPTION
Adding some small changes to security docs

`security-basic-authentication-howto` 
* missing the `quarkus` prefix in application property file

`security-getting-started-tutorial` 
* changing the postgresql name from `elytron_security_jpa` to `quarkus` to be the same as it's used in quickstart.
* Adding subsection to split text to look better. See [security-getting-started-tutorial#create-the-maven-project](https://quarkus.io/guides/security-getting-started-tutorial#create-the-maven-project) as part of `For Windows users:` conatins even adding extension. I tried to just split (using `//-`) without adding the subsection but it still look like it's the all for windows. If you have some better sugestion I'm open to it.

The `security-proactive-authentication` removing the names of package as rest of the guide not using them.