### PR TITLE
Use quarkus-rest instead of quarkus-resteasy as default extension in maven plugin

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -63,7 +63,7 @@ public class CreateProjectMojo extends AbstractMojo {
     private static final String DEFAULT_GROUP_ID = "org.acme";
     private static final String DEFAULT_ARTIFACT_ID = "code-with-quarkus";
     private static final String DEFAULT_VERSION = "1.0.0-SNAPSHOT";
-    private static final String DEFAULT_EXTENSIONS = "resteasy";
+    private static final String DEFAULT_EXTENSIONS = "rest";
 
     @Parameter(defaultValue = "${project}")
     protected MavenProject project;


### PR DESCRIPTION
Not sure if this was forgotten or if intentional but I think we should default to quarkus-rest.