### PR TITLE
Properly fail when TLS reload config is invalid

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -694,11 +694,16 @@ public class VertxHttpRecorder {
                         } else {
                             if (httpManagementServerOptions.isSsl()
                                     && (managementConfig.ssl.certificate.reloadPeriod.isPresent())) {
-                                long l = TlsCertificateReloader.initCertReloadingAction(
-                                        vertx, ar.result(), httpManagementServerOptions, managementConfig.ssl, registry,
-                                        managementConfig.tlsConfigurationName);
-                                if (l != -1) {
-                                    refresTaskIds.add(l);
+                                try {
+                                    long l = TlsCertificateReloader.initCertReloadingAction(
+                                            vertx, ar.result(), httpManagementServerOptions, managementConfig.ssl, registry,
+                                            managementConfig.tlsConfigurationName);
+                                    if (l != -1) {
+                                        refresTaskIds.add(l);
+                                    }
+                                } catch (IllegalArgumentException e) {
+                                    managementInterfaceFuture.completeExceptionally(e);
+                                    return;
                                 }
                             }
 
@@ -1332,11 +1337,16 @@ public class VertxHttpRecorder {
                         }
 
                         if (https && (quarkusConfig.ssl.certificate.reloadPeriod.isPresent())) {
-                            long l = TlsCertificateReloader.initCertReloadingAction(
-                                    vertx, httpsServer, httpsOptions, quarkusConfig.ssl, registry,
-                                    quarkusConfig.tlsConfigurationName);
-                            if (l != -1) {
-                                reloadingTasks.add(l);
+                            try {
+                                long l = TlsCertificateReloader.initCertReloadingAction(
+                                        vertx, httpsServer, httpsOptions, quarkusConfig.ssl, registry,
+                                        quarkusConfig.tlsConfigurationName);
+                                if (l != -1) {
+                                    reloadingTasks.add(l);
+                                }
+                            } catch (IllegalArgumentException e) {
+                                startFuture.fail(e);
+                                return;
                             }
                         }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
@@ -43,6 +43,9 @@ public class TlsCertificateReloader {
 
     private static final Logger LOGGER = Logger.getLogger(TlsCertificateReloader.class);
 
+    /**
+     * @throws IllegalArgumentException if any of the configuration is invalid
+     */
     public static long initCertReloadingAction(Vertx vertx, HttpServer server,
             HttpServerOptions options, ServerSslConfig configuration,
             TlsConfigurationRegistry registry, Optional<String> tlsConfigurationName) {


### PR DESCRIPTION
This now means that Quarkus will exit completely on dev-mode's the first start 
if the configuration contains the invalid reload value.

This might not be ideal, but it's far better than the previous behavior where the application
was stuck and had to be killed with `kill -9`

- Fixes: #43247