### PR TITLE
Qute: reflection fallback value resolver optimization

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/AccessorCandidate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/AccessorCandidate.java
@@ -10,4 +10,15 @@ interface AccessorCandidate {
      */
     ValueAccessor getAccessor(EvalContext context);
 
+    /**
+     * If the accessor can be shared and does not need to access the {@link EvalContext}
+     * <p>
+     * For example, getters and field accessors are stateless.
+     *
+     * @return {@code true} if the accessor can be shared, {@code false} otherwise
+     */
+    default boolean isShared(EvalContext context) {
+        return true;
+    }
+
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
@@ -141,9 +141,9 @@ class EvaluatorImpl implements Evaluator {
 
         if (tryCachedResolver) {
             // Try the cached resolver first
-            ValueResolver cachedResolver = evalContext.getCachedResolver();
-            if (cachedResolver != null && cachedResolver.appliesTo(evalContext)) {
-                return cachedResolver.resolve(evalContext).thenCompose(r -> {
+            ValueResolver cached = evalContext.getCachedResolver();
+            if (cached != null && cached.appliesTo(evalContext)) {
+                return cached.resolve(evalContext).thenCompose(r -> {
                     if (Results.isNotFound(r)) {
                         return resolve(evalContext, null, false, expression, isLastPart, partIndex);
                     } else {
@@ -214,7 +214,7 @@ class EvaluatorImpl implements Evaluator {
                 return resolve(evalContext, remainingResolvers, false, expression, isLastPart, partIndex);
             } else {
                 // Cache the first resolver where a result is found
-                evalContext.setCachedResolver(foundResolver);
+                evalContext.setCachedResolver(foundResolver.getCachedResolver(evalContext));
                 return CompletionStageSupport.toCompletionStage(r);
             }
         });

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
@@ -58,4 +58,18 @@ final class MethodsCandidate implements AccessorCandidate {
         };
     }
 
+    @Override
+    public boolean isShared(EvalContext context) {
+        if (methods.size() == 1) {
+            for (Expression param : context.getParams()) {
+                if (param.isLiteral()) {
+                    return false;
+                }
+            }
+            // Single method; all params are literals
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ReflectionValueResolver.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ReflectionValueResolver.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,9 +47,8 @@ public class ReflectionValueResolver implements ValueResolver {
     @Override
     public CompletionStage<Object> resolve(EvalContext context) {
         Object base = context.getBase();
-        MemberKey key = MemberKey.from(context);
         // At this point the candidate for the given key should be already computed
-        AccessorCandidate candidate = candidates.get(key).orElse(null);
+        AccessorCandidate candidate = candidates.get(MemberKey.from(context)).orElse(null);
         if (candidate == null) {
             return Results.notFound(context);
         }
@@ -57,6 +57,15 @@ public class ReflectionValueResolver implements ValueResolver {
             return Results.notFound(context);
         }
         return accessor.getValue(base);
+    }
+
+    @Override
+    public ValueResolver getCachedResolver(EvalContext context) {
+        // The value must be computed and the accessor must exist
+        AccessorCandidate candidate = candidates.get(MemberKey.from(context)).orElseThrow();
+        return candidate.isShared(context)
+                ? new AccessorResolver(context.getBase().getClass(), candidate.getAccessor(context))
+                : new CandidateResolver(context.getBase().getClass(), candidate);
     }
 
     public void clearCache() {
@@ -162,7 +171,7 @@ public class ReflectionValueResolver implements ValueResolver {
                 }
             }
         }
-        return foundMatch.size() == 1 ? Collections.singletonList(foundMatch.get(0)) : foundMatch;
+        return foundMatch.size() == 1 ? List.of(foundMatch.get(0)) : foundMatch;
     }
 
     private static boolean isMethodCandidate(Method method) {
@@ -200,6 +209,51 @@ public class ReflectionValueResolver implements ValueResolver {
         char chars[] = name.toCharArray();
         chars[0] = Character.toLowerCase(chars[0]);
         return new String(chars);
+    }
+
+    static class AccessorResolver implements ValueResolver {
+
+        private final Class<?> matchedClass;
+        private final ValueAccessor accessor;
+
+        private AccessorResolver(Class<?> matchedClass, ValueAccessor accessor) {
+            this.matchedClass = Objects.requireNonNull(matchedClass);
+            this.accessor = Objects.requireNonNull(accessor);
+        }
+
+        @Override
+        public boolean appliesTo(EvalContext context) {
+            return ValueResolver.matchClass(context, matchedClass);
+        }
+
+        @Override
+        public CompletionStage<Object> resolve(EvalContext context) {
+            return accessor.getValue(context.getBase());
+        }
+
+    }
+
+    static class CandidateResolver implements ValueResolver {
+
+        private final Class<?> matchedClass;
+        private final AccessorCandidate candidate;
+
+        private CandidateResolver(Class<?> matchedClass, AccessorCandidate candidate) {
+            this.matchedClass = Objects.requireNonNull(matchedClass);
+            this.candidate = Objects.requireNonNull(candidate);
+            ;
+        }
+
+        @Override
+        public boolean appliesTo(EvalContext context) {
+            return ValueResolver.matchClass(context, matchedClass);
+        }
+
+        @Override
+        public CompletionStage<Object> resolve(EvalContext context) {
+            return candidate.getAccessor(context).getValue(context.getBase());
+        }
+
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolver.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolver.java
@@ -22,6 +22,20 @@ public interface ValueResolver extends Resolver, WithPriority {
     }
 
     /**
+     * When {@link #appliesTo(EvalContext)} returns {@code true} for a specific {@link EvalContext} and the subsequent
+     * invocation of {@link #resolve(EvalContext)} does not return {@link Results#NotFound} the value resolver returned from
+     * this method is cached for the specific part of an expression.
+     * <p>
+     * By default, the resolver itself is cached. However, it is also possible to return an optimized version.
+     *
+     * @param context
+     * @return the resolver that should be cached
+     */
+    default ValueResolver getCachedResolver(EvalContext context) {
+        return this;
+    }
+
+    /**
      *
      * @return a new builder
      */


### PR DESCRIPTION
- add ValueResolver#getCachedResolver() so that reflection value resolver can optimize the cached resolver and save two concurrent hash map lookups and 2 MemberKey instances

I can observe ~ 20% higher throughput in the [reflection value resolver benchmark](https://github.com/mkouba/qute-benchmarks/blob/main/src/main/java/io/quarkus/qute/benchmark/Reflect.java) (when compared to the main branch).

cc @franz1981 