### PR TITLE
Update OAuth2 docs because of change in Bearer token check change 

### DIFF
--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -418,7 +418,7 @@ class TokenSecuredResourceTest {
     void testPermitAll() {
         RestAssured.given()
                 .when()
-                .header("Authorization", "Bearer: " + BEARER_TOKEN) // <3>
+                .header("Authorization", "Bearer " + BEARER_TOKEN) // <3>
                 .get("/secured/permit-all")
                 .then()
                 .statusCode(200)
@@ -429,7 +429,7 @@ class TokenSecuredResourceTest {
     void testRolesAllowed() {
         RestAssured.given()
                 .when()
-                .header("Authorization", "Bearer: " + BEARER_TOKEN)
+                .header("Authorization", "Bearer " + BEARER_TOKEN)
                 .get("/secured/roles-allowed")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
This PR updating docs as the https://github.com/quarkusio/quarkus/pull/42595 changed how the String of Bearer token is checked.

Fix PR for quickstart https://github.com/quarkusio/quarkus-quickstarts/pull/1445

This docs update is just reflect these quickstart changes