### PR TITLE
QuarkusComponentTest: programmatic lookup improvements

### DIFF
--- a/docs/src/main/asciidoc/testing-components.adoc
+++ b/docs/src/main/asciidoc/testing-components.adoc
@@ -177,6 +177,19 @@ Dependent beans injected into the fields and test method arguments are correctly
 
 NOTE: Arguments of a `@ParameterizedTest` method that are provided by an `ArgumentsProvider`, for example with `@org.junit.jupiter.params.provider.ValueArgumentsProvider`, must be annotated with `@SkipInject`. 
 
+=== Tested components
+
+The initial set of tested components is derived from the test class:
+
+1. The types of all fields annotated with `@jakarta.inject.Inject` are considered the component types.
+2. The types of test methods parameters that are not annotated with `@InjectMock`, `@SkipInject`, or `@org.mockito.Mock` are also considered the component types.
+3. If `@QuarkusComponentTest#addNestedClassesAsComponents()` is set to `true` (default) then all static nested classes declared on the test class are components too.
+
+NOTE: `@Inject Instance<T>` and `@Inject @All List<T>` injection points are handled specifically. The actual type argument is registered as a component. However, if the type argument is an interface the implementations _are not registered_ automatically. 
+
+Additional component classes can be set using `@QuarkusComponentTest#value()` or `QuarkusComponentTestExtensionBuilder#addComponentClasses()`.
+
+
 [[auto_mocking]]
 === Auto Mocking Unsatisfied Dependencies
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceImpl.java
@@ -119,7 +119,7 @@ public class InstanceImpl<T> implements InjectableInstance<T> {
         return new Guard<>(result);
     }
 
-    static <T> InstanceImpl<T> forGlobalEntrypoint(Type requiredType, Set<Annotation> requiredQualifiers) {
+    public static <T> InstanceImpl<T> forGlobalEntrypoint(Type requiredType, Set<Annotation> requiredQualifiers) {
         return new InstanceImpl<>(new CreationalContextImpl<>(null), requiredType, requiredQualifiers,
                 null, null, Collections.emptySet(), null, -1, false, true);
     }
@@ -309,7 +309,7 @@ public class InstanceImpl<T> implements InjectableInstance<T> {
         return getBeanInstance(bean());
     }
 
-    void destroy() {
+    public void destroy() {
         creationalContext.release();
     }
 

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
@@ -3,8 +3,10 @@ package io.quarkus.test.component;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -27,7 +29,7 @@ public class QuarkusComponentTestExtensionBuilder {
     public static final int DEFAULT_CONFIG_SOURCE_ORDINAL = 500;
 
     private final Map<String, String> configProperties = new HashMap<>();
-    private final List<Class<?>> componentClasses = new ArrayList<>();
+    private final Set<Class<?>> componentClasses = new HashSet<>();
     private final List<MockBeanConfiguratorImpl<?>> mockConfigurators = new ArrayList<>();
     private final List<AnnotationsTransformer> annotationsTransformers = new ArrayList<>();
     private final List<Converter<?>> configConverters = new ArrayList<>();
@@ -164,7 +166,7 @@ public class QuarkusComponentTestExtensionBuilder {
             converters = List.copyOf(converters);
         }
         return new QuarkusComponentTestExtension(new QuarkusComponentTestConfiguration(Map.copyOf(configProperties),
-                List.copyOf(componentClasses), List.copyOf(mockConfigurators), useDefaultConfigProperties,
+                Set.copyOf(componentClasses), List.copyOf(mockConfigurators), useDefaultConfigProperties,
                 addNestedClassesAsComponents, configSourceOrdinal,
                 List.copyOf(annotationsTransformers), converters, configBuilderCustomizer));
     }

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/InstanceComponentTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/InstanceComponentTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class InstanceComponentTest {
+
+    @Inject
+    Instance<SomeBean> instance;
+
+    @Test
+    public void testComponents() {
+        assertTrue(instance.get().ping());
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/InstanceInterfaceTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/InstanceInterfaceTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class InstanceInterfaceTest {
+
+    @Inject
+    Instance<SomeInterface> instance;
+
+    @Test
+    public void testComponents() {
+        // SomeInterface is registered as component but no implementation is added automatically
+        assertTrue(instance.isUnsatisfied());
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/InstanceInterfaceUnremovableTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/InstanceInterfaceUnremovableTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class InstanceInterfaceUnremovableTest {
+
+    @Inject
+    Instance<SomeInterface> instance;
+
+    @Test
+    public void testComponents() {
+        assertTrue(instance.isResolvable());
+    }
+
+    @Dependent
+    public static class Foo implements SomeInterface {
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ListAllComponentTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ListAllComponentTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.arc.All;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class ListAllComponentTest {
+
+    @Inject
+    @All
+    List<SomeBean> components;
+
+    @Test
+    public void testComponents() {
+        // SomeBean is registered as component
+        assertEquals(1, components.size());
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ListAllInterfaceTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ListAllInterfaceTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.arc.All;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class ListAllInterfaceTest {
+
+    @Inject
+    @All
+    List<SomeInterface> components;
+
+    @Test
+    public void testComponents() {
+        // SomeInterface is registered as component but no implementation is added automatically
+        assertEquals(0, components.size());
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ListAllInterfaceUnremovableTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ListAllInterfaceUnremovableTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.arc.All;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class ListAllInterfaceUnremovableTest {
+
+    @Inject
+    @All
+    List<SomeInterface> components;
+
+    @Test
+    public void testComponents() {
+        assertEquals(1, components.size());
+    }
+
+    @Dependent
+    public static class Foo implements SomeInterface {
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ListAllMockTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ListAllMockTest.java
@@ -27,10 +27,6 @@ public class ListAllMockTest {
     @InjectMock
     Delta delta;
 
-    @Inject
-    @All
-    List<Delta> deltas;
-
     @InjectMock
     @SimpleQualifier
     Bravo bravo;
@@ -42,7 +38,6 @@ public class ListAllMockTest {
         assertFalse(component.ping());
         assertEquals(1, component.bravos.size());
         assertEquals("ok", component.bravos.get(0).ping());
-        assertEquals(deltas.get(0).ping(), component.ping());
     }
 
     @Singleton

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/SomeBean.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/SomeBean.java
@@ -1,0 +1,20 @@
+package io.quarkus.test.component.declarative;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SomeBean implements SomeInterface {
+
+    private boolean val;
+
+    public boolean ping() {
+        return val;
+    }
+
+    @PostConstruct
+    void init() {
+        val = true;
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/SomeInterface.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/SomeInterface.java
@@ -1,0 +1,5 @@
+package io.quarkus.test.component.declarative;
+
+public interface SomeInterface {
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionTest.java
@@ -3,9 +3,12 @@ package io.quarkus.test.component.paraminject;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.function.Supplier;
+
+import jakarta.enterprise.inject.Instance;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -43,7 +46,8 @@ public class ParameterInjectionTest {
             // And so no matching bean exists
             @SkipInject Supplier<Object> shouldBeTrue,
             // @All List<> needs special handling
-            @All List<MyComponent> allMyComponents) {
+            @All List<MyComponent> allMyComponents,
+            Instance<MyComponent> instance) {
         Mockito.when(charlie.ping()).thenReturn("foo");
         assertNotNull(testInfo);
         assertEquals("foo and BAZ", myComponent.ping());
@@ -51,6 +55,8 @@ public class ParameterInjectionTest {
         assertEquals(1, allMyComponents.size());
         assertEquals(myComponent.ping(), allMyComponents.get(0).ping());
         assertEquals(Boolean.TRUE, shouldBeTrue.get());
+        assertNotNull(instance);
+        assertTrue(instance.isResolvable());
     }
 
     public static class MyParamResolver implements ParameterResolver {


### PR DESCRIPTION
- handle programmatic lookup injection points specifically: register type arguments as tested components and consider these types in the unused beans removal exclusion
- support programmatic lookup in test method params (`Instance<>`, `@All List<>`)
- add "Tested components" section in the docs
- related to #42643