### PR TITLE
Fix Boolean serializer

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -357,6 +357,7 @@ public abstract class JacksonCodeGenerator {
                 case "java.lang.Long" -> "long";
                 case "java.lang.Double" -> "double";
                 case "java.lang.Float" -> "float";
+                case "java.lang.Boolean" -> "boolean";
                 default -> fieldType.name().toString();
             };
         }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/Dog.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/Dog.java
@@ -7,11 +7,22 @@ public class Dog extends AbstractNamedPet {
     @JsonProperty("age")
     private int publicAge;
 
+    @JsonProperty("vaccinated")
+    private Boolean publicVaccinated;
+
     public int getPublicAge() {
         return publicAge;
     }
 
     public void setPublicAge(int publicAge) {
         this.publicAge = publicAge;
+    }
+
+    public Boolean getPublicVaccinated() {
+        return publicVaccinated;
+    }
+
+    public void setPublicVaccinated(Boolean publicVaccinated) {
+        this.publicVaccinated = publicVaccinated;
     }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -171,6 +171,7 @@ public class SimpleJsonResource extends SuperClass<Person> {
         dog.setPrivateName("Jack");
         dog.setPublicName("Leo");
         dog.setVeterinarian(createVeterinarian());
+        dog.setPublicVaccinated(true);
         return dog;
     }
 

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -661,7 +661,7 @@ public class SimpleJsonTest {
     public void testEcho() {
         RestAssured
                 .with()
-                .body("{\"publicName\":\"Leo\",\"veterinarian\":{\"name\":\"Dolittle\"},\"age\":5}")
+                .body("{\"publicName\":\"Leo\",\"veterinarian\":{\"name\":\"Dolittle\"},\"age\":5,\"vaccinated\":true}")
                 .contentType("application/json; charset=utf-8")
                 .post("/simple/dog-echo")
                 .then()
@@ -670,6 +670,7 @@ public class SimpleJsonTest {
                 .body("publicName", Matchers.is("Leo"))
                 .body("privateName", Matchers.nullValue())
                 .body("age", Matchers.is(5))
+                .body("vaccinated", Matchers.is(true))
                 .body("veterinarian.name", Matchers.is("Dolittle"))
                 .body("veterinarian.title", Matchers.nullValue());
     }


### PR DESCRIPTION
We didn't have a mapping for boxed boolean to primitive as the jackson generator method has a primitive parameter, without that change we get a `java.lang.NoSuchMethodError: 'void com.fasterxml.jackson.core.JsonGenerator.writeBoolean(java.lang.Boolean)'`

Handled this scenario and added a test.

Fixes [#43057](https://github.com/quarkusio/quarkus/issues/43057)