### PR TITLE
Satisfy GraalVM's classpath needs for the deletion of `org.h2.fulltext.FullTextLucene`

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -120,7 +120,8 @@
         <httpasync.version>4.1.5</httpasync.version>
         <cronutils.version>9.2.1</cronutils.version>
         <quartz.version>2.3.2</quartz.version>
-        <h2.version>2.3.232</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions -->
+        <h2.version>2.3.232</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions
+                                              and dependencies jts-core and lucene-core need to be updated in extensions/jdbc/jdbc-h2/runtime/pom.xml -->
         <postgresql-jdbc.version>42.7.4</postgresql-jdbc.version>
         <mariadb-jdbc.version>3.4.1</mariadb-jdbc.version>
         <mysql-jdbc.version>8.3.0</mysql-jdbc.version>

--- a/extensions/jdbc/jdbc-h2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-h2/runtime/pom.xml
@@ -22,9 +22,18 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
+            <!--
+                Needed by GraalVM to delete org.h2.fulltext.FullTextLucene
+                https://github.com/quarkusio/quarkus/issues/42228
+            -->
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>9.7.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
-            <version>1.17.0</version>
+            <version>1.19.0</version>
             <!--
                 TODO: Make this an optional dependency?
                 Graal compiler not happy with broken classpaths


### PR DESCRIPTION
Adds `org.apache.lucene:lucene-core:9.7.0` as a dependency since it's
required to delete `org.h2.fulltext.FullTextLucene` in
`io.quarkus.jdbc.h2.runtime.graalvm.DeleteFullTextLucene`.

Also updates `org.locationtech.jts:jts-core` to 1.19.0 since that's the
latest version used by h2 2.232.

Fixes https://github.com/quarkusio/quarkus/issues/42228
