### PR TITLE
Add Javadoc for DevMojo#jvmArgs

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -246,6 +246,10 @@ public class DevMojo extends AbstractMojo {
     @Parameter
     private File workingDir;
 
+    /**
+     * Allows configuring arbitrary JVM arguments. Multiple arguments can be specified by delimiting them with a space
+     * character.
+     */
     @Parameter(defaultValue = "${jvm.args}")
     private String jvmArgs;
 


### PR DESCRIPTION
I had to set this in a sample, and it took me
a few tries to come up with the proper syntax
for passing multiple parameters as the description of the property was completely absent