### PR TITLE
Fix jar file reference close race condition

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/JarResource.java
@@ -155,7 +155,7 @@ public class JarResource implements ClassLoadingResource {
             // so the future must be already completed
             var ref = futureRef.getNow(null);
             if (ref != null) {
-                ref.close(this);
+                ref.markForClosing(this);
             }
         }
     }


### PR DESCRIPTION
Possible solution for https://github.com/quarkusio/quarkus/issues/43158

This is fixing a potential race while virtual threads try to "help" and in-progress release by moving forward the shared atomic reference: we need to make sure that `JarFileReference`s cleanup don't mess up with a freshly jar file shared by the virtual thread.
At the same time if there's an in progress jar file ref load from a platform thread, the virtual thread doesn't have to replace the in progress task.