### PR TITLE
Qute: print origin if non-literal value used in bracket notation

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -1078,9 +1078,11 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
                 value = literal.toString();
             } else {
                 throw TemplateException.builder()
-                        .message((literal == null ? "Null" : "Non-literal")
-                                + " value used in bracket notation [{value}] {origin}")
+                        .message((literal == null ? "Null value" : "Non-literal value [{value}]")
+                                + " used in bracket notation in expression \\{{expr}\\}{#if origin.hasNonGeneratedTemplateId??} in{origin}{/if}")
                         .argument("value", value)
+                        .argument("expr", exprValue)
+                        .origin(origin)
                         .build();
             }
         } else {

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -466,6 +467,15 @@ public class ParserTest {
         assertSectionParams(engine, "{#let my = (bad or not) id=1}", Map.of("my", "(bad or not)", "id", "1"));
         assertSectionParams(engine, "{#let my= (bad or not) id=1}", Map.of("my", "(bad or not)", "id", "1"));
 
+    }
+
+    @Test
+    public void testNonLiteralBracketNotation() {
+        TemplateException e = assertThrows(TemplateException.class,
+                () -> Engine.builder().addDefaults().build().parse("{foo[bar]}", null, "baz"));
+        assertNotNull(e.getOrigin());
+        assertEquals("Non-literal value [bar] used in bracket notation in expression {foo[bar]} in template [baz] line 1",
+                e.getMessage());
     }
 
     private void assertSectionParams(Engine engine, String content, Map<String, String> expectedParams) {


### PR DESCRIPTION
- fixes #42733