### PR TITLE
Set FormAuthenticationMechanism cookie Max-Age

### DIFF
--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkus.security.webauthn;
 
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.function.Supplier;
 
@@ -72,7 +73,8 @@ public class WebAuthnRecorder {
                 PersistentLoginManager loginManager = new PersistentLoginManager(key, config.cookieName(),
                         config.sessionTimeout().toMillis(),
                         config.newCookieInterval().toMillis(), false, config.cookieSameSite().name(),
-                        config.cookiePath().orElse(null));
+                        config.cookiePath().orElse(null),
+                        config.cookieMaxAge().map(Duration::toSeconds).orElse(-1L));
                 String loginPage = config.loginPage().startsWith("/") ? config.loginPage() : "/" + config.loginPage();
                 return new WebAuthnAuthenticationMechanism(loginManager, loginPage);
             }

--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRunTimeConfig.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRunTimeConfig.java
@@ -254,4 +254,11 @@ public interface WebAuthnRunTimeConfig {
      */
     @WithDefault("/")
     Optional<String> cookiePath();
+
+    /**
+     * Max-Age attribute for the session cookie. This is the amount of time the browser will keep the cookie.
+     *
+     * The default value is empty, which means the cookie will be kept until the browser is closed.
+     */
+    Optional<Duration> cookieMaxAge();
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthCookiesTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthCookiesTestCase.java
@@ -60,6 +60,7 @@ public class FormAuthCookiesTestCase {
             "quarkus.http.auth.form.cookie-name=laitnederc-sukrauq\n" +
             "quarkus.http.auth.form.cookie-same-site=lax\n" +
             "quarkus.http.auth.form.http-only-cookie=true\n" +
+            "quarkus.http.auth.form.cookie-max-age=PT2M\n" +
             "quarkus.http.auth.session.encryption-key=CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT\n";
 
     @RegisterExtension
@@ -108,7 +109,7 @@ public class FormAuthCookiesTestCase {
                 .statusCode(302)
                 .header("location", containsString("/admin%E2%9D%A4"))
                 .cookie("laitnederc-sukrauq", detailedCookie().value(notNullValue())
-                        .httpOnly(true).sameSite("Lax"));
+                        .httpOnly(true).sameSite("Lax").maxAge(120));
 
         RestAssured
                 .given()

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
@@ -119,4 +119,12 @@ public class FormAuthRuntimeConfig {
      */
     @ConfigItem(defaultValue = "strict")
     public CookieSameSite cookieSameSite = CookieSameSite.STRICT;
+
+    /**
+     * Max-Age attribute for the session cookie. This is the amount of time the browser will keep the cookie.
+     *
+     * The default value is empty, which means the cookie will be kept until the browser is closed.
+     */
+    @ConfigItem
+    public Optional<Duration> cookieMaxAge;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
@@ -5,6 +5,7 @@ import static io.quarkus.vertx.http.runtime.security.FormAuthenticationEvent.cre
 
 import java.net.URI;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
@@ -88,7 +89,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
         FormAuthRuntimeConfig runtimeForm = httpConfiguration.auth.form;
         this.loginManager = new PersistentLoginManager(key, runtimeForm.cookieName, runtimeForm.timeout.toMillis(),
                 runtimeForm.newCookieInterval.toMillis(), runtimeForm.httpOnlyCookie, runtimeForm.cookieSameSite.name(),
-                runtimeForm.cookiePath.orElse(null));
+                runtimeForm.cookiePath.orElse(null), runtimeForm.cookieMaxAge.map(Duration::toSeconds).orElse(-1L));
         this.loginPage = startWithSlash(runtimeForm.loginPage.orElse(null));
         this.errorPage = startWithSlash(runtimeForm.errorPage.orElse(null));
         this.landingPage = startWithSlash(runtimeForm.landingPage.orElse(null));

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
@@ -39,15 +39,17 @@ public class PersistentLoginManager {
     private final boolean httpOnlyCookie;
     private final CookieSameSite cookieSameSite;
     private final String cookiePath;
+    private final long maxAgeSeconds;
 
     public PersistentLoginManager(String encryptionKey, String cookieName, long timeoutMillis, long newCookieIntervalMillis,
-            boolean httpOnlyCookie, String cookieSameSite, String cookiePath) {
+            boolean httpOnlyCookie, String cookieSameSite, String cookiePath, long maxAgeSeconds) {
         this.cookieName = cookieName;
         this.newCookieIntervalMillis = newCookieIntervalMillis;
         this.timeoutMillis = timeoutMillis;
         this.httpOnlyCookie = httpOnlyCookie;
         this.cookieSameSite = CookieSameSite.valueOf(cookieSameSite);
         this.cookiePath = cookiePath;
+        this.maxAgeSeconds = maxAgeSeconds;
         try {
             if (encryptionKey == null) {
                 this.secretKey = KeyGenerator.getInstance("AES").generateKey();
@@ -139,10 +141,16 @@ public class PersistentLoginManager {
             message.put(iv);
             message.put(encrypted);
             String cookieValue = Base64.getEncoder().encodeToString(message.array());
-            context.addCookie(
-                    Cookie.cookie(cookieName, cookieValue).setPath(cookiePath).setSameSite(cookieSameSite)
-                            .setSecure(secureCookie)
-                            .setHttpOnly(httpOnlyCookie));
+
+            Cookie cookie = Cookie.cookie(cookieName, cookieValue)
+                    .setPath(cookiePath)
+                    .setSameSite(cookieSameSite)
+                    .setSecure(secureCookie)
+                    .setHttpOnly(httpOnlyCookie);
+            if (maxAgeSeconds >= 0) {
+                cookie.setMaxAge(maxAgeSeconds);
+            }
+            context.addCookie(cookie);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Currently, the cookie set by `FormAuthenticationMechanism` is discarded as soon as the browser is closed because the `max-age` property is not set.

This PR instructs the browser to keep the cookie for as long as the server considers it valid, regardless of any browser restarts.

This fixes https://github.com/quarkusio/quarkus/issues/42463 which has more information about the issue.
