### PR TITLE
Improve robustness of Kafka messaging tests

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/KafkaDevServicesContinuousTestingTestCase.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/KafkaDevServicesContinuousTestingTestCase.java
@@ -6,7 +6,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -43,7 +42,6 @@ public class KafkaDevServicesContinuousTestingTestCase {
 
     //see https://github.com/quarkusio/quarkus/issues/19180
     @Test
-    @Disabled("flaky")
     public void testContinuousTestingScenario1() {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         var result = utils.waitForNextCompletion();
@@ -68,7 +66,6 @@ public class KafkaDevServicesContinuousTestingTestCase {
     }
 
     @Test
-    @Disabled("flaky")
     public void testContinuousTestingScenario2() {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         var result = utils.waitForNextCompletion();

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/KafkaDevServicesContinuousTestingWorkingAppPropsTestCase.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/KafkaDevServicesContinuousTestingWorkingAppPropsTestCase.java
@@ -6,7 +6,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -38,7 +37,6 @@ public class KafkaDevServicesContinuousTestingWorkingAppPropsTestCase {
      * See https://github.com/quarkusio/quarkus/issues/19180.
      */
     @Test
-    @Disabled("flaky")
     public void testContinuousTestingScenario3() {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         var result = utils.waitForNextCompletion();

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/PriceResource.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/PriceResource.java
@@ -1,5 +1,8 @@
 package io.quarkus.smallrye.reactivemessaging.kafka.deployment.testing;
 
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
 //
 //import org.eclipse.microprofile.reactive.messaging.Channel;
 //import org.reactivestreams.Publisher;
@@ -9,8 +12,14 @@ package io.quarkus.smallrye.reactivemessaging.kafka.deployment.testing;
 //import jakarta.ws.rs.Produces;
 //import jakarta.ws.rs.core.MediaType;
 //
-//@Path("/prices")
+@Path("/prices")
 public class PriceResource {
+
+    @GET
+    public String ok() {
+        return "ok";
+    }
+
     //    private final Publisher<Double> processedPrices;
     //
     //    public PriceResource(@Channel("processed-prices") Publisher<Double> processedPrices) {

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/PriceResourceET.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/PriceResourceET.java
@@ -1,6 +1,5 @@
 package io.quarkus.smallrye.reactivemessaging.kafka.deployment.testing;
 
-import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -14,20 +13,20 @@ import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
 
 @QuarkusTest
 class PriceResourceET {
-    @TestHTTPEndpoint(PriceResource.class)
-    @TestHTTPResource("/stream")
-    URI uri;
 
     @Test
     public void sseStream() {
+        Awaitility.await().untilAsserted(() -> {
+            RestAssured.get("http://localhost:8081/prices").then().statusCode(200);
+        });
+
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target(this.uri);
+        WebTarget target = client.target("http://localhost:8081/prices/stream");
 
         List<Double> received = new CopyOnWriteArrayList<>();
 


### PR DESCRIPTION
Improve the Kafka messaging tests to avoid the issue when accessing a missing resource (because the code is commented out).

Fix #24378