### PR TITLE
Documentation: Add a note related to quarkus-picocli in dev mode

### DIFF
--- a/docs/src/main/asciidoc/picocli.adoc
+++ b/docs/src/main/asciidoc/picocli.adoc
@@ -298,6 +298,10 @@ annotationProcessor 'info.picocli:picocli-codegen'
 == Development Mode
 
 In the development mode, i.e. when running `mvn quarkus:dev`, the application is executed and restarted every time the `Space bar` key is pressed. You can also pass arguments to your command line app via the `quarkus.args` system property, e.g. `mvn quarkus:dev -Dquarkus.args='--help'` and `mvn quarkus:dev -Dquarkus.args='-c -w --val 1'`. For gradle project arguments can be passed using `--quarkus-args`.
+[NOTE]
+====
+If you're creating a typical Quarkus application (e.g., HTTP-based services) that includes command-line functionality, you'll need to handle the application's lifecycle differently. In the `Runnable.run()` method of your command, make sure to use `Quarkus.waitForExit()` or `Quarkus.asyncExit()`. This will prevent the application from shutting down prematurely and ensure a proper shutdown process.
+====
 
 == Kubernetes support
 


### PR DESCRIPTION
This adds a note to the Quarkus-picocli guide docs regarding the lifecycle behavior in dev mode.
The motivation was this issue--> [https://github.com/quarkusio/quarkus/issues/43182](https://github.com/quarkusio/quarkus/issues/43182)