### PR TITLE
Enhance mailer to support XOAuth2 authentication

### DIFF
--- a/extensions/mailer/runtime/pom.xml
+++ b/extensions/mailer/runtime/pom.xml
@@ -36,6 +36,14 @@
             <artifactId>smallrye-mutiny-vertx-mail-client</artifactId>
         </dependency>
         <dependency>
+          <groupId>io.smallrye.reactive</groupId>
+          <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>io.quarkus.security</groupId>
+          <artifactId>quarkus-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.davidmoten</groupId>
             <artifactId>subethasmtp</artifactId>
             <scope>test</scope>

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.mailer.runtime;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.regex.Pattern;
@@ -272,4 +273,16 @@ public class MailerRuntimeConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean logRejectedRecipients = false;
+
+    /**
+     * Parameters that should be sent to the OAuth2 provider to acquire a token.
+     */
+    @ConfigItem
+    public Map<String, String> oauth2Params = Map.of();
+
+    /**
+     * OAuth2 token endpoint
+     */
+    @ConfigItem
+    public Optional<String> oauth2TokenEndpoint = Optional.empty();
 }


### PR DESCRIPTION
This is the most earliest prototype, and it will have to be reworked. It is only for us with Clement to start playing with various setups.
Particularly, with Microsoft, the system message, if it will work, will most likely require a token acquisition request with the system username and password - it is not clear right now if we want to reuse the username and password properties for it or create new ones.
 
With Google, if it will work, a JWT bearer token grant will be required.
In both cases, for now, a Map of properties is expected to be filled in with the OAuth2/OIDC provider specific properties.
The token url property for this case may be set up later as that Map property or it will be discovered with another webClient call.

For `TokenCredential` (user login driving the token acquisition) to work, `Mailer` would need be refactored to accept Paulo's `AuthOperation` dynamically. It will also be required for the refresh token to work cleanly.

I'll play around with this code for the next few weeks with Google, Microsoft, specifically trying to see if the system email case can be sorted out.

CC @cescoffier  