### PR TITLE
Add a note on JsonFormat annotation and ORM FormatMapper

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1395,6 +1395,9 @@ and annotating the implementation with the appropriate qualifiers:
 
 [source,java]
 ----
+import io.quarkus.hibernate.orm.JsonFormat;
+import org.hibernate.type.format.FormatMapper;
+
 @JsonFormat // <1>
 @PersistenceUnitExtension // <2>
 public class MyJsonFormatMapper implements FormatMapper { // <3>
@@ -1412,6 +1415,9 @@ public class MyJsonFormatMapper implements FormatMapper { // <3>
 <1> Annotate the format mapper implementation with the `@JsonFormat` qualifier
 to tell Quarkus that this mapper is specific to JSON serialization/deserialization.
 +
+WARNING: Make sure the Quarkus-specific `@io.quarkus.hibernate.orm.JsonFormat` annotation is used
+and not the one from Jackson.
++
 <2> Annotate the format mapper implementation with the `@PersistenceUnitExtension` qualifier
 to tell Quarkus it should be used in the default persistence unit.
 +
@@ -1422,6 +1428,9 @@ In case of a custom XML format mapper, a different CDI qualifier must be applied
 
 [source,java]
 ----
+import io.quarkus.hibernate.orm.XmlFormat;
+import org.hibernate.type.format.FormatMapper;
+
 @XmlFormat // <1>
 @PersistenceUnitExtension // <2>
 public class MyJsonFormatMapper implements FormatMapper { // <3>


### PR DESCRIPTION
So that there's a slightly better chance that the correct annotation is used and not the `com.fasterxml.jackson.annotation.JsonFormat` one.