### PR TITLE
Remove mvn.config hack for mvnd

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--Dmaven.multiModuleProjectDirectory=${session.rootDirectory}


### PR DESCRIPTION
This does not seem needed anymore see: https://github.com/apache/maven-mvnd/pull/1056

I was able to build with `mvnd clean install -Dquickly` with mvnd 1.0.2.

Would fail with mvnd 1.0.1