### PR TITLE
OIDC: Prevent concurrent tenant creations

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -119,17 +119,18 @@ public class DefaultTenantConfigResolver {
                             final String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
 
                             if (tenantId != null && !isTenantSetByAnnotation(context, tenantId)) {
-                                TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                                // WARN: The order (check dynamic before static) is important!
+                                var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                                 if (tenantContext != null) {
                                     // Dynamic map may contain the static contexts initialized on demand,
-                                    if (tenantConfigBean.getStaticTenantsConfig().containsKey(tenantId)) {
+                                    if (tenantConfigBean.getStaticTenant(tenantId) != null) {
                                         context.put(CURRENT_STATIC_TENANT_ID, tenantId);
                                     }
                                     return tenantContext.getOidcTenantConfig();
                                 }
                             }
 
-                            TenantConfigContext tenant = getStaticTenantContext(context);
+                            var tenant = getStaticTenantContext(context);
                             if (tenant != null) {
                                 tenantConfig = tenant.oidcConfig;
                             }
@@ -156,12 +157,11 @@ public class DefaultTenantConfigResolver {
         if (tenantContext != null && !tenantContext.ready) {
 
             // check if the connection has already been created
-            TenantConfigContext readyTenantContext = tenantConfigBean.getDynamicTenantsConfig()
-                    .get(tenantContext.oidcConfig.tenantId.get());
+            var readyTenantContext = tenantConfigBean.getDynamicTenant(tenantContext.oidcConfig.tenantId.get());
             if (readyTenantContext == null) {
                 LOG.debugf("Tenant '%s' is not initialized yet, trying to create OIDC connection now",
                         tenantContext.oidcConfig.tenantId.get());
-                return tenantConfigBean.getTenantConfigContextFactory().apply(tenantContext.oidcConfig);
+                return tenantConfigBean.createTenantContext(tenantContext.oidcConfig, false);
             } else {
                 tenantContext = readyTenantContext;
             }
@@ -206,7 +206,7 @@ public class DefaultTenantConfigResolver {
     }
 
     private TenantConfigContext getStaticTenantContext(String tenantId) {
-        TenantConfigContext configContext = tenantId != null ? tenantConfigBean.getStaticTenantsConfig().get(tenantId) : null;
+        TenantConfigContext configContext = tenantId != null ? tenantConfigBean.getStaticTenant(tenantId) : null;
         if (configContext == null) {
             if (tenantId != null && !tenantId.isEmpty()) {
                 LOG.debugf(
@@ -255,7 +255,12 @@ public class DefaultTenantConfigResolver {
                     //shouldn't happen, but guard against it anyway
                     oidcConfig = Uni.createFrom().nullItem();
                 } else {
-                    oidcConfig = oidcConfig.onItem().transform(cfg -> OidcUtils.resolveProviderConfig(cfg));
+                    oidcConfig = oidcConfig.onItem().transform(new Function<OidcTenantConfig, OidcTenantConfig>() {
+                        @Override
+                        public OidcTenantConfig apply(OidcTenantConfig cfg) {
+                            return OidcUtils.resolveProviderConfig(cfg);
+                        }
+                    });
                 }
                 context.put(CURRENT_DYNAMIC_TENANT_CONFIG, oidcConfig);
             }
@@ -270,18 +275,18 @@ public class DefaultTenantConfigResolver {
             @Override
             public Uni<? extends TenantConfigContext> apply(OidcTenantConfig tenantConfig) {
                 if (tenantConfig != null) {
-                    String tenantId = tenantConfig.getTenantId()
+                    var tenantId = tenantConfig.getTenantId()
                             .orElseThrow(() -> new OIDCException("Tenant configuration must have tenant id"));
-                    TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                    var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                     if (tenantContext == null) {
-                        return tenantConfigBean.getTenantConfigContextFactory().apply(tenantConfig);
+                        return tenantConfigBean.createTenantContext(tenantConfig, true);
                     } else {
                         return Uni.createFrom().item(tenantContext);
                     }
                 } else {
-                    final String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
+                    String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
                     if (tenantId != null && !isTenantSetByAnnotation(context, tenantId)) {
-                        TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                        var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                         if (tenantContext != null) {
                             return Uni.createFrom().item(tenantContext);
                         }
@@ -324,21 +329,22 @@ public class DefaultTenantConfigResolver {
         }
 
         // 2. path-matching tenant resolver
-        var pathMatchingTenantResolver = PathMatchingTenantResolver.of(tenantConfigBean.getStaticTenantsConfig(), rootPath,
+        var staticTenants = tenantConfigBean.getStaticTenantsConfig();
+        var pathMatchingTenantResolver = PathMatchingTenantResolver.of(staticTenants, rootPath,
                 tenantConfigBean.getDefaultTenant());
         if (pathMatchingTenantResolver != null) {
             staticTenantResolvers.add(pathMatchingTenantResolver);
         }
 
         // 3. default static tenant resolver
-        if (!tenantConfigBean.getStaticTenantsConfig().isEmpty()) {
+        if (!staticTenants.isEmpty()) {
             staticTenantResolvers.add(defaultStaticTenantResolver);
         }
 
         // 4. issuer-based tenant resolver
         if (resolveTenantsWithIssuer) {
             IssuerBasedTenantResolver.addIssuerBasedTenantResolver(staticTenantResolvers,
-                    tenantConfigBean.getStaticTenantsConfig(), tenantConfigBean.getDefaultTenant());
+                    staticTenants, tenantConfigBean.getDefaultTenant());
         }
 
         return staticTenantResolvers.toArray(new TenantResolver[0]);
@@ -351,7 +357,7 @@ public class DefaultTenantConfigResolver {
             String[] pathSegments = context.request().path().split("/");
             if (pathSegments.length > 0) {
                 String lastPathSegment = pathSegments[pathSegments.length - 1];
-                if (tenantConfigBean.getStaticTenantsConfig().containsKey(lastPathSegment)) {
+                if (tenantConfigBean.getStaticTenant(lastPathSegment) != null) {
                     LOG.debugf(
                             "Tenant id '%s' is selected on the '%s' request path", lastPathSegment, context.normalizedPath());
                     return lastPathSegment;
@@ -390,14 +396,13 @@ public class DefaultTenantConfigResolver {
             return null;
         }
 
-        private static ImmutablePathMatcher.ImmutablePathMatcherBuilder<String> addPath(String tenant, OidcTenantConfig config,
+        private static void addPath(String tenant, OidcTenantConfig config,
                 ImmutablePathMatcher.ImmutablePathMatcherBuilder<String> builder) {
             if (config != null && config.tenantPaths.isPresent()) {
                 for (String path : config.tenantPaths.get()) {
                     builder.addPath(path, tenant);
                 }
             }
-            return builder;
         }
     }
 
@@ -406,14 +411,11 @@ public class DefaultTenantConfigResolver {
             return tenantConfigBean.getDefaultTenant().getOidcTenantConfig();
         }
 
-        if (tenantConfigBean.getStaticTenantsConfig().containsKey(sessionTenantId)) {
-            return tenantConfigBean.getStaticTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
+        var tenant = tenantConfigBean.getStaticTenant(sessionTenantId);
+        if (tenant == null) {
+            tenant = tenantConfigBean.getDynamicTenant(sessionTenantId);
         }
-
-        if (tenantConfigBean.getDynamicTenantsConfig().containsKey(sessionTenantId)) {
-            return tenantConfigBean.getDynamicTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
-        }
-        return null;
+        return tenant != null ? tenant.getOidcTenantConfig() : null;
     }
 
     public String getRootPath() {
@@ -449,7 +451,7 @@ public class DefaultTenantConfigResolver {
                         if (tenantContext.getOidcMetadata().getIssuer().equals(iss)) {
                             OidcUtils.storeExtractedBearerToken(context, token);
 
-                            final String tenantId = tenantContext.oidcConfig.tenantId.get();
+                            final String tenantId = tenantContext.oidcConfig.tenantId.orElseThrow();
                             LOG.debugf("Resolved the '%s' OIDC tenant based on the matching issuer '%s'", tenantId, iss);
                             return tenantId;
                         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -153,7 +153,7 @@ public class DefaultTenantConfigResolver {
     private Uni<TenantConfigContext> initializeStaticTenantIfContextNotReady(TenantConfigContext tenantContext) {
         requireNonNull(tenantContext, "tenantContext must never be null");
 
-        if (!tenantContext.ready) {
+        if (!tenantContext.isReady()) {
             return tenantConfigBean.getOrCreateTenantContext(tenantContext.oidcConfig, false);
         }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.runtime;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -42,6 +43,13 @@ public class OidcConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean resolveTenantsWithIssuer;
+
+    /**
+     * If configured, limit the number of active dynamic OIDC tenant contexts to this value.
+     * If not set, the number of active dynamic OIDC tenant contexts is unlimited.
+     */
+    @ConfigItem
+    public OptionalInt dynamicTenantLimit;
 
     /**
      * Default TokenIntrospection and UserInfo cache configuration.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -124,13 +124,14 @@ public class OidcRecorder {
                     createStaticTenantContext(vertxValue, tenant.getValue(), false, tenant.getKey(), defaultTlsConfiguration));
         }
 
+        int tenantLimit = Math.max(0, config.dynamicTenantLimit.orElse(0));
         return new TenantConfigBean(staticTenantsConfig, defaultTenantContext, new LongSupplier() {
             @Override
             public long getAsLong() {
                 return System.nanoTime();
             }
         },
-                Math.max(0, config.dynamicTenantLimit.orElse(0)),
+                tenantLimit,
                 new TenantConfigBean.TenantContextFactory() {
                     @Override
                     public Uni<TenantConfigContext> create(OidcTenantConfig oidcConfig, boolean dynamicTenant,

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -1,12 +1,16 @@
 package io.quarkus.oidc.runtime;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import jakarta.enterprise.context.spi.CreationalContext;
 
 import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 
 public class TenantConfigBean {
@@ -14,33 +18,58 @@ public class TenantConfigBean {
     private final Map<String, TenantConfigContext> staticTenantsConfig;
     private final Map<String, TenantConfigContext> dynamicTenantsConfig;
     private final TenantConfigContext defaultTenant;
-    private final Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory;
+    private final TenantContextFactory tenantContextFactory;
+
+    @FunctionalInterface
+    public interface TenantContextFactory {
+        Uni<TenantConfigContext> create(OidcTenantConfig oidcTenantConfig, boolean dynamicTenant, String tenantId);
+    }
 
     public TenantConfigBean(
             Map<String, TenantConfigContext> staticTenantsConfig,
-            Map<String, TenantConfigContext> dynamicTenantsConfig,
             TenantConfigContext defaultTenant,
-            Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory) {
-        this.staticTenantsConfig = staticTenantsConfig;
-        this.dynamicTenantsConfig = dynamicTenantsConfig;
+            TenantContextFactory tenantContextFactory) {
+        this.staticTenantsConfig = new ConcurrentHashMap<>(staticTenantsConfig);
+        this.dynamicTenantsConfig = new ConcurrentHashMap<>();
         this.defaultTenant = defaultTenant;
-        this.tenantConfigContextFactory = tenantConfigContextFactory;
+        this.tenantContextFactory = tenantContextFactory;
+    }
+
+    public Uni<TenantConfigContext> createTenantContext(OidcTenantConfig oidcConfig, boolean dynamicTenant) {
+        if (oidcConfig.logout.backchannel.path.isPresent()) {
+            throw new ConfigurationException(
+                    "BackChannel Logout is currently not supported for dynamic tenants");
+        }
+        var tenantId = oidcConfig.getTenantId().orElseThrow();
+        if (!dynamicTenantsConfig.containsKey(tenantId)) {
+            Uni<TenantConfigContext> uniContext = tenantContextFactory.create(oidcConfig, dynamicTenant, tenantId);
+            return uniContext.onItem().transform(
+                    new Function<TenantConfigContext, TenantConfigContext>() {
+                        @Override
+                        public TenantConfigContext apply(TenantConfigContext t) {
+                            dynamicTenantsConfig.putIfAbsent(tenantId, t);
+                            return t;
+                        }
+                    });
+        } else {
+            return Uni.createFrom().item(dynamicTenantsConfig.get(tenantId));
+        }
+    }
+
+    public TenantConfigContext getStaticTenant(String tenantId) {
+        return staticTenantsConfig.get(tenantId);
     }
 
     public Map<String, TenantConfigContext> getStaticTenantsConfig() {
-        return staticTenantsConfig;
+        return unmodifiableMap(staticTenantsConfig);
+    }
+
+    public TenantConfigContext getDynamicTenant(String tenantId) {
+        return dynamicTenantsConfig.get(tenantId);
     }
 
     public TenantConfigContext getDefaultTenant() {
         return defaultTenant;
-    }
-
-    public Function<OidcTenantConfig, Uni<TenantConfigContext>> getTenantConfigContextFactory() {
-        return tenantConfigContextFactory;
-    }
-
-    public Map<String, TenantConfigContext> getDynamicTenantsConfig() {
-        return dynamicTenantsConfig;
     }
 
     public static class Destroyer implements BeanDestroyer<TenantConfigBean> {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -16,6 +16,9 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 
 public class TenantConfigBean {
+    /*
+     * Note: this class is publicly documented on https://quarkus.io/guides/security-oidc-code-flow-authentication.
+     */
 
     private static final Logger LOG = Logger.getLogger(TenantConfigBean.class);
 
@@ -29,7 +32,7 @@ public class TenantConfigBean {
         Uni<TenantConfigContext> create(OidcTenantConfig oidcTenantConfig, boolean dynamicTenant, String tenantId);
     }
 
-    public TenantConfigBean(
+    TenantConfigBean(
             Map<String, TenantConfigContext> staticTenantsConfig,
             TenantConfigContext defaultTenant,
             TenantContextFactory tenantContextFactory) {
@@ -39,16 +42,16 @@ public class TenantConfigBean {
         this.tenantContextFactory = tenantContextFactory;
     }
 
-    public Uni<TenantConfigContext> createTenantContext(OidcTenantConfig oidcConfig, boolean dynamicTenant) {
+    Uni<TenantConfigContext> getOrCreateTenantContext(OidcTenantConfig oidcConfig, boolean dynamicTenant) {
         var tenantId = oidcConfig.getTenantId().orElseThrow();
-        if (dynamicTenant && oidcConfig.logout.backchannel.path.isPresent()) {
-            throw new ConfigurationException(
-                    "BackChannel Logout is currently not supported for dynamic tenants (tenant ID: " + tenantId + ")");
-        }
         var tenants = dynamicTenant ? dynamicTenantsConfig : staticTenantsConfig;
         var tenant = tenants.get(tenantId);
         if (tenant == null || !tenant.ready) {
             LOG.tracef("Creating %s tenant config for %s", dynamicTenant ? "dynamic" : "static", tenantId);
+            if (dynamicTenant && oidcConfig.logout.backchannel.path.isPresent()) {
+                throw new ConfigurationException(
+                        "BackChannel Logout is currently not supported for dynamic tenants (tenant ID: " + tenantId + ")");
+            }
             Uni<TenantConfigContext> uniContext = tenantContextFactory.create(oidcConfig, dynamicTenant, tenantId);
             return uniContext.onItem().transform(
                     new Function<TenantConfigContext, TenantConfigContext>() {
@@ -60,24 +63,58 @@ public class TenantConfigBean {
                             return t;
                         }
                     });
-        } else {
-            LOG.tracef("Immediately returning ready %s tenant config for %s", dynamicTenant ? "dynamic" : "static", tenantId);
-            return Uni.createFrom().item(tenant);
         }
+        LOG.tracef("Immediately returning ready %s tenant config for %s", dynamicTenant ? "dynamic" : "static", tenantId);
+        return Uni.createFrom().item(tenant);
     }
 
-    public TenantConfigContext getStaticTenant(String tenantId) {
+    /**
+     * Returns a static tenant's config context or {@code null}, if the tenant does not exist.
+     */
+    public TenantConfigContext getStaticTenantConfigContext(String tenantId) {
         return staticTenantsConfig.get(tenantId);
     }
 
+    /**
+     * Returns a static tenant's OIDC configuration or {@code null}, if the tenant does not exist.
+     */
+    public OidcTenantConfig getStaticTenantOidcConfig(String tenantId) {
+        var context = getStaticTenantConfigContext(tenantId);
+        return context != null ? context.oidcConfig : null;
+    }
+
+    /**
+     * Returns an unmodifiable map containing the static tenant config contexts by tenant-ID.
+     */
     public Map<String, TenantConfigContext> getStaticTenantsConfig() {
         return unmodifiableMap(staticTenantsConfig);
     }
 
-    public TenantConfigContext getDynamicTenant(String tenantId) {
+    /**
+     * Returns a dynamic tenant's config context or {@code null}, if the tenant does not exist.
+     */
+    public TenantConfigContext getDynamicTenantConfigContext(String tenantId) {
         return dynamicTenantsConfig.get(tenantId);
     }
 
+    /**
+     * Returns a dynamic tenant's OIDC configuration or {@code null}, if the tenant does not exist.
+     */
+    public OidcTenantConfig getDynamicTenantOidcConfig(String tenantId) {
+        var context = getDynamicTenantConfigContext(tenantId);
+        return context != null ? context.oidcConfig : null;
+    }
+
+    /**
+     * Returns an unmodifiable map containing the dynamic tenant config contexts by tenant-ID.
+     */
+    public Map<String, TenantConfigContext> getDynamicTenantsConfig() {
+        return unmodifiableMap(dynamicTenantsConfig);
+    }
+
+    /**
+     * Returns the default tenant's config context.
+     */
     public TenantConfigContext getDefaultTenant() {
         return defaultTenant;
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -1,10 +1,14 @@
 package io.quarkus.oidc.runtime;
 
-import static java.util.Collections.unmodifiableMap;
-
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 
@@ -14,8 +18,10 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.oidc.OidcTenantConfig;
-import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.tls.TlsConfiguration;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
 
 public class TenantConfigBean {
     /*
@@ -24,8 +30,8 @@ public class TenantConfigBean {
 
     private static final Logger LOG = Logger.getLogger(TenantConfigBean.class);
 
-    private final Map<String, TenantConfigContext> staticTenantsConfig;
-    private final Map<String, TenantConfigContext> dynamicTenantsConfig;
+    private final TenantsMap staticTenantsConfig;
+    private final TenantsMap dynamicTenantsConfig;
     private final TenantConfigContext defaultTenant;
     private final TenantContextFactory tenantContextFactory;
     private final LongSupplier clock;
@@ -44,8 +50,8 @@ public class TenantConfigBean {
             LongSupplier clock,
             int dynamicTenantLimit,
             TenantContextFactory tenantContextFactory) {
-        this.staticTenantsConfig = new ConcurrentHashMap<>(staticTenantsConfig);
-        this.dynamicTenantsConfig = new ConcurrentHashMap<>();
+        this.staticTenantsConfig = new TenantsMap(false, false, staticTenantsConfig);
+        this.dynamicTenantsConfig = new TenantsMap(true, dynamicTenantLimit > 0, Map.of());
         this.clock = clock;
         this.dynamicTenantLimit = dynamicTenantLimit;
         this.defaultTenant = defaultTenant;
@@ -55,45 +61,21 @@ public class TenantConfigBean {
     Uni<TenantConfigContext> getOrCreateTenantContext(OidcTenantConfig oidcConfig, boolean dynamicTenant) {
         var tenantId = oidcConfig.getTenantId().orElseThrow();
         var tenants = dynamicTenant ? dynamicTenantsConfig : staticTenantsConfig;
-        var tenant = tenants.get(tenantId);
-        if (tenant == null || !tenant.isReady()) {
-            LOG.tracef("Creating %s tenant config for %s", dynamicTenant ? "dynamic" : "static", tenantId);
-            if (dynamicTenant && oidcConfig.logout.backchannel.path.isPresent()) {
-                throw new ConfigurationException(
-                        "BackChannel Logout is currently not supported for dynamic tenants (tenant ID: " + tenantId + ")");
-            }
-            Uni<TenantConfigContext> uniContext = tenantContextFactory.create(oidcConfig, dynamicTenant, tenantId);
-            return uniContext.onItem().transform(
-                    new Function<>() {
-                        @Override
-                        public TenantConfigContext apply(TenantConfigContext t) {
-                            LOG.debugf("Updating %s %s tenant config for %s", dynamicTenant ? "dynamic" : "static",
-                                    t.isReady() ? "ready" : "not-ready", tenantId);
-                            t.lastUsed = clock.getAsLong();
-                            TenantConfigContext previous = tenants.put(tenantId, t);
-                            if (previous != null) {
-                                // Concurrent calls to createTenantContext may race, better "destroy" the previous
-                                // provider, if there's one.
-                                destroyContext(previous);
-                            } else if (dynamicTenant) {
-                                enforceDynamicTenantLimit();
-                            }
-                            return t;
-                        }
-                    });
+
+        // Fast-path, no volatile reads
+        var context = tenants.fastGet(tenantId);
+        if (context != null && context.isReady()) {
+            return Uni.createFrom().item(context);
         }
-        if (dynamicTenant) {
-            tenant.lastUsed = clock.getAsLong();
-        }
-        LOG.tracef("Immediately returning ready %s tenant config for %s", dynamicTenant ? "dynamic" : "static", tenantId);
-        return Uni.createFrom().item(tenant);
+
+        return tenants.slowGetOrCreateReady(tenantId, oidcConfig);
     }
 
     /**
      * Returns a static tenant's config context or {@code null}, if the tenant does not exist.
      */
     public TenantConfigContext getStaticTenantConfigContext(String tenantId) {
-        return staticTenantsConfig.get(tenantId);
+        return staticTenantsConfig.fastGet(tenantId);
     }
 
     /**
@@ -108,19 +90,14 @@ public class TenantConfigBean {
      * Returns an unmodifiable map containing the static tenant config contexts by tenant-ID.
      */
     public Map<String, TenantConfigContext> getStaticTenantsConfig() {
-        return unmodifiableMap(staticTenantsConfig);
+        return staticTenantsConfig.tenantsCopy();
     }
 
     /**
      * Returns a dynamic tenant's config context or {@code null}, if the tenant does not exist.
      */
     public TenantConfigContext getDynamicTenantConfigContext(String tenantId) {
-        TenantConfigContext context = dynamicTenantsConfig.get(tenantId);
-        if (context == null) {
-            return null;
-        }
-        context.lastUsed = clock.getAsLong();
-        return context;
+        return dynamicTenantsConfig.fastGet(tenantId);
     }
 
     /**
@@ -135,7 +112,7 @@ public class TenantConfigBean {
      * Returns an unmodifiable map containing the dynamic tenant config contexts by tenant-ID.
      */
     public Map<String, TenantConfigContext> getDynamicTenantsConfig() {
-        return unmodifiableMap(dynamicTenantsConfig);
+        return dynamicTenantsConfig.tenantsCopy();
     }
 
     /**
@@ -157,16 +134,16 @@ public class TenantConfigBean {
         public void destroy(TenantConfigBean instance, CreationalContext<TenantConfigBean> creationalContext,
                 Map<String, Object> params) {
             destroyContext(instance.defaultTenant);
-            for (var i : instance.staticTenantsConfig.values()) {
-                destroyContext(i);
+            for (var i : instance.staticTenantsConfig.holders()) {
+                destroyContext(i.context());
             }
-            for (var i : instance.dynamicTenantsConfig.values()) {
-                destroyContext(i);
+            for (var i : instance.dynamicTenantsConfig.holders()) {
+                destroyContext(i.context());
             }
         }
     }
 
-    record EvictionCandidate(String tenantId, TenantConfigContext context, long lastUsed) {
+    record EvictionCandidate(String tenantId, TenantHolder holder, long lastUsed) {
     }
 
     /**
@@ -195,22 +172,35 @@ public class TenantConfigBean {
         }
         try {
             do {
+                // Note: `dynamicTenantsConfig.entrySet()` creates a copy of the "live" map while holding the
+                // tenants-map lock.
+                Set<Map.Entry<String, TenantHolder>> dynamicTenants = dynamicTenantsConfig.entrySet();
+
+                // Re-calculate the number of tenants to evict - the value might have changed since the start
+                // of the `enforceDynamicTenantLimit()` function or since the last check at the end of the
+                // do-while loop.
+                toEvict = dynamicTenants.size() - limit;
+                if (toEvict <= 0) {
+                    // Nothing to evict
+                    return;
+                }
+
                 EvictionCandidate[] candidates = new EvictionCandidate[toEvict];
                 int numCandidates = 0;
                 // Current max
                 long maxLastUsed = Long.MAX_VALUE;
 
-                // Collect the required number of tenants to evict by visiting each dynamic tenant
-                for (Map.Entry<String, TenantConfigContext> e : dynamicTenantsConfig.entrySet()) {
-                    TenantConfigContext c = e.getValue();
-                    long lastUsed = c.lastUsed;
+                // Collect the required number of tenants to evict by visiting each dynamic tenant.
+                for (Map.Entry<String, TenantHolder> e : dynamicTenants) {
+                    var holder = e.getValue();
+                    long lastUsed = holder.lastUsed;
                     if (lastUsed >= maxLastUsed) {
                         // Tenant is too young, skip
                         continue;
                     }
 
                     // Found a candidate with a lastUsed less than the current oldest
-                    EvictionCandidate evictionCandidate = new EvictionCandidate(e.getKey(), c, lastUsed);
+                    EvictionCandidate evictionCandidate = new EvictionCandidate(e.getKey(), holder, lastUsed);
                     if (numCandidates < toEvict) {
                         // Collect until we hit the number of tenants to evict
                         candidates[numCandidates++] = evictionCandidate;
@@ -237,6 +227,7 @@ public class TenantConfigBean {
                     evictTenant(candidate);
                 }
 
+                // Check if there's more to do...
                 toEvict = dynamicTenantsConfig.size() - limit;
             } while (toEvict > 0);
         } finally {
@@ -246,9 +237,14 @@ public class TenantConfigBean {
 
     // VisibleForTesting
     boolean evictTenant(EvictionCandidate candidate) {
-        if (candidate != null && candidate.lastUsed == candidate.context.lastUsed) {
+        // Note: candidate.holder is the "live" holder object, not a copy, so `lastUsed` is the real value.
+        // There is still a very unlikely (but technically possible) race condition that the tenant was accessed
+        // before it could be removed from the map _and_ the change to the map became visible.
+        if (candidate != null && candidate.lastUsed == candidate.holder.lastUsed) {
+            var context = candidate.holder.context();
+            // Note: the `.remove()` operates while holding the tenants-map lock.
             dynamicTenantsConfig.remove(candidate.tenantId);
-            destroyContext(candidate.context);
+            destroyContext(context);
             return true;
         }
         return false;
@@ -260,5 +256,325 @@ public class TenantConfigBean {
             max = Math.max(max, candidate.lastUsed);
         }
         return max;
+    }
+
+    // Tenant contexts are managed via the following map-container (`TenantsMap`) and map-value type (`TenantHolder`),
+    // both are optimized for the "99.99% case" that the maps of static and dynamic tenants are "fully populated" and
+    // all (active) tenants have a "ready" context.
+    //
+    // Retrieving a tenant hits the "fast path" in the vast majority of all invocations, accessing only non-volatile
+    // fields and a non-concurrent hash map.
+    //
+    // In case a tenant is not yet present (new dynamic tenant ID or late-initialized static default tenant), the
+    // implementations switches to the "slow path" and creates a new hash map with the new tenant and updates the
+    // non-volatile field referencing the tenants-map. Other threads that might not yet "see" the updated tenants-map
+    // field would also enter the slow path - but once the slow path has been executed, the update to the tenants-map
+    // field will be "visible".
+    //
+    // The `TenantHolder` uses a mixture of non-volatile (the "99.99% case" is accessing a ready context) and
+    // volatile fields. The latter are used to make changes immediately "visible" to other threads - the order of
+    // writes is important here. Unlike `TenantsMap`, the `TenantHolder` class does not use/need a lock object or
+    // monitor.
+
+    /**
+     * Manages tenants, optimized for non-volatile reads for performance reasons.
+     */
+    private final class TenantsMap {
+        private final boolean dynamicTenants;
+        private final boolean needsClock;
+        private final Lock lock = new ReentrantLock();
+
+        // Contains non-concurrent `java.util.HashMap` to reduce the amount of volatile read.
+        private Map<String, TenantHolder> tenants;
+
+        TenantsMap(boolean dynamicTenants, boolean needsClock, Map<String, TenantConfigContext> source) {
+            this.dynamicTenants = dynamicTenants;
+            this.needsClock = needsClock;
+            this.tenants = new HashMap<>(source.size() * 4 / 3 + 1);
+            for (Map.Entry<String, TenantConfigContext> e : source.entrySet()) {
+                var context = e.getValue();
+                var holder = new TenantHolder(context);
+                tenants.put(e.getKey(), holder);
+            }
+        }
+
+        /**
+         * "Fast get" a tenant. "Fast" means that the implementation does not touch {@code volatile}s (except for
+         * {@link TenantHolder#lastUsed}, if needed).
+         */
+        TenantConfigContext fastGet(String tenantId) {
+            var holder = tenants.get(tenantId);
+            LOG.tracef("fast get-tenant %s, exists: %s, has context: %s", tenantId, holder,
+                    holder != null && holder.context() != null);
+            if (holder != null) {
+                if (needsClock) {
+                    holder.setLastUsed(clock.getAsLong());
+                }
+                return holder.context();
+            }
+            return null;
+        }
+
+        /**
+         * "Slow get or create" a tenant. "Slow" means that the function runs with {@link #lock} held, the
+         * implementation does not block for a long time.
+         *
+         * <p>
+         * TODO:
+         * <ul>
+         * <li>Check
+         * {@link io.quarkus.oidc.runtime.OidcRecorder#createTenantContext(Vertx, OidcTenantConfig, boolean, String, TlsConfiguration)}
+         * <li>{@link OidcCommonUtils#verifyEndpointUrl(String)} triggers DNS round trips!
+         * <li>{@link OidcRecorder#createOidcClientUni(OidcTenantConfig, Vertx, TlsConfiguration)} might block</li>
+         * </ul>
+         */
+        Uni<TenantConfigContext> slowGetOrCreateReady(String tenantId, OidcTenantConfig oidcConfig) {
+            // Locks make changes visible
+            lock.lock();
+            try {
+                // Lookup the tenant holder
+                var holder = tenants.get(tenantId);
+                LOG.tracef("slow get-tenant %s, exists: %s", tenantId, holder);
+                if (holder != null) {
+                    var context = holder.context();
+                    if (context != null && context.isReady()) {
+                        // Tenant holder exists and is ready - this branch is entered when the current thead could not "see" the update to either the `tenants` map or the update of the fields in `TenantHolder` before.
+                        LOG.tracef("slow get-tenant %s, returning ready context", tenantId);
+                        if (needsClock) {
+                            holder.setLastUsed(clock.getAsLong());
+                        }
+                        return Uni.createFrom().item(context);
+                    }
+
+                    var future = holder.ctxFuture;
+                    if (future == null) {
+                        // "Nothing" is trying to create the ready context yet, start creation and provide a future to which concurrent creation-requests can subscribe to.
+                        holder.ctxFuture = new CompletableFuture<>();
+                        LOG.tracef("slow get-tenant %s, start creation (existing tenant)", tenantId);
+                        return create(tenantId, oidcConfig, holder, holder);
+                    }
+
+                    // Another thread already created the future, subscribe to it.
+                    LOG.tracef("slow get-tenant %s, returning Uni from future", tenantId);
+                    return Uni.createFrom().future(future);
+                }
+
+                // Tenant is not in the tenants-map, add it with a future to which concurrent creation-requests can subscribe to and start creation.
+                var newTenants = new HashMap<>(tenants);
+                var newHolder = new TenantHolder(null);
+                newHolder.ctxFuture = new CompletableFuture<>();
+                if (needsClock) {
+                    newHolder.setLastUsed(clock.getAsLong());
+                }
+                newTenants.put(tenantId, newHolder);
+                this.tenants = newTenants;
+
+                LOG.tracef("slow get-tenant %s, start creation (new tenant)", tenantId);
+                var creation = create(tenantId, oidcConfig, null, newHolder);
+
+                LOG.tracef("slow get-tenant %s, returning Uni from creation", tenantId);
+                return creation;
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        void remove(String tenantId) {
+            // Locks make changes visible
+            lock.lock();
+            try {
+                tenants.remove(tenantId);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private Uni<TenantConfigContext> create(String tenantId, OidcTenantConfig oidcConfig, TenantHolder previous,
+                TenantHolder holder) {
+            Uni<TenantConfigContext> creation = tenantContextFactory.create(oidcConfig, dynamicTenants, tenantId).onItem()
+                    .transform(
+                            new Function<>() {
+                                @Override
+                                public TenantConfigContext apply(TenantConfigContext t) {
+                                    LOG.debugf("Updating %s %s tenant config for %s", dynamicTenants ? "dynamic" : "static",
+                                            t.isReady() ? "ready" : "not-ready", tenantId);
+
+                                    holder.setContext(t);
+                                    if (needsClock) {
+                                        holder.setLastUsed(clock.getAsLong());
+                                    }
+
+                                    if (previous != null) {
+                                        // Concurrent calls to createTenantContext may race, better "destroy" the previous
+                                        // provider, if there's one.
+                                        destroyContext(previous.context());
+                                    } else if (dynamicTenants) {
+                                        enforceDynamicTenantLimit();
+                                    }
+                                    return t;
+                                }
+                            });
+            creation = creation.onFailure().invoke(new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable t) {
+                    holder.failed(t);
+                }
+            });
+            return creation;
+        }
+
+        Map<String, TenantConfigContext> tenantsCopy() {
+            Map<String, TenantHolder> map;
+            // Locks make changes visible
+            lock.lock();
+            try {
+                map = tenants;
+            } finally {
+                lock.unlock();
+            }
+            Map<String, TenantConfigContext> copy = new HashMap<>(map.size() * 4 / 3 + 1);
+            for (Map.Entry<String, TenantHolder> e : map.entrySet()) {
+                copy.put(e.getKey(), e.getValue().context());
+            }
+            return copy;
+        }
+
+        Collection<TenantHolder> holders() {
+            // Locks make changes visible
+            lock.lock();
+            try {
+                return tenants.values();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        int size() {
+            // Locks make changes visible
+            lock.lock();
+            try {
+                return tenants.size();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public Set<Map.Entry<String, TenantHolder>> entrySet() {
+            // Locks make changes visible
+            lock.lock();
+            try {
+                return tenants.entrySet();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Holds the {@link TenantConfigContext} for a tenant, optimized for non-volatile reads for "ready" tenants.
+     */
+    // VisibleForTesting
+    static final class TenantHolder {
+        /**
+         * Only populated when the context is ready.
+         */
+        TenantConfigContext readyContext;
+
+        private volatile CompletableFuture<TenantConfigContext> ctxFuture;
+        private volatile TenantConfigContext context;
+        private volatile long lastUsed;
+
+        TenantHolder(TenantConfigContext context) {
+            if (context != null) {
+                if (context.isReady()) {
+                    this.readyContext = context;
+                } else {
+                    this.context = context;
+                }
+            }
+        }
+
+        TenantConfigContext context() {
+            // Fast path, no volatile read
+            var c = readyContext;
+            if (c != null) {
+                return c;
+            }
+
+            // Slow path, volatile read
+            return context;
+        }
+
+        void setLastUsed(long lastUsed) {
+            this.lastUsed = lastUsed;
+        }
+
+        /**
+         * Called when tenant-creation returned a context.
+         *
+         * <p>
+         * Completes the completable-future to which concurrent creation-requests might have subscribed to.
+         *
+         * <p>
+         * If {@code ctx} is ready, directly populate it into the non-{@code volatile} {@link #readyContext} field,
+         * otherwise into the {@code volatile} {@link #context} field.
+         *
+         * <p>
+         * Clears the {@link #ctxFuture} field, completes the future.
+         */
+        void setContext(TenantConfigContext ctx) {
+            if (ctx != null) {
+                // Read `ctxFuture` _before_ updating the context fields.
+                var future = this.ctxFuture;
+                if (ctx.isReady()) {
+                    // non-volatile write
+                    this.readyContext = ctx;
+                    // volatile write ("publishes" the non-volatile write to readyContext)
+                    // Also setting a "ready" to this field, so that a call to `#context()` can read the updated
+                    // state "immediately".
+                    this.context = ctx;
+                } else {
+                    // It is rather not the case that this if-branch would ever be executed, but it does not hurt to
+                    // handle the not-ready case here.
+
+                    // non-volatile write
+                    this.readyContext = null;
+                    // volatile write ("publishes" the non-volatile write to readyContext)
+                    this.context = ctx;
+                }
+                if (future != null) {
+                    // Reset `ctxFuture` as the last step, after updating the other fields above.
+                    // At worst, a racing execution of `slowGetOrCreateReady` would retrieve the same result,
+                    // which is not different from the handling of a concurrent execution.
+                    this.ctxFuture = null;
+                    if (!future.isDone()) {
+                        // Propagate the result
+                        future.complete(ctx);
+                    }
+                }
+            }
+        }
+
+        /**
+         * Called when tenant-creation failed, for example when the OIDC server is (still) not reachable.
+         *
+         * <p>
+         * Clears {@link #ctxFuture} and propagates the failure to concurrent creation-requests via that future.
+         *
+         * <p>
+         * Once the {@link #ctxFuture} is cleared, a following tenant-create request causes an immediate retry.
+         * We could memoize the failure for some time and delay the next creation-request to throttle creation attempts
+         * against an unreachable/down OIDC service.
+         */
+        void failed(Throwable t) {
+            var future = this.ctxFuture;
+            if (future != null) {
+                this.ctxFuture = null;
+                if (!future.isDone()) {
+                    // Propagate the failure
+                    future.completeExceptionally(t);
+                }
+            }
+        }
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -51,8 +51,6 @@ public class TenantConfigContext {
      */
     private final SecretKey internalIdTokenGeneratedKey;
 
-    volatile long lastUsed;
-
     public static TenantConfigContext notReadyContext(OidcTenantConfig config) {
         return new TenantConfigContext(null, config,
                 getRedirectFiltersMap(TenantFeatureFinder.find(config, OidcRedirectFilter.class)));

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanAsyncTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanAsyncTest.java
@@ -1,0 +1,179 @@
+package io.quarkus.oidc.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.smallrye.mutiny.Uni;
+
+public class TenantConfigBeanAsyncTest {
+
+    private static ExecutorService executor;
+    private Semaphore asyncCompletion;
+    private AtomicInteger started;
+
+    @BeforeAll
+    static void beforeAll() {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        executor.shutdown();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        started = new AtomicInteger();
+        asyncCompletion = new Semaphore(0);
+    }
+
+    Uni<TenantConfigContext> asyncCreate(String tenantId) {
+        return Uni.createFrom().completionStage(CompletableFuture.supplyAsync(() -> {
+            try {
+                started.incrementAndGet();
+                asyncCompletion.acquire();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return testContext(tenantId);
+        }, executor));
+    }
+
+    @Test
+    public void dynamicTenantsLimitAsync() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        Set<String> evictedTenants = new HashSet<>();
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> asyncCreate(tenantId)) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                boolean evicted = super.evictTenant(candidate);
+                if (evicted) {
+                    evictedTenants.add(candidate.tenantId());
+                }
+                return evicted;
+            }
+        };
+
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            Uni<TenantConfigContext> uni = bean.getOrCreateTenantContext(tenantConfig("tenant-" + i), true);
+
+            asyncCompletion.release();
+            uni.await().indefinitely();
+
+            for (int i1 = 0; i1 < i - limit; i1++) {
+                String tenantId = "tenant-" + i1;
+                assertNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+                assertTrue(evictedTenants.contains(tenantId), tenantId);
+            }
+        }
+
+        assertEquals(10, started.get());
+    }
+
+    @Test
+    public void dynamicTenantsLimitDelayedEvictionAsync() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> asyncCreate(tenantId));
+
+        bean.tenantEvictionRunning.set(true);
+
+        List<Uni<TenantConfigContext>> unis = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            String tenantId = "tenant-" + i;
+            unis.add(bean.getOrCreateTenantContext(tenantConfig(tenantId), true));
+            assertEquals(i + 1, bean.getDynamicTenantsConfig().size());
+        }
+
+        bean.tenantEvictionRunning.set(false);
+
+        clock.incrementAndGet();
+        unis.add(bean.getOrCreateTenantContext(tenantConfig("tenant-X"), true));
+
+        asyncCompletion.release(11);
+        Uni.combine().all().unis(unis).with(l -> l).await().indefinitely();
+        assertEquals(11, started.get());
+
+        assertEquals(3, bean.getDynamicTenantsConfig().size());
+    }
+
+    @Test
+    public void dynamicTenantsLimitDelayedEvictionConcurrentAccessAsync() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        AtomicInteger concurrentAccessRemaining = new AtomicInteger(5);
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> asyncCreate(tenantId)) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                if (concurrentAccessRemaining.decrementAndGet() >= 0) {
+                    candidate.holder().setLastUsed(clock.incrementAndGet());
+                }
+                return super.evictTenant(candidate);
+            }
+        };
+
+        bean.tenantEvictionRunning.set(true);
+
+        List<Uni<TenantConfigContext>> unis = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            unis.add(bean.getOrCreateTenantContext(tenantConfig("tenant-" + i), true));
+            assertEquals(i + 1, bean.getDynamicTenantsConfig().size());
+        }
+
+        bean.tenantEvictionRunning.set(false);
+
+        clock.incrementAndGet();
+        unis.add(bean.getOrCreateTenantContext(tenantConfig("tenant-X"), true));
+
+        asyncCompletion.release(11);
+        Uni.combine().all().unis(unis).with(l -> l).await().indefinitely();
+        assertEquals(11, started.get());
+
+        assertEquals(3, bean.getDynamicTenantsConfig().size());
+    }
+
+    static TenantConfigContext testContext(String tenantId) {
+        OidcTenantConfig config = tenantConfig(tenantId);
+        return new TenantConfigContext(null, config, Collections.emptyMap());
+    }
+
+    static OidcTenantConfig tenantConfig(String tenantId) {
+        OidcTenantConfig config = new OidcTenantConfig();
+        config.setTenantId(tenantId);
+        return config;
+    }
+}

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanConcurrencyTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanConcurrencyTest.java
@@ -1,0 +1,155 @@
+package io.quarkus.oidc.runtime;
+
+import static io.quarkus.oidc.runtime.TenantConfigBeanAsyncTest.tenantConfig;
+import static io.quarkus.oidc.runtime.TenantConfigBeanAsyncTest.testContext;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.smallrye.mutiny.Uni;
+
+public class TenantConfigBeanConcurrencyTest {
+    @Test
+    public void concurrentCreatesSuccessDynamicTenant() throws Exception {
+        // using "availableProcessors" is just an illusion...
+        var concurrency = Runtime.getRuntime().availableProcessors();
+
+        var enterLatch = new CountDownLatch(1);
+        var createLatch = new CountDownLatch(1);
+        var entered = new AtomicInteger();
+        var tenantId = "my-tenant";
+
+        var executor = Executors.newCachedThreadPool();
+        try {
+
+            var bean = new TenantConfigBean(Map.of(), testContext("Default"), System::nanoTime, 0,
+                    (oidcTenantConfig, dynamicTenant, id) -> Uni.createFrom()
+                            .completionStage(CompletableFuture.supplyAsync(() -> {
+                                entered.incrementAndGet();
+                                enterLatch.countDown();
+                                try {
+                                    createLatch.await();
+                                } catch (InterruptedException e) {
+                                    throw new RuntimeException(e);
+                                }
+                                return testReadyContext(id);
+                            }, executor)));
+
+            var unis = new ArrayList<Uni<TenantConfigContext>>();
+            for (int i = 0; i < concurrency; i++) {
+                unis.add(bean.getOrCreateTenantContext(tenantConfig(tenantId), true));
+            }
+
+            enterLatch.await();
+            assertEquals(1, entered.get());
+
+            assertNull(bean.getDynamicTenantConfigContext(tenantId));
+            assertNull(bean.getDynamicTenantOidcConfig(tenantId));
+
+            createLatch.countDown();
+
+            TenantConfigContext context = null;
+            OidcTenantConfig config = null;
+            for (int i = 0; i < unis.size(); i++) {
+                var uni = unis.get(i);
+                TenantConfigContext ctx = uni.await().indefinitely();
+
+                if (i == 0) {
+                    context = bean.getDynamicTenantConfigContext(tenantId);
+                    assertNotNull(context);
+                    assertTrue(context.isReady());
+                    config = bean.getDynamicTenantOidcConfig(tenantId);
+                    assertNotNull(config);
+                }
+
+                assertSame(context, ctx);
+                assertSame(config, ctx.oidcConfig);
+            }
+
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void concurrentCreatesSuccessStaticTenant() throws Exception {
+        // using "availableProcessors" is just an illusion...
+        var concurrency = Runtime.getRuntime().availableProcessors();
+
+        var enterLatch = new CountDownLatch(1);
+        var createLatch = new CountDownLatch(1);
+        var entered = new AtomicInteger();
+        var tenantId = "my-tenant";
+
+        var executor = Executors.newCachedThreadPool();
+        try {
+
+            var bean = new TenantConfigBean(Map.of(tenantId, testContext(tenantId)), testContext("Default"), System::nanoTime,
+                    0,
+                    (oidcTenantConfig, dynamicTenant, id) -> Uni.createFrom()
+                            .completionStage(CompletableFuture.supplyAsync(() -> {
+                                entered.incrementAndGet();
+                                enterLatch.countDown();
+                                try {
+                                    createLatch.await();
+                                } catch (InterruptedException e) {
+                                    throw new RuntimeException(e);
+                                }
+                                return testReadyContext(id);
+                            }, executor)));
+
+            var unis = new ArrayList<Uni<TenantConfigContext>>();
+            for (int i = 0; i < concurrency; i++) {
+                unis.add(bean.getOrCreateTenantContext(tenantConfig(tenantId), false));
+            }
+
+            enterLatch.await();
+            assertEquals(1, entered.get());
+
+            assertNotNull(bean.getStaticTenantConfigContext(tenantId));
+            assertFalse(bean.getStaticTenantConfigContext(tenantId).isReady());
+            assertNotNull(bean.getStaticTenantOidcConfig(tenantId));
+
+            createLatch.countDown();
+
+            TenantConfigContext context = null;
+            OidcTenantConfig config = null;
+            for (int i = 0; i < unis.size(); i++) {
+                var uni = unis.get(i);
+                TenantConfigContext ctx = uni.await().indefinitely();
+
+                if (i == 0) {
+                    context = bean.getStaticTenantConfigContext(tenantId);
+                    assertNotNull(context);
+                    assertTrue(context.isReady());
+                    config = bean.getStaticTenantOidcConfig(tenantId);
+                    assertNotNull(config);
+                }
+
+                assertSame(context, ctx);
+                assertSame(config, ctx.oidcConfig);
+            }
+
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    static TenantConfigContext testReadyContext(String tenantId) {
+        OidcTenantConfig config = tenantConfig(tenantId);
+        return new TenantConfigContext(new OidcProvider(null, null, null, null), config, Map.of());
+    }
+}

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanSyncTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanSyncTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.smallrye.mutiny.Uni;
 
-public class TenantConfigBeanTest {
+public class TenantConfigBeanSyncTest {
 
     /**
      * Straight forward dynamic-tenant limit test, create 10 tenants - implementation limits the number of dynamic tenants.
@@ -193,7 +193,7 @@ public class TenantConfigBeanTest {
             boolean evictTenant(EvictionCandidate candidate) {
                 Long newLastUsed = newMaxLastUsed.get(candidate.tenantId());
                 if (newLastUsed != null) {
-                    candidate.context().lastUsed = newLastUsed;
+                    candidate.holder().setLastUsed(newLastUsed);
                 }
                 boolean evicted = super.evictTenant(candidate);
                 if (evicted) {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TenantConfigBeanTest.java
@@ -1,0 +1,246 @@
+package io.quarkus.oidc.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.smallrye.mutiny.Uni;
+
+public class TenantConfigBeanTest {
+
+    /**
+     * Straight forward dynamic-tenant limit test, create 10 tenants - implementation limits the number of dynamic tenants.
+     */
+    @Test
+    public void dynamicTenantsLimit() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        Set<String> evictedTenants = new HashSet<>();
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> Uni.createFrom().item(testContext(tenantId))) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                boolean evicted = super.evictTenant(candidate);
+                if (evicted) {
+                    evictedTenants.add(candidate.tenantId());
+                }
+                return evicted;
+            }
+        };
+
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            bean.getOrCreateTenantContext(tenantConfig("tenant-" + i), true).await().indefinitely();
+
+            for (int i1 = 0; i1 < i - limit; i1++) {
+                String tenantId = "tenant-" + i1;
+                assertNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+                assertTrue(evictedTenants.contains(tenantId), tenantId);
+            }
+        }
+    }
+
+    /**
+     * Simulate delayed eviction (already running).
+     *
+     * <ol>
+     * <li>Create 10 tenants (no/blocked eviction).
+     * <li>Unblock eviction.
+     * <li>Create another tenant.
+     * <li>First 8 created tenants must have been evicted.
+     * </ol>
+     */
+    @Test
+    public void dynamicTenantsLimitDelayedEviction() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        Set<String> evictedTenants = new HashSet<>();
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> Uni.createFrom().item(testContext(tenantId))) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                boolean evicted = super.evictTenant(candidate);
+                if (evicted) {
+                    evictedTenants.add(candidate.tenantId());
+                }
+                return evicted;
+            }
+        };
+
+        bean.tenantEvictionRunning.set(true);
+
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            String tenantId = "tenant-" + i;
+            bean.getOrCreateTenantContext(tenantConfig(tenantId), true).await().indefinitely();
+            assertTrue(evictedTenants.isEmpty(), tenantId);
+        }
+
+        bean.tenantEvictionRunning.set(false);
+
+        clock.incrementAndGet();
+        bean.getOrCreateTenantContext(tenantConfig("tenant-X"), true).await().indefinitely();
+        for (int i = 0; i < 8; i++) {
+            String tenantId = "tenant-" + i;
+            assertNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertTrue(evictedTenants.contains(tenantId), tenantId);
+        }
+    }
+
+    /**
+     * Simulate delayed eviction (already running).
+     *
+     * <ol>
+     * <li>Create 10 tenants (no/blocked eviction).
+     * <li>Simulate usa of the first 5 tenants.
+     * <li>Unblock eviction.
+     * <li>Create another tenant.
+     * <li>Tenants 0-2 + 5-9 must have been evicted (3,4,X are the three newest).
+     * </ol>
+     */
+    @Test
+    public void dynamicTenantsLimitDelayedEvictionRecentlyUsed() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        Set<String> evictedTenants = new HashSet<>();
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> Uni.createFrom().item(testContext(tenantId))) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                boolean evicted = super.evictTenant(candidate);
+                if (evicted) {
+                    evictedTenants.add(candidate.tenantId());
+                }
+                return evicted;
+            }
+        };
+
+        bean.tenantEvictionRunning.set(true);
+
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            String tenantId = "tenant-" + i;
+            bean.getOrCreateTenantContext(tenantConfig(tenantId), true).await().indefinitely();
+            assertTrue(evictedTenants.isEmpty(), tenantId);
+        }
+
+        for (int i = 0; i < 5; i++) {
+            clock.incrementAndGet();
+            bean.getDynamicTenantConfigContext("tenant-" + i);
+        }
+
+        bean.tenantEvictionRunning.set(false);
+
+        clock.incrementAndGet();
+        bean.getOrCreateTenantContext(tenantConfig("tenant-X"), true).await().indefinitely();
+
+        Stream.of(0, 1, 2, 5, 6, 7, 8, 9).forEach(i -> {
+            String tenantId = "tenant-" + i;
+            assertNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertTrue(evictedTenants.contains(tenantId), tenantId);
+        });
+        {
+            String tenantId = "tenant-X";
+            assertNotNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertFalse(evictedTenants.contains(tenantId), tenantId);
+        }
+    }
+
+    /**
+     * Simulate delayed eviction (already running).
+     *
+     * <ol>
+     * <li>Create 10 tenants (no/blocked eviction).
+     * <li>Unblock eviction.
+     * <li>Create another tenant.
+     * <li>Simulate use of the first 5 tenants _during_ eviction.
+     * <li>Tenants 0-2 + 5-9 must have been evicted (3,4,X are the three newest).
+     * </ol>
+     */
+    @Test
+    public void dynamicTenantsLimitDelayedEvictionConcurrentAccess() {
+        AtomicLong clock = new AtomicLong();
+
+        int limit = 3;
+
+        Set<String> evictedTenants = new HashSet<>();
+        Map<String, Long> newMaxLastUsed = new HashMap<>();
+
+        TenantConfigBean bean = new TenantConfigBean(Collections.emptyMap(), testContext("Default"), clock::get, limit,
+                (oidcTenantConfig, dynamicTenant, tenantId) -> Uni.createFrom().item(testContext(tenantId))) {
+            @Override
+            boolean evictTenant(EvictionCandidate candidate) {
+                Long newLastUsed = newMaxLastUsed.get(candidate.tenantId());
+                if (newLastUsed != null) {
+                    candidate.context().lastUsed = newLastUsed;
+                }
+                boolean evicted = super.evictTenant(candidate);
+                if (evicted) {
+                    evictedTenants.add(candidate.tenantId());
+                }
+                return evicted;
+            }
+        };
+
+        bean.tenantEvictionRunning.set(true);
+
+        for (int i = 0; i < 10; i++) {
+            clock.incrementAndGet();
+            String tenantId = "tenant-" + i;
+            bean.getOrCreateTenantContext(tenantConfig(tenantId), true).await().indefinitely();
+            assertTrue(evictedTenants.isEmpty(), tenantId);
+        }
+
+        bean.tenantEvictionRunning.set(false);
+
+        for (int i = 0; i < 5; i++) {
+            newMaxLastUsed.put("tenant-" + i, clock.incrementAndGet());
+        }
+
+        clock.incrementAndGet();
+        bean.getOrCreateTenantContext(tenantConfig("tenant-X"), true).await().indefinitely();
+
+        Stream.of(0, 1, 2, 5, 6, 7, 8, 9).forEach(i -> {
+            String tenantId = "tenant-" + i;
+            assertNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertTrue(evictedTenants.contains(tenantId), tenantId);
+        });
+        {
+            String tenantId = "tenant-X";
+            assertNotNull(bean.getDynamicTenantConfigContext(tenantId), tenantId);
+            assertFalse(evictedTenants.contains(tenantId), tenantId);
+        }
+    }
+
+    static TenantConfigContext testContext(String tenantId) {
+        OidcTenantConfig config = tenantConfig(tenantId);
+        return new TenantConfigContext(null, config, Collections.emptyMap());
+    }
+
+    static OidcTenantConfig tenantConfig(String tenantId) {
+        OidcTenantConfig config = new OidcTenantConfig();
+        config.setTenantId(tenantId);
+        return config;
+    }
+}

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -62,7 +62,7 @@ public class ProtectedResource {
     }
 
     private String getClientName() {
-        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenantsConfig().get(session.getTenantId())
+        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenant(session.getTenantId())
                 .getOidcTenantConfig();
         return oidcConfig.getClientName().get();
     }

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -62,8 +62,7 @@ public class ProtectedResource {
     }
 
     private String getClientName() {
-        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenant(session.getTenantId())
-                .getOidcTenantConfig();
+        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenantOidcConfig(session.getTenantId());
         return oidcConfig.getClientName().get();
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
@@ -39,7 +39,7 @@ public class TenantRefresh {
             // Cookie format: jwt|<tenant id>
 
             String[] pair = sessionExpired.split("\\|");
-            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenantsConfig().get(pair[1]).getOidcTenantConfig();
+            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenant(pair[1]).getOidcTenantConfig();
             JsonWebToken jwt = new DefaultJWTParser().decrypt(pair[0], oidcConfig.credentials.secret.get());
 
             OidcUtils.removeCookie(context, oidcConfig, "session_expired");

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
@@ -39,7 +39,7 @@ public class TenantRefresh {
             // Cookie format: jwt|<tenant id>
 
             String[] pair = sessionExpired.split("\\|");
-            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenant(pair[1]).getOidcTenantConfig();
+            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenantConfigContext(pair[1]).getOidcTenantConfig();
             JsonWebToken jwt = new DefaultJWTParser().decrypt(pair[0], oidcConfig.credentials.secret.get());
 
             OidcUtils.removeCookie(context, oidcConfig, "session_expired");

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -199,6 +199,7 @@ quarkus.http.proxy.allow-forwarded=true
 
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime".level=DEBUG
 quarkus.log.category."io.quarkus.resteasy.runtime.AuthenticationFailedExceptionMapper".level=DEBUG
 quarkus.log.category."io.quarkus.resteasy.runtime.AuthenticationCompletionExceptionMapper".level=DEBUG
 quarkus.log.category."io.quarkus.resteasy.runtime.UnauthorizedExceptionMapper".level=DEBUG

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -358,7 +358,8 @@ public class CodeFlowTest {
             page = webClient.getPage(endpointLocationWithoutQueryUri.toURL());
             String response = page.getBody().asNormalizedText();
             assertTrue(
-                    response.startsWith("tenant-https:reauthenticated?code=b&expiresAt=" + expiresAt + "&expiresInDuration="));
+                    response.startsWith("tenant-https:reauthenticated?code=b&expiresAt=" + expiresAt + "&expiresInDuration="),
+                    response);
             Integer duration = Integer.valueOf(response.substring(response.length() - 1));
             assertTrue(duration > 1 && duration < 5);
 

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -233,6 +233,7 @@ quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime".level=DEBUG
 quarkus.log.file.enable=true
 quarkus.log.file.format=%C - %s%n
 


### PR DESCRIPTION
Refactors `TenantConfigBean` internally to both prevent concurrent creation of the same OIDC tenant and optimizes the implementation to use non-volatile fields.

Tenant contexts are managed via the map-container (`TenantsMap`) and map-value type (`TenantHolder`), both are optimized for the "99.99% case" that the maps of static and dynamic tenants are "fully populated" and all (active) tenants have a "ready" context.

Retrieving a tenant hits the "fast path" in the vast majority of all invocations, accessing only non-volatile fields and a non-concurrent hash map.

In case a tenant is not yet present (new dynamic tenant ID or late-initialized static default tenant), the implementations switches to the "slow path" and creates a new hash map with the new tenant and updates the non-volatile field referencing the tenants-map. Other threads that might not yet "see" the updated tenants-map field would also enter the slow path - but once the slow path has been executed, the update to the tenants-map field will be "visible".

The `TenantHolder` uses a mixture of non-volatile (the "99.99% case" is accessing a ready context) and volatile fields. The latter are used to make changes immediately "visible" to other threads - the order of writes is important here. Unlike `TenantsMap`, the `TenantHolder` class does not use/need a lock object or monitor.
