### PR TITLE
Fix guide URL in web-dependency-locator

### DIFF
--- a/extensions/web-dependency-locator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/web-dependency-locator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,7 +8,7 @@ metadata:
   - "webjar"
   - "mvnpm"
   - "importmap"
-  guide: "https://quarkus.io/guides/http-reference"
+  guide: "https://quarkus.io/guides/web-dependency-locator"
   categories:
   - "web"
   status: "stable"


### PR DESCRIPTION
`web-dependency-locator` currently indicates that its guide is https://quarkus.io/guides/http-reference, but with https://github.com/quarkusio/quarkus/pull/40298 a dedicated guide was created for this extension.

