### PR TITLE
Don't capture stacktraces for REST Client by default

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -287,7 +287,7 @@ public interface RestClientsConfig {
      * If {@code true}, the stacktrace of the invocation of the REST Client method is captured.
      * This stacktrace will be used if the invocation throws an exception
      */
-    @WithDefault("true")
+    @WithDefault("false")
     boolean captureStacktrace();
 
     /**


### PR DESCRIPTION
The reason the default is now set to false is that capturing the stacktrace is a [very CPU intensive](https://github.com/quarkusio/quarkus/issues/42508#issuecomment-2286079647) operation. Although this leads to a slightly worse user experience, it's not too bad because the error does contain
the REST Client class and method that caused the error