### PR TITLE
False error message on cli plug with flags

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
@@ -176,7 +177,8 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
                         .collect(Collectors.toList());
                 if (!unmatchedSubcommands.isEmpty()) {
                     missingCommand.append("-").append(unmatchedSubcommands.get(0));
-                    return Optional.of(missingCommand.toString());
+                    // We don't want the root itself to be added to the result
+                    return Optional.of(missingCommand.toString().replaceFirst(Pattern.quote(root.getCommandName() + "-"), ""));
                 }
 
                 currentParseResult = currentParseResult.subcommand();

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
@@ -178,7 +177,7 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
                 if (!unmatchedSubcommands.isEmpty()) {
                     missingCommand.append("-").append(unmatchedSubcommands.get(0));
                     // We don't want the root itself to be added to the result
-                    return Optional.of(missingCommand.toString().replaceFirst(Pattern.quote(root.getCommandName() + "-"), ""));
+                    return Optional.of(stripRootPrefix(missingCommand.toString(), root.getCommandName() + "-"));
                 }
 
                 currentParseResult = currentParseResult.subcommand();
@@ -193,6 +192,14 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
             // This will be handled by Picocli at a later step.
             return Optional.empty();
         }
+    }
+
+    private static String stripRootPrefix(String command, String rootPrefix) {
+        if (!command.startsWith(rootPrefix)) {
+            return command;
+        }
+
+        return command.substring(rootPrefix.length());
     }
 
     @Override


### PR DESCRIPTION
Resolves: #42784

The `checkMissingCommand` method has two exit point each behaving differently. One is including the root command as prefix and the other is not. The pull request aligns the two, by removing the prefix, which is also what the rest of the code expects.