### PR TITLE
Remove TrustedHosts policy from the oidc-client-registrations test realm

### DIFF
--- a/integration-tests/oidc-client-registration/src/main/resources/quarkus-realm.json
+++ b/integration-tests/oidc-client-registration/src/main/resources/quarkus-realm.json
@@ -1202,24 +1202,6 @@
   "components": {
     "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
       {
-        "id": "9b4e5b69-1d07-489b-b8a5-07329c957141",
-        "name": "Trusted Hosts",
-        "providerId": "trusted-hosts",
-        "subType": "anonymous",
-        "subComponents": {},
-        "config": {
-          "host-sending-registration-request-must-match": [
-            "true"
-          ],
-          "trusted-hosts": [
-            "172.17.0.1"
-          ],
-          "client-uris-must-match": [
-            "false"
-          ]
-        }
-      },
-      {
         "id": "e2f513d3-44e3-435c-8b2a-68a5d384fd97",
         "name": "Full Scope Disabled",
         "providerId": "scope",


### PR DESCRIPTION
Fixes #43106.

The test realm had a trusted host policy enabled (to accept client registrations from trusted hosts only, when no initial access token is used), but it is only causing side-effects as in #43106.

It is not really a test issue how to configure Keycloak to allow anonymous client registrations. Besides, there is a Max Clients policy there allowing up to 200 new clients per realm. As far as the test is concerned, as long as Keycloak registers new clients, all is fine.

See https://www.keycloak.org/docs/latest/securing_apps/#_client_registration_policies (the max clients policy is in the tests realm too).

CC @snazy 