### PR TITLE
Fix hierarchical otlp props lookup, add Grafana traces check

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
@@ -310,7 +310,7 @@ public class OTelExporterRecorder {
     }
 
     private URI getTracesUri(OtlpExporterRuntimeConfig exporterRuntimeConfig) {
-        String endpoint = resolveTraceEndpoint(exporterRuntimeConfig);
+        String endpoint = exporterRuntimeConfig.traces().endpoint().orElse(DEFAULT_GRPC_BASE_URI);
         if (endpoint.isEmpty()) {
             return null;
         }
@@ -318,33 +318,11 @@ public class OTelExporterRecorder {
     }
 
     private URI getMetricsUri(OtlpExporterRuntimeConfig exporterRuntimeConfig) {
-        String endpoint = resolveTraceEndpoint(exporterRuntimeConfig);
+        String endpoint = exporterRuntimeConfig.metrics().endpoint().orElse(DEFAULT_GRPC_BASE_URI);
         if (endpoint.isEmpty()) {
             return null;
         }
         return ExporterBuilderUtil.validateEndpoint(endpoint);
-    }
-
-    static String resolveTraceEndpoint(final OtlpExporterRuntimeConfig runtimeConfig) {
-        String endpoint = runtimeConfig.traces().endpoint()
-                .filter(OTelExporterRecorder::excludeDefaultEndpoint)
-                .orElse(runtimeConfig.endpoint()
-                        .filter(OTelExporterRecorder::excludeDefaultEndpoint)
-                        .orElse(DEFAULT_GRPC_BASE_URI));
-        return endpoint.trim();
-    }
-
-    static String resolveMetricEndpoint(final OtlpExporterRuntimeConfig runtimeConfig) {
-        String endpoint = runtimeConfig.metrics().endpoint()
-                .filter(OTelExporterRecorder::excludeDefaultEndpoint)
-                .orElse(runtimeConfig.endpoint()
-                        .filter(OTelExporterRecorder::excludeDefaultEndpoint)
-                        .orElse(DEFAULT_GRPC_BASE_URI));
-        return endpoint.trim();
-    }
-
-    private static boolean excludeDefaultEndpoint(String endpoint) {
-        return !DEFAULT_GRPC_BASE_URI.equals(endpoint);
     }
 
     static class HttpClientOptionsConsumer implements Consumer<HttpClientOptions> {

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
@@ -17,10 +17,32 @@ import io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterTrac
 
 class OtlpExporterProviderTest {
 
+    static String resolveTraceEndpoint(final OtlpExporterRuntimeConfig runtimeConfig) {
+        String endpoint = runtimeConfig.traces().endpoint()
+                .filter(OtlpExporterProviderTest::excludeDefaultEndpoint)
+                .orElse(runtimeConfig.endpoint()
+                        .filter(OtlpExporterProviderTest::excludeDefaultEndpoint)
+                        .orElse(DEFAULT_GRPC_BASE_URI));
+        return endpoint.trim();
+    }
+
+    static String resolveMetricEndpoint(final OtlpExporterRuntimeConfig runtimeConfig) {
+        String endpoint = runtimeConfig.metrics().endpoint()
+                .filter(OtlpExporterProviderTest::excludeDefaultEndpoint)
+                .orElse(runtimeConfig.endpoint()
+                        .filter(OtlpExporterProviderTest::excludeDefaultEndpoint)
+                        .orElse(DEFAULT_GRPC_BASE_URI));
+        return endpoint.trim();
+    }
+
+    private static boolean excludeDefaultEndpoint(String endpoint) {
+        return !DEFAULT_GRPC_BASE_URI.equals(endpoint);
+    }
+
     @Test
     public void resolveTraceEndpoint_newWins() {
         assertEquals("http://localhost:2222/",
-                OTelExporterRecorder.resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
+                resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
                         "http://localhost:1111/",
                         "http://localhost:2222/")));
     }
@@ -28,7 +50,7 @@ class OtlpExporterProviderTest {
     @Test
     public void resolveTraceEndpoint_globalWins() {
         assertEquals("http://localhost:1111/",
-                OTelExporterRecorder.resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
+                resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
                         "http://localhost:1111/",
                         DEFAULT_GRPC_BASE_URI)));
     }
@@ -36,7 +58,7 @@ class OtlpExporterProviderTest {
     @Test
     public void resolveTraceEndpoint_legacyTraceWins() {
         assertEquals("http://localhost:2222/",
-                OTelExporterRecorder.resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
+                resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
                         DEFAULT_GRPC_BASE_URI,
                         "http://localhost:2222/")));
     }
@@ -44,7 +66,7 @@ class OtlpExporterProviderTest {
     @Test
     public void resolveTraceEndpoint_legacyGlobalWins() {
         assertEquals(DEFAULT_GRPC_BASE_URI,
-                OTelExporterRecorder.resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
+                resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
                         DEFAULT_GRPC_BASE_URI,
                         null)));
     }
@@ -52,7 +74,7 @@ class OtlpExporterProviderTest {
     @Test
     public void resolveTraceEndpoint_testIsSet() {
         assertEquals(DEFAULT_GRPC_BASE_URI,
-                OTelExporterRecorder.resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
+                resolveTraceEndpoint(createOtlpExporterRuntimeConfig(
                         null,
                         null)));
     }
@@ -60,7 +82,7 @@ class OtlpExporterProviderTest {
     @Test
     public void resolveMetricEndpoint_newWins() {
         assertEquals("http://localhost:2222/",
-                OTelExporterRecorder.resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
+                resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
                         "http://localhost:1111/",
                         "http://localhost:2222/")));
     }
@@ -68,7 +90,7 @@ class OtlpExporterProviderTest {
     @Test
     public void resolveMetricEndpoint_globalWins() {
         assertEquals("http://localhost:1111/",
-                OTelExporterRecorder.resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
+                resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
                         "http://localhost:1111/",
                         DEFAULT_GRPC_BASE_URI)));
     }
@@ -76,7 +98,7 @@ class OtlpExporterProviderTest {
     @Test
     public void resolveMetricEndpoint_legacyTraceWins() {
         assertEquals("http://localhost:2222/",
-                OTelExporterRecorder.resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
+                resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
                         DEFAULT_GRPC_BASE_URI,
                         "http://localhost:2222/")));
     }
@@ -84,7 +106,7 @@ class OtlpExporterProviderTest {
     @Test
     public void resolveMetricEndpoint_legacyGlobalWins() {
         assertEquals(DEFAULT_GRPC_BASE_URI,
-                OTelExporterRecorder.resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
+                resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
                         DEFAULT_GRPC_BASE_URI,
                         null)));
     }
@@ -92,7 +114,7 @@ class OtlpExporterProviderTest {
     @Test
     public void resolveMetricEndpoint_testIsSet() {
         assertEquals(DEFAULT_GRPC_BASE_URI,
-                OTelExporterRecorder.resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
+                resolveMetricEndpoint(createOtlpExporterRuntimeConfig(
                         null,
                         null)));
     }

--- a/integration-tests/observability-lgtm/src/main/resources/application.properties
+++ b/integration-tests/observability-lgtm/src/main/resources/application.properties
@@ -6,12 +6,9 @@ quarkus.micrometer.export.otlp.enabled=true
 quarkus.micrometer.export.otlp.publish=true
 quarkus.micrometer.export.otlp.step=PT5S
 quarkus.micrometer.export.otlp.default-registry=true
-%dev.quarkus.micrometer.export.otlp.url=http://${quarkus.otel-collector.url}/v1/metrics
 %prod.quarkus.micrometer.export.otlp.url=http://localhost:4318/v1/metrics
 
 #opentelemetry
-quarkus.otel.exporter.otlp.traces.protocol=http/protobuf
-%dev.quarkus.otel.exporter.otlp.traces.endpoint=http://${quarkus.otel-collector.url}
 %prod.quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4318
 
 #quarkus.observability.lgtm.image-name=grafana/otel-lgtm

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestBase.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestBase.java
@@ -28,6 +28,9 @@ public abstract class LgtmTestBase {
         Awaitility.await().atMost(61, TimeUnit.SECONDS).until(
                 () -> client.query("xvalue_X"),
                 result -> !result.data.result.isEmpty());
+        Awaitility.await().atMost(61, TimeUnit.SECONDS).until(
+                () -> client.traces("quarkus-integration-test-observability-lgtm", 20, 3),
+                result -> !result.traces.isEmpty());
     }
 
 }

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/support/GrafanaClient.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/support/GrafanaClient.java
@@ -89,4 +89,23 @@ public class GrafanaClient {
                 });
         return ref.get();
     }
+
+    public TempoResult traces(String service, int limit, int spss) {
+        AtomicReference<TempoResult> ref = new AtomicReference<>();
+        String path = "/api/datasources/proxy/uid/tempo/api/search?q=%7Bresource.service.name%3D%22"
+                + service + "%22%7D&limit=" + limit + "&spss=" + spss;
+        handle(
+                path,
+                HttpRequest.Builder::GET,
+                HttpResponse.BodyHandlers.ofString(),
+                (r, b) -> {
+                    try {
+                        TempoResult result = MAPPER.readValue(b, TempoResult.class);
+                        ref.set(result);
+                    } catch (JsonProcessingException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+        return ref.get();
+    }
 }

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/support/TempoResult.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/support/TempoResult.java
@@ -1,0 +1,38 @@
+package io.quarkus.observability.test.support;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TempoResult {
+    public List<Map<Object, Object>> traces;
+    public Metrics metrics;
+
+    // getters and setters
+
+    @Override
+    public String toString() {
+        return "TempoResult{" +
+                "traces=" + traces +
+                ", metrics=" + metrics +
+                '}';
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Metrics {
+        public int inspectedBytes;
+        public int completedJobs;
+        public int totalJobs;
+
+        @Override
+        public String toString() {
+            return "Metrics{" +
+                    "inspectedBytes=" + inspectedBytes +
+                    ", completedJobs=" + completedJobs +
+                    ", totalJobs=" + totalJobs +
+                    '}';
+        }
+    }
+}


### PR DESCRIPTION
Hierarchy property lookup with DevServices is atm broken for OTLP / Observability,
since both - default and fallback - end-up with the same ordinal, hence default is used.
Where actually fallback should be used -- since it's defined (added to config) in the LgtmResource class.

e.g.
```
# default set on OtlpExporterTracesConfig
quarkus.otel.exporter.otlp.traces.protocol=grpc
```
vs.
```
quarkus.otel.exporter.otlp.protocol=http/protobuf
```