### PR TITLE
Handle trailing slashes for endpoints with regex path params

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -135,7 +135,6 @@ public class RequestMapper<T> {
                 if (matchPos == 1) { //matchPos == 1 corresponds to '/' as a root level match
                     doPrefixMatch = prefixAllowed || pathLength == 1; //if prefix is allowed, or we've matched the whole thing
                 } else if (path.charAt(matchPos) == '/') {
-                    // match /world/ with matchPos = 6 and mathPos == pathLengh - 1
                     doPrefixMatch = prefixAllowed || matchPos == pathLength - 1; //if prefix is allowed, or the remainder is only a trailing /
                 }
             }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -76,24 +76,20 @@ public class RequestMapper<T> {
             for (int i = 1; i < potentialMatch.template.components.length; ++i) {
                 URITemplate.TemplateComponent segment = potentialMatch.template.components[i];
                 if (segment.type == URITemplate.Type.CUSTOM_REGEX) {
-                    if (initialMatch.getRemaining().isEmpty() || initialMatch.getRemaining().equals("/")) {
-                        matched = true;
-                    } else {
-                        boolean endSlash = path.charAt(path.length() - 1) == '/';
-                        // exclude any path end slash when matching, but include it in the matched length
-                        Matcher matcher = segment.pattern.matcher(
-                                endSlash ? path.substring(0, path.length() - 1) : path);
-                        matched = matcher.find(matchPos);
-                        if (!matched || matcher.start() != matchPos) {
-                            break;
-                        }
-                        matchPos = matcher.end();
-                        if (endSlash) {
-                            matchPos++;
-                        }
-                        for (String group : segment.groups) {
-                            params[paramCount++] = matcher.group(group);
-                        }
+                    // exclude any path end slash when matching a subdir, but include it in the matched length
+                    boolean endSlash = matchPos < path.length() && path.charAt(path.length() - 1) == '/';
+                    Matcher matcher = segment.pattern.matcher(
+                            endSlash ? path.substring(0, path.length() - 1) : path);
+                    matched = matcher.find(matchPos);
+                    if (!matched || matcher.start() != matchPos) {
+                        break;
+                    }
+                    matchPos = matcher.end();
+                    if (endSlash) {
+                        matchPos++;
+                    }
+                    for (String group : segment.groups) {
+                        params[paramCount++] = matcher.group(group);
                     }
                 } else if (segment.type == URITemplate.Type.LITERAL) {
                     //make sure the literal text is the same

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexPathTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexPathTest.java
@@ -1,0 +1,89 @@
+package org.jboss.resteasy.reactive.server.vertx.test.matching;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class RegexPathTest {
+
+    @RegisterExtension
+    static ResteasyReactiveUnitTest test = new ResteasyReactiveUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(EndingSlashTest.TestResource.class);
+                }
+            });
+
+    @Test
+    public void test() {
+
+        get("/hello/world/1")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello World! 1"));
+
+        get("/hello/world/1/")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello World! 1"));
+
+        get("/hello/again/1")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello Again! 1"));
+
+        get("/hello/again/1/")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello Again! 1"));
+
+        get("/hello/again/2/surprise")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello Surprise! 2"));
+
+        get("/hello/again/2/surprise/")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello Surprise! 2"));
+    }
+
+    @Path("/hello")
+    public static class TestResource {
+
+        @GET
+        @Path("/world/{sample}")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello(int sample) {
+            return "Hello World! " + sample;
+        }
+
+        @GET
+        @Path("/again/{sample:\\d+}")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String helloWithRegex(int sample) {
+            return "Hello Again! " + sample;
+        }
+
+        @GET
+        @Path("/again/{sample:\\d+}/surprise")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String helloWithRegexSecond(int sample) {
+            return "Hello Surprise! " + sample;
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexPathTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexPathTest.java
@@ -41,6 +41,24 @@ public class RegexPathTest {
                 .statusCode(200)
                 .body(equalTo("Hello World! 1"));
 
+        get("/hello/")
+                .then()
+                .statusCode(404);
+
+        get("/hello/1")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello! 1"));
+
+        get("/hello/1/")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello! 1"));
+
+        get("/hello/again/")
+                .then()
+                .statusCode(404);
+
         get("/hello/again/1")
                 .then()
                 .statusCode(200)
@@ -54,12 +72,12 @@ public class RegexPathTest {
         get("/hello/again/2/surprise")
                 .then()
                 .statusCode(200)
-                .body(equalTo("Hello Surprise! 2"));
+                .body(equalTo("Hello Again Surprise! 2"));
 
         get("/hello/again/2/surprise/")
                 .then()
                 .statusCode(200)
-                .body(equalTo("Hello Surprise! 2"));
+                .body(equalTo("Hello Again Surprise! 2"));
     }
 
     @Path("/hello")
@@ -68,22 +86,29 @@ public class RegexPathTest {
         @GET
         @Path("/world/{sample}")
         @Produces(MediaType.TEXT_PLAIN)
-        public String hello(int sample) {
+        public String helloWorld(int sample) {
             return "Hello World! " + sample;
+        }
+
+        @GET
+        @Path("/{sample:\\d+}")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello(int sample) {
+            return "Hello! " + sample;
         }
 
         @GET
         @Path("/again/{sample:\\d+}")
         @Produces(MediaType.TEXT_PLAIN)
-        public String helloWithRegex(int sample) {
+        public String helloAgain(int sample) {
             return "Hello Again! " + sample;
         }
 
         @GET
         @Path("/again/{sample:\\d+}/surprise")
         @Produces(MediaType.TEXT_PLAIN)
-        public String helloWithRegexSecond(int sample) {
-            return "Hello Surprise! " + sample;
+        public String helloAgainSurprise(int sample) {
+            return "Hello Again Surprise! " + sample;
         }
     }
 }


### PR DESCRIPTION
For Reactive REST endpoints don't include the path end slash when performing regex path param matches.

- Fixes: #42687