### PR TITLE
Fix for resolving entity fields based on collections and generics

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/MethodNameParserTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/MethodNameParserTest.java
@@ -17,6 +17,10 @@ import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.spring.data.deployment.generics.ChildBase;
+import io.quarkus.spring.data.deployment.generics.ParentBase;
+import io.quarkus.spring.data.deployment.generics.ParentBaseRepository;
+
 public class MethodNameParserTest {
 
     private final Class<?> repositoryClass = PersonRepository.class;
@@ -93,6 +97,32 @@ public class MethodNameParserTest {
         UnableToParseMethodException exception = assertThrows(UnableToParseMethodException.class,
                 () -> parseMethod(repositoryClass, "findAllBy_", entityClass, additionalClasses));
         assertThat(exception).hasMessageContaining("Person does not contain a field named: _");
+    }
+
+    @Test
+    public void testGenericsWithWildcard() throws Exception {
+        Class[] additionalClasses = new Class[] { ChildBase.class };
+
+        MethodNameParser.Result result = parseMethod(ParentBaseRepository.class, "countParentsByChildren_Nombre",
+                ParentBase.class,
+                additionalClasses);
+        assertThat(result).isNotNull();
+        assertSameClass(result.getEntityClass(), ParentBase.class);
+        assertThat(result.getQuery()).isEqualTo("FROM ParentBase WHERE children.nombre = ?1");
+        assertThat(result.getParamCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldParseRepositoryMethodOverEntityContainingACollection() throws Exception {
+        Class[] additionalClasses = new Class[] { LoginEvent.class };
+
+        MethodNameParser.Result result = parseMethod(UserRepository.class, "countUsersByLoginEvents_Id",
+                User.class,
+                additionalClasses);
+        assertThat(result).isNotNull();
+        assertSameClass(result.getEntityClass(), User.class);
+        assertThat(result.getQuery()).isEqualTo("FROM User WHERE loginEvents.id = ?1");
+        assertThat(result.getParamCount()).isEqualTo(1);
     }
 
     private AbstractStringAssert<?> assertSameClass(ClassInfo classInfo, Class<?> aClass) {

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/UserRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/UserRepository.java
@@ -28,4 +28,6 @@ public interface UserRepository extends JpaRepository<User, String> {
 
     // purposely with compiled parameter name not matching the query to also test that @Param takes precedence
     User getUserByFullNameUsingNamedQueries(@Param("name") String arg);
+
+    long countUsersByLoginEvents_Id(Long id);
 }

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/generics/ChildBase.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/generics/ChildBase.java
@@ -1,0 +1,9 @@
+package io.quarkus.spring.data.deployment.generics;
+
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public class ChildBase {
+    String nombre;
+    String detail;
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/generics/ParentBase.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/generics/ParentBase.java
@@ -1,0 +1,17 @@
+package io.quarkus.spring.data.deployment.generics;
+
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.OneToMany;
+
+@MappedSuperclass
+public class ParentBase<T extends ChildBase> {
+    String name;
+    String detail;
+    int age;
+    float test;
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<T> children;
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/generics/ParentBaseRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/generics/ParentBaseRepository.java
@@ -1,0 +1,7 @@
+package io.quarkus.spring.data.deployment.generics;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParentBaseRepository<T extends ParentBase<?>> extends JpaRepository<T, Long> {
+    long countParentsByChildren_Nombre(String name);
+}


### PR DESCRIPTION
Fixes #34395

The problem  was that the resolveNestedFields method  didn't resolver correctly collection fields. For example if Person had a `List<Address> addresses`, or `List<T>` in case where wildcard is used. When dealing with a single field, Address address, there is no problem. 
What happens with the list is that it takes the wrong type, List instead of T/Address, and checks and checks that the field preceded by '_' (e.g. _isoCode) is a Person field. Also it tries to get `List`from the index and it is not indexed at this point.  

cc @geoand , @Michael-AT-Corporation 