### PR TITLE
Fix image properties applied on gradle task configuration

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 
 import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 public abstract class ImageBuild extends ImageTask {
@@ -20,8 +21,14 @@ public abstract class ImageBuild extends ImageTask {
     @Inject
     public ImageBuild() {
         super("Perform an image build");
+    }
+
+    @TaskAction
+    @Override
+    public void checkRequiredExtensions() {
         MapProperty<String, String> forcedProperties = extension().forcedPropertiesProperty();
         forcedProperties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
         forcedProperties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, getProject().provider(() -> builder().name()));
+        super.checkRequiredExtensions();
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
@@ -15,13 +15,13 @@ public abstract class ImagePush extends ImageTask {
     @Inject
     public ImagePush() {
         super("Perform an image push");
-        MapProperty<String, String> forcedProperties = extension().forcedPropertiesProperty();
-        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
-        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_PUSH, "true");
     }
 
     @TaskAction
     public void checkRequiredExtensions() {
+        MapProperty<String, String> forcedProperties = extension().forcedPropertiesProperty();
+        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
+        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_PUSH, "true");
         List<String> containerImageExtensions = getProject().getConfigurations().stream()
                 .flatMap(c -> c.getDependencies().stream())
                 .map(d -> d.getName())


### PR DESCRIPTION
Set the tasks's forcedProperties on task execution rather than task configuration.

- Fixes: #42256