### PR TITLE
Refactor Continuous Testing JSON/RPC

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassResult.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassResult.java
@@ -3,7 +3,10 @@ package io.quarkus.deployment.dev.testing;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TestClassResult implements Comparable<TestClassResult> {
+import io.quarkus.dev.testing.results.TestClassResultInterface;
+import io.quarkus.dev.testing.results.TestResultInterface;
+
+public class TestClassResult implements TestClassResultInterface {
     final String className;
     final List<TestResult> passing;
     final List<TestResult> failing;
@@ -11,7 +14,11 @@ public class TestClassResult implements Comparable<TestClassResult> {
     final long latestRunId;
     final long time;
 
-    public TestClassResult(String className, List<TestResult> passing, List<TestResult> failing, List<TestResult> skipped,
+    public TestClassResult(
+            String className,
+            List<TestResult> passing,
+            List<TestResult> failing,
+            List<TestResult> skipped,
             long time) {
         this.className = className;
         this.passing = passing;
@@ -19,15 +26,16 @@ public class TestClassResult implements Comparable<TestClassResult> {
         this.skipped = skipped;
         this.time = time;
         long runId = 0;
-        for (TestResult i : passing) {
-            runId = Math.max(i.runId, runId);
+        for (TestResultInterface i : passing) {
+            runId = Math.max(i.getRunId(), runId);
         }
-        for (TestResult i : failing) {
-            runId = Math.max(i.runId, runId);
+        for (TestResultInterface i : failing) {
+            runId = Math.max(i.getRunId(), runId);
         }
         latestRunId = runId;
     }
 
+    @Override
     public String getClassName() {
         return className;
     }
@@ -53,10 +61,6 @@ public class TestClassResult implements Comparable<TestClassResult> {
     }
 
     @Override
-    public int compareTo(TestClassResult o) {
-        return className.compareTo(o.className);
-    }
-
     public List<TestResult> getResults() {
         List<TestResult> ret = new ArrayList<>();
         ret.addAll(passing);
@@ -64,4 +68,5 @@ public class TestClassResult implements Comparable<TestClassResult> {
         ret.addAll(skipped);
         return ret;
     }
+
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestResult.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestResult.java
@@ -7,7 +7,9 @@ import java.util.List;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 
-public class TestResult {
+import io.quarkus.dev.testing.results.TestResultInterface;
+
+public class TestResult implements TestResultInterface {
 
     final String displayName;
     final String testClass;
@@ -49,18 +51,22 @@ public class TestResult {
         return testExecutionResult;
     }
 
+    @Override
     public List<String> getLogOutput() {
         return logOutput;
     }
 
+    @Override
     public String getDisplayName() {
         return displayName;
     }
 
+    @Override
     public String getTestClass() {
         return testClass;
     }
 
+    @Override
     public List<String> getTags() {
         return tags;
     }
@@ -69,23 +75,42 @@ public class TestResult {
         return uniqueId;
     }
 
+    @Override
     public boolean isTest() {
         return test;
     }
 
+    @Override
+    public String getId() {
+        return uniqueId.toString();
+    }
+
+    @Override
     public long getRunId() {
         return runId;
     }
 
+    @Override
     public long getTime() {
         return time;
     }
 
+    @Override
     public List<Throwable> getProblems() {
         return problems;
     }
 
+    @Override
     public boolean isReportable() {
         return reportable;
+    }
+
+    @Override
+    public State getState() {
+        return switch (testExecutionResult.getStatus()) {
+            case FAILED -> State.FAILED;
+            case ABORTED -> State.SKIPPED;
+            case SUCCESSFUL -> State.PASSED;
+        };
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunResults.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestRunResults.java
@@ -7,8 +7,10 @@ import java.util.List;
 import java.util.Map;
 
 import io.quarkus.deployment.dev.ClassScanResult;
+import io.quarkus.dev.testing.results.TestResultInterface;
+import io.quarkus.dev.testing.results.TestRunResultsInterface;
 
-public class TestRunResults {
+public class TestRunResults implements TestRunResultsInterface {
 
     /**
      * The run id
@@ -28,7 +30,7 @@ public class TestRunResults {
     private final long started;
     private final long completed;
 
-    private final Map<String, TestClassResult> results;
+    private final Map<String, ? extends TestClassResult> results;
     private final Map<String, TestClassResult> currentFailing = new HashMap<>();
     private final Map<String, TestClassResult> historicFailing = new HashMap<>();
     private final Map<String, TestClassResult> currentPassing = new HashMap<>();
@@ -58,9 +60,9 @@ public class TestRunResults {
         long currentFailedCount = 0;
         long currentSkippedCount = 0;
         for (Map.Entry<String, TestClassResult> i : results.entrySet()) {
-            passedCount += i.getValue().getPassing().stream().filter(TestResult::isTest).count();
-            failedCount += i.getValue().getFailing().stream().filter(TestResult::isTest).count();
-            skippedCount += i.getValue().getSkipped().stream().filter(TestResult::isTest).count();
+            passedCount += i.getValue().getPassing().stream().filter(TestResultInterface::isTest).count();
+            failedCount += i.getValue().getFailing().stream().filter(TestResultInterface::isTest).count();
+            skippedCount += i.getValue().getSkipped().stream().filter(TestResultInterface::isTest).count();
             currentPassedCount += i.getValue().getPassing().stream().filter(s -> s.isTest() && s.getRunId() == id).count();
             currentFailedCount += i.getValue().getFailing().stream().filter(s -> s.isTest() && s.getRunId() == id).count();
             currentSkippedCount += i.getValue().getSkipped().stream().filter(s -> s.isTest() && s.getRunId() == id).count();
@@ -98,6 +100,7 @@ public class TestRunResults {
         this.currentSkippedCount = currentSkippedCount;
     }
 
+    @Override
     public long getId() {
         return id;
     }
@@ -110,6 +113,7 @@ public class TestRunResults {
         return full;
     }
 
+    @Override
     public Map<String, TestClassResult> getResults() {
         return Collections.unmodifiableMap(results);
     }
@@ -130,14 +134,17 @@ public class TestRunResults {
         return historicPassing;
     }
 
+    @Override
     public long getStartedTime() {
         return started;
     }
 
+    @Override
     public long getCompletedTime() {
         return completed;
     }
 
+    @Override
     public long getTotalTime() {
         return completed - started;
     }
@@ -154,34 +161,42 @@ public class TestRunResults {
         return skipped;
     }
 
+    @Override
     public long getPassedCount() {
         return passedCount;
     }
 
+    @Override
     public long getFailedCount() {
         return failedCount;
     }
 
+    @Override
     public long getSkippedCount() {
         return skippedCount;
     }
 
+    @Override
     public long getCurrentPassedCount() {
         return currentPassedCount;
     }
 
+    @Override
     public long getCurrentFailedCount() {
         return currentFailedCount;
     }
 
+    @Override
     public long getCurrentSkippedCount() {
         return currentSkippedCount;
     }
 
+    @Override
     public long getTotalCount() {
         return getPassedCount() + getFailedCount() + getSkippedCount();
     }
 
+    @Override
     public long getCurrentTotalCount() {
         return getCurrentPassedCount() + getCurrentFailedCount() + getCurrentSkippedCount();
     }

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/testing/results/TestClassResultInterface.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/testing/results/TestClassResultInterface.java
@@ -1,0 +1,16 @@
+package io.quarkus.dev.testing.results;
+
+import java.util.List;
+
+public interface TestClassResultInterface extends Comparable<TestClassResultInterface> {
+
+    String getClassName();
+
+    List<? extends TestResultInterface> getResults();
+
+    @Override
+    default int compareTo(TestClassResultInterface o) {
+        return getClassName().compareTo(o.getClassName());
+    }
+
+}

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/testing/results/TestResultInterface.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/testing/results/TestResultInterface.java
@@ -1,0 +1,34 @@
+package io.quarkus.dev.testing.results;
+
+import java.util.List;
+
+public interface TestResultInterface {
+    List<String> getLogOutput();
+
+    String getDisplayName();
+
+    String getTestClass();
+
+    List<String> getTags();
+
+    boolean isTest();
+
+    String getId();
+
+    long getRunId();
+
+    long getTime();
+
+    List<Throwable> getProblems();
+
+    boolean isReportable();
+
+    State getState();
+
+    enum State {
+        PASSED,
+        FAILED,
+        SKIPPED
+    }
+
+}

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/testing/results/TestRunResultsInterface.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/testing/results/TestRunResultsInterface.java
@@ -1,0 +1,31 @@
+package io.quarkus.dev.testing.results;
+
+import java.util.Map;
+
+public interface TestRunResultsInterface {
+    long getId();
+
+    Map<String, ? extends TestClassResultInterface> getResults();
+
+    long getStartedTime();
+
+    long getCompletedTime();
+
+    long getTotalTime();
+
+    long getPassedCount();
+
+    long getFailedCount();
+
+    long getSkippedCount();
+
+    long getCurrentPassedCount();
+
+    long getCurrentFailedCount();
+
+    long getCurrentSkippedCount();
+
+    long getTotalCount();
+
+    long getCurrentTotalCount();
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -16,6 +16,7 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.dev.testing.TestRunResults;
 import io.quarkus.deployment.dev.testing.TestSupport;
 import io.quarkus.dev.spi.DevModeType;
+import io.quarkus.dev.testing.results.TestRunResultsInterface;
 import io.quarkus.devui.deployment.InternalPageBuildItem;
 import io.quarkus.devui.runtime.continuoustesting.ContinuousTestingJsonRPCService;
 import io.quarkus.devui.runtime.continuoustesting.ContinuousTestingRecorder;
@@ -237,7 +238,7 @@ public class ContinuousTestingProcessor {
     }
 
     private void registerGetResultsMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
-        actions.addAction("getResults", ignored -> {
+        actions.<TestRunResultsInterface> addAction("getResults", ignored -> {
             try {
                 Optional<TestSupport> ts = TestSupport.instance();
                 if (testsDisabled(launchModeBuildItem, ts)) {

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing.js
@@ -78,7 +78,6 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
 
     static properties = {
         _state: {state: true},
-        _results: {state: true},
         _busy: {state: true},
         _detailsOpenedItem: {state: true, type: Array},
         _displayTags: {state: true, type: Boolean},
@@ -93,6 +92,45 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
         this._displayTags = true;
     }
 
+    set _tests(value) {
+        this._state = value;
+        this._state?.result?.passed?.forEach(item => item.style = "successful");
+        this._state?.result?.failed?.forEach(item => item.style = "failed");
+        this._state?.result?.skipped?.forEach(item => item.style = "aborted");
+    }
+
+    get _tests() {
+        return this._state;
+    }
+
+    get _testsReceived() {
+        return this._tests != null;
+    }
+
+    get _testsEnabled() {
+        return this._tests?.config?.enabled ?? false;
+    }
+
+    get _testsCurrentlyRunning() {
+        return this._tests?.inProgress ?? false;
+    }
+
+    get _testResult() {
+        return this._tests?.result;
+    }
+
+    get _hasTestResult() {
+        return (this._testResult?.counts?.total ?? 0) > 0
+    }
+
+    get _hasFailedTestResult() {
+        return (this._testResult?.counts?.failed ?? 0) > 0;
+    }
+
+    get _hasTestResultWithTags() {
+        return (this._testResult?.tags?.length ?? 0) > 0;
+    }
+
     connectedCallback() {
         super.connectedCallback();
         this._lastKnownState();
@@ -105,11 +143,8 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
     }
 
     _createObservers(){
-        this._streamStateObserver = this.jsonRpc.streamTestState().onNext(jsonRpcResponse => {
-            this._state = JSON.parse(jsonRpcResponse.result);
-        });
-        this._streamResultsObserver = this.jsonRpc.streamTestResults().onNext(jsonRpcResponse => {
-            this._results = jsonRpcResponse.result;
+        this._streamStateObserver = this.jsonRpc.streamState().onNext(jsonRpcResponse => {
+            this._tests = jsonRpcResponse.result;
         });
     }
 
@@ -120,13 +155,8 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
 
     _lastKnownState(){
         // Get last known
-        this.jsonRpc.lastKnownState().then(jsonRpcResponse => {
-            this._state = JSON.parse(jsonRpcResponse.result);
-        });
-        this.jsonRpc.lastKnownResults().then(jsonRpcResponse => {
-            if(jsonRpcResponse.result){
-                this._results = jsonRpcResponse.result;
-            }
+        this.jsonRpc.currentState().then(jsonRpcResponse => {
+            this._tests = jsonRpcResponse.result;
         });
     }
 
@@ -137,77 +167,36 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
     }
 
     render() {
-        let results = this._prepareResultsToRender();
         return html`
-            ${this._renderMenuBar(results)}
-            ${this._renderResults(results)}
+            ${this._renderMenuBar()}
+            ${this._renderResults()}
             ${this._renderBarChart()}
         `;
     }
 
-    _prepareResultsToRender() {
-        if(this._state && this._state.running && this._results && this._results.results) {
-            let itemsByState = {
-                passing: [],
-                failing: [],
-                skipped: [],
-            }
-            Object
-                .values(this._results.results)
-                .forEach(item => {
-                    itemsByState.passing.push(...item.passing.filter( obj => obj.test === true ));
-                    itemsByState.failing.push(...item.failing.filter( obj => obj.test === true ));
-                    itemsByState.skipped.push(...item.skipped.filter( obj => obj.test === true ));
-                });
-            let items = itemsByState.failing.concat(
-                itemsByState.passing,
-                itemsByState.skipped
-            );
-            let hasTags = items.find( item => item.tags && item.tags.length > 0 );
-            return {
-                items: items,
-                meta: {
-                    hasTags: hasTags,
-                    failing: itemsByState.failing.length,
-                    passing: itemsByState.passing.length,
-                    skipped: itemsByState.skipped.length,
-                },
-            }
-        } else {
-            return {
-                items: [],
-                meta: {
-                    hasTags: false,
-                    failing: 0,
-                    passing: 0,
-                    skipped: 0,
-                },
-            };
-        }
-    }
-
-    _renderMenuBar(results){
-        if(this._state){
-            return html`<div class="menubar">
+    _renderMenuBar(){
+        if(this._testsReceived) {
+            return html`
+            <div class="menubar">
                 <div>
-                    ${this._renderStopStartButton()}
+                    ${this._renderStartStopButton()}
                     ${this._renderRunAllButton()}
                     ${this._renderRunFailedButton()}
                     ${this._renderToggleBrokenOnly()}
-                    ${this._renderToggleDisplayTags(results)}
+                    ${this._renderToggleDisplayTags()}
                 </div>
                 ${this._renderBusyIndicator()}
-            </div>`;
-        }else{
-            return html`<div class="menubar">
-                ${this._renderStartButton()}
             </div>`;
         }
     }
 
     _renderBarChart(){
-        if(this._state && this._state.running && this._state.run > 0){
-            let values = [this._state.passed, this._state.failed, this._state.skipped];
+        if(this._testsEnabled && this._hasTestResult){
+            let values = [
+                this._testResult.counts?.passed ?? 0,
+                this._testResult.counts?.failed ?? 0,
+                this._testResult.counts?.skipped ?? 0
+            ];
             return html`<echarts-horizontal-stacked-bar name = "Tests"
                             sectionTitles="${this._chartTitles.toString()}" 
                             sectionValues="${values.toString()}"
@@ -216,33 +205,30 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
         }
     }
 
-    _renderStateChart(){
-        let values = [this._state.passed, this._state.failed, this._state.skipped];
-        return html`<echarts-pie name = "Tests"
-                            sectionTitles="${this._chartTitles.toString()}" 
-                            sectionValues="${values.toString()}"
-                            sectionColors="${this._chartColors.toString()}">
-                        </echarts-pie>`;
-    }
-
     _renderBusyIndicator(){
-        if(this._state && this._state.inProgress){
+        if(this._testsCurrentlyRunning){
             return html`<vaadin-progress-bar class="progress" indeterminate></vaadin-progress-bar>`;
-        }else if(this._results && this._state && this._state.running){
+        }else if(this._testsEnabled && this._testResult?.totalTime){
 
              return html`<span class="total">
                          Total time: 
-                         <qui-badge><span>${this._results.totalTime}ms</span></qui-badge>
+                         <qui-badge><span>${this._testResult?.totalTime}ms</span></qui-badge>
                      </span>`
         }
         
     }
 
-    _renderResults(results){
-        if(results.items.length > 0){
+    _renderResults(){
+        let items = [];
+        if(this._testsEnabled) {
+            items.push(... (this._testResult?.failed ?? []));
+            items.push(... (this._testResult?.passed ?? []));
+            items.push(... (this._testResult?.skipped ?? []));
+        }
+        if(items.length > 0){
 
             return html`
-                <vaadin-grid .items="${results.items}" class="resultTable" theme="no-border"
+                <vaadin-grid .items="${items}" class="resultTable" theme="no-border"
                                 .detailsOpenedItems="${this._detailsOpenedItem}"
                             @active-item-changed="${(event) => {
                             const prop = event.detail.value;
@@ -251,7 +237,7 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
                         ${gridRowDetailsRenderer(this._descriptionRenderer, [])}
                 >
                 ${
-                    this._displayTags && results.meta.hasTags 
+                    this._displayTags && this._hasTestResultWithTags
                     ? html`<vaadin-grid-sort-column path="tags" header="Tags" ${columnBodyRenderer((prop) => this._tagsRenderer(prop), [])}></vaadin-grid-sort-column>`
                     : ''
                 }
@@ -327,12 +313,13 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
     }
 
     _testRenderer(testLine){
-        let level = testLine.testExecutionResult.status.toLowerCase();
-
-        return html`<qui-ide-link fileName='${testLine.testClass}'
-                        lineNumber=0><vaadin-icon class="ideIcon" icon="font-awesome-solid:code"></vaadin-icon></qui-ide-link>
+        let level = testLine.style ?? '';
+        return html`<qui-ide-link fileName='${testLine.className}'
+                        lineNumber=0>
+                        <vaadin-icon class="ideIcon" icon="font-awesome-solid:code"></vaadin-icon>
+                    </qui-ide-link>
                     <span class="${level}">
-                        ${testLine.testClass}
+                        ${testLine.className}
                     </span>`;
     }
 
@@ -340,7 +327,7 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
         var dn = testLine.displayName;
         var hi = dn.lastIndexOf('#');
         var n = dn.substring(hi + 1);
-        let level = testLine.testExecutionResult.status.toLowerCase();
+        let level = testLine.style ?? '';
         return html`<span class="${level}">
                         ${n}
                     </span>`;
@@ -352,36 +339,20 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
                     </span>`;        
     }
 
-    _detailsRenderer(prop) {
-        return html`<p>${prop}</p>
-        <hr/>
-        <p>${this._detailsOpenedItem}</p>`;
-    }
-
-
-    _renderStopStartButton(){        
-        if(this._state && this._state.running){
-            return this._renderStopButton();
-        }
-        return this._renderStartButton();
-    }
-
-    _renderStartButton(){
-        return html`<vaadin-button id="start-cnt-testing-btn" theme="tertiary" @click="${this._start}" ?disabled=${this._busy}>
-                        <vaadin-icon icon="font-awesome-solid:play"></vaadin-icon>
-                        Start
-                    </vaadin-button>`;
-    }
-
-    _renderStopButton(){
-        return html`<vaadin-button id="stop-cnt-testing-btn" theme="tertiary" @click="${this._stop}" ?disabled=${this._state.inProgress || this._busy}>
-                        <vaadin-icon icon="font-awesome-solid:stop"></vaadin-icon>
-                        Stop
+    _renderStartStopButton(){
+        return html`<vaadin-button 
+                            id="start-cnt-testing-btn" 
+                            theme="tertiary" 
+                            @click="${!this._testsEnabled ? this._start : this._stop}" 
+                            ?disabled=${this._busy}>
+                        <vaadin-icon icon="font-awesome-solid:${!this._testsEnabled ? 'play' : 'stop'}"></vaadin-icon>
+            <vaadin-icon icon="font-awesome-solid:stop"></vaadin-icon>
+                        ${!this._testsEnabled ? 'Start' : 'Stop'}
                     </vaadin-button>`;
     }
 
     _renderRunAllButton(){
-        if(this._state && this._state.running){
+        if(this._testsEnabled){
             return html`<vaadin-button id="run-all-cnt-testing-btn" theme="tertiary" @click="${this._runAll}" ?disabled=${this._state.inProgress || this._busy}>
                             <vaadin-icon icon="font-awesome-solid:person-running"></vaadin-icon>
                             Run all
@@ -390,7 +361,7 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
     }
 
     _renderRunFailedButton(){
-        if(this._state && this._state.running && this._state.failed > 0){
+        if(this._testsEnabled && this._hasFailedTestResult){
             return html`<vaadin-button id="run-failed-cnt-testing-btn" theme="tertiary" @click="${this._runFailed}" ?disabled=${this._state.inProgress || this._busy}>
                             <vaadin-icon class="warning" icon="font-awesome-solid:person-falling-burst" ></vaadin-icon>
                             Run failed
@@ -399,22 +370,22 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
     }
 
     _renderToggleBrokenOnly(){
-        if(this._state && this._state.running){
+        if(this._testsEnabled){
             return html`<vaadin-checkbox id="run-failed-cnt-testing-chk" theme="small"
                                     @change="${this._toggleBrokenOnly}"
-                                    ?checked=${this._state.isBrokenOnly}
-                                    ?disabled=${this._state.inProgress || this._busy}
+                                    ?checked=${this._tests.config.brokenOnly}
+                                    ?disabled=${this._testsCurrentlyRunning || this._busy}
                                     label="Only run failing tests">
                         </vaadin-checkbox>`;
         }
     }
 
-    _renderToggleDisplayTags(results) {
-        if(this._state && this._state.running){
+    _renderToggleDisplayTags() {
+        if(this._testsEnabled){
             return html`<vaadin-checkbox id="display-tags-cnt-testing-chk" theme="small"
                                          @change="${this._toggleDisplayTags}"
                                          ?checked=${this._displayTags}
-                                         ?disabled=${this._state.inProgress || this._busy || !results.meta.hasTags}
+                                         ?disabled=${this._busy || !this._hasTestResultWithTags}
                                          label="Display tags (if available)">
             </vaadin-checkbox>`;
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/continuoustesting/ContinuousTestingJsonRPCState.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/continuoustesting/ContinuousTestingJsonRPCState.java
@@ -1,0 +1,217 @@
+package io.quarkus.devui.runtime.continuoustesting;
+
+public class ContinuousTestingJsonRPCState {
+
+    private boolean inProgress;
+    private Config config;
+    private Result result;
+
+    public boolean isInProgress() {
+        return inProgress;
+    }
+
+    public ContinuousTestingJsonRPCState setInProgress(boolean inProgress) {
+        this.inProgress = inProgress;
+        return this;
+    }
+
+    public Config getConfig() {
+        return config;
+    }
+
+    public ContinuousTestingJsonRPCState setConfig(Config config) {
+        this.config = config;
+        return this;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    public ContinuousTestingJsonRPCState setResult(Result result) {
+        this.result = result;
+        return this;
+    }
+
+    public static class Config {
+
+        private boolean enabled;
+        private boolean brokenOnly;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public Config setEnabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public boolean isBrokenOnly() {
+            return brokenOnly;
+        }
+
+        public Config setBrokenOnly(boolean brokenOnly) {
+            this.brokenOnly = brokenOnly;
+            return this;
+        }
+    }
+
+    public static class Result {
+
+        private Counts counts;
+        private long totalTime;
+        private String[] tags;
+        private Item[] passed;
+        private Item[] failed;
+        private Item[] skipped;
+
+        public Counts getCounts() {
+            return counts;
+        }
+
+        public Result setCounts(Counts counts) {
+            this.counts = counts;
+            return this;
+        }
+
+        public long getTotalTime() {
+            return totalTime;
+        }
+
+        public Result setTotalTime(long totalTime) {
+            this.totalTime = totalTime;
+            return this;
+        }
+
+        public String[] getTags() {
+            return tags;
+        }
+
+        public Result setTags(String[] tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Item[] getPassed() {
+            return passed;
+        }
+
+        public Result setPassed(Item[] passed) {
+            this.passed = passed;
+            return this;
+        }
+
+        public Item[] getFailed() {
+            return failed;
+        }
+
+        public Result setFailed(Item[] failed) {
+            this.failed = failed;
+            return this;
+        }
+
+        public Item[] getSkipped() {
+            return skipped;
+        }
+
+        public Result setSkipped(Item[] skipped) {
+            this.skipped = skipped;
+            return this;
+        }
+
+        public static class Counts {
+
+            private long passed;
+            private long failed;
+            private long skipped;
+
+            public long getPassed() {
+                return passed;
+            }
+
+            public Counts setPassed(long passed) {
+                this.passed = passed;
+                return this;
+            }
+
+            public long getFailed() {
+                return failed;
+            }
+
+            public Counts setFailed(long failed) {
+                this.failed = failed;
+                return this;
+            }
+
+            public long getSkipped() {
+                return skipped;
+            }
+
+            public Counts setSkipped(long skipped) {
+                this.skipped = skipped;
+                return this;
+            }
+
+            public long getTotal() {
+                return passed + failed + skipped;
+            }
+        }
+
+        public static class Item {
+
+            private String[] tags;
+            private String className;
+            private String displayName;
+            private long time;
+            private Throwable[] problems;
+
+            public String[] getTags() {
+                return tags;
+            }
+
+            public Item setTags(String[] tags) {
+                this.tags = tags;
+                return this;
+            }
+
+            public String getClassName() {
+                return className;
+            }
+
+            public Item setClassName(String className) {
+                this.className = className;
+                return this;
+            }
+
+            public String getDisplayName() {
+                return displayName;
+            }
+
+            public Item setDisplayName(String displayName) {
+                this.displayName = displayName;
+                return this;
+            }
+
+            public long getTime() {
+                return time;
+            }
+
+            public Item setTime(long time) {
+                this.time = time;
+                return this;
+            }
+
+            public Throwable[] getProblems() {
+                return problems;
+            }
+
+            public Item setProblems(Throwable[] problems) {
+                this.problems = problems;
+                return this;
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR resolves #43067 by refactoring the JSON that is exchanged with the RPC service for continuous testing.
 - more intuitive structure (see [Sample JSON](https://github.com/user-attachments/files/16921030/_state.json))
 - less payload (50%)
 - specialized on the UI requirements, so the UI is not required to do further logic
 - merged both stream observers (`_state` and `_results`) to a single one (they were always published at the same time in the RPC service, so they triggered two events that led to rendering in the UI at the same time) 
