### PR TITLE
Introduce per invocation override of REST Client's base URL

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -372,6 +372,11 @@ quarkus.rest-client.extensions-api.url=https://stage.code.quarkus.io/api
 quarkus.rest-client.extensions-api.scope=jakarta.inject.Singleton
 ----
 
+[IMPORTANT]
+====
+Setting the base URL of the client is **mandatory**, however the REST Client supports per-invocation overrides of the base URL using the `@io.quarkus.rest.client.reactive.Url` annotation.
+====
+
 === Disabling Hostname Verification
 
 To disable the SSL hostname verification for a specific REST client, add the following property to your configuration:

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/url/UrlOnStringParameterTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/url/UrlOnStringParameterTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.rest.client.reactive.url;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.UnknownHostException;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.Url;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UrlOnStringParameterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(
+                    jar -> jar.addClasses(Resource.class, Client.class))
+            .overrideConfigKey("quarkus.rest-client.client.uri", "http://does-not-exist.io");
+
+    @RestClient
+    Client client;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    Integer testPort;
+
+    @Test
+    public void testOverride() {
+        String result = client.test(String.format("http://localhost:%d", testPort));
+        assertEquals("bar", result);
+
+    }
+
+    @Test
+    public void testNoOverride() {
+        assertThatThrownBy(() -> client.test(null)).cause().isInstanceOf(UnknownHostException.class);
+    }
+
+    @Path("test")
+    @RegisterRestClient(configKey = "client")
+    public interface Client {
+
+        @Path("count")
+        @GET
+        String test(@Url String uri);
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        @GET
+        @Path("count")
+        public String test() {
+            return "bar";
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/url/UrlOnUriParameterTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/url/UrlOnUriParameterTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.rest.client.reactive.url;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.UnknownHostException;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestQuery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.NotBody;
+import io.quarkus.rest.client.reactive.Url;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UrlOnUriParameterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(
+                    jar -> jar.addClasses(Resource.class, Client.class))
+            .overrideConfigKey("quarkus.rest-client.\"client\".url", "http://does-not-exist.io");
+
+    @RestClient
+    Client client;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    Integer testPort;
+
+    @Test
+    public void testOverride() {
+        String result = client.test("test", URI.create(String.format("http://localhost:%d", testPort)), "bar");
+        assertEquals("bar", result);
+
+    }
+
+    @Test
+    public void testNoOverride() {
+        assertThatThrownBy(() -> client.test("test", null, "bar")).cause().isInstanceOf(UnknownHostException.class);
+    }
+
+    @Path("test")
+    @RegisterRestClient(configKey = "client")
+    public interface Client {
+
+        @Path("count")
+        @GET
+        String test(@NotBody String unused, @Url URI uri, @RestQuery String foo);
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        @GET
+        @Path("count")
+        public String test(@RestQuery String foo) {
+            return foo;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/url/UrlOnUrlParameterTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/url/UrlOnUrlParameterTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.rest.client.reactive.url;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestHeader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.Url;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UrlOnUrlParameterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(
+                    jar -> jar.addClasses(Resource.class, Client.class))
+            .overrideConfigKey(
+                    "quarkus.rest-client.\"io.quarkus.rest.client.reactive.url.UrlOnUrlParameterTest$Client\".uri",
+                    "http://does-not-exist.io");
+
+    @RestClient
+    Client client;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    Integer testPort;
+
+    @Test
+    public void testOverride() throws MalformedURLException {
+        String result = client.test(new URL(String.format("http://localhost:%d/", testPort)), "bar");
+        assertEquals("bar", result);
+
+    }
+
+    @Test
+    public void testNoOverride() {
+        assertThatThrownBy(() -> client.test(null, "bar")).cause().isInstanceOf(UnknownHostException.class);
+    }
+
+    @Path("test")
+    @RegisterRestClient(configKey = "client")
+    public interface Client {
+
+        @Path("count")
+        @GET
+        String test(@Url URL uri, @RestHeader String foo);
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        @GET
+        @Path("count")
+        public String test(@RestHeader String foo) {
+            return foo;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/Url.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/Url.java
@@ -1,0 +1,23 @@
+package io.quarkus.rest.client.reactive;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Allows for a per invocation override the base URL.
+ * At most a one such annotation can be used per REST Client method and the supported types are:
+ *
+ * <ul>
+ * {@link String}</li>
+ * {@link java.net.URI}</li>
+ * {@link java.net.URL}</li>
+ * </ul>
+ */
+@Target({ ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Url {
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/WebTargetImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/WebTargetImpl.java
@@ -254,6 +254,11 @@ public class WebTargetImpl implements WebTarget {
         return newInstance(client, copy, configuration);
     }
 
+    @SuppressWarnings("unused") // this is used in the REST Client to support @BaseUrl
+    public WebTargetImpl withNewUri(URI uri) {
+        return newInstance(client, UriBuilder.fromUri(uri), configuration);
+    }
+
     @SuppressWarnings("unused")
     public WebTargetImpl queryParams(MultivaluedMap<String, Object> parameters)
             throws IllegalArgumentException, NullPointerException {

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -235,6 +236,8 @@ public final class ResteasyReactiveDotNames {
     public static final DotName INPUT_STREAM = DotName.createSimple(InputStream.class.getName());
     public static final DotName OUTPUT_STREAM = DotName.createSimple(OutputStream.class.getName());
     public static final DotName THROWABLE = DotName.createSimple(Throwable.class.getName());
+    public static final DotName URI = DotName.createSimple(java.net.URI.class.getName());
+    public static final DotName URL = DotName.createSimple(java.net.URL.class.getName());
 
     public static final DotName JSONP_JSON_OBJECT = DotName.createSimple(jakarta.json.JsonObject.class.getName());
     public static final DotName JSONP_JSON_ARRAY = DotName.createSimple(jakarta.json.JsonArray.class.getName());


### PR DESCRIPTION
This is done by introducing the `@Url` annotation that can be placed on a method parameter.
When this parameter is not null, it will be used as the base URL for the specific invocation.

- Closes: #43316