### PR TITLE
Config Doc: use HTML tables to be able to output markdown inside cells

### DIFF
--- a/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/generator/MarkdownFormatter.java
+++ b/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/generator/MarkdownFormatter.java
@@ -19,15 +19,7 @@ final class MarkdownFormatter extends AbstractFormatter {
 
     @Override
     public String formatSectionTitle(ConfigSection configSection) {
-        // markdown only has 6 heading levels
-        int headingLevel = Math.min(6, 2 + configSection.getLevel());
-        return "#".repeat(headingLevel) + " " + super.formatSectionTitle(configSection);
-    }
-
-    @Override
-    public String escapeCellContent(String value) {
-        String cellContent = super.escapeCellContent(value);
-        return cellContent == null ? null : cellContent.replace("\n\n", "<br><br>").replace("\n", " ");
+        return "&nbsp;".repeat(configSection.getLevel() * 4) + super.formatSectionTitle(configSection);
     }
 
     @Override

--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/markdown/default/allConfig.qute.md
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/markdown/default/allConfig.qute.md
@@ -4,8 +4,15 @@
 
 # {extensionConfigRootsEntry.key.formatName}
 
-| Configuration property | Type | Default |
-|------------------------|------|---------|
+<table>
+<thead>
+<tr>
+<th align="left">Configuration property</th>
+<th>Type</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody>
 {#for configRoot in extensionConfigRootsEntry.value.values}
 {#for item in configRoot.items}
 {#if !item.deprecated}
@@ -17,6 +24,8 @@
 {/if}
 {/for}
 {/for}
+</tbody>
+</table>
 {/for}
 
 {#if includeDurationNote}

--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/markdown/default/configReference.qute.md
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/markdown/default/configReference.qute.md
@@ -1,16 +1,22 @@
 🔒: Configuration property fixed at build time - All other configuration properties are overridable at runtime
 
-{#if configItemCollection.nonDeprecatedProperties}
-| Configuration property | Type | Default |
-|------------------------|------|---------|
+<table>
+<thead>
+<tr>
+<th align="left">Configuration property</th>
+<th>Type</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody>
 {#for property in configItemCollection.nonDeprecatedProperties}
 {#configProperty configProperty=property extension=extension additionalAnchorPrefix=additionalAnchorPrefix /}
 {/for}
-{/if}
 {#for section in configItemCollection.nonDeprecatedSections}
-
 {#configSection configSection=section extension=extension additionalAnchorPrefix=additionalAnchorPrefix displayConfigRootDescription=false /}
 {/for}
+</tbody>
+</table>
 
 {#if includeDurationNote}
 {#durationNote summaryTableId /}

--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/markdown/default/tags/configProperty.qute.md
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/markdown/default/tags/configProperty.qute.md
@@ -1,1 +1,21 @@
-| {#if configProperty.phase.fixedAtBuildTime}🔒 {/if}`{configProperty.path.property}`{#for additionalPath in configProperty.additionalPaths}<br>`{additionalPath.property}`{/for}<br><br>{configProperty.formatDescription.escapeCellContent.or("")}{#envVar configProperty /} | {configProperty.formatTypeDescription.escapeCellContent.or("")} | {#if configProperty.defaultValue}{configProperty.formatDefaultValue.escapeCellContent}{/if} |
+<tr>
+<td>
+
+{#if configProperty.phase.fixedAtBuildTime}🔒 {/if}`{configProperty.path.property}`
+{#for additionalPath in configProperty.additionalPaths}
+`{additionalPath.property}`
+{/for}
+
+{configProperty.formatDescription.escapeCellContent.or("")}
+
+{#envVar configProperty /}
+</td>
+<td>
+
+{configProperty.formatTypeDescription.escapeCellContent.or("")}
+</td>
+<td>
+
+{#if configProperty.defaultValue}{configProperty.formatDefaultValue.escapeCellContent}{/if}
+</td>
+</tr>

--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/markdown/default/tags/configSection.qute.md
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/markdown/default/tags/configSection.qute.md
@@ -1,13 +1,14 @@
+<thead>
+<tr>
+<th align="left" colspan="3">
 {configSection.formatTitle}
+</th>
+</tr>
+</thead>
 
-{#if configSection.nonDeprecatedProperties}
-| Configuration property | Type | Default |
-|------------------------|------|---------|
 {#for property in configSection.nonDeprecatedProperties}
 {#configProperty configProperty=property extension=extension additionalAnchorPrefix=additionalAnchorPrefix /}
 {/for}
-{/if}
 {#for subsection in configSection.nonDeprecatedSections}
-
 {#configSection configSection=subsection extension=extension additionalAnchorPrefix=additionalAnchorPrefix /}
 {/for}


### PR DESCRIPTION
This fixes [this comment](https://github.com/quarkusio/quarkus/pull/42907#issuecomment-2343083212) by @gsmet 

Sample output of `allConfig.qute.md` for CommaFeed: https://gist.github.com/Athou/18d9ab535a4d7bebd74d916c4b023407

I think `io.quarkus.maven.config.doc.generator.MarkdownFormatter#escapeCellContent` may need to be updated to escape HTML to avoid breaking the table cells, but I'm not sure what's the best way to do that.