### PR TITLE
Auto log for dev services in containers

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -47,7 +47,7 @@ Extensions can:
 
 - <<add-links-to-an-extension-card,Add links to an extension card>>
 - <<add-full-pages,Add full custom pages>>
-- <<add-a-log-file,Add a log stream>>
+- <<add-a-footer-tab,Add a footer tab>>
 - <<add-a-section-menu,Add a section menu>>
 - <<custom-cards,Create a custom card>>
 
@@ -822,7 +822,7 @@ https://github.com/quarkusio/quarkus/blob/main/extensions/vertx-http/dev-ui-reso
 ====== Log
 
 The log controller is used to add control buttons to a (footer) log.
-See <<Add a log file>>.
+See <<Add a footer tab>>.
 
 image::dev-ui-log-control-v2.png[alt=Dev UI Log control,role="center"]
 
@@ -1145,9 +1145,9 @@ See the https://github.com/quarkusio/quarkus/tree/main/extensions/vertx-http/dev
 The state in Dev UI uses https://github.com/gitaarik/lit-state[LitState]. You can read more about it in their https://gitaarik.github.io/lit-state/build/[documentation].
 
 
-== Add a log file
+== Add a footer tab
 
-Apart from adding a card and a page, extensions can add a log to the footer. This is useful for logging things that are happening continuously. A page will lose connection to the backend when navigating away from that page, and a log in the footer will be permanently connected.
+Apart from adding a card and a page, extensions can add a tab to the footer. This is useful for things that are happening continuously. A page will lose connection to the backend when navigating away from that page, and a log in the footer will be permanently connected.
 
 Adding something to the footer works exactly like adding a Card, except you use a `FooterPageBuildItem` rather than a `CardPageBuildItem`.
 
@@ -1178,6 +1178,59 @@ export class QwcJokesLog extends LitElement {
 ----
 
 https://github.com/phillip-kruger/quarkus-jokes/blob/main/deployment/src/main/resources/dev-ui/qwc-jokes-log.js[Example code]
+
+=== Add a log to the footer
+
+There is an easy way to add a log stream to the footer, without having to create the above mentioned footer. 
+If you just want to stream a log to a tab you can just produce a `FooterLogBuildItem`. This way you only provide a name and a `Flow.Publisher<String>` for your log.
+
+Here is an example from the Dev Services deployment module:
+
+[source,java]
+----
+@BuildStep(onlyIf = { IsDevelopment.class })
+public List<DevServiceDescriptionBuildItem> config(
+        // ...
+        BuildProducer<FooterLogBuildItem> footerLogProducer){
+
+        // ...
+
+    // Dev UI Log stream
+    for (DevServiceDescriptionBuildItem service : serviceDescriptions) {
+        if (service.getContainerInfo() != null) {
+            footerLogProducer.produce(new FooterLogBuildItem(service.getName(), () -> {
+                return createLogPublisher(service.getContainerInfo().getId());
+            }));
+        }
+    }
+}
+
+// ...
+
+private Flow.Publisher<String> createLogPublisher(String containerId) {
+    try (FrameConsumerResultCallback resultCallback = new FrameConsumerResultCallback()) {
+        SubmissionPublisher<String> publisher = new SubmissionPublisher<>();
+        resultCallback.addConsumer(OutputFrame.OutputType.STDERR,
+                frame -> publisher.submit(frame.getUtf8String()));
+        resultCallback.addConsumer(OutputFrame.OutputType.STDOUT,
+                frame -> publisher.submit(frame.getUtf8String()));
+        LogContainerCmd logCmd = DockerClientFactory.lazyClient()
+                .logContainerCmd(containerId)
+                .withFollowStream(true)
+                .withTailAll()
+                .withStdErr(true)
+                .withStdOut(true);
+        logCmd.exec(resultCallback);
+
+        return publisher;
+    } catch (Exception e) {
+        throw new RuntimeException(e);
+    }
+}
+
+----
+
+
 
 == Add a section menu
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -107,6 +107,7 @@ public class BuildTimeContentProcessor {
         internalImportMapBuildItem.add("qwc-hot-reload-element", contextRoot + "qwc/qwc-hot-reload-element.js");
         internalImportMapBuildItem.add("qwc-abstract-log-element", contextRoot + "qwc/qwc-abstract-log-element.js");
         internalImportMapBuildItem.add("qwc-server-log", contextRoot + "qwc/qwc-server-log.js");
+        internalImportMapBuildItem.add("qwc-footer-log", contextRoot + "qwc/qwc-footer-log.js");
         internalImportMapBuildItem.add("qwc-extension-link", contextRoot + "qwc/qwc-extension-link.js");
         // Quarkus UI
         internalImportMapBuildItem.add("qui-ide-link", contextRoot + "qui/qui-ide-link.js");

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer-log.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer-log.js
@@ -1,0 +1,192 @@
+import { QwcAbstractLogElement, html, css} from 'qwc-abstract-log-element';
+import { repeat } from 'lit/directives/repeat.js';
+import { LogController } from 'log-controller';
+import { JsonRpc } from 'jsonrpc';
+
+/**
+ * This component represent Log file in the footer.
+ */
+export class QwcFooterLog extends QwcAbstractLogElement {
+    logControl = new LogController(this);
+    jsonRpc = new JsonRpc(this,false);
+    
+    static styles = css`
+        .log {
+            width: 100%;
+            height: 100%;
+            max-height: 100%;
+            display: flex;
+            flex-direction:column;
+        }
+    
+        .text-warn {
+            color: var(--lumo-warning-color-50pct);
+        }
+        .text-error{
+            color: var(--lumo-error-text-color);
+        }
+    
+        .message {
+        }
+    `;
+    
+    static properties = {
+        jsonRPCMethodName:{type: String},
+        _messages: {state:true},
+        _zoom: {state:true},
+        _increment: {state: false},
+        _followLog: {state: false},
+        _observer: {state:false}
+    };
+    
+    constructor() {
+        super();
+
+        this.logControl
+                .addToggle("On/off switch", true, (e) => {
+                    this._toggleOnOffClicked(e);
+                }).addItem("Zoom out", "font-awesome-solid:magnifying-glass-minus", "var(--lumo-tertiary-text-color)", (e) => {
+                    this._zoomOut();
+                }).addItem("Zoom in", "font-awesome-solid:magnifying-glass-plus", "var(--lumo-tertiary-text-color)", (e) => {
+                    this._zoomIn();
+                }).addItem("Clear", "font-awesome-solid:trash-can", "var(--lumo-error-color)", (e) => {
+                    this._clearLog();
+                }).addFollow("Follow log", true , (e) => {
+                    this._toggleFollowLog(e);
+                }).done();
+                
+        this._messages = [];
+        this._zoom = parseFloat(1.0);
+        this._increment = parseFloat(0.05);
+        this._followLog = true;
+        this.jsonRPCMethodName = null;
+    }
+    
+    connectedCallback() {
+        super.connectedCallback();
+        this._toggleOnOff(true);
+    }
+    
+    disconnectedCallback() {
+        this._toggleOnOff(false);
+        
+        super.disconnectedCallback();
+    }
+    
+    render() {
+        if(this.jsonRPCMethodName){
+            return html`<code class="log" style="font-size: ${this._zoom}em;">
+                ${repeat(
+                    this._messages,
+                    (message) => message.sequenceNumber,
+                    (message, index) => html`
+                    <div class="logEntry">
+                        ${this._renderLogEntry(message)}
+                    </div>
+                  `
+                  )}
+                </code>`;
+        }
+    }
+    
+    _renderLogEntry(message){
+        
+        if(message.length>0){
+            let c="message";
+            if (message.includes(' ERROR ')) {
+                c = "text-error";
+            } else if (message.includes(' WARN ')) {
+                c = "text-warn";
+            }
+
+            return html`<span class='${c}'>${message}</span>`;
+        }else{
+            return html`<br/>`;
+        }
+    }
+    
+    _handleKeyPress(event) {
+        if (event.key === 'Enter') {
+            this._addLogEntry("");
+        }
+    }
+    
+    _handleZoomIn(event){
+        this._zoomIn();
+    }
+    
+    _handleZoomOut(event){
+        this._zoomOut();
+    }
+    
+    _toggleOnOffClicked(e){
+        this._toggleOnOff(e);
+        // Add line on stop
+        if(!e){
+            this._addLogEntry("----------------------------------------------------------------------");
+        }
+    }
+    
+    hotReload(){
+        this._clearLog();
+        if(this._observer != null){
+            this._toggleOnOff(true);
+        }
+    }
+    
+    _toggleOnOff(e){
+        if(e){
+            this._observer = this.jsonRpc[this.jsonRPCMethodName]().onNext(jsonRpcResponse => {
+                this._addLogEntry(jsonRpcResponse.result);
+            });
+        }else{
+            this._observer.cancel();
+            this._observer = null;
+        }
+    }
+    
+    _addLogEntry(entry){
+        this._messages = [
+            ...this._messages,
+            entry
+        ];
+
+        this._scrollToBottom();
+    }
+    
+    async _scrollToBottom(){
+        if(this._followLog){
+            await this.updateComplete;
+            
+            const last = Array.from(
+                this.shadowRoot.querySelectorAll('.logEntry')
+            ).pop();
+            
+            if(last){
+                last.scrollIntoView({
+                    behavior: "smooth",
+                    block: "end"
+                });
+            }
+        }
+    }
+    
+    _zoomOut(){
+        this._zoom = parseFloat(parseFloat(this._zoom) - parseFloat(this._increment)).toFixed(2);
+    }
+    
+    _zoomIn(){
+        this._zoom = parseFloat(parseFloat(this._zoom) + parseFloat(this._increment)).toFixed(2);
+    }
+    
+    _clearLog(){
+        this._messages = [];
+    }
+    
+    _toggleFollowLog(e){
+        this._followLog = e;
+        this._scrollToBottom();   
+    }
+    
+}
+customElements.define('qwc-footer-log', QwcFooterLog);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer.js
@@ -295,8 +295,14 @@ export class QwcFooter extends observeState(LitElement) {
     }
 
     _renderTabBody(footerTab){
-        let dynamicFooter = `<${footerTab.componentName} namespace="${footerTab.namespace}"></${footerTab.componentName}>`;
-        return html`${unsafeHTML(dynamicFooter)}`;
+        if(footerTab.componentName === "qwc-footer-log"){ // Reusable footer log.
+            let jsonRpcMethodName = footerTab.metadata.jsonRpcMethodName;
+            let dynamicFooter = `<${footerTab.componentName} title="${footerTab.title}" namespace="${footerTab.namespace}" jsonRpcMethodName="${jsonRpcMethodName}"></${footerTab.componentName}>`;
+            return html`${unsafeHTML(dynamicFooter)}`;
+        }else{
+            let dynamicFooter = `<${footerTab.componentName} title="${footerTab.title}" namespace="${footerTab.namespace}"></${footerTab.componentName}>`;
+            return html`${unsafeHTML(dynamicFooter)}`;
+        }
     }
 
     _tabSelected(index){

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/FooterLogBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/FooterLogBuildItem.java
@@ -1,0 +1,29 @@
+package io.quarkus.devui.spi.buildtime;
+
+import java.util.concurrent.Flow;
+import java.util.function.Supplier;
+
+import io.quarkus.devui.spi.AbstractDevUIBuildItem;
+
+/**
+ * Add a log to the footer of dev ui
+ */
+public final class FooterLogBuildItem extends AbstractDevUIBuildItem {
+
+    private final String name;
+    private final Supplier<Flow.Publisher<String>> publisherSupplier;
+
+    public FooterLogBuildItem(String name, Supplier<Flow.Publisher<String>> publisherSupplier) {
+        super(DEV_UI);
+        this.name = name;
+        this.publisherSupplier = publisherSupplier;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Flow.Publisher<String> getPublisher() {
+        return publisherSupplier.get();
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -246,7 +246,7 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
 
         try (StringWriter sw = new StringWriter()) {
             sw.write(NL + HEADING + NL);
-            sw.write("------------------------" + NL);
+            sw.write("---------------------------" + NL);
             sw.write(NL);
             sw.write("Details:");
             sw.write(NL);


### PR DESCRIPTION
This PR add a log tab in the Dev UI Footer for every Dev Service, started with a container. It also adds an easy way to add log in the footer tab for any other case, example Dev Services that does not use containers, or just any extension that want to add a log.
![auto_footer_containers](https://github.com/user-attachments/assets/50d24a7e-2aab-4c7f-8b3c-35e9693e254d)
