### PR TITLE
Update OidcRequestFilter to use OidcRequestContext

### DIFF
--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
@@ -21,6 +21,7 @@ import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcEndpoint.Type;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
+import io.quarkus.oidc.common.OidcRequestFilter.OidcRequestContext;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.smallrye.mutiny.Multi;
@@ -157,9 +158,10 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
             Buffer body) {
         if (!filters.isEmpty()) {
             OidcRequestContextProperties props = new OidcRequestContextProperties();
+            OidcRequestContext context = new OidcRequestContext(request, body, props);
             for (OidcRequestFilter filter : OidcCommonUtils.getMatchingOidcRequestFilters(filters,
                     OidcEndpoint.Type.CLIENT_REGISTRATION)) {
-                filter.filter(request, body, props);
+                filter.filter(context);
             }
         }
         return request;

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
@@ -20,6 +20,7 @@ import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcEndpoint.Type;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
+import io.quarkus.oidc.common.OidcRequestFilter.OidcRequestContext;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.smallrye.mutiny.Uni;
@@ -162,9 +163,10 @@ public class RegisteredClientImpl implements RegisteredClient {
     private HttpRequest<Buffer> filter(HttpRequest<Buffer> request, Buffer body) {
         if (!filters.isEmpty()) {
             OidcRequestContextProperties props = new OidcRequestContextProperties();
+            OidcRequestContext context = new OidcRequestContext(request, body, props);
             for (OidcRequestFilter filter : OidcCommonUtils.getMatchingOidcRequestFilters(filters,
                     OidcEndpoint.Type.CLIENT_CONFIGURATION)) {
-                filter.filter(request, body, props);
+                filter.filter(context);
             }
         }
         return request;

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -20,6 +20,7 @@ import io.quarkus.oidc.client.Tokens;
 import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
+import io.quarkus.oidc.common.OidcRequestFilter.OidcRequestContext;
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials.Jwt.Source;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
@@ -293,8 +294,9 @@ public class OidcClientImpl implements OidcClient {
         if (!filters.isEmpty()) {
             OidcRequestContextProperties props = new OidcRequestContextProperties(
                     Map.of(CLIENT_ID_ATTRIBUTE, oidcConfig.getId().orElse(DEFAULT_OIDC_CLIENT_ID)));
+            OidcRequestContext context = new OidcRequestContext(request, body, props);
             for (OidcRequestFilter filter : OidcCommonUtils.getMatchingOidcRequestFilters(filters, endpointType)) {
-                filter.filter(request, body, props);
+                filter.filter(context);
             }
         }
         return request;

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestFilter.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestFilter.java
@@ -12,11 +12,35 @@ import io.vertx.mutiny.ext.web.client.HttpRequest;
 public interface OidcRequestFilter {
 
     /**
+     * OIDC request context which provides access to the HTTP request headers and body, as well as context properties.
+     */
+    record OidcRequestContext(HttpRequest<Buffer> request, Buffer requestBody, OidcRequestContextProperties contextProperties) {
+    }
+
+    /**
+     * Filter OIDC request.
+     *
+     * @param requestContext the request context which provides access to the HTTP request headers and body, as well as context
+     *        properties.
+     *
+     */
+    default void filter(OidcRequestContext requestContext) {
+        filter(requestContext.request(), requestContext.requestBody(), requestContext.contextProperties());
+    }
+
+    /**
      * Filter OIDC requests
      *
      * @param request HTTP request that can have its headers customized
      * @param requestBody request body, will be null for HTTP GET methods, may be null for other HTTP methods
      * @param contextProperties context properties that can be available in context of some requests
+     *
+     * @deprecated use {@link #filter(OidcRequestContext)}
      */
-    void filter(HttpRequest<Buffer> request, Buffer requestBody, OidcRequestContextProperties contextProperties);
+    @Deprecated(forRemoval = true)
+    default void filter(HttpRequest<Buffer> request, Buffer requestBody, OidcRequestContextProperties contextProperties) {
+        throw new UnsupportedOperationException(
+                "filter(HttpRequest<Buffer> request, Buffer requestBody, OidcRequestContextProperties contextProperties)"
+                        + " method is not implemented");
+    }
 }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -43,6 +43,7 @@ import io.quarkus.credentials.runtime.CredentialsProviderFinder;
 import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
+import io.quarkus.oidc.common.OidcRequestFilter.OidcRequestContext;
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials;
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials.Provider;
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials.Secret;
@@ -497,8 +498,9 @@ public class OidcCommonUtils {
                     : new HashMap<>(contextProperties.getAll());
             newProperties.put(OidcRequestContextProperties.DISCOVERY_ENDPOINT, discoveryUrl);
             OidcRequestContextProperties requestProps = new OidcRequestContextProperties(newProperties);
+            OidcRequestContext context = new OidcRequestContext(request, null, requestProps);
             for (OidcRequestFilter filter : getMatchingOidcRequestFilters(filters, OidcEndpoint.Type.DISCOVERY)) {
-                filter.filter(request, null, requestProps);
+                filter.filter(context);
             }
         }
         return sendRequest(vertx, request, blockingDnsLookup).onItem().transform(resp -> {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -18,6 +18,7 @@ import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
+import io.quarkus.oidc.common.OidcRequestFilter.OidcRequestContext;
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials.Secret.Method;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
@@ -274,8 +275,9 @@ public class OidcProviderClient implements Closeable {
             newProperties.put(OidcUtils.TENANT_ID_ATTRIBUTE, oidcConfig.getTenantId().orElse(OidcUtils.DEFAULT_TENANT_ID));
             newProperties.put(OidcConfigurationMetadata.class.getName(), metadata);
             OidcRequestContextProperties newContextProperties = new OidcRequestContextProperties(newProperties);
+            OidcRequestContext context = new OidcRequestContext(request, body, newContextProperties);
             for (OidcRequestFilter filter : OidcCommonUtils.getMatchingOidcRequestFilters(filters, endpointType)) {
-                filter.filter(request, body, newContextProperties);
+                filter.filter(context);
             }
         }
         return request;

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcDiscoveryJwksRequestCustomizer.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcDiscoveryJwksRequestCustomizer.java
@@ -6,7 +6,6 @@ import io.quarkus.arc.Unremovable;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcEndpoint.Type;
-import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.vertx.mutiny.core.buffer.Buffer;
@@ -18,13 +17,13 @@ import io.vertx.mutiny.ext.web.client.HttpRequest;
 public class OidcDiscoveryJwksRequestCustomizer implements OidcRequestFilter {
 
     @Override
-    public void filter(HttpRequest<Buffer> request, Buffer buffer, OidcRequestContextProperties contextProps) {
-        if (!request.uri().endsWith(".well-known/openid-configuration")
-                && !isJwksRequest(request)) {
-            throw new OIDCException("Filter is applied to the wrong endpoint: " + request.uri());
+    public void filter(OidcRequestContext rc) {
+        if (!rc.request().uri().endsWith(".well-known/openid-configuration")
+                && !isJwksRequest(rc.request())) {
+            throw new OIDCException("Filter is applied to the wrong endpoint: " + rc.request().uri());
         }
-        request.putHeader("Filter", "OK");
-        request.putHeader(OidcUtils.TENANT_ID_ATTRIBUTE, contextProps.getString(OidcUtils.TENANT_ID_ATTRIBUTE));
+        rc.request().putHeader("Filter", "OK");
+        rc.request().putHeader(OidcUtils.TENANT_ID_ATTRIBUTE, rc.contextProperties().getString(OidcUtils.TENANT_ID_ATTRIBUTE));
     }
 
     private boolean isJwksRequest(HttpRequest<Buffer> request) {


### PR DESCRIPTION
The goal of this PR is to align `OidcRequestFilter` with the way [OidcRedirectFilter](https://github.com/quarkusio/quarkus/blob/main/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcRedirectFilter.java) packages several parameters into a single context object, to make it consistent, in preparation for the introduction of `OidcResponseFilter`, and to hide a little bit lower level Vert.x client specific API references as not every filter may be needing them.

So this PR deprecates the current `OidcRequestFilter` method and introduces a more compact version of it.
It is not really critical to have this PR merged, but once `OidcResponseFilter` is introduced, with `OidcRedirectFilter` being already around, the `OidcRequestFilter` API would look quite low level and out of sync compared to the API of those 2 filter types