### PR TITLE
ArC: fix the situation when a framework bean uses an application decorator

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/cdi/bcextensions/SynthBeanForExternalClassTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/cdi/bcextensions/SynthBeanForExternalClassTest.java
@@ -25,7 +25,7 @@ import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class SynthBeanForExternalClass {
+public class SynthBeanForExternalClassTest {
     // the test includes an _application_ that declares a build compatible extension
     // (in the Runtime CL), which creates a synthetic bean for a class that is _outside_
     // of the application (in the Base Runtime CL)

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/cdi/bcextensions/SynthObserverAsIfInExternalClassTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/cdi/bcextensions/SynthObserverAsIfInExternalClassTest.java
@@ -24,7 +24,7 @@ import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class SynthObserverAsIfInExternalClass {
+public class SynthObserverAsIfInExternalClassTest {
     // the test includes an _application_ that declares a build compatible extension
     // (in the Runtime CL), which creates a synthetic observer which is "as if" declared
     // in a class that is _outside_ of the application (in the Base Runtime CL)

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/decorator/DecoratorOfExternalBeanTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/decorator/DecoratorOfExternalBeanTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.arc.test.decorator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.supplement.SomeBeanInExternalLibrary;
+import io.quarkus.arc.test.supplement.SomeInterfaceInExternalLibrary;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DecoratorOfExternalBeanTest {
+    // the test includes an _application_ decorator (in the Runtime CL) that applies
+    // to a bean that is _outside_ of the application (in the Base Runtime CL)
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClass(MyDecorator.class))
+            // we need a non-application archive, so cannot use `withAdditionalDependency()`
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-arc-test-supplement", Version.getVersion())));
+
+    @Inject
+    SomeBeanInExternalLibrary bean;
+
+    @Test
+    public void test() {
+        assertEquals("Delegated: Hello", bean.hello());
+    }
+
+    @Decorator
+    public static class MyDecorator implements SomeInterfaceInExternalLibrary {
+        @Inject
+        @Delegate
+        SomeInterfaceInExternalLibrary delegate;
+
+        @Override
+        public String hello() {
+            return "Delegated: " + delegate.hello();
+        }
+    }
+}

--- a/extensions/arc/test-supplement/pom.xml
+++ b/extensions/arc/test-supplement/pom.xml
@@ -13,4 +13,11 @@
     <name>Quarkus - ArC - Test Supplement</name>
     <description>Supplement archive for ArC tests</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/extensions/arc/test-supplement/src/main/java/io/quarkus/arc/test/supplement/SomeBeanInExternalLibrary.java
+++ b/extensions/arc/test-supplement/src/main/java/io/quarkus/arc/test/supplement/SomeBeanInExternalLibrary.java
@@ -1,0 +1,11 @@
+package io.quarkus.arc.test.supplement;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class SomeBeanInExternalLibrary implements SomeInterfaceInExternalLibrary {
+    @Override
+    public String hello() {
+        return "Hello";
+    }
+}

--- a/extensions/arc/test-supplement/src/main/java/io/quarkus/arc/test/supplement/SomeInterfaceInExternalLibrary.java
+++ b/extensions/arc/test-supplement/src/main/java/io/quarkus/arc/test/supplement/SomeInterfaceInExternalLibrary.java
@@ -1,0 +1,5 @@
+package io.quarkus.arc.test.supplement;
+
+public interface SomeInterfaceInExternalLibrary {
+    String hello();
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -344,7 +344,9 @@ public class BeanGenerator extends AbstractGenerator {
             return Collections.emptyList();
         }
 
-        boolean isApplicationClass = applicationClassPredicate.test(beanClass.name()) || bean.isForceApplicationClass();
+        boolean isApplicationClass = applicationClassPredicate.test(beanClass.name())
+                || bean.isForceApplicationClass()
+                || bean.hasBoundDecoratorWhichIsApplicationClass(applicationClassPredicate);
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.BEAN : null, generateSources);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.Typed;
@@ -512,6 +513,15 @@ public class BeanInfo implements InjectionTargetInfo {
                         .thenComparing(DecoratorInfo::getBeanClass)
                         .reversed());
         return bound;
+    }
+
+    boolean hasBoundDecoratorWhichIsApplicationClass(Predicate<DotName> isApplicationClass) {
+        for (DecoratorInfo decorator : getBoundDecorators()) {
+            if (isApplicationClass.test(decorator.getImplClazz().name())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -98,8 +98,9 @@ public class ClientProxyGenerator extends AbstractGenerator {
             return Collections.emptyList();
         }
 
-        boolean applicationClass = applicationClassPredicate.test(getApplicationClassTestName(bean));
-        ResourceClassOutput classOutput = new ResourceClassOutput(applicationClass,
+        boolean isApplicationClass = applicationClassPredicate.test(getApplicationClassTestName(bean))
+                || bean.hasBoundDecoratorWhichIsApplicationClass(applicationClassPredicate);
+        ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.CLIENT_PROXY : null, generateSources);
 
         // Foo_ClientProxy extends Foo implements ClientProxy

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -112,7 +112,9 @@ public class SubclassGenerator extends AbstractGenerator {
             return Collections.emptyList();
         }
 
-        ResourceClassOutput classOutput = new ResourceClassOutput(applicationClassPredicate.test(bean.getBeanClass()),
+        boolean isApplicationClass = applicationClassPredicate.test(bean.getBeanClass())
+                || bean.hasBoundDecoratorWhichIsApplicationClass(applicationClassPredicate);
+        ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.SUBCLASS : null,
                 generateSources);
 


### PR DESCRIPTION
ArC-generated classes for framework beans are by default _not_ application classes. This causes problems in hierarchical classloader environments (dev/test mode) when there is an application decorator that applies to the framework bean.

This commit fixes that issue by turning the ArC-generated classes for framework beans into application classes whenever an application decorator applies. This makes package access impossible, which is an unfortunate downside.

The problem doesn't exist in a flat classloading environment, such as prod mode.