### PR TITLE
Update commons-lang3 to 3.17.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -95,7 +95,7 @@
         <gizmo.version>1.8.0</gizmo.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <commons-lang3.version>3.14.0</commons-lang3.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
         <commons-codec.version>1.17.1</commons-codec.version>
         <classmate.version>1.7.0</classmate.version>
         <!-- See root POM for hibernate-orm.version, hibernate-reactive.version, hibernate-validator.version,

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -32,7 +32,7 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
 
         this.baseContainerRuntimeArgs = new String[] { "--env", "LANG=C", "--rm" };
 
-        containerName = "build-native-" + RandomStringUtils.random(5, true, false);
+        containerName = "build-native-" + RandomStringUtils.insecure().next(5, true, false);
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -124,7 +124,7 @@ public class UpxCompressionBuildStep {
         commandLine.add("--rm");
         commandLine.add("--entrypoint=upx");
 
-        String containerName = "upx-" + RandomStringUtils.random(5, true, false);
+        String containerName = "upx-" + RandomStringUtils.insecure().next(5, true, false);
         commandLine.add("--name");
         commandLine.add(containerName);
 

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -56,7 +56,7 @@
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <commons-codec.version>1.17.1</commons-codec.version>
         <commons-io.version>2.16.1</commons-io.version>
-        <commons-lang.version>3.16.0</commons-lang.version>
+        <commons-lang.version>3.17.0</commons-lang.version>
         <guava.version>33.3.0-jre</guava.version>
         <guava.failureaccess.version>1.0.1</guava.failureaccess.version><!-- keep in sync with guava.version -->
         <j2objc.annotations.version>2.8</j2objc.annotations.version><!-- keep in sync with guava.version -->

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
@@ -31,7 +31,7 @@ public class RabbitMQConnectorDynCredsTest {
         @Override
         public Map<String, String> start() {
             String username = "tester";
-            String password = RandomStringUtils.random(10);
+            String password = RandomStringUtils.insecure().next(10);
 
             rabbit = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.12-management"))
                     .withNetwork(Network.SHARED)

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -50,7 +50,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     private Map<String, String> labels;
     private final Map<String, String> systemProps = new HashMap<>();
     private boolean isSsl;
-    private final String containerName = "quarkus-integration-test-" + RandomStringUtils.random(5, true, false);
+    private final String containerName = "quarkus-integration-test-" + RandomStringUtils.insecure().next(5, true, false);
     private String containerRuntimeBinaryName;
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private Optional<String> entryPoint;

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -319,7 +319,7 @@ public final class IntegrationTestUtil {
                 if (networkIdOpt.isPresent()) {
                     networkId = networkIdOpt.get();
                 } else {
-                    networkId = "quarkus-integration-test-" + RandomStringUtils.random(5, true, false);
+                    networkId = "quarkus-integration-test-" + RandomStringUtils.insecure().next(5, true, false);
                     manageNetwork = true;
                 }
             }


### PR DESCRIPTION
Draft until 3.17.0 actually exists.

Fixes: https://github.com/quarkusio/quarkus/issues/42686

Looks like the dust settled on this and 3.17 will be OK

When compared to 3.14, 3 new singleton instances are available;

`Random*Utils.secure()`  that uses `SecureRandom()`
`Random*Utils.secureStrong()` that uses `SecureRandom.getInstanceStrong()`
`Random*Utils.insecure()` that uses `ThreadLocalRandom` as 3.14 was using

This PR uses insecure() to have the same behaviour as 3.14.

I personally do not think it is worthwhile to get rid of RandomStringUtils because a mistake happened in the lib, these things happen.