### PR TITLE
Add runtime properties to Quarkus builder

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -227,7 +227,8 @@ public class CodeGenerator {
         if (previouslyRecordedProperties.isEmpty()) {
             try {
                 readConfig(appModel, mode, buildSystemProps, deploymentClassLoader, configReader -> {
-                    var config = configReader.initConfiguration(mode, buildSystemProps, appModel.getPlatformProperties());
+                    var config = configReader.initConfiguration(mode, buildSystemProps, new Properties(),
+                            appModel.getPlatformProperties());
                     final Map<String, String> allProps = new HashMap<>();
                     for (String name : config.getPropertyNames()) {
                         allProps.put(name, ConfigTrackingValueTransformer.asString(config.getConfigValue(name)));
@@ -287,7 +288,8 @@ public class CodeGenerator {
     public static Config getConfig(ApplicationModel appModel, LaunchMode launchMode, Properties buildSystemProps,
             QuarkusClassLoader deploymentClassLoader) throws CodeGenException {
         return readConfig(appModel, launchMode, buildSystemProps, deploymentClassLoader,
-                configReader -> configReader.initConfiguration(launchMode, buildSystemProps, appModel.getPlatformProperties()));
+                configReader -> configReader.initConfiguration(launchMode, buildSystemProps, new Properties(),
+                        appModel.getPlatformProperties()));
     }
 
     public static <T> T readConfig(ApplicationModel appModel, LaunchMode launchMode, Properties buildSystemProps,

--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -132,12 +132,14 @@ public final class ExtensionLoader {
      * @throws IOException if the class loader could not load a resource
      * @throws ClassNotFoundException if a build step class is not found
      */
-    public static Consumer<BuildChainBuilder> loadStepsFrom(ClassLoader classLoader, Properties buildSystemProps,
+    public static Consumer<BuildChainBuilder> loadStepsFrom(ClassLoader classLoader,
+            Properties buildSystemProps, Properties runtimeProperties,
             ApplicationModel appModel, LaunchMode launchMode, DevModeType devModeType)
             throws IOException, ClassNotFoundException {
 
         final BuildTimeConfigurationReader reader = new BuildTimeConfigurationReader(classLoader);
-        final SmallRyeConfig src = reader.initConfiguration(launchMode, buildSystemProps, appModel.getPlatformProperties());
+        final SmallRyeConfig src = reader.initConfiguration(launchMode, buildSystemProps, runtimeProperties,
+                appModel.getPlatformProperties());
         // install globally
         QuarkusConfigFactory.setConfig(src);
         final BuildTimeConfigurationReader.ReadResult readResult = reader.readConfiguration(src);

--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -55,6 +55,7 @@ public class QuarkusAugmentor {
     private final Collection<Path> excludedFromIndexing;
     private final LiveReloadBuildItem liveReloadBuildItem;
     private final Properties buildSystemProperties;
+    private final Properties runtimeProperties;
     private final Path targetDir;
     private final ApplicationModel effectiveModel;
     private final Supplier<DependencyInfoProvider> depInfoProvider;
@@ -75,6 +76,7 @@ public class QuarkusAugmentor {
         this.excludedFromIndexing = builder.excludedFromIndexing;
         this.liveReloadBuildItem = builder.liveReloadState;
         this.buildSystemProperties = builder.buildSystemProperties;
+        this.runtimeProperties = builder.runtimeProperties;
         this.targetDir = builder.targetDir;
         this.effectiveModel = builder.effectiveModel;
         this.baseName = builder.baseName;
@@ -102,13 +104,9 @@ public class QuarkusAugmentor {
             final BuildChainBuilder chainBuilder = BuildChain.builder();
             chainBuilder.setClassLoader(deploymentClassLoader);
 
-            //provideCapabilities(chainBuilder);
-
-            //TODO: we load everything from the deployment class loader
-            //this allows the deployment config (application.properties) to be loaded, but in theory could result
-            //in additional stuff from the deployment leaking in, this is unlikely but has a bit of a smell.
             ExtensionLoader.loadStepsFrom(deploymentClassLoader,
                     buildSystemProperties == null ? new Properties() : buildSystemProperties,
+                    runtimeProperties == null ? new Properties() : runtimeProperties,
                     effectiveModel, launchMode, devModeType)
                     .accept(chainBuilder);
 
@@ -210,6 +208,7 @@ public class QuarkusAugmentor {
         LaunchMode launchMode = LaunchMode.NORMAL;
         LiveReloadBuildItem liveReloadState = new LiveReloadBuildItem();
         Properties buildSystemProperties;
+        Properties runtimeProperties;
 
         ApplicationModel effectiveModel;
         String baseName = QUARKUS_APPLICATION;
@@ -319,6 +318,15 @@ public class QuarkusAugmentor {
 
         public Builder setBuildSystemProperties(final Properties buildSystemProperties) {
             this.buildSystemProperties = buildSystemProperties;
+            return this;
+        }
+
+        public Properties getRuntimeProperties() {
+            return runtimeProperties;
+        }
+
+        public Builder setRuntimeProperties(final Properties runtimeProperties) {
+            this.runtimeProperties = runtimeProperties;
             return this;
         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
@@ -51,6 +51,7 @@ public class JBangAugmentorImpl implements BiConsumer<CuratedApplication, Map<St
                     .setTargetDir(quarkusBootstrap.getTargetDirectory())
                     .setDeploymentClassLoader(curatedApplication.createDeploymentClassLoader())
                     .setBuildSystemProperties(quarkusBootstrap.getBuildSystemProperties())
+                    .setRuntimeProperties(quarkusBootstrap.getRuntimeProperties())
                     .setEffectiveModel(curatedApplication.getApplicationModel());
             if (quarkusBootstrap.getBaseName() != null) {
                 builder.setBaseName(quarkusBootstrap.getBaseName());

--- a/core/launcher/src/main/java/io/quarkus/launcher/JBangIntegration.java
+++ b/core/launcher/src/main/java/io/quarkus/launcher/JBangIntegration.java
@@ -12,6 +12,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 
@@ -46,6 +47,7 @@ public class JBangIntegration {
             return ret;
         }
 
+        Properties configurationProperties = new Properties();
         for (String comment : comments) {
             //we allow config to be provided via //Q:CONFIG name=value
             if (comment.startsWith(CONFIG)) {
@@ -54,7 +56,7 @@ public class JBangIntegration {
                 if (equals == -1) {
                     throw new RuntimeException("invalid config  " + comment);
                 }
-                System.setProperty(conf.substring(0, equals), conf.substring(equals + 1));
+                configurationProperties.setProperty(conf.substring(0, equals), conf.substring(equals + 1));
             }
         }
 
@@ -117,12 +119,15 @@ public class JBangIntegration {
             Thread.currentThread().setContextClassLoader(loader);
             Class<?> launcher = loader.loadClass("io.quarkus.bootstrap.jbang.JBangBuilderImpl");
             return (Map<String, Object>) launcher
-                    .getDeclaredMethod("postBuild", Path.class, Path.class, List.class, List.class, boolean.class).invoke(
+                    .getDeclaredMethod("postBuild", Path.class, Path.class, List.class, List.class, Properties.class,
+                            boolean.class)
+                    .invoke(
                             null,
                             appClasses,
                             pomFile,
                             repositories,
                             dependencies,
+                            configurationProperties,
                             nativeImage);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -65,6 +65,7 @@ public class QuarkusBootstrap implements Serializable {
     private final List<Path> excludeFromClassPath;
 
     private final Properties buildSystemProperties;
+    private final Properties runtimeProperties;
     private final String baseName;
     private final String originalBaseName;
     private final Path targetDirectory;
@@ -100,6 +101,7 @@ public class QuarkusBootstrap implements Serializable {
         this.excludeFromClassPath = new ArrayList<>(builder.excludeFromClassPath);
         this.projectRoot = builder.projectRoot != null ? builder.projectRoot.normalize() : null;
         this.buildSystemProperties = builder.buildSystemProperties != null ? builder.buildSystemProperties : new Properties();
+        this.runtimeProperties = builder.runtimeProperties != null ? builder.runtimeProperties : new Properties();
         this.mode = builder.mode;
         this.offline = builder.offline;
         this.test = builder.test;
@@ -202,6 +204,10 @@ public class QuarkusBootstrap implements Serializable {
         return buildSystemProperties;
     }
 
+    public Properties getRuntimeProperties() {
+        return runtimeProperties;
+    }
+
     public Path getProjectRoot() {
         return projectRoot;
     }
@@ -266,6 +272,7 @@ public class QuarkusBootstrap implements Serializable {
                 .setProjectRoot(projectRoot)
                 .setBaseClassLoader(baseClassLoader)
                 .setBuildSystemProperties(buildSystemProperties)
+                .setRuntimeProperties(runtimeProperties)
                 .setMode(mode)
                 .setTest(test)
                 .setLocalProjectDiscovery(localProjectDiscovery)
@@ -316,6 +323,7 @@ public class QuarkusBootstrap implements Serializable {
         final List<Path> additionalDeploymentArchives = new ArrayList<>();
         final List<Path> excludeFromClassPath = new ArrayList<>();
         Properties buildSystemProperties;
+        Properties runtimeProperties;
         Mode mode = Mode.PROD;
         Boolean offline;
         boolean test;
@@ -386,6 +394,11 @@ public class QuarkusBootstrap implements Serializable {
 
         public Builder setBuildSystemProperties(Properties buildSystemProperties) {
             this.buildSystemProperties = buildSystemProperties;
+            return this;
+        }
+
+        public Builder setRuntimeProperties(Properties runtimeProperties) {
+            this.runtimeProperties = runtimeProperties;
             return this;
         }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/jbang/JBangBuilderImpl.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/jbang/JBangBuilderImpl.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.eclipse.aether.repository.RemoteRepository;
@@ -26,8 +27,12 @@ import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.maven.dependency.ResolvedArtifactDependency;
 
 public class JBangBuilderImpl {
-    public static Map<String, Object> postBuild(Path appClasses, Path pomFile, List<Map.Entry<String, String>> repositories,
+    public static Map<String, Object> postBuild(
+            Path appClasses,
+            Path pomFile,
+            List<Map.Entry<String, String>> repositories,
             List<Map.Entry<String, Path>> dependencies,
+            Properties configurationProperties,
             boolean nativeImage) {
         final MavenArtifactResolver quarkusResolver;
         try {
@@ -80,6 +85,8 @@ public class JBangBuilderImpl {
                     }).collect(Collectors.toList()))
                     .setAppArtifact(appArtifact)
                     .setIsolateDeployment(true)
+                    .setBuildSystemProperties(configurationProperties)
+                    .setRuntimeProperties(configurationProperties)
                     .setMode(QuarkusBootstrap.Mode.PROD);
 
             CuratedApplication app = builder


### PR DESCRIPTION
This allows integrators to set runtime properties to be recorded in the Quarkus build.

- Fixes #30087 