### PR TITLE
Show exception cause during logging filter initialization

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -269,7 +269,7 @@ public class LoggingSetupRecorder {
                 try {
                     nameToFilter.put(name, logFilterFactory.create(className));
                 } catch (Exception e) {
-                    throw new RuntimeException("Unable to create instance of Logging Filter '" + className + "'");
+                    throw new RuntimeException("Unable to create instance of Logging Filter '" + className + "'", e);
                 }
             }
         });


### PR DESCRIPTION
- Closes #43051

The exception cause is properly propagated:
```
ERROR: Failed to start server in (development) mode
Error details:
java.lang.RuntimeException: Unable to create instance of Logging Filter 'org.keycloak.quarkus.runtime.configuration.filters.SyslogLogLevelFilter'
        at io.quarkus.runtime.logging.LoggingSetupRecorder$4.accept(LoggingSetupRecorder.java:272)
        at io.quarkus.runtime.logging.LoggingSetupRecorder$4.accept(LoggingSetupRecorder.java:266)
        at java.base/java.util.HashMap.forEach(HashMap.java:1429)
        at io.quarkus.runtime.logging.LoggingSetupRecorder.createNamedFilters(LoggingSetupRecorder.java:266)
        at io.quarkus.runtime.logging.LoggingSetupRecorder.initializeLogging(LoggingSetupRecorder.java:141)
        at io.quarkus.deployment.steps.LoggingResourceProcessor$setupLoggingRuntimeInit2024815463.deploy_0(Unknown Source)
        at io.quarkus.deployment.steps.LoggingResourceProcessor$setupLoggingRuntimeInit2024815463.deploy(Unknown Source)
        at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
        at io.quarkus.runtime.Application.start(Application.java:101)
        at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:119)
        at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
        at org.keycloak.quarkus.runtime.KeycloakMain.start(KeycloakMain.java:141)
        at org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.run(AbstractStartCommand.java:42)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2030)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.keycloak.quarkus.runtime.cli.Picocli.parseAndRun(Picocli.java:138)
        at org.keycloak.quarkus.runtime.KeycloakMain.main(KeycloakMain.java:101)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:62)
        at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:33)
Caused by: org.keycloak.quarkus.runtime.cli.PropertyException: Invalid log category format: org.keycloak.timer.debug. The format is 'category:level' such as 'org.keycloak:debug'.
        at org.keycloak.quarkus.runtime.configuration.LogLevelContext.validateLogLevel(LogLevelContext.java:102)
        at org.keycloak.quarkus.runtime.configuration.LogLevelContext.parse(LogLevelContext.java:74)
        at org.keycloak.quarkus.runtime.configuration.filters.LogLevelFilter.handleContext(LogLevelFilter.java:39)
        at org.keycloak.quarkus.runtime.configuration.filters.LogLevelFilter.<init>(LogLevelFilter.java:23)
        at org.keycloak.quarkus.runtime.configuration.filters.SyslogLogLevelFilter.<init>(SyslogLogLevelFilter.java:9)
        at org.keycloak.quarkus.runtime.configuration.filters.SyslogLogLevelFilter_Bean.doCreate(Unknown Source)
        at org.keycloak.quarkus.runtime.configuration.filters.SyslogLogLevelFilter_Bean.create(Unknown Source)
        at org.keycloak.quarkus.runtime.configuration.filters.SyslogLogLevelFilter_Bean.create(Unknown Source)
        at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:119)
        at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:38)
        at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:35)
        at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:32)
        at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
        at io.quarkus.arc.impl.ComputingCacheContextInstances.computeIfAbsent(ComputingCacheContextInstances.java:19)
        at io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:35)
        at org.keycloak.quarkus.runtime.configuration.filters.SyslogLogLevelFilter_Bean.get(Unknown Source)
        at org.keycloak.quarkus.runtime.configuration.filters.SyslogLogLevelFilter_Bean.get(Unknown Source)
        at io.quarkus.arc.impl.ArcContainerImpl.beanInstanceHandle(ArcContainerImpl.java:559)
        at io.quarkus.arc.impl.ArcContainerImpl.beanInstanceHandle(ArcContainerImpl.java:539)
        at io.quarkus.arc.impl.ArcContainerImpl.beanInstanceHandle(ArcContainerImpl.java:572)
        at io.quarkus.arc.impl.ArcContainerImpl.instanceHandle(ArcContainerImpl.java:534)
        at io.quarkus.arc.impl.ArcContainerImpl.instance(ArcContainerImpl.java:294)
        at io.quarkus.arc.runtime.logging.ArcLogFilterFactory.create(ArcLogFilterFactory.java:17)
        at io.quarkus.runtime.logging.LoggingSetupRecorder$4.accept(LoggingSetupRecorder.java:270)
        ... 26 more
Exception in thread "Shutdown thread" java.lang.NullPointerException: Cannot invoke "io.quarkus.runtime.Application.isStarted()" because "app" is null
        at io.quarkus.runtime.ApplicationLifecycleManager$ShutdownHookThread.run(ApplicationLifecycleManager.java:455)
```