### PR TITLE
WebSockets next: improve default strategies for unhandled failures

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -424,8 +424,8 @@ The method that declares a most-specific supertype of the actual exception is se
 NOTE: The `@io.quarkus.websockets.next.OnError` annotation can be also used to declare a global error handler, i.e. a method that is not declared on a WebSocket endpoint. Such a method may not accept `@PathParam` paremeters. Error handlers declared on an endpoint take precedence over the global error handlers.
 
 When an error occurs but no error handler can handle the failure, Quarkus uses the strategy specified by `quarkus.websockets-next.server.unhandled-failure-strategy`.
-By default, the connection is closed.
-Alternatively, an error message can be logged or no operation performed.
+For server endpoints, the error message is logged and the connection is closed by default.
+For client endpoints, the error message is logged by default.
 
 [[serialization]]
 === Serialization and deserialization

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledMessageFailureDefaultStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledMessageFailureDefaultStrategyTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.websockets.next.test.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
@@ -11,7 +12,6 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.websockets.next.WebSocketClientConnection;
@@ -37,11 +37,10 @@ public class UnhandledMessageFailureDefaultStrategyTest {
                 .baseUri(testUri)
                 .connectAndAwait();
         connection.sendTextAndAwait("foo");
-        assertTrue(ServerEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
-        assertTrue(ClientMessageErrorEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
-        assertTrue(connection.isClosed());
-        assertEquals(WebSocketCloseStatus.INTERNAL_SERVER_ERROR.code(), connection.closeReason().getCode());
-        assertTrue(ClientMessageErrorEndpoint.MESSAGES.isEmpty());
+        assertFalse(connection.isClosed());
+        connection.sendTextAndAwait("bar");
+        assertTrue(ClientMessageErrorEndpoint.MESSAGE_LATCH.await(5, TimeUnit.SECONDS));
+        assertEquals("bar", ClientMessageErrorEndpoint.MESSAGES.get(0));
     }
 
 }

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledOpenFailureCloseStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledOpenFailureCloseStrategyTest.java
@@ -1,7 +1,6 @@
 package io.quarkus.websockets.next.test.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
@@ -12,21 +11,22 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.websockets.next.WebSocketClientConnection;
 import io.quarkus.websockets.next.WebSocketConnector;
 
-public class UnhandledMessageFailureLogStrategyTest {
+public class UnhandledOpenFailureCloseStrategyTest {
 
     @RegisterExtension
     public static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot(root -> {
-                root.addClasses(ServerEndpoint.class, ClientMessageErrorEndpoint.class);
-            }).overrideConfigKey("quarkus.websockets-next.client.unhandled-failure-strategy", "log");
+                root.addClasses(ServerEndpoint.class, ClientOpenErrorEndpoint.class);
+            }).overrideConfigKey("quarkus.websockets-next.client.unhandled-failure-strategy", "close");
 
     @Inject
-    WebSocketConnector<ClientMessageErrorEndpoint> connector;
+    WebSocketConnector<ClientOpenErrorEndpoint> connector;
 
     @TestHTTPResource("/")
     URI testUri;
@@ -36,11 +36,11 @@ public class UnhandledMessageFailureLogStrategyTest {
         WebSocketClientConnection connection = connector
                 .baseUri(testUri)
                 .connectAndAwait();
-        connection.sendTextAndAwait("foo");
-        assertFalse(connection.isClosed());
-        connection.sendTextAndAwait("bar");
-        assertTrue(ClientMessageErrorEndpoint.MESSAGE_LATCH.await(5, TimeUnit.SECONDS));
-        assertEquals("bar", ClientMessageErrorEndpoint.MESSAGES.get(0));
+        assertTrue(ServerEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(ClientOpenErrorEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
+        assertTrue(connection.isClosed());
+        assertEquals(WebSocketCloseStatus.INVALID_MESSAGE_TYPE.code(), connection.closeReason().getCode());
+        assertTrue(ClientOpenErrorEndpoint.MESSAGES.isEmpty());
     }
 
 }

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledOpenFailureDefaultStrategyTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/UnhandledOpenFailureDefaultStrategyTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.websockets.next.test.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
@@ -11,7 +13,6 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.websockets.next.WebSocketClientConnection;
@@ -36,11 +37,11 @@ public class UnhandledOpenFailureDefaultStrategyTest {
         WebSocketClientConnection connection = connector
                 .baseUri(testUri)
                 .connectAndAwait();
-        assertTrue(ServerEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
-        assertTrue(ClientOpenErrorEndpoint.CLOSED_LATCH.await(5, TimeUnit.SECONDS));
-        assertTrue(connection.isClosed());
-        assertEquals(WebSocketCloseStatus.INTERNAL_SERVER_ERROR.code(), connection.closeReason().getCode());
-        assertTrue(ClientOpenErrorEndpoint.MESSAGES.isEmpty());
+        connection.sendTextAndAwait("foo");
+        assertFalse(connection.isClosed());
+        assertNull(connection.closeReason());
+        assertTrue(ClientOpenErrorEndpoint.MESSAGE_LATCH.await(5, TimeUnit.SECONDS));
+        assertEquals("foo", ClientOpenErrorEndpoint.MESSAGES.get(0));
     }
 
 }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/UnhandledFailureStrategy.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/UnhandledFailureStrategy.java
@@ -5,11 +5,15 @@ package io.quarkus.websockets.next;
  */
 public enum UnhandledFailureStrategy {
     /**
-     * Close the connection.
+     * Log the error message and close the connection.
+     */
+    LOG_AND_CLOSE,
+    /**
+     * Close the connection silently.
      */
     CLOSE,
     /**
-     * Log an error message.
+     * Log the error message.
      */
     LOG,
     /**

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsClientRuntimeConfig.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsClientRuntimeConfig.java
@@ -43,9 +43,12 @@ public interface WebSocketsClientRuntimeConfig {
     /**
      * The strategy used when an error occurs but no error handler can handle the failure.
      * <p>
-     * By default, the connection is closed when an unhandled failure occurs.
+     * By default, the error message is logged when an unhandled failure occurs.
+     * <p>
+     * Note that clients should not close the WebSocket connection arbitrarily. See also RFC-6455
+     * <a href="https://datatracker.ietf.org/doc/html/rfc6455#section-7.3">section 7.3</a>.
      */
-    @WithDefault("close")
+    @WithDefault("log")
     UnhandledFailureStrategy unhandledFailureStrategy();
 
     /**

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsServerRuntimeConfig.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketsServerRuntimeConfig.java
@@ -49,9 +49,9 @@ public interface WebSocketsServerRuntimeConfig {
     /**
      * The strategy used when an error occurs but no error handler can handle the failure.
      * <p>
-     * By default, the connection is closed when an unhandled failure occurs.
+     * By default, the error message is logged and the connection is closed when an unhandled failure occurs.
      */
-    @WithDefault("close")
+    @WithDefault("log-and-close")
     UnhandledFailureStrategy unhandledFailureStrategy();
 
     /**

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/TrafficLogger.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/TrafficLogger.java
@@ -84,9 +84,10 @@ class TrafficLogger {
 
     void connectionClosed(WebSocketConnectionBase connection) {
         if (LOG.isDebugEnabled()) {
-            LOG.debugf("%s connection closed, Connection[%s]",
+            LOG.debugf("%s connection closed, Connection[%s], %s",
                     typeToString(),
-                    connectionToString(connection));
+                    connectionToString(connection),
+                    connection.closeReason());
         }
     }
 


### PR DESCRIPTION
- introduce UnhandledFailureStrategy.LOG_AND_CLOSE
- WebSocketsClientRuntimeConfig#unhandledFailureStrategy - change the default value from "close" to "log"
- WebSocketsServerRuntimeConfig#unhandledFailureStrategy - change the default value from "close" to "log-and-close"
- resolves #42569