### PR TITLE
Rename GH labels area/resteasy to area/resteasy-classic and area/resteasy-reactive to area/rest

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -301,7 +301,8 @@ triage:
       title: "rest.client"
       notify: [cescoffier, geoand]
       directories:
-        - extensions/rest-client/
+        - extensions/resteasy-classic/rest-client/
+        - extensions/resteasy-reactive/rest-client/
     - id: smallrye
       labels: [area/smallrye]
       title: "smallrye"

--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -611,8 +611,8 @@ triage:
       labels: [area/reactive-streams-operators]
       directories:
         - extensions/reactive-streams-operators/
-    - id: resteasy
-      labels: [area/resteasy]
+    - id: resteasy-classic
+      labels: [area/resteasy-classic]
       directories:
         - extensions/resteasy-classic/
         - extensions/resteasy-classic/resteasy
@@ -625,8 +625,8 @@ triage:
         - integration-tests/resteasy-jackson/
         - integration-tests/elytron-resteasy/
         - integration-tests/virtual-http-resteasy/
-    - id: resteasy-reactive
-      labels: [area/resteasy-reactive]
+    - id: rest
+      labels: [area/rest]
       title: resteasy.reactive
       notify: [geoand, FroMage, stuartwdouglas]
       directories:

--- a/.github/quarkus-github-lottery.yml
+++ b/.github/quarkus-github-lottery.yml
@@ -118,7 +118,7 @@ participants:
       days: ["WEDNESDAY", "FRIDAY"]
       maxIssues: 3
     maintenance:
-      labels: ["area/core", "area/testing", "area/kotlin", "area/spring", "area/resteasy-reactive", "area/kubernetes"]
+      labels: ["area/core", "area/testing", "area/kotlin", "area/spring", "area/rest", "area/kubernetes"]
       days: ["WEDNESDAY", "FRIDAY"]
       feedback:
         needed:


### PR DESCRIPTION
I'll do the actual label renaming in the GitHub UI as soon as this gets approved, so I can limit the amount of problems with the bot trying to assign labels that no longer exist.