### PR TITLE
Return InputStream if entity is null in REST Reactive Client

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/ResponseImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/ResponseImpl.java
@@ -88,19 +88,18 @@ public class ResponseImpl extends Response {
         checkClosed();
         // this check seems very ugly, but it seems to be needed by the TCK
         // this will likely require a better solution
-        if (entity instanceof GenericEntity) {
-            GenericEntity<?> genericEntity = (GenericEntity<?>) entity;
+        if (entity instanceof GenericEntity genericEntity) {
             if (genericEntity.getRawType().equals(genericEntity.getType())) {
                 return ((GenericEntity<?>) entity).getEntity();
             }
         }
-        return entity;
+        return entity == null ? entityStream : entity;
     }
 
     protected void setEntity(Object entity) {
         this.entity = entity;
-        if (entity instanceof InputStream) {
-            this.entityStream = (InputStream) entity;
+        if (entity instanceof InputStream inputStream) {
+            this.entityStream = inputStream;
         }
     }
 

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/JAXRSResponseClient.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/JAXRSResponseClient.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.rest.client.main;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/client-logger")
+@RegisterRestClient(configKey = "w-client-logger")
+public interface JAXRSResponseClient {
+
+    @GET
+    Response call();
+
+    @GET
+    Uni<Response> asyncCall();
+}


### PR DESCRIPTION
As specified in `jakarta.ws.rs.core.Response#getEntity`: 
> Get the message entity Java instance. Returns null if the message does not contain an entity body. If the entity is represented by an un-consumed input stream the method will return the input stream.

- Fixes #25496
- Fixes #41887