### PR TITLE
OIDC: Encapsulate static/dynamic tenants maps in `TenantConfigBean`

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -119,17 +119,18 @@ public class DefaultTenantConfigResolver {
                             final String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
 
                             if (tenantId != null && !isTenantSetByAnnotation(context, tenantId)) {
-                                TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                                // WARN: The order (check dynamic before static) is important!
+                                var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                                 if (tenantContext != null) {
                                     // Dynamic map may contain the static contexts initialized on demand,
-                                    if (tenantConfigBean.getStaticTenantsConfig().containsKey(tenantId)) {
+                                    if (tenantConfigBean.getStaticTenant(tenantId) != null) {
                                         context.put(CURRENT_STATIC_TENANT_ID, tenantId);
                                     }
                                     return tenantContext.getOidcTenantConfig();
                                 }
                             }
 
-                            TenantConfigContext tenant = getStaticTenantContext(context);
+                            var tenant = getStaticTenantContext(context);
                             if (tenant != null) {
                                 tenantConfig = tenant.oidcConfig;
                             }
@@ -156,12 +157,11 @@ public class DefaultTenantConfigResolver {
         if (tenantContext != null && !tenantContext.ready) {
 
             // check if the connection has already been created
-            TenantConfigContext readyTenantContext = tenantConfigBean.getDynamicTenantsConfig()
-                    .get(tenantContext.oidcConfig.tenantId.get());
+            var readyTenantContext = tenantConfigBean.getDynamicTenant(tenantContext.oidcConfig.tenantId.get());
             if (readyTenantContext == null) {
                 LOG.debugf("Tenant '%s' is not initialized yet, trying to create OIDC connection now",
                         tenantContext.oidcConfig.tenantId.get());
-                return tenantConfigBean.getTenantConfigContextFactory().apply(tenantContext.oidcConfig);
+                return tenantConfigBean.createTenantContext(tenantContext.oidcConfig, false);
             } else {
                 tenantContext = readyTenantContext;
             }
@@ -206,7 +206,7 @@ public class DefaultTenantConfigResolver {
     }
 
     private TenantConfigContext getStaticTenantContext(String tenantId) {
-        TenantConfigContext configContext = tenantId != null ? tenantConfigBean.getStaticTenantsConfig().get(tenantId) : null;
+        TenantConfigContext configContext = tenantId != null ? tenantConfigBean.getStaticTenant(tenantId) : null;
         if (configContext == null) {
             if (tenantId != null && !tenantId.isEmpty()) {
                 LOG.debugf(
@@ -255,7 +255,12 @@ public class DefaultTenantConfigResolver {
                     //shouldn't happen, but guard against it anyway
                     oidcConfig = Uni.createFrom().nullItem();
                 } else {
-                    oidcConfig = oidcConfig.onItem().transform(cfg -> OidcUtils.resolveProviderConfig(cfg));
+                    oidcConfig = oidcConfig.onItem().transform(new Function<OidcTenantConfig, OidcTenantConfig>() {
+                        @Override
+                        public OidcTenantConfig apply(OidcTenantConfig cfg) {
+                            return OidcUtils.resolveProviderConfig(cfg);
+                        }
+                    });
                 }
                 context.put(CURRENT_DYNAMIC_TENANT_CONFIG, oidcConfig);
             }
@@ -270,18 +275,18 @@ public class DefaultTenantConfigResolver {
             @Override
             public Uni<? extends TenantConfigContext> apply(OidcTenantConfig tenantConfig) {
                 if (tenantConfig != null) {
-                    String tenantId = tenantConfig.getTenantId()
+                    var tenantId = tenantConfig.getTenantId()
                             .orElseThrow(() -> new OIDCException("Tenant configuration must have tenant id"));
-                    TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                    var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                     if (tenantContext == null) {
-                        return tenantConfigBean.getTenantConfigContextFactory().apply(tenantConfig);
+                        return tenantConfigBean.createTenantContext(tenantConfig, true);
                     } else {
                         return Uni.createFrom().item(tenantContext);
                     }
                 } else {
-                    final String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
+                    String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
                     if (tenantId != null && !isTenantSetByAnnotation(context, tenantId)) {
-                        TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                        var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                         if (tenantContext != null) {
                             return Uni.createFrom().item(tenantContext);
                         }
@@ -324,21 +329,22 @@ public class DefaultTenantConfigResolver {
         }
 
         // 2. path-matching tenant resolver
-        var pathMatchingTenantResolver = PathMatchingTenantResolver.of(tenantConfigBean.getStaticTenantsConfig(), rootPath,
+        var staticTenants = tenantConfigBean.getStaticTenantsConfig();
+        var pathMatchingTenantResolver = PathMatchingTenantResolver.of(staticTenants, rootPath,
                 tenantConfigBean.getDefaultTenant());
         if (pathMatchingTenantResolver != null) {
             staticTenantResolvers.add(pathMatchingTenantResolver);
         }
 
         // 3. default static tenant resolver
-        if (!tenantConfigBean.getStaticTenantsConfig().isEmpty()) {
+        if (!staticTenants.isEmpty()) {
             staticTenantResolvers.add(defaultStaticTenantResolver);
         }
 
         // 4. issuer-based tenant resolver
         if (resolveTenantsWithIssuer) {
             IssuerBasedTenantResolver.addIssuerBasedTenantResolver(staticTenantResolvers,
-                    tenantConfigBean.getStaticTenantsConfig(), tenantConfigBean.getDefaultTenant());
+                    staticTenants, tenantConfigBean.getDefaultTenant());
         }
 
         return staticTenantResolvers.toArray(new TenantResolver[0]);
@@ -351,7 +357,7 @@ public class DefaultTenantConfigResolver {
             String[] pathSegments = context.request().path().split("/");
             if (pathSegments.length > 0) {
                 String lastPathSegment = pathSegments[pathSegments.length - 1];
-                if (tenantConfigBean.getStaticTenantsConfig().containsKey(lastPathSegment)) {
+                if (tenantConfigBean.getStaticTenant(lastPathSegment) != null) {
                     LOG.debugf(
                             "Tenant id '%s' is selected on the '%s' request path", lastPathSegment, context.normalizedPath());
                     return lastPathSegment;
@@ -390,14 +396,13 @@ public class DefaultTenantConfigResolver {
             return null;
         }
 
-        private static ImmutablePathMatcher.ImmutablePathMatcherBuilder<String> addPath(String tenant, OidcTenantConfig config,
+        private static void addPath(String tenant, OidcTenantConfig config,
                 ImmutablePathMatcher.ImmutablePathMatcherBuilder<String> builder) {
             if (config != null && config.tenantPaths.isPresent()) {
                 for (String path : config.tenantPaths.get()) {
                     builder.addPath(path, tenant);
                 }
             }
-            return builder;
         }
     }
 
@@ -406,14 +411,11 @@ public class DefaultTenantConfigResolver {
             return tenantConfigBean.getDefaultTenant().getOidcTenantConfig();
         }
 
-        if (tenantConfigBean.getStaticTenantsConfig().containsKey(sessionTenantId)) {
-            return tenantConfigBean.getStaticTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
+        var tenant = tenantConfigBean.getStaticTenant(sessionTenantId);
+        if (tenant == null) {
+            tenant = tenantConfigBean.getDynamicTenant(sessionTenantId);
         }
-
-        if (tenantConfigBean.getDynamicTenantsConfig().containsKey(sessionTenantId)) {
-            return tenantConfigBean.getDynamicTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
-        }
-        return null;
+        return tenant != null ? tenant.getOidcTenantConfig() : null;
     }
 
     public String getRootPath() {
@@ -449,7 +451,7 @@ public class DefaultTenantConfigResolver {
                         if (tenantContext.getOidcMetadata().getIssuer().equals(iss)) {
                             OidcUtils.storeExtractedBearerToken(context, token);
 
-                            final String tenantId = tenantContext.oidcConfig.tenantId.get();
+                            final String tenantId = tenantContext.oidcConfig.tenantId.orElseThrow();
                             LOG.debugf("Resolved the '%s' OIDC tenant based on the matching issuer '%s'", tenantId, iss);
                             return tenantId;
                         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -1,12 +1,16 @@
 package io.quarkus.oidc.runtime;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import jakarta.enterprise.context.spi.CreationalContext;
 
 import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 
 public class TenantConfigBean {
@@ -14,33 +18,58 @@ public class TenantConfigBean {
     private final Map<String, TenantConfigContext> staticTenantsConfig;
     private final Map<String, TenantConfigContext> dynamicTenantsConfig;
     private final TenantConfigContext defaultTenant;
-    private final Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory;
+    private final TenantContextFactory tenantContextFactory;
+
+    @FunctionalInterface
+    public interface TenantContextFactory {
+        Uni<TenantConfigContext> create(OidcTenantConfig oidcTenantConfig, boolean dynamicTenant, String tenantId);
+    }
 
     public TenantConfigBean(
             Map<String, TenantConfigContext> staticTenantsConfig,
-            Map<String, TenantConfigContext> dynamicTenantsConfig,
             TenantConfigContext defaultTenant,
-            Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory) {
-        this.staticTenantsConfig = staticTenantsConfig;
-        this.dynamicTenantsConfig = dynamicTenantsConfig;
+            TenantContextFactory tenantContextFactory) {
+        this.staticTenantsConfig = new ConcurrentHashMap<>(staticTenantsConfig);
+        this.dynamicTenantsConfig = new ConcurrentHashMap<>();
         this.defaultTenant = defaultTenant;
-        this.tenantConfigContextFactory = tenantConfigContextFactory;
+        this.tenantContextFactory = tenantContextFactory;
+    }
+
+    public Uni<TenantConfigContext> createTenantContext(OidcTenantConfig oidcConfig, boolean dynamicTenant) {
+        if (oidcConfig.logout.backchannel.path.isPresent()) {
+            throw new ConfigurationException(
+                    "BackChannel Logout is currently not supported for dynamic tenants");
+        }
+        var tenantId = oidcConfig.getTenantId().orElseThrow();
+        if (!dynamicTenantsConfig.containsKey(tenantId)) {
+            Uni<TenantConfigContext> uniContext = tenantContextFactory.create(oidcConfig, dynamicTenant, tenantId);
+            return uniContext.onItem().transform(
+                    new Function<TenantConfigContext, TenantConfigContext>() {
+                        @Override
+                        public TenantConfigContext apply(TenantConfigContext t) {
+                            dynamicTenantsConfig.putIfAbsent(tenantId, t);
+                            return t;
+                        }
+                    });
+        } else {
+            return Uni.createFrom().item(dynamicTenantsConfig.get(tenantId));
+        }
+    }
+
+    public TenantConfigContext getStaticTenant(String tenantId) {
+        return staticTenantsConfig.get(tenantId);
     }
 
     public Map<String, TenantConfigContext> getStaticTenantsConfig() {
-        return staticTenantsConfig;
+        return unmodifiableMap(staticTenantsConfig);
+    }
+
+    public TenantConfigContext getDynamicTenant(String tenantId) {
+        return dynamicTenantsConfig.get(tenantId);
     }
 
     public TenantConfigContext getDefaultTenant() {
         return defaultTenant;
-    }
-
-    public Function<OidcTenantConfig, Uni<TenantConfigContext>> getTenantConfigContextFactory() {
-        return tenantConfigContextFactory;
-    }
-
-    public Map<String, TenantConfigContext> getDynamicTenantsConfig() {
-        return dynamicTenantsConfig;
     }
 
     public static class Destroyer implements BeanDestroyer<TenantConfigBean> {

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -62,7 +62,7 @@ public class ProtectedResource {
     }
 
     private String getClientName() {
-        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenantsConfig().get(session.getTenantId())
+        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenant(session.getTenantId())
                 .getOidcTenantConfig();
         return oidcConfig.getClientName().get();
     }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
@@ -39,7 +39,7 @@ public class TenantRefresh {
             // Cookie format: jwt|<tenant id>
 
             String[] pair = sessionExpired.split("\\|");
-            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenantsConfig().get(pair[1]).getOidcTenantConfig();
+            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenant(pair[1]).getOidcTenantConfig();
             JsonWebToken jwt = new DefaultJWTParser().decrypt(pair[0], oidcConfig.credentials.secret.get());
 
             OidcUtils.removeCookie(context, oidcConfig, "session_expired");


### PR DESCRIPTION
Lets `TenantConfigBean` be the sole "owner" of the static/dynamic tenants maps, adds/changes accessor methods for tenants. Also introduces a functional interface to create tenants.

No functional change, only moving code around.

Also some minor code cleanups (reducing the amount of warnings in IntelliJ).
