### PR TITLE
Do not warn about property change when the property is mapped in build and runtime

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -664,6 +664,10 @@ public final class BuildTimeConfigurationReader {
                 }
             }
 
+            // Mappings may map the same property between build and runtime. In that case runtime wins.
+            allBuildTimeValues.keySet().removeAll(runTimeValues.keySet());
+            buildTimeRunTimeValues.keySet().removeAll(runTimeValues.keySet());
+
             Set<String> relocatesOrFallbacks = new HashSet<>();
             for (String unknownBuildProperty : unknownBuildProperties) {
                 ConfigValue configValue = config.getConfigValue(unknownBuildProperty);


### PR DESCRIPTION
Mappings now allow us to map the same property in different config phases, which old config roots did not. That restriction means that a property mapped both at build time and runtime would receive a warning if modified by runtime.

The problem with the wrong warnings was introduced by https://github.com/quarkusio/quarkus/pull/42106, namely:

https://github.com/quarkusio/quarkus/pull/42106/files#diff-481bcfd93c179379817ad3e7013830913c33b03317b7444c7ffa0a7bf2c58a5aR69-R71

Which is required by:
https://github.com/quarkusio/quarkus/pull/42106/files#diff-97429049f54dc587b3b05727330a73994cb216f10179439fd8f654e302bbb98dR82-R85

Previously, the code just checked the' ...url` property in build time directly without using a root/mapping, so we never noticed the issue.  