### PR TITLE
Gradle - Correctly merge classes dir when using dev mode

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -633,7 +633,7 @@ public abstract class QuarkusDev extends QuarkusTask {
             }
         }
         Path classesDir = classesDirs.isEmpty() ? null
-                : QuarkusGradleUtils.mergeClassesDirs(classesDirs, project.getWorkspaceModule().getBuildDir(), root, false);
+                : QuarkusGradleUtils.mergeClassesDirs(classesDirs, project.getWorkspaceModule().getBuildDir(), true, false);
         Path generatedSourcesPath = sources.getSourceDirs().isEmpty() ? null
                 : sources.getSourceDirs().iterator().next().getAptSourcesDir();
 


### PR DESCRIPTION
We were returning an empty dir before which would trigger the use of the resources dir instead.

Also simplify the logic as it was quite hard to follow and it's actually quite simple.

Fixes #42860