### PR TITLE
Use a Quarkus-specific clock provider that is reinitialized at runtime

### DIFF
--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -87,6 +87,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuil
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveFieldBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.recording.RecorderContext;
@@ -592,6 +593,12 @@ class HibernateValidatorProcessor {
                                 shutdownContext,
                                 localesBuildTimeConfig,
                                 hibernateValidatorBuildTimeConfig)));
+    }
+
+    @BuildStep
+    public RuntimeReinitializedClassBuildItem reinitClockProviderSystemTimezone() {
+        return new RuntimeReinitializedClassBuildItem(
+                "io.quarkus.hibernate.validator.runtime.clockprovider.HibernateValidatorClockProviderSystemZoneIdHolder");
     }
 
     @BuildStep

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -31,6 +31,7 @@ import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.arc.runtime.BeanContainerListener;
 import io.quarkus.hibernate.validator.ValidatorFactoryCustomizer;
+import io.quarkus.hibernate.validator.runtime.clockprovider.RuntimeReinitializedDefaultClockProvider;
 import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyConfigSupport;
 import io.quarkus.runtime.LocalesBuildTimeConfig;
 import io.quarkus.runtime.ShutdownContext;
@@ -129,6 +130,11 @@ public class HibernateValidatorRecorder {
                 InstanceHandle<ClockProvider> configuredClockProvider = Arc.container().instance(ClockProvider.class);
                 if (configuredClockProvider.isAvailable()) {
                     configuration.clockProvider(configuredClockProvider.get());
+                } else {
+                    // If user didn't provide a custom clock provider we want to set our own.
+                    // This provider ensure the correct behavior in a native mode as it does not
+                    // cache the time zone at a build time.
+                    configuration.clockProvider(RuntimeReinitializedDefaultClockProvider.INSTANCE);
                 }
 
                 // Hibernate Validator-specific configuration

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/clockprovider/HibernateValidatorClockProviderSystemZoneIdHolder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/clockprovider/HibernateValidatorClockProviderSystemZoneIdHolder.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.validator.runtime.clockprovider;
+
+import java.time.ZoneId;
+
+/**
+ * A helper class holding a system timezone.
+ * <p>
+ * It is reloaded at runtime to provide the runtime-system time zone
+ * to the constraints based on a {@link jakarta.validation.ClockProvider}.
+ * <p>
+ * Note, that we do not hold the timezone constant in the clock provider itself as we need to "reinitialize" this class,
+ * so that the timezone is set to the actual runtime-system-timezone.
+ * Having a constant in the clock provider and asking to reload the provider class leads to native build failure:
+ * <p>
+ * <em>
+ * Error: An object of type 'io.quarkus.hibernate.validator.runtime.clockprovider.HibernateValidatorClockProvider' was found in
+ * the image heap. This type, however, is marked for initialization at image run time for the following reason: classes are
+ * initialized at run time by default.
+ * This is not allowed for correctness reasons: All objects that are stored in the image heap must be initialized at build time.
+ * </em>
+ * <p>
+ * And we do have instances of the clock provider/clock in the Hibernate Validator metadata as we eagerly initialize
+ * constraints.
+ */
+class HibernateValidatorClockProviderSystemZoneIdHolder {
+    static final ZoneId SYSTEM_ZONE_ID = ZoneId.systemDefault();
+}

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/clockprovider/RuntimeReinitializedDefaultClockProvider.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/clockprovider/RuntimeReinitializedDefaultClockProvider.java
@@ -1,0 +1,45 @@
+package io.quarkus.hibernate.validator.runtime.clockprovider;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import jakarta.validation.ClockProvider;
+
+/**
+ * A Quarkus-specific clock provider that can provide a clock based on a runtime system time zone.
+ */
+public class RuntimeReinitializedDefaultClockProvider implements ClockProvider {
+
+    public static final RuntimeReinitializedDefaultClockProvider INSTANCE = new RuntimeReinitializedDefaultClockProvider();
+
+    private static final RuntimeReinitializedDefaultClock clock = new RuntimeReinitializedDefaultClock();
+
+    private RuntimeReinitializedDefaultClockProvider() {
+    }
+
+    @Override
+    public Clock getClock() {
+        return clock;
+    }
+
+    private static class RuntimeReinitializedDefaultClock extends Clock {
+
+        @Override
+        public ZoneId getZone() {
+            // we delegate getting the zone id value to a helper class that is reinitialized at runtime
+            // allowing to pick up an actual runtime timezone.
+            return HibernateValidatorClockProviderSystemZoneIdHolder.SYSTEM_ZONE_ID;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return Clock.system(zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.now();
+        }
+    }
+}

--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -217,6 +217,24 @@
                                 <user.language>en</user.language>
                             </systemPropertyVariables>
                         </configuration>
+                        <executions>
+                            <!--
+                                This additional execution runs the tests with non-default timezone to test
+                                how various Clock-based constraints would behave in a native mode.
+                             -->
+                            <execution>
+                                <id>test-nondefault-timezone</id>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <quarkus.test.arg-line>--env TZ=Europe/Helsinki</quarkus.test.arg-line>
+                                    </systemPropertyVariables>
+                                </configuration>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -4,6 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -23,6 +24,7 @@ import jakarta.validation.Validator;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.groups.ConvertGroup;
 import jakarta.ws.rs.Consumes;
@@ -321,6 +323,17 @@ public class HibernateValidatorTestResource
         return result;
     }
 
+    @GET
+    @Path("/rest-end-point-clock-based-constraints")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testClockBasedConstraints() {
+        ResultBuilder result = new ResultBuilder();
+
+        result.append(formatViolations(validator.validate(new Task())));
+
+        return result.build();
+    }
+
     private String formatViolations(Set<? extends ConstraintViolation<?>> violations) {
         if (violations.isEmpty()) {
             return "passed";
@@ -446,5 +459,10 @@ public class HibernateValidatorTestResource
 
         @SuppressWarnings("unused")
         private String property;
+    }
+
+    public static class Task {
+        @PastOrPresent
+        public LocalDateTime created = LocalDateTime.now();
     }
 }

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -532,4 +532,12 @@ public class HibernateValidatorFunctionalityTest {
             response.body(containsString("must not be null"));
         }
     }
+
+    @Test
+    void testClockBasedConstraints() {
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-clock-based-constraints")
+                .then()
+                .body(is("passed"));
+    }
 }


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/32831

So that reloading at runtime, we've discussed in the issue comments,  worked! 

I've also added another execution to the native tests to pass a non-default timezone to get that scenario tested. But if there's a simpler way to achieve that -- please let me know 😃 