### PR TITLE
Support injection of the @BeanParam parameters into a custom permission referenced in the @PermissionAllowed security annotation

### DIFF
--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -830,7 +830,7 @@ Your custom class must define exactly one constructor that accepts the permissio
 In this scenario, the permission `list` is added to the `SecurityIdentity` instance as `new CustomPermission("list")`.
 
 You can also create a custom `java.security.Permission` class with additional constructor parameters.
-These additional parameters get matched with arguments of the method annotated with the `@PermissionsAllowed` annotation.
+These additional parameters names get matched with arguments names of the method annotated with the `@PermissionsAllowed` annotation.
 Later, Quarkus instantiates your custom permission with actual arguments, with which the method annotated with the `@PermissionsAllowed` has been invoked.
 
 .Example of a custom `java.security.Permission` class that accepts additional arguments
@@ -910,12 +910,12 @@ import org.acme.library.LibraryPermission.Library;
 public class LibraryService {
 
     @PermissionsAllowed(value = "tv:write", permission = LibraryPermission.class) <1>
-    public Library updateLibrary(String newDesc, Library update) {
-        update.description = newDesc;
-        return update;
+    public Library updateLibrary(String newDesc, Library library) {
+        library.description = newDesc;
+        return library;
     }
 
-    @PermissionsAllowed(value = "tv:write", permission = LibraryPermission.class, params = "library") <2>
+    @PermissionsAllowed(value = "tv:write", permission = LibraryPermission.class) <2>
     @PermissionsAllowed(value = {"tv:read", "tv:list"}, permission = LibraryPermission.class)
     public Library migrateLibrary(Library migrate, Library library) {
         // migrate libraries
@@ -924,10 +924,11 @@ public class LibraryService {
 
 }
 ----
-<1> The formal parameter `update` is identified as the first `Library` parameter and gets passed to the `LibraryPermission` class.
+<1> The formal parameter `library` is identified as the parameter matching same-named `LibraryPermission` constructor parameter.
+Therefore, Quarkus will pass the `library` parameter to the `LibraryPermission` class constructor.
 However, the `LibraryPermission` must be instantiated each time the `updateLibrary` method is invoked.
-<2> Here, the first `Library` parameter is `migrate`; therefore, the `library` parameter gets marked explicitly through `PermissionsAllowed#params`.
-The permission constructor and the annotated method must have the parameter `library` set; otherwise, validation fails.
+<2> Here, the second `Library` parameter matches the name `library`,
+while the `migrate` parameter is ignored during the `LibraryPermission` permission instantiation.
 
 .Example of a resource secured with the `LibraryPermission`
 
@@ -1077,6 +1078,125 @@ public @interface CanWrite {
 }
 ----
 <1> Any method or class annotated with the `@CanWrite` annotation is secured with this `@PermissionsAllowed` annotation instance.
+
+[[permission-bean-params]]
+=== Pass `@BeanParam` parameters into a custom permission
+
+Quarkus can map fields of a secured method parameters to a custom permission constructor parameters.
+You can use this feature to pass `jakarta.ws.rs.BeanParam` parameters into your custom permission.
+Let's consider following Jakarta REST resource:
+
+[source,java]
+----
+package org.acme.security.rest.resource;
+
+import io.quarkus.security.PermissionsAllowed;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/hello")
+public class SimpleResource {
+
+    @PermissionsAllowed(value = "say:hello", permission = BeanParamPermission.class,
+        params = "beanParam.securityContext.userPrincipal.name") <1>
+    @GET
+    public String sayHello(@BeanParam SimpleBeanParam beanParam) {
+        return "Hello from " + beanParam.uriInfo.getPath();
+    }
+
+}
+----
+<1> The `params` annotation attribute specifies that user principal name should be passed to the `BeanParamPermission` constructor.
+Other `BeanParamPermission` constructor parameters like `customAuthorizationHeader` and `query` are matched automatically.
+Quarkus identifies the `BeanParamPermission` constructor parameters among `beanParam` fields and their public accessors.
+To avoid ambiguous resolution, automatic detection only works for the `beanParam` fields.
+For that reason, we had to specify path to the user principal name explicitly.
+
+Where the `SimpleBeanParam` class is declared like in the example below:
+
+[source,java]
+----
+package org.acme.security.rest.dto;
+
+import java.util.List;
+
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+
+public class SimpleBeanParam {
+
+    @HeaderParam("CustomAuthorization")
+    private String customAuthorizationHeader;
+
+    @Context
+    SecurityContext securityContext;
+
+    @Context
+    public UriInfo uriInfo;
+
+    @QueryParam("query")
+    public String query;    <1>
+
+    public SecurityContext getSecurityContext() { <2>
+        return securityContext;
+    }
+
+    public String customAuthorizationHeader() { <3>
+        return customAuthorizationHeader;
+    }
+}
+----
+<1> Quarkus Security can only pass public fields to a custom permission constructor.
+<2> Quarkus Security automatically uses public getter methods if they are available.
+<3> The `customAuthorizationHeader` field is not public, therefore Quarkus access this field with the `customAuthorizationHeader` accessor.
+That is particularly useful with Java records, where generated accessors are not prefixed with `get`.
+
+Here is an example of the `BeanParamPermission` permission that checks user principal, custom header and query parameter:
+
+[source,java]
+----
+package org.acme.security.permission;
+
+import java.security.Permission;
+
+public class BeanParamPermission extends Permission {
+
+    private final String actions;
+
+    public BeanParamPermission(String permissionName, String customAuthorizationHeader, String name, String query) {
+        super(permissionName);
+        this.actions = computeActions(customAuthorizationHeader, name, query);
+    }
+
+    @Override
+    public boolean implies(Permission p) {
+        boolean nameMatches = getName().equals(p.getName());
+        boolean actionMatches = actions.equals(p.getActions());
+        return nameMatches && actionMatches;
+    }
+
+    private static String computeActions(String customAuthorizationHeader, String name, String query) {
+        boolean queryParamAllowedForPermissionName = checkQueryParams(query);
+        boolean usernameWhitelisted = isUserNameWhitelisted(name);
+        boolean customAuthorizationMatches = checkCustomAuthorization(customAuthorizationHeader);
+        var isAuthorized = queryParamAllowedForPermissionName && usernameWhitelisted && customAuthorizationMatches;
+        if (isAuthorized) {
+            return "hello";
+        } else {
+            return "goodbye";
+        }
+    }
+
+    ...
+}
+----
+
+NOTE: You can pass `@BeanParam` directly into a custom permission constructor and access its fields programmatically in the constructor instead.
+Ability to reference `@BeanParam` fields with the `@PermissionsAllowed#params` attribute is useful when you have multiple differently structured `@BeanParam` classes.
 
 == References
 

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/BeanParamPermissionIdentityAugmentor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/BeanParamPermissionIdentityAugmentor.java
@@ -1,0 +1,34 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import java.security.Permission;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.security.StringPermission;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class BeanParamPermissionIdentityAugmentor implements SecurityIdentityAugmentor {
+
+    @Override
+    public Uni<SecurityIdentity> augment(SecurityIdentity securityIdentity,
+            AuthenticationRequestContext authenticationRequestContext) {
+        var possessedPermission = createPossessedPermission(securityIdentity);
+        var augmentedIdentity = QuarkusSecurityIdentity
+                .builder(securityIdentity)
+                .addPermissionChecker(requiredPermission -> Uni
+                        .createFrom()
+                        .item(requiredPermission.implies(possessedPermission)))
+                .build();
+        return Uni.createFrom().item(augmentedIdentity);
+    }
+
+    private Permission createPossessedPermission(SecurityIdentity securityIdentity) {
+        // here comes your business logic
+        return securityIdentity.isAnonymous() ? new StringPermission("list") : new StringPermission("read");
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/MyBeanParam.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/MyBeanParam.java
@@ -1,0 +1,11 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import jakarta.ws.rs.BeanParam;
+
+import org.jboss.resteasy.reactive.RestHeader;
+import org.jboss.resteasy.reactive.RestQuery;
+
+public record MyBeanParam(@RestQuery String queryParam, @BeanParam Headers headers) {
+    public record Headers(@RestHeader String authorization) {
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/MyPermission.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/MyPermission.java
@@ -1,0 +1,47 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import java.security.Permission;
+import java.util.Objects;
+
+public class MyPermission extends Permission {
+
+    static final MyPermission EMPTY = new MyPermission("my-perm", null, null);
+
+    private final String authorization;
+    private final String queryParam;
+
+    public MyPermission(String permissionName, String authorization, String queryParam) {
+        super(permissionName);
+        this.authorization = authorization;
+        this.queryParam = queryParam;
+    }
+
+    @Override
+    public boolean implies(Permission permission) {
+        if (permission instanceof MyPermission myPermission) {
+            return myPermission.authorization != null && "query1".equals(myPermission.queryParam);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MyPermission that = (MyPermission) o;
+        return Objects.equals(authorization, that.authorization)
+                && Objects.equals(queryParam, that.queryParam);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authorization, queryParam);
+    }
+
+    @Override
+    public String getActions() {
+        return "";
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/OtherBeanParam.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/OtherBeanParam.java
@@ -1,0 +1,30 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+
+public class OtherBeanParam {
+
+    @HeaderParam("CustomAuthorization")
+    private String customAuthorizationHeader;
+
+    @Context
+    SecurityContext securityContext;
+
+    @Context
+    public UriInfo uriInfo;
+
+    @QueryParam("query")
+    public String query;
+
+    public SecurityContext getSecurityContext() {
+        return securityContext;
+    }
+
+    public String customAuthorizationHeader() {
+        return customAuthorizationHeader;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/OtherBeanParamPermission.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/OtherBeanParamPermission.java
@@ -1,0 +1,60 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import java.security.Permission;
+
+public class OtherBeanParamPermission extends Permission {
+
+    private final String actions;
+
+    public OtherBeanParamPermission(String permissionName, String customAuthorizationHeader, String name, String query) {
+        super(permissionName);
+        this.actions = computeActions(customAuthorizationHeader, name, query);
+    }
+
+    @Override
+    public String getActions() {
+        return actions;
+    }
+
+    @Override
+    public boolean implies(Permission p) {
+        boolean nameMatches = getName().equals(p.getName());
+        boolean actionMatches = getActions().equals(p.getActions());
+        return nameMatches && actionMatches;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    private static String computeActions(String customAuthorizationHeader, String name, String query) {
+        boolean queryParamAllowedForPermissionName = checkQueryParams(query);
+        boolean usernameWhitelisted = isUserNameWhitelisted(name);
+        boolean customAuthorizationMatches = checkCustomAuthorization(customAuthorizationHeader);
+        var isAuthorized = queryParamAllowedForPermissionName && usernameWhitelisted && customAuthorizationMatches;
+        if (isAuthorized) {
+            return "hello";
+        } else {
+            return "goodbye";
+        }
+    }
+
+    private static boolean checkCustomAuthorization(String customAuthorization) {
+        return "customAuthorization".equals(customAuthorization);
+    }
+
+    private static boolean isUserNameWhitelisted(String userName) {
+        return "admin".equals(userName);
+    }
+
+    private static boolean checkQueryParams(String queryParam) {
+        return "myQueryParam".equals(queryParam);
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermissionsAllowedBeanParamTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermissionsAllowedBeanParamTest.java
@@ -1,0 +1,166 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import java.security.BasicPermission;
+import java.security.Permission;
+
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.RestCookie;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+
+public class PermissionsAllowedBeanParamTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class, SimpleBeanParam.class,
+                            SimpleResource.class, SimpleBeanParamPermission.class, MyPermission.class, MyBeanParam.class,
+                            OtherBeanParamPermission.class, OtherBeanParam.class));
+
+    @BeforeAll
+    public static void setupUsers() {
+        var sayHelloPossessedPerm = new BasicPermission("say", "hello") {
+            @Override
+            public boolean implies(Permission p) {
+                return getName().equals(p.getName()) && getActions().equals(p.getActions());
+            }
+
+            @Override
+            public String getActions() {
+                return "hello";
+            }
+        };
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", SimpleBeanParamPermission.EMPTY, MyPermission.EMPTY, sayHelloPossessedPerm)
+                .add("user", "user", sayHelloPossessedPerm);
+    }
+
+    @Test
+    public void testSimpleBeanParam() {
+        getSimpleBeanParamReq()
+                .post("/simple/param")
+                .then().statusCode(401);
+        getSimpleBeanParamReq()
+                .auth().preemptive().basic("user", "user")
+                .post("/simple/param")
+                .then().statusCode(403);
+        getSimpleBeanParamReq()
+                .auth().preemptive().basic("admin", "admin")
+                .post("/simple/param")
+                .then().statusCode(200).body(Matchers.equalTo("OK"));
+    }
+
+    @Test
+    public void testRecordBeanParam() {
+        RestAssured
+                .given()
+                .auth().preemptive().basic("user", "user")
+                .queryParam("queryParam", "query1")
+                .get("/simple/record-param")
+                .then().statusCode(403);
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .queryParam("queryParam", "query1")
+                .get("/simple/record-param")
+                .then().statusCode(200)
+                .body(Matchers.equalTo("OK"));
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .queryParam("queryParam", "wrong-query-param")
+                .get("/simple/record-param")
+                .then().statusCode(403);
+    }
+
+    @Test
+    public void testAutodetectedParams() {
+        RestAssured
+                .given()
+                .body("autodetected")
+                .auth().preemptive().basic("admin", "admin")
+                .header("CustomAuthorization", "customAuthorization")
+                .queryParam("query", "myQueryParam")
+                .get("/simple/autodetect-params")
+                .then().statusCode(200).body(Matchers.equalTo("autodetected"));
+        // wrong custom authorization
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .header("CustomAuthorization", "wrongAuthorization")
+                .queryParam("query", "myQueryParam")
+                .get("/simple/autodetect-params")
+                .then().statusCode(403);
+        // wrong query param
+        RestAssured
+                .given()
+                .body("autodetected")
+                .auth().preemptive().basic("admin", "admin")
+                .header("CustomAuthorization", "customAuthorization")
+                .queryParam("query", "wrongQueryParam")
+                .get("/simple/autodetect-params")
+                .then().statusCode(403);
+        // wrong principal
+        RestAssured
+                .given()
+                .body("autodetected")
+                .auth().preemptive().basic("user", "user")
+                .header("CustomAuthorization", "customAuthorization")
+                .queryParam("query", "myQueryParam")
+                .get("/simple/autodetect-params")
+                .then().statusCode(403);
+    }
+
+    private static RequestSpecification getSimpleBeanParamReq() {
+        return RestAssured
+                .with()
+                .header("header", "one-header")
+                .queryParam("query", "one-query")
+                .queryParam("queryList", "one")
+                .queryParam("queryList", "two")
+                .queryParam("int", "666")
+                .cookie("cookie", "cookie")
+                .body("OK");
+    }
+
+    @Path("/simple")
+    public static class SimpleResource {
+
+        @PermissionsAllowed(value = "perm1", permission = SimpleBeanParamPermission.class, params = { "cookie",
+                "beanParam.header", "beanParam.publicQuery", "beanParam.queryList", "beanParam.securityContext",
+                "beanParam.uriInfo", "beanParam.privateQuery" })
+        @Path("/param")
+        @POST
+        public String simpleBeanParam(@BeanParam SimpleBeanParam beanParam, String payload, @RestCookie String cookie) {
+            return payload;
+        }
+
+        @PermissionsAllowed(value = "perm2", permission = MyPermission.class, params = { "beanParam.queryParam",
+                "beanParam.headers.authorization" })
+        @Path("/record-param")
+        @GET
+        public String recordBeanParam(@BeanParam MyBeanParam beanParam) {
+            return "OK";
+        }
+
+        @PermissionsAllowed(value = "say:hello", permission = OtherBeanParamPermission.class, params = "otherBeanParam.securityContext.userPrincipal.name")
+        @Path("/autodetect-params")
+        @GET
+        public String autodetectedParams(String payload, @BeanParam OtherBeanParam otherBeanParam) {
+            return payload;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SimpleBeanParam.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SimpleBeanParam.java
@@ -1,0 +1,33 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import java.util.List;
+
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+
+public class SimpleBeanParam {
+    @QueryParam("query")
+    private String privateQuery;
+
+    @QueryParam("query")
+    public String publicQuery;
+
+    @HeaderParam("header")
+    public String header;
+
+    @QueryParam("queryList")
+    public List<String> queryList;
+
+    @Context
+    public SecurityContext securityContext;
+
+    @Context
+    public UriInfo uriInfo;
+
+    public String getPrivateQuery() {
+        return privateQuery;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SimpleBeanParamPermission.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/SimpleBeanParamPermission.java
@@ -1,0 +1,76 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import java.security.Permission;
+import java.util.List;
+import java.util.Objects;
+
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.junit.jupiter.api.Assertions;
+
+public class SimpleBeanParamPermission extends Permission {
+
+    static final SimpleBeanParamPermission EMPTY = new SimpleBeanParamPermission(null, null, null, null, null, null, null,
+            null);
+
+    private final String publicQuery;
+    private final String header;
+    private final List<String> queryList;
+    private final SecurityContext securityContext;
+    private final UriInfo uriInfo;
+    private final String privateQuery;
+    private final String cookie;
+
+    public SimpleBeanParamPermission(String name, String publicQuery, String header, List<String> queryList,
+            SecurityContext securityContext, UriInfo uriInfo, String privateQuery, String cookie) {
+        super(name);
+        this.publicQuery = publicQuery;
+        this.header = header;
+        this.queryList = queryList;
+        this.securityContext = securityContext;
+        this.uriInfo = uriInfo;
+        this.privateQuery = privateQuery;
+        this.cookie = cookie;
+    }
+
+    @Override
+    public boolean implies(Permission p) {
+        if (p instanceof SimpleBeanParamPermission simplePermission) {
+            Assertions.assertEquals("perm1", simplePermission.getName());
+            Assertions.assertEquals("one-query", simplePermission.privateQuery);
+            Assertions.assertEquals("one-query", simplePermission.publicQuery);
+            Assertions.assertEquals("one-header", simplePermission.header);
+            Assertions.assertEquals("admin", simplePermission.securityContext.getUserPrincipal().getName());
+            Assertions.assertNotNull(simplePermission.securityContext);
+            Assertions.assertEquals("/simple/param", simplePermission.uriInfo.getPath());
+            Assertions.assertEquals("one", simplePermission.queryList.get(0));
+            Assertions.assertEquals("two", simplePermission.queryList.get(1));
+            Assertions.assertEquals("cookie", simplePermission.cookie);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        SimpleBeanParamPermission that = (SimpleBeanParamPermission) o;
+        return Objects.equals(publicQuery, that.publicQuery) && Objects.equals(header, that.header)
+                && Objects.equals(queryList, that.queryList) && Objects.equals(securityContext, that.securityContext)
+                && Objects.equals(uriInfo, that.uriInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(publicQuery, header, queryList, securityContext, uriInfo);
+    }
+
+    @Override
+    public String getActions() {
+        return "";
+    }
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/ClassLevelComputedPermissionsAllowedTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/ClassLevelComputedPermissionsAllowedTest.java
@@ -132,9 +132,9 @@ public class ClassLevelComputedPermissionsAllowedTest {
     public static class AllStrAutodetectedPermission extends Permission {
         private final boolean pass;
 
-        public AllStrAutodetectedPermission(String name, String[] actions, String str1, String str2, String str3) {
+        public AllStrAutodetectedPermission(String name, String[] actions, String exclamationMark, String world, String hello) {
             super(name);
-            this.pass = "hello".equals(str1) && "world".equals(str2) && "!".equals(str3);
+            this.pass = "hello".equals(hello) && "world".equals(world) && "!".equals(exclamationMark);
         }
 
         @Override

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/CombinedAccessParam.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/CombinedAccessParam.java
@@ -1,0 +1,22 @@
+package io.quarkus.security.test.permissionsallowed;
+
+public class CombinedAccessParam {
+
+    public final ParamField paramField;
+
+    CombinedAccessParam(ParamField paramField) {
+        this.paramField = paramField;
+    }
+
+    public static final class ParamField {
+        private final String value;
+
+        ParamField(String value) {
+            this.value = value;
+        }
+
+        public SimpleFieldParam myVal() {
+            return new SimpleFieldParam(value);
+        }
+    }
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/ComplexFieldParam.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/ComplexFieldParam.java
@@ -1,0 +1,20 @@
+package io.quarkus.security.test.permissionsallowed;
+
+public final class ComplexFieldParam {
+
+    public final NestedFieldParam nestedFieldParam;
+
+    ComplexFieldParam(NestedFieldParam nestedFieldParam) {
+        this.nestedFieldParam = nestedFieldParam;
+    }
+
+    public static final class NestedFieldParam {
+
+        public final SimpleFieldParam simpleFieldParam;
+
+        public NestedFieldParam(SimpleFieldParam simpleFieldParam) {
+            this.simpleFieldParam = simpleFieldParam;
+        }
+    }
+
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/CustomPermissionWithMultipleArgs.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/CustomPermissionWithMultipleArgs.java
@@ -1,0 +1,28 @@
+package io.quarkus.security.test.permissionsallowed;
+
+import java.security.BasicPermission;
+import java.security.Permission;
+
+public class CustomPermissionWithMultipleArgs extends BasicPermission {
+
+    public static final String EXPECTED_FIELD_STRING_ARGUMENT = "expectedFieldStringArgument";
+    public static final int EXPECTED_FIELD_INT_ARGUMENT = 100;
+    public static final long EXPECTED_FIELD_LONG_ARGUMENT = 357;
+
+    private final String arg;
+    private final int fourth;
+    private final long first;
+
+    public CustomPermissionWithMultipleArgs(String name, String propertyOne, int fourth, long first) {
+        super(name);
+        this.arg = propertyOne;
+        this.first = first;
+        this.fourth = fourth;
+    }
+
+    @Override
+    public boolean implies(Permission p) {
+        return EXPECTED_FIELD_STRING_ARGUMENT.equals(arg) && EXPECTED_FIELD_INT_ARGUMENT == fourth
+                && EXPECTED_FIELD_LONG_ARGUMENT == first;
+    }
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/CustomPermissionWithStringArg.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/CustomPermissionWithStringArg.java
@@ -1,0 +1,21 @@
+package io.quarkus.security.test.permissionsallowed;
+
+import java.security.BasicPermission;
+import java.security.Permission;
+
+public class CustomPermissionWithStringArg extends BasicPermission {
+
+    public static final String EXPECTED_FIELD_STRING_ARGUMENT = "expectedFieldStringArgument";
+
+    private final String arg;
+
+    public CustomPermissionWithStringArg(String name, String propertyOne) {
+        super(name);
+        this.arg = propertyOne;
+    }
+
+    @Override
+    public boolean implies(Permission p) {
+        return EXPECTED_FIELD_STRING_ARGUMENT.equals(arg);
+    }
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/InjectionPermissionsAllowedTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/InjectionPermissionsAllowedTest.java
@@ -91,10 +91,11 @@ public class InjectionPermissionsAllowedTest {
     public static class AllStrAutodetectedPermission extends Permission {
         private final boolean pass;
 
-        public AllStrAutodetectedPermission(String name, String[] actions, String str1, String str2, String str3) {
+        public AllStrAutodetectedPermission(String name, String[] actions, String hello, String world, String exclamationMark) {
             super(name);
             var sourceOfTruth = Arc.container().instance(SourceOfTruth.class).get();
-            this.pass = "hello".equals(str1) && "world".equals(str2) && "!".equals(str3) && sourceOfTruth.shouldPass();
+            this.pass = "hello".equals(hello) && "world".equals(world) && "!".equals(exclamationMark)
+                    && sourceOfTruth.shouldPass();
         }
 
         @Override

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/MethodLevelComputedPermissionsAllowedTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/MethodLevelComputedPermissionsAllowedTest.java
@@ -168,24 +168,24 @@ public class MethodLevelComputedPermissionsAllowedTest {
         }
 
         @PermissionsAllowed(value = "permissionName:action1234", permission = InheritanceWithActionsPermission.class)
-        public String autodetect(Parent parent) {
+        public String autodetect(Parent obj) {
             return SUCCESS;
         }
 
         @PermissionsAllowed(value = { "permissionName:action1234",
                 "permission1:action1" }, permission = InheritanceWithActionsPermission.class)
-        public String autodetectMultiplePermissions(Parent parent) {
+        public String autodetectMultiplePermissions(Parent obj) {
             return SUCCESS;
         }
 
         @PermissionsAllowed(value = "permissionName:action1234", permission = InheritanceWithActionsPermission.class)
-        public Uni<String> autodetectNonBlocking(Parent parent) {
+        public Uni<String> autodetectNonBlocking(Parent obj) {
             return Uni.createFrom().item(SUCCESS);
         }
 
         @PermissionsAllowed(value = { "permissionName:action1234",
                 "permission1:action1" }, permission = InheritanceWithActionsPermission.class)
-        public Uni<String> autodetectMultiplePermissionsNonBlocking(Parent parent) {
+        public Uni<String> autodetectMultiplePermissionsNonBlocking(Parent obj) {
             return Uni.createFrom().item(SUCCESS);
         }
 
@@ -227,13 +227,13 @@ public class MethodLevelComputedPermissionsAllowedTest {
 
         @PermissionsAllowed("read")
         @PermissionsAllowed(value = "permissionName:action1234", permission = InheritanceWithActionsPermission.class)
-        public Uni<String> combinationNonBlocking(Parent parent) {
+        public Uni<String> combinationNonBlocking(Parent obj) {
             return Uni.createFrom().item(SUCCESS);
         }
 
         @PermissionsAllowed("read")
         @PermissionsAllowed(value = "permissionName:action1234", permission = InheritanceWithActionsPermission.class)
-        public String combination(Parent parent) {
+        public String combination(Parent obj) {
             return SUCCESS;
         }
     }
@@ -332,9 +332,9 @@ public class MethodLevelComputedPermissionsAllowedTest {
     public static class AllStrAutodetectedPermission extends Permission {
         private final boolean pass;
 
-        public AllStrAutodetectedPermission(String name, String[] actions, String str1, String str2, String str3) {
+        public AllStrAutodetectedPermission(String name, String[] actions, String hello, String exclamationMark, String world) {
             super(name);
-            this.pass = "hello".equals(str1) && "world".equals(str2) && "!".equals(str3);
+            this.pass = "hello".equals(hello) && "world".equals(world) && "!".equals(exclamationMark);
         }
 
         @Override
@@ -367,11 +367,11 @@ public class MethodLevelComputedPermissionsAllowedTest {
     public static class AllIntAutodetectedPermission extends Permission {
         private final boolean pass;
 
-        public AllIntAutodetectedPermission(String name, String[] actions, int i, int j, int k) {
+        public AllIntAutodetectedPermission(String name, String[] actions, int three, int two, int one) {
             super(name);
             // here we expect to match 'int' secured method parameters and have them passed here
             // considering secured method has also 'Object' and 'String' parameters, the task is more complex
-            this.pass = i == 1 && j == 2 && k == 3;
+            this.pass = one == 1 && two == 2 && three == 3;
         }
 
         @Override

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/NestedMethodsObject.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/NestedMethodsObject.java
@@ -1,0 +1,35 @@
+package io.quarkus.security.test.permissionsallowed;
+
+public class NestedMethodsObject {
+
+    private final String property;
+
+    public NestedMethodsObject(String property) {
+        this.property = property;
+    }
+
+    public SecondTier second() {
+        return new SecondTier();
+    }
+
+    public final class SecondTier {
+
+        public ThirdTier third() {
+            return new ThirdTier();
+        }
+
+    }
+
+    public final class ThirdTier {
+        public FourthTier fourth() {
+            return new FourthTier();
+        }
+    }
+
+    public final class FourthTier {
+        public String getPropertyOne() {
+            return property;
+        }
+    }
+
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/PermissionsAllowedNestedParamsTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/PermissionsAllowedNestedParamsTest.java
@@ -1,0 +1,110 @@
+package io.quarkus.security.test.permissionsallowed;
+
+import static io.quarkus.security.test.permissionsallowed.CustomPermissionWithMultipleArgs.EXPECTED_FIELD_INT_ARGUMENT;
+import static io.quarkus.security.test.permissionsallowed.CustomPermissionWithMultipleArgs.EXPECTED_FIELD_LONG_ARGUMENT;
+import static io.quarkus.security.test.permissionsallowed.CustomPermissionWithStringArg.EXPECTED_FIELD_STRING_ARGUMENT;
+import static io.quarkus.security.test.utils.IdentityMock.USER;
+import static io.quarkus.security.test.utils.SecurityTestUtils.assertFailureFor;
+import static io.quarkus.security.test.utils.SecurityTestUtils.assertSuccess;
+
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.StringPermission;
+import io.quarkus.security.test.utils.AuthData;
+import io.quarkus.security.test.utils.IdentityMock;
+import io.quarkus.security.test.utils.SecurityTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PermissionsAllowedNestedParamsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(IdentityMock.class, AuthData.class, SecurityTestUtils.class, StringRecord.class,
+                            SecuredBean.class, CustomPermissionWithStringArg.class, TopTierRecord.class, SimpleFieldParam.class,
+                            ComplexFieldParam.class, NestedMethodsObject.class, CombinedAccessParam.class,
+                            CustomPermissionWithMultipleArgs.class));
+
+    @Inject
+    SecuredBean securedBean;
+
+    @Test
+    public void testNestedRecordParam_NestingLevelOne() {
+        assertSuccess(() -> securedBean.nestedRecordParam_OneTier(new StringRecord(EXPECTED_FIELD_STRING_ARGUMENT)), USER);
+        assertFailureFor(() -> securedBean.nestedRecordParam_OneTier(new StringRecord("unexpected_value")),
+                ForbiddenException.class, USER);
+    }
+
+    @Test
+    public void testNestedRecordParam_NestingLevelThree() {
+        var validTopTierRecord = new TopTierRecord(
+                new TopTierRecord.SecondTierRecord(null, new StringRecord(EXPECTED_FIELD_STRING_ARGUMENT)), -1);
+        assertSuccess(() -> securedBean.nestedRecordParam_ThreeTiers(validTopTierRecord), USER);
+        var invalidTopTierRecord = new TopTierRecord(
+                new TopTierRecord.SecondTierRecord(null, new StringRecord("unexpected_value")), -1);
+        assertFailureFor(() -> securedBean.nestedRecordParam_ThreeTiers(invalidTopTierRecord), ForbiddenException.class, USER);
+    }
+
+    @Test
+    public void testNestedFieldParam_NestingLevelOne() {
+        assertSuccess(() -> securedBean.nestedFieldParam_OneTier(new SimpleFieldParam(EXPECTED_FIELD_STRING_ARGUMENT)), USER);
+        assertFailureFor(() -> securedBean.nestedFieldParam_OneTier(new SimpleFieldParam("unexpected_value")),
+                ForbiddenException.class, USER);
+    }
+
+    @Test
+    public void testNestedFieldParam_NestingLevelThree() {
+        var validComplexParam = new ComplexFieldParam(
+                new ComplexFieldParam.NestedFieldParam(new SimpleFieldParam(EXPECTED_FIELD_STRING_ARGUMENT)));
+        assertSuccess(() -> securedBean.nestedFieldParam_ThreeTiers(validComplexParam), USER);
+        var invalidComplexParam = new ComplexFieldParam(
+                new ComplexFieldParam.NestedFieldParam(new SimpleFieldParam("unexpected_value")));
+        assertFailureFor(() -> securedBean.nestedFieldParam_ThreeTiers(invalidComplexParam),
+                ForbiddenException.class, USER);
+    }
+
+    @Test
+    public void multipleNestedMethods() {
+        var validNestedMethods = new NestedMethodsObject(EXPECTED_FIELD_STRING_ARGUMENT);
+        assertSuccess(() -> securedBean.multipleNestedMethods(validNestedMethods), USER);
+        var invalidNestedMethods = new NestedMethodsObject("unexpected_value");
+        assertFailureFor(() -> securedBean.multipleNestedMethods(invalidNestedMethods), ForbiddenException.class, USER);
+    }
+
+    @Test
+    public void combinedFieldAndMethodAccess() {
+        var validCombinedParam = new CombinedAccessParam(new CombinedAccessParam.ParamField(EXPECTED_FIELD_STRING_ARGUMENT));
+        assertSuccess(() -> securedBean.combinedParam(validCombinedParam), USER);
+        var invalidCombinedParam = new CombinedAccessParam(new CombinedAccessParam.ParamField("unexpected_value"));
+        assertFailureFor(() -> securedBean.combinedParam(invalidCombinedParam), ForbiddenException.class, USER);
+    }
+
+    @Test
+    public void simpleAndNestedParamCombination() {
+        var readPerm = new AuthData(Set.of(), false, "ignored", Set.of(new StringPermission("read")));
+        var noReadPerm = new AuthData(Set.of(), false, "ignored", Set.of(new StringPermission("write")));
+        var validCombinedParam = new CombinedAccessParam(new CombinedAccessParam.ParamField(EXPECTED_FIELD_STRING_ARGUMENT));
+        // succeed as all params are correct
+        assertSuccess(() -> securedBean.simpleAndNested(EXPECTED_FIELD_LONG_ARGUMENT, -1, validCombinedParam, -2,
+                EXPECTED_FIELD_INT_ARGUMENT, -3), readPerm);
+        // fail as String permission is wrong
+        assertFailureFor(() -> securedBean.simpleAndNested(EXPECTED_FIELD_LONG_ARGUMENT, -1, validCombinedParam, -2,
+                EXPECTED_FIELD_INT_ARGUMENT, -3), ForbiddenException.class, noReadPerm);
+        // fail as long param is wrong
+        assertFailureFor(() -> securedBean.simpleAndNested(0, -1, validCombinedParam, -2, EXPECTED_FIELD_INT_ARGUMENT, -3),
+                ForbiddenException.class, readPerm);
+        // fail as int param is wrong
+        assertFailureFor(() -> securedBean.simpleAndNested(EXPECTED_FIELD_LONG_ARGUMENT, -1, validCombinedParam, -2, -9, -3),
+                ForbiddenException.class, readPerm);
+        // fail as combined param is wrong
+        var invalidCombinedParam = new CombinedAccessParam(new CombinedAccessParam.ParamField("unexpected_value"));
+        assertFailureFor(() -> securedBean.simpleAndNested(EXPECTED_FIELD_LONG_ARGUMENT, -1, invalidCombinedParam, -2,
+                EXPECTED_FIELD_INT_ARGUMENT, -3), ForbiddenException.class, readPerm);
+    }
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/SecuredBean.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/SecuredBean.java
@@ -1,0 +1,47 @@
+package io.quarkus.security.test.permissionsallowed;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.security.PermissionsAllowed;
+
+@ApplicationScoped
+public class SecuredBean {
+
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "record.propertyOne")
+    public String nestedRecordParam_OneTier(StringRecord record) {
+        return record.propertyOne();
+    }
+
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "record.secondTier.thirdTier.propertyOne")
+    public String nestedRecordParam_ThreeTiers(TopTierRecord record) {
+        return record.secondTier().thirdTier().propertyOne();
+    }
+
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "simpleParam.propertyOne")
+    public String nestedFieldParam_OneTier(SimpleFieldParam simpleParam) {
+        return simpleParam.propertyOne;
+    }
+
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "complexParam.nestedFieldParam.simpleFieldParam.propertyOne")
+    public String nestedFieldParam_ThreeTiers(ComplexFieldParam complexParam) {
+        return complexParam.nestedFieldParam.simpleFieldParam.propertyOne;
+    }
+
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "obj.second.third.fourth.propertyOne")
+    public String multipleNestedMethods(NestedMethodsObject obj) {
+        return obj.second().third().fourth().getPropertyOne();
+    }
+
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithStringArg.class, params = "obj.paramField.myVal.propertyOne")
+    public String combinedParam(CombinedAccessParam obj) {
+        return obj.paramField.myVal().propertyOne;
+    }
+
+    @PermissionsAllowed("read")
+    @PermissionsAllowed(value = "ignored", permission = CustomPermissionWithMultipleArgs.class, params = { "fourth",
+            "obj.paramField.myVal.propertyOne", "first" })
+    public String simpleAndNested(long first, long second, CombinedAccessParam obj, int third, int fourth, int fifth) {
+        return first + "" + first;
+    }
+
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/SimpleFieldParam.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/SimpleFieldParam.java
@@ -1,0 +1,10 @@
+package io.quarkus.security.test.permissionsallowed;
+
+public class SimpleFieldParam {
+
+    public final String propertyOne;
+
+    public SimpleFieldParam(String propertyOne) {
+        this.propertyOne = propertyOne;
+    }
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/StringRecord.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/StringRecord.java
@@ -1,0 +1,4 @@
+package io.quarkus.security.test.permissionsallowed;
+
+public record StringRecord(String propertyOne) {
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/TopTierRecord.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/TopTierRecord.java
@@ -1,0 +1,8 @@
+package io.quarkus.security.test.permissionsallowed;
+
+public record TopTierRecord(SecondTierRecord secondTier, int ignored) {
+
+    public record SecondTierRecord(String ignored, StringRecord thirdTier) {
+    }
+
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/UnknownParamPermissionsAllowedValidationFailureTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/UnknownParamPermissionsAllowedValidationFailureTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.security.test.permissionsallowed;
+
+import java.security.BasicPermission;
+import java.util.UUID;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UnknownParamPermissionsAllowedValidationFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .assertException(t -> {
+                Assertions.assertEquals(RuntimeException.class, t.getClass(), t.getMessage());
+                Assertions.assertTrue(t.getMessage().contains("Parameter 'id' specified via @PermissionsAllowed#params"));
+                Assertions.assertTrue(t.getMessage().contains("SecuredBean#securedBean"));
+                Assertions.assertTrue(t.getMessage().contains("cannot be matched to any constructor"));
+                Assertions.assertTrue(t.getMessage().contains("OrganizationUnitIdPermission' parameter"));
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+    @Singleton
+    public static class SecuredBean {
+
+        @PermissionsAllowed(value = "ignored", params = "id", permission = OrganizationUnitIdPermission.class)
+        public void securedBean(UUID aOrganizationUnitId) {
+            // EMPTY
+        }
+
+    }
+
+    public static class OrganizationUnitIdPermission extends BasicPermission {
+
+        public OrganizationUnitIdPermission(String name, UUID aOrganizationUnitId) {
+            super(name);
+        }
+    }
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/UnusedParamPermissionsAllowedValidationFailureTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/permissionsallowed/UnusedParamPermissionsAllowedValidationFailureTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.security.test.permissionsallowed;
+
+import java.security.BasicPermission;
+import java.util.UUID;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UnusedParamPermissionsAllowedValidationFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .assertException(t -> {
+                Assertions.assertEquals(RuntimeException.class, t.getClass(), t.getMessage());
+                Assertions.assertTrue(t.getMessage().contains("nestedParam1.something"));
+                Assertions.assertTrue(t.getMessage().contains("cannot be matched to any constructor"));
+                Assertions.assertTrue(t.getMessage().contains("OrganizationUnitIdPermission' parameter"));
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+    @Singleton
+    public static class SecuredBean {
+
+        @PermissionsAllowed(value = "ignored", params = { "aOrganizationUnitId",
+                "nestedParam1.something" }, permission = OrganizationUnitIdPermission.class)
+        public void securedBean(UUID aOrganizationUnitId, NestedParam1 nestedParam1) {
+            // EMPTY
+        }
+
+    }
+
+    public static class NestedParam1 {
+        final String something;
+
+        public NestedParam1(String something) {
+            this.something = something;
+        }
+    }
+
+    public static class OrganizationUnitIdPermission extends BasicPermission {
+
+        public OrganizationUnitIdPermission(String name, UUID aOrganizationUnitId) {
+            super(name);
+        }
+    }
+}


### PR DESCRIPTION
- Closes: https://github.com/quarkusio/quarkus/issues/43231

This PR allows to pass into custom `java.security.Permission` only parameters you need from a `@BeanParam`. I can imagine you have different types of `@BeanParam`s that share a header or query param etc. that you want to pass. It's alternative, but not only option. Instead of this, users could introduce level of abstraction (shared interface) they will inject into the `java.security.Permission` instead.

IMO what this can be convenient in very simple scenarios, like when you want to pass `beanParam.field` into your custom  `java.security.Permission`.

Permission constructor parameters are newly matched automatically based on secured method parameter names.