### PR TITLE
OIDC: Limit number of dynamic tenants

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -119,17 +119,18 @@ public class DefaultTenantConfigResolver {
                             final String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
 
                             if (tenantId != null && !isTenantSetByAnnotation(context, tenantId)) {
-                                TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                                // WARN: The order (check dynamic before static) is important!
+                                var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                                 if (tenantContext != null) {
                                     // Dynamic map may contain the static contexts initialized on demand,
-                                    if (tenantConfigBean.getStaticTenantsConfig().containsKey(tenantId)) {
+                                    if (tenantConfigBean.getStaticTenant(tenantId) != null) {
                                         context.put(CURRENT_STATIC_TENANT_ID, tenantId);
                                     }
                                     return tenantContext.getOidcTenantConfig();
                                 }
                             }
 
-                            TenantConfigContext tenant = getStaticTenantContext(context);
+                            var tenant = getStaticTenantContext(context);
                             if (tenant != null) {
                                 tenantConfig = tenant.oidcConfig;
                             }
@@ -156,12 +157,11 @@ public class DefaultTenantConfigResolver {
         if (tenantContext != null && !tenantContext.ready) {
 
             // check if the connection has already been created
-            TenantConfigContext readyTenantContext = tenantConfigBean.getDynamicTenantsConfig()
-                    .get(tenantContext.oidcConfig.tenantId.get());
+            var readyTenantContext = tenantConfigBean.getDynamicTenant(tenantContext.oidcConfig.tenantId.get());
             if (readyTenantContext == null) {
                 LOG.debugf("Tenant '%s' is not initialized yet, trying to create OIDC connection now",
                         tenantContext.oidcConfig.tenantId.get());
-                return tenantConfigBean.getTenantConfigContextFactory().apply(tenantContext.oidcConfig);
+                return tenantConfigBean.createTenantContext(tenantContext.oidcConfig, false);
             } else {
                 tenantContext = readyTenantContext;
             }
@@ -206,7 +206,7 @@ public class DefaultTenantConfigResolver {
     }
 
     private TenantConfigContext getStaticTenantContext(String tenantId) {
-        TenantConfigContext configContext = tenantId != null ? tenantConfigBean.getStaticTenantsConfig().get(tenantId) : null;
+        TenantConfigContext configContext = tenantId != null ? tenantConfigBean.getStaticTenant(tenantId) : null;
         if (configContext == null) {
             if (tenantId != null && !tenantId.isEmpty()) {
                 LOG.debugf(
@@ -255,7 +255,12 @@ public class DefaultTenantConfigResolver {
                     //shouldn't happen, but guard against it anyway
                     oidcConfig = Uni.createFrom().nullItem();
                 } else {
-                    oidcConfig = oidcConfig.onItem().transform(cfg -> OidcUtils.resolveProviderConfig(cfg));
+                    oidcConfig = oidcConfig.onItem().transform(new Function<OidcTenantConfig, OidcTenantConfig>() {
+                        @Override
+                        public OidcTenantConfig apply(OidcTenantConfig cfg) {
+                            return OidcUtils.resolveProviderConfig(cfg);
+                        }
+                    });
                 }
                 context.put(CURRENT_DYNAMIC_TENANT_CONFIG, oidcConfig);
             }
@@ -270,18 +275,18 @@ public class DefaultTenantConfigResolver {
             @Override
             public Uni<? extends TenantConfigContext> apply(OidcTenantConfig tenantConfig) {
                 if (tenantConfig != null) {
-                    String tenantId = tenantConfig.getTenantId()
+                    var tenantId = tenantConfig.getTenantId()
                             .orElseThrow(() -> new OIDCException("Tenant configuration must have tenant id"));
-                    TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                    var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                     if (tenantContext == null) {
-                        return tenantConfigBean.getTenantConfigContextFactory().apply(tenantConfig);
+                        return tenantConfigBean.createTenantContext(tenantConfig, true);
                     } else {
                         return Uni.createFrom().item(tenantContext);
                     }
                 } else {
-                    final String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
+                    String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
                     if (tenantId != null && !isTenantSetByAnnotation(context, tenantId)) {
-                        TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                        var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                         if (tenantContext != null) {
                             return Uni.createFrom().item(tenantContext);
                         }
@@ -324,21 +329,22 @@ public class DefaultTenantConfigResolver {
         }
 
         // 2. path-matching tenant resolver
-        var pathMatchingTenantResolver = PathMatchingTenantResolver.of(tenantConfigBean.getStaticTenantsConfig(), rootPath,
+        var staticTenants = tenantConfigBean.getStaticTenantsConfig();
+        var pathMatchingTenantResolver = PathMatchingTenantResolver.of(staticTenants, rootPath,
                 tenantConfigBean.getDefaultTenant());
         if (pathMatchingTenantResolver != null) {
             staticTenantResolvers.add(pathMatchingTenantResolver);
         }
 
         // 3. default static tenant resolver
-        if (!tenantConfigBean.getStaticTenantsConfig().isEmpty()) {
+        if (!staticTenants.isEmpty()) {
             staticTenantResolvers.add(defaultStaticTenantResolver);
         }
 
         // 4. issuer-based tenant resolver
         if (resolveTenantsWithIssuer) {
             IssuerBasedTenantResolver.addIssuerBasedTenantResolver(staticTenantResolvers,
-                    tenantConfigBean.getStaticTenantsConfig(), tenantConfigBean.getDefaultTenant());
+                    staticTenants, tenantConfigBean.getDefaultTenant());
         }
 
         return staticTenantResolvers.toArray(new TenantResolver[0]);
@@ -351,7 +357,7 @@ public class DefaultTenantConfigResolver {
             String[] pathSegments = context.request().path().split("/");
             if (pathSegments.length > 0) {
                 String lastPathSegment = pathSegments[pathSegments.length - 1];
-                if (tenantConfigBean.getStaticTenantsConfig().containsKey(lastPathSegment)) {
+                if (tenantConfigBean.getStaticTenant(lastPathSegment) != null) {
                     LOG.debugf(
                             "Tenant id '%s' is selected on the '%s' request path", lastPathSegment, context.normalizedPath());
                     return lastPathSegment;
@@ -390,14 +396,13 @@ public class DefaultTenantConfigResolver {
             return null;
         }
 
-        private static ImmutablePathMatcher.ImmutablePathMatcherBuilder<String> addPath(String tenant, OidcTenantConfig config,
+        private static void addPath(String tenant, OidcTenantConfig config,
                 ImmutablePathMatcher.ImmutablePathMatcherBuilder<String> builder) {
             if (config != null && config.tenantPaths.isPresent()) {
                 for (String path : config.tenantPaths.get()) {
                     builder.addPath(path, tenant);
                 }
             }
-            return builder;
         }
     }
 
@@ -406,14 +411,11 @@ public class DefaultTenantConfigResolver {
             return tenantConfigBean.getDefaultTenant().getOidcTenantConfig();
         }
 
-        if (tenantConfigBean.getStaticTenantsConfig().containsKey(sessionTenantId)) {
-            return tenantConfigBean.getStaticTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
+        var tenant = tenantConfigBean.getStaticTenant(sessionTenantId);
+        if (tenant == null) {
+            tenant = tenantConfigBean.getDynamicTenant(sessionTenantId);
         }
-
-        if (tenantConfigBean.getDynamicTenantsConfig().containsKey(sessionTenantId)) {
-            return tenantConfigBean.getDynamicTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
-        }
-        return null;
+        return tenant != null ? tenant.getOidcTenantConfig() : null;
     }
 
     public String getRootPath() {
@@ -449,7 +451,7 @@ public class DefaultTenantConfigResolver {
                         if (tenantContext.getOidcMetadata().getIssuer().equals(iss)) {
                             OidcUtils.storeExtractedBearerToken(context, token);
 
-                            final String tenantId = tenantContext.oidcConfig.tenantId.get();
+                            final String tenantId = tenantContext.oidcConfig.tenantId.orElseThrow();
                             LOG.debugf("Resolved the '%s' OIDC tenant based on the matching issuer '%s'", tenantId, iss);
                             return tenantId;
                         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -153,7 +153,7 @@ public class DefaultTenantConfigResolver {
     private Uni<TenantConfigContext> initializeStaticTenantIfContextNotReady(TenantConfigContext tenantContext) {
         requireNonNull(tenantContext, "tenantContext must never be null");
 
-        if (!tenantContext.ready) {
+        if (!tenantContext.isReady()) {
             return tenantConfigBean.getOrCreateTenantContext(tenantContext.oidcConfig, false);
         }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.runtime;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -42,6 +43,13 @@ public class OidcConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean resolveTenantsWithIssuer;
+
+    /**
+     * If configured, limit the number of active dynamic OIDC tenant contexts to this value.
+     * If not set, the number of active dynamic OIDC tenant contexts is unlimited.
+     */
+    @ConfigItem
+    public OptionalInt dynamicTenantLimit;
 
     /**
      * Default TokenIntrospection and UserInfo cache configuration.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -1,12 +1,16 @@
 package io.quarkus.oidc.runtime;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import jakarta.enterprise.context.spi.CreationalContext;
 
 import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 
 public class TenantConfigBean {
@@ -14,33 +18,58 @@ public class TenantConfigBean {
     private final Map<String, TenantConfigContext> staticTenantsConfig;
     private final Map<String, TenantConfigContext> dynamicTenantsConfig;
     private final TenantConfigContext defaultTenant;
-    private final Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory;
+    private final TenantContextFactory tenantContextFactory;
+
+    @FunctionalInterface
+    public interface TenantContextFactory {
+        Uni<TenantConfigContext> create(OidcTenantConfig oidcTenantConfig, boolean dynamicTenant, String tenantId);
+    }
 
     public TenantConfigBean(
             Map<String, TenantConfigContext> staticTenantsConfig,
-            Map<String, TenantConfigContext> dynamicTenantsConfig,
             TenantConfigContext defaultTenant,
-            Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory) {
-        this.staticTenantsConfig = staticTenantsConfig;
-        this.dynamicTenantsConfig = dynamicTenantsConfig;
+            TenantContextFactory tenantContextFactory) {
+        this.staticTenantsConfig = new ConcurrentHashMap<>(staticTenantsConfig);
+        this.dynamicTenantsConfig = new ConcurrentHashMap<>();
         this.defaultTenant = defaultTenant;
-        this.tenantConfigContextFactory = tenantConfigContextFactory;
+        this.tenantContextFactory = tenantContextFactory;
+    }
+
+    public Uni<TenantConfigContext> createTenantContext(OidcTenantConfig oidcConfig, boolean dynamicTenant) {
+        if (oidcConfig.logout.backchannel.path.isPresent()) {
+            throw new ConfigurationException(
+                    "BackChannel Logout is currently not supported for dynamic tenants");
+        }
+        var tenantId = oidcConfig.getTenantId().orElseThrow();
+        if (!dynamicTenantsConfig.containsKey(tenantId)) {
+            Uni<TenantConfigContext> uniContext = tenantContextFactory.create(oidcConfig, dynamicTenant, tenantId);
+            return uniContext.onItem().transform(
+                    new Function<TenantConfigContext, TenantConfigContext>() {
+                        @Override
+                        public TenantConfigContext apply(TenantConfigContext t) {
+                            dynamicTenantsConfig.putIfAbsent(tenantId, t);
+                            return t;
+                        }
+                    });
+        } else {
+            return Uni.createFrom().item(dynamicTenantsConfig.get(tenantId));
+        }
+    }
+
+    public TenantConfigContext getStaticTenant(String tenantId) {
+        return staticTenantsConfig.get(tenantId);
     }
 
     public Map<String, TenantConfigContext> getStaticTenantsConfig() {
-        return staticTenantsConfig;
+        return unmodifiableMap(staticTenantsConfig);
+    }
+
+    public TenantConfigContext getDynamicTenant(String tenantId) {
+        return dynamicTenantsConfig.get(tenantId);
     }
 
     public TenantConfigContext getDefaultTenant() {
         return defaultTenant;
-    }
-
-    public Function<OidcTenantConfig, Uni<TenantConfigContext>> getTenantConfigContextFactory() {
-        return tenantConfigContextFactory;
-    }
-
-    public Map<String, TenantConfigContext> getDynamicTenantsConfig() {
-        return dynamicTenantsConfig;
     }
 
     public static class Destroyer implements BeanDestroyer<TenantConfigBean> {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -16,6 +16,9 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 
 public class TenantConfigBean {
+    /*
+     * Note: this class is publicly documented on https://quarkus.io/guides/security-oidc-code-flow-authentication.
+     */
 
     private static final Logger LOG = Logger.getLogger(TenantConfigBean.class);
 
@@ -29,7 +32,7 @@ public class TenantConfigBean {
         Uni<TenantConfigContext> create(OidcTenantConfig oidcTenantConfig, boolean dynamicTenant, String tenantId);
     }
 
-    public TenantConfigBean(
+    TenantConfigBean(
             Map<String, TenantConfigContext> staticTenantsConfig,
             TenantConfigContext defaultTenant,
             TenantContextFactory tenantContextFactory) {
@@ -39,16 +42,16 @@ public class TenantConfigBean {
         this.tenantContextFactory = tenantContextFactory;
     }
 
-    public Uni<TenantConfigContext> createTenantContext(OidcTenantConfig oidcConfig, boolean dynamicTenant) {
+    Uni<TenantConfigContext> getOrCreateTenantContext(OidcTenantConfig oidcConfig, boolean dynamicTenant) {
         var tenantId = oidcConfig.getTenantId().orElseThrow();
-        if (dynamicTenant && oidcConfig.logout.backchannel.path.isPresent()) {
-            throw new ConfigurationException(
-                    "BackChannel Logout is currently not supported for dynamic tenants (tenant ID: " + tenantId + ")");
-        }
         var tenants = dynamicTenant ? dynamicTenantsConfig : staticTenantsConfig;
         var tenant = tenants.get(tenantId);
         if (tenant == null || !tenant.ready) {
             LOG.tracef("Creating %s tenant config for %s", dynamicTenant ? "dynamic" : "static", tenantId);
+            if (dynamicTenant && oidcConfig.logout.backchannel.path.isPresent()) {
+                throw new ConfigurationException(
+                        "BackChannel Logout is currently not supported for dynamic tenants (tenant ID: " + tenantId + ")");
+            }
             Uni<TenantConfigContext> uniContext = tenantContextFactory.create(oidcConfig, dynamicTenant, tenantId);
             return uniContext.onItem().transform(
                     new Function<TenantConfigContext, TenantConfigContext>() {
@@ -60,24 +63,58 @@ public class TenantConfigBean {
                             return t;
                         }
                     });
-        } else {
-            LOG.tracef("Immediately returning ready %s tenant config for %s", dynamicTenant ? "dynamic" : "static", tenantId);
-            return Uni.createFrom().item(tenant);
         }
+        LOG.tracef("Immediately returning ready %s tenant config for %s", dynamicTenant ? "dynamic" : "static", tenantId);
+        return Uni.createFrom().item(tenant);
     }
 
-    public TenantConfigContext getStaticTenant(String tenantId) {
+    /**
+     * Returns a static tenant's config context or {@code null}, if the tenant does not exist.
+     */
+    public TenantConfigContext getStaticTenantConfigContext(String tenantId) {
         return staticTenantsConfig.get(tenantId);
     }
 
+    /**
+     * Returns a static tenant's OIDC configuration or {@code null}, if the tenant does not exist.
+     */
+    public OidcTenantConfig getStaticTenantOidcConfig(String tenantId) {
+        var context = getStaticTenantConfigContext(tenantId);
+        return context != null ? context.oidcConfig : null;
+    }
+
+    /**
+     * Returns an unmodifiable map containing the static tenant config contexts by tenant-ID.
+     */
     public Map<String, TenantConfigContext> getStaticTenantsConfig() {
         return unmodifiableMap(staticTenantsConfig);
     }
 
-    public TenantConfigContext getDynamicTenant(String tenantId) {
+    /**
+     * Returns a dynamic tenant's config context or {@code null}, if the tenant does not exist.
+     */
+    public TenantConfigContext getDynamicTenantConfigContext(String tenantId) {
         return dynamicTenantsConfig.get(tenantId);
     }
 
+    /**
+     * Returns a dynamic tenant's OIDC configuration or {@code null}, if the tenant does not exist.
+     */
+    public OidcTenantConfig getDynamicTenantOidcConfig(String tenantId) {
+        var context = getDynamicTenantConfigContext(tenantId);
+        return context != null ? context.oidcConfig : null;
+    }
+
+    /**
+     * Returns an unmodifiable map containing the dynamic tenant config contexts by tenant-ID.
+     */
+    public Map<String, TenantConfigContext> getDynamicTenantsConfig() {
+        return unmodifiableMap(dynamicTenantsConfig);
+    }
+
+    /**
+     * Returns the default tenant's config context.
+     */
     public TenantConfigContext getDefaultTenant() {
         return defaultTenant;
     }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanTest.java
@@ -1,0 +1,246 @@
+package io.quarkus.oidc.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.smallrye.mutiny.Uni;
+
+public class TenantConfigBeanTest {
+
+    /**
+     * Straight forward dynamic-tenant limit test, create 10 tenants - implementation limits the number of dynamic tenants.
+     */
+    @Test
+    public void dynamicTenantsLimit() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        Set<String> evictedTenants = new HashSet<>();
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> Uni.createFrom().item(testContext(tenantId))) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                boolean evicted = super.evictTenant(candidate);
+                if (evicted) {
+                    evictedTenants.add(candidate.tenantId());
+                }
+                return evicted;
+            }
+        };
+
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            bean.getOrCreateTenantContext(tenantConfig("tenant-" + i), true).await().indefinitely();
+
+            for (int i1 = 0; i1 < i - limit; i1++) {
+                String tenantId = "tenant-" + i1;
+                assertNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+                assertTrue(evictedTenants.contains(tenantId), tenantId);
+            }
+        }
+    }
+
+    /**
+     * Simulate delayed eviction (already running).
+     *
+     * <ol>
+     * <li>Create 10 tenants (no/blocked eviction).
+     * <li>Unblock eviction.
+     * <li>Create another tenant.
+     * <li>First 8 created tenants must have been evicted.
+     * </ol>
+     */
+    @Test
+    public void dynamicTenantsLimitDelayedEviction() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        Set<String> evictedTenants = new HashSet<>();
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> Uni.createFrom().item(testContext(tenantId))) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                boolean evicted = super.evictTenant(candidate);
+                if (evicted) {
+                    evictedTenants.add(candidate.tenantId());
+                }
+                return evicted;
+            }
+        };
+
+        bean.tenantEvictionRunning.set(true);
+
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            String tenantId = "tenant-" + i;
+            bean.getOrCreateTenantContext(tenantConfig(tenantId), true).await().indefinitely();
+            assertTrue(evictedTenants.isEmpty(), tenantId);
+        }
+
+        bean.tenantEvictionRunning.set(false);
+
+        clock.incrementAndGet();
+        bean.getOrCreateTenantContext(tenantConfig("tenant-X"), true).await().indefinitely();
+        for (int i = 0; i < 8; i++) {
+            String tenantId = "tenant-" + i;
+            assertNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertTrue(evictedTenants.contains(tenantId), tenantId);
+        }
+    }
+
+    /**
+     * Simulate delayed eviction (already running).
+     *
+     * <ol>
+     * <li>Create 10 tenants (no/blocked eviction).
+     * <li>Simulate usa of the first 5 tenants.
+     * <li>Unblock eviction.
+     * <li>Create another tenant.
+     * <li>Tenants 0-2 + 5-9 must have been evicted (3,4,X are the three newest).
+     * </ol>
+     */
+    @Test
+    public void dynamicTenantsLimitDelayedEvictionRecentlyUsed() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        Set<String> evictedTenants = new HashSet<>();
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> Uni.createFrom().item(testContext(tenantId))) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                boolean evicted = super.evictTenant(candidate);
+                if (evicted) {
+                    evictedTenants.add(candidate.tenantId());
+                }
+                return evicted;
+            }
+        };
+
+        bean.tenantEvictionRunning.set(true);
+
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            String tenantId = "tenant-" + i;
+            bean.getOrCreateTenantContext(tenantConfig(tenantId), true).await().indefinitely();
+            assertTrue(evictedTenants.isEmpty(), tenantId);
+        }
+
+        for (int i = 0; i < 5; i++) {
+            clock.incrementAndGet();
+            bean.getDynamicTenantConfigContext("tenant-" + i);
+        }
+
+        bean.tenantEvictionRunning.set(false);
+
+        clock.incrementAndGet();
+        bean.getOrCreateTenantContext(tenantConfig("tenant-X"), true).await().indefinitely();
+
+        Stream.of(0, 1, 2, 5, 6, 7, 8, 9).forEach(i -> {
+            String tenantId = "tenant-" + i;
+            assertNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertTrue(evictedTenants.contains(tenantId), tenantId);
+        });
+        {
+            String tenantId = "tenant-X";
+            assertNotNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertFalse(evictedTenants.contains(tenantId), tenantId);
+        }
+    }
+
+    /**
+     * Simulate delayed eviction (already running).
+     *
+     * <ol>
+     * <li>Create 10 tenants (no/blocked eviction).
+     * <li>Unblock eviction.
+     * <li>Create another tenant.
+     * <li>Simulate use of the first 5 tenants _during_ eviction.
+     * <li>Tenants 0-2 + 5-9 must have been evicted (3,4,X are the three newest).
+     * </ol>
+     */
+    @Test
+    public void dynamicTenantsLimitDelayedEvictionConcurrentAccess() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        Set<String> evictedTenants = new HashSet<>();
+        Map<String, Long> newMaxLastUsed = new HashMap<>();
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> Uni.createFrom().item(testContext(tenantId))) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                Long newLastUsed = newMaxLastUsed.get(candidate.tenantId());
+                if (newLastUsed != null) {
+                    candidate.context().lastUsed = newLastUsed;
+                }
+                boolean evicted = super.evictTenant(candidate);
+                if (evicted) {
+                    evictedTenants.add(candidate.tenantId());
+                }
+                return evicted;
+            }
+        };
+
+        bean.tenantEvictionRunning.set(true);
+
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            String tenantId = "tenant-" + i;
+            bean.getOrCreateTenantContext(tenantConfig(tenantId), true).await().indefinitely();
+            assertTrue(evictedTenants.isEmpty(), tenantId);
+        }
+
+        bean.tenantEvictionRunning.set(false);
+
+        for (int i = 0; i < 5; i++) {
+            newMaxLastUsed.put("tenant-" + i, clock.incrementAndGet());
+        }
+
+        clock.incrementAndGet();
+        bean.getOrCreateTenantContext(tenantConfig("tenant-X"), true).await().indefinitely();
+
+        Stream.of(0, 1, 2, 5, 6, 7, 8, 9).forEach(i -> {
+            String tenantId = "tenant-" + i;
+            assertNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertTrue(evictedTenants.contains(tenantId), tenantId);
+        });
+        {
+            String tenantId = "tenant-X";
+            assertNotNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertFalse(evictedTenants.contains(tenantId), tenantId);
+        }
+    }
+
+    static TenantConfigContext testContext(String tenantId) {
+        OidcTenantConfig config = tenantConfig(tenantId);
+        return new TenantConfigContext(null, config, Collections.emptyMap());
+    }
+
+    static OidcTenantConfig tenantConfig(String tenantId) {
+        OidcTenantConfig config = new OidcTenantConfig();
+        config.setTenantId(tenantId);
+        return config;
+    }
+}

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -62,7 +62,7 @@ public class ProtectedResource {
     }
 
     private String getClientName() {
-        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenantsConfig().get(session.getTenantId())
+        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenant(session.getTenantId())
                 .getOidcTenantConfig();
         return oidcConfig.getClientName().get();
     }

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -62,8 +62,7 @@ public class ProtectedResource {
     }
 
     private String getClientName() {
-        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenant(session.getTenantId())
-                .getOidcTenantConfig();
+        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenantOidcConfig(session.getTenantId());
         return oidcConfig.getClientName().get();
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
@@ -39,7 +39,7 @@ public class TenantRefresh {
             // Cookie format: jwt|<tenant id>
 
             String[] pair = sessionExpired.split("\\|");
-            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenantsConfig().get(pair[1]).getOidcTenantConfig();
+            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenant(pair[1]).getOidcTenantConfig();
             JsonWebToken jwt = new DefaultJWTParser().decrypt(pair[0], oidcConfig.credentials.secret.get());
 
             OidcUtils.removeCookie(context, oidcConfig, "session_expired");

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
@@ -39,7 +39,7 @@ public class TenantRefresh {
             // Cookie format: jwt|<tenant id>
 
             String[] pair = sessionExpired.split("\\|");
-            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenant(pair[1]).getOidcTenantConfig();
+            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenantConfigContext(pair[1]).getOidcTenantConfig();
             JsonWebToken jwt = new DefaultJWTParser().decrypt(pair[0], oidcConfig.credentials.secret.get());
 
             OidcUtils.removeCookie(context, oidcConfig, "session_expired");

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -199,6 +199,7 @@ quarkus.http.proxy.allow-forwarded=true
 
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime".level=DEBUG
 quarkus.log.category."io.quarkus.resteasy.runtime.AuthenticationFailedExceptionMapper".level=DEBUG
 quarkus.log.category."io.quarkus.resteasy.runtime.AuthenticationCompletionExceptionMapper".level=DEBUG
 quarkus.log.category."io.quarkus.resteasy.runtime.UnauthorizedExceptionMapper".level=DEBUG

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -358,7 +358,8 @@ public class CodeFlowTest {
             page = webClient.getPage(endpointLocationWithoutQueryUri.toURL());
             String response = page.getBody().asNormalizedText();
             assertTrue(
-                    response.startsWith("tenant-https:reauthenticated?code=b&expiresAt=" + expiresAt + "&expiresInDuration="));
+                    response.startsWith("tenant-https:reauthenticated?code=b&expiresAt=" + expiresAt + "&expiresInDuration="),
+                    response);
             Integer duration = Integer.valueOf(response.substring(response.length() - 1));
             assertTrue(duration > 1 && duration < 5);
 

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -233,6 +233,7 @@ quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime".level=DEBUG
 quarkus.log.file.enable=true
 quarkus.log.file.format=%C - %s%n
 


### PR DESCRIPTION
Introduce a new configuration option `quarkus.oidc.dynamic-tenant-limit` as an opt-in to limit the number of active dynamic OIDC tenants. The default is no dynamic tenant limit.

This change adds the field `volatile long TenantConfigContext.lastUsed`, and removes the field `TenantConfigContext.ready` to keep the heap footprint the same. The `lastUsed` field is initially set to "now" and updated when the dynamic tenant is being accessed.

When a new dynamic tenant is about to be added to the dynamic tenants map, eviction runs, if there are more dynamic tenants than configured via `dynami-tenant-limit`. The eviction algo is built to iterate over the dynamic tenants only once - it may need to iterate more often, if one of the eviction candidates has been accessed in the mean time. There is no linked-list structure to form an LRU list/queue, as that likely causes more runtime overhead (pointer updates, synchronization) than the cost of iterating over the list once in a while. The assumption is that the map of dynamic tenants has not a lot of "churn".

Fixes #42803