### PR TITLE
Revert "Adding os-arch specific profiles to try to reduce the number of dependencies that are pulled on each platform"

### DIFF
--- a/extensions/grpc/codegen/pom.xml
+++ b/extensions/grpc/codegen/pom.xml
@@ -13,7 +13,6 @@
     <name>Quarkus - gRPC - Code Gen</name>
 
     <dependencies>
-        <!-- Shared Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
@@ -27,6 +26,115 @@
             <artifactId>protobuf-java-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>linux-aarch_64</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>linux-ppcle_64</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>linux-s390_64</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>linux-x86_32</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>linux-x86_64</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>osx-x86_64</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>osx-aarch_64</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>windows-x86_32</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>windows-x86_64</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>linux-aarch_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>linux-ppcle_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>linux-s390_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>linux-x86_32</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>osx-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>osx-aarch_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>windows-x86_32</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>windows-x86_64</classifier>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-protoc-plugin</artifactId>
             <classifier>shaded</classifier>
@@ -37,236 +145,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Linux ARM 64-bit -->
-        <profile>
-            <id>linux-aarch64</id>
-            <activation>
-                <os>
-                    <family>unix</family>
-                    <arch>aarch64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protoc</artifactId>
-                    <classifier>linux-aarch_64</classifier>
-                    <type>exe</type>
-                </dependency>
-                <dependency>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>protoc-gen-grpc-java</artifactId>
-                    <classifier>linux-aarch_64</classifier>
-                    <type>exe</type>
-                </dependency>
-            </dependencies>
-        </profile>
 
-        <!-- Linux PPC 64-bit -->
-        <profile>
-            <id>linux-ppcle64</id>
-            <activation>
-                <os>
-                    <family>unix</family>
-                    <arch>ppc64le</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protoc</artifactId>
-                    <classifier>linux-ppcle_64</classifier>
-                    <type>exe</type>
-                </dependency>
-                <dependency>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>protoc-gen-grpc-java</artifactId>
-                    <classifier>linux-ppcle_64</classifier>
-                    <type>exe</type>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!-- Linux s390 64-bit -->
-        <profile>
-            <id>linux-s390x</id>
-            <activation>
-                <os>
-                    <family>unix</family>
-                    <arch>s390x</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protoc</artifactId>
-                    <classifier>linux-s390_64</classifier>
-                    <type>exe</type>
-                </dependency>
-                <dependency>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>protoc-gen-grpc-java</artifactId>
-                    <classifier>linux-s390_64</classifier>
-                    <type>exe</type>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!-- Linux x86 32-bit -->
-        <profile>
-            <id>linux-x86_32</id>
-            <activation>
-                <os>
-                    <name>Linux</name>
-                    <family>unix</family>
-                    <arch>x86</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protoc</artifactId>
-                    <classifier>linux-x86_32</classifier>
-                    <type>exe</type>
-                </dependency>
-                <dependency>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>protoc-gen-grpc-java</artifactId>
-                    <classifier>linux-x86_32</classifier>
-                    <type>exe</type>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!-- Linux x86 64-bit -->
-        <profile>
-            <id>linux-x86_64</id>
-            <activation>
-                <os>
-                    <family>unix</family>
-                    <arch>amd64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protoc</artifactId>
-                    <classifier>linux-x86_64</classifier>
-                    <type>exe</type>
-                </dependency>
-                <dependency>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>protoc-gen-grpc-java</artifactId>
-                    <classifier>linux-x86_64</classifier>
-                    <type>exe</type>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!-- macOS x86 64-bit -->
-        <profile>
-            <id>osx-x86_64</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protoc</artifactId>
-                    <classifier>osx-x86_64</classifier>
-                    <type>exe</type>
-                </dependency>
-                <dependency>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>protoc-gen-grpc-java</artifactId>
-                    <classifier>osx-x86_64</classifier>
-                    <type>exe</type>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!-- macOS ARM 64-bit -->
-        <profile>
-            <id>osx-aarch64</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                    <arch>aarch64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protoc</artifactId>
-                    <classifier>osx-aarch_64</classifier>
-                    <type>exe</type>
-                </dependency>
-                <dependency>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>protoc-gen-grpc-java</artifactId>
-                    <classifier>osx-aarch_64</classifier>
-                    <type>exe</type>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!-- Windows x86 32-bit -->
-        <profile>
-            <id>windows-x86_32</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                    <arch>x86</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protoc</artifactId>
-                    <classifier>windows-x86_32</classifier>
-                    <type>exe</type>
-                </dependency>
-                <dependency>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>protoc-gen-grpc-java</artifactId>
-                    <classifier>windows-x86_32</classifier>
-                    <type>exe</type>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!-- Windows x86 64-bit -->
-        <profile>
-            <id>windows-x86_64</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                    <arch>amd64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protoc</artifactId>
-                    <classifier>windows-x86_64</classifier>
-                    <type>exe</type>
-                </dependency>
-                <dependency>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>protoc-gen-grpc-java</artifactId>
-                    <classifier>windows-x86_64</classifier>
-                    <type>exe</type>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
This reverts commit 66e1b75691176d5f884ab47074e2696d9e17aef6.

Unfortunately, Gradle doesn't support profiles based on OS/family.

Failure is:
```
2024-09-04T22:15:34.1085928Z Caused by: io.quarkus.bootstrap.prebuild.CodeGenException: Failed to find com.google.protobuf:protoc:linux-x86_64:exe among dependencies
2024-09-04T22:15:34.1087773Z 	at io.quarkus.grpc.deployment.GrpcCodeGen.makeExecutableFromPath(GrpcCodeGen.java:447)
2024-09-04T22:15:34.1089227Z 	at io.quarkus.grpc.deployment.GrpcCodeGen.initExecutables(GrpcCodeGen.java:419)
2024-09-04T22:15:34.1090532Z 	at io.quarkus.grpc.deployment.GrpcCodeGen.trigger(GrpcCodeGen.java:144)
2024-09-04T22:15:34.1091798Z 	at io.quarkus.deployment.CodeGenerator.lambda$trigger$4(CodeGenerator.java:206)
2024-09-04T22:15:34.1093167Z 	at io.quarkus.deployment.CodeGenerator.callWithClassloader(CodeGenerator.java:181)
2024-09-04T22:15:34.1094438Z 	at io.quarkus.deployment.CodeGenerator.trigger(CodeGenerator.java:203)
2024-09-04T22:15:34.1095769Z 	at io.quarkus.deployment.CodeGenerator.initAndRun(CodeGenerator.java:80)
```

For the following tests:

```
2024-09-04T22:20:20.5018240Z [ERROR] Failures: 
2024-09-04T22:20:20.5019176Z [ERROR] io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartBuildIT.testGradle(String)[1]
2024-09-04T22:20:20.5021051Z [ERROR]   Run 1: QuarkusCodestartBuildIT.testGradle:86->generateProjectRunTests:116->generateProjectRunTests:137 
2024-09-04T22:20:20.5022167Z expected: 0
2024-09-04T22:20:20.5022546Z  but was: 1
2024-09-04T22:20:20.5023675Z [ERROR]   Run 2: QuarkusCodestartBuildIT.testGradle:86->generateProjectRunTests:116->generateProjectRunTests:137 
2024-09-04T22:20:20.5024703Z expected: 0
2024-09-04T22:20:20.5024928Z  but was: 1
2024-09-04T22:20:20.5025602Z [ERROR]   Run 3: QuarkusCodestartBuildIT.testGradle:86->generateProjectRunTests:116->generateProjectRunTests:137 
2024-09-04T22:20:20.5026237Z expected: 0
2024-09-04T22:20:20.5026446Z  but was: 1
2024-09-04T22:20:20.5027083Z [ERROR]   Run 4: QuarkusCodestartBuildIT.testGradle:86->generateProjectRunTests:116->generateProjectRunTests:137 
2024-09-04T22:20:20.5027839Z expected: 0
2024-09-04T22:20:20.5028045Z  but was: 1
2024-09-04T22:20:20.5028249Z [INFO] 
2024-09-04T22:20:20.5028813Z [ERROR] io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartBuildIT.testGradleKotlinDSL(String)[1]
2024-09-04T22:20:20.5029944Z [ERROR]   Run 1: QuarkusCodestartBuildIT.testGradleKotlinDSL:93->generateProjectRunTests:116->generateProjectRunTests:137 
2024-09-04T22:20:20.5030716Z expected: 0
2024-09-04T22:20:20.5030928Z  but was: 1
2024-09-04T22:20:20.5031595Z [ERROR]   Run 2: QuarkusCodestartBuildIT.testGradleKotlinDSL:93->generateProjectRunTests:116->generateProjectRunTests:137 
2024-09-04T22:20:20.5032268Z expected: 0
2024-09-04T22:20:20.5032476Z  but was: 1
2024-09-04T22:20:20.5033137Z [ERROR]   Run 3: QuarkusCodestartBuildIT.testGradleKotlinDSL:93->generateProjectRunTests:116->generateProjectRunTests:137 
2024-09-04T22:20:20.5033834Z expected: 0
2024-09-04T22:20:20.5034041Z  but was: 1
2024-09-04T22:20:20.5034708Z [ERROR]   Run 4: QuarkusCodestartBuildIT.testGradleKotlinDSL:93->generateProjectRunTests:116->generateProjectRunTests:137 
2024-09-04T22:20:20.5035362Z expected: 0
2024-09-04T22:20:20.5035567Z  but was: 1
```

It went unnoticed because AFAICS our devtools test don't declare all the necessary dependencies... we also need to fix that.