### PR TITLE
Use prettier arrow in stack traces (to highlight the line with the error)

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/DecorateStackUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/DecorateStackUtil.java
@@ -64,9 +64,9 @@ public class DecorateStackUtil {
                     if (currentLine >= lineNumber - contextRange) {
                         String ln = String.valueOf(currentLine);
                         if (currentLine == lineNumber) {
-                            ln = "-> " + ln + "  ";
+                            ln = "→ " + ln + "  ";
                         } else {
-                            ln = "   " + ln + "  ";
+                            ln = "  " + ln + "  ";
                         }
 
                         contextQueue.add("\t" + ln + line);


### PR DESCRIPTION
## TLDR: the 'after'

*EDIT:* After testing on Windows, I've changed the arrow. 
 
<img width="1540" alt="image" src="https://github.com/user-attachments/assets/fa09107e-ffe8-449a-ad43-f7311bd23e0d">

## What problem were we solving?

In @phillip-kruger's recent demo of the advanced exception context, I noticed that we use an ascii-art arrow. 
<img width="640" alt="image" src="https://github.com/user-attachments/assets/5aaa0fef-7018-4553-8375-d1131c717a79">

"Hmm," I thought. "With so many nice arrows in the unicode spec these days, why don't we use one of them instead?" With hindsight, I should have asked @phillip-kruger if he’d tried this already, but I thought “I won’t bother him with a conversation for a one-character change, I’ll just do the PR and we can discuss it there.” Then I started testing, and realised why Philip maybe opted for the ascii art. But by then it was too late, and I was invested.

![image](https://github.com/user-attachments/assets/1985a982-2014-498d-854f-9559c4d9b275)

There are two risks with this change: 
- Will the character be available in the terminal and browser font on the developer's system?
- Can we make the code in the line with the arrow align properly with the rest?

It turns out both are a problem, but I think I got there in the end. 

## Cross-platform test results

### MacOS

<img width="1540" alt="image" src="https://github.com/user-attachments/assets/c78aea82-149d-4cf3-8558-fef3caf071a3">

<img width="673" alt="image" src="https://github.com/user-attachments/assets/51bb9916-7329-4188-a7c6-5e351a7ab9f0">

### Windows 

![image](https://github.com/user-attachments/assets/896095e0-57db-4a0c-8d4c-f67f82ba9bb4)

![image](https://github.com/user-attachments/assets/60d466ef-e1fa-4e5c-923d-2fbe3b9af8dd)

### Linux 

![image](https://github.com/user-attachments/assets/5794938a-4158-4828-b780-3139158bfcc2)

![image](https://github.com/user-attachments/assets/c6851cc6-a9fd-4868-bfa2-d74a42b2e9b7)

## The workings-out 

### Character width issues 

Even on a single machine, I got character-alignment problems. It turns out that fixed-width fonts do not have a consistent width for the arrows. It will presumably vary by OS, and it also varies between browser and terminal. I liked the heavy arrow ⮕, but that was subtly misaligned in the browser:

<img width="640" alt="image" src="https://github.com/user-attachments/assets/a6fd13d8-8434-4868-8975-b1ca63e1ad07">

... and hopelessly misaligned in the terminal:

<img width="640" alt="image" src="https://github.com/user-attachments/assets/08f0fb05-dea5-4f47-8aa4-da3fabd4307a">

⟶ is nice and prominent, perfect in the console, 

<img width="640" alt="image" src="https://github.com/user-attachments/assets/50318f58-eca8-4dc0-9ec2-b18c99b68ae7">

But terrible in the browser

<img width="640" alt="image" src="https://github.com/user-attachments/assets/e10061b7-cb3e-4aba-9fd8-13f5c62937cc">

In my experiments, ⇨ works in the browser:

<img width="640" alt="image" src="https://github.com/user-attachments/assets/1adcf5bb-8e31-445f-8f8b-b42dbde37543">

and also the terminal 

<img width="640" alt="image" src="https://github.com/user-attachments/assets/f22d6d05-67a5-4c33-84a2-816b06c1e48d">

It's a bit more visible than ⇾, which also worked for me in terms of width:

<img width="640" alt="image" src="https://github.com/user-attachments/assets/663b1df9-73cf-47e0-b4bb-f8b51fe0a34c">

<img width="640" alt="image" src="https://github.com/user-attachments/assets/b19fc2c9-a6b8-4d3e-a291-7ecb3b1260f3">

### Character set issues

Once I found an arrow that rendered well in both terminal and browser on Mac, we tried it on Windows, and ... no good.

![image](https://github.com/user-attachments/assets/d5377ce4-652c-4008-8894-92ca0e2e9462)

So I went back to the drawing board. 

## How to test 

Here's some text which can be pasted into a terminal to test on other OSes:

```
Exception in GreetingResource.java:14
          12      @Produces(MediaType.TEXT_PLAIN)
          13      public String hello() {
        ⇨ 14          if (Math.random( )> 0.01) { throw new RuntimeException("test");}
          15          return "Hello from Quarkus RESTyes";
          16      }
```

(Testing in the browser would need a build of the patch.)

## Other options 
For reference, here are all the arrows I considered, along with a `.` to show alignment. Only the fourth one works on Windows:

⟶ .
⭢ .
⮕ .
→ .
⇨ .
⇢ .
⇾ .