### PR TITLE
Docs: Fix example in "Accessing Static Fields and Methods"

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -2395,12 +2395,12 @@ public class Statuses {
     public static final String OFF = "off";
 }
 ----
-<1> A name resolver with the namespace `model_Status` is generated automatically.
+<1> A name resolver with the namespace `model_Statuses` is generated automatically.
 
 .Template Accessing Class Constants
 [source,html]
 ----
-{#if machine.status == model_Status:ON}
+{#if machine.status == model_Statuses:ON}
   The machine is ON!
 {/if}
 ----


### PR DESCRIPTION
In my opinion the example provided in section "4.7.1. Accessing Static Fields and Methods" is not working.

In this change https://github.com/quarkusio/quarkus/pull/22024/files#diff-c2466ea58430f533cbe0c33ca9ade344beaef598a94cb34b9dd69d7757205469 the example was duplicated to have it twice:

* Once with `@TemplateData` (where the class `Statuses` was introduced)
* Once with the new `@TemplateEnum` possibility (where the enum is called `Status`)

Before that change the `@TemplateData` was on the enum `Status` which leads to the confusion.

Related PR: https://github.com/quarkusio/quarkus/pull/22024
