### PR TITLE
Use jdk17 for quarkus maven plugin and extension maven plugin

### DIFF
--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -15,10 +15,6 @@
     <name>Quarkus - Maven Plugin</name>
 
     <properties>
-        <!-- Not sure exactly why but the Maven plugins need to be compiled with Java 11 -->
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
-
         <quarkus.version>${project.version}</quarkus.version>
     </properties>
 
@@ -250,7 +246,7 @@
             <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
-                <version>0.3.5</version>
+                <version>0.9.0.M3</version>
                 <executions>
                     <execution>
                         <id>index-project</id>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -33,9 +33,6 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.inject.version>1</javax.inject.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Not sure exactly why but the Maven plugins need to be compiled with Java 11 -->
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
         <maven-core.version>3.9.12</maven-core.version>
         <jackson-bom.version>2.20.1</jackson-bom.version>
         <smallrye-beanbag.version>1.6.1</smallrye-beanbag.version>
@@ -137,7 +134,7 @@
             <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
-                <version>0.3.5</version>
+                <version>0.9.0.M3</version>
                 <executions>
                     <execution>
                         <id>index-project</id>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy-deploymentconfig/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy-deploymentconfig/pom.xml
@@ -8,9 +8,7 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This needs a few things in order to work.

It needs a recent maven to build as it needs (simplified)
```
[INFO] +- org.apache.maven:maven-core:jar:3.9.8:provided
[INFO] |  +- org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.9.0.M3:provided
[INFO] |  +- com.google.inject:guice:jar:5.1.0:provided
```

guice 5.1.0 is needed for JDK17 support. Sisu brings a old guice so using the one provided by maven-core make the thing work.

This: https://github.com/quarkusio/quarkus-quickstarts/pull/1444 was also needed otherwise the CI step "Quickstarts Compilation - JDK 17" would fail for the same reason (guice).

CI is green on my fork.