### PR TITLE
Fix javadoc for quarkus.bootstrap.incubating-model-resolver

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
@@ -44,7 +44,7 @@ public class BootstrapConfig {
     boolean disableJarCache;
 
     /**
-     * A temporary option introduced to avoid a logging warning when {@code }-Dquarkus.bootstrap.incubating-model-resolver}
+     * A temporary option introduced to avoid a logging warning when {@code -Dquarkus.bootstrap.incubating-model-resolver}
      * is added to the build command line.
      * This option enables an incubating implementation of the Quarkus Application Model resolver.
      * This option will be removed as soon as the incubating implementation becomes the default one.


### PR DESCRIPTION
Noticed while working on the config doc.