### PR TITLE
Change default behavior of `@WithTestResource`

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -1,5 +1,8 @@
 package io.quarkus.test.common;
 
+import static io.quarkus.test.common.TestResourceScope.GLOBAL;
+import static io.quarkus.test.common.TestResourceScope.RESTRICTED_TO_CLASS;
+
 import java.io.Closeable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -23,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -35,41 +39,60 @@ import org.jboss.jandex.IndexView;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 
+/**
+ * Manages {@link QuarkusTestResourceLifecycleManager}
+ */
 public class TestResourceManager implements Closeable {
     private static final DotName QUARKUS_TEST_RESOURCE = DotName.createSimple(QuarkusTestResource.class);
     private static final DotName WITH_TEST_RESOURCE = DotName.createSimple(WithTestResource.class);
     public static final String CLOSEABLE_NAME = TestResourceManager.class.getName() + ".closeable";
 
-    private final List<TestResourceEntry> sequentialTestResourceEntries;
-    private final List<TestResourceEntry> parallelTestResourceEntries;
-    private final List<TestResourceEntry> allTestResourceEntries;
+    private final List<TestResourceStartInfo> sequentialTestResources;
+    private final List<TestResourceStartInfo> parallelTestResources;
+    private final List<TestResourceStartInfo> allTestResources;
     private final Map<String, String> configProperties = new ConcurrentHashMap<>();
+    private final Set<TestResourceComparisonInfo> testResourceComparisonInfo;
+
     private boolean started = false;
-    private boolean hasPerTestResources = false;
+
     private TestStatus testStatus = new TestStatus(null);
 
     public TestResourceManager(Class<?> testClass) {
         this(testClass, null, Collections.emptyList(), false);
     }
 
-    public TestResourceManager(Class<?> testClass, Class<?> profileClass, List<TestResourceClassEntry> additionalTestResources,
+    public TestResourceManager(Class<?> testClass,
+            Class<?> profileClass,
+            List<TestResourceClassEntry> additionalTestResources,
             boolean disableGlobalTestResources) {
         this(testClass, profileClass, additionalTestResources, disableGlobalTestResources, Collections.emptyMap(),
                 Optional.empty());
     }
 
-    public TestResourceManager(Class<?> testClass, Class<?> profileClass, List<TestResourceClassEntry> additionalTestResources,
-            boolean disableGlobalTestResources, Map<String, String> devServicesProperties,
+    public TestResourceManager(Class<?> testClass,
+            Class<?> profileClass,
+            List<TestResourceClassEntry> additionalTestResources,
+            boolean disableGlobalTestResources,
+            Map<String, String> devServicesProperties,
             Optional<String> containerNetworkId) {
         this(testClass, profileClass, additionalTestResources, disableGlobalTestResources, devServicesProperties,
                 containerNetworkId, PathTestHelper.getTestClassesLocation(testClass));
     }
 
-    public TestResourceManager(Class<?> testClass, Class<?> profileClass, List<TestResourceClassEntry> additionalTestResources,
-            boolean disableGlobalTestResources, Map<String, String> devServicesProperties,
-            Optional<String> containerNetworkId, Path testClassLocation) {
-        this.parallelTestResourceEntries = new ArrayList<>();
-        this.sequentialTestResourceEntries = new ArrayList<>();
+    /**
+     * This is safe to call as it doesn't do anything other than create state - no {@link QuarkusTestResourceLifecycleManager}
+     * is ever touched
+     * at this stage.
+     */
+    public TestResourceManager(Class<?> testClass,
+            Class<?> profileClass,
+            List<TestResourceClassEntry> additionalTestResources,
+            boolean disableGlobalTestResources,
+            Map<String, String> devServicesProperties,
+            Optional<String> containerNetworkId,
+            Path testClassLocation) {
+        this.parallelTestResources = new ArrayList<>();
+        this.sequentialTestResources = new ArrayList<>();
 
         // we need to keep track of duplicate entries to make sure we don't start the same resource
         // multiple times even if there are multiple same @WithTestResource annotations
@@ -77,14 +100,22 @@ public class TestResourceManager implements Closeable {
         if (disableGlobalTestResources) {
             uniqueEntries = new HashSet<>(additionalTestResources);
         } else {
-            uniqueEntries = getUniqueTestResourceClassEntries(testClassLocation, testClass, profileClass,
+            uniqueEntries = uniqueTestResourceClassEntries(testClassLocation, testClass, profileClass,
                     additionalTestResources);
         }
+
+        this.testResourceComparisonInfo = new HashSet<>();
+        for (TestResourceClassEntry uniqueEntry : uniqueEntries) {
+            testResourceComparisonInfo.add(new TestResourceComparisonInfo(
+                    uniqueEntry.testResourceLifecycleManagerClass().getName(), uniqueEntry.getScope()));
+        }
+
         Set<TestResourceClassEntry> remainingUniqueEntries = initParallelTestResources(uniqueEntries);
         initSequentialTestResources(remainingUniqueEntries);
 
-        this.allTestResourceEntries = new ArrayList<>(sequentialTestResourceEntries);
-        this.allTestResourceEntries.addAll(parallelTestResourceEntries);
+        this.allTestResources = new ArrayList<>(sequentialTestResources);
+        this.allTestResources.addAll(parallelTestResources);
+
         DevServicesContext context = new DevServicesContext() {
             @Override
             public Map<String, String> devServicesProperties() {
@@ -96,7 +127,7 @@ public class TestResourceManager implements Closeable {
                 return containerNetworkId;
             }
         };
-        for (var i : allTestResourceEntries) {
+        for (var i : allTestResources) {
             if (i.getTestResource() instanceof DevServicesContext.ContextAware) {
                 ((DevServicesContext.ContextAware) i.getTestResource()).setIntegrationTestContext(context);
             }
@@ -108,7 +139,7 @@ public class TestResourceManager implements Closeable {
     }
 
     public void init(String testProfileName) {
-        for (TestResourceEntry entry : allTestResourceEntries) {
+        for (TestResourceStartInfo entry : allTestResources) {
             try {
                 QuarkusTestResourceLifecycleManager testResource = entry.getTestResource();
                 testResource.setContext(new QuarkusTestResourceLifecycleManager.Context() {
@@ -138,13 +169,13 @@ public class TestResourceManager implements Closeable {
     public Map<String, String> start() {
         started = true;
         Map<String, String> allProps = new ConcurrentHashMap<>();
-        int taskSize = parallelTestResourceEntries.size() + 1;
+        int taskSize = parallelTestResources.size() + 1;
         ExecutorService executor = Executors.newFixedThreadPool(taskSize);
         List<Runnable> tasks = new ArrayList<>(taskSize);
-        for (TestResourceEntry entry : parallelTestResourceEntries) {
-            tasks.add(new TestResourceEntryRunnable(entry, allProps));
+        for (TestResourceStartInfo entry : parallelTestResources) {
+            tasks.add(new TestResourceRunnable(entry, allProps));
         }
-        tasks.add(new TestResourceEntryRunnable(sequentialTestResourceEntries, allProps));
+        tasks.add(new TestResourceRunnable(sequentialTestResources, allProps));
 
         try {
             // convert the tasks into an array of CompletableFuture
@@ -163,7 +194,7 @@ public class TestResourceManager implements Closeable {
     }
 
     public void inject(Object testInstance) {
-        for (TestResourceEntry entry : allTestResourceEntries) {
+        for (TestResourceStartInfo entry : allTestResources) {
             QuarkusTestResourceLifecycleManager quarkusTestResourceLifecycleManager = entry.getTestResource();
             quarkusTestResourceLifecycleManager.inject(testInstance);
             quarkusTestResourceLifecycleManager.inject(new DefaultTestInjector(testInstance));
@@ -175,7 +206,7 @@ public class TestResourceManager implements Closeable {
             return;
         }
         started = false;
-        for (TestResourceEntry entry : allTestResourceEntries) {
+        for (TestResourceStartInfo entry : allTestResources) {
             try {
                 entry.getTestResource().stop();
             } catch (Exception e) {
@@ -205,17 +236,17 @@ public class TestResourceManager implements Closeable {
         Set<TestResourceClassEntry> remainingUniqueEntries = new LinkedHashSet<>(uniqueEntries);
         for (TestResourceClassEntry entry : uniqueEntries) {
             if (entry.isParallel()) {
-                TestResourceEntry testResourceEntry = buildTestResourceEntry(entry);
-                this.parallelTestResourceEntries.add(testResourceEntry);
+                TestResourceStartInfo testResourceStartInfo = buildTestResourceEntry(entry);
+                this.parallelTestResources.add(testResourceStartInfo);
                 remainingUniqueEntries.remove(entry);
             }
         }
-        parallelTestResourceEntries.sort(new Comparator<TestResourceEntry>() {
+        parallelTestResources.sort(new Comparator<TestResourceStartInfo>() {
 
             private final QuarkusTestResourceLifecycleManagerComparator lifecycleManagerComparator = new QuarkusTestResourceLifecycleManagerComparator();
 
             @Override
-            public int compare(TestResourceEntry o1, TestResourceEntry o2) {
+            public int compare(TestResourceStartInfo o1, TestResourceStartInfo o2) {
                 return lifecycleManagerComparator.compare(o1.getTestResource(), o2.getTestResource());
             }
         });
@@ -227,8 +258,8 @@ public class TestResourceManager implements Closeable {
         Set<TestResourceClassEntry> remainingUniqueEntries = new LinkedHashSet<>(uniqueEntries);
         for (TestResourceClassEntry entry : uniqueEntries) {
             if (!entry.isParallel()) {
-                TestResourceEntry testResourceEntry = buildTestResourceEntry(entry);
-                this.sequentialTestResourceEntries.add(testResourceEntry);
+                TestResourceStartInfo testResourceStartInfo = buildTestResourceEntry(entry);
+                this.sequentialTestResources.add(testResourceStartInfo);
                 remainingUniqueEntries.remove(entry);
             }
         }
@@ -236,16 +267,16 @@ public class TestResourceManager implements Closeable {
         for (QuarkusTestResourceLifecycleManager quarkusTestResourceLifecycleManager : ServiceLoader.load(
                 QuarkusTestResourceLifecycleManager.class,
                 Thread.currentThread().getContextClassLoader())) {
-            TestResourceEntry testResourceEntry = new TestResourceEntry(quarkusTestResourceLifecycleManager);
-            this.sequentialTestResourceEntries.add(testResourceEntry);
+            TestResourceStartInfo testResourceStartInfo = new TestResourceStartInfo(quarkusTestResourceLifecycleManager);
+            this.sequentialTestResources.add(testResourceStartInfo);
         }
 
-        this.sequentialTestResourceEntries.sort(new Comparator<TestResourceEntry>() {
+        this.sequentialTestResources.sort(new Comparator<>() {
 
             private final QuarkusTestResourceLifecycleManagerComparator lifecycleManagerComparator = new QuarkusTestResourceLifecycleManagerComparator();
 
             @Override
-            public int compare(TestResourceEntry o1, TestResourceEntry o2) {
+            public int compare(TestResourceStartInfo o1, TestResourceStartInfo o2) {
                 return lifecycleManagerComparator.compare(o1.getTestResource(), o2.getTestResource());
             }
         });
@@ -253,10 +284,11 @@ public class TestResourceManager implements Closeable {
         return remainingUniqueEntries;
     }
 
-    private TestResourceManager.TestResourceEntry buildTestResourceEntry(TestResourceClassEntry entry) {
+    private TestResourceStartInfo buildTestResourceEntry(TestResourceClassEntry entry) {
         Class<? extends QuarkusTestResourceLifecycleManager> testResourceClass = entry.clazz;
         try {
-            return new TestResourceEntry(testResourceClass.getConstructor().newInstance(), entry.args, entry.configAnnotation);
+            return new TestResourceStartInfo(testResourceClass.getConstructor().newInstance(), entry.args,
+                    entry.configAnnotation);
         } catch (InstantiationException
                 | IllegalAccessException
                 | IllegalArgumentException
@@ -267,82 +299,80 @@ public class TestResourceManager implements Closeable {
         }
     }
 
-    private Set<TestResourceClassEntry> getUniqueTestResourceClassEntries(Path testClassLocation, Class<?> testClass,
+    private Set<TestResourceClassEntry> uniqueTestResourceClassEntries(Path testClassLocation, Class<?> testClass,
             Class<?> profileClass,
             List<TestResourceClassEntry> additionalTestResources) {
-        IndexView index = TestClassIndexer.readIndex(testClassLocation, testClass);
-        Set<TestResourceClassEntry> uniqueEntries = new LinkedHashSet<>();
-        // reload the test and profile classes in the right CL
-        Class<?> testClassFromTCCL;
-        Class<?> profileClassFromTCCL;
-        try {
-            testClassFromTCCL = Class.forName(testClass.getName(), false, Thread.currentThread().getContextClassLoader());
-            if (profileClass != null) {
-                profileClassFromTCCL = Class.forName(profileClass.getName(), false,
-                        Thread.currentThread().getContextClassLoader());
-            } else {
-                profileClassFromTCCL = null;
-            }
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-        // handle meta-annotations: in this case we must rely on reflection because meta-annotations are not indexed
-        // because they are not in the user's test folder but come from test extensions
-        collectMetaAnnotations(testClassFromTCCL, Class::getSuperclass, uniqueEntries);
-        collectMetaAnnotations(testClassFromTCCL, Class::getEnclosingClass, uniqueEntries);
+        Class<?> profileClassFromTCCL = profileClass != null ? alwaysFromTccl(profileClass) : null;
+        Consumer<Set<TestResourceClassEntry>> profileMetaAnnotationsConsumer = null;
         if (profileClassFromTCCL != null) {
-            collectMetaAnnotations(profileClassFromTCCL, Class::getSuperclass, uniqueEntries);
-        }
-        for (AnnotationInstance annotation : findQuarkusTestResourceInstances(testClass, index)) {
-            try {
-                Class<? extends QuarkusTestResourceLifecycleManager> testResourceClass = loadTestResourceClassFromTCCL(
-                        annotation.value().asString());
-
-                AnnotationValue argsAnnotationValue = annotation.value("initArgs");
-                Map<String, String> args;
-                if (argsAnnotationValue == null) {
-                    args = Collections.emptyMap();
-                } else {
-                    args = new HashMap<>();
-                    AnnotationInstance[] resourceArgsInstances = argsAnnotationValue.asNestedArray();
-                    for (AnnotationInstance resourceArgsInstance : resourceArgsInstances) {
-                        args.put(resourceArgsInstance.value("name").asString(), resourceArgsInstance.value().asString());
-                    }
-                }
-
-                boolean isParallel = false;
-                AnnotationValue parallelAnnotationValue = annotation.value("parallel");
-                if (parallelAnnotationValue != null) {
-                    isParallel = parallelAnnotationValue.asBoolean();
-                }
-
-                if (restrictToAnnotatedClass(annotation)) {
-                    hasPerTestResources = true;
-                }
-
-                uniqueEntries.add(new TestResourceClassEntry(testResourceClass, args, null, isParallel));
-            } catch (IllegalArgumentException | SecurityException e) {
-                throw new RuntimeException("Unable to instantiate the test resource " + annotation.value().asString(), e);
-            }
+            profileMetaAnnotationsConsumer = new ProfileMetaAnnotationsUniqueEntriesConsumer(profileClassFromTCCL);
         }
 
+        Set<TestResourceClassEntry> uniqueEntries = getUniqueTestResourceClassEntries(testClass, testClassLocation,
+                profileMetaAnnotationsConsumer);
         uniqueEntries.addAll(additionalTestResources);
         return uniqueEntries;
     }
 
-    private void collectMetaAnnotations(Class<?> testClassFromTCCL, Function<Class<?>, Class<?>> next,
+    /**
+     * Allows Quarkus to extra basic information about which test resources a test class will require
+     */
+    public static Set<TestResourceManager.TestResourceComparisonInfo> testResourceComparisonInfo(Class<?> testClass,
+            Path testClassLocation) {
+        Set<TestResourceClassEntry> uniqueEntries = getUniqueTestResourceClassEntries(testClass, testClassLocation, null);
+        if (uniqueEntries.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<TestResourceManager.TestResourceComparisonInfo> result = new HashSet<>(uniqueEntries.size());
+        for (TestResourceClassEntry entry : uniqueEntries) {
+            result.add(new TestResourceComparisonInfo(entry.testResourceLifecycleManagerClass().getName(), entry.getScope()));
+        }
+        return result;
+    }
+
+    private static Set<TestResourceClassEntry> getUniqueTestResourceClassEntries(Class<?> testClass,
+            Path testClassLocation,
+            Consumer<Set<TestResourceClassEntry>> afterMetaAnnotationAction) {
+        Class<?> testClassFromTCCL = alwaysFromTccl(testClass);
+
+        Set<TestResourceClassEntry> uniqueEntries = new LinkedHashSet<>();
+
+        // handle meta-annotations: in this case we must rely on reflection because meta-annotations are not indexed
+        // because they are not in the user's test folder but come from test extensions
+        collectMetaAnnotations(testClassFromTCCL, Class::getSuperclass, uniqueEntries);
+        collectMetaAnnotations(testClassFromTCCL, Class::getEnclosingClass, uniqueEntries);
+        if (afterMetaAnnotationAction != null) {
+            afterMetaAnnotationAction.accept(uniqueEntries);
+        }
+        for (AnnotationInstance annotation : findTestResourceInstancesOfClass(testClass,
+                TestClassIndexer.readIndex(testClassLocation, testClass))) {
+            uniqueEntries.add(TestResourceClassEntryHandler.produceEntry(annotation));
+        }
+        return uniqueEntries;
+    }
+
+    private static Class<?> alwaysFromTccl(Class<?> testClass) {
+        if (testClass.getClassLoader().equals(Thread.currentThread().getContextClassLoader())) {
+            return testClass;
+        }
+        try {
+            return Class.forName(testClass.getName(), false, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void collectMetaAnnotations(Class<?> testClassFromTCCL, Function<Class<?>, Class<?>> next,
             Set<TestResourceClassEntry> uniqueEntries) {
         while (testClassFromTCCL != null && !testClassFromTCCL.getName().equals("java.lang.Object")) {
             for (Annotation metaAnnotation : testClassFromTCCL.getAnnotations()) {
                 for (Annotation ann : metaAnnotation.annotationType().getAnnotations()) {
                     if (ann.annotationType() == WithTestResource.class) {
                         addTestResourceEntry((WithTestResource) ann, metaAnnotation, uniqueEntries);
-                        hasPerTestResources = true;
                         break;
                     } else if (ann.annotationType() == WithTestResource.List.class) {
                         Arrays.stream(((WithTestResource.List) ann).value())
                                 .forEach(res -> addTestResourceEntry(res, metaAnnotation, uniqueEntries));
-                        hasPerTestResources = true;
                         break;
                     } else if (ann.annotationType() == WithTestResourceRepeatable.class) {
                         for (Annotation repeatableMetaAnn : testClassFromTCCL
@@ -351,18 +381,15 @@ public class TestResourceManager implements Closeable {
                                     .getAnnotation(WithTestResource.class);
                             if (quarkusTestResource != null) {
                                 addTestResourceEntry(quarkusTestResource, repeatableMetaAnn, uniqueEntries);
-                                hasPerTestResources = true;
                             }
                         }
                     } else if (ann.annotationType() == QuarkusTestResource.class) {
                         addTestResourceEntry((QuarkusTestResource) ann, metaAnnotation, uniqueEntries);
-                        hasPerTestResources = true;
                         break;
                     } else if (ann.annotationType() == QuarkusTestResource.List.class) {
                         for (QuarkusTestResource quarkusTestResource : ((QuarkusTestResource.List) ann).value()) {
                             addTestResourceEntry(quarkusTestResource, metaAnnotation, uniqueEntries);
                         }
-                        hasPerTestResources = true;
                         break;
                     } else if (ann.annotationType() == QuarkusTestResourceRepeatable.class) {
                         for (Annotation repeatableMetaAnn : testClassFromTCCL
@@ -371,7 +398,6 @@ public class TestResourceManager implements Closeable {
                                     .getAnnotation(QuarkusTestResource.class);
                             if (quarkusTestResource != null) {
                                 addTestResourceEntry(quarkusTestResource, repeatableMetaAnn, uniqueEntries);
-                                hasPerTestResources = true;
                             }
                         }
                     }
@@ -381,9 +407,9 @@ public class TestResourceManager implements Closeable {
         }
     }
 
-    private void addTestResourceEntry(Class<? extends QuarkusTestResourceLifecycleManager> testResourceClass,
+    private static void addTestResourceEntry(Class<? extends QuarkusTestResourceLifecycleManager> testResourceClass,
             ResourceArg[] argsAnnotationValue, Annotation originalAnnotation,
-            Set<TestResourceClassEntry> uniqueEntries, boolean parallel) {
+            boolean parallel, TestResourceScope scope, Set<TestResourceClassEntry> uniqueEntries) {
 
         // NOTE: we don't need to check restrictToAnnotatedClass because by design config-based annotations
         // are not discovered outside the test class, so they're restricted
@@ -391,34 +417,26 @@ public class TestResourceManager implements Closeable {
                 .collect(Collectors.toMap(ResourceArg::name, ResourceArg::value));
 
         uniqueEntries
-                .add(new TestResourceClassEntry(testResourceClass, args, originalAnnotation, parallel));
+                .add(new TestResourceClassEntry(testResourceClass, args, originalAnnotation, parallel, scope));
     }
 
-    private void addTestResourceEntry(WithTestResource quarkusTestResource, Annotation originalAnnotation,
+    private static void addTestResourceEntry(WithTestResource quarkusTestResource, Annotation originalAnnotation,
             Set<TestResourceClassEntry> uniqueEntries) {
 
-        addTestResourceEntry(quarkusTestResource.value(), quarkusTestResource.initArgs(), originalAnnotation, uniqueEntries,
-                quarkusTestResource.parallel());
+        addTestResourceEntry(quarkusTestResource.value(), quarkusTestResource.initArgs(), originalAnnotation,
+                quarkusTestResource.parallel(), quarkusTestResource.restrictToAnnotatedClass() ? RESTRICTED_TO_CLASS : GLOBAL,
+                uniqueEntries);
     }
 
-    private void addTestResourceEntry(QuarkusTestResource quarkusTestResource, Annotation originalAnnotation,
+    private static void addTestResourceEntry(QuarkusTestResource quarkusTestResource, Annotation originalAnnotation,
             Set<TestResourceClassEntry> uniqueEntries) {
 
-        addTestResourceEntry(quarkusTestResource.value(), quarkusTestResource.initArgs(), originalAnnotation, uniqueEntries,
-                quarkusTestResource.parallel());
+        addTestResourceEntry(quarkusTestResource.value(), quarkusTestResource.initArgs(), originalAnnotation,
+                quarkusTestResource.parallel(), quarkusTestResource.restrictToAnnotatedClass() ? RESTRICTED_TO_CLASS : GLOBAL,
+                uniqueEntries);
     }
 
-    @SuppressWarnings("unchecked")
-    private Class<? extends QuarkusTestResourceLifecycleManager> loadTestResourceClassFromTCCL(String className) {
-        try {
-            return (Class<? extends QuarkusTestResourceLifecycleManager>) Class.forName(className, true,
-                    Thread.currentThread().getContextClassLoader());
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private Collection<AnnotationInstance> findQuarkusTestResourceInstances(Class<?> testClass, IndexView index) {
+    private static Collection<AnnotationInstance> findTestResourceInstancesOfClass(Class<?> testClass, IndexView index) {
         // collect all test supertypes for matching per-test targets
         Set<String> testClasses = new HashSet<>();
         Class<?> current = testClass;
@@ -457,12 +475,8 @@ public class TestResourceManager implements Closeable {
         return testResourceAnnotations;
     }
 
-    // NOTE: called by reflection in QuarkusTestExtension
-    public boolean hasPerTestResources() {
-        return hasPerTestResources;
-    }
-
-    private boolean keepTestResourceAnnotation(AnnotationInstance annotation, ClassInfo targetClass, Set<String> testClasses) {
+    private static boolean keepTestResourceAnnotation(AnnotationInstance annotation, ClassInfo targetClass,
+            Set<String> testClasses) {
         if (targetClass.isAnnotation()) {
             // meta-annotations have already been handled in collectMetaAnnotations
             return false;
@@ -475,61 +489,109 @@ public class TestResourceManager implements Closeable {
         return true;
     }
 
-    private boolean restrictToAnnotatedClass(AnnotationInstance annotation) {
-        AnnotationValue restrict = annotation.value("restrictToAnnotatedClass");
-
-        return (annotation.name().equals(WITH_TEST_RESOURCE) && ((restrict == null) || restrict.asBoolean()))
-                ||
-                (annotation.name().equals(QUARKUS_TEST_RESOURCE) && ((restrict != null) && restrict.asBoolean()));
+    private static boolean restrictToAnnotatedClass(AnnotationInstance annotation) {
+        return TestResourceClassEntryHandler.determineScope(annotation) != GLOBAL;
     }
 
+    /**
+     * Provides the basic information needed for comparing the test resources currently in use
+     */
+    @SuppressWarnings("unused") // called with reflection in TestResourceManagerReflections
+    public Set<TestResourceComparisonInfo> testResourceComparisonInfo() {
+        return testResourceComparisonInfo;
+    }
+
+    /**
+     * Quarkus needs to restart if one of the following is true:
+     * <ul>
+     * <li>at least one the existing test resources is restricted to the test class</li>
+     * <li>at least one the next test resources is restricted to the test class</li>
+     * </ul>
+     */
+    public static boolean testResourcesRequireReload(Set<TestResourceComparisonInfo> existing,
+            Set<TestResourceComparisonInfo> next) {
+        return hasRestrictedToClassScope(existing) || hasRestrictedToClassScope(next);
+    }
+
+    private static boolean hasRestrictedToClassScope(Set<TestResourceComparisonInfo> existing) {
+        for (TestResourceComparisonInfo info : existing) {
+            if (info.scope == RESTRICTED_TO_CLASS) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Contains all the metadata that is needed to handle the lifecycle and perform all the bookkeeping associated
+     * with a Test Resource.
+     * When this information is produced by {@link TestResourceManager}, nothing has yet been started, so interrogating
+     * it is perfectly fine.
+     */
     public static class TestResourceClassEntry {
 
-        private Class<? extends QuarkusTestResourceLifecycleManager> clazz;
-        private Map<String, String> args;
-        private boolean parallel;
-        private Annotation configAnnotation;
+        private final Class<? extends QuarkusTestResourceLifecycleManager> clazz;
+        private final Map<String, String> args;
+        private final boolean parallel;
+        private final Annotation configAnnotation;
+        private final TestResourceScope scope;
 
         public TestResourceClassEntry(Class<? extends QuarkusTestResourceLifecycleManager> clazz, Map<String, String> args,
                 Annotation configAnnotation,
-                boolean parallel) {
+                boolean parallel,
+                TestResourceScope scope) {
             this.clazz = clazz;
             this.args = args;
             this.configAnnotation = configAnnotation;
             this.parallel = parallel;
+            this.scope = scope;
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o)
+        public boolean equals(Object object) {
+            if (this == object) {
                 return true;
-            if (o == null || getClass() != o.getClass())
+            }
+            if (object == null || getClass() != object.getClass()) {
                 return false;
-            TestResourceClassEntry that = (TestResourceClassEntry) o;
-            return clazz.equals(that.clazz) && args.equals(that.args) && Objects.equals(configAnnotation, that.configAnnotation)
-                    && parallel == that.parallel;
+            }
+            TestResourceClassEntry entry = (TestResourceClassEntry) object;
+            return parallel == entry.parallel && Objects.equals(clazz, entry.clazz) && Objects.equals(args,
+                    entry.args) && Objects.equals(configAnnotation, entry.configAnnotation) && scope == entry.scope;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(clazz, args, configAnnotation, parallel);
+            return Objects.hash(clazz, args, parallel, configAnnotation, scope);
         }
 
         public boolean isParallel() {
             return parallel;
         }
+
+        public Class<? extends QuarkusTestResourceLifecycleManager> testResourceLifecycleManagerClass() {
+            return clazz;
+        }
+
+        public TestResourceScope getScope() {
+            return scope;
+        }
     }
 
-    private static class TestResourceEntryRunnable implements Runnable {
-        private final List<TestResourceEntry> entries;
+    public record TestResourceComparisonInfo(String testResourceLifecycleManagerClass, TestResourceScope scope) {
+
+    }
+
+    private static class TestResourceRunnable implements Runnable {
+        private final List<TestResourceStartInfo> entries;
         private final Map<String, String> allProps;
 
-        public TestResourceEntryRunnable(TestResourceEntry entry,
+        public TestResourceRunnable(TestResourceStartInfo entry,
                 Map<String, String> allProps) {
             this(Collections.singletonList(entry), allProps);
         }
 
-        public TestResourceEntryRunnable(List<TestResourceEntry> entries,
+        public TestResourceRunnable(List<TestResourceStartInfo> entries,
                 Map<String, String> allProps) {
             this.entries = entries;
             this.allProps = allProps;
@@ -537,7 +599,7 @@ public class TestResourceManager implements Closeable {
 
         @Override
         public void run() {
-            for (TestResourceEntry entry : entries) {
+            for (TestResourceStartInfo entry : entries) {
                 try {
                     Map<String, String> start = entry.getTestResource().start();
                     if (start != null) {
@@ -551,17 +613,20 @@ public class TestResourceManager implements Closeable {
         }
     }
 
-    private static class TestResourceEntry {
+    /**
+     * Contains all the information necessary to start a {@link QuarkusTestResourceLifecycleManager}
+     */
+    private static class TestResourceStartInfo {
 
         private final QuarkusTestResourceLifecycleManager testResource;
         private final Map<String, String> args;
         private final Annotation configAnnotation;
 
-        public TestResourceEntry(QuarkusTestResourceLifecycleManager testResource) {
+        public TestResourceStartInfo(QuarkusTestResourceLifecycleManager testResource) {
             this(testResource, Collections.emptyMap(), null);
         }
 
-        public TestResourceEntry(QuarkusTestResourceLifecycleManager testResource, Map<String, String> args,
+        public TestResourceStartInfo(QuarkusTestResourceLifecycleManager testResource, Map<String, String> args,
                 Annotation configAnnotation) {
             this.testResource = testResource;
             this.args = args;
@@ -614,4 +679,166 @@ public class TestResourceManager implements Closeable {
 
     }
 
+    /**
+     * The entry point to handling the differences between {@link QuarkusTestResource} and {@link WithTestResource}
+     * (and whatever else we potentially come up with in the future).
+     */
+    private sealed interface TestResourceClassEntryHandler
+            permits QuarkusTestResourceTestResourceClassEntryHandler, WithTestResourceTestResourceClassEntryHandler {
+
+        List<TestResourceClassEntryHandler> HANDLERS = List
+                .of(new QuarkusTestResourceTestResourceClassEntryHandler(),
+                        new WithTestResourceTestResourceClassEntryHandler());
+
+        /**
+         * Find the {@link TestResourceScope} of the provided annotation
+         */
+        static TestResourceScope determineScope(AnnotationInstance annotation) {
+            for (TestResourceClassEntryHandler handler : HANDLERS) {
+                if (handler.appliesTo(annotation)) {
+                    return handler.scope(annotation);
+                }
+            }
+            throw new IllegalStateException("Annotation '" + annotation.name() + "' is not supported");
+        }
+
+        /**
+         * Extract all the metadata needed from the provided annotation
+         */
+        static TestResourceClassEntry produceEntry(AnnotationInstance annotation) {
+            for (TestResourceClassEntryHandler producer : TestResourceClassEntryHandler.HANDLERS) {
+                if (producer.appliesTo(annotation)) {
+                    return producer.produce(annotation);
+                }
+            }
+            throw new IllegalStateException("Annotation '" + annotation.name() + "' is not supported");
+        }
+
+        /**
+         * Whether the strategy applies to the current annotation
+         */
+        boolean appliesTo(AnnotationInstance annotation);
+
+        TestResourceScope scope(AnnotationInstance annotationInstance);
+
+        TestResourceClassEntry produce(AnnotationInstance annotation);
+    }
+
+    /**
+     * Hold code that is common for handling both {@link QuarkusTestResource} and {@link WithTestResource}
+     */
+    private static abstract class AbstractTestResourceClassEntryHandler {
+
+        Class<? extends QuarkusTestResourceLifecycleManager> lifecycleManager(AnnotationInstance annotation) {
+            return loadTestResourceClassFromTCCL(annotation.value().asString());
+        }
+
+        @SuppressWarnings("unchecked")
+        Class<? extends QuarkusTestResourceLifecycleManager> loadTestResourceClassFromTCCL(String className) {
+            try {
+                return (Class<? extends QuarkusTestResourceLifecycleManager>) Class.forName(className, true,
+                        Thread.currentThread().getContextClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        Map<String, String> args(AnnotationInstance annotation) {
+            AnnotationValue argsAnnotationValue = annotation.value("initArgs");
+            Map<String, String> args;
+            if (argsAnnotationValue == null) {
+                return Collections.emptyMap();
+            } else {
+                args = new HashMap<>();
+                AnnotationInstance[] resourceArgsInstances = argsAnnotationValue.asNestedArray();
+                for (AnnotationInstance resourceArgsInstance : resourceArgsInstances) {
+                    args.put(resourceArgsInstance.value("name").asString(), resourceArgsInstance.value().asString());
+                }
+                return args;
+            }
+        }
+
+        boolean isParallel(AnnotationInstance annotation) {
+            AnnotationValue parallelAnnotationValue = annotation.value("parallel");
+            if (parallelAnnotationValue != null) {
+                return parallelAnnotationValue.asBoolean();
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Handles {@link QuarkusTestResource}
+     */
+    private static final class QuarkusTestResourceTestResourceClassEntryHandler extends
+            AbstractTestResourceClassEntryHandler
+            implements TestResourceClassEntryHandler {
+
+        @Override
+        public boolean appliesTo(AnnotationInstance annotation) {
+            return QUARKUS_TEST_RESOURCE.equals(annotation.name());
+        }
+
+        @Override
+        public TestResourceClassEntry produce(AnnotationInstance annotation) {
+            return new TestResourceClassEntry(lifecycleManager(annotation), args(annotation), null, isParallel(annotation),
+                    scope(annotation));
+        }
+
+        @Override
+        public TestResourceScope scope(AnnotationInstance annotation) {
+            TestResourceScope scope = GLOBAL;
+            AnnotationValue restrict = annotation.value("restrictToAnnotatedClass");
+            if (restrict != null) {
+                if (restrict.asBoolean()) {
+                    scope = RESTRICTED_TO_CLASS;
+                }
+            }
+            return scope;
+        }
+    }
+
+    /**
+     * Handles {@link WithTestResource}
+     */
+    private static final class WithTestResourceTestResourceClassEntryHandler extends
+            AbstractTestResourceClassEntryHandler
+            implements TestResourceClassEntryHandler {
+
+        @Override
+        public boolean appliesTo(AnnotationInstance annotation) {
+            return WITH_TEST_RESOURCE.equals(annotation.name());
+        }
+
+        @Override
+        public TestResourceClassEntry produce(AnnotationInstance annotation) {
+            return new TestResourceClassEntry(lifecycleManager(annotation), args(annotation), null, isParallel(annotation),
+                    scope(annotation));
+        }
+
+        @Override
+        public TestResourceScope scope(AnnotationInstance annotation) {
+            TestResourceScope scope = RESTRICTED_TO_CLASS;
+            AnnotationValue restrict = annotation.value("restrictToAnnotatedClass");
+            if (restrict != null) {
+                if (!restrict.asBoolean()) {
+                    scope = GLOBAL;
+                }
+            }
+            return scope;
+        }
+    }
+
+    private static class ProfileMetaAnnotationsUniqueEntriesConsumer implements Consumer<Set<TestResourceClassEntry>> {
+        private final Class<?> profileClassFromTCCL;
+
+        public ProfileMetaAnnotationsUniqueEntriesConsumer(Class<?> profileClassFromTCCL) {
+            this.profileClassFromTCCL = profileClassFromTCCL;
+        }
+
+        @Override
+        public void accept(Set<TestResourceClassEntry> entries) {
+            collectMetaAnnotations(profileClassFromTCCL, Class::getSuperclass, entries);
+        }
+    }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceScope.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceScope.java
@@ -5,10 +5,21 @@ package io.quarkus.test.common;
  */
 public enum TestResourceScope {
 
-    /**
+    /*
      * The declaration order must be from the narrowest scope to the widest
      */
-    RESTRICTED_TO_CLASS, // means that Quarkus will run the test in complete isolation, i.e. it will restart every time it finds such a resource
-    MATCHING_RESOURCE, // means that Quarkus will not restart when running consecutive tests that use the same resource
-    GLOBAL, // means the resource applies to all tests in the testsuite
+
+    /**
+     * Means that Quarkus will run the test in complete isolation, i.e. it will restart every time it finds such a resource
+     */
+    RESTRICTED_TO_CLASS,
+    /**
+     * Means that Quarkus will not restart when running consecutive tests that use the same resource
+     */
+    MATCHING_RESOURCE,
+
+    /**
+     * Means the resource applies to all tests in the testsuite
+     */
+    GLOBAL
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceScope.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceScope.java
@@ -1,0 +1,14 @@
+package io.quarkus.test.common;
+
+/**
+ * Defines how Quarkus behaves with regard to the application of the resource to this test and the testsuite in general
+ */
+public enum TestResourceScope {
+
+    /**
+     * The declaration order must be from the narrowest scope to the widest
+     */
+    RESTRICTED_TO_CLASS, // means that Quarkus will run the test in complete isolation, i.e. it will restart every time it finds such a resource
+    MATCHING_RESOURCE, // means that Quarkus will not restart when running consecutive tests that use the same resource
+    GLOBAL, // means the resource applies to all tests in the testsuite
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/WithTestResource.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/WithTestResource.java
@@ -13,11 +13,20 @@ import io.quarkus.test.common.WithTestResource.List;
 /**
  * Used to define a test resource, which can affect various aspects of the application lifecycle.
  * <p>
+ * As of Quarkus 3.16, the default behavior of the annotation (meaning that {@code scope} has not been set)
+ * is that test classes annotated with the same {@code WithTestResource} will <strong>not</strong> force a restart
+ * of Quarkus.
+ * <p>
+ * The equivalent behavior to {@code QuarkusTestResource(restrictToAnnotatedClass = false)} is to use
+ * {@code WithTestResource(scope = TestResourceScope.GLOBAL)},
+ * while the equivalent behavior to {@code QuarkusTestResource(restrictToAnnotatedClass = true)} is to use
+ * {@code WithTestResource(scope = TestResourceScope.RESTRICTED_TO_CLASS)},
+ * <p>
  * WARNING: this annotation, introduced in 3.13, caused some issues so it was decided to undeprecate
  * {@link QuarkusTestResource} and rework the behavior of this annotation. For now, we recommend not using it
  * until we improve its behavior.
  * <p>
- * Note: When using the {@code restrictToAnnotatedClass=true} (which is the default), each test that is annotated
+ * Note: When using the {@code scope=TestResourceScope.RESTRICTED_TO_CLASS}, each test that is annotated
  * with {@code @WithTestResource} will result in the application being re-augmented and restarted (in a similar fashion
  * as happens in dev-mode when a change is detected) in order to incorporate the settings configured by the annotation.
  * If there are many instances of the annotation used throughout the testsuite, this could result in slow test execution.
@@ -28,14 +37,6 @@ import io.quarkus.test.common.WithTestResource.List;
  * started <b>before</b> <b>any</b> test is run.
  * <p>
  * Note that test resources are never restarted when running {@code @Nested} test classes.
- * <p>
- * The only difference with {@link QuarkusTestResource} is that the default value for
- * {@link #restrictToAnnotatedClass()} {@code == true}.
- * </p>
- * <p>
- * This means that any resources managed by {@link #value()} apply to an individual test class or test profile, unlike with
- * {@link QuarkusTestResource} where a resource applies to all test classes.
- * </p>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -61,15 +62,11 @@ public @interface WithTestResource {
     boolean parallel() default false;
 
     /**
-     * Whether this annotation should only be enabled if it is placed on the currently running test class or test profile.
-     * Note that this defaults to true for meta-annotations since meta-annotations are only considered
-     * for the current test class or test profile.
-     * <p>
-     * Note: When this is set to {@code true} (which is the default), the annotation {@code @WithTestResource} will result
-     * in the application being re-augmented and restarted (in a similar fashion as happens in dev-mode when a change is
-     * detected) in order to incorporate the settings configured by the annotation.
+     * Defines how Quarkus behaves with regard to the application of the resource to this test and the test-suite in general.
+     * The default is {@link TestResourceScope#MATCHING_RESOURCE} which means that if two tests are annotated with the same
+     * {@link WithTestResource} annotation, no restart will take place between tests.
      */
-    boolean restrictToAnnotatedClass() default true;
+    TestResourceScope scope() default TestResourceScope.MATCHING_RESOURCE;
 
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.RUNTIME)

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerInjectorTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerInjectorTest.java
@@ -29,7 +29,7 @@ public class TestResourceManagerInjectorTest {
         Assertions.assertEquals("dummy", foo.dummy.value);
     }
 
-    @WithTestResource(value = UsingTestInjectorLifecycleManager.class, restrictToAnnotatedClass = false)
+    @WithTestResource(value = UsingTestInjectorLifecycleManager.class, scope = TestResourceScope.GLOBAL)
     public static class UsingInjectorTest {
     }
 

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerReloadTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerReloadTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.test.common;
+
+import static io.quarkus.test.common.TestResourceManager.testResourcesRequireReload;
+import static io.quarkus.test.common.TestResourceScope.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.TestResourceManager.TestResourceComparisonInfo;
+
+public class TestResourceManagerReloadTest {
+
+    @Test
+    public void emptyResources() {
+        assertFalse(testResourcesRequireReload(Collections.emptySet(), Set.of()));
+    }
+
+    @Test
+    public void differentCount() {
+        assertTrue(testResourcesRequireReload(Collections.emptySet(),
+                Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS))));
+
+        assertTrue(testResourcesRequireReload(Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS)),
+                Collections.emptySet()));
+    }
+
+    @Test
+    public void sameSingleRestrictedToClassResource() {
+        assertTrue(testResourcesRequireReload(
+                Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS)),
+                Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS))));
+    }
+
+    @Test
+    public void sameSingleMatchingResource() {
+        assertFalse(testResourcesRequireReload(
+                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCE)),
+                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCE))));
+    }
+
+    @Test
+    public void differentSingleMatchingResource() {
+        assertTrue(testResourcesRequireReload(
+                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCE)),
+                Set.of(new TestResourceComparisonInfo("test2", MATCHING_RESOURCE))));
+    }
+
+    @Test
+    public void sameMultipleMatchingResource() {
+        assertFalse(testResourcesRequireReload(
+                Set.of(
+                        new TestResourceComparisonInfo("test", MATCHING_RESOURCE),
+                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCE),
+                        new TestResourceComparisonInfo("test3", GLOBAL)),
+                Set.of(new TestResourceComparisonInfo("test3", GLOBAL),
+                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCE),
+                        new TestResourceComparisonInfo("test", MATCHING_RESOURCE))));
+    }
+
+    @Test
+    public void differentMultipleMatchingResource() {
+        assertTrue(testResourcesRequireReload(
+                Set.of(
+                        new TestResourceComparisonInfo("test", MATCHING_RESOURCE),
+                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCE),
+                        new TestResourceComparisonInfo("test3", GLOBAL)),
+                Set.of(new TestResourceComparisonInfo("test3", GLOBAL),
+                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCE),
+                        new TestResourceComparisonInfo("TEST", MATCHING_RESOURCE))));
+    }
+}

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerTest.java
@@ -49,8 +49,8 @@ public class TestResourceManagerTest {
         Assertions.assertEquals("value2", props.get("key2"));
     }
 
-    @WithTestResource(value = FirstLifecycleManager.class, restrictToAnnotatedClass = false)
-    @WithTestResource(value = SecondLifecycleManager.class, restrictToAnnotatedClass = false)
+    @WithTestResource(value = FirstLifecycleManager.class, scope = TestResourceScope.GLOBAL)
+    @WithTestResource(value = SecondLifecycleManager.class, scope = TestResourceScope.GLOBAL)
     public static class MyTest {
     }
 
@@ -99,8 +99,8 @@ public class TestResourceManagerTest {
         }
     }
 
-    @WithTestResource(value = FirstSequentialQuarkusTestResource.class, restrictToAnnotatedClass = false)
-    @WithTestResource(value = SecondSequentialQuarkusTestResource.class, restrictToAnnotatedClass = false)
+    @WithTestResource(value = FirstSequentialQuarkusTestResource.class, scope = TestResourceScope.GLOBAL)
+    @WithTestResource(value = SecondSequentialQuarkusTestResource.class, scope = TestResourceScope.GLOBAL)
     public static class SequentialTestResourcesTest {
     }
 
@@ -150,8 +150,8 @@ public class TestResourceManagerTest {
         }
     }
 
-    @WithTestResource(value = FirstParallelQuarkusTestResource.class, parallel = true, restrictToAnnotatedClass = false)
-    @WithTestResource(value = SecondParallelQuarkusTestResource.class, parallel = true, restrictToAnnotatedClass = false)
+    @WithTestResource(value = FirstParallelQuarkusTestResource.class, parallel = true, scope = TestResourceScope.GLOBAL)
+    @WithTestResource(value = SecondParallelQuarkusTestResource.class, parallel = true, scope = TestResourceScope.GLOBAL)
     public static class ParallelTestResourcesTest {
     }
 
@@ -257,7 +257,7 @@ public class TestResourceManagerTest {
         }
     }
 
-    @WithTestResource(value = AnnotationBasedQuarkusTestResource.class, restrictToAnnotatedClass = false)
+    @WithTestResource(value = AnnotationBasedQuarkusTestResource.class, scope = TestResourceScope.GLOBAL)
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     @Repeatable(WithAnnotationBasedTestResource.List.class)

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -5,7 +5,6 @@ import static io.quarkus.test.common.PathTestHelper.getAppClassLocationForTestLo
 import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
 
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -39,10 +38,8 @@ import io.quarkus.deployment.dev.testing.CurrentTestApplication;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.common.PathTestHelper;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.RestorableSystemProperties;
 import io.quarkus.test.common.TestClassIndexer;
-import io.quarkus.test.common.WithTestResource;
 
 public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithContextExtension {
 
@@ -268,43 +265,6 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
         }
 
         return null;
-    }
-
-    protected static boolean hasPerTestResources(ExtensionContext extensionContext) {
-        return hasPerTestResources(extensionContext.getRequiredTestClass());
-    }
-
-    public static boolean hasPerTestResources(Class<?> requiredTestClass) {
-        while (requiredTestClass != Object.class) {
-            for (WithTestResource testResource : requiredTestClass.getAnnotationsByType(WithTestResource.class)) {
-                if (testResource.restrictToAnnotatedClass()) {
-                    return true;
-                }
-            }
-
-            for (QuarkusTestResource testResource : requiredTestClass.getAnnotationsByType(QuarkusTestResource.class)) {
-                if (testResource.restrictToAnnotatedClass()) {
-                    return true;
-                }
-            }
-            // scan for meta-annotations
-            for (Annotation annotation : requiredTestClass.getAnnotations()) {
-                // skip TestResource annotations
-                var annotationType = annotation.annotationType();
-
-                if ((annotationType != WithTestResource.class) && (annotationType != QuarkusTestResource.class)) {
-                    // look for a TestResource on the annotation itself
-                    if ((annotationType.getAnnotationsByType(WithTestResource.class).length > 0)
-                            || (annotationType.getAnnotationsByType(QuarkusTestResource.class).length > 0)) {
-                        // meta-annotations are per-test scoped for now
-                        return true;
-                    }
-                }
-            }
-            // look up
-            requiredTestClass = requiredTestClass.getSuperclass();
-        }
-        return false;
     }
 
     protected static class PrepareResult {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -8,8 +8,6 @@ import static java.lang.ProcessBuilder.Redirect.DISCARD;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
@@ -19,10 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.CodeSource;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -153,38 +148,6 @@ public final class IntegrationTestUtil {
             }
         }
         return new TestProfileAndProperties(testProfile, properties);
-    }
-
-    /**
-     * Since {@link TestResourceManager} is loaded from the ClassLoader passed in as an argument,
-     * we need to convert the user input {@link QuarkusTestProfile.TestResourceEntry} into instances of
-     * {@link TestResourceManager.TestResourceClassEntry}
-     * that are loaded from that ClassLoader
-     */
-    static <T> List<T> getAdditionalTestResources(
-            QuarkusTestProfile profileInstance, ClassLoader classLoader) {
-        if ((profileInstance == null) || profileInstance.testResources().isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        try {
-            Constructor<?> testResourceClassEntryConstructor = Class
-                    .forName(TestResourceManager.TestResourceClassEntry.class.getName(), true, classLoader)
-                    .getConstructor(Class.class, Map.class, Annotation.class, boolean.class);
-
-            List<QuarkusTestProfile.TestResourceEntry> testResources = profileInstance.testResources();
-            List<T> result = new ArrayList<>(testResources.size());
-            for (QuarkusTestProfile.TestResourceEntry testResource : testResources) {
-                T instance = (T) testResourceClassEntryConstructor.newInstance(
-                        Class.forName(testResource.getClazz().getName(), true, classLoader), testResource.getArgs(),
-                        null, testResource.isParallel());
-                result.add(instance);
-            }
-
-            return result;
-        } catch (Exception e) {
-            throw new IllegalStateException("Unable to handle profile " + profileInstance.getClass(), e);
-        }
     }
 
     static void startLauncher(ArtifactLauncher launcher, Map<String, String> additionalProperties, Runnable sslSetter)

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -3,10 +3,10 @@ package io.quarkus.test.junit;
 import static io.quarkus.test.junit.IntegrationTestUtil.activateLogging;
 import static io.quarkus.test.junit.IntegrationTestUtil.determineBuildOutputDirectory;
 import static io.quarkus.test.junit.IntegrationTestUtil.determineTestProfileAndProperties;
-import static io.quarkus.test.junit.IntegrationTestUtil.getAdditionalTestResources;
 import static io.quarkus.test.junit.IntegrationTestUtil.getSysPropsToRestore;
 import static io.quarkus.test.junit.IntegrationTestUtil.handleDevServices;
 import static io.quarkus.test.junit.IntegrationTestUtil.readQuarkusArtifactProperties;
+import static io.quarkus.test.junit.TestResourceUtil.TestResourceManagerReflections.copyEntriesFromProfile;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -122,7 +122,7 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
                 TestProfileAndProperties testProfileAndProperties = determineTestProfileAndProperties(profile, sysPropRestore);
 
                 testResourceManager = new TestResourceManager(requiredTestClass, profile,
-                        getAdditionalTestResources(testProfileAndProperties.testProfile,
+                        copyEntriesFromProfile(testProfileAndProperties.testProfile,
                                 context.getRequiredTestClass().getClassLoader()),
                         testProfileAndProperties.testProfile != null
                                 && testProfileAndProperties.testProfile.disableGlobalTestResources());

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/TestResourceUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/TestResourceUtil.java
@@ -1,0 +1,202 @@
+package io.quarkus.test.junit;
+
+import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
+
+import java.io.Closeable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import io.quarkus.test.common.TestResourceManager;
+import io.quarkus.test.common.TestResourceScope;
+
+/**
+ * Contains methods that are needed for determining how to deal with {@link io.quarkus.test.common.QuarkusTestResource} and
+ * {@link io.quarkus.test.common.WithTestResource}
+ */
+final class TestResourceUtil {
+
+    private TestResourceUtil() {
+    }
+
+    /**
+     * This is where we decide if the test resources of the current state vs the ones required by the next test class
+     * to be executed require a Quarkus restart.
+     */
+    static boolean testResourcesRequireReload(QuarkusTestExtensionState state, Class<?> nextTestClass) {
+        Set<TestResourceManager.TestResourceComparisonInfo> existingTestResources = existingTestResources(state);
+        Set<TestResourceManager.TestResourceComparisonInfo> nextTestResources = nextTestResources(nextTestClass);
+
+        return TestResourceManager.testResourcesRequireReload(existingTestResources, nextTestResources);
+    }
+
+    static Set<TestResourceManager.TestResourceComparisonInfo> existingTestResources(QuarkusTestExtensionState state) {
+        if (state == null) {
+            return Collections.emptySet();
+        }
+        Closeable closeable = state.testResourceManager;
+        if (closeable instanceof TestResourceManager testResourceManager) {
+            return TestResourceManagerReflections
+                    .testResourceComparisonInfo(testResourceManager);
+        }
+        return Collections.emptySet();
+    }
+
+    static Set<TestResourceManager.TestResourceComparisonInfo> nextTestResources(Class<?> requiredTestClass) {
+        return TestResourceManager
+                .testResourceComparisonInfo(requiredTestClass, getTestClassesLocation(requiredTestClass));
+    }
+
+    /**
+     * Contains a bunch of utilities that are needed for handling {@link TestResourceManager}
+     * via reflection (due to different classloaders)
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    static final class TestResourceManagerReflections {
+
+        private TestResourceManagerReflections() {
+        }
+
+        /**
+         * Since {@link TestResourceManager} is loaded from the ClassLoader passed in as an argument,
+         * we need to convert the user input {@link QuarkusTestProfile.TestResourceEntry} into instances of
+         * {@link TestResourceManager.TestResourceClassEntry} that are loaded from that ClassLoader
+         */
+        static <T> List<T> copyEntriesFromProfile(
+                QuarkusTestProfile profileInstance, ClassLoader classLoader) {
+            if ((profileInstance == null) || profileInstance.testResources().isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            try {
+                Class testResourceScopeClass = classLoader.loadClass(TestResourceScope.class.getName());
+                Constructor<?> testResourceClassEntryConstructor = Class
+                        .forName(TestResourceManager.TestResourceClassEntry.class.getName(), true, classLoader)
+                        .getConstructor(Class.class, Map.class, Annotation.class, boolean.class, testResourceScopeClass);
+
+                List<QuarkusTestProfile.TestResourceEntry> testResources = profileInstance.testResources();
+                List<T> result = new ArrayList<>(testResources.size());
+                for (QuarkusTestProfile.TestResourceEntry testResource : testResources) {
+                    T instance = (T) testResourceClassEntryConstructor.newInstance(
+                            Class.forName(testResource.getClazz().getName(), true, classLoader), testResource.getArgs(),
+                            null, testResource.isParallel(),
+                            Enum.valueOf(testResourceScopeClass, TestResourceScope.RESTRICTED_TO_CLASS.name()));
+                    result.add(instance);
+                }
+
+                return result;
+            } catch (Exception e) {
+                throw new IllegalStateException("Unable to handle profile " + profileInstance.getClass(), e);
+            }
+        }
+
+        /**
+         * Corresponds to {@link TestResourceManager#TestResourceManager(Class, Class, List, boolean, Map, Optional, Path)}
+         */
+        static Closeable createReflectively(Class<?> testResourceManagerClass,
+                Class<?> testClass,
+                Class<?> profileClass,
+                List<TestResourceManager.TestResourceClassEntry> additionalTestResources,
+                boolean disableGlobalTestResources,
+                Map<String, String> devServicesProperties,
+                Optional<String> containerNetworkId,
+                Path testClassLocation) {
+            try {
+                return (Closeable) testResourceManagerClass
+                        .getConstructor(Class.class, Class.class, List.class, boolean.class, Map.class, Optional.class,
+                                Path.class)
+                        .newInstance(testClass, profileClass, additionalTestResources, disableGlobalTestResources,
+                                devServicesProperties, containerNetworkId, testClassLocation);
+            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+                    | NoSuchMethodException | SecurityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /**
+         * Corresponds to {@link TestResourceManager#TestResourceManager(Class, Class, List, boolean, Map, Optional)}
+         */
+        static Closeable createReflectively(Class<?> testResourceManagerClass,
+                Class<?> testClass,
+                Class<?> profileClass,
+                List<TestResourceManager.TestResourceClassEntry> additionalTestResources,
+                boolean disableGlobalTestResources,
+                Map<String, String> devServicesProperties,
+                Optional<String> containerNetworkId) {
+            try {
+                return (Closeable) testResourceManagerClass
+                        .getConstructor(Class.class, Class.class, List.class, boolean.class, Map.class, Optional.class)
+                        .newInstance(testClass, profileClass, additionalTestResources, disableGlobalTestResources,
+                                devServicesProperties, containerNetworkId);
+            } catch (InstantiationException | IllegalArgumentException | IllegalAccessException | InvocationTargetException
+                    | NoSuchMethodException | SecurityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /**
+         * Corresponds to {@link TestResourceManager#init(String)}
+         */
+        static void initReflectively(Object testResourceManager, Class<?> profileClassName) {
+            try {
+                testResourceManager.getClass().getMethod("init", String.class).invoke(testResourceManager,
+                        profileClassName != null ? profileClassName.getName() : null);
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+                    | SecurityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /**
+         * Corresponds to {@link TestResourceManager#start()}
+         */
+        public static Map<String, String> startReflectively(Object testResourceManager) {
+            try {
+                return (Map<String, String>) testResourceManager.getClass().getMethod("start")
+                        .invoke(testResourceManager);
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+                    | SecurityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /**
+         * Corresponds to {@link TestResourceManager#testResourceComparisonInfo()}
+         */
+        static Set<TestResourceManager.TestResourceComparisonInfo> testResourceComparisonInfo(Object testResourceManager) {
+            try {
+                Set originalSet = (Set) testResourceManager.getClass().getMethod("testResourceComparisonInfo")
+                        .invoke(testResourceManager);
+                if (originalSet.isEmpty()) {
+                    return Collections.emptySet();
+                }
+
+                Set<TestResourceManager.TestResourceComparisonInfo> result = new HashSet<>(originalSet.size());
+                for (var entry : originalSet) {
+                    String testResourceLifecycleManagerClass = (String) entry.getClass()
+                            .getMethod("testResourceLifecycleManagerClass").invoke(entry);
+                    Object originalTestResourceScope = entry.getClass().getMethod("scope").invoke(entry);
+                    TestResourceScope testResourceScope = null;
+                    if (originalTestResourceScope != null) {
+                        testResourceScope = TestResourceScope.valueOf(originalTestResourceScope.toString());
+                    }
+                    result.add(new TestResourceManager.TestResourceComparisonInfo(testResourceLifecycleManagerClass,
+                            testResourceScope));
+                }
+
+                return result;
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+                    | SecurityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.ClassOrdererContext;
 import org.junit.jupiter.api.Nested;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.TestResourceScope;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
@@ -140,7 +141,9 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
     private boolean hasRestrictedResource(ClassDescriptor classDescriptor) {
         return classDescriptor.findRepeatableAnnotations(WithTestResource.class).stream()
-                .anyMatch(res -> res.restrictToAnnotatedClass() || isMetaTestResource(res, classDescriptor)) ||
+                .anyMatch(
+                        res -> res.scope() == TestResourceScope.RESTRICTED_TO_CLASS || isMetaTestResource(res, classDescriptor))
+                ||
                 classDescriptor.findRepeatableAnnotations(QuarkusTestResource.class).stream()
                         .anyMatch(res -> res.restrictToAnnotatedClass() || isMetaTestResource(res, classDescriptor));
     }

--- a/test-framework/junit5/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
+++ b/test-framework/junit5/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
@@ -28,6 +28,7 @@ import org.mockito.quality.Strictness;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.common.TestResourceScope;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -205,7 +206,8 @@ class QuarkusTestProfileAwareClassOrdererTest {
             Class<? extends QuarkusTestResourceLifecycleManager> managerClass, boolean restrictToAnnotatedClass) {
         WithTestResource withResourceMock = Mockito.mock(WithTestResource.class, withSettings().strictness(Strictness.LENIENT));
         doReturn(managerClass).when(withResourceMock).value();
-        when(withResourceMock.restrictToAnnotatedClass()).thenReturn(restrictToAnnotatedClass);
+        when(withResourceMock.scope()).thenReturn(
+                restrictToAnnotatedClass ? TestResourceScope.RESTRICTED_TO_CLASS : TestResourceScope.MATCHING_RESOURCE);
         when(mock.findRepeatableAnnotations(WithTestResource.class)).thenReturn(List.of(withResourceMock));
     }
 
@@ -223,7 +225,7 @@ class QuarkusTestProfileAwareClassOrdererTest {
 
     // this single made-up test class needs an actual annotation since the orderer will have to do the meta-check directly
     // because ClassDescriptor does not offer any details whether an annotation is directly annotated or meta-annotated
-    @WithTestResource(value = Manager3.class, restrictToAnnotatedClass = false)
+    @WithTestResource(value = Manager3.class, scope = TestResourceScope.GLOBAL)
     private static class Test02 {
     }
 


### PR DESCRIPTION
The new default `@WithTestResource` behavior is
for Quarkus to NOT restart when consecutive tests
are using the same `@WithTestResource` annotations.

Despite the first first commit being a refactor and not a behavior change, 
it is where the heavy lifting is done (while hopefully making the code clearer to read). 

The second commit which brings the change just takes the structure put in place
by the previous one and changes the default.

~~P.S. For now, I only have the refactoring code in this PR, which I want to test against CI as it **should not** include any behavior change~~