### PR TITLE
Missing sourceSets for Kotlin in Project Descriptor

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/workspace/descriptors/ProjectDescriptorBuilder.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/workspace/descriptors/ProjectDescriptorBuilder.java
@@ -138,6 +138,11 @@ public class ProjectDescriptorBuilder {
                 }
             });
             tasks.put(task.getName(), new QuarkusTaskDescriptor(task.getName(), COMPILE, srcDir.get(), destDir));
+            SourceSetContainer sourceSets = task.getProject().getExtensions().getByType(SourceSetContainer.class);
+            sourceSets.stream().filter(sourceSet -> sourceSet.getOutput().getClassesDirs().contains(destDir))
+                    .forEach(sourceSet -> sourceSetTasks
+                            .computeIfAbsent(sourceSet.getName(), s -> new HashSet<>())
+                            .add(task.getName()));
         }
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/KotlinIsIncludedInQuarkusJarTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/KotlinIsIncludedInQuarkusJarTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.junit.jupiter.api.Test;
+
+public class KotlinIsIncludedInQuarkusJarTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testFastJarFormatWorks() throws Exception {
+
+        final File projectDir = getProjectDir("basic-kotlin-application-project");
+
+        runGradleWrapper(projectDir, "clean", "build");
+
+        final Path quarkusApp = projectDir.toPath().resolve("build").resolve("quarkus-app").resolve("app");
+        assertThat(quarkusApp).exists();
+        Path jar = quarkusApp.resolve("code-with-quarkus-unspecified.jar");
+        assertThat(jar).exists();
+        try (JarFile jarFile = new JarFile(jar.toFile())) {
+            assertJarContainsEntry(jarFile, "basic-kotlin-application-project/src/main/kotlin/org/acme/MyMainClass.class");
+            assertJarContainsEntry(jarFile, "org/acme/GreetingResource.class");
+            assertJarContainsEntry(jarFile, "META-INF/code-with-quarkus.kotlin_module");
+        }
+    }
+
+    private void assertJarContainsEntry(JarFile jarFile, String expectedEntry) {
+        boolean entryFound = false;
+        Enumeration<JarEntry> entries = jarFile.entries();
+        while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            System.out.println(entry.getName());
+            if (entry.getName().equals(expectedEntry)) {
+                entryFound = true;
+                break;
+            }
+        }
+        assertTrue(entryFound, "Expected entry " + expectedEntry + " not found in JAR file.");
+    }
+}


### PR DESCRIPTION
SourceSets for the Kotlin tasks were not included in the `ProjectDescriptorBuilder` (my mistake).

This PR adds a new integrating test to verify that the Kotlin classes have been included in the jar. 



Additional tests:
Comparing 3.13.1 vs 314.3, diff in the Kotlin classes:
<img width="1050" alt="Screenshot 2024-09-16 at 8 04 45 PM" src="https://github.com/user-attachments/assets/c834664c-765a-41ab-91ab-2b3473b3a755">

Comparing 3.13.1 vs This PR, no diff in the Kotlin classes:
<img width="1058" alt="Screenshot 2024-09-16 at 8 05 29 PM" src="https://github.com/user-attachments/assets/db00360c-2265-45e3-8465-abf1a4d11671">

- Fixes: #43242.