### PR TITLE
Save Objects::hash varargs array allocation on JarResource::hashCode

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -185,6 +185,8 @@ public class JarResource implements ClassLoadingResource {
 
     @Override
     public int hashCode() {
-        return Objects.hash(manifestInfo, jarPath);
+        int result = Objects.hashCode(manifestInfo);
+        result = 31 * result + Objects.hashCode(jarPath);
+        return result;
     }
 }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -180,13 +180,11 @@ public class JarResource implements ClassLoadingResource {
         if (o == null || getClass() != o.getClass())
             return false;
         JarResource that = (JarResource) o;
-        return Objects.equals(manifestInfo, that.manifestInfo) && jarPath.equals(that.jarPath);
+        return jarPath.equals(that.jarPath);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hashCode(manifestInfo);
-        result = 31 * result + Objects.hashCode(jarPath);
-        return result;
+        return Objects.hashCode(jarPath);
     }
 }


### PR DESCRIPTION
Starting up  quarkus app in JVM mode still allocate useless varargs Object[] while computing JarResource::hashCode, see the allocation flamegraphs at:

![image](https://github.com/user-attachments/assets/4308a153-a58e-4995-b109-09e92fb1ae85)

The code there is unlikely to become hot and avoid performing such allocation...
