### PR TITLE
Config Doc - Reset list status for passthrough maps

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/ResolvedType.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/ResolvedType.java
@@ -70,7 +70,7 @@ public record ResolvedType(
         return new ResolvedType(type, unwrappedResolvedType.unwrappedType,
                 unwrappedResolvedType.binaryName, unwrappedResolvedType.qualifiedName, unwrappedResolvedType.simplifiedName,
                 unwrappedResolvedType.isPrimitive,
-                true, unwrappedResolvedType.isList,
+                true, false,
                 unwrappedResolvedType.isOptional,
                 unwrappedResolvedType.isDeclared, unwrappedResolvedType.isInterface, unwrappedResolvedType.isClass,
                 unwrappedResolvedType.isEnum, unwrappedResolvedType.isDuration, unwrappedResolvedType.isConfigGroup);


### PR DESCRIPTION
When we have a passthroup map, we don't want to mark the type as list: we want it reported as a map.