### PR TITLE
Mitigate concurrent classes definition in RunnerClassLoader

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
@@ -36,4 +36,25 @@ public interface ClassLoadingResource {
     default void resetInternalCaches() {
         //no-op
     }
+
+    /**
+     * Notifies this ClassLoadingResource that the definition of a class is about to begin.
+     *
+     * @param className The name of the class to be defined.
+     * @return true if the ClassLoader should actually attempt the definition of this class, false if the definition of the same
+     *         class has been already requested by a different thread and then the current thread should wait for that
+     *         definition to be completed and load the class without redefining it.
+     */
+    default boolean definingClass(String className) {
+        return true;
+    }
+
+    /**
+     * Notifies this ClassLoadingResource that the definition of a class is terminated.
+     *
+     * @param className The name of the class to be defined.
+     */
+    default void classDefined(String className) {
+        //no-op
+    }
 }


### PR DESCRIPTION
The intent of this pull request is to mitigate the concurrent loading (or define to be more precise) of the same classes by multiple threads as reported [here](https://github.com/quarkusio/quarkus/issues/42874) by @gsmet.

Note that I wrote "mitigate" instead of "solve", because I believe that given the concurrent nature of our classloader I believe that it's impossible to structurally solve the problem or at least that a solution consistently preventing ANY concurrent class definition will have a cost in terms of performances and/or memory occupation that will largely overcome its advantages.

As suggested by @franz1981 the main problem that we have at the moment is in the fact that multiple threads could try to define the same class. This behaviour is expected and inherent with the classloader's concurrent mechanisms. When this happens the classloader raises a `LinkageError` that is [properly managed](https://github.com/quarkusio/quarkus/blob/3c731e20d2c07e2d80f21f32492676f8d9e82d6b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java#L154) by discarding the attempted duplicated class definition and returning the class defined by the thread that _won the race_. This means however that we're basically using an exception for the normal control flow, which is a known performance antipattern, and something that should be avoided as much as possible. 

To diagnose this problem I simply printed a log statement like

`System.out.println("Duplicated class definition: " + name);`

in the catch block of that `LinkageError`.  Giving a single run of the `fullMicroProfile` benchmark of the `quarkus-startstop` application with this set up I saw that in average that duplicated class definition is performed around 50 times per run:
```
Duplicated class definition: io.vertx.core.net.impl.TCPServerBase
Duplicated class definition: io.vertx.core.net.impl.TCPServerBase
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.net.impl.TCPServerBase
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.net.impl.TCPServerBase
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.net.impl.TCPServerBase
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.net.impl.TCPServerBase
Duplicated class definition: io.vertx.core.net.impl.TCPServerBase
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.net.impl.TCPServerBase
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.netty.channel.AbstractChannel$AbstractUnsafe$6
Duplicated class definition: io.netty.buffer.PoolArena$1
```
As anticipated this pull request allows, with a negligible cost, to largely mitigate this problem, so that, with this fix in place, the typical run of the same application now only has from 2 
```
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
```
to maximum 5
```
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.vertx.core.http.impl.HttpServerImpl$HttpStreamHandler
Duplicated class definition: io.quarkus.vertx.http.runtime.VertxHttpRecorder$WebDeploymentVerticle$3
Duplicated class definition: io.netty.channel.AbstractChannel$AbstractUnsafe$6
```
of those concurrent class definition.

The implementation of this improvement uses a single value cache to store the class currently to be defined from a given jar and blocks the other threads attempting to deifne that same class, making them to wait until the first thread that initiated the class definition process has completed it. Note that for virtual threads this blocking heuristic cannot be used and it is necessary to keep the completely non-blocking behaviour that we had before. 

/cc @dmlloyd @Sanne @geoand @gsmet @franz1981 