### PR TITLE
Revert "Satisfy GraalVM's classpath needs for the deletion of `org.h2.fulltext.FullTextLucene`"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -121,7 +121,7 @@
         <cronutils.version>9.2.1</cronutils.version>
         <quartz.version>2.3.2</quartz.version>
         <h2.version>2.3.232</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions
-                                              and dependencies jts-core and lucene-core need to be updated in extensions/jdbc/jdbc-h2/runtime/pom.xml -->
+                                              and the dependency jts-core needs to be updated in extensions/jdbc/jdbc-h2/runtime/pom.xml -->
         <postgresql-jdbc.version>42.7.4</postgresql-jdbc.version>
         <mariadb-jdbc.version>3.4.1</mariadb-jdbc.version>
         <mysql-jdbc.version>8.3.0</mysql-jdbc.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -340,6 +340,11 @@ public interface NativeConfig {
      * If errors should be reported at runtime. This is a more relaxed setting, however it is not recommended as it
      * means
      * your application may fail at runtime if an unsupported feature is used by accident.
+     *
+     * Note that the use of this flag may result in build time failures due to {@code ClassNotFoundException}s.
+     * Reason most likely being that the Quarkus extension already optimized it away or do not actually need it.
+     * In such cases you should explicitly add the corresponding dependency providing the missing classes as a
+     * dependency to your project.
      */
     @WithDefault("false")
     boolean reportErrorsAtRuntime();

--- a/extensions/jdbc/jdbc-h2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-h2/runtime/pom.xml
@@ -22,15 +22,6 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
-            <!--
-                Needed by GraalVM to delete org.h2.fulltext.FullTextLucene
-                https://github.com/quarkusio/quarkus/issues/42228
-            -->
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-core</artifactId>
-            <version>9.7.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
             <version>1.19.0</version>


### PR DESCRIPTION
Follow up to discussion https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Lucene.20in.20jdbc-h2.3F where we concluded that optional dependencies should not be added by default for the shake of making `quarkus.native.report-errors-at-runtime` easy to use, since its' use is discouraged either way.

Instead we document the issue as known explaining what the work around is.

Ideally we could have Quarkus catch the error and report some more user-friendly like

```
`quarkus.native.report-errors-at-runtime` is set and a `NoClassDefFoundError` was thrown by GraalVM's `AnnotationSubstitutionProcessor` which indicates that you should explicitly add the corresponding dependency providing the missing classes as a dependency to your project.
```

Reverts #42859