### PR TITLE
Support OIDC signed UserInfo with charset content type parameters

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -415,7 +415,7 @@ public class OidcProvider implements Closeable {
 
                     @Override
                     public Uni<UserInfo> apply(UserInfoResponse response) {
-                        if (APPLICATION_JWT_CONTENT_TYPE.equals(response.contentType())) {
+                        if (isApplicationJwtContentType(response.contentType())) {
                             if (oidcConfig.jwks.resolveEarly) {
                                 try {
                                     LOG.debugf("Verifying the signed UserInfo with the local JWK keys: %s", response.data());
@@ -444,6 +444,21 @@ public class OidcProvider implements Closeable {
                         }
                     }
                 });
+    }
+
+    static boolean isApplicationJwtContentType(String ct) {
+        if (ct == null) {
+            return false;
+        }
+        ct = ct.trim();
+        if (!ct.startsWith(APPLICATION_JWT_CONTENT_TYPE)) {
+            return false;
+        }
+        if (ct.length() == APPLICATION_JWT_CONTENT_TYPE.length()) {
+            return true;
+        }
+        String remainder = ct.substring(APPLICATION_JWT_CONTENT_TYPE.length()).trim();
+        return remainder.indexOf(';') == 0;
     }
 
     public Uni<AuthorizationCodeTokens> getCodeFlowTokens(String code, String redirectUri, String codeVerifier) {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -309,5 +310,16 @@ public class OidcProviderTest {
                 assertTrue(ex.getMessage().contains("Claim2 is not allowed!"));
             }
         }
+    }
+
+    @Test
+    public void testJwtContentTypeCheck() {
+        assertTrue(OidcProvider.isApplicationJwtContentType("application/jwt"));
+        assertTrue(OidcProvider.isApplicationJwtContentType(" application/jwt "));
+        assertTrue(OidcProvider.isApplicationJwtContentType("application/jwt;charset=UTF-8"));
+        assertTrue(OidcProvider.isApplicationJwtContentType(" application/jwt ; charset=UTF-8"));
+        assertFalse(OidcProvider.isApplicationJwtContentType(" application/jwt-custom"));
+        assertFalse(OidcProvider.isApplicationJwtContentType(" application/json"));
+        assertFalse(OidcProvider.isApplicationJwtContentType(null));
     }
 }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -617,7 +617,7 @@ public class CodeFlowAuthorizationTest {
                 get(urlEqualTo("/auth/realms/quarkus/protocol/openid-connect/signeduserinfo"))
                         .withHeader("Authorization", containing("Bearer ey"))
                         .willReturn(aResponse()
-                                .withHeader("Content-Type", "application/jwt")
+                                .withHeader("Content-Type", " application/jwt ; charset=UTF-8")
                                 .withBody(
                                         Jwt.preferredUserName("alice")
                                                 .issuer("https://server.example.com")


### PR DESCRIPTION
Fixes #42958.

https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse mentions `application/jwt` when signed UserInfo is returned but in practice the content type may have extra parameters, `charset` is only one of them.

So this PR takes care of such cases by checking if it is a standalone `application/jwt`  or is it `application/jwt`  but with some extra parameters with `;` being a separator. I'd like to avoid regular expressions as it will increase the cost while it does not really matter what those content type parameters are, not that I'm aware of at this moment of time anyway, signed JWT tokens are Base64URL encoded characters, so it is just a standard Base64 alphabet minus a few characters like `=` etc