### PR TITLE
Register resource classes for reflection when ContainerResponseFilter exists

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/InterceptorContainer.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/InterceptorContainer.java
@@ -33,6 +33,10 @@ public class InterceptorContainer<T> {
         Collections.sort(nameResourceInterceptors);
     }
 
+    public boolean isEmpty() {
+        return globalResourceInterceptors.isEmpty() && nameResourceInterceptors.isEmpty();
+    }
+
     public ResourceInterceptor<T> create() {
         return new ResourceInterceptor<>();
     }

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/EntityStreamSettingContainerResponseFilter.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/EntityStreamSettingContainerResponseFilter.kt
@@ -1,0 +1,28 @@
+package io.quarkus.it.resteasy.reactive.kotlin
+
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerResponseContext
+import jakarta.ws.rs.container.ContainerResponseFilter
+import jakarta.ws.rs.ext.Provider
+import java.io.ByteArrayInputStream
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestContext
+
+@Provider
+class EntityStreamSettingContainerResponseFilter : ContainerResponseFilter {
+    override fun filter(
+        requestContext: ContainerRequestContext?,
+        responseContext: ContainerResponseContext?
+    ) {
+        if (requestContext is ResteasyReactiveContainerRequestContext) {
+            if (
+                "hello".equals(
+                    requestContext.serverRequestContext.resteasyReactiveResourceInfo.name
+                )
+            ) {
+                responseContext?.setEntity(
+                    ByteArrayInputStream("Hello Quarkus REST".toByteArray(Charsets.UTF_8))
+                )
+            }
+        }
+    }
+}

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/ReactiveGreetingResource.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/ReactiveGreetingResource.kt
@@ -30,7 +30,7 @@ class ReactiveGreetingResource @Inject constructor(val req: RequestScopedKotlinC
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/{name}")
-    suspend fun hello(name: String): String {
+    suspend fun namedHello(name: String): String {
         delay(50)
         return "Hello $name"
     }

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/ReactiveGreetingResourceTest.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/ReactiveGreetingResourceTest.kt
@@ -19,7 +19,9 @@ class ReactiveGreetingResourceTest {
         When { get("/hello-resteasy-reactive/") } Then
             {
                 statusCode(200)
-                body(`is`("Hello RestEASY Reactive"))
+                body(
+                    `is`("Hello Quarkus REST")
+                ) // the result comes from EntityStreamSettingContainerResponseFilter
             }
     }
 


### PR DESCRIPTION
This is needed because those filters can call
`setEntityStream` which then forces the use of the
slow path for calling writers

- Closes: #42537