### PR TITLE
GRPC pom: Adding operating system specific profiles

### DIFF
--- a/extensions/grpc/codegen/pom.xml
+++ b/extensions/grpc/codegen/pom.xml
@@ -13,6 +13,7 @@
     <name>Quarkus - gRPC - Code Gen</name>
 
     <dependencies>
+        <!-- Shared Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
@@ -26,115 +27,6 @@
             <artifactId>protobuf-java-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protoc</artifactId>
-            <classifier>linux-aarch_64</classifier>
-            <type>exe</type>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protoc</artifactId>
-            <classifier>linux-ppcle_64</classifier>
-            <type>exe</type>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protoc</artifactId>
-            <classifier>linux-s390_64</classifier>
-            <type>exe</type>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protoc</artifactId>
-            <classifier>linux-x86_32</classifier>
-            <type>exe</type>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protoc</artifactId>
-            <classifier>linux-x86_64</classifier>
-            <type>exe</type>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protoc</artifactId>
-            <classifier>osx-x86_64</classifier>
-            <type>exe</type>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protoc</artifactId>
-            <classifier>osx-aarch_64</classifier>
-            <type>exe</type>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protoc</artifactId>
-            <classifier>windows-x86_32</classifier>
-            <type>exe</type>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protoc</artifactId>
-            <classifier>windows-x86_64</classifier>
-            <type>exe</type>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>protoc-gen-grpc-java</artifactId>
-            <type>exe</type>
-            <classifier>linux-aarch_64</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>protoc-gen-grpc-java</artifactId>
-            <type>exe</type>
-            <classifier>linux-ppcle_64</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>protoc-gen-grpc-java</artifactId>
-            <type>exe</type>
-            <classifier>linux-s390_64</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>protoc-gen-grpc-java</artifactId>
-            <type>exe</type>
-            <classifier>linux-x86_32</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>protoc-gen-grpc-java</artifactId>
-            <type>exe</type>
-            <classifier>linux-x86_64</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>protoc-gen-grpc-java</artifactId>
-            <type>exe</type>
-            <classifier>osx-x86_64</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>protoc-gen-grpc-java</artifactId>
-            <type>exe</type>
-            <classifier>osx-aarch_64</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>protoc-gen-grpc-java</artifactId>
-            <type>exe</type>
-            <classifier>windows-x86_32</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>protoc-gen-grpc-java</artifactId>
-            <type>exe</type>
-            <classifier>windows-x86_64</classifier>
-        </dependency>
-
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-protoc-plugin</artifactId>
             <classifier>shaded</classifier>
@@ -145,11 +37,236 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
         </dependency>
     </dependencies>
+    <profiles>
+        <!-- Linux ARM 64-bit -->
+        <profile>
+            <id>linux-aarch64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protoc</artifactId>
+                    <classifier>linux-aarch_64</classifier>
+                    <type>exe</type>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <classifier>linux-aarch_64</classifier>
+                    <type>exe</type>
+                </dependency>
+            </dependencies>
+        </profile>
 
+        <!-- Linux PPC 64-bit -->
+        <profile>
+            <id>linux-ppcle64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>ppc64le</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protoc</artifactId>
+                    <classifier>linux-ppcle_64</classifier>
+                    <type>exe</type>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <classifier>linux-ppcle_64</classifier>
+                    <type>exe</type>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Linux s390 64-bit -->
+        <profile>
+            <id>linux-s390x</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>s390x</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protoc</artifactId>
+                    <classifier>linux-s390_64</classifier>
+                    <type>exe</type>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <classifier>linux-s390_64</classifier>
+                    <type>exe</type>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Linux x86 32-bit -->
+        <profile>
+            <id>linux-x86_32</id>
+            <activation>
+                <os>
+                    <name>Linux</name>
+                    <family>unix</family>
+                    <arch>x86</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protoc</artifactId>
+                    <classifier>linux-x86_32</classifier>
+                    <type>exe</type>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <classifier>linux-x86_32</classifier>
+                    <type>exe</type>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Linux x86 64-bit -->
+        <profile>
+            <id>linux-x86_64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protoc</artifactId>
+                    <classifier>linux-x86_64</classifier>
+                    <type>exe</type>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <classifier>linux-x86_64</classifier>
+                    <type>exe</type>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- macOS x86 64-bit -->
+        <profile>
+            <id>osx-x86_64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protoc</artifactId>
+                    <classifier>osx-x86_64</classifier>
+                    <type>exe</type>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <classifier>osx-x86_64</classifier>
+                    <type>exe</type>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- macOS ARM 64-bit -->
+        <profile>
+            <id>osx-aarch64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protoc</artifactId>
+                    <classifier>osx-aarch_64</classifier>
+                    <type>exe</type>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <classifier>osx-aarch_64</classifier>
+                    <type>exe</type>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Windows x86 32-bit -->
+        <profile>
+            <id>windows-x86_32</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                    <arch>x86</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protoc</artifactId>
+                    <classifier>windows-x86_32</classifier>
+                    <type>exe</type>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <classifier>windows-x86_32</classifier>
+                    <type>exe</type>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Windows x86 64-bit -->
+        <profile>
+            <id>windows-x86_64</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protoc</artifactId>
+                    <classifier>windows-x86_64</classifier>
+                    <type>exe</type>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <classifier>windows-x86_64</classifier>
+                    <type>exe</type>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Fix #42931

In which this PR adds operating system specific profiles to pull only the dependencies needed for the machine being built.
This should help cut down on the pulling of extra files we don't need.

I've run the `./mvnw -Dquickly` from the root and all tests passed.
I verified on MacOS that ONLY the mac .exe gets pulled during the test by deleting the `~/.m2/repository/io/grpc/protoc-gen-gprc-java` folder prior to running the tests.

I've run the `/.mvnw -Dquickly` on my Fedora 39 Linux machine and all tests passed.
I verified on `Fedora Linux` that ONLY the `linux-x86_64.exe` gets pulled during the test by deleting the `~/.m2/repository/io/grpc/protoc-gen-gprc-java` folder prior to running the tests.

I also tried to cut down the file even further by just using the `os.detected.classifier` in the two protoc dependencies rather than spelling out each arch/os but I got an error from maven saying the `version` was missing.

I see the `os.detected.classifier` printed out at the beginning of the tests but it appears it's not available for the grpc tests?

Anyway, this change should work better by eliminating pulling down files for other operatings systems that aren't needed.

I could NOT verify the `s390` or `ppc` archictectures since I don't have those around.. I just had Linux, Mac and windows.
