### PR TITLE
Add decorate to all contents types and added text base error response

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -327,5 +327,6 @@ public class HttpConfiguration {
     public enum PayloadHint {
         JSON,
         HTML,
+        TEXT
     }
 }


### PR DESCRIPTION
Fix #42870

I also aligned this with the 404 page (see https://github.com/quarkusio/quarkus/pull/41989) by adding a text based response for curl.

![curl_error](https://github.com/user-attachments/assets/3e2c50a6-45f1-4f6c-af29-0a756ab231eb)
