### PR TITLE
Config Doc - Avoid annotations in primitive type name

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/ResolvedType.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/ResolvedType.java
@@ -34,10 +34,8 @@ public record ResolvedType(
         return unwrappedType.toString();
     }
 
-    public static ResolvedType ofPrimitive(TypeMirror unwrappedType) {
-        String primitiveName = unwrappedType.toString();
-
-        return new ResolvedType(unwrappedType, unwrappedType, primitiveName, primitiveName, primitiveName, true, false, false,
+    public static ResolvedType ofPrimitive(TypeMirror unwrappedType, String typeName) {
+        return new ResolvedType(unwrappedType, unwrappedType, typeName, typeName, typeName, true, false, false,
                 false, false, false, false, false, false, false);
     }
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
@@ -183,7 +183,7 @@ public class ConfigResolver {
             if (discoveryConfigProperty.getType().isMap()) {
                 // it is a leaf pass through map, it is always optional
                 optional = true;
-                typeQualifiedName = discoveryConfigProperty.getType().wrapperType().toString();
+                typeQualifiedName = utils.element().getQualifiedName(discoveryConfigProperty.getType().wrapperType());
                 typeSimplifiedName = utils.element().simplifyGenericType(discoveryConfigProperty.getType().wrapperType());
 
                 potentiallyMappedPath += ConfigNamingUtil.getMapKey(discoveryConfigProperty.getMapKey());
@@ -191,7 +191,7 @@ public class ConfigResolver {
                         .map(p -> p + ConfigNamingUtil.getMapKey(discoveryConfigProperty.getMapKey()))
                         .collect(Collectors.toCollection(ArrayList::new));
             } else if (discoveryConfigProperty.getType().isList()) {
-                typeQualifiedName = discoveryConfigProperty.getType().wrapperType().toString();
+                typeQualifiedName = utils.element().getQualifiedName(discoveryConfigProperty.getType().wrapperType());
             }
 
             PropertyPath propertyPath = new PropertyPath(potentiallyMappedPath,

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigAnnotationScanner.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigAnnotationScanner.java
@@ -197,7 +197,8 @@ public class ConfigAnnotationScanner {
             }
         } else {
             TypeMirror superclass = clazz.getSuperclass();
-            if (superclass.getKind() != TypeKind.NONE && !superclass.toString().equals(Object.class.getName())) {
+            if (superclass.getKind() != TypeKind.NONE
+                    && !utils.element().getQualifiedName(superclass).equals(Object.class.getName())) {
                 TypeElement superclassTypeElement = (TypeElement) ((DeclaredType) superclass).asElement();
 
                 debug("Detected superclass: " + superclassTypeElement, clazz);
@@ -324,7 +325,7 @@ public class ConfigAnnotationScanner {
 
     private ResolvedType resolveType(TypeMirror typeMirror) {
         if (typeMirror.getKind().isPrimitive()) {
-            return ResolvedType.ofPrimitive(typeMirror);
+            return ResolvedType.ofPrimitive(typeMirror, utils.element().getQualifiedName(typeMirror));
         }
         if (typeMirror.getKind() == TypeKind.ARRAY) {
             ResolvedType resolvedType = resolveType(((ArrayType) typeMirror).getComponentType());
@@ -369,7 +370,7 @@ public class ConfigAnnotationScanner {
             isConfigGroup = utils.element().isAnnotationPresent(typeElement, Types.ANNOTATION_CONFIG_GROUP);
         } else if (typeElement.getKind() == ElementKind.CLASS) {
             isClass = true;
-            isDuration = typeMirror.toString().equals(Duration.class.getName());
+            isDuration = utils.element().getQualifiedName(typeMirror).equals(Duration.class.getName());
             isConfigGroup = utils.element().isAnnotationPresent(typeElement, Types.ANNOTATION_CONFIG_GROUP);
         }
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigMappingListener.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigMappingListener.java
@@ -43,7 +43,7 @@ public class ConfigMappingListener extends AbstractConfigListener {
         AnnotationMirror configDocFileNameAnnotation = null;
 
         for (AnnotationMirror annotationMirror : configRoot.getAnnotationMirrors()) {
-            String annotationName = annotationMirror.getAnnotationType().toString();
+            String annotationName = utils.element().getQualifiedName(annotationMirror.getAnnotationType());
 
             if (annotationName.equals(Types.ANNOTATION_CONFIG_ROOT)) {
                 configRootAnnotation = annotationMirror;

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/LegacyConfigRootListener.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/LegacyConfigRootListener.java
@@ -44,7 +44,7 @@ public class LegacyConfigRootListener extends AbstractConfigListener {
         AnnotationMirror configDocFileNameAnnotation = null;
 
         for (AnnotationMirror annotationMirror : configRoot.getAnnotationMirrors()) {
-            String annotationName = annotationMirror.getAnnotationType().toString();
+            String annotationName = utils.element().getQualifiedName(annotationMirror.getAnnotationType());
 
             if (annotationName.equals(Types.ANNOTATION_CONFIG_ROOT)) {
                 configRootAnnotation = annotationMirror;

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/JavadocUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/JavadocUtil.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public final class JavadocUtil {
 
     static final String VERTX_JAVA_DOC_SITE = "https://vertx.io/docs/apidocs/";
-    static final String OFFICIAL_JAVA_DOC_BASE_LINK = "https://docs.oracle.com/en/java/javase/17/docs/api/";
+    static final String OFFICIAL_JAVA_DOC_BASE_LINK = "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/";
     static final String AGROAL_API_JAVA_DOC_SITE = "https://javadoc.io/doc/io.agroal/agroal-api/latest/";
     static final String LOG_LEVEL_REDIRECT_URL = "https://javadoc.io/doc/org.jboss.logmanager/jboss-logmanager/latest/org/jboss/logmanager/Level.html";
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/util/ElementUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/util/ElementUtil.java
@@ -29,6 +29,34 @@ public class ElementUtil {
         this.processingEnv = processingEnv;
     }
 
+    public String getQualifiedName(TypeMirror type) {
+        switch (type.getKind()) {
+            case BOOLEAN:
+                return "boolean";
+            case BYTE:
+                return "byte";
+            case CHAR:
+                return "char";
+            case DOUBLE:
+                return "double";
+            case FLOAT:
+                return "float";
+            case INT:
+                return "int";
+            case LONG:
+                return "long";
+            case SHORT:
+                return "short";
+            case DECLARED:
+                return ((TypeElement) ((DeclaredType) type).asElement()).getQualifiedName().toString();
+            default:
+                // note that it includes annotations, which is something we don't want
+                // thus why all this additional work above...
+                // this default should never be triggered AFAIK, it's there to be extra safe
+                return type.toString();
+        }
+    }
+
     public String getBinaryName(TypeElement clazz) {
         return processingEnv.getElementUtils().getBinaryName(clazz).toString();
     }


### PR DESCRIPTION
While this was already correctly handled for declared types, primitive types don't have an API to get the name without the annotations being present (toString() contains the annotations and there is no other way to get a string representation of the type...).

Fixing it by making sure we get to the type name.

This avoids having things like:
`@io.smallrye.config.WithConverter(io.quarkus.runtime.init.InitRuntimeConfig.BooleanConverter.class) boolean` in the doc.
Or Bean Validation constraints when they are used.