### PR TITLE
Extend reflection configuration for VertX

### DIFF
--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -54,7 +54,9 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo.ClassOutput;
@@ -273,5 +275,21 @@ class VertxProcessor {
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException("Unable to load type: " + name, e);
         }
+    }
+
+    @BuildStep
+    void registerNativeImageResources(BuildProducer<NativeImageResourceBuildItem> resources) {
+        // Accessed by io.vertx.core.impl.VertxBuilder.<init>
+        resources.produce(new NativeImageResourceBuildItem("META-INF/services/io.vertx.core.spi.VertxServiceProvider"));
+        // Accessed by io.vertx.core.impl.VertxImpl.<init>
+        resources.produce(new NativeImageResourceBuildItem("META-INF/services/io.vertx.core.spi.VerticleFactory"));
+    }
+
+    @BuildStep
+    void registerReflectivelyAccessedMethods(BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods) {
+        // Accessed by io.vertx.core.impl.VertxImpl.<init>
+        reflectiveMethods.produce(new ReflectiveMethodBuildItem("java.lang.Thread$Builder$OfVirtual", "name",
+                String.class, long.class));
+        reflectiveMethods.produce(new ReflectiveMethodBuildItem("java.lang.Thread$Builder", "factory", new Class[0]));
     }
 }


### PR DESCRIPTION
Doesn't seem to fix any functionality issues but prevents
`MissingRegistrationErrors` from being thrown when
`ThrowMissingRegistrationErrors` is enabled.

Related to quarkusio#41995

Trimmed down version of https://github.com/quarkusio/quarkus/pull/42229 as discussed in https://github.com/quarkusio/quarkus/pull/42229#issuecomment-2324628833