### PR TITLE
Update Vertx to version 4.5.10

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -35,7 +35,7 @@
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <opentelemetry-alpha.version>2.5.0-alpha</opentelemetry-alpha.version>
         <opentelemetry-semconv.version>1.26.0-alpha</opentelemetry-semconv.version>
-        <quarkus-http.version>5.3.1</quarkus-http.version>
+        <quarkus-http.version>5.3.2</quarkus-http.version>
         <micrometer.version>1.13.3</micrometer.version><!-- keep in sync with hdrhistogram -->
         <hdrhistogram.version>2.2.2</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>
@@ -62,7 +62,7 @@
         <smallrye-context-propagation.version>2.1.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.14.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.15.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.24.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.6.1</smallrye-stork.version>
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
@@ -114,7 +114,7 @@
         <wildfly-elytron.version>2.5.2.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.1.Final</jboss-marshalling.version>
         <jboss-threads.version>3.6.1.Final</jboss-threads.version>
-        <vertx.version>4.5.9</vertx.version>
+        <vertx.version>4.5.10</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>


### PR DESCRIPTION
- Update Mutiny bindings to 3.15.0
- Update Quarkus HTTP to version 5.3.2


* Fix https://github.com/quarkusio/quarkus/issues/42724
* Fix https://nvd.nist.gov/vuln/detail/CVE-2024-8391
* Also related to https://github.com/quarkusio/quarkus/discussions/42636