### PR TITLE
Add support for Socket Logging Handler with basic ECS format logging

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/LogSocketFormatBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/LogSocketFormatBuildItem.java
@@ -1,0 +1,36 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Optional;
+import java.util.logging.Formatter;
+
+import org.wildfly.common.Assert;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+
+/**
+ * The socket format build item. Producing this item will cause the logging subsystem to disregard its
+ * socket logging formatting configuration and use the formatter provided instead. If multiple formatters
+ * are enabled at runtime, a warning message is printed and only one is used.
+ */
+public final class LogSocketFormatBuildItem extends MultiBuildItem {
+    private final RuntimeValue<Optional<Formatter>> formatterValue;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param formatterValue the optional formatter runtime value to use (must not be {@code null})
+     */
+    public LogSocketFormatBuildItem(final RuntimeValue<Optional<Formatter>> formatterValue) {
+        this.formatterValue = Assert.checkNotNullParam("formatterValue", formatterValue);
+    }
+
+    /**
+     * Get the formatter value.
+     *
+     * @return the formatter value
+     */
+    public RuntimeValue<Optional<Formatter>> getFormatterValue() {
+        return formatterValue;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -75,6 +75,7 @@ import io.quarkus.deployment.builditem.LogCategoryMinLevelDefaultsBuildItem;
 import io.quarkus.deployment.builditem.LogConsoleFormatBuildItem;
 import io.quarkus.deployment.builditem.LogFileFormatBuildItem;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
+import io.quarkus.deployment.builditem.LogSocketFormatBuildItem;
 import io.quarkus.deployment.builditem.LogSyslogFormatBuildItem;
 import io.quarkus.deployment.builditem.NamedLogHandlersBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
@@ -249,6 +250,7 @@ public final class LoggingResourceProcessor {
             final List<LogConsoleFormatBuildItem> consoleFormatItems,
             final List<LogFileFormatBuildItem> fileFormatItems,
             final List<LogSyslogFormatBuildItem> syslogFormatItems,
+            final List<LogSocketFormatBuildItem> socketFormatItems,
             final Optional<ConsoleFormatterBannerBuildItem> possibleBannerBuildItem,
             final List<LogStreamBuildItem> logStreamBuildItems,
             final BuildProducer<ShutdownListenerBuildItem> shutdownListenerBuildItemBuildProducer,
@@ -290,6 +292,8 @@ public final class LoggingResourceProcessor {
                     .map(LogFileFormatBuildItem::getFormatterValue).collect(Collectors.toList());
             List<RuntimeValue<Optional<Formatter>>> possibleSyslogFormatters = syslogFormatItems.stream()
                     .map(LogSyslogFormatBuildItem::getFormatterValue).collect(Collectors.toList());
+            List<RuntimeValue<Optional<Formatter>>> possibleSocketFormatters = socketFormatItems.stream()
+                    .map(LogSocketFormatBuildItem::getFormatterValue).collect(Collectors.toList());
 
             context.registerSubstitution(InheritableLevel.ActualLevel.class, String.class, InheritableLevel.Substitution.class);
             context.registerSubstitution(InheritableLevel.Inherited.class, String.class, InheritableLevel.Substitution.class);
@@ -308,6 +312,7 @@ public final class LoggingResourceProcessor {
                             categoryMinLevelDefaults.content, alwaysEnableLogStream,
                             streamingDevUiLogHandler, handlers, namedHandlers,
                             possibleConsoleFormatters, possibleFileFormatters, possibleSyslogFormatters,
+                            possibleSocketFormatters,
                             possibleSupplier, launchModeBuildItem.getLaunchMode(), true)));
 
             List<LogCleanupFilterElement> additionalLogCleanupFilters = new ArrayList<>(logCleanupFilters.size());

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 
 import org.jboss.logmanager.handlers.AsyncHandler.OverflowAction;
+import org.jboss.logmanager.handlers.SocketHandler;
 import org.jboss.logmanager.handlers.SyslogHandler.Facility;
 import org.jboss.logmanager.handlers.SyslogHandler.Protocol;
 import org.jboss.logmanager.handlers.SyslogHandler.SyslogType;
@@ -78,6 +79,14 @@ public interface LogRuntimeConfig {
     SyslogConfig syslog();
 
     /**
+     * Socket logging.
+     * <p>
+     * Logging to a socket is also supported but not enabled by default.
+     */
+    @ConfigDocSection
+    SocketConfig socket();
+
+    /**
      * Logging categories.
      * <p>
      * Logging is done on a per-category basis. Each category can be independently configured.
@@ -114,6 +123,15 @@ public interface LogRuntimeConfig {
     @WithName("handler.syslog")
     @ConfigDocSection
     Map<String, SyslogConfig> syslogHandlers();
+
+    /**
+     * Socket handlers.
+     * <p>
+     * The named socket handlers configured here can be linked to one or more categories.
+     */
+    @WithName("handler.socket")
+    @ConfigDocSection
+    Map<String, SocketConfig> socketHandlers();
 
     /**
      * Log cleanup filters - internal use.
@@ -389,6 +407,59 @@ public interface LogRuntimeConfig {
 
         /**
          * Syslog async logging config
+         */
+        AsyncConfig async();
+    }
+
+    interface SocketConfig {
+
+        /**
+         * If socket logging should be enabled
+         */
+        @WithDefault("false")
+        boolean enable();
+
+        /**
+         *
+         * The IP address and port of the server receiving the logs
+         */
+        @WithDefault("localhost:4560")
+        @WithConverter(InetSocketAddressConverter.class)
+        InetSocketAddress endpoint();
+
+        /**
+         * Sets the protocol used to connect to the syslog server
+         */
+        @WithDefault("tcp")
+        SocketHandler.Protocol protocol();
+
+        /**
+         * Enables or disables blocking when attempting to reconnect a
+         * {@link Protocol#TCP
+         * TCP} or {@link Protocol#SSL_TCP SSL TCP} protocol
+         */
+        @WithDefault("false")
+        boolean blockOnReconnect();
+
+        /**
+         * The log message format
+         */
+        @WithDefault("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n")
+        String format();
+
+        /**
+         * The log level specifying, which message levels will be logged by socket logger
+         */
+        @WithDefault("ALL")
+        Level level();
+
+        /**
+         * The name of the filter to link to the file handler.
+         */
+        Optional<String> filter();
+
+        /**
+         * Socket async logging config
          */
         AsyncConfig async();
     }

--- a/docs/src/main/asciidoc/centralized-log-management.adoc
+++ b/docs/src/main/asciidoc/centralized-log-management.adoc
@@ -236,6 +236,77 @@ networks:
 
 Launch your application, you should see your logs arriving inside the Elastic Stack; you can use Kibana available at http://localhost:5601/ to access them.
 
+
+[[logstash_ecs]]
+== GELF alternative: Send logs to Logstash in the ECS (Elastic Common Schema) format
+
+You can also send your logs to Logstash using a TCP input in the https://www.elastic.co/guide/en/ecs-logging/overview/current/intro.html[ECS] format.
+To achieve this we will use the `quarkus-logging-json` extension to format the logs in JSON format and the socket handler to send them to Logstash.
+
+For this you can use the same `docker-compose.yml` file as above but with a different Logstash pipeline configuration.
+
+[source]
+----
+input {
+  tcp {
+    port => 4560
+    coded => json
+  }
+}
+
+filter {
+  if ![span][id] and [mdc][spanId] {
+    mutate { rename => { "[mdc][spanId]" => "[span][id]" } }
+  }
+  if ![trace][id] and [mdc][traceId] {
+    mutate { rename => {"[mdc][traceId]" => "[trace][id]"} }
+  }
+}
+
+output {
+  stdout {}
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+  }
+}
+----
+
+Then configure your application to log in JSON format instead of GELF
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-logging-json</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-logging-json")
+----
+
+and specify the host and port of your Logstash endpoint. To be ECS compliant, specify the log format.
+
+[source, properties]
+----
+# to keep the logs in the usual format in the console
+quarkus.log.console.json=false
+
+quarkus.log.socket.enable=true
+quarkus.log.socket.json=true
+quarkus.log.socket.endpoint=localhost:4560
+
+# to have the exception serialized into a single text element
+quarkus.log.socket.json.exception-output-type=formatted
+
+# specify the format of the produced JSON log
+quarkus.log.socket.json.log-format=ECS
+----
+
+
 == Send logs to Fluentd (EFK)
 
 First, you need to create a Fluentd image with the needed plugins: elasticsearch and input-gelf.
@@ -421,6 +492,7 @@ quarkus.log.syslog.hostname=quarkus-test
 ----
 
 Launch your application, you should see your logs arriving inside EFK: you can use Kibana available at http://localhost:5601/ to access them.
+
 
 == Elasticsearch indexing consideration
 

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -511,6 +511,24 @@ quarkus.log.category."com.example".use-parent-handlers=false
 For details about its configuration, see the xref:#quarkus-core_section_quarkus-log-syslog[Syslog logging configuration] reference.
 
 
+=== Socket log handler
+
+This handler will send the logs to a socket.
+It is disabled by default, so you must first enable it.
+When enabled, it sends all log events to a socket, for instance to a Logstash server.
+
+This will typically be used in conjunction with the `quarkus-logging-json` extension so send logs in ECS format to an Elasticsearch instance.
+An example configuration can be found in the xref:centralized-log-management.adoc[Centralized log management] guide.
+
+* A global configuration example:
++
+[source, properties]
+----
+quarkus.log.socket.enable=true
+quarkus.log.socket.endpoint=localhost:4560
+----
+
+
 == Add a logging filter to your log handler
 
 Log handlers, such as the console log handler, can be linked with a link:https://docs.oracle.com/en/java/javase/17/docs/api/java.logging/java/util/logging/Filter.html[filter] that determines whether a log record should be logged.

--- a/extensions/logging-json/deployment/src/main/java/io/quarkus/logging/json/deployment/LoggingJsonProcessor.java
+++ b/extensions/logging-json/deployment/src/main/java/io/quarkus/logging/json/deployment/LoggingJsonProcessor.java
@@ -5,6 +5,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LogConsoleFormatBuildItem;
 import io.quarkus.deployment.builditem.LogFileFormatBuildItem;
+import io.quarkus.deployment.builditem.LogSocketFormatBuildItem;
 import io.quarkus.deployment.builditem.LogSyslogFormatBuildItem;
 import io.quarkus.logging.json.runtime.JsonLogConfig;
 import io.quarkus.logging.json.runtime.LoggingJsonRecorder;
@@ -27,5 +28,11 @@ public final class LoggingJsonProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     public LogSyslogFormatBuildItem setUpSyslogFormatter(LoggingJsonRecorder recorder, JsonLogConfig config) {
         return new LogSyslogFormatBuildItem(recorder.initializeSyslogJsonLogging(config));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public LogSocketFormatBuildItem setUpSocketFormatter(LoggingJsonRecorder recorder, JsonLogConfig config) {
+        return new LogSocketFormatBuildItem(recorder.initializeSocketJsonLogging(config));
     }
 }

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/SocketJsonFormatterCustomConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/SocketJsonFormatterCustomConfigTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.logging.json;
+
+import static io.quarkus.logging.json.SocketJsonFormatterDefaultConfigTest.getJsonFormatter;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneId;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.logmanager.formatters.StructuredFormatter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.logging.json.runtime.AdditionalFieldConfig;
+import io.quarkus.logging.json.runtime.JsonFormatter;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SocketJsonFormatterCustomConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(SocketJsonFormatterDefaultConfigTest.class))
+            .withConfigurationResource("application-socket-json-formatter-custom.properties");
+
+    @Test
+    public void jsonFormatterCustomConfigurationTest() {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+        assertThat(jsonFormatter.isPrettyPrint()).isTrue();
+        assertThat(jsonFormatter.getDateTimeFormatter().toString())
+                .isEqualTo("Value(DayOfMonth)' 'Text(MonthOfYear,SHORT)' 'Value(Year,4,19,EXCEEDS_PAD)");
+        assertThat(jsonFormatter.getDateTimeFormatter().getZone()).isEqualTo(ZoneId.of("UTC+05:00"));
+        assertThat(jsonFormatter.getExceptionOutputType())
+                .isEqualTo(StructuredFormatter.ExceptionOutputType.DETAILED_AND_FORMATTED);
+        assertThat(jsonFormatter.getRecordDelimiter()).isEqualTo("\n;");
+        assertThat(jsonFormatter.isPrintDetails()).isTrue();
+        assertThat(jsonFormatter.getExcludedKeys()).containsExactly("timestamp", "sequence");
+        assertThat(jsonFormatter.getAdditionalFields().size()).isEqualTo(2);
+        assertThat(jsonFormatter.getAdditionalFields().containsKey("foo")).isTrue();
+        assertThat(jsonFormatter.getAdditionalFields().get("foo").type).isEqualTo(AdditionalFieldConfig.Type.INT);
+        assertThat(jsonFormatter.getAdditionalFields().get("foo").value).isEqualTo("42");
+        assertThat(jsonFormatter.getAdditionalFields().containsKey("bar")).isTrue();
+        assertThat(jsonFormatter.getAdditionalFields().get("bar").type).isEqualTo(AdditionalFieldConfig.Type.STRING);
+        assertThat(jsonFormatter.getAdditionalFields().get("bar").value).isEqualTo("baz");
+    }
+
+    @Test
+    public void jsonFormatterOutputTest() throws Exception {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+        String line = jsonFormatter.format(new LogRecord(Level.INFO, "Hello, World!"));
+
+        JsonNode node = new ObjectMapper().readTree(line);
+        // "level" has been renamed to HEY
+        Assertions.assertThat(node.has("level")).isFalse();
+        Assertions.assertThat(node.has("HEY")).isTrue();
+        Assertions.assertThat(node.get("HEY").asText()).isEqualTo("INFO");
+
+        // excluded fields
+        Assertions.assertThat(node.has("timestamp")).isFalse();
+        Assertions.assertThat(node.has("sequence")).isFalse();
+
+        // additional fields
+        Assertions.assertThat(node.has("foo")).isTrue();
+        Assertions.assertThat(node.get("foo").asInt()).isEqualTo(42);
+        Assertions.assertThat(node.has("bar")).isTrue();
+        Assertions.assertThat(node.get("bar").asText()).isEqualTo("baz");
+        Assertions.assertThat(node.get("message").asText()).isEqualTo("Hello, World!");
+    }
+}

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/SocketJsonFormatterDefaultConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/SocketJsonFormatterDefaultConfigTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.logging.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import org.jboss.logmanager.formatters.StructuredFormatter;
+import org.jboss.logmanager.handlers.SocketHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
+import io.quarkus.logging.json.runtime.JsonFormatter;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SocketJsonFormatterDefaultConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-socket-json-formatter-default.properties");
+
+    @Test
+    public void jsonFormatterDefaultConfigurationTest() {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+        assertThat(jsonFormatter.isPrettyPrint()).isFalse();
+        assertThat(jsonFormatter.getDateTimeFormatter().toString())
+                .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault()).toString());
+        assertThat(jsonFormatter.getDateTimeFormatter().getZone()).isEqualTo(ZoneId.systemDefault());
+        assertThat(jsonFormatter.getExceptionOutputType()).isEqualTo(StructuredFormatter.ExceptionOutputType.DETAILED);
+        assertThat(jsonFormatter.getRecordDelimiter()).isEqualTo("\n");
+        assertThat(jsonFormatter.isPrintDetails()).isFalse();
+        assertThat(jsonFormatter.getExcludedKeys()).isEmpty();
+        assertThat(jsonFormatter.getAdditionalFields().entrySet()).isEmpty();
+    }
+
+    public static JsonFormatter getJsonFormatter() {
+        LogManager logManager = LogManager.getLogManager();
+        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
+
+        QuarkusDelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
+        assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
+
+        Handler handler = Arrays.stream(delayedHandler.getHandlers())
+                .filter(h -> (h instanceof SocketHandler))
+                .findFirst().orElse(null);
+        assertThat(handler).isNotNull();
+        assertThat(handler.getLevel()).isEqualTo(Level.WARNING);
+
+        Formatter formatter = handler.getFormatter();
+        assertThat(formatter).isInstanceOf(JsonFormatter.class);
+        return (JsonFormatter) formatter;
+    }
+}

--- a/extensions/logging-json/deployment/src/test/resources/application-socket-json-formatter-custom.properties
+++ b/extensions/logging-json/deployment/src/test/resources/application-socket-json-formatter-custom.properties
@@ -1,0 +1,16 @@
+quarkus.log.level=INFO
+quarkus.log.socket.enable=true
+quarkus.log.socket.level=WARNING
+quarkus.log.socket.json=true
+quarkus.log.socket.json.pretty-print=true
+quarkus.log.socket.json.date-format=d MMM uuuu
+quarkus.log.socket.json.record-delimiter=\n;
+quarkus.log.socket.json.zone-id=UTC+05:00
+quarkus.log.socket.json.exception-output-type=DETAILED_AND_FORMATTED
+quarkus.log.socket.json.print-details=true
+quarkus.log.socket.json.key-overrides=level=HEY
+quarkus.log.socket.json.excluded-keys=timestamp,sequence
+quarkus.log.socket.json.additional-field.foo.value=42
+quarkus.log.socket.json.additional-field.foo.type=int
+quarkus.log.socket.json.additional-field.bar.value=baz
+quarkus.log.socket.json.additional-field.bar.type=string

--- a/extensions/logging-json/deployment/src/test/resources/application-socket-json-formatter-default.properties
+++ b/extensions/logging-json/deployment/src/test/resources/application-socket-json-formatter-default.properties
@@ -1,0 +1,5 @@
+quarkus.log.level=INFO
+quarkus.log.socket.enable=true
+quarkus.log.socket.level=WARNING
+quarkus.log.socket.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n
+quarkus.log.socket.json=true

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonLogConfig.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonLogConfig.java
@@ -40,6 +40,13 @@ public class JsonLogConfig {
     @ConfigItem(name = "syslog.json")
     JsonConfig syslogJson;
 
+    /**
+     * Socket logging.
+     */
+    @ConfigDocSection
+    @ConfigItem(name = "socket.json")
+    JsonConfig socketJson;
+
     @ConfigGroup
     public static class JsonConfig {
         /**
@@ -98,5 +105,16 @@ public class JsonLogConfig {
         @ConfigItem
         @ConfigDocMapKey("field-name")
         Map<String, AdditionalFieldConfig> additionalField;
+
+        /**
+         * Specify the format of the produced JSON
+         */
+        @ConfigItem(defaultValue = "DEFAULT")
+        LogFormat logFormat;
+
+        public enum LogFormat {
+            DEFAULT,
+            ECS
+        }
     }
 }

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
@@ -1,8 +1,17 @@
 package io.quarkus.logging.json.runtime;
 
+import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Formatter;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logmanager.PropertyValues;
+import org.jboss.logmanager.formatters.StructuredFormatter.Key;
+
+import io.quarkus.logging.json.runtime.AdditionalFieldConfig.Type;
 import io.quarkus.logging.json.runtime.JsonLogConfig.JsonConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
@@ -22,7 +31,19 @@ public class LoggingJsonRecorder {
         return getFormatter(config.syslogJson);
     }
 
+    public RuntimeValue<Optional<Formatter>> initializeSocketJsonLogging(JsonLogConfig config) {
+        return getFormatter(config.socketJson);
+    }
+
     private RuntimeValue<Optional<Formatter>> getFormatter(JsonConfig config) {
+        if (config.logFormat == JsonConfig.LogFormat.ECS) {
+            addEcsFieldOverrides(config);
+        }
+
+        return getDefaultFormatter(config);
+    }
+
+    private RuntimeValue<Optional<Formatter>> getDefaultFormatter(JsonConfig config) {
         if (!config.enable) {
             return new RuntimeValue<>(Optional.empty());
         }
@@ -42,5 +63,44 @@ public class LoggingJsonRecorder {
             formatter.setZoneId(zoneId);
         }
         return new RuntimeValue<>(Optional.of(formatter));
+    }
+
+    private void addEcsFieldOverrides(JsonConfig config) {
+        EnumMap<Key, String> keyOverrides = PropertyValues.stringToEnumMap(Key.class, config.keyOverrides.orElse(null));
+        keyOverrides.putIfAbsent(Key.TIMESTAMP, "@timestamp");
+        keyOverrides.putIfAbsent(Key.LOGGER_NAME, "log.logger");
+        keyOverrides.putIfAbsent(Key.LEVEL, "log.level");
+        keyOverrides.putIfAbsent(Key.PROCESS_ID, "process.pid");
+        keyOverrides.putIfAbsent(Key.PROCESS_NAME, "process.name");
+        keyOverrides.putIfAbsent(Key.THREAD_NAME, "process.thread.name");
+        keyOverrides.putIfAbsent(Key.THREAD_ID, "process.thread.id");
+        keyOverrides.putIfAbsent(Key.HOST_NAME, "host.hostname");
+        keyOverrides.putIfAbsent(Key.SEQUENCE, "event.sequence");
+        keyOverrides.putIfAbsent(Key.EXCEPTION_MESSAGE, "error.message");
+        keyOverrides.putIfAbsent(Key.STACK_TRACE, "error.stack_trace");
+        config.keyOverrides = Optional.of(PropertyValues.mapToString(keyOverrides));
+
+        config.additionalField.computeIfAbsent("ecs.version", k -> buildFieldConfig("1.12.2", Type.STRING));
+        config.additionalField.computeIfAbsent("data_stream.type", k -> buildFieldConfig("logs", Type.STRING));
+
+        Config quarkusConfig = ConfigProvider.getConfig();
+        quarkusConfig.getOptionalValue("quarkus.application.name", String.class).ifPresent(
+                s -> config.additionalField.computeIfAbsent("service.name", k -> buildFieldConfig(s, Type.STRING)));
+        quarkusConfig.getOptionalValue("quarkus.application.version", String.class).ifPresent(
+                s -> config.additionalField.computeIfAbsent("service.version", k -> buildFieldConfig(s, Type.STRING)));
+        quarkusConfig.getOptionalValue("quarkus.profile", String.class).ifPresent(
+                s -> config.additionalField.computeIfAbsent("service.environment", k -> buildFieldConfig(s, Type.STRING)));
+
+        Set<String> excludedKeys = config.excludedKeys.orElseGet(HashSet::new);
+        excludedKeys.add(Key.LOGGER_CLASS_NAME.getKey());
+        excludedKeys.add(Key.RECORD.getKey());
+        config.excludedKeys = Optional.of(excludedKeys);
+    }
+
+    private AdditionalFieldConfig buildFieldConfig(String value, Type type) {
+        AdditionalFieldConfig field = new AdditionalFieldConfig();
+        field.type = type;
+        field.value = value;
+        return field;
     }
 }

--- a/integration-tests/test-extension/extension/deployment/src/main/resources/application-socket-output.properties
+++ b/integration-tests/test-extension/extension/deployment/src/main/resources/application-socket-output.properties
@@ -1,0 +1,8 @@
+quarkus.log.level=INFO
+quarkus.log.socket.enable=true
+quarkus.log.socket.endpoint=localhost:5140
+quarkus.log.socket.protocol=TCP
+quarkus.log.socket.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n
+quarkus.log.socket.level=WARNING
+# Resource path to DSAPublicKey base64 encoded bytes
+quarkus.root.dsa-key-location=/DSAPublicKey.encoded

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SocketHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/SocketHandlerTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.logging;
+
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.handlers.SocketHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class SocketHandlerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-socket-output.properties")
+            .withApplicationRoot((jar) -> jar
+                    .addClass(LoggingTestsHelper.class)
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"));
+
+    @Test
+    void socketOutputTest() {
+        Handler handler = getHandler(SocketHandler.class);
+        assertThat(handler.getLevel()).isEqualTo(Level.WARNING);
+
+        Formatter formatter = handler.getFormatter();
+        assertThat(formatter).isInstanceOf(PatternFormatter.class);
+        PatternFormatter patternFormatter = (PatternFormatter) formatter;
+        assertThat(patternFormatter.getPattern()).isEqualTo("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n");
+
+        SocketHandler socketHandler = (SocketHandler) handler;
+        assertThat(socketHandler.getPort()).isEqualTo(5140);
+        assertThat(socketHandler.getAddress().getHostAddress()).isEqualTo("127.0.0.1");
+        assertThat(socketHandler.getProtocol()).isEqualTo(SocketHandler.Protocol.TCP);
+        assertThat(socketHandler.isBlockOnReconnect()).isFalse();
+    }
+}


### PR DESCRIPTION
This pull request is a followup of PR #23128 and is greatly inspired by the following provided by @geoand https://github.com/quarkusio/quarkus/compare/main...geoand:%2323127?expand=1

It allows sending logs in ECS format to a socket (typically a logstash tcp input)

fixes #23127 and answers my own question on [StackOverFlow](https://stackoverflow.com/questions/78952158/send-quarkus-logs-to-logstash-elk-in-json-format-over-logstash-tcp-input)