### PR TITLE
Avoid publishing the `docs` module in Maven Central in extension template

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
@@ -45,9 +45,6 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
-        {#if has-docs-module}
-        <module>docs</module>
-        {/if}
     </modules>
 {#if quarkus.bom}
 
@@ -120,5 +117,21 @@
             </plugins>
         </pluginManagement>
     </build>
+{/if}
+{#if has-docs-module}
+    <profiles>
+        <profile>
+            <id>docs</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <modules>
+                <module>docs</module>
+            </modules>
+        </profile>
+    </profiles>
 {/if}
 </project>

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
@@ -16,7 +16,6 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
-        <module>docs</module>
     </modules>
 
     <scm>
@@ -70,6 +69,18 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>docs</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <modules>
+                <module>docs</module>
+            </modules>
+        </profile>
         <profile>
             <id>it</id>
             <activation>


### PR DESCRIPTION
Because the `docs` module does not publish any Javadoc artifact (and the resulting JAR doesn't contain any binaries), it doesn't meet the requirements to be deployed in Maven Central.

See https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources for more info