### PR TITLE
Include AuthenticationCompletionException messages in HTTP response in devmode

### DIFF
--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -103,7 +103,7 @@ public class CodeFlowDevModeTestCase {
             }
             webClient.getCookieManager().clearCookies();
 
-            // Now set the correct client-id
+            // Now set the correct client secret
             test.modifyResourceFile("application.properties", s -> s.replace("secret-from-vault-typo", "secret-from-vault"));
 
             page = webClient.getPage("http://localhost:8080/protected");

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode-default-tenant.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode-default-tenant.properties
@@ -1,6 +1,7 @@
 quarkus.oidc.client-id=quarkus-web-app
 quarkus.oidc.credentials.secret=secret
 #quarkus.oidc.application-type=web-app
+#quarkus.oidc.authentication.scopes=invalid-scope
 
-quarkus.log.category."org.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
+quarkus.log.category."org.htmlunit".level=ERROR
 

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -8,7 +8,7 @@ quarkus.oidc.credentials.client-secret.provider.key=secret-from-vault-typo
 quarkus.oidc.application-type=web-app
 quarkus.oidc.logout.path=/protected/logout
 quarkus.oidc.authentication.pkce-required=true
-quarkus.log.category."org.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
+quarkus.log.category."org.htmlunit".level=ERROR
 quarkus.log.category."io.quarkus.oidc.runtime.TenantConfigContext".level=DEBUG
 quarkus.log.file.enable=true
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -19,7 +19,9 @@ import org.jboss.logging.Logger;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.runtime.ErrorPageAction;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.TemplateHtmlBuilder;
+import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationException;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.UnauthorizedException;
@@ -109,7 +111,14 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
                 //end here as failing event makes it possible to customize response, however when proactive security is
                 //disabled, this should be handled elsewhere and if we get to this point bad things have happened,
                 //so it is better to send a response than to hang
-                event.response().end();
+
+                if (event.failure() instanceof AuthenticationCompletionException
+                        && event.failure().getMessage() != null
+                        && LaunchMode.current() == LaunchMode.DEVELOPMENT) {
+                    event.response().end(event.failure().getMessage());
+                } else {
+                    event.response().end();
+                }
                 return;
             }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -28,6 +28,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -275,7 +276,13 @@ public class HttpSecurityRecorder {
                     protected void proceed(Throwable throwable) {
                         //we can't fail event here as request processing has already begun (e.g. in RESTEasy Reactive)
                         //and extensions may have their ways to handle failures
-                        event.end();
+                        if (throwable instanceof AuthenticationCompletionException
+                                && throwable.getMessage() != null
+                                && LaunchMode.current() == LaunchMode.DEVELOPMENT) {
+                            event.end(throwable.getMessage());
+                        } else {
+                            event.end();
+                        }
                     }
                 });
             }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -126,6 +126,7 @@ public class CodeFlowTest {
             // response from Quarkus
             webResponse = webClient.loadWebResponse(new WebRequest(endpointLocationUri.toURL()));
             assertEquals(401, webResponse.getStatusCode());
+            assertEquals("", webResponse.getContentAsString(), "The reason behind 401 can only be returned in devmode");
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
Fixes #41890.

It really fixes a bug rather than a planned enhancement.

Sometimes, when the user is redirected to the OIDC provider and something goes wrong at the OIDC provider's side, an error code and optional error description is returned. 

 Awhile back, @FroMage asked about an option to customize such error responses so now users can register error handlers and refer to them with `quarkus.oidc.authentication.error-path` property.

But if they haven't registered it, they will get a rather obscure warning and 401 in the browser without any further clues.

@maxandersen was concerned about it the other day, but also @Sanne and indeed @Fromage have also been concerned.

So first of all, this PR improves a log message reported when the user is redirected back to Quarkus with the error code.
And it goes over all/most of `AuthenticationCompletionException` cases,  initializes `AuthenticationCompletionException` with the error message, and allows this error message be reported back to the user, but in devmode only, to avoid accidentally leaking too many details. 