### PR TITLE
Make generated Jackson serializers to work with null values of boxed types

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -145,10 +145,6 @@ public abstract class JacksonCodeGenerator {
         return name.substring(0, 1).toUpperCase() + name.substring(1);
     }
 
-    protected static boolean isBooleanType(String type) {
-        return type.equals("boolean") || type.equals("java.lang.Boolean");
-    }
-
     protected static boolean vetoedClassName(String className) {
         return className.startsWith("java.") || className.startsWith("jakarta.") || className.startsWith("io.vertx.core.json.");
     }
@@ -224,7 +220,7 @@ public abstract class JacksonCodeGenerator {
         if (namedAccessor != null) {
             return namedAccessor;
         }
-        String methodName = (isBooleanType(fieldInfo.type().name().toString()) ? "is" : "get") + ucFirst(fieldInfo.name());
+        String methodName = (fieldInfo.type().name().toString().equals("boolean") ? "is" : "get") + ucFirst(fieldInfo.name());
         return findMethod(classInfo, methodName);
     }
 

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -491,7 +491,8 @@ public class SimpleJsonResource extends SuperClass<Person> {
                 type = ((ParameterizedType) type).getActualTypeArguments()[0];
             }
             if (!type.getTypeName().equals(Person.class.getName())) {
-                throw new IllegalArgumentException("Only Person type can be handled");
+                throw new IllegalArgumentException(
+                        "Type'" + type.getTypeName() + "' cannot be handled. Only 'Person' type is valid");
             }
             return objectMapper.reader().with(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES);
         }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -674,4 +674,21 @@ public class SimpleJsonTest {
                 .body("veterinarian.name", Matchers.is("Dolittle"))
                 .body("veterinarian.title", Matchers.nullValue());
     }
+
+    @Test
+    public void testEchoWithMissingPrimitive() {
+        RestAssured
+                .with()
+                .body("{\"publicName\":\"Leo\",\"veterinarian\":{\"name\":\"Dolittle\"},\"age\":5}")
+                .contentType("application/json; charset=utf-8")
+                .post("/simple/dog-echo")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("publicName", Matchers.is("Leo"))
+                .body("privateName", Matchers.nullValue())
+                .body("age", Matchers.is(5))
+                .body("veterinarian.name", Matchers.is("Dolittle"))
+                .body("veterinarian.title", Matchers.nullValue());
+    }
 }


### PR DESCRIPTION
As mentioned [here](https://github.com/quarkusio/quarkus/issues/43104#issuecomment-2337992871), merging [this commit](https://github.com/quarkusio/quarkus/commit/c9e613075397fcda1c2d726f9ccda4d04c765c90) actually unveiled a couple of defects in the generated Jackson serializers:

1. The getter method of a boolean field should start with "is" only when using the primitive type boolean, but not with the corresponding boxed type `java.lang.Boolean`. Fixed [here](https://github.com/quarkusio/quarkus/compare/main...mariofusco:q43104?expand=1#diff-e67eb43613dd12446dfb933a15e32d2c96b6c46c484b9de2fa17574329d69db4L227).
2. When the Java object to be serialized has a boxed type field, the value of the field is automatically unboxed during the serialization, but of course this fails when the value is null, so it has to be guarded by a null check. Fixed [here](https://github.com/quarkusio/quarkus/compare/main...mariofusco:q43104?expand=1#diff-7397165a1cec242fcc986e0672c4d51d55c82b00f9626ff7978aa4e5537762fcR279).