### PR TITLE
Fix a copy and paste issue in the OIDC client registration doc

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
@@ -233,8 +233,6 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
 
 Alternatively, you can use `OidcClientRegistrations` to prepare a new `OidcClientRegistration` and use `OidcClientRegistration` to register a client. For example:
 
-The above configuration is sufficient for registering new clients using this configuration. For example:
-
 [source,java]
 ----
 package io.quarkus.it.keycloak;


### PR DESCRIPTION
This PR removes the text which is already typed above in this section