### PR TITLE
Display JUnit Tags in Dev UI (Continuous Testing)

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -46,6 +46,7 @@ import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.reporting.ReportEntry;
@@ -258,8 +259,9 @@ public class JunitTestRunner {
                                 if (testClass != null) {
                                     Map<UniqueId, TestResult> results = resultsByClass.computeIfAbsent(testClass.getName(),
                                             s -> new HashMap<>());
-                                    TestResult result = new TestResult(displayName, testClass.getName(), id,
-                                            TestExecutionResult.aborted(null),
+                                    TestResult result = new TestResult(displayName, testClass.getName(),
+                                            toTagList(testIdentifier),
+                                            id, TestExecutionResult.aborted(null),
                                             logHandler.captureOutput(), testIdentifier.isTest(), runId, 0, true);
                                     results.put(id, result);
                                     if (result.isTest()) {
@@ -312,8 +314,9 @@ public class JunitTestRunner {
                                 }
                                 Map<UniqueId, TestResult> results = resultsByClass.computeIfAbsent(testClassName,
                                         s -> new HashMap<>());
-                                TestResult result = new TestResult(displayName, testClassName, id,
-                                        testExecutionResult,
+                                TestResult result = new TestResult(displayName, testClassName,
+                                        toTagList(testIdentifier),
+                                        id, testExecutionResult,
                                         logHandler.captureOutput(), testIdentifier.isTest(), runId,
                                         System.currentTimeMillis() - startTimes.get(testIdentifier), true);
                                 if (!results.containsKey(id)) {
@@ -332,6 +335,7 @@ public class JunitTestRunner {
                                         results.put(id,
                                                 new TestResult(currentNonDynamicTest.get().getDisplayName(),
                                                         result.getTestClass(),
+                                                        toTagList(testIdentifier),
                                                         currentNonDynamicTest.get().getUniqueIdObject(),
                                                         TestExecutionResult.failed(failure), List.of(), false, runId, 0,
                                                         false));
@@ -349,6 +353,7 @@ public class JunitTestRunner {
                                     for (TestIdentifier child : children) {
                                         UniqueId childId = UniqueId.parse(child.getUniqueId());
                                         result = new TestResult(child.getDisplayName(), testClassName,
+                                                toTagList(testIdentifier),
                                                 childId,
                                                 testExecutionResult,
                                                 logHandler.captureOutput(), child.isTest(), runId,
@@ -417,6 +422,15 @@ public class JunitTestRunner {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static List<String> toTagList(TestIdentifier testIdentifier) {
+        return testIdentifier
+                .getTags()
+                .stream()
+                .map(TestTag::getName)
+                .sorted()
+                .toList();
     }
 
     private Class<?> getTestClassFromSource(Optional<TestSource> optionalTestSource) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestResult.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestResult.java
@@ -11,6 +11,7 @@ public class TestResult {
 
     final String displayName;
     final String testClass;
+    final List<String> tags;
     final UniqueId uniqueId;
     final TestExecutionResult testExecutionResult;
     final List<String> logOutput;
@@ -20,10 +21,12 @@ public class TestResult {
     final List<Throwable> problems;
     final boolean reportable;
 
-    public TestResult(String displayName, String testClass, UniqueId uniqueId, TestExecutionResult testExecutionResult,
+    public TestResult(String displayName, String testClass, List<String> tags, UniqueId uniqueId,
+            TestExecutionResult testExecutionResult,
             List<String> logOutput, boolean test, long runId, long time, boolean reportable) {
         this.displayName = displayName;
         this.testClass = testClass;
+        this.tags = tags;
         this.uniqueId = uniqueId;
         this.testExecutionResult = testExecutionResult;
         this.logOutput = logOutput;
@@ -56,6 +59,10 @@ public class TestResult {
 
     public String getTestClass() {
         return testClass;
+    }
+
+    public List<String> getTags() {
+        return tags;
     }
 
     public UniqueId getUniqueId() {


### PR DESCRIPTION
I strongly use JUnits `@Tag` annotation to organize my tests, and I think this could be helpful to display them in the Dev UI. So I added this feature and a non-persistent checkbox to hide the tags, if needed.

See these screenshots:
![Display Tags Feature (Dark Mode)](https://github.com/user-attachments/assets/586c0403-86fe-4d19-ada9-7b25e26a100c)
![Display Tags Feature (Light Mode)](https://github.com/user-attachments/assets/02da0d94-134e-4841-94bb-7c909776f12b)

(`Q` is the shortcut for the `io.quarkus.test.junit.QuarkusTest` tag, so the user can see which test is a Quarkus test, and which one isn't.)

**Hint:**
The Vaadin Grid seems to recycle components, so the `<qui-badge>` too. However, this component is not implemented recyclable, which leads to inconsistent rendering. I have created a `<qui-recyclable-badge>`, that we can remove when the original badge is fixed. (see PR: https://github.com/qomponent/qui-badge/pull/4)

What do you think - is this a helpful feature?