### PR TITLE
Update rest-data-panache docs to clarify experimental status

### DIFF
--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -13,7 +13,6 @@ include::_attributes.adoc[]
 A lot of web applications are monotonous CRUD applications with REST APIs that are tedious to write.
 To streamline this task, REST Data with Panache extension can generate the basic CRUD endpoints for your entities and repositories.
 
-While this extension is still experimental and provides a limited feature set, we hope to get an early feedback for it.
 Currently, this extension supports Hibernate ORM and MongoDB with Panache and can generate CRUD resources that work with `application/json` and `application/hal+json` content.
 
 == Setting up REST Data with Panache
@@ -23,17 +22,20 @@ Please, check out the next compatibility table to use the right one according to
 
 .Compatibility Table
 |===
-|Extension |Hibernate | RESTEasy
+|Extension |Status |Hibernate |RESTEasy
 
 |<<hr-hibernate-orm,quarkus-hibernate-orm-rest-data-panache>>
+|`Stable`
 |`ORM`
 |`Classic and Reactive`
 
 |<<hr-hibernate-reactive,quarkus-hibernate-reactive-rest-data-panache>>
+|`Experimental`
 |`Reactive`
 |`Reactive`
 
 |<<hr-mongodb,quarkus-mongodb-rest-data-panache>>
+|`Experimental`
 |`ORM`
 |`Classic and Reactive`
 |===


### PR DESCRIPTION
The Panache extension for generating CRUD resources is split into 3 packages, the most-used one of which is stable. But readers of the guide are greeted with a warning claiming the feature is experimental, which is driving teams away from using it. This patch removes the warning and clarifies in the compatibility table the status of each package, as per https://quarkus.io/extensions/?search-regex=panache&status=stable