### PR TITLE
Redis Cache: support more complex types

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/types/TypeParser.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/types/TypeParser.java
@@ -1,0 +1,233 @@
+package io.quarkus.deployment.types;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.quarkus.runtime.types.GenericArrayTypeImpl;
+import io.quarkus.runtime.types.ParameterizedTypeImpl;
+import io.quarkus.runtime.types.WildcardTypeImpl;
+
+/**
+ * Creates a {@link Type} by parsing the given string according to the following grammar:
+ *
+ * <pre>
+ * Type -> VoidType | PrimitiveType | ReferenceType
+ * VoidType -> 'void'
+ * PrimitiveType -> 'boolean' | 'byte' | 'short' | 'int'
+ *                | 'long' | 'float' | 'double' | 'char'
+ * ReferenceType -> PrimitiveType ('[' ']')+
+ *                | ClassType ('<' TypeArgument (',' TypeArgument)* '>')? ('[' ']')*
+ * ClassType -> FULLY_QUALIFIED_NAME
+ * TypeArgument -> ReferenceType | WildcardType
+ * WildcardType -> '?' | '?' ('extends' | 'super') ReferenceType
+ * </pre>
+ *
+ * Notice that the resulting type never contains type variables, only "proper" types.
+ * Also notice that the grammar above does not support all kinds of nested types;
+ * it should be possible to add that later, if there's an actual need.
+ * <p>
+ * Types produced by this parser can be transferred from build time to runtime
+ * via the recorder mechanism.
+ */
+public class TypeParser {
+    public static Type parse(String str) {
+        return new TypeParser(str).parse();
+    }
+
+    private final String str;
+
+    private int pos = 0;
+
+    private TypeParser(String str) {
+        this.str = Objects.requireNonNull(str);
+    }
+
+    private Type parse() {
+        Type result;
+
+        String token = nextToken();
+        if (token.isEmpty()) {
+            throw unexpected(token);
+        } else if (token.equals("void")) {
+            result = void.class;
+        } else if (isPrimitiveType(token) && peekToken().isEmpty()) {
+            result = parsePrimitiveType(token);
+        } else {
+            result = parseReferenceType(token);
+        }
+
+        expect("");
+        return result;
+    }
+
+    private Type parseReferenceType(String token) {
+        if (isPrimitiveType(token)) {
+            Type primitive = parsePrimitiveType(token);
+            return parseArrayType(primitive);
+        } else if (isClassType(token)) {
+            Type result = parseClassType(token);
+            if (peekToken().equals("<")) {
+                expect("<");
+                List<Type> typeArguments = new ArrayList<>();
+                typeArguments.add(parseTypeArgument());
+                while (peekToken().equals(",")) {
+                    expect(",");
+                    typeArguments.add(parseTypeArgument());
+                }
+                expect(">");
+                result = new ParameterizedTypeImpl(result, typeArguments.toArray(Type[]::new));
+            }
+            if (peekToken().equals("[")) {
+                return parseArrayType(result);
+            }
+            return result;
+        } else {
+            throw unexpected(token);
+        }
+    }
+
+    private Type parseArrayType(Type elementType) {
+        expect("[");
+        expect("]");
+        int dimensions = 1;
+        while (peekToken().equals("[")) {
+            expect("[");
+            expect("]");
+            dimensions++;
+        }
+
+        if (elementType instanceof Class<?> clazz) {
+            return parseClassType("[".repeat(dimensions)
+                    + (clazz.isPrimitive() ? clazz.descriptorString() : "L" + clazz.getName() + ";"));
+        } else {
+            Type result = elementType;
+            for (int i = 0; i < dimensions; i++) {
+                result = new GenericArrayTypeImpl(result);
+            }
+            return result;
+        }
+    }
+
+    private Type parseTypeArgument() {
+        String token = nextToken();
+        if (token.equals("?")) {
+            if (peekToken().equals("extends")) {
+                expect("extends");
+                Type bound = parseReferenceType(nextToken());
+                return WildcardTypeImpl.withUpperBound(bound);
+            } else if (peekToken().equals("super")) {
+                expect("super");
+                Type bound = parseReferenceType(nextToken());
+                return WildcardTypeImpl.withLowerBound(bound);
+            } else {
+                return WildcardTypeImpl.defaultInstance();
+            }
+        } else {
+            return parseReferenceType(token);
+        }
+    }
+
+    private boolean isPrimitiveType(String token) {
+        return token.equals("boolean")
+                || token.equals("byte")
+                || token.equals("short")
+                || token.equals("int")
+                || token.equals("long")
+                || token.equals("float")
+                || token.equals("double")
+                || token.equals("char");
+    }
+
+    private Type parsePrimitiveType(String token) {
+        return switch (token) {
+            case "boolean" -> boolean.class;
+            case "byte" -> byte.class;
+            case "short" -> short.class;
+            case "int" -> int.class;
+            case "long" -> long.class;
+            case "float" -> float.class;
+            case "double" -> double.class;
+            case "char" -> char.class;
+            default -> throw unexpected(token);
+        };
+    }
+
+    private boolean isClassType(String token) {
+        return !token.isEmpty() && Character.isJavaIdentifierStart(token.charAt(0));
+    }
+
+    private Type parseClassType(String token) {
+        try {
+            return Class.forName(token, true, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Unknown class: " + token, e);
+        }
+    }
+
+    // ---
+
+    private void expect(String expected) {
+        String token = nextToken();
+        if (!expected.equals(token)) {
+            throw unexpected(token);
+        }
+    }
+
+    private IllegalArgumentException unexpected(String token) {
+        if (token.isEmpty()) {
+            throw new IllegalArgumentException("Unexpected end of input: " + str);
+        }
+        return new IllegalArgumentException("Unexpected token '" + token + "' at position " + (pos - token.length())
+                + ": " + str);
+    }
+
+    private String peekToken() {
+        // skip whitespace
+        while (pos < str.length() && Character.isWhitespace(str.charAt(pos))) {
+            pos++;
+        }
+
+        // end of input
+        if (pos == str.length()) {
+            return "";
+        }
+
+        int pos = this.pos;
+
+        // current char is a token on its own
+        if (isSpecial(str.charAt(pos))) {
+            return str.substring(pos, pos + 1);
+        }
+
+        // token is a keyword or fully qualified name
+        int begin = pos;
+        while (pos < str.length() && Character.isJavaIdentifierStart(str.charAt(pos))) {
+            do {
+                pos++;
+            } while (pos < str.length() && Character.isJavaIdentifierPart(str.charAt(pos)));
+
+            if (pos < str.length() && str.charAt(pos) == '.') {
+                pos++;
+            } else {
+                return str.substring(begin, pos);
+            }
+        }
+
+        if (pos == str.length()) {
+            throw new IllegalArgumentException("Unexpected end of input: " + str);
+        }
+        throw new IllegalArgumentException("Unexpected character '" + str.charAt(pos) + "' at position " + pos + ": " + str);
+    }
+
+    private String nextToken() {
+        String result = peekToken();
+        pos += result.length();
+        return result;
+    }
+
+    private boolean isSpecial(char c) {
+        return c == ',' || c == '?' || c == '<' || c == '>' || c == '[' || c == ']';
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/types/TypeParserTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/types/TypeParserTest.java
@@ -1,0 +1,157 @@
+package io.quarkus.deployment.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.util.TypeLiteral;
+
+import org.junit.jupiter.api.Test;
+
+public class TypeParserTest {
+    @Test
+    public void testVoid() {
+        assertCorrect("void", void.class);
+        assertCorrect(" void", void.class);
+        assertCorrect("void ", void.class);
+        assertCorrect(" void ", void.class);
+    }
+
+    @Test
+    public void testPrimitive() {
+        assertCorrect("boolean", boolean.class);
+        assertCorrect(" byte", byte.class);
+        assertCorrect("short ", short.class);
+        assertCorrect(" int ", int.class);
+        assertCorrect("\tlong", long.class);
+        assertCorrect("float\t", float.class);
+        assertCorrect("\tdouble\t", double.class);
+        assertCorrect(" \n char \n ", char.class);
+    }
+
+    @Test
+    public void testPrimitiveArray() {
+        assertCorrect("boolean[]", boolean[].class);
+        assertCorrect("byte [][]", byte[][].class);
+        assertCorrect("short [] [] []", short[][][].class);
+        assertCorrect("int [ ] [ ] [ ] [ ]", int[][][][].class);
+        assertCorrect("long   [][][]", long[][][].class);
+        assertCorrect(" float[][]", float[][].class);
+        assertCorrect(" double [] ", double[].class);
+        assertCorrect(" char [ ][ ]  ", char[][].class);
+    }
+
+    @Test
+    public void testClass() {
+        assertCorrect("java.lang.Object", Object.class);
+        assertCorrect("java.lang.String", String.class);
+
+        assertCorrect(" java.lang.Boolean", Boolean.class);
+        assertCorrect("java.lang.Byte ", Byte.class);
+        assertCorrect(" java.lang.Short ", Short.class);
+        assertCorrect("\tjava.lang.Integer", Integer.class);
+        assertCorrect("java.lang.Long\t", Long.class);
+        assertCorrect("\tjava.lang.Float\t", Float.class);
+        assertCorrect("   java.lang.Double", Double.class);
+        assertCorrect("java.lang.Character   ", Character.class);
+    }
+
+    @Test
+    public void testClassArray() {
+        assertCorrect("java.lang.Object[]", Object[].class);
+        assertCorrect("java.lang.String[][]", String[][].class);
+
+        assertCorrect("java.lang.Boolean[][][]", Boolean[][][].class);
+        assertCorrect("java.lang.Byte[][][][]", Byte[][][][].class);
+        assertCorrect("java.lang.Short[][][]", Short[][][].class);
+        assertCorrect("java.lang.Integer[][]", Integer[][].class);
+        assertCorrect("java.lang.Long[]", Long[].class);
+        assertCorrect("java.lang.Float[][]", Float[][].class);
+        assertCorrect("java.lang.Double[][][]", Double[][][].class);
+        assertCorrect("java.lang.Character[][][][]", Character[][][][].class);
+    }
+
+    @Test
+    public void testParameterizedType() {
+        assertCorrect("java.util.List<java.lang.Integer>", new TypeLiteral<List<Integer>>() {
+        }.getType());
+        assertCorrect("java.util.Map<java.lang.Integer, int[]>", new TypeLiteral<Map<Integer, int[]>>() {
+        }.getType());
+
+        assertCorrect("java.util.List<? extends java.lang.Integer>", new TypeLiteral<List<? extends Integer>>() {
+        }.getType());
+        assertCorrect("java.util.Map<? super int[][], java.util.List<?>>", new TypeLiteral<Map<? super int[][], List<?>>>() {
+        }.getType());
+    }
+
+    @Test
+    public void testParameterizedTypeArray() {
+        assertCorrect("java.util.List<java.lang.Integer>[]", new TypeLiteral<List<Integer>[]>() {
+        }.getType());
+        assertCorrect("java.util.Map<java.lang.Integer, int[]>[][]", new TypeLiteral<Map<Integer, int[]>[][]>() {
+        }.getType());
+    }
+
+    @Test
+    public void testIncorrect() {
+        assertIncorrect("");
+        assertIncorrect(" ");
+        assertIncorrect("\t");
+        assertIncorrect("    ");
+        assertIncorrect("  \n  ");
+
+        assertIncorrect(".");
+        assertIncorrect(",");
+        assertIncorrect("[");
+        assertIncorrect("]");
+        assertIncorrect("<");
+        assertIncorrect(">");
+
+        assertIncorrect("int.");
+        assertIncorrect("int,");
+        assertIncorrect("int[");
+        assertIncorrect("int]");
+        assertIncorrect("int[[]");
+        assertIncorrect("int[][");
+        assertIncorrect("int[]]");
+        assertIncorrect("int[0]");
+        assertIncorrect("int<");
+        assertIncorrect("int>");
+        assertIncorrect("int<>");
+
+        assertIncorrect("java.util.List<");
+        assertIncorrect("java.util.List<>");
+        assertIncorrect("java.util.List<java.lang.Integer");
+        assertIncorrect("java.util.List<java.lang.Integer>>");
+        assertIncorrect("java.util.List<java.util.List<java.lang.Integer");
+        assertIncorrect("java.util.List<java.util.List<java.lang.Integer>");
+        assertIncorrect("java.util.List<java.util.List<java.lang.Integer>>>");
+
+        assertIncorrect("java.util.List<int>");
+        assertIncorrect("java.util.Map<int, long>");
+
+        assertIncorrect("java.lang.Integer.");
+        assertIncorrect("java .lang.Integer");
+        assertIncorrect("java. lang.Integer");
+        assertIncorrect("java . lang.Integer");
+        assertIncorrect(".java.lang.Integer");
+        assertIncorrect(".java.lang.Integer.");
+
+        assertIncorrect("java.lang.Integer[");
+        assertIncorrect("java.lang.Integer[[]");
+        assertIncorrect("java.lang.Integer[][");
+        assertIncorrect("java.lang.Integer[]]");
+        assertIncorrect("java.lang.Integer[0]");
+    }
+
+    private void assertCorrect(String str, Type expectedType) {
+        assertEquals(expectedType, TypeParser.parse(str));
+    }
+
+    private void assertIncorrect(String str) {
+        assertThrows(IllegalArgumentException.class, () -> TypeParser.parse(str));
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/types/GenericArrayTypeImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/types/GenericArrayTypeImpl.java
@@ -1,0 +1,53 @@
+package io.quarkus.runtime.types;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
+/**
+ * @author Marko Luksa
+ * @author Jozef Hartinger
+ */
+public class GenericArrayTypeImpl implements GenericArrayType {
+
+    private Type genericComponentType;
+
+    public GenericArrayTypeImpl(Type genericComponentType) {
+        this.genericComponentType = genericComponentType;
+    }
+
+    public GenericArrayTypeImpl(Class<?> rawType, Type... actualTypeArguments) {
+        this.genericComponentType = new ParameterizedTypeImpl(rawType, actualTypeArguments);
+    }
+
+    @Override
+    public Type getGenericComponentType() {
+        return genericComponentType;
+    }
+
+    @Override
+    public int hashCode() {
+        return ((genericComponentType == null) ? 0 : genericComponentType.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof GenericArrayType) {
+            GenericArrayType that = (GenericArrayType) obj;
+            if (genericComponentType == null) {
+                return that.getGenericComponentType() == null;
+            } else {
+                return genericComponentType.equals(that.getGenericComponentType());
+            }
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(genericComponentType.toString());
+        sb.append("[]");
+        return sb.toString();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/types/ParameterizedTypeImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/types/ParameterizedTypeImpl.java
@@ -1,0 +1,86 @@
+package io.quarkus.runtime.types;
+
+import java.io.Serializable;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+public class ParameterizedTypeImpl implements ParameterizedType, Serializable {
+
+    private static final long serialVersionUID = -3005183010706452884L;
+
+    private final Type[] actualTypeArguments;
+    private final Type rawType;
+    private final Type ownerType;
+
+    public ParameterizedTypeImpl(Type rawType, Type... actualTypeArguments) {
+        this(rawType, actualTypeArguments, null);
+    }
+
+    public ParameterizedTypeImpl(Type rawType, Type[] actualTypeArguments, Type ownerType) {
+        this.actualTypeArguments = actualTypeArguments;
+        this.rawType = rawType;
+        this.ownerType = ownerType;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+        return Arrays.copyOf(actualTypeArguments, actualTypeArguments.length);
+    }
+
+    @Override
+    public Type getOwnerType() {
+        return ownerType;
+    }
+
+    @Override
+    public Type getRawType() {
+        return rawType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(actualTypeArguments) ^ (ownerType == null ? 0 : ownerType.hashCode())
+                ^ (rawType == null ? 0 : rawType.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj instanceof ParameterizedType that) {
+            Type thatOwnerType = that.getOwnerType();
+            Type thatRawType = that.getRawType();
+            return (ownerType == null ? thatOwnerType == null : ownerType.equals(thatOwnerType))
+                    && (rawType == null ? thatRawType == null : rawType.equals(thatRawType))
+                    && Arrays.equals(actualTypeArguments, that.getActualTypeArguments());
+        } else {
+            return false;
+        }
+
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (rawType instanceof Class) {
+            sb.append(((Class<?>) rawType).getName());
+        } else {
+            sb.append(rawType);
+        }
+        if (actualTypeArguments.length > 0) {
+            sb.append("<");
+            for (Type actualType : actualTypeArguments) {
+                if (actualType instanceof Class) {
+                    sb.append(((Class<?>) actualType).getName());
+                } else {
+                    sb.append(actualType);
+                }
+                sb.append(", ");
+            }
+            sb.delete(sb.length() - 2, sb.length());
+            sb.append(">");
+        }
+        return sb.toString();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/types/WildcardTypeImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/types/WildcardTypeImpl.java
@@ -1,0 +1,73 @@
+package io.quarkus.runtime.types;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+
+/**
+ * This code was mainly copied from Weld codebase.
+ *
+ * Implementation of {@link WildcardType}.
+ *
+ * Note that per JLS a wildcard may define either the upper bound or the lower bound. A wildcard may not have multiple bounds.
+ *
+ * @author Jozef Hartinger
+ *
+ */
+public class WildcardTypeImpl implements WildcardType {
+
+    public static WildcardType defaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    public static WildcardType withUpperBound(Type type) {
+        return new WildcardTypeImpl(new Type[] { type }, DEFAULT_LOWER_BOUND);
+    }
+
+    public static WildcardType withLowerBound(Type type) {
+        return new WildcardTypeImpl(DEFAULT_UPPER_BOUND, new Type[] { type });
+    }
+
+    private static final Type[] DEFAULT_UPPER_BOUND = new Type[] { Object.class };
+    private static final Type[] DEFAULT_LOWER_BOUND = new Type[0];
+    private static final WildcardType DEFAULT_INSTANCE = new WildcardTypeImpl(DEFAULT_UPPER_BOUND, DEFAULT_LOWER_BOUND);
+
+    private final Type[] upperBound;
+    private final Type[] lowerBound;
+
+    private WildcardTypeImpl(Type[] upperBound, Type[] lowerBound) {
+        this.upperBound = upperBound;
+        this.lowerBound = lowerBound;
+    }
+
+    @Override
+    public Type[] getUpperBounds() {
+        return upperBound;
+    }
+
+    @Override
+    public Type[] getLowerBounds() {
+        return lowerBound;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof WildcardType)) {
+            return false;
+        }
+        WildcardType other = (WildcardType) obj;
+        return Arrays.equals(lowerBound, other.getLowerBounds()) && Arrays.equals(upperBound, other.getUpperBounds());
+    }
+
+    @Override
+    public int hashCode() {
+        // We deliberately use the logic from JDK/guava
+        return Arrays.hashCode(lowerBound) ^ Arrays.hashCode(upperBound);
+    }
+}

--- a/extensions/redis-cache/deployment/src/main/java/io/quarkus/cache/redis/deployment/RedisCacheProcessor.java
+++ b/extensions/redis-cache/deployment/src/main/java/io/quarkus/cache/redis/deployment/RedisCacheProcessor.java
@@ -16,6 +16,7 @@ import jakarta.enterprise.inject.spi.DeploymentException;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
@@ -34,6 +35,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.types.TypeParser;
 import io.quarkus.redis.deployment.client.RequestedRedisClientBuildItem;
 import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.smallrye.mutiny.Uni;
@@ -69,11 +71,25 @@ public class RedisCacheProcessor {
 
     @BuildStep
     @Record(STATIC_INIT)
-    void determineValueTypes(RedisCacheBuildRecorder recorder, CombinedIndexBuildItem combinedIndex,
+    void determineKeyValueTypes(RedisCacheBuildRecorder recorder, CombinedIndexBuildItem combinedIndex,
             CacheNamesBuildItem cacheNamesBuildItem, RedisCachesBuildTimeConfig buildConfig) {
-        Map<String, String> resolvedValuesTypesFromAnnotations = valueTypesFromCacheResultAnnotation(combinedIndex);
 
-        Map<String, String> valueTypes = new HashMap<>();
+        Map<String, java.lang.reflect.Type> keyTypes = new HashMap<>();
+        RedisCacheBuildTimeConfig defaultBuildTimeConfig = buildConfig.defaultConfig;
+        for (String cacheName : cacheNamesBuildItem.getNames()) {
+            RedisCacheBuildTimeConfig namedBuildTimeConfig = buildConfig.cachesConfig.get(cacheName);
+
+            if (namedBuildTimeConfig != null && namedBuildTimeConfig.keyType.isPresent()) {
+                keyTypes.put(cacheName, TypeParser.parse(namedBuildTimeConfig.keyType.get()));
+            } else if (defaultBuildTimeConfig.keyType.isPresent()) {
+                keyTypes.put(cacheName, TypeParser.parse(defaultBuildTimeConfig.keyType.get()));
+            }
+        }
+        recorder.setCacheKeyTypes(keyTypes);
+
+        Map<String, Type> resolvedValuesTypesFromAnnotations = valueTypesFromCacheResultAnnotation(combinedIndex);
+
+        Map<String, java.lang.reflect.Type> valueTypes = new HashMap<>();
         Optional<String> defaultValueType = buildConfig.defaultConfig.valueType;
         Set<String> cacheNames = cacheNamesBuildItem.getNames();
         for (String cacheName : cacheNames) {
@@ -89,12 +105,13 @@ public class RedisCacheProcessor {
                 }
             }
 
-            if (valueType == null) { // TODO: does it make sense to use the return type of method annotated with @CacheResult as the last resort or should it override the default cache config?
-                valueType = resolvedValuesTypesFromAnnotations.get(cacheName);
+            if (valueType == null && resolvedValuesTypesFromAnnotations.containsKey(cacheName)) {
+                // TODO: does it make sense to use the return type of method annotated with @CacheResult as the last resort or should it override the default cache config?
+                valueType = typeToString(resolvedValuesTypesFromAnnotations.get(cacheName));
             }
 
             if (valueType != null) {
-                valueTypes.put(cacheName, valueType);
+                valueTypes.put(cacheName, TypeParser.parse(valueType));
             } else {
                 throw new DeploymentException("Unable to determine the value type for '" + cacheName
                         + "' Redis cache. An appropriate configuration value for 'quarkus.cache.redis." + cacheName
@@ -104,7 +121,7 @@ public class RedisCacheProcessor {
         recorder.setCacheValueTypes(valueTypes);
     }
 
-    private static Map<String, String> valueTypesFromCacheResultAnnotation(CombinedIndexBuildItem combinedIndex) {
+    private static Map<String, Type> valueTypesFromCacheResultAnnotation(CombinedIndexBuildItem combinedIndex) {
         Map<String, Set<Type>> valueTypesFromAnnotations = new HashMap<>();
 
         // first go through @CacheResult instances and simply record the return types
@@ -133,7 +150,7 @@ public class RedisCacheProcessor {
             return Collections.emptyMap();
         }
 
-        Map<String, String> result = new HashMap<>();
+        Map<String, Type> result = new HashMap<>();
 
         // now apply our resolution logic on the obtained types
         for (var entry : valueTypesFromAnnotations.entrySet()) {
@@ -146,17 +163,15 @@ public class RedisCacheProcessor {
             }
 
             Type type = typeSet.iterator().next();
-            String resolvedType = null;
-            if (type.kind() == Type.Kind.CLASS) {
-                resolvedType = type.asClassType().name().toString();
-            } else if (type.kind() == Type.Kind.PRIMITIVE) {
-                resolvedType = type.asPrimitiveType().name().toString();
-            } else if ((type.kind() == Type.Kind.PARAMETERIZED_TYPE) && UNI.equals(type.name())) {
+            Type resolvedType = null;
+            if (type.kind() == Type.Kind.PARAMETERIZED_TYPE && UNI.equals(type.name())) {
                 ParameterizedType parameterizedType = type.asParameterizedType();
                 List<Type> arguments = parameterizedType.arguments();
                 if (arguments.size() == 1) {
-                    resolvedType = arguments.get(0).name().toString();
+                    resolvedType = arguments.get(0);
                 }
+            } else {
+                resolvedType = type;
             }
 
             if (resolvedType != null) {
@@ -169,5 +184,49 @@ public class RedisCacheProcessor {
         }
 
         return result;
+    }
+
+    private static String typeToString(Type type) {
+        StringBuilder result = new StringBuilder();
+        typeToString(type, result);
+        return result.toString();
+    }
+
+    private static void typeToString(Type type, StringBuilder result) {
+        switch (type.kind()) {
+            case VOID, PRIMITIVE, CLASS -> result.append(type.name().toString());
+            case ARRAY -> {
+                typeToString(type.asArrayType().elementType(), result);
+                result.append("[]".repeat(type.asArrayType().deepDimensions()));
+            }
+            case PARAMETERIZED_TYPE -> {
+                if (type.asParameterizedType().owner() != null) {
+                    throw new IllegalArgumentException("Unsupported type: " + type);
+                }
+
+                result.append(type.name().toString());
+                result.append('<');
+                boolean first = true;
+                for (Type typeArgument : type.asParameterizedType().arguments()) {
+                    if (!first) {
+                        result.append(", ");
+                    }
+                    typeToString(typeArgument, result);
+                    first = false;
+                }
+                result.append('>');
+            }
+            case WILDCARD_TYPE -> {
+                result.append('?');
+                if (type.asWildcardType().superBound() != null) {
+                    result.append(" super ");
+                    typeToString(type.asWildcardType().superBound(), result);
+                } else if (type.asWildcardType().extendsBound() != ClassType.OBJECT_TYPE) {
+                    result.append(" extends ");
+                    typeToString(type.asWildcardType().extendsBound(), result);
+                }
+            }
+            default -> throw new IllegalArgumentException("Unsupported type: " + type);
+        }
     }
 }

--- a/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/ComplexCachedService.java
+++ b/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/ComplexCachedService.java
@@ -1,0 +1,37 @@
+package io.quarkus.cache.redis.deployment;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.cache.CacheResult;
+
+@ApplicationScoped
+public class ComplexCachedService {
+    static final String CACHE_NAME_GENERIC = "test-cache-generic";
+    static final String CACHE_NAME_ARRAY = "test-cache-array";
+    static final String CACHE_NAME_GENERIC_ARRAY = "test-cache-generic-array";
+
+    @CacheResult(cacheName = CACHE_NAME_GENERIC)
+    public List<String> genericReturnType(String key) {
+        return List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+    }
+
+    @CacheResult(cacheName = CACHE_NAME_ARRAY)
+    public int[] arrayReturnType(String key) {
+        int[] result = new int[2];
+        result[0] = ThreadLocalRandom.current().nextInt();
+        result[1] = ThreadLocalRandom.current().nextInt();
+        return result;
+    }
+
+    @CacheResult(cacheName = CACHE_NAME_GENERIC_ARRAY)
+    public List<? extends CharSequence>[] genericArrayReturnType(String key) {
+        return new List[] {
+                List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()),
+                List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        };
+    }
+}

--- a/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/ComplexTypesRedisCacheTest.java
+++ b/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/ComplexTypesRedisCacheTest.java
@@ -1,0 +1,102 @@
+package io.quarkus.cache.redis.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ComplexTypesRedisCacheTest {
+    private static final String KEY_1 = "1";
+    private static final String KEY_2 = "2";
+    private static final String KEY_3 = "3";
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(ComplexCachedService.class, TestUtil.class));
+
+    @Inject
+    ComplexCachedService cachedService;
+
+    @Test
+    public void testGeneric() {
+        RedisDataSource redisDataSource = Arc.container().select(RedisDataSource.class).get();
+        List<String> allKeysAtStart = TestUtil.allRedisKeys(redisDataSource);
+
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        List<String> value1 = cachedService.genericReturnType(KEY_1);
+        List<String> newKeys = TestUtil.allRedisKeys(redisDataSource);
+        assertEquals(allKeysAtStart.size() + 1, newKeys.size());
+        assertThat(newKeys).contains(expectedCacheKey(ComplexCachedService.CACHE_NAME_GENERIC, KEY_1));
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        List<String> value2 = cachedService.genericReturnType(KEY_1);
+        assertEquals(value1, value2);
+        assertEquals(allKeysAtStart.size() + 1, TestUtil.allRedisKeys(redisDataSource).size());
+    }
+
+    @Test
+    public void testArray() {
+        RedisDataSource redisDataSource = Arc.container().select(RedisDataSource.class).get();
+        List<String> allKeysAtStart = TestUtil.allRedisKeys(redisDataSource);
+
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        int[] value1 = cachedService.arrayReturnType(KEY_2);
+        List<String> newKeys = TestUtil.allRedisKeys(redisDataSource);
+        assertEquals(allKeysAtStart.size() + 1, newKeys.size());
+        assertThat(newKeys).contains(expectedCacheKey(ComplexCachedService.CACHE_NAME_ARRAY, KEY_2));
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        int[] value2 = cachedService.arrayReturnType(KEY_2);
+        assertArrayEquals(value1, value2);
+        assertEquals(allKeysAtStart.size() + 1, TestUtil.allRedisKeys(redisDataSource).size());
+    }
+
+    @Test
+    public void testGenericArray() {
+        RedisDataSource redisDataSource = Arc.container().select(RedisDataSource.class).get();
+        List<String> allKeysAtStart = TestUtil.allRedisKeys(redisDataSource);
+
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        List<? extends CharSequence>[] value1 = cachedService.genericArrayReturnType(KEY_3);
+        List<String> newKeys = TestUtil.allRedisKeys(redisDataSource);
+        assertEquals(allKeysAtStart.size() + 1, newKeys.size());
+        assertThat(newKeys).contains(expectedCacheKey(ComplexCachedService.CACHE_NAME_GENERIC_ARRAY, KEY_3));
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        List<? extends CharSequence>[] value2 = cachedService.genericArrayReturnType(KEY_3);
+        assertArrayEquals(value1, value2);
+        assertEquals(allKeysAtStart.size() + 1, TestUtil.allRedisKeys(redisDataSource).size());
+    }
+
+    private static String expectedCacheKey(String cacheName, String key) {
+        return "cache:" + cacheName + ":" + key;
+    }
+}

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCache.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCache.java
@@ -3,6 +3,8 @@ package io.quarkus.cache.redis.runtime;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import jakarta.enterprise.util.TypeLiteral;
+
 import io.quarkus.cache.Cache;
 import io.smallrye.mutiny.Uni;
 
@@ -12,32 +14,17 @@ public interface RedisCache extends Cache {
      * When configured, gets the default type of the value stored in the cache.
      * The configured type is used when no type is passed into the {@link #get(Object, Class, Function)}.
      *
-     * @return the type, {@code null} if not configured.
+     * @deprecated should have never been exposed publicly
+     * @return the type, {@code null} if not configured or if not a {@code Class}.
      */
+    @Deprecated
     Class<?> getDefaultValueType();
 
     @Override
-    default <K, V> Uni<V> get(K key, Function<K, V> valueLoader) {
-        Class<V> type = (Class<V>) getDefaultValueType();
-        if (type == null) {
-            throw new UnsupportedOperationException("Cannot use `get` method without a default type configured. " +
-                    "Consider using the `get` method accepting the type or configure the default type for the cache " +
-                    getName());
-        }
-        return get(key, type, valueLoader);
-    }
+    <K, V> Uni<V> get(K key, Function<K, V> valueLoader);
 
-    @SuppressWarnings("unchecked")
     @Override
-    default <K, V> Uni<V> getAsync(K key, Function<K, Uni<V>> valueLoader) {
-        Class<V> type = (Class<V>) getDefaultValueType();
-        if (type == null) {
-            throw new UnsupportedOperationException("Cannot use `getAsync` method without a default type configured. " +
-                    "Consider using the `getAsync` method accepting the type or configure the default type for the cache " +
-                    getName());
-        }
-        return getAsync(key, type, valueLoader);
-    }
+    <K, V> Uni<V> getAsync(K key, Function<K, Uni<V>> valueLoader);
 
     /**
      * Allows retrieving a value from the Redis cache.
@@ -55,6 +42,18 @@ public interface RedisCache extends Cache {
      * Allows retrieving a value from the Redis cache.
      *
      * @param key the key
+     * @param type the type of the value
+     * @param valueLoader the value loader called when there is no value stored in the cache
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return the Uni emitting the cached value.
+     */
+    <K, V> Uni<V> get(K key, TypeLiteral<V> type, Function<K, V> valueLoader);
+
+    /**
+     * Allows retrieving a value from the Redis cache.
+     *
+     * @param key the key
      * @param clazz the class of the value
      * @param valueLoader the value loader called when there is no value stored in the cache
      * @param <K> the type of key
@@ -62,6 +61,18 @@ public interface RedisCache extends Cache {
      * @return the Uni emitting the cached value.
      */
     <K, V> Uni<V> getAsync(K key, Class<V> clazz, Function<K, Uni<V>> valueLoader);
+
+    /**
+     * Allows retrieving a value from the Redis cache.
+     *
+     * @param key the key
+     * @param type the type of the value
+     * @param valueLoader the value loader called when there is no value stored in the cache
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return the Uni emitting the cached value.
+     */
+    <K, V> Uni<V> getAsync(K key, TypeLiteral<V> type, Function<K, Uni<V>> valueLoader);
 
     /**
      * Put a value in the cache.
@@ -86,4 +97,6 @@ public interface RedisCache extends Cache {
     <K, V> Uni<V> getOrDefault(K key, V defaultValue);
 
     <K, V> Uni<V> getOrNull(K key, Class<V> clazz);
+
+    <K, V> Uni<V> getOrNull(K key, TypeLiteral<V> type);
 }

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheBuildRecorder.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheBuildRecorder.java
@@ -1,5 +1,6 @@
 package io.quarkus.cache.redis.runtime;
 
+import java.lang.reflect.Type;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -20,7 +21,8 @@ public class RedisCacheBuildRecorder {
     private final RedisCachesBuildTimeConfig buildConfig;
     private final RuntimeValue<RedisCachesConfig> redisCacheConfigRV;
 
-    private static Map<String, String> valueTypes;
+    private static Map<String, Type> keyTypes;
+    private static Map<String, Type> valueTypes;
 
     public RedisCacheBuildRecorder(RedisCachesBuildTimeConfig buildConfig, RuntimeValue<RedisCachesConfig> redisCacheConfigRV) {
         this.buildConfig = buildConfig;
@@ -35,13 +37,12 @@ public class RedisCacheBuildRecorder {
             }
 
             @Override
-            @SuppressWarnings({ "rawtypes", "unchecked" })
             public Supplier<CacheManager> get(Context context) {
                 return new Supplier<CacheManager>() {
                     @Override
                     public CacheManager get() {
-                        Set<RedisCacheInfo> cacheInfos = RedisCacheInfoBuilder.build(context.cacheNames(), buildConfig,
-                                redisCacheConfigRV.getValue(), valueTypes);
+                        Set<RedisCacheInfo> cacheInfos = RedisCacheInfoBuilder.build(context.cacheNames(),
+                                redisCacheConfigRV.getValue(), keyTypes, valueTypes);
                         if (cacheInfos.isEmpty()) {
                             return new CacheManagerImpl(Collections.emptyMap());
                         } else {
@@ -66,7 +67,11 @@ public class RedisCacheBuildRecorder {
         };
     }
 
-    public void setCacheValueTypes(Map<String, String> valueTypes) {
+    public void setCacheKeyTypes(Map<String, Type> keyTypes) {
+        RedisCacheBuildRecorder.keyTypes = keyTypes;
+    }
+
+    public void setCacheValueTypes(Map<String, Type> valueTypes) {
         RedisCacheBuildRecorder.valueTypes = valueTypes;
     }
 }

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheInfo.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheInfo.java
@@ -1,5 +1,6 @@
 package io.quarkus.cache.redis.runtime;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -29,12 +30,12 @@ public class RedisCacheInfo {
     /**
      * The default type of the value stored in the cache.
      */
-    public String valueType;
+    public Type valueType;
 
     /**
      * The key type, {@code String} by default.
      */
-    public String keyType = String.class.getName();
+    public Type keyType = String.class;
 
     /**
      * Whether the access to the cache should be using optimistic locking

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheInfoBuilder.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheInfoBuilder.java
@@ -1,5 +1,6 @@
 package io.quarkus.cache.redis.runtime;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -8,8 +9,8 @@ import io.quarkus.runtime.configuration.HashSetFactory;
 
 public class RedisCacheInfoBuilder {
 
-    public static Set<RedisCacheInfo> build(Set<String> cacheNames, RedisCachesBuildTimeConfig buildTimeConfig,
-            RedisCachesConfig runtimeConfig, Map<String, String> valueTypes) {
+    public static Set<RedisCacheInfo> build(Set<String> cacheNames, RedisCachesConfig runtimeConfig,
+            Map<String, Type> keyTypes, Map<String, Type> valueTypes) {
         if (cacheNames.isEmpty()) {
             return Collections.emptySet();
         } else {
@@ -50,14 +51,8 @@ public class RedisCacheInfoBuilder {
 
                 cacheInfo.valueType = valueTypes.get(cacheName);
 
-                RedisCacheBuildTimeConfig defaultBuildTimeConfig = buildTimeConfig.defaultConfig;
-                RedisCacheBuildTimeConfig namedBuildTimeConfig = buildTimeConfig.cachesConfig
-                        .get(cacheInfo.name);
-
-                if (namedBuildTimeConfig != null && namedBuildTimeConfig.keyType.isPresent()) {
-                    cacheInfo.keyType = namedBuildTimeConfig.keyType.get();
-                } else if (defaultBuildTimeConfig.keyType.isPresent()) {
-                    cacheInfo.keyType = defaultBuildTimeConfig.keyType.get();
+                if (keyTypes.containsKey(cacheName)) {
+                    cacheInfo.keyType = keyTypes.get(cacheName);
                 }
 
                 if (namedRuntimeConfig != null && namedRuntimeConfig.useOptimisticLocking.isPresent()) {

--- a/extensions/redis-cache/runtime/src/test/java/io/quarkus/cache/redis/runtime/RedisCacheImplTest.java
+++ b/extensions/redis-cache/runtime/src/test/java/io/quarkus/cache/redis/runtime/RedisCacheImplTest.java
@@ -46,7 +46,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         String k = UUID.randomUUID().toString();
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "foo";
-        info.valueType = String.class.getName();
+        info.valueType = String.class;
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
         assertThat(cache.get(k, s -> "hello").await().indefinitely()).isEqualTo("hello");
@@ -59,7 +59,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         String k = UUID.randomUUID().toString();
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "foo";
-        info.valueType = String.class.getName();
+        info.valueType = String.class;
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
 
         Redis redis = Redis.createClient(vertx, new RedisOptions()
@@ -86,7 +86,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         String k = UUID.randomUUID().toString();
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "foo";
-        info.valueType = String.class.getName();
+        info.valueType = String.class;
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
         server.close();
@@ -98,7 +98,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         String k = UUID.randomUUID().toString();
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "foo";
-        info.valueType = String.class.getName();
+        info.valueType = String.class;
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
         info.useOptimisticLocking = true;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
@@ -111,7 +111,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
     public void testPutAndWaitForInvalidation() {
         String k = UUID.randomUUID().toString();
         RedisCacheInfo info = new RedisCacheInfo();
-        info.valueType = String.class.getName();
+        info.valueType = String.class;
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(1));
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
         assertThat(cache.get(k, s -> "hello").await().indefinitely()).isEqualTo("hello");
@@ -125,7 +125,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         String k = UUID.randomUUID().toString();
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "foo";
-        info.valueType = String.class.getName();
+        info.valueType = String.class;
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(1));
         info.expireAfterAccess = Optional.of(Duration.ofSeconds(1));
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
@@ -144,7 +144,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
     @Test
     public void testManualInvalidation() {
         RedisCacheInfo info = new RedisCacheInfo();
-        info.valueType = String.class.getName();
+        info.valueType = String.class;
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
         cache.get("foo", s -> "hello").await().indefinitely();
@@ -188,7 +188,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
     public void testGetOrNull() {
         RedisCacheInfo info = new RedisCacheInfo();
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
-        info.valueType = Person.class.getName();
+        info.valueType = Person.class;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
         Person person = cache.getOrNull("foo", Person.class).await().indefinitely();
         assertThat(person).isNull();
@@ -208,7 +208,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
     public void testGetOrDefault() {
         RedisCacheInfo info = new RedisCacheInfo();
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
-        info.valueType = Person.class.getName();
+        info.valueType = Person.class;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
         Person person = cache.getOrDefault("foo", new Person("bar", "BAR")).await().indefinitely();
         assertThat(person).isNotNull()
@@ -234,7 +234,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
     public void testCacheNullValue() {
         RedisCacheInfo info = new RedisCacheInfo();
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
-        info.valueType = Person.class.getName();
+        info.valueType = Person.class;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
         // with custom key
@@ -248,8 +248,8 @@ class RedisCacheImplTest extends RedisCacheTestBase {
     public void testExceptionInValueLoader() {
         RedisCacheInfo info = new RedisCacheInfo();
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
-        info.valueType = Person.class.getName();
-        info.keyType = Double.class.getName();
+        info.valueType = Person.class;
+        info.keyType = Double.class;
         info.name = "foo";
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
@@ -271,8 +271,8 @@ class RedisCacheImplTest extends RedisCacheTestBase {
     public void testPutShouldPopulateCache() {
         RedisCacheInfo info = new RedisCacheInfo();
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
-        info.valueType = Person.class.getName();
-        info.keyType = Integer.class.getName();
+        info.valueType = Person.class;
+        info.keyType = Integer.class;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
         cache.put(1, new Person("luke", "skywalker")).await().indefinitely();
@@ -287,8 +287,8 @@ class RedisCacheImplTest extends RedisCacheTestBase {
     public void testPutShouldPopulateCacheWithOptimisticLocking() {
         RedisCacheInfo info = new RedisCacheInfo();
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
-        info.valueType = Person.class.getName();
-        info.keyType = Integer.class.getName();
+        info.valueType = Person.class;
+        info.keyType = Integer.class;
         info.useOptimisticLocking = true;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
@@ -305,7 +305,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         String k = UUID.randomUUID().toString();
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "foo";
-        info.valueType = String.class.getName();
+        info.valueType = String.class;
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(1));
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
@@ -330,7 +330,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         String k = UUID.randomUUID().toString();
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "foo";
-        info.valueType = String.class.getName();
+        info.valueType = String.class;
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(1));
         info.useOptimisticLocking = true;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
@@ -378,7 +378,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "star-wars";
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
-        info.valueType = Person.class.getName();
+        info.valueType = Person.class;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
         assertThat(cache
@@ -408,7 +408,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "star-wars";
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
-        info.valueType = Person.class.getName();
+        info.valueType = Person.class;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
         server.close();
@@ -434,7 +434,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "star-wars";
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
-        info.valueType = Person.class.getName();
+        info.valueType = Person.class;
         info.useOptimisticLocking = true;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
@@ -465,7 +465,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "put";
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
-        info.valueType = Person.class.getName();
+        info.valueType = Person.class;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
         Person luke = new Person("luke", "skywalker");
@@ -484,7 +484,7 @@ class RedisCacheImplTest extends RedisCacheTestBase {
         RedisCacheInfo info = new RedisCacheInfo();
         info.name = "put";
         info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
-        info.valueType = Person.class.getName();
+        info.valueType = Person.class;
         RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
 
         Person luke = new Person("luke", "skywalker");
@@ -496,17 +496,6 @@ class RedisCacheImplTest extends RedisCacheTestBase {
 
         await().untilAsserted(() -> assertThat(cache.get("test", x -> leia)
                 .await().indefinitely()).isEqualTo(leia));
-    }
-
-    @Test
-    void testInitializationWithAnUnknownClass() {
-        RedisCacheInfo info = new RedisCacheInfo();
-        info.name = "put";
-        info.expireAfterWrite = Optional.of(Duration.ofSeconds(2));
-        info.valueType = Person.class.getPackage().getName() + ".Missing";
-
-        assertThatThrownBy(() -> new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED))
-                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
This includes generic types, like `List<String>`, array types, like `int[]`, and more.

The type parser in this commit is reasonably complete. Omitting type variables should not be an issue; nested types might, but adding support for them should be doable later.

Fixes #41301