### PR TITLE
[3.8] Upgrade opentelemetry-semconv to 1.26.0-alpha

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -33,7 +33,7 @@
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
         <opentelemetry.version>1.32.0</opentelemetry.version>
         <opentelemetry-alpha.version>1.32.0-alpha</opentelemetry-alpha.version>
-        <opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version> <!-- keep in sync with opentelemetry-java-instrumentation in the alpha bom-->
+        <opentelemetry-semconv.version>1.26.0-alpha</opentelemetry-semconv.version> <!-- this is not aligned with OpenTelemetry as it was updated to allow a CXF upgrade -->
         <quarkus-http.version>5.2.4</quarkus-http.version>
         <micrometer.version>1.12.2</micrometer.version><!-- keep in sync with hdrhistogram -->
         <hdrhistogram.version>2.1.12</hdrhistogram.version><!-- keep in sync with micrometer -->


### PR DESCRIPTION
(cherry picked from commit c038ed9e89b3676e1cf153bf161fdc5ddf835956)

This was previously discussed and vetted by @brunobat . The origin of the request is @ppalaga so that he can upgrade CXF to fix CVEs in 3.8.