### PR TITLE
Avoid `NullPointerException`s when application fails to start

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -452,13 +452,15 @@ public class ApplicationLifecycleManager {
             }
             //take a reliable reference before changing the application state:
             final Application app = currentApplication;
-            if (app.isStarted()) {
-                // On CLI apps, SIGINT won't call io.quarkus.runtime.Application#stop(),
-                // making the awaitShutdown() below block the application termination process
-                // It should be a noop if called twice anyway
-                app.stop();
+            if (app != null) {
+                if (app.isStarted()) {
+                    // On CLI apps, SIGINT won't call io.quarkus.runtime.Application#stop(),
+                    // making the awaitShutdown() below block the application termination process
+                    // It should be a noop if called twice anyway
+                    app.stop();
+                }
+                app.awaitShutdown();
             }
-            app.awaitShutdown();
             currentApplication = null;
             System.out.flush();
             System.err.flush();


### PR DESCRIPTION
Follow up to https://github.com/quarkusio/quarkus/pull/42208