### PR TITLE
Registering Liquibase BigIntType and Additional Classes for Reflection

### DIFF
--- a/integration-tests/liquibase/src/main/resources/db/xml/changeLog.xml
+++ b/integration-tests/liquibase/src/main/resources/db/xml/changeLog.xml
@@ -5,9 +5,8 @@
                         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <include relativeToChangelogFile="true" file="create-tables.xml" />
-
     <include relativeToChangelogFile="true" file="test/test.xml" />
-
+    <include relativeToChangelogFile="true" file="test/test-data-types.xml" />
     <include relativeToChangelogFile="true" file="create-views.xml" />
 
     <includeAll relativeToChangelogFile="true" path="includeAll" />

--- a/integration-tests/liquibase/src/main/resources/db/xml/test/test-data-types.xml
+++ b/integration-tests/liquibase/src/main/resources/db/xml/test/test-data-types.xml
@@ -1,0 +1,21 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                                       https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="dev (generated)" id="create-data-types-tables-1">
+        <createTable tableName="TYPE_TEST">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="decimal_col" type="decimal" autoIncrement="true"/>
+            <column name="int_col" type="int" autoIncrement="true"/>
+            <column name="med_int_col" type="mediumint" autoIncrement="true"/>
+            <column name="number_col" type="number" autoIncrement="true"/>
+            <column name="small_int_col" type="smallint" autoIncrement="true"/>
+            <column name="tiny_int_col" type="tinyint" autoIncrement="true"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityTest.java
+++ b/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseFunctionalityTest.java
@@ -30,7 +30,7 @@ public class LiquibaseFunctionalityTest {
                 .get("/liquibase/update")
                 .then()
                 .body(is(
-                        "create-tables-1,test-1,create-view-inline,create-view-file-abs,create-view-file-rel,"
+                        "create-tables-1,test-1,create-data-types-tables-1,create-view-inline,create-view-file-abs,create-view-file-rel,"
                                 + ("includeAll-1,includeAll-2,")
                                 + "json-create-tables-1,json-test-1,"
                                 + "sql-create-tables-1,sql-test-1,"


### PR DESCRIPTION
Fixes #42928

- Registering additional types for native image reflection
- Double registrations removed
- Integration tests for data types using `autoIncrement`