### PR TITLE
Add OidcClient expiresIn property

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -34,13 +34,21 @@ public class OidcClientConfig extends OidcClientCommonConfig {
     public Optional<List<String>> scopes = Optional.empty();
 
     /**
-     * Refresh token time skew in seconds.
-     * If this property is enabled then the configured number of seconds is added to the current time
+     * Refresh token time skew.
+     * If this property is enabled then the configured duration is converted to seconds and is added to the current time
      * when checking whether the access token should be refreshed. If the sum is greater than this access token's
      * expiration time then a refresh is going to happen.
      */
     @ConfigItem
     public Optional<Duration> refreshTokenTimeSkew = Optional.empty();
+
+    /**
+     * Access token expiration period relative to the current time.
+     * This property is only checked when an access token grant response
+     * does not include an access token expiration property.
+     */
+    @ConfigItem
+    public Optional<Duration> accessTokenExpiresIn = Optional.empty();
 
     /**
      * If the access token 'expires_in' property should be checked as an absolute time value

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -244,7 +244,8 @@ public class OidcClientImpl implements OidcClient {
             JsonObject json = buffer.toJsonObject();
             // access token
             final String accessToken = json.getString(oidcConfig.grant.accessTokenProperty);
-            final Long accessTokenExpiresAt = getExpiresAtValue(accessToken, json.getValue(oidcConfig.grant.expiresInProperty));
+            final Long accessTokenExpiresAt = getAccessTokenExpiresAtValue(accessToken,
+                    json.getValue(oidcConfig.grant.expiresInProperty));
 
             final String refreshToken = json.getString(oidcConfig.grant.refreshTokenProperty);
             final Long refreshTokenExpiresAt = getExpiresAtValue(refreshToken,
@@ -259,6 +260,15 @@ public class OidcClientImpl implements OidcClient {
                     errorMessage);
             throw new OidcClientException(errorMessage);
         }
+    }
+
+    private Long getAccessTokenExpiresAtValue(String token, Object expiresInValue) {
+        Long expiresAt = getExpiresAtValue(token, expiresInValue);
+        if (expiresAt == null && oidcConfig.accessTokenExpiresIn.isPresent()) {
+            final long now = System.currentTimeMillis() / 1000;
+            expiresAt = now + oidcConfig.accessTokenExpiresIn.get().toSeconds();
+        }
+        return expiresAt;
     }
 
     private Long getExpiresAtValue(String token, Object expiresInValue) {

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -38,6 +38,10 @@ public class FrontendResource {
     Tokens tokens;
 
     @Inject
+    @NamedOidcClient("configured-expires-in")
+    Tokens tokensConfiguredExpiresIn;
+
+    @Inject
     @NamedOidcClient("non-standard-response-without-header")
     OidcClient tokensWithoutHeader;
 
@@ -77,6 +81,16 @@ public class FrontendResource {
     public String echoTokenNonStandardResponse() {
         try {
             return tokens.getAccessToken() + " " + tokens.getRefreshToken();
+        } catch (OidcClientException ex) {
+            throw new WebApplicationException(401);
+        }
+    }
+
+    @GET
+    @Path("echoTokenConfiguredExpiresIn")
+    public String echoTokenConfiguredExpiresIn() {
+        try {
+            return tokensConfiguredExpiresIn.getAccessToken() + " " + tokensConfiguredExpiresIn.getAccessTokenExpiresAt();
         } catch (OidcClientException ex) {
             throw new WebApplicationException(401);
         }

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -7,6 +7,12 @@ quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
 
+quarkus.oidc-client.configured-expires-in.token-path=${keycloak.url}/tokens-without-expires-in
+quarkus.oidc-client.configured-expires-in.client-id=quarkus-app
+quarkus.oidc-client.configured-expires-in.credentials.client-secret.value=secret
+quarkus.oidc-client.configured-expires-in.credentials.client-secret.method=post
+quarkus.oidc-client.configured-expires-in.access-token-expires-in=5S
+
 quarkus.oidc-client.jwtbearer.auth-server-url=${keycloak.url}
 quarkus.oidc-client.jwtbearer.discovery-enabled=false
 quarkus.oidc-client.jwtbearer.token-path=/tokens-jwtbearer

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -79,6 +79,14 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .withBody(
                                 "{\"access_token\":\"access_token_2\", \"expires_in\":4, \"refresh_token\":\"refresh_token_2\", \"refresh_expires_in\":1}")));
 
+        server.stubFor(WireMock.post("/tokens-without-expires-in")
+                .withRequestBody(matching("grant_type=client_credentials&client_id=quarkus-app&client_secret=secret"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                        .withBody(
+                                "{\"access_token\":\"access_token_without_expires_in\"}")));
+
         server.stubFor(WireMock.post("/refresh-token-only")
                 .withRequestBody(
                         matching("grant_type=refresh_token&refresh_token=shared_refresh_token&extra_param=extra_param_value"))

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -5,6 +5,7 @@ import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -28,6 +29,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
 
 @QuarkusTest
 @QuarkusTestResource(KeycloakRealmResourceManager.class)
@@ -42,6 +44,21 @@ public class OidcClientTest {
                 .then()
                 .statusCode(200)
                 .body(equalTo("access_token_jwt_bearer"));
+    }
+
+    @Test
+    public void testGetAccessTokenWithConfiguredExpiresIn() {
+        Response r = RestAssured.when().get("/frontend/echoTokenConfiguredExpiresIn");
+        assertEquals(200, r.statusCode());
+        String[] data = r.body().asString().split(" ");
+        assertEquals(2, data.length);
+        assertEquals("access_token_without_expires_in", data[0]);
+
+        long now = System.currentTimeMillis() / 1000;
+        long expectedExpiresAt = now + 5;
+        long accessTokenExpiresAt = Long.valueOf(data[1]);
+        assertTrue(accessTokenExpiresAt >= expectedExpiresAt
+                && accessTokenExpiresAt <= expectedExpiresAt + 2);
     }
 
     @Test


### PR DESCRIPTION
Fixes #41067.

Salesforce does not return an access token `expires_in` property, so the access token is used indefinitely, unless it is revoked manually using the OidcClient revoke token method or a custom filter is used to force the token refresh, by checking manually the custom expiration time.

This PR adds a configuration property to make it much easier to deal with. 
Users set `quarkus.oidc-client.access-token-expires-in=some-duration`, this property is checked only when the token grant response does not include an expiration time, and the built-in OIDC client code takes care of the rest. 

The test only confirms that the access token expires at property is available, even with the token grant response returning no such property, there are a few tests there which already check the actual token refresh when the token expires.