### PR TITLE
ArC - static methods interception: fix the set of copied annotations

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/staticmethods/InterceptedStaticMethodTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/staticmethods/InterceptedStaticMethodTest.java
@@ -2,10 +2,12 @@ package io.quarkus.arc.test.interceptor.staticmethods;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -19,15 +21,12 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InterceptorBinding;
 import jakarta.interceptor.InvocationContext;
 
-import org.jboss.jandex.AnnotationTarget;
-import org.jboss.jandex.AnnotationTarget.Kind;
-import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.AnnotationTransformation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opentest4j.AssertionFailedError;
 
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
-import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildStep;
@@ -37,8 +36,9 @@ public class InterceptedStaticMethodTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar
-                    .addClasses(InterceptMe.class, Simple.class, AnotherSimple.class, SimpleInterceptor.class))
+            .withApplicationRoot(root -> root
+                    .addClasses(InterceptMe.class, NotNull.class, WithClassPolicy.class, Simple.class, AnotherSimple.class,
+                            SimpleInterceptor.class))
             .addBuildChainCustomizer(buildCustomizer());
 
     static Consumer<BuildChainBuilder> buildCustomizer() {
@@ -50,23 +50,10 @@ public class InterceptedStaticMethodTest {
 
                     @Override
                     public void execute(BuildContext context) {
-                        context.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
-
-                            @Override
-                            public boolean appliesTo(Kind kind) {
-                                return AnnotationTarget.Kind.METHOD == kind;
-                            }
-
-                            @Override
-                            public void transform(TransformationContext context) {
-                                MethodInfo method = context.getTarget().asMethod();
-                                if (method.declaringClass().name().toString()
-                                        .endsWith("AnotherSimple")) {
-                                    context.transform().add(InterceptMe.class).done();
-                                }
-                            }
-
-                        }));
+                        context.produce(new AnnotationsTransformerBuildItem(
+                                AnnotationTransformation.forMethods()
+                                        .whenMethod(AnotherSimple.class, "ping")
+                                        .transform(tc -> tc.add(InterceptMe.class))));
                     }
                 }).produces(AnnotationsTransformerBuildItem.class).build();
             }
@@ -84,8 +71,9 @@ public class InterceptedStaticMethodTest {
 
     public static class Simple {
 
+        @WithClassPolicy
         @InterceptMe
-        public static String ping(String val) {
+        public static String ping(@NotNull String val) {
             return val.toUpperCase();
         }
 
@@ -124,7 +112,12 @@ public class InterceptedStaticMethodTest {
             // verify annotations can be inspected
             if (ctx.getMethod().getDeclaringClass().getName().equals(Simple.class.getName())) {
                 assertEquals(1, ctx.getMethod().getAnnotations().length);
-                assertNotNull(ctx.getMethod().getAnnotation(InterceptMe.class));
+                assertTrue(ctx.getMethod().isAnnotationPresent(InterceptMe.class));
+                assertFalse(ctx.getMethod().isAnnotationPresent(WithClassPolicy.class));
+                assertFalse(ctx.getMethod().isAnnotationPresent(NotNull.class));
+                if (ctx.getMethod().getName().equals("ping")) {
+                    assertTrue(ctx.getMethod().getParameters()[0].isAnnotationPresent(NotNull.class));
+                }
             }
             Object ret = ctx.proceed();
             if (ret != null) {
@@ -147,6 +140,16 @@ public class InterceptedStaticMethodTest {
     @Target({ TYPE, METHOD })
     @Retention(RUNTIME)
     @interface InterceptMe {
+
+    }
+
+    @Retention(RUNTIME)
+    @interface NotNull {
+
+    }
+
+    @Retention(CLASS)
+    @interface WithClassPolicy {
 
     }
 


### PR DESCRIPTION
- also only consider annotations with RetentionPolicy.RUNTIME because AnnotatedElement#addAnnotation(AnnotationInstance) does not reflect the original RetentionPolicy
- fixes #42828