### PR TITLE
Fix Keycloak Dev service to allocate default client id and secret

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -853,16 +853,14 @@ public class KeycloakDevServicesProcessor {
     }
 
     private static String getOidcClientId() {
-        boolean isService = "service".equals(getOidcApplicationType());
         // if the application type is web-app or hybrid, OidcRecorder will enforce that the client id and secret are configured
         return ConfigProvider.getConfig().getOptionalValue(CLIENT_ID_CONFIG_KEY, String.class)
-                .orElse(!isService ? "quarkus-app" : "");
+                .orElse(capturedDevServicesConfiguration.createClient ? "quarkus-app" : "");
     }
 
     private static String getOidcClientSecret() {
-        boolean isService = "service".equals(getOidcApplicationType());
         // if the application type is web-app or hybrid, OidcRecorder will enforce that the client id and secret are configured
         return ConfigProvider.getConfig().getOptionalValue(CLIENT_SECRET_CONFIG_KEY, String.class)
-                .orElse(!isService ? "secret" : "");
+                .orElse(capturedDevServicesConfiguration.createClient ? "secret" : "");
     }
 }


### PR DESCRIPTION
This PR fixes a bug I introduced with the OIDC dynamic client registration PR where for some reasons I decided not to return a default client id and secret for `service` applications when devservice is used, I was adding tests involving an OIDC web-app where I did not want the client created because it was dynamically registered, but I honestly don't remember why I coded it that way. It was not caught earlier because it does look like all the tests depending on the KC devservice already have a client id configured for service applications... 

The logic is that the client id and secret should not be registered as OIDC properties if no client is expected to be created but the allocation is wrong, it should be an empty value only if no client creation is allowed.
 
Spotted at #42935.

It is a `main` branch issue only, so no regressions for the released versions.

@michalvavrik Please pick up this update once it is merged, thanks