### PR TITLE
TLS - Prevent Duplicate Entries in .env File

### DIFF
--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/DotEnvHelper.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/DotEnvHelper.java
@@ -1,0 +1,48 @@
+package io.quarkus.tls.cli;
+
+import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.DOT_ENV_FILE;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DotEnvHelper {
+
+    private DotEnvHelper() {
+        // Avoid direct instantiation
+    }
+
+    public static List<String> readDotEnvFile() throws IOException {
+        if (!DOT_ENV_FILE.exists()) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(Files.readAllLines(DOT_ENV_FILE.toPath()));
+    }
+
+    public static void addOrReplaceProperty(List<String> content, String key, String value) {
+        var line = hasLine(content, key);
+        if (line != -1) {
+            content.set(line, key + "=" + value);
+        } else {
+            content.add(key + "=" + value);
+        }
+    }
+
+    private static int hasLine(List<String> content, String key) {
+        for (int i = 0; i < content.size(); i++) {
+            if (content.get(i).startsWith(key + "=") || content.get(i).startsWith(key + " =")) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public static void deleteQuietly(File file) {
+        if (file.isFile()) {
+            file.delete();
+        }
+    }
+}

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptPrepareCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptPrepareCommand.java
@@ -1,15 +1,16 @@
 package io.quarkus.tls.cli.letsencrypt;
 
-import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.*;
+import static io.quarkus.tls.cli.DotEnvHelper.addOrReplaceProperty;
+import static io.quarkus.tls.cli.DotEnvHelper.deleteQuietly;
+import static io.quarkus.tls.cli.DotEnvHelper.readDotEnvFile;
+import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.CA_FILE;
 import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.CERT_FILE;
 import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.DOT_ENV_FILE;
 import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.KEY_FILE;
 import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.LETS_ENCRYPT_DIR;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -72,9 +73,7 @@ public class LetsEncryptPrepareCommand implements Callable<Integer> {
         }
 
         // Delete the CA file, we do not use it.
-        if (CA_FILE.isFile()) {
-            CA_FILE.delete();
-        }
+        deleteQuietly(CA_FILE);
 
         // Step 3 - Create .env file or append if exists
         List<String> dotEnvContent = readDotEnvFile();
@@ -95,31 +94,6 @@ public class LetsEncryptPrepareCommand implements Callable<Integer> {
                 domain,
                 tlsConfigurationName != null ? " -tls-configuration-name=" + tlsConfigurationName : "");
         return 0;
-    }
-
-    List<String> readDotEnvFile() throws IOException {
-        if (!DOT_ENV_FILE.exists()) {
-            return new ArrayList<>();
-        }
-        return new ArrayList<>(Files.readAllLines(DOT_ENV_FILE.toPath()));
-    }
-
-    void addOrReplaceProperty(List<String> content, String key, String value) {
-        var line = hasLine(content, key);
-        if (line != -1) {
-            content.set(line, key + "=" + value);
-        } else {
-            content.add(key + "=" + value);
-        }
-    }
-
-    private int hasLine(List<String> content, String key) {
-        for (int i = 0; i < content.size(); i++) {
-            if (content.get(i).startsWith(key + "=") || content.get(i).startsWith(key + " =")) {
-                return i;
-            }
-        }
-        return -1;
     }
 
 }


### PR DESCRIPTION
Previously, when generating local certificates, running the command multiple times could result in duplicate lines being written to the `.env` file. This PR resolves the issue by implementing the same mechanism used in the Let's Encrypt commands, ensuring that duplicate entries are avoided.
