### PR TITLE
Fix OIDC Discord provider configuration

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -191,14 +191,17 @@ public class KnownOidcProviders {
     private static OidcTenantConfig discord() {
         // Ref https://discord.com/developers/docs/topics/oauth2
         OidcTenantConfig ret = new OidcTenantConfig();
+        ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
         ret.setAuthServerUrl("https://discord.com/api/oauth2");
         ret.setDiscoveryEnabled(false);
         ret.setAuthorizationPath("authorize");
         ret.setTokenPath("token");
+        ret.setJwksPath("keys");
         ret.getAuthentication().setScopes(List.of("identify", "email"));
         ret.getAuthentication().setIdTokenRequired(false);
         ret.getToken().setVerifyAccessTokenWithUserInfo(true);
         ret.setUserInfoPath("https://discord.com/api/users/@me");
+
         return ret;
     }
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/KnownOidcProvidersTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/KnownOidcProvidersTest.java
@@ -529,10 +529,12 @@ public class KnownOidcProvidersTest {
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.DISCORD));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
+        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
         assertFalse(config.discoveryEnabled.get());
         assertEquals("https://discord.com/api/oauth2", config.getAuthServerUrl().get());
         assertEquals("authorize", config.getAuthorizationPath().get());
         assertEquals("token", config.getTokenPath().get());
+        assertEquals("keys", config.getJwksPath().get());
         assertEquals("https://discord.com/api/users/@me", config.getUserInfoPath().get());
         assertEquals(List.of("identify", "email"), config.authentication.scopes.get());
         assertFalse(config.getAuthentication().idTokenRequired.get());


### PR DESCRIPTION
Minor updates to the OIDC Discord properties, looking at them for the upcoming demo:
* it must be a web-app by default to have an authorization code flow initiated
* it took me a little while, but it actually supports OIDC now (though I can't find it anywhere in the Discord docs), while the current configuration does not expect it and the ID token which is returned can not be verified, since the discovery is disabled by no JWK keys is configured, so adding a property to specify a JWKS endpoint 