### PR TITLE
Introduce OidcResponseFilter

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -336,7 +336,7 @@ public class OidcTokenRequestCustomizer implements OidcRequestFilter {
     public void filter(OidcRequestContext requestContext) {
         OidcConfigurationMetadata metadata = requestContext.contextProperties().get(OidcConfigurationMetadata.class.getName()); <1>
         // Metadata URI is absolute, request URI value is relative
-        if (metadata.getTokenUri().endsWith(request.uri())) { <2>
+        if (metadata.getTokenUri().endsWith(requestContext.request().uri())) { <2>
             requestContext.request().putHeader("TokenGrantDigest", calculateDigest(requestContext.requestBody().toString()));
         }
     }
@@ -348,7 +348,7 @@ public class OidcTokenRequestCustomizer implements OidcRequestFilter {
 <1> Get `OidcConfigurationMetadata`, which contains all supported OIDC endpoint addresses.
 <2> Use `OidcConfigurationMetadata` to filter requests to the OIDC token endpoint only.
 
-Alternatively, you can use an `@OidcEndpoint` annotation to apply this filter to the token endpoint requests only:
+Alternatively, you can use an `@OidcEndpoint` annotation to apply this filter to responses from the OIDC discovery endpoint only:
 
 [source,java]
 ----
@@ -374,6 +374,56 @@ public class OidcDiscoveryRequestCustomizer implements OidcRequestFilter {
 }
 ----
 <1> Restrict this filter to requests targeting the OIDC discovery endpoint only.
+
+`OidcRequestContextProperties` can be used to access request properties.
+Currently, you can use a `tenand_id` key to access the OIDC tenant id and a `grant_type` key to access the grant type which the OIDC provider uses to acquire tokens.
+The `grant_type` can only be set to either `authorization_code` or `refresh_token` grant type, when requests are made to the token endpoint. It is `null` in all other cases.
+
+[[code-flow-oidc-response-filters]]
+=== OIDC response filters
+
+You can filter responses from the OIDC providers by registering one or more `OidcResponseFilter` implementations, which can check the response status, headers and body in order to log them or perform other actions.
+
+You can have a single filter intercepting all the OIDC responses, or use an `@OidcEndpoint` annotation to apply this filter to the specific endpoint responses only. For example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.runtime.OidcUtils;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.TOKEN) <1>
+public class TokenEndpointResponseFilter implements OidcResponseFilter {
+    private static final Logger LOG = Logger.getLogger(TokenResponseFilter.class);
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        String contentType = rc.responseHeaders().get("Content-Type"); <2>
+        if (contentType.equals("application/json")
+                && OidcConstants.AUTHORIZATION_CODE.equals(rc.requestProperties().get(OidcConstants.GRANT_TYPE)) <3>
+                && "code-flow-user-info-cached-in-idtoken".equals(rc.requestProperties().get(OidcUtils.TENANT_ID_ATTRIBUTE)) <3>
+                && rc.responseBody().toJsonObject().containsKey("id_token")) { <4>
+            LOG.debug("Authorization code completed for tenant 'code-flow-user-info-cached-in-idtoken'");
+        }
+    }
+}
+
+----
+<1> Restrict this filter to requests targeting the OIDC token endpoint only.
+<2> Check the response `Content-Type` header.
+<3> Use `OidcRequestContextProperties` request properties to check only an `authorization_code` token grant response for the `code-flow-user-info-cached-in-idtoken` tenant.
+<4> Confirm the response JSON contains an `id_token` property.
 
 === Redirecting to and from the OIDC provider
 

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -1107,7 +1107,9 @@ quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-lev
 [[oidc-client-ref-oidc-request-filters]]
 == OIDC request filters
 
-You can filter OIDC requests made by Quarkus to the OIDC provider by registering one or more `OidcRequestFilter` implementations, which can update or add new request headers. For example, a filter can analyze the request body and add its digest as a new header value:
+You can filter OIDC requests made by OIDC client to the OIDC provider by registering one or more `OidcRequestFilter` implementations, which can update or add new request headers, or analyze the request body.
+
+You can have a single filter intercepting requests to all OIDC provider endpoints, or use an `@OidcEndpoint` annotation to apply this filter to requests to specific endpoints only. For example:
 
 [source,java]
 ----
@@ -1116,11 +1118,12 @@ package io.quarkus.it.keycloak;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.quarkus.arc.Unremovable;
-import io.quarkus.oidc.common.OidcRequestContext;
+import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcRequestFilter;
 import io.vertx.core.http.HttpMethod;
 
 @ApplicationScoped
+@OidcEndpoint(value = Type.TOKEN)
 @Unremovable
 public class OidcRequestCustomizer implements OidcRequestFilter {
 
@@ -1128,7 +1131,7 @@ public class OidcRequestCustomizer implements OidcRequestFilter {
     public void filter(OidcRequestContext requestContext) {
         HttpMethod method = requestContext.request().method();
         String uri = requestContext.request().uri();
-        if (method == HttpMethod.POST && uri.endsWith("/service") && requestContext.requestBody() != null) {
+        if (method == HttpMethod.POST && uri.endsWith("/token") && requestContext.requestBody() != null) {
             requestContext.request().putHeader("Digest", calculateDigest(requestContext.requestBody().toString()));
         }
     }
@@ -1138,6 +1141,53 @@ public class OidcRequestCustomizer implements OidcRequestFilter {
     }
 }
 ----
+
+`OidcRequestContextProperties` can be used to access request properties.
+Currently, you can use a `client_id` key to access the client tenant id and a `grant_type` key to access the grant type which the OIDC client uses to acquire tokens.
+
+[[oidc-client-ref-oidc-response-filters]]
+== OIDC response filters
+
+You can filter responses to the OIDC client requests by registering one or more `OidcResponseFilter` implementations, which can check the response status, headers and body, in order to log them or perform other actions.
+
+You can have a single filter intercepting responses to all OIDC client requests, or use an `@OidcEndpoint` annotation to apply this filter to the responses to the specific OIDC client requests only. For example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.TOKEN) <1>
+public class TokenEndpointResponseFilter implements OidcResponseFilter {
+    private static final Logger LOG = Logger.getLogger(TokenEndpointResponseFilter.class);
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        String contentType = rc.responseHeaders().get("Content-Type"); <2>
+        if (contentType.equals("application/json")
+                && "refresh_token".equals(rc.requestProperties().get(OidcConstants.GRANT_TYPE)) <3>
+                && rc.responseBody().toJsonObject().containsKey("refresh_token")) { <4>
+            LOG.debug("Tokens have been refreshed");
+        }
+    }
+
+}
+----
+<1> Restrict this filter to requests targeting the OIDC token endpoint only.
+<2> Check the response `Content-Type` header.
+<3> Use `OidcRequestContextProperties` request properties to confirm it is a `refresh_grant` token grant response.
+<4> Confirm the response JSON contains a `refresh_token` property.
 
 [[token-propagation-rest]]
 == Token Propagation for Quarkus REST

--- a/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
@@ -496,6 +496,129 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
 If you register clients dynamically, on demand, as described in the <<register-clients-on-demand>> section, the problem of the duplicate client registration should not arise.
 You can persist the already registered client's registration URI and registration token if necessary though and check them too to avoid any duplicate reservation risk.
 
+[[oidc-client-registration-oidc-request-filters]]
+== OIDC request filters
+
+You can filter OIDC client registration and registered client requests registering one or more `OidcRequestFilter` implementations, which can update or add new request headers. For example, a filter can analyze the request body and add its digest as a new header value:
+
+You can have a single filter intercepting all the OIDC registration and registered client requests, or use an `@OidcEndpoint` annotation to apply this filter to either OIDC registration or registered client endpoint responses only. For example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcRequestFilter;
+import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.CLIENT_REGISTRATION) <1>
+public class ClientRegistrationRequestFilter implements OidcRequestFilter {
+    private static final Logger LOG = Logger.getLogger(ClientRegistrationRequestFilter.class);
+
+    @Override
+    public void filter(OidcRequestContext rc) {
+        JsonObject body = rc.requestBody().toJsonObject();
+        if ("Default Client".equals(body.getString("client_name"))) { <2>
+            LOG.debug("'Default Client' registration request");
+        }
+    }
+
+}
+----
+<1> Restrict this filter to requests targeting the OIDC client registration endpoint only.
+<2> Check the 'client_name' property in the request metadata JSON.
+
+`OidcRequestContextProperties` can be used to access request properties.
+Currently, you can use a `client_id` key to access the client tenant id and a `grant_type` key to access the grant type which the OIDC client uses to acquire tokens.
+
+[[oidc-client-registration-oidc-response-filters]]
+== OIDC response filters
+
+You can filter responses to OIDC client registration and registered client requests by registering one or more `OidcResponseFilter` implementations, which can check the response status, headers and body in order to log them or perform other actions.
+
+You can have a single filter intercepting responses to all the OIDC registration and registered client requests, or use an `@OidcEndpoint` annotation to apply this filter to responses from either OIDC registration or registered client endpoint only. For example:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.vertx.core.json.JsonObject;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.CLIENT_REGISTRATION) <1>
+public class ClientRegistrationResponseFilter implements OidcResponseFilter {
+    private static final Logger LOG = Logger.getLogger(ClientRegistrationResponseFilter.class);
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        String contentType = rc.responseHeaders().get("Content-Type"); <2>
+        JsonObject body = rc.responseBody().toJsonObject();
+        if (contentType.startsWith("application/json")
+                && "Default Client".equals(body.getString("client_name"))) { <3>
+            LOG.debug("'Default Client' has been registered");
+        }
+    }
+
+}
+
+----
+<1> Restrict this filter to requests targeting the OIDC client registration endpoint only.
+<2> Check the response `Content-Type` header.
+<3> Check the 'client_name' property in the response metadata JSON.
+
+or
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcResponseFilter;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.REGISTERED_CLIENT) <1>
+public class RegisteredClientResponseFilter implements OidcResponseFilter {
+    private static final Logger LOG = Logger.getLogger(RegisteredClientResponseFilter.class);
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        String contentType = rc.responseHeaders().get("Content-Type"); <2>
+        if (contentType.startsWith("application/json")
+                && "Default Client Updated".equals(rc.responseBody().toJsonObject().getString("client_name"))) { <3>
+            LOG.debug("Registered 'Default Client' has had its name updated to 'Default Client Updated'");
+        }
+    }
+
+}
+
+----
+<1> Restrict this filter to requests targeting the registered OIDC client endpoint only.
+<2> Check the response `Content-Type` header.
+<3> Confirm the client name property was updated.
+
 [[configuration-reference]]
 == Configuration reference
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcResponseFilter.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcResponseFilter.java
@@ -1,0 +1,27 @@
+package io.quarkus.oidc.common;
+
+import io.vertx.mutiny.core.MultiMap;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+/**
+ * Response filter which can be used to intercept HTTP responses from the OIDC provider.
+ * <p/>
+ * Filter can be restricted to a specific OIDC endpoint with a {@link OidcEndpoint} annotation.
+ */
+public interface OidcResponseFilter {
+
+    /**
+     * OIDC response context which provides access to the HTTP response status code, headers and body.
+     */
+    record OidcResponseContext(OidcRequestContextProperties requestProperties,
+            int statusCode, MultiMap responseHeaders, Buffer responseBody) {
+    }
+
+    /**
+     * Filter OIDC responses.
+     *
+     * @param responseContext the response context which provides access to the HTTP response status code, headers and body.
+     *
+     */
+    void filter(OidcResponseContext responseContext);
+}

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -41,9 +41,12 @@ import io.quarkus.arc.ClientProxy;
 import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.credentials.runtime.CredentialsProviderFinder;
 import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
 import io.quarkus.oidc.common.OidcRequestFilter.OidcRequestContext;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.quarkus.oidc.common.OidcResponseFilter.OidcResponseContext;
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials;
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials.Provider;
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials.Secret;
@@ -494,26 +497,30 @@ public class OidcCommonUtils {
                 || (t instanceof OidcEndpointAccessException && ((OidcEndpointAccessException) t).getErrorStatus() == 404));
     }
 
-    public static Uni<JsonObject> discoverMetadata(WebClient client, Map<OidcEndpoint.Type, List<OidcRequestFilter>> filters,
-            OidcRequestContextProperties contextProperties, String authServerUrl,
+    public static Uni<JsonObject> discoverMetadata(WebClient client,
+            Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
+            OidcRequestContextProperties contextProperties, Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters,
+            String authServerUrl,
             long connectionDelayInMillisecs, Vertx vertx, boolean blockingDnsLookup) {
         final String discoveryUrl = getDiscoveryUri(authServerUrl);
         HttpRequest<Buffer> request = client.getAbs(discoveryUrl);
-        if (!filters.isEmpty()) {
-            Map<String, Object> newProperties = contextProperties == null ? new HashMap<>()
-                    : new HashMap<>(contextProperties.getAll());
-            newProperties.put(OidcRequestContextProperties.DISCOVERY_ENDPOINT, discoveryUrl);
-            OidcRequestContextProperties requestProps = new OidcRequestContextProperties(newProperties);
+        final OidcRequestContextProperties requestProps = requestFilters.isEmpty() ? null
+                : getDiscoveryRequestProps(contextProperties, discoveryUrl);
+        if (!requestFilters.isEmpty()) {
             OidcRequestContext context = new OidcRequestContext(request, null, requestProps);
-            for (OidcRequestFilter filter : getMatchingOidcRequestFilters(filters, OidcEndpoint.Type.DISCOVERY)) {
+            for (OidcRequestFilter filter : getMatchingOidcRequestFilters(requestFilters, OidcEndpoint.Type.DISCOVERY)) {
                 filter.filter(context);
             }
         }
         return sendRequest(vertx, request, blockingDnsLookup).onItem().transform(resp -> {
+
+            Buffer buffer = resp.body();
+            filterHttpResponse(requestProps, resp, buffer, responseFilters, OidcEndpoint.Type.DISCOVERY);
+
             if (resp.statusCode() == 200) {
-                return resp.bodyAsJsonObject();
+                return buffer.toJsonObject();
             } else {
-                String errorMessage = resp.bodyAsString();
+                String errorMessage = buffer.toString();
                 if (errorMessage != null && !errorMessage.isEmpty()) {
                     LOG.warnf("Discovery request %s has failed, status code: %d, error message: %s", discoveryUrl,
                             resp.statusCode(), errorMessage);
@@ -531,6 +538,25 @@ public class OidcCommonUtils {
                     // don't wrap it to avoid information leak
                     return new RuntimeException("OIDC Server is not available");
                 });
+    }
+
+    private static OidcRequestContextProperties getDiscoveryRequestProps(
+            OidcRequestContextProperties contextProperties, String discoveryUrl) {
+        Map<String, Object> newProperties = contextProperties == null ? new HashMap<>()
+                : new HashMap<>(contextProperties.getAll());
+        newProperties.put(OidcRequestContextProperties.DISCOVERY_ENDPOINT, discoveryUrl);
+        return new OidcRequestContextProperties(newProperties);
+    }
+
+    public static void filterHttpResponse(OidcRequestContextProperties requestProps,
+            HttpResponse<Buffer> resp, Buffer buffer,
+            Map<Type, List<OidcResponseFilter>> responseFilters, OidcEndpoint.Type type) {
+        if (!responseFilters.isEmpty()) {
+            OidcResponseContext context = new OidcResponseContext(requestProps, resp.statusCode(), resp.headers(), buffer);
+            for (OidcResponseFilter filter : getMatchingOidcResponseFilters(responseFilters, type)) {
+                filter.filter(context);
+            }
+        }
     }
 
     public static String getDiscoveryUri(String authServerUrl) {
@@ -564,18 +590,26 @@ public class OidcCommonUtils {
     }
 
     public static Map<OidcEndpoint.Type, List<OidcRequestFilter>> getOidcRequestFilters() {
+        return getOidcFilters(OidcRequestFilter.class);
+    }
+
+    public static Map<OidcEndpoint.Type, List<OidcResponseFilter>> getOidcResponseFilters() {
+        return getOidcFilters(OidcResponseFilter.class);
+    }
+
+    private static <T> Map<OidcEndpoint.Type, List<T>> getOidcFilters(Class<T> filterClass) {
         ArcContainer container = Arc.container();
         if (container != null) {
-            Map<OidcEndpoint.Type, List<OidcRequestFilter>> map = new HashMap<>();
-            for (OidcRequestFilter filter : container.listAll(OidcRequestFilter.class).stream().map(handle -> handle.get())
+            Map<OidcEndpoint.Type, List<T>> map = new HashMap<>();
+            for (T filter : container.listAll(filterClass).stream().map(handle -> handle.get())
                     .collect(Collectors.toList())) {
                 OidcEndpoint endpoint = ClientProxy.unwrap(filter).getClass().getAnnotation(OidcEndpoint.class);
                 if (endpoint != null) {
                     for (OidcEndpoint.Type type : endpoint.value()) {
-                        map.computeIfAbsent(type, k -> new ArrayList<OidcRequestFilter>()).add(filter);
+                        map.computeIfAbsent(type, k -> new ArrayList<T>()).add(filter);
                     }
                 } else {
-                    map.computeIfAbsent(OidcEndpoint.Type.ALL, k -> new ArrayList<OidcRequestFilter>()).add(filter);
+                    map.computeIfAbsent(OidcEndpoint.Type.ALL, k -> new ArrayList<T>()).add(filter);
                 }
             }
             return map;
@@ -585,8 +619,19 @@ public class OidcCommonUtils {
 
     public static List<OidcRequestFilter> getMatchingOidcRequestFilters(Map<OidcEndpoint.Type, List<OidcRequestFilter>> filters,
             OidcEndpoint.Type type) {
-        List<OidcRequestFilter> typeSpecific = filters.get(type);
-        List<OidcRequestFilter> all = filters.get(OidcEndpoint.Type.ALL);
+        return getMatchingOidcFilters(filters, type);
+    }
+
+    public static List<OidcResponseFilter> getMatchingOidcResponseFilters(
+            Map<OidcEndpoint.Type, List<OidcResponseFilter>> filters,
+            OidcEndpoint.Type type) {
+        return getMatchingOidcFilters(filters, type);
+    }
+
+    private static <T> List<T> getMatchingOidcFilters(Map<OidcEndpoint.Type, List<T>> filters,
+            OidcEndpoint.Type type) {
+        List<T> typeSpecific = filters.get(type);
+        List<T> all = filters.get(OidcEndpoint.Type.ALL);
         if (typeSpecific == null && all == null) {
             return List.of();
         }
@@ -595,7 +640,7 @@ public class OidcCommonUtils {
         } else if (typeSpecific == null && all != null) {
             return all;
         } else {
-            List<OidcRequestFilter> combined = new ArrayList<>(typeSpecific.size() + all.size());
+            List<T> combined = new ArrayList<>(typeSpecific.size() + all.size());
             combined.addAll(typeSpecific);
             combined.addAll(all);
             return combined;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -40,6 +40,7 @@ import io.quarkus.oidc.TenantIdentityProvider;
 import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
+import io.quarkus.oidc.common.OidcResponseFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcTlsSupport;
@@ -530,6 +531,7 @@ public class OidcRecorder {
         WebClient client = WebClient.create(mutinyVertx, options);
 
         Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters = OidcCommonUtils.getOidcRequestFilters();
+        Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters = OidcCommonUtils.getOidcResponseFilters();
 
         Uni<OidcConfigurationMetadata> metadataUni = null;
         if (!oidcConfig.discoveryEnabled.orElse(true)) {
@@ -539,7 +541,8 @@ public class OidcRecorder {
             OidcRequestContextProperties contextProps = new OidcRequestContextProperties(
                     Map.of(OidcUtils.TENANT_ID_ATTRIBUTE, oidcConfig.getTenantId().orElse(OidcUtils.DEFAULT_TENANT_ID)));
             metadataUni = OidcCommonUtils
-                    .discoverMetadata(client, oidcRequestFilters, contextProps, authServerUriString, connectionDelayInMillisecs,
+                    .discoverMetadata(client, oidcRequestFilters, contextProps, oidcResponseFilters, authServerUriString,
+                            connectionDelayInMillisecs,
                             mutinyVertx,
                             oidcConfig.useBlockingDnsLookup)
                     .onItem()
@@ -586,7 +589,8 @@ public class OidcRecorder {
                                             + " Use 'quarkus.oidc.user-info-path' if the discovery is disabled."));
                         }
                         return Uni.createFrom()
-                                .item(new OidcProviderClient(client, vertx, metadata, oidcConfig, oidcRequestFilters));
+                                .item(new OidcProviderClient(client, vertx, metadata, oidcConfig, oidcRequestFilters,
+                                        oidcResponseFilters));
                     }
 
                 });

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/TokenEndpointResponseFilter.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/TokenEndpointResponseFilter.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.TOKEN)
+public class TokenEndpointResponseFilter implements OidcResponseFilter {
+    private static final Logger LOG = Logger.getLogger(TokenEndpointResponseFilter.class);
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        String contentType = rc.responseHeaders().get("Content-Type");
+        if (contentType.equals("application/json")
+                && rc.responseBody().toJsonObject().containsKey("refresh_token")
+                && "refresh_token".equals(rc.requestProperties().get(OidcConstants.GRANT_TYPE))) {
+            LOG.debug("Tokens have been refreshed");
+        }
+    }
+
+}

--- a/integration-tests/oidc-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-reactive/src/main/resources/application.properties
@@ -40,5 +40,7 @@ io.quarkus.it.keycloak.MisconfiguredClientFilter/mp-rest/url=http://localhost:80
 
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.TokenEndpointResponseFilter".min-level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.TokenEndpointResponseFilter".level=TRACE
 quarkus.log.file.enable=true
 quarkus.log.file.format=%C - %s%n

--- a/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -116,7 +116,8 @@ public class OidcClientTest {
                                 "quarkus log file " + accessLogFilePath + " is missing");
 
                         int tokenAcquisitionCount = 0;
-                        int tokenRefreshedCount = 0;
+                        int tokenRefreshedOidcClientLogCount = 0;
+                        int tokenRefreshResponseFilterLogCount = 0;
 
                         try (BufferedReader reader = new BufferedReader(
                                 new InputStreamReader(new ByteArrayInputStream(Files.readAllBytes(accessLogFilePath)),
@@ -124,9 +125,12 @@ public class OidcClientTest {
                             String line = null;
                             while ((line = reader.readLine()) != null) {
                                 if (line.contains("Default OidcClient has refreshed the tokens")) {
-                                    tokenRefreshedCount++;
+                                    tokenRefreshedOidcClientLogCount++;
                                 } else if (line.contains("Default OidcClient has acquired the tokens")) {
                                     tokenAcquisitionCount++;
+                                }
+                                if (line.contains("Tokens have been refreshed")) {
+                                    tokenRefreshResponseFilterLogCount++;
                                 }
 
                             }
@@ -135,8 +139,11 @@ public class OidcClientTest {
                         assertEquals(1, tokenAcquisitionCount,
                                 "Log file must contain a single OidcClientImpl token acquisition confirmation");
                         // only the reactive filter is refreshing the token
-                        assertEquals(1, tokenRefreshedCount,
+                        assertEquals(1, tokenRefreshedOidcClientLogCount,
                                 "Log file must contain a single OidcClientImpl token refresh confirmation");
+
+                        assertEquals(1, tokenRefreshResponseFilterLogCount,
+                                "Log file must contain a single OidcResponseFilter token refresh confirmation");
                     }
                 });
     }

--- a/integration-tests/oidc-client-registration/pom.xml
+++ b/integration-tests/oidc-client-registration/pom.xml
@@ -33,6 +33,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc</artifactId>
         </dependency>

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientRegistrationRequestFilter.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientRegistrationRequestFilter.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcRequestFilter;
+import io.vertx.core.json.JsonObject;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.CLIENT_REGISTRATION)
+public class ClientRegistrationRequestFilter implements OidcRequestFilter {
+    private static final Logger LOG = Logger.getLogger(ClientRegistrationRequestFilter.class);
+
+    @Override
+    public void filter(OidcRequestContext rc) {
+        JsonObject body = rc.requestBody().toJsonObject();
+        if ("Default Client".equals(body.getString("client_name"))) {
+            LOG.debug("'Default Client' registration request");
+        }
+    }
+
+}

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientRegistrationResponseFilter.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientRegistrationResponseFilter.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.vertx.core.json.JsonObject;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.CLIENT_REGISTRATION)
+public class ClientRegistrationResponseFilter implements OidcResponseFilter {
+    private static final Logger LOG = Logger.getLogger(ClientRegistrationResponseFilter.class);
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        String contentType = rc.responseHeaders().get("Content-Type");
+        JsonObject body = rc.responseBody().toJsonObject();
+        if (contentType.startsWith("application/json")
+                && "Default Client".equals(body.getString("client_name"))) {
+            LOG.debug("'Default Client' has been registered");
+        }
+    }
+
+}

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/RegisteredClientResponseFilter.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/RegisteredClientResponseFilter.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcResponseFilter;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.REGISTERED_CLIENT)
+public class RegisteredClientResponseFilter implements OidcResponseFilter {
+    private static final Logger LOG = Logger.getLogger(RegisteredClientResponseFilter.class);
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        String contentType = rc.responseHeaders().get("Content-Type");
+        if (contentType.startsWith("application/json")
+                && "Default Client Updated".equals(rc.responseBody().toJsonObject().getString("client_name"))) {
+            LOG.debug("Registered 'Default Client' has had its name updated to 'Default Client Updated'");
+        }
+    }
+
+}

--- a/integration-tests/oidc-client-registration/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-registration/src/main/resources/application.properties
@@ -15,5 +15,12 @@ quarkus.oidc-client-registration.tenant-client.metadata.client-name=Tenant Clien
 quarkus.oidc-client-registration.tenant-client.metadata.redirect-uri=http://localhost:8081/protected/tenant
 
 quarkus.log.category."org.htmlunit".level=ERROR
-quarkus.log.category."io.quarkus.oidc.runtime".min-level=TRACE
-quarkus.log.category."io.quarkus.oidc.runtime".level=TRACE
+
+quarkus.log.category."io.quarkus.it.keycloak.ClientRegistrationRequestFilter".min-level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.ClientRegistrationRequestFilter".level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.ClientRegistrationResponseFilter".min-level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.ClientRegistrationResponseFilter".level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.RegisteredClientResponseFilter".min-level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.RegisteredClientResponseFilter".level=TRACE
+quarkus.log.file.enable=true
+quarkus.log.file.format=%C - %s%n

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/SignedUserInfoResponseFilter.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/SignedUserInfoResponseFilter.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcResponseFilter;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.USERINFO)
+public class SignedUserInfoResponseFilter implements OidcResponseFilter {
+    private static final Logger LOG = Logger.getLogger(SignedUserInfoResponseFilter.class);
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        String contentType = rc.responseHeaders().get("Content-Type");
+        if (contentType.startsWith("application/jwt") && rc.responseBody().toString().startsWith("ey")) {
+            LOG.debug("Response contains signed UserInfo");
+        }
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TokenResponseFilter.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TokenResponseFilter.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
+import io.quarkus.oidc.common.OidcResponseFilter;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.runtime.OidcUtils;
+
+@ApplicationScoped
+@Unremovable
+@OidcEndpoint(value = Type.TOKEN)
+public class TokenResponseFilter implements OidcResponseFilter {
+    private static final Logger LOG = Logger.getLogger(TokenResponseFilter.class);
+
+    @Override
+    public void filter(OidcResponseContext rc) {
+        if (rc.statusCode() == 200
+                && rc.responseHeaders().get("Content-Type").equals("application/json")
+                && OidcConstants.AUTHORIZATION_CODE.equals(rc.requestProperties().get(OidcConstants.GRANT_TYPE))
+                && "code-flow-user-info-github-cached-in-idtoken"
+                        .equals(rc.requestProperties().get(OidcUtils.TENANT_ID_ATTRIBUTE))) {
+            LOG.debug("Authorization code completed for tenant 'code-flow-user-info-github-cached-in-idtoken'");
+        }
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -233,6 +233,10 @@ quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.SignedUserInfoResponseFilter".min-level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.SignedUserInfoResponseFilter".level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.TokenResponseFilter".min-level=TRACE
+quarkus.log.category."io.quarkus.it.keycloak.TokenResponseFilter".level=TRACE
 quarkus.log.file.enable=true
 quarkus.log.file.format=%C - %s%n
 


### PR DESCRIPTION
This PR introduces `OidcResponseFilter` to support filtering responses to all `quarkus-oidc`, `quarkus-oidc-client` and `quarkus-oidc-client-registration` calls. With `OidcRequestFilter` and `OidcRedirectFilter` already available, all the direct and indirect communication channels with the OIDC server can not be filtered.

I'll clean up and open for review early next week 

- Fixes: #42117.