### PR TITLE
Fail if more than one OIDC JWT credential key property is configured

### DIFF
--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientTooManyJwtCredentialKeyPropsTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientTooManyJwtCredentialKeyPropsTestCase.java
@@ -1,0 +1,49 @@
+package io.quarkus.oidc.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OidcClientTooManyJwtCredentialKeyPropsTestCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(
+                            "quarkus.oidc-client.token-path=http://localhost:8180/oidc/tokens\n"
+                                    + "quarkus.oidc-client.client-id=quarkus\n"
+                                    + "quarkus.oidc-client.credentials.jwt.secret=secret\n"
+                                    + "quarkus.oidc-client.credentials.jwt.key=base64encPrivateKey\n"
+                                    + "quarkus.oidc-client.grant.type=jwt"),
+                            "application.properties"))
+            .assertException(t -> {
+                Throwable e = t;
+                ConfigurationException te = null;
+                while (e != null) {
+                    if (e instanceof ConfigurationException) {
+                        te = (ConfigurationException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                assertNotNull(te);
+                assertEquals(
+                        "Only a single OIDC JWT credential key property can be configured, but you have configured:"
+                                + " quarkus.oidc-client.credentials.jwt.key,quarkus.oidc-client.credentials.jwt.secret",
+                        te.getMessage(),
+                        "Too many JWT credential key properties are configured");
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -67,7 +67,7 @@ public class OidcClientImpl implements OidcClient {
         this.filters = filters;
         this.clientSecretBasicAuthScheme = OidcCommonUtils.initClientSecretBasicAuth(oidcClientConfig);
         this.jwtBearerAuthentication = oidcClientConfig.credentials.jwt.source == Source.BEARER;
-        this.clientJwtKey = jwtBearerAuthentication ? null : OidcCommonUtils.initClientJwtKey(oidcClientConfig);
+        this.clientJwtKey = jwtBearerAuthentication ? null : OidcCommonUtils.initClientJwtKey(oidcClientConfig, false);
     }
 
     @Override

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
@@ -205,6 +205,7 @@ public class OidcClientCommonConfig extends OidcCommonConfig {
 
             /**
              * If provided, indicates that JWT is signed using a secret key.
+             * It is mutually exclusive with {@link #key}, {@link #keyFile} and {@link #keyStore} properties.
              */
             @ConfigItem
             public Optional<String> secret = Optional.empty();
@@ -218,6 +219,7 @@ public class OidcClientCommonConfig extends OidcCommonConfig {
             /**
              * String representation of a private key. If provided, indicates that JWT is signed using a private key in PEM or
              * JWK format.
+             * It is mutually exclusive with {@link #secret}, {@link #keyFile} and {@link #keyStore} properties.
              * You can use the {@link #signatureAlgorithm} property to override the default key algorithm, `RS256`.
              */
             @ConfigItem
@@ -225,6 +227,7 @@ public class OidcClientCommonConfig extends OidcCommonConfig {
 
             /**
              * If provided, indicates that JWT is signed using a private key in PEM or JWK format.
+             * It is mutually exclusive with {@link #secret}, {@link #key} and {@link #keyStore} properties.
              * You can use the {@link #signatureAlgorithm} property to override the default key algorithm, `RS256`.
              */
             @ConfigItem
@@ -232,6 +235,7 @@ public class OidcClientCommonConfig extends OidcCommonConfig {
 
             /**
              * If provided, indicates that JWT is signed using a private key from a keystore.
+             * It is mutually exclusive with {@link #secret}, {@link #key} and {@link #keyFile} properties.
              */
             @ConfigItem
             public Optional<String> keyStoreFile = Optional.empty();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -62,7 +62,7 @@ public class OidcProviderClient implements Closeable {
         this.metadata = metadata;
         this.oidcConfig = oidcConfig;
         this.clientSecretBasicAuthScheme = OidcCommonUtils.initClientSecretBasicAuth(oidcConfig);
-        this.clientJwtKey = OidcCommonUtils.initClientJwtKey(oidcConfig);
+        this.clientJwtKey = OidcCommonUtils.initClientJwtKey(oidcConfig, true);
         this.introspectionBasicAuthScheme = initIntrospectionBasicAuthScheme(oidcConfig);
         this.filters = filters;
         this.clientSecretQueryAuthentication = oidcConfig.credentials.clientSecret.method.orElse(null) == Method.QUERY;


### PR DESCRIPTION
Fixes #42920.

This PR throws a `ConfigurationException` if more than one OIDC Credential JWT key property is configured as the consequences can be very confusing as shown in #42920.

OIDC Credential JWT group is used to configure various properties related to preparing a JWT authentication token which in turn is used to acquire an access token. The type of the key material can affect the way the JWT token is signed and can in turn impact how the OIDC provider handles it, which is why it is important to make sure only a single key property is used.

Other groups must also be reviewed, but I'll start with the JWT group.

Keeping in draft until I add a test