### PR TITLE
KafkaStreamsProducer no longer shuts down the injected executorservice

### DIFF
--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
@@ -164,9 +164,6 @@ public class KafkaStreamsProducer {
 
     void onStop(@Observes ShutdownEvent event) {
         shutdown = true;
-        if (executorService != null) {
-            executorService.shutdown();
-        }
         if (kafkaStreams != null) {
             LOGGER.debug("Stopping Kafka Streams pipeline");
             kafkaStreams.close();


### PR DESCRIPTION
Fixes #43228