### PR TITLE
Change OidcEndpoint.Type for the dynamically registered client

### DIFF
--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
@@ -165,7 +165,7 @@ public class RegisteredClientImpl implements RegisteredClient {
             OidcRequestContextProperties props = new OidcRequestContextProperties();
             OidcRequestContext context = new OidcRequestContext(request, body, props);
             for (OidcRequestFilter filter : OidcCommonUtils.getMatchingOidcRequestFilters(filters,
-                    OidcEndpoint.Type.CLIENT_CONFIGURATION)) {
+                    OidcEndpoint.Type.REGISTERED_CLIENT)) {
                 filter.filter(context);
             }
         }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcEndpoint.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcEndpoint.java
@@ -48,9 +48,9 @@ public @interface OidcEndpoint {
          */
         CLIENT_REGISTRATION,
         /**
-         * Applies to the configuration requests of the dynamically registered OIDC clients
+         * Applies to requests to dynamically registered OIDC client endpoints
          */
-        CLIENT_CONFIGURATION
+        REGISTERED_CLIENT
     }
 
     /**


### PR DESCRIPTION
Minor update to the code currently on `main` only.

`OidcEndpoint.Type` can be used to restrict `OidcRequestFilter`, and soon, `OidcResponseFilter`, to filtering specific OIDC endpoints only.
As far as OIDC dynamic client registration is concerned, it can make calls to 2 endpoints:
* the client registration endpoint (`OidcEndpoint.Type: CLIENT_REGISTRATION`).
* the endpoint representing a newly registered client, where the client's configuration can be read again, or updated, or the whole client registration can be deleted. Currently this endpoint is represented by the `OidcEndpoint.Type: CLIENT_CONFIGURATION` endpoint type, but it does not feel quite right. PR proposes to change it to `REGISTERED_CLIENT`, to align with the `RegisteredClient` class name which manages the registered client

