### PR TITLE
Sync Pulsar image version in pulsar-getting-started guide

### DIFF
--- a/docs/src/main/asciidoc/pulsar-getting-started.adoc
+++ b/docs/src/main/asciidoc/pulsar-getting-started.adoc
@@ -405,7 +405,7 @@ version: '3.8'
 services:
 
   pulsar:
-    image: apachepulsar/pulsar:3.0.0
+    image: apachepulsar/pulsar:3.3.0
     command: [
       "sh", "-c",
       "bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone -nfw -nss"


### PR DESCRIPTION
Sync Pulsar image version in pulsar-getting-started guide

Code is using 3.3.0

 * https://github.com/quarkusio/quarkus/blob/main/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarContainer.java#L16
 * https://github.com/quarkusio/quarkus/blob/main/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesBuildTimeConfig.java#L37