### PR TITLE
Deprecate quarkus.datasource.jdbc.tracing

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -146,7 +146,10 @@ public interface DataSourceJdbcRuntimeConfig {
 
     /**
      * Enable JDBC tracing.
+     *
+     * @deprecated in favor of OpenTelemetry {@link #telemetry()}
      */
+    @Deprecated(forRemoval = true, since = "3.16")
     DataSourceJdbcTracingRuntimeConfig tracing();
 
     /**

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcTracingRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcTracingRuntimeConfig.java
@@ -6,7 +6,11 @@ import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
+/**
+ * @deprecated in favor of OpenTelemetry {@link DataSourceJdbcRuntimeConfig#telemetry()}
+ */
 @ConfigGroup
+@Deprecated(forRemoval = true, since = "3.16")
 public interface DataSourceJdbcTracingRuntimeConfig {
 
     /**


### PR DESCRIPTION
Deprecate the `quarkus.datasource.jdbc.tracing configuration` and remove it in a future version

- Closes: https://github.com/quarkusio/quarkus/issues/42563. 