### PR TITLE
Update OIDC client filters to check if OIDC client feature is enabled

### DIFF
--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/AbstractOidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/AbstractOidcClientRequestFilter.java
@@ -21,6 +21,11 @@ public class AbstractOidcClientRequestFilter extends AbstractTokensProducer impl
 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
+        if (isClientFeatureDisabled()) {
+            LOG.debug("OIDC client filter can not acquire and propagate tokens because "
+                    + "OIDC client is disabled with `quarkus.oidc-client.enabled=false`");
+            return;
+        }
         try {
             final String accessToken = getAccessToken();
             requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, BEARER_SCHEME_WITH_SPACE + accessToken);

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ClientWebApplicationExceptionMapper.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ClientWebApplicationExceptionMapper.java
@@ -1,0 +1,17 @@
+package io.quarkus.oidc.client.reactive.filter;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
+
+@Provider
+public class ClientWebApplicationExceptionMapper implements ExceptionMapper<ClientWebApplicationException> {
+
+    @Override
+    public Response toResponse(ClientWebApplicationException t) {
+        return Response.status(t.getResponse().getStatus()).build();
+    }
+
+}

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/NamedOidcClientFilterDevModeTest.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/NamedOidcClientFilterDevModeTest.java
@@ -18,7 +18,8 @@ public class NamedOidcClientFilterDevModeTest {
             ProtectedResourceServiceAnnotationOidcClient.class,
             ProtectedResourceServiceConfigPropertyOidcClient.class,
             ProtectedResourceServiceCustomProviderConfigPropOidcClient.class,
-            OidcClientResource.class
+            OidcClientResource.class,
+            ClientWebApplicationExceptionMapper.class
     };
 
     @RegisterExtension
@@ -31,8 +32,47 @@ public class NamedOidcClientFilterDevModeTest {
     public void testGerUserConfigPropertyAndAnnotation() {
         // test OidcClientFilter with OidcClient selected via annotation or config-property
 
+        // Client feature is disabled
         // OidcClient selected via @OidcClient("clientName")
         RestAssured.when().get("/oidc-client/annotation/user-name")
+                .then()
+                .statusCode(401);
+
+        RestAssured.when().get("/oidc-client/annotation/anonymous-user-name")
+                .then()
+                .statusCode(204)
+                .body(equalTo(""));
+
+        // @OidcClientFilter: OidcClient selected via `quarkus.oidc-client-filter.client-name=config-property`
+        RestAssured.when().get("/oidc-client/config-property/user-name")
+                .then()
+                .statusCode(401);
+
+        RestAssured.when().get("/oidc-client/config-property/anonymous-user-name")
+                .then()
+                .statusCode(204)
+                .body(equalTo(""));
+
+        // @RegisterProvider(OidcClientRequestReactiveFilter.class): OidcClient selected via `quarkus.oidc-client-filter.client-name=config-property`
+        RestAssured.when().get("/oidc-client/custom-provider-config-property/user-name")
+                .then()
+                .statusCode(401);
+
+        RestAssured.when().get("/oidc-client/custom-provider-config-property/anonymous-user-name")
+                .then()
+                .statusCode(204)
+                .body(equalTo(""));
+
+        test.modifyResourceFile("application.properties", s -> s.replace(".enabled=false", ".enabled=true"));
+
+        // Client feature is enabled
+        // OidcClient selected via @OidcClient("clientName")
+        RestAssured.when().get("/oidc-client/annotation/user-name")
+                .then()
+                .statusCode(200)
+                .body(equalTo("jdoe"));
+
+        RestAssured.when().get("/oidc-client/annotation/anonymous-user-name")
                 .then()
                 .statusCode(200)
                 .body(equalTo("jdoe"));
@@ -43,8 +83,17 @@ public class NamedOidcClientFilterDevModeTest {
                 .statusCode(200)
                 .body(equalTo("alice"));
 
+        RestAssured.when().get("/oidc-client/config-property/anonymous-user-name")
+                .then()
+                .statusCode(200)
+                .body(equalTo("alice"));
+
         // @RegisterProvider(OidcClientRequestReactiveFilter.class): OidcClient selected via `quarkus.oidc-client-filter.client-name=config-property`
         RestAssured.when().get("/oidc-client/custom-provider-config-property/user-name")
+                .then()
+                .statusCode(200)
+                .body(equalTo("alice"));
+        RestAssured.when().get("/oidc-client/custom-provider-config-property/anonymous-user-name")
                 .then()
                 .statusCode(200)
                 .body(equalTo("alice"));

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientResource.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientResource.java
@@ -28,14 +28,32 @@ public class OidcClientResource {
     }
 
     @GET
+    @Path("/annotation/anonymous-user-name")
+    public String annotationAnonymousUserName() {
+        return protectedResourceServiceAnnotationOidcClient.getAnonymousUserName();
+    }
+
+    @GET
     @Path("/config-property/user-name")
     public String configPropertyUserName() {
         return protectedResourceServiceConfigPropertyOidcClient.getUserName();
     }
 
     @GET
+    @Path("/config-property/anonymous-user-name")
+    public String configPropertyAnonymousUserName() {
+        return protectedResourceServiceConfigPropertyOidcClient.getAnonymousUserName();
+    }
+
+    @GET
     @Path("/custom-provider-config-property/user-name")
     public String customProviderConfigPropertyUserName() {
         return protectedResourceServiceCustomProviderConfigPropOidcClient.getUserName();
+    }
+
+    @GET
+    @Path("/custom-provider-config-property/anonymous-user-name")
+    public String customProviderConfigPropertyAnonymousUserName() {
+        return protectedResourceServiceCustomProviderConfigPropOidcClient.getAnonymousUserName();
     }
 }

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResource.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResource.java
@@ -7,10 +7,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
-import io.quarkus.security.Authenticated;
-
 @Path("/protected")
-@Authenticated
 public class ProtectedResource {
 
     @Inject
@@ -19,6 +16,12 @@ public class ProtectedResource {
     @GET
     @RolesAllowed("user")
     public String principalName() {
+        return principal.getName();
+    }
+
+    @GET
+    @Path("/anonymous")
+    public String anonymousPrincipalName() {
         return principal.getName();
     }
 }

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResourceServiceAnnotationOidcClient.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResourceServiceAnnotationOidcClient.java
@@ -14,4 +14,8 @@ public interface ProtectedResourceServiceAnnotationOidcClient {
 
     @GET
     String getUserName();
+
+    @GET
+    @Path("/anonymous")
+    String getAnonymousUserName();
 }

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResourceServiceConfigPropertyOidcClient.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResourceServiceConfigPropertyOidcClient.java
@@ -14,4 +14,8 @@ public interface ProtectedResourceServiceConfigPropertyOidcClient {
 
     @GET
     String getUserName();
+
+    @GET
+    @Path("/anonymous")
+    String getAnonymousUserName();
 }

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResourceServiceCustomProviderConfigPropOidcClient.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResourceServiceCustomProviderConfigPropOidcClient.java
@@ -13,4 +13,8 @@ public interface ProtectedResourceServiceCustomProviderConfigPropOidcClient {
 
     @GET
     String getUserName();
+
+    @GET
+    @Path("/anonymous")
+    String getAnonymousUserName();
 }

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/resources/application-oidc-client-reactive-filter.properties
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/resources/application-oidc-client-reactive-filter.properties
@@ -2,6 +2,8 @@ quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.client-id=quarkus-service-app
 quarkus.oidc.credentials.secret=secret
 
+quarkus.oidc-client.enabled=false
+
 quarkus.rest-client-oidc-filter.client-name=config-property
 quarkus.oidc-client.config-property.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.config-property.client-id=${quarkus.oidc.client-id}

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/AbstractOidcClientRequestReactiveFilter.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/AbstractOidcClientRequestReactiveFilter.java
@@ -26,6 +26,11 @@ public class AbstractOidcClientRequestReactiveFilter extends AbstractTokensProdu
 
     @Override
     public void filter(ResteasyReactiveClientRequestContext requestContext) {
+        if (isClientFeatureDisabled()) {
+            LOG.debug("OIDC client filter can not acquire and propagate tokens because "
+                    + "OIDC client is disabled with `quarkus.oidc-client.enabled=false`");
+            return;
+        }
         requestContext.suspend();
 
         super.getTokens().subscribe().with(new Consumer<>() {

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientBuildTimeConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientBuildTimeConfig.java
@@ -1,12 +1,13 @@
 package io.quarkus.oidc.client.runtime;
 
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 /**
  * Build time configuration for OIDC client.
  */
-@ConfigRoot
+@ConfigRoot(name = "oidc-client", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class OidcClientBuildTimeConfig {
     /**
      * If the OIDC client extension is enabled.


### PR DESCRIPTION
Fixes #41827.

When the OIDC client filter is registered with the `@OidcClient` annotation, disabling the OIDC client feature with `quarkus.oidc-client.enabled=false` makes `@OidcClient` ineffective because it is processed at the OIDC client filter build time and is preconditioned on the underlying OIDC client feature being enabled.

However, when the OIDC client filter is registered directly using a `@RegisterRestClient` annotation, the fact that the OIDC client feature is disabled with `quarkus.oidc-client.enabled=false` is not relevant, it is just a standard, generic JAX-RS provider registration. Then, when the request is made, the filter tries to do something with the disabled client and the request fails.

This PR attempts to fix it by updating OIDC client filters to check the build time `quarkus.oidc-client.enabled` property and avoid any OidcClient related initialization or processing if it is disabled.

The test has been updated. Specifically, when the OIDC client is disabled, the test gets `401` when a secured `ProtectedResource` method is called because it does not get an expected token. But it gets an empty response when a public method in the `ProtectedResource` is called, proving no token is arriving, with the OidcClient filter not impacting the request flow, even though the OidcClient is disabled.

When the OidcClient is enabled, the public method returns a user name, similarly to when a secured method is called,  due to the proactive authentication, proving the token is flowing in this case as well