### PR TITLE
Fix Kafka Streams flaky health check tests

### DIFF
--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsStartupFailureTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsStartupFailureTest.java
@@ -40,9 +40,9 @@ public class KafkaStreamsStartupFailureTest {
         assertEquals(State.CREATED, kafkaStreams.state());
         RestAssured.get("/q/health/ready").then()
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
-                .body("checks[0].name", CoreMatchers.is("Kafka Streams topics health check"))
-                .body("checks[0].status", CoreMatchers.is("DOWN"))
-                .body("checks[0].data.missing_topics", CoreMatchers.is("nonexisting-topic"));
+                .rootPath("checks.find { it.name ==  'Kafka Streams topics health check' }")
+                .body("status", CoreMatchers.is("DOWN"))
+                .body("data.missing_topics", CoreMatchers.is("nonexisting-topic"));
         assertTrue(Application.currentApplication().isStarted());
 
         Application.currentApplication().stop();

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -149,15 +149,15 @@ public class KafkaStreamsTest {
     public void testKafkaStreamsNotAliveAndNotReady() throws Exception {
         RestAssured.get("/q/health/ready").then()
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
-                .body("checks[0].name", CoreMatchers.is("Kafka Streams topics health check"))
-                .body("checks[0].status", CoreMatchers.is("DOWN"))
-                .body("checks[0].data.missing_topics", CoreMatchers.is("streams-test-categories,streams-test-customers"));
+                .rootPath("checks.find { it.name ==  'Kafka Streams topics health check' }")
+                .body("status", CoreMatchers.is("DOWN"))
+                .body("data.missing_topics", CoreMatchers.is("streams-test-categories,streams-test-customers"));
 
         RestAssured.when().get("/q/health/live").then()
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
-                .body("checks[0].name", CoreMatchers.is("Kafka Streams state health check"))
-                .body("checks[0].status", CoreMatchers.is("DOWN"))
-                .body("checks[0].data.state", CoreMatchers.is("CREATED"));
+                .rootPath("checks.find { it.name ==  'Kafka Streams state health check' }")
+                .body("status", CoreMatchers.is("DOWN"))
+                .body("data.state", CoreMatchers.is("CREATED"));
 
         RestAssured.when().get("/q/health").then()
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE);
@@ -166,15 +166,15 @@ public class KafkaStreamsTest {
     public void testKafkaStreamsAliveAndReady() throws Exception {
         RestAssured.get("/q/health/ready").then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("checks[0].name", CoreMatchers.is("Kafka Streams topics health check"))
-                .body("checks[0].status", CoreMatchers.is("UP"))
-                .body("checks[0].data.available_topics", CoreMatchers.is("streams-test-categories,streams-test-customers"));
+                .rootPath("checks.find { it.name ==  'Kafka Streams topics health check' }")
+                .body("status", CoreMatchers.is("UP"))
+                .body("data.available_topics", CoreMatchers.is("streams-test-categories,streams-test-customers"));
 
         RestAssured.when().get("/q/health/live").then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("checks[0].name", CoreMatchers.is("Kafka Streams state health check"))
-                .body("checks[0].status", CoreMatchers.is("UP"))
-                .body("checks[0].data.state", CoreMatchers.is("RUNNING"));
+                .rootPath("checks.find { it.name ==  'Kafka Streams state health check' }")
+                .body("status", CoreMatchers.is("UP"))
+                .body("data.state", CoreMatchers.is("RUNNING"));
 
         RestAssured.when().get("/q/health").then()
                 .statusCode(HttpStatus.SC_OK);


### PR DESCRIPTION
Health check order may change between kafka client and kafka streams extensions