### PR TITLE
mention gradle dsl kts not supported in quarkus update

### DIFF
--- a/docs/src/main/asciidoc/update-quarkus.adoc
+++ b/docs/src/main/asciidoc/update-quarkus.adoc
@@ -20,6 +20,7 @@ Post-update, if expected updates are missing, consider the following reasons:
 
 - The recipe might not include a specific item in your project.
 - Your project might use an extension that is incompatible with the latest {project-name} version.
+- If you have Gradle Kotlin build files (`.kts`), Quarkus Update https://github.com/quarkusio/quarkus/issues/33046[will fail] until OpenRewrite supports these.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
just to inform users so they are aware of the gradle kts limitation.

related to https://github.com/quarkusio/quarkus/issues/33046