### PR TITLE
Compatibility with configuration cache for image tasks

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageCheckRequirementsTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageCheckRequirementsTask.java
@@ -1,0 +1,121 @@
+package io.quarkus.gradle.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.gradle.tooling.ToolingUtils;
+import io.quarkus.maven.dependency.ArtifactCoords;
+
+public abstract class ImageCheckRequirementsTask extends DefaultTask {
+
+    @OutputFile
+    public abstract RegularFileProperty getOutputFile();
+
+    private static final String DEPLOYMENT_SUFFIX = "-deployment";
+    static final String QUARKUS_PREFIX = "quarkus-";
+    static final String QUARKUS_CONTAINER_IMAGE_PREFIX = "quarkus-container-image-";
+    static final String QUARKUS_CONTAINER_IMAGE_BUILD = "quarkus.container-image.build";
+    static final String QUARKUS_CONTAINER_IMAGE_PUSH = "quarkus.container-image.push";
+    static final String QUARKUS_CONTAINER_IMAGE_BUILDER = "quarkus.container-image.builder";
+
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract RegularFileProperty getApplicationModel();
+
+    static final Map<String, ImageCheckRequirementsTask.Builder> BUILDERS = new HashMap<>();
+    static {
+        for (ImageCheckRequirementsTask.Builder builder : ImageCheckRequirementsTask.Builder.values()) {
+            BUILDERS.put(builder.name(), builder);
+        }
+    }
+
+    enum Builder {
+        docker,
+        jib,
+        buildpack,
+        openshift
+    }
+
+    Optional<ImageCheckRequirementsTask.Builder> builderFromSystemProperties() {
+        return Optional.ofNullable(System.getProperty(QUARKUS_CONTAINER_IMAGE_BUILDER))
+                .filter(BUILDERS::containsKey)
+                .map(BUILDERS::get);
+    }
+
+    List<ImageCheckRequirementsTask.Builder> availableBuilders() throws IOException {
+        // This will only pickup direct dependencies and not transitives
+        // This means that extensions like quarkus-container-image-openshift via quarkus-openshift are not picked up
+        // So, let's relax our filters a bit so that we can pickup quarkus-openshift directly (relax the prefix requirement).
+        ApplicationModel appModel = ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath());
+        return appModel.getDependencies()
+                .stream()
+                .map(ArtifactCoords::getArtifactId)
+                .filter(n -> n.startsWith(QUARKUS_CONTAINER_IMAGE_PREFIX) || n.startsWith(QUARKUS_PREFIX))
+                .map(n -> n.replace(QUARKUS_CONTAINER_IMAGE_PREFIX, "").replace(QUARKUS_PREFIX, "").replace(DEPLOYMENT_SUFFIX,
+                        ""))
+                .filter(BUILDERS::containsKey)
+                .map(BUILDERS::get)
+                .collect(Collectors.toList());
+    }
+
+    private Builder builder() {
+        return builderFromSystemProperties()
+                .or(() -> {
+                    try {
+                        return availableBuilders().stream().findFirst();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .orElse(ImageCheckRequirementsTask.Builder.docker);
+    }
+
+    @TaskAction
+    public void checkRequiredExtensions() throws IOException {
+
+        // Currently forcedDependencies() is not implemented for gradle.
+        // So, let's give users a meaningful warning message.
+        List<Builder> availableBuidlers = availableBuilders();
+        Optional<Builder> missingBuilder = Optional.of(builder()).filter(Predicate.not(availableBuidlers::contains));
+        missingBuilder.map(builder -> QUARKUS_CONTAINER_IMAGE_PREFIX + builder.name()).ifPresent(missingDependency -> {
+            throw new GradleException(String.format(
+                    "Task: %s requires extensions: %s. " +
+                            "To add the extensions to the project, you can run the following command:\n" +
+                            "\tgradle addExtension --extensions=%s",
+                    getName(), missingDependency, missingDependency));
+        });
+
+        if (!missingBuilder.isPresent() && availableBuidlers.isEmpty()) {
+            String availableExtensions = Arrays.stream(Builder.values())
+                    .map(Builder::name)
+                    .collect(Collectors.joining(", ", "[", "]"));
+
+            throw new GradleException(String.format(
+                    "Task: %s requires one of the extensions: %s. " +
+                            "To add the extensions to the project, you can run the following command:\n" +
+                            "\tgradle addExtension --extensions=<extension name>",
+                    getName(), availableExtensions));
+        }
+
+        File outputFile = getOutputFile().get().getAsFile();
+        Files.write(outputFile.toPath(), builder().name().getBytes());
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageCheckRequirementsTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageCheckRequirementsTask.java
@@ -61,7 +61,7 @@ public abstract class ImageCheckRequirementsTask extends DefaultTask {
     }
 
     List<ImageCheckRequirementsTask.Builder> availableBuilders() throws IOException {
-        // This will only pickup direct dependencies and not transitives
+        // This will pick up all dependencies set in the serialized ApplicationModel.
         // This means that extensions like quarkus-container-image-openshift via quarkus-openshift are not picked up
         // So, let's relax our filters a bit so that we can pickup quarkus-openshift directly (relax the prefix requirement).
         ApplicationModel appModel = ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath());

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
@@ -1,45 +1,26 @@
-
 package io.quarkus.gradle.tasks;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import static io.quarkus.gradle.tasks.ImageCheckRequirementsTask.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.TaskAction;
 
 public abstract class ImagePush extends ImageTask {
 
     @Inject
     public ImagePush() {
-        super("Perform an image push");
-        MapProperty<String, String> forcedProperties = extension().forcedPropertiesProperty();
-        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
-        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_PUSH, "true");
+        super("Perform an image push", true);
     }
 
     @TaskAction
-    public void checkRequiredExtensions() {
-        List<String> containerImageExtensions = getProject().getConfigurations().stream()
-                .flatMap(c -> c.getDependencies().stream())
-                .map(d -> d.getName())
-                .filter(n -> n.startsWith(QUARKUS_CONTAINER_IMAGE_PREFIX))
-                .map(n -> n.replaceAll("-deployment$", ""))
-                .collect(Collectors.toList());
-
-        List<String> extensions = Arrays.stream(ImageBuild.Builder.values()).map(b -> QUARKUS_CONTAINER_IMAGE_PREFIX + b.name())
-                .collect(Collectors.toList());
-
-        if (containerImageExtensions.isEmpty()) {
-            getLogger().warn("Task: {} requires a container image extension.", getName());
-            getLogger().warn("Available container image exntesions: [{}]",
-                    extensions.stream().collect(Collectors.joining(", ")));
-            getLogger().warn("To add an extension to the project, you can run one of the commands below:");
-            extensions.forEach(e -> {
-                getLogger().warn("\tgradle addExtension --extensions={}", e);
-            });
-        }
+    public void imagePush() {
+        Map<String, String> forcedProperties = new HashMap<String, String>();
+        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
+        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_PUSH, "true");
+        getAdditionalForcedProperties().get().getProperties().putAll(forcedProperties);
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
@@ -1,95 +1,23 @@
 
 package io.quarkus.gradle.tasks;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
-
-import io.quarkus.gradle.dependency.ApplicationDeploymentClasspathBuilder;
-import io.quarkus.gradle.tooling.ToolingUtils;
-import io.quarkus.runtime.LaunchMode;
 
 public abstract class ImageTask extends QuarkusBuildTask {
 
-    private static final String DEPLOYMENT_SUFFIX = "-deployment";
-    static final String QUARKUS_PREFIX = "quarkus-";
-    static final String QUARKUS_CONTAINER_IMAGE_PREFIX = "quarkus-container-image-";
-    static final String QUARKUS_CONTAINER_IMAGE_BUILD = "quarkus.container-image.build";
-    static final String QUARKUS_CONTAINER_IMAGE_PUSH = "quarkus.container-image.push";
-    static final String QUARKUS_CONTAINER_IMAGE_BUILDER = "quarkus.container-image.builder";
-
-    static final Map<String, Builder> BUILDERS = new HashMap<>();
-    static {
-        for (Builder builder : Builder.values()) {
-            BUILDERS.put(builder.name(), builder);
-        }
+    ImageTask(String description, boolean compatible) {
+        super(description, compatible);
     }
 
-    enum Builder {
-        docker,
-        jib,
-        buildpack,
-        openshift
-    }
-
-    public ImageTask(String description) {
-        super(description, false);
-    }
-
-    public Builder builder() {
-        return builderFromSystemProperties()
-                .or(() -> availableBuilders().stream().findFirst())
-                .orElse(Builder.docker);
-    }
-
-    Optional<Builder> builderFromSystemProperties() {
-        return Optional.ofNullable(System.getProperty(QUARKUS_CONTAINER_IMAGE_BUILDER))
-                .filter(BUILDERS::containsKey)
-                .map(BUILDERS::get);
-    }
-
-    List<Builder> availableBuilders() {
-        // This will only pickup direct dependencies and not transitives
-        // This means that extensions like quarkus-container-image-openshift via quarkus-openshift are not picked up
-        // So, let's relax our filters a bit so that we can pickup quarkus-openshift directly (relax the prefix requirement).
-        return getProject().getConfigurations()
-                .getByName(ToolingUtils.toDeploymentConfigurationName(
-                        ApplicationDeploymentClasspathBuilder.getFinalRuntimeConfigName(LaunchMode.NORMAL)))
-                .getDependencies().stream()
-                .map(d -> d.getName())
-                .filter(n -> n.startsWith(QUARKUS_CONTAINER_IMAGE_PREFIX) || n.startsWith(QUARKUS_PREFIX))
-                .map(n -> n.replace(QUARKUS_CONTAINER_IMAGE_PREFIX, "").replace(QUARKUS_PREFIX, "").replace(DEPLOYMENT_SUFFIX,
-                        ""))
-                .filter(BUILDERS::containsKey)
-                .map(BUILDERS::get)
-                .collect(Collectors.toList());
-    }
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract RegularFileProperty getBuilderName();
 
     @TaskAction
-    public void checkRequiredExtensions() {
-        // Currently forcedDependencies() is not implemented for gradle.
-        // So, let's give users a meaningful warning message.
-        List<Builder> availableBuidlers = availableBuilders();
-        Optional<Builder> missingBuilder = Optional.of(builder()).filter(Predicate.not(availableBuidlers::contains));
-        missingBuilder.map(builder -> QUARKUS_CONTAINER_IMAGE_PREFIX + builder.name()).ifPresent(missingDependency -> {
-            getLogger().warn("Task: {} requires extensions: {}", getName(), missingDependency);
-            getLogger().warn("To add the extensions to the project you can run the following command:");
-            getLogger().warn("\tgradle addExtension --extensions={}", missingDependency);
-            abort("Aborting.");
-        });
-
-        if (!missingBuilder.isPresent() && availableBuidlers.isEmpty()) {
-            getLogger().warn("Task: {} requires on of extensions: {}", getName(),
-                    Arrays.stream(Builder.values()).map(Builder::name).collect(Collectors.joining(", ", "[", "]")));
-            getLogger().warn("To add the extensions to the project you can run the following command:");
-            getLogger().warn("\tgradle addExtension --extensions=<extension name>");
-            abort("Aborting.");
-        }
+    public void imageTask() {
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -48,7 +48,8 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
         Map<String, ?> nativeArgsMap = new HashMap<>();
         action.execute(nativeArgsMap);
         for (Map.Entry<String, ?> nativeArg : nativeArgsMap.entrySet()) {
-            additionalForcedProperties.put(expandConfigurationKey(nativeArg.getKey()), nativeArg.getValue().toString());
+            getAdditionalForcedProperties().get().getProperties().put(expandConfigurationKey(nativeArg.getKey()),
+                    nativeArg.getValue().toString());
         }
         return this;
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
@@ -49,7 +49,8 @@ public abstract class QuarkusShowEffectiveConfig extends QuarkusBuildTask {
         try {
             ApplicationModel appModel = resolveAppModelForBuild();
             EffectiveConfig effectiveConfig = getExtensionView()
-                    .buildEffectiveConfiguration(appModel.getAppArtifact(), additionalForcedProperties);
+                    .buildEffectiveConfiguration(appModel.getAppArtifact(),
+                            getAdditionalForcedProperties().get().getProperties());
             SmallRyeConfig config = effectiveConfig.getConfig();
             List<String> sourceNames = new ArrayList<>();
             config.getConfigSources().forEach(configSource -> sourceNames.add(configSource.getName()));

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/services/ForcedPropertieBuildService.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/services/ForcedPropertieBuildService.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle.tasks.services;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+public abstract class ForcedPropertieBuildService implements BuildService<BuildServiceParameters.None> {
+
+    Map<String, String> properties = new HashMap<>();
+
+    public ForcedPropertieBuildService() {
+
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
@@ -1,8 +1,6 @@
 package io.quarkus.gradle.tasks;
 
 import static io.quarkus.gradle.QuarkusPlugin.DEPLOY_TASK_NAME;
-import static io.quarkus.gradle.QuarkusPlugin.IMAGE_BUILD_TASK_NAME;
-import static io.quarkus.gradle.QuarkusPlugin.IMAGE_PUSH_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_BUILD_APP_PARTS_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_BUILD_DEP_TASK_NAME;
 import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_BUILD_TASK_NAME;
@@ -48,10 +46,7 @@ public class TasksConfigurationCacheCompatibilityTest {
     }
 
     private static Stream<String> nonCompatibleQuarkusBuildTasks() {
-        return Stream.of(
-                IMAGE_BUILD_TASK_NAME,
-                IMAGE_PUSH_TASK_NAME,
-                DEPLOY_TASK_NAME);
+        return Stream.of(DEPLOY_TASK_NAME);
     }
 
     @Test

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -828,6 +828,8 @@ The current state of compatibility is shown in the following table:
 |`quarkusAppPartsBuild`|✅
 |`quarkusShowEffectiveConfig`|✅
 |`quarkusBuild`|✅
+|`imageBuild`|✅
+|`imagePush`|✅
 |`quarkusDev`|❌
 |`quarkusRun`|❌
 |`quarkusRemoteDev`|❌
@@ -835,8 +837,6 @@ The current state of compatibility is shown in the following table:
 |`quarkusGoOffline`|❌
 |`quarkusInfo`|❌
 |`quarkusUpdate`|❌
-|`imageBuild`|❌
-|`imagePush`|❌
 |`deploy`|❌
 |`listExtensions`|❌
 |`listCategories`|❌

--- a/integration-tests/gradle/src/main/resources/it-test-basic-project/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/gradle/src/main/resources/it-test-basic-project/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,97 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./gradlew build
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/code-with-quarkus-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-jvm
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
+# Additionally you will have to set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# when running the container
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-jvm
+#
+# This image uses the `run-java.sh` script to run the application.
+# This scripts computes the command line to execute your Java application, and
+# includes memory/GC tuning.
+# You can configure the behavior using the following environment properties:
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
+#   in JAVA_OPTS (example: "-Dsome.property=foo")
+# - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
+#   used to calculate a default maximal heap memory based on a containers restriction.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio
+#   of the container available memory as set here. The default is `50` which means 50%
+#   of the available memory is used as an upper boundary. You can skip this mechanism by
+#   setting this value to `0` in which case no `-Xmx` option is added.
+# - JAVA_INITIAL_MEM_RATIO: Is used when no `-Xms` option is given in JAVA_OPTS. This
+#   is used to calculate a default initial heap memory based on the maximum heap memory.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xms` is set to a ratio
+#   of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx`
+#   is used as the initial heap size. You can skip this mechanism by setting this value
+#   to `0` in which case no `-Xms` option is added (example: "25")
+# - JAVA_MAX_INITIAL_MEM: Is used when no `-Xms` option is given in JAVA_OPTS.
+#   This is used to calculate the maximum value of the initial heap memory. If used in
+#   a container without any memory constraints for the container then this option has
+#   no effect. If there is a memory constraint then `-Xms` is limited to the value set
+#   here. The default is 4096MB which means the calculated value of `-Xms` never will
+#   be greater than 4096MB. The value of this variable is expressed in MB (example: "4096")
+# - JAVA_DIAGNOSTICS: Set this to get some diagnostics information to standard output
+#   when things are happening. This option, if set to true, will set
+#  `-XX:+UnlockDiagnosticVMOptions`. Disabled by default (example: "true").
+# - JAVA_DEBUG: If set remote debugging will be switched on. Disabled by default (example:
+#    true").
+# - JAVA_DEBUG_PORT: Port used for remote debugging. Defaults to 5005 (example: "8787").
+# - CONTAINER_CORE_LIMIT: A calculated core limit as described in
+#   https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. (example: "2")
+# - CONTAINER_MAX_MEMORY: Memory limit given to the container (example: "1024").
+# - GC_MIN_HEAP_FREE_RATIO: Minimum percentage of heap free after GC to avoid expansion.
+#   (example: "20")
+# - GC_MAX_HEAP_FREE_RATIO: Maximum percentage of heap free after GC to avoid shrinking.
+#   (example: "40")
+# - GC_TIME_RATIO: Specifies the ratio of the time spent outside the garbage collection.
+#   (example: "4")
+# - GC_ADAPTIVE_SIZE_POLICY_WEIGHT: The weighting given to the current GC time versus
+#   previous GC times. (example: "90")
+# - GC_METASPACE_SIZE: The initial metaspace size. (example: "20")
+# - GC_MAX_METASPACE_SIZE: The maximum metaspace size. (example: "100")
+# - GC_CONTAINER_OPTIONS: Specify Java GC to use. The value of this variable should
+#   contain the necessary JRE command-line options to specify the required GC, which
+#   will override the default of `-XX:+UseParallelGC` (example: -XX:+UseG1GC).
+# - HTTPS_PROXY: The location of the https proxy. (example: "myuser@127.0.0.1:8080")
+# - HTTP_PROXY: The location of the http proxy. (example: "myuser@127.0.0.1:8080")
+# - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
+#   accessed directly. (example: "foo.example.com,bar.example.com")
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.18
+
+ENV LANGUAGE='en_US:en'
+
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=185 build/quarkus-app/lib/ /deployments/lib/
+COPY --chown=185 build/quarkus-app/*.jar /deployments/
+COPY --chown=185 build/quarkus-app/app/ /deployments/app/
+COPY --chown=185 build/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 185
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
+

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/ImageTasksWithConfigurationCacheTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/ImageTasksWithConfigurationCacheTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+public class ImageTasksWithConfigurationCacheTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "cannot access the file because another process has locked a portion of the file")
+    public void shouldReuseConfigurationCacheImageBuildIfTheExtensionIsAdded() throws Exception {
+        File projectDir = getProjectDir("it-test-basic-project");
+
+        runGradleWrapper(projectDir, "addExtension", "--extensions=quarkus-container-image-docker");
+
+        BuildResult buildResult = runGradleWrapper(projectDir, "imageBuild");
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":imageBuild"))).isTrue();
+
+        assertTrue(buildResult.getOutput().contains("Configuration cache entry stored"));
+        BuildResult buildResult3 = runGradleWrapper(projectDir, "imageBuild");
+        assertTrue(buildResult3.getOutput().contains("Reusing configuration cache."));
+
+    }
+
+    @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "cannot access the file because another process has locked a portion of the file")
+    public void shouldReuseConfigurationCacheWithProjectIsolationImageBuildIfTheExtensionIsAdded() throws Exception {
+        File projectDir = getProjectDir("it-test-basic-project");
+
+        runGradleWrapper(projectDir, "addExtension", "--extensions=quarkus-container-image-docker");
+
+        BuildResult buildResult = runGradleWrapper(projectDir, "imageBuild", "-Dorg.gradle.unsafe.isolated-projects=true");
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":imageBuild"))).isTrue();
+
+        assertTrue(buildResult.getOutput().contains("Configuration cache entry stored"));
+        BuildResult buildResult3 = runGradleWrapper(projectDir, "imageBuild", "-Dorg.gradle.unsafe.isolated-projects=true");
+        assertTrue(buildResult3.getOutput().contains("Reusing configuration cache."));
+
+    }
+
+    @Test
+    public void shouldFailIfExtensionIsNotDefinedInTheBuild() throws Exception {
+        File projectDir = getProjectDir("it-test-basic-project");
+        BuildResult buildResultImageBuild = runGradleWrapper(true, projectDir, "clean", "imageBuild", "--no-build-cache");
+        assertTrue(buildResultImageBuild.getOutput()
+                .contains("Task: quarkusImageExtensionChecks requires extensions: quarkus-container-image-docker"));
+
+        BuildResult buildResultImagePush = runGradleWrapper(true, projectDir, "clean", "imagePush", "--no-build-cache");
+        assertTrue(buildResultImagePush.getOutput()
+                .contains("Task: quarkusImageExtensionChecks requires extensions: quarkus-container-image-docker"));
+
+    }
+}


### PR DESCRIPTION
**ImageTask Compatibility with Configuration Cache:**
The current issues identified are:
* When the task configuration is incorrect, the abort method in `QuarkusBuildTask` is called. This method accesses the incompatible object getProject().
* Disabling the task execution during runtime is also not compatible with the configuration cache.
* Accessing project dependencies to retrieve extensions to get the builder name.
* The ImageTasks are finalized by `QuarkusBuild`.

The proposal includes:
* Creating a new task(`ImageCheckRequirementsTask`) that checks for the extensions. These extensions are retrieved from the Application Model, which was previously serialized with the extensions included and is compatible with the configuration cache.
ImagePush/ImageBuild will depend on this new task. If the required extension is not found, we can safely fail the build without mutating the state of quarkusBuild.
* Introducing a new BuildService(`ForcedPropertieBuildService`) to represent the additional forcedProperties used across different tasks in the QuarkusBuildTasks family. This shared object is used during the build to add additional properties, such as those used by the ImageTasks, and could be utilized for future tasks (the next step will involve evaluating Deploy tasks).
* The proposal also includes new integration tests for the ImageBuild task, testing for incorrect configurations due to the lack of extensions, and verifying the configuration cache compatibility when building the Docker image, covering isolated projects as well.

Fixes https://github.com/quarkusio/quarkus/issues/42256