### PR TITLE
Expose property `quarkus.hibernate-orm.flush.mode`

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/ConfigPropertiesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/ConfigPropertiesTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.hibernate.orm.config.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.orm.config.properties.defaultpu.MyEntityForDefaultPU;
+import io.quarkus.hibernate.orm.config.properties.overridespu.MyEntityForOverridesPU;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that configuration properties set in Quarkus are translated to the right key and value in Hibernate ORM.
+ */
+public class ConfigPropertiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(MyEntityForDefaultPU.class.getPackage())
+                    .addPackage(MyEntityForOverridesPU.class.getPackage()))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.packages", MyEntityForDefaultPU.class.getPackageName())
+            .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".packages", MyEntityForOverridesPU.class.getPackageName())
+            .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".datasource", "<default>")
+            // Overrides to test that Quarkus configuration properties are taken into account
+            .overrideConfigKey("quarkus.hibernate-orm.\"overrides\".flush.mode", "always");
+
+    @Inject
+    Session sessionForDefaultPU;
+
+    @Inject
+    @PersistenceUnit("overrides")
+    Session sessionForOverridesPU;
+
+    @Test
+    @Transactional
+    public void propertiesAffectingSession() {
+        assertThat(sessionForDefaultPU.getHibernateFlushMode()).isEqualTo(FlushMode.AUTO);
+        assertThat(sessionForOverridesPU.getHibernateFlushMode()).isEqualTo(FlushMode.ALWAYS);
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/defaultpu/MyEntityForDefaultPU.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/defaultpu/MyEntityForDefaultPU.java
@@ -1,0 +1,31 @@
+package io.quarkus.hibernate.orm.config.properties.defaultpu;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class MyEntityForDefaultPU {
+    @Id
+    private long id;
+
+    private String name;
+
+    public MyEntityForDefaultPU() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/overridespu/MyEntityForOverridesPU.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/properties/overridespu/MyEntityForOverridesPU.java
@@ -1,0 +1,31 @@
+package io.quarkus.hibernate.orm.config.properties.overridespu;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class MyEntityForOverridesPU {
+    @Id
+    private long id;
+
+    private String name;
+
+    public MyEntityForOverridesPU() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -18,6 +18,7 @@ import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.HibernateHints;
 import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
 import org.hibernate.service.Service;
@@ -453,6 +454,9 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
             runtimeSettingsBuilder.put(AvailableSettings.LOG_SLOW_QUERY,
                     persistenceUnitConfig.log().queriesSlowerThanMs().get());
         }
+
+        runtimeSettingsBuilder.put(HibernateHints.HINT_FLUSH_MODE,
+                persistenceUnitConfig.flush().mode());
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -3,6 +3,8 @@ package io.quarkus.hibernate.orm.runtime;
 import java.util.Map;
 import java.util.Optional;
 
+import org.hibernate.FlushMode;
+
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
@@ -49,6 +51,12 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
      */
     @ConfigDocSection
     HibernateOrmConfigPersistenceUnitLog log();
+
+    /**
+     * Flush configuration.
+     */
+    @ConfigDocSection
+    HibernateOrmConfigPersistenceUnitFlush flush();
 
     /**
      * Properties that should be passed on directly to Hibernate ORM.
@@ -198,6 +206,23 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
          */
         Optional<Long> queriesSlowerThanMs();
 
+    }
+
+    @ConfigGroup
+    interface HibernateOrmConfigPersistenceUnitFlush {
+        /**
+         * The default flushing strategy, or when to flush entities to the database in a Hibernate session:
+         * before every query, on commit, ...
+         *
+         * This default can be overridden on a per-session basis with `Session#setHibernateFlushMode()`
+         * or on a per-query basis with the hint `HibernateHints#HINT_FLUSH_MODE`.
+         *
+         * See the javadoc of `org.hibernate.FlushMode` for details.
+         *
+         * @asciidoclet
+         */
+        @WithDefault("auto")
+        FlushMode mode();
     }
 
 }

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -18,6 +18,7 @@ import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.HibernateHints;
 import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
 import org.hibernate.reactive.provider.service.ReactiveGenerationTarget;
@@ -361,6 +362,9 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
             runtimeSettingsBuilder.put(AvailableSettings.LOG_SLOW_QUERY,
                     persistenceUnitConfig.log().queriesSlowerThanMs().get());
         }
+
+        runtimeSettingsBuilder.put(HibernateHints.HINT_FLUSH_MODE,
+                persistenceUnitConfig.flush().mode());
     }
 
     @Override


### PR DESCRIPTION
So that people have a decent way to work around problems such as #42322 or #42902

Fixes #29604

I wonder whether the property should be named  `quarkus.hibernate-orm.flush.mode` or  `quarkus.hibernate-orm.flush-mode`. We already have  `quarkus.hibernate-orm.fetch.batch-size`, so it seemed more natural to do the same for `flush`, but I'm open to suggestions.
