### PR TITLE
Reduce Agroal pool logging

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import javax.sql.XADataSource;
@@ -55,6 +56,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.LogCategoryBuildItem;
 import io.quarkus.deployment.builditem.RemovedResourceBuildItem;
 import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -420,5 +422,10 @@ class AgroalProcessor {
         reflectiveClassProducer.produce(ReflectiveClassBuildItem.builder(
                 "com.sun.rowset.providers.RIOptimisticProvider",
                 "com.sun.rowset.providers.RIXMLProvider").build());
+    }
+
+    @BuildStep
+    void reduceLogging(BuildProducer<LogCategoryBuildItem> logCategories) {
+        logCategories.produce(new LogCategoryBuildItem("io.agroal.pool", Level.WARNING));
     }
 }


### PR DESCRIPTION
In Quarkus LangChain4j, we ended up with log entries like:

> 2024-09-04 15:59:04,507 INFO  [io.agr.pool] (executor-thread-1) Datasource '<default>': Pool interceptors: [io.quarkiverse.langchain4j.pgvector.PgVectorAgroalPoolInterceptor_X57UyAR6Zcr9HEqaFpEAQVtGhO8_Synthetic_ClientProxy@762e5bc7 (priority 0)]

It's not something the user should be bothered with.

Note that Luis will give us more flexibility in a future Agroal version so that we can specifically filter out this message but I'm not sure we will be able to backport the update so this will do until we do better.