### PR TITLE
Avoid an OIDC refresh token call if the JWT refresh token has expired

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -846,4 +846,29 @@ public final class OidcUtils {
         }
         return attribute;
     }
+
+    public static boolean isJwtTokenExpired(String token) {
+        if (!isOpaqueToken(token)) {
+            JsonObject claims = decodeJwtContent(token);
+            Long expiresAt = getJwtExpiresAtClaim(claims);
+            if (expiresAt == null) {
+                return false;
+            }
+            final long nowSecs = System.currentTimeMillis() / 1000;
+            return nowSecs > expiresAt;
+        }
+        return false;
+    }
+
+    private static Long getJwtExpiresAtClaim(JsonObject claims) {
+        if (claims == null || !claims.containsKey(Claims.exp.name())) {
+            return null;
+        }
+        try {
+            return claims.getLong(Claims.exp.name());
+        } catch (IllegalArgumentException ex) {
+            LOG.debug("Refresh JWT expiry claim can not be converted to Long");
+            return null;
+        }
+    }
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Path;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
+import io.quarkus.oidc.RefreshToken;
 import io.quarkus.oidc.UserInfo;
 import io.quarkus.oidc.runtime.DefaultTokenIntrospectionUserInfoCache;
 import io.quarkus.security.Authenticated;
@@ -32,6 +33,9 @@ public class CodeFlowUserInfoResource {
     @Inject
     DefaultTokenIntrospectionUserInfoCache tokenCache;
 
+    @Inject
+    RefreshToken refreshToken;
+
     @GET
     @Path("/code-flow-user-info-only")
     public String access() {
@@ -51,7 +55,8 @@ public class CodeFlowUserInfoResource {
     @GET
     @Path("/code-flow-user-info-github-cached-in-idtoken")
     public String accessGitHubCachedInIdToken() {
-        return access();
+        return access() +
+                (refreshToken.getToken() != null ? ", refresh_token:" + refreshToken.getToken() : "");
     }
 
     @GET


### PR DESCRIPTION
Fixes #41830.

This PR is really about an optimization as opposed to a bug fix. If Quarkus OIDC can figure out that the refresh token has expired, then there is no point to attempt to use it and make another call to refresh the tokens, as it will fail anyway.

So the PR checks if the refresh token is in JWT format as in the case of #41830, and if yes, it checks the expiry `exp` claim, which is a number of seconds from the epoch, and if it is less than the current time, it has expired, and no another refresh call is made.
I've done a minor code refactoring, where the refresh token is checked, just to avoid some duplication, but the only new change which is made here is this refresh token expiry check.

Added a test to confirm it is effective.

This PR will most likely benefit Keycloak users only as it is the only provider I know of which allocates refresh tokens in the JWT format. Most other providers issue binary refresh tokens. In the future, we might be able to support checking the expiry of binary refresh tokens too if their expiry time is returned as a JSON property... 