### PR TITLE
Make sure OIDC issuer-based tenant resolver can recover when OIDC server becomes available after Quarkus app started

### DIFF
--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -9,7 +9,7 @@ quarkus.oidc.application-type=web-app
 quarkus.oidc.logout.path=/protected/logout
 quarkus.oidc.authentication.pkce-required=true
 quarkus.log.category."org.htmlunit".level=ERROR
-quarkus.log.category."io.quarkus.oidc.runtime.TenantConfigContext".level=DEBUG
+quarkus.log.category."io.quarkus.oidc.runtime.TenantConfigContextImpl".level=DEBUG
 quarkus.log.file.enable=true
 
 # use blocking DNS lookup so that we have it tested somewhere

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -87,7 +87,7 @@ public class BackChannelLogoutHandler {
                                     try {
                                         // Do the general validation of the logout token now, compare with the IDToken later
                                         // Check the signature, as well the issuer and audience if it is configured
-                                        TokenVerificationResult result = tenantContext.provider
+                                        TokenVerificationResult result = tenantContext.provider()
                                                 .verifyLogoutJwtToken(encodedLogoutToken);
 
                                         if (verifyLogoutTokenClaims(result)) {
@@ -162,9 +162,9 @@ public class BackChannelLogoutHandler {
         }
 
         private boolean isMatchingTenant(String requestPath, TenantConfigContext tenant) {
-            return tenant.oidcConfig.isTenantEnabled()
-                    && tenant.oidcConfig.getTenantId().get().equals(oidcTenantConfig.getTenantId().get())
-                    && requestPath.equals(getRootPath() + tenant.oidcConfig.logout.backchannel.path.orElse(null));
+            return tenant.oidcConfig().isTenantEnabled()
+                    && tenant.oidcConfig().getTenantId().get().equals(oidcTenantConfig.getTenantId().get())
+                    && requestPath.equals(getRootPath() + tenant.oidcConfig().logout.backchannel.path.orElse(null));
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -37,7 +37,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             @Override
             public Uni<ChallengeData> apply(TenantConfigContext tenantContext) {
                 return Uni.createFrom().item(new ChallengeData(HttpResponseStatus.UNAUTHORIZED.code(),
-                        HttpHeaderNames.WWW_AUTHENTICATE, tenantContext.oidcConfig.token.authorizationScheme));
+                        HttpHeaderNames.WWW_AUTHENTICATE, tenantContext.oidcConfig().token.authorizationScheme));
             }
         });
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
@@ -1,0 +1,87 @@
+package io.quarkus.oidc.runtime;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import javax.crypto.SecretKey;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.oidc.OidcConfigurationMetadata;
+import io.quarkus.oidc.OidcRedirectFilter;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.Redirect;
+import io.smallrye.mutiny.Uni;
+
+final class LazyTenantConfigContext implements TenantConfigContext {
+
+    private static final Logger LOG = Logger.getLogger(LazyTenantConfigContext.class);
+
+    private final Supplier<Uni<TenantConfigContext>> staticTenantCreator;
+    private volatile TenantConfigContext delegate;
+
+    LazyTenantConfigContext(TenantConfigContext delegate, Supplier<Uni<TenantConfigContext>> staticTenantCreator) {
+        this.staticTenantCreator = staticTenantCreator;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Uni<TenantConfigContext> initialize() {
+        if (!delegate.ready()) {
+            LOG.debugf("Tenant '%s' is not initialized yet, trying to create OIDC connection now",
+                    delegate.oidcConfig().tenantId.get());
+            return staticTenantCreator.get().invoke(ctx -> LazyTenantConfigContext.this.delegate = ctx);
+        }
+        return Uni.createFrom().item(delegate);
+    }
+
+    @Override
+    public OidcTenantConfig oidcConfig() {
+        return delegate.oidcConfig();
+    }
+
+    @Override
+    public OidcProvider provider() {
+        return delegate.provider();
+    }
+
+    @Override
+    public boolean ready() {
+        return delegate.ready();
+    }
+
+    @Override
+    public OidcTenantConfig getOidcTenantConfig() {
+        return delegate.getOidcTenantConfig();
+    }
+
+    @Override
+    public OidcConfigurationMetadata getOidcMetadata() {
+        return delegate.getOidcMetadata();
+    }
+
+    @Override
+    public OidcProviderClient getOidcProviderClient() {
+        return delegate.getOidcProviderClient();
+    }
+
+    @Override
+    public SecretKey getStateEncryptionKey() {
+        return delegate.getStateEncryptionKey();
+    }
+
+    @Override
+    public SecretKey getTokenEncSecretKey() {
+        return delegate.getTokenEncSecretKey();
+    }
+
+    @Override
+    public SecretKey getInternalIdTokenSecretKey() {
+        return delegate.getInternalIdTokenSecretKey();
+    }
+
+    @Override
+    public List<OidcRedirectFilter> getOidcRedirectFilters(Redirect.Location loc) {
+        return delegate.getOidcRedirectFilters(loc);
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigurationMetadataProducer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigurationMetadataProducer.java
@@ -20,8 +20,8 @@ public class OidcConfigurationMetadataProducer {
     OidcConfigurationMetadata produce() {
         OidcConfigurationMetadata configMetadata = OidcUtils.getAttribute(identity, OidcUtils.CONFIG_METADATA_ATTRIBUTE);
 
-        if (configMetadata == null && tenantConfig.getDefaultTenant().oidcConfig.tenantEnabled) {
-            configMetadata = tenantConfig.getDefaultTenant().provider.getMetadata();
+        if (configMetadata == null && tenantConfig.getDefaultTenant().oidcConfig().tenantEnabled) {
+            configMetadata = tenantConfig.getDefaultTenant().provider().getMetadata();
         }
         if (configMetadata == null) {
             throw new OIDCException("OidcConfigurationMetadata can not be injected");

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -350,7 +350,7 @@ public final class OidcUtils {
             TenantConfigContext resolvedContext, JsonObject tokenJson, JsonObject rolesJson, UserInfo userInfo,
             TokenIntrospection introspectionResult, TokenAuthenticationRequest request) {
 
-        OidcTenantConfig config = resolvedContext.oidcConfig;
+        OidcTenantConfig config = resolvedContext.oidcConfig();
         QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
         builder.addCredential(credential);
         AuthorizationCodeTokens codeTokens = (AuthorizationCodeTokens) requestData.get(AuthorizationCodeTokens.class.getName());
@@ -464,8 +464,8 @@ public final class OidcUtils {
 
     public static void setSecurityIdentityConfigMetadata(QuarkusSecurityIdentity.Builder builder,
             TenantConfigContext resolvedContext) {
-        if (resolvedContext.provider.client != null) {
-            builder.addAttribute(CONFIG_METADATA_ATTRIBUTE, resolvedContext.provider.client.getMetadata());
+        if (resolvedContext.provider().client != null) {
+            builder.addAttribute(CONFIG_METADATA_ATTRIBUTE, resolvedContext.provider().client.getMetadata());
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
@@ -1,0 +1,287 @@
+package io.quarkus.oidc.runtime;
+
+import static io.quarkus.oidc.runtime.OidcProvider.ANY_ISSUER;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.jboss.logging.Logger;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TenantResolver;
+import io.quarkus.vertx.http.runtime.security.ImmutablePathMatcher;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+final class StaticTenantResolver {
+
+    private static final Logger LOG = Logger.getLogger(StaticTenantResolver.class);
+
+    private final TenantResolver[] staticTenantResolvers;
+    private final IssuerBasedTenantResolver issuerBasedTenantResolver;
+
+    StaticTenantResolver(TenantConfigBean tenantConfigBean, String rootPath, boolean resolveTenantsWithIssuer,
+            Instance<TenantResolver> tenantResolverInstance) {
+        List<TenantResolver> staticTenantResolvers = new ArrayList<>();
+        // STATIC TENANT RESOLVERS BY PRIORITY:
+        // 0. annotation based resolver
+
+        // 1. custom tenant resolver
+        if (tenantResolverInstance.isResolvable()) {
+            if (tenantResolverInstance.isAmbiguous()) {
+                throw new IllegalStateException("Multiple " + TenantResolver.class + " beans registered");
+            }
+            staticTenantResolvers.add(tenantResolverInstance.get());
+        }
+
+        // 2. path-matching tenant resolver
+        var pathMatchingTenantResolver = PathMatchingTenantResolver.of(tenantConfigBean.getStaticTenantsConfig(), rootPath,
+                tenantConfigBean.getDefaultTenant());
+        if (pathMatchingTenantResolver != null) {
+            staticTenantResolvers.add(pathMatchingTenantResolver);
+        }
+
+        // 3. default static tenant resolver
+        if (!tenantConfigBean.getStaticTenantsConfig().isEmpty()) {
+            staticTenantResolvers.add(new DefaultStaticTenantResolver(tenantConfigBean));
+        }
+
+        this.staticTenantResolvers = staticTenantResolvers.toArray(new TenantResolver[0]);
+
+        // 4. issuer-based tenant resolver
+        if (resolveTenantsWithIssuer) {
+            this.issuerBasedTenantResolver = IssuerBasedTenantResolver.of(
+                    tenantConfigBean.getStaticTenantsConfig(), tenantConfigBean.getDefaultTenant());
+        } else {
+            this.issuerBasedTenantResolver = null;
+        }
+    }
+
+    Uni<String> resolve(RoutingContext context) {
+        for (TenantResolver resolver : staticTenantResolvers) {
+            final String tenantId = resolver.resolve(context);
+            if (tenantId != null) {
+                return Uni.createFrom().item(tenantId);
+            }
+        }
+
+        if (issuerBasedTenantResolver != null) {
+            return issuerBasedTenantResolver.resolveTenant(context);
+        }
+
+        return Uni.createFrom().nullItem();
+    }
+
+    private static final class DefaultStaticTenantResolver implements TenantResolver {
+
+        private final TenantConfigBean tenantConfigBean;
+
+        private DefaultStaticTenantResolver(TenantConfigBean tenantConfigBean) {
+            this.tenantConfigBean = tenantConfigBean;
+        }
+
+        @Override
+        public String resolve(RoutingContext context) {
+            String[] pathSegments = context.request().path().split("/");
+            if (pathSegments.length > 0) {
+                String lastPathSegment = pathSegments[pathSegments.length - 1];
+                if (tenantConfigBean.getStaticTenantsConfig().containsKey(lastPathSegment)) {
+                    LOG.debugf(
+                            "Tenant id '%s' is selected on the '%s' request path", lastPathSegment, context.normalizedPath());
+                    return lastPathSegment;
+                }
+            }
+            return null;
+        }
+    }
+
+    private static final class PathMatchingTenantResolver implements TenantResolver {
+        private static final String DEFAULT_TENANT = "PathMatchingTenantResolver#DefaultTenant";
+        private final ImmutablePathMatcher<String> staticTenantPaths;
+
+        private PathMatchingTenantResolver(ImmutablePathMatcher<String> staticTenantPaths) {
+            this.staticTenantPaths = staticTenantPaths;
+        }
+
+        private static PathMatchingTenantResolver of(Map<String, TenantConfigContext> staticTenantsConfig, String rootPath,
+                TenantConfigContext defaultTenant) {
+            final var builder = ImmutablePathMatcher.<String> builder().rootPath(rootPath);
+            addPath(DEFAULT_TENANT, defaultTenant.oidcConfig(), builder);
+            for (Map.Entry<String, TenantConfigContext> e : staticTenantsConfig.entrySet()) {
+                addPath(e.getKey(), e.getValue().oidcConfig(), builder);
+            }
+            return builder.hasPaths() ? new PathMatchingTenantResolver(builder.build()) : null;
+        }
+
+        @Override
+        public String resolve(RoutingContext context) {
+            String tenantId = staticTenantPaths.match(context.normalizedPath()).getValue();
+            if (tenantId != null) {
+                LOG.debugf(
+                        "Tenant id '%s' is selected on the '%s' request path", tenantId, context.normalizedPath());
+                return tenantId;
+            }
+            return null;
+        }
+
+        private static ImmutablePathMatcher.ImmutablePathMatcherBuilder<String> addPath(String tenant, OidcTenantConfig config,
+                ImmutablePathMatcher.ImmutablePathMatcherBuilder<String> builder) {
+            if (config != null && config.tenantPaths.isPresent()) {
+                for (String path : config.tenantPaths.get()) {
+                    builder.addPath(path, tenant);
+                }
+            }
+            return builder;
+        }
+    }
+
+    private static final class IssuerBasedTenantResolver {
+
+        private final TenantConfigContext[] tenantConfigContexts;
+        private final boolean detectedTenantWithoutMetadata;
+        private final Map<String, AtomicBoolean> tenantToRetry;
+
+        private IssuerBasedTenantResolver(TenantConfigContext[] tenantConfigContexts, boolean detectedTenantWithoutMetadata,
+                Map<String, AtomicBoolean> tenantToRetry) {
+            this.tenantConfigContexts = tenantConfigContexts;
+            this.detectedTenantWithoutMetadata = detectedTenantWithoutMetadata;
+            this.tenantToRetry = tenantToRetry;
+        }
+
+        private Uni<String> resolveTenant(RoutingContext context) {
+            return resolveTenant(context, 0);
+        }
+
+        private Uni<String> resolveTenant(RoutingContext context, int index) {
+            if (index == tenantConfigContexts.length) {
+                return Uni.createFrom().nullItem();
+            }
+            var tenantContext = tenantConfigContexts[index];
+            if (detectedTenantWithoutMetadata) {
+                // this is static tenant that didn't have OIDC metadata available at startup
+
+                if (tenantContext.getOidcMetadata() == null) {
+                    if (tenantContext.ready()) {
+                        return resolveTenant(context, index + 1);
+                    }
+
+                    if (!tryToInitialize(tenantContext)) {
+                        return resolveTenant(context, index + 1);
+                    }
+
+                    return tenantContext.initialize()
+                            .onItemOrFailure()
+                            .transformToUni(new BiFunction<TenantConfigContext, Throwable, Uni<? extends String>>() {
+                                @Override
+                                public Uni<String> apply(TenantConfigContext newContext, Throwable throwable) {
+                                    if (throwable != null) {
+                                        return resolveTenant(context, index + 1);
+                                    }
+                                    if (newContext.ready() && !isTenantWithoutIssuer(newContext)) {
+                                        return getTenantId(newContext, context, index);
+                                    }
+                                    return resolveTenant(context, index + 1);
+                                }
+                            });
+                }
+
+                if (isTenantWithoutIssuer(tenantContext)) {
+                    return resolveTenant(context, index + 1);
+                }
+            }
+
+            return getTenantId(tenantContext, context, index);
+        }
+
+        private Uni<String> getTenantId(TenantConfigContext tenantContext, RoutingContext context, int index) {
+            var tenantId = getTenantId(context, tenantContext);
+            if (tenantId == null) {
+                return resolveTenant(context, index + 1);
+            }
+            return Uni.createFrom().item(tenantId);
+        }
+
+        /**
+         * When static tenant couldn't be initialized on Quarkus application startup,
+         * this strategy permits one more attempt on the first request when the issuer-based tenant resolver is applied.
+         */
+        private boolean tryToInitialize(TenantConfigContext context) {
+            var tenantId = context.oidcConfig().tenantId.get();
+            return this.tenantToRetry.get(tenantId).compareAndExchange(true, false);
+        }
+
+        private static String getTenantId(RoutingContext context, TenantConfigContext tenantContext) {
+            final String token = OidcUtils.extractBearerToken(context, tenantContext.oidcConfig());
+            if (token != null && !OidcUtils.isOpaqueToken(token)) {
+                final var tokenJson = OidcUtils.decodeJwtContent(token);
+                if (tokenJson != null) {
+
+                    final String iss = tokenJson.getString(Claims.iss.name());
+                    if (tenantContext.getOidcMetadata().getIssuer().equals(iss)) {
+                        OidcUtils.storeExtractedBearerToken(context, token);
+
+                        final String tenantId = tenantContext.oidcConfig().tenantId.get();
+                        LOG.debugf("Resolved the '%s' OIDC tenant based on the matching issuer '%s'", tenantId, iss);
+                        return tenantId;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static boolean isTenantWithoutIssuer(TenantConfigContext tenantContext) {
+            return tenantContext.getOidcMetadata().getIssuer() == null
+                    || ANY_ISSUER.equals(tenantContext.getOidcMetadata().getIssuer());
+        }
+
+        private static IssuerBasedTenantResolver of(Map<String, TenantConfigContext> tenantConfigContexts) {
+            var contextsWithIssuer = new ArrayList<TenantConfigContext>();
+            boolean detectedTenantWithoutMetadata = false;
+            Map<String, AtomicBoolean> tenantToRetry = new HashMap<>();
+            for (TenantConfigContext context : tenantConfigContexts.values()) {
+                if (context.oidcConfig().tenantEnabled && !OidcUtils.isWebApp(context.oidcConfig())) {
+                    if (context.getOidcMetadata() == null) {
+                        // if the tenant metadata are not available, we can't decide now
+                        detectedTenantWithoutMetadata = true;
+                        contextsWithIssuer.add(context);
+                        tenantToRetry.put(context.oidcConfig().tenantId.get(), new AtomicBoolean(true));
+                    } else if (context.getOidcMetadata().getIssuer() != null
+                            && !ANY_ISSUER.equals(context.getOidcMetadata().getIssuer())) {
+                        contextsWithIssuer.add(context);
+                    }
+                }
+            }
+            if (contextsWithIssuer.isEmpty()) {
+                return null;
+            } else {
+                var tenantInitStrategy = detectedTenantWithoutMetadata ? Map.copyOf(tenantToRetry) : null;
+                return new IssuerBasedTenantResolver(contextsWithIssuer.toArray(new TenantConfigContext[0]),
+                        detectedTenantWithoutMetadata, tenantInitStrategy);
+            }
+        }
+
+        private static IssuerBasedTenantResolver of(Map<String, TenantConfigContext> staticTenantsConfig,
+                TenantConfigContext defaultTenant) {
+            Map<String, TenantConfigContext> tenantConfigContexts = new HashMap<>(staticTenantsConfig);
+            tenantConfigContexts.put(OidcUtils.DEFAULT_TENANT_ID, defaultTenant);
+            var issuerTenantResolver = IssuerBasedTenantResolver.of(tenantConfigContexts);
+            if (issuerTenantResolver != null) {
+                return issuerTenantResolver;
+            } else {
+                LOG.debug("The 'quarkus.oidc.resolve-tenants-with-issuer' configuration property is set to true, "
+                        + "but no static tenant supports this feature. To use this feature, please configure at least "
+                        + "one static tenant with the discovered or configured issuer and set either 'service' or "
+                        + "'hybrid' application type");
+                return null;
+            }
+        }
+    }
+
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -21,7 +21,7 @@ public class TenantConfigBean {
             Map<String, TenantConfigContext> dynamicTenantsConfig,
             TenantConfigContext defaultTenant,
             Function<OidcTenantConfig, Uni<TenantConfigContext>> tenantConfigContextFactory) {
-        this.staticTenantsConfig = staticTenantsConfig;
+        this.staticTenantsConfig = Map.copyOf(staticTenantsConfig);
         this.dynamicTenantsConfig = dynamicTenantsConfig;
         this.defaultTenant = defaultTenant;
         this.tenantConfigContextFactory = tenantConfigContextFactory;
@@ -48,17 +48,17 @@ public class TenantConfigBean {
         @Override
         public void destroy(TenantConfigBean instance, CreationalContext<TenantConfigBean> creationalContext,
                 Map<String, Object> params) {
-            if (instance.defaultTenant != null && instance.defaultTenant.provider != null) {
-                instance.defaultTenant.provider.close();
+            if (instance.defaultTenant != null && instance.defaultTenant.provider() != null) {
+                instance.defaultTenant.provider().close();
             }
             for (var i : instance.staticTenantsConfig.values()) {
-                if (i.provider != null) {
-                    i.provider.close();
+                if (i.provider() != null) {
+                    i.provider().close();
                 }
             }
             for (var i : instance.dynamicTenantsConfig.values()) {
-                if (i.provider != null) {
-                    i.provider.close();
+                if (i.provider() != null) {
+                    i.provider().close();
                 }
             }
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -1,234 +1,60 @@
 package io.quarkus.oidc.runtime;
 
-import java.nio.charset.StandardCharsets;
-import java.security.PrivateKey;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.function.Supplier;
 
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 
-import org.jboss.logging.Logger;
-
-import io.quarkus.arc.ClientProxy;
-import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcConfigurationMetadata;
 import io.quarkus.oidc.OidcRedirectFilter;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.Redirect;
-import io.quarkus.oidc.common.runtime.OidcCommonUtils;
-import io.quarkus.runtime.configuration.ConfigurationException;
+import io.smallrye.mutiny.Uni;
 
-public class TenantConfigContext {
-    private static final Logger LOG = Logger.getLogger(TenantConfigContext.class);
-
-    /**
-     * OIDC Provider
-     */
-    final OidcProvider provider;
+public sealed interface TenantConfigContext permits TenantConfigContextImpl, LazyTenantConfigContext {
 
     /**
      * Tenant configuration
      */
-    final OidcTenantConfig oidcConfig;
-
-    final Map<Redirect.Location, List<OidcRedirectFilter>> redirectFilters;
+    OidcTenantConfig oidcConfig();
 
     /**
-     * PKCE Secret Key
+     * OIDC Provider
      */
-    private final SecretKey stateSecretKey;
+    OidcProvider provider();
+
+    boolean ready();
+
+    OidcTenantConfig getOidcTenantConfig();
+
+    OidcConfigurationMetadata getOidcMetadata();
+
+    OidcProviderClient getOidcProviderClient();
+
+    SecretKey getStateEncryptionKey();
+
+    SecretKey getTokenEncSecretKey();
+
+    SecretKey getInternalIdTokenSecretKey();
+
+    List<OidcRedirectFilter> getOidcRedirectFilters(Redirect.Location loc);
 
     /**
-     * Token Encryption Secret Key
+     * Only static tenants that are not {@link #ready()} can and need to be initialized.
+     *
+     * @return self, or in case of not {@link #ready()}, possibly ready self
      */
-    private final SecretKey tokenEncSecretKey;
-
-    /**
-     * Internal ID token generated key
-     */
-    private final SecretKey internalIdTokenGeneratedKey;
-
-    final boolean ready;
-
-    public TenantConfigContext(OidcProvider client, OidcTenantConfig config) {
-        this(client, config, true);
+    default Uni<TenantConfigContext> initialize() {
+        return Uni.createFrom().item(this);
     }
 
-    public TenantConfigContext(OidcProvider provider, OidcTenantConfig config, boolean ready) {
-        this.provider = provider;
-        this.oidcConfig = config;
-        this.redirectFilters = getRedirectFiltersMap(TenantFeatureFinder.find(config, OidcRedirectFilter.class));
-        this.ready = ready;
-
-        boolean isService = OidcUtils.isServiceApp(config);
-        stateSecretKey = !isService && provider != null && provider.client != null ? createStateSecretKey(config) : null;
-        tokenEncSecretKey = !isService && provider != null && provider.client != null
-                ? createTokenEncSecretKey(config, provider)
-                : null;
-        internalIdTokenGeneratedKey = !isService && provider != null && provider.client != null
-                ? generateIdTokenSecretKey(config, provider)
-                : null;
+    static TenantConfigContext createReady(OidcProvider provider, OidcTenantConfig config) {
+        return new TenantConfigContextImpl(provider, config);
     }
 
-    private static SecretKey createStateSecretKey(OidcTenantConfig config) {
-        if (config.authentication.pkceRequired.orElse(false) || config.authentication.nonceRequired) {
-            String stateSecret = null;
-            if (config.authentication.pkceSecret.isPresent() && config.authentication.getStateSecret().isPresent()) {
-                throw new ConfigurationException(
-                        "Both 'quarkus.oidc.authentication.state-secret' and 'quarkus.oidc.authentication.pkce-secret' are configured");
-            }
-            if (config.authentication.getStateSecret().isPresent()) {
-                stateSecret = config.authentication.getStateSecret().get();
-            } else if (config.authentication.pkceSecret.isPresent()) {
-                stateSecret = config.authentication.pkceSecret.get();
-            }
-
-            if (stateSecret == null) {
-                LOG.debug("'quarkus.oidc.authentication.state-secret' is not configured");
-                String possiblePkceSecret = OidcCommonUtils.getClientOrJwtSecret(config.credentials);
-                if (possiblePkceSecret != null && possiblePkceSecret.length() < 32) {
-                    LOG.debug("Client secret is less than 32 characters long, the state secret will be generated");
-                } else {
-                    stateSecret = possiblePkceSecret;
-                }
-            }
-            try {
-                if (stateSecret == null) {
-                    LOG.debug("Secret key for encrypting state cookie is missing, auto-generating it");
-                    SecretKey key = OidcCommonUtils.generateSecretKey();
-                    return key;
-                }
-                byte[] secretBytes = stateSecret.getBytes(StandardCharsets.UTF_8);
-                if (secretBytes.length < 32) {
-                    String errorMessage = "Secret key for encrypting state cookie should be at least 32 characters long"
-                            + " for the strongest state cookie encryption to be produced."
-                            + " Please update 'quarkus.oidc.authentication.state-secret' or update the configured client secret.";
-                    if (secretBytes.length < 16) {
-                        throw new ConfigurationException(
-                                "Secret key for encrypting state cookie is less than 16 characters long");
-                    } else {
-                        LOG.debug(errorMessage);
-                    }
-                }
-                return new SecretKeySpec(OidcUtils.getSha256Digest(secretBytes), "AES");
-            } catch (Exception ex) {
-                throw new OIDCException(ex);
-            }
-        }
-        return null;
-    }
-
-    private static SecretKey createTokenEncSecretKey(OidcTenantConfig config, OidcProvider provider) {
-        if (config.tokenStateManager.encryptionRequired) {
-            String encSecret = null;
-            if (config.tokenStateManager.encryptionSecret.isPresent()) {
-                encSecret = config.tokenStateManager.encryptionSecret.get();
-            } else {
-                LOG.debug("'quarkus.oidc.token-state-manager.encryption-secret' is not configured");
-                encSecret = OidcCommonUtils.getClientOrJwtSecret(config.credentials);
-            }
-            try {
-                if (encSecret != null) {
-                    byte[] secretBytes = encSecret.getBytes(StandardCharsets.UTF_8);
-                    if (secretBytes.length < 32) {
-                        String errorMessage = "Secret key for encrypting tokens in a session cookie should be at least 32 characters long"
-                                + " for the strongest cookie encryption to be produced."
-                                + " Please configure 'quarkus.oidc.token-state-manager.encryption-secret'"
-                                + " or update the configured client secret. You can disable the session cookie"
-                                + " encryption with 'quarkus.oidc.token-state-manager.encryption-required=false'"
-                                + " but only if it is considered to be safe in your application's network.";
-                        if (secretBytes.length < 16) {
-                            LOG.warn(errorMessage);
-                        } else {
-                            LOG.debug(errorMessage);
-                        }
-                    }
-                    return OidcUtils.createSecretKeyFromDigest(secretBytes);
-                } else if (provider.client.getClientJwtKey() instanceof PrivateKey) {
-                    return OidcUtils.createSecretKeyFromDigest(((PrivateKey) provider.client.getClientJwtKey()).getEncoded());
-                }
-
-                LOG.warn(
-                        "Secret key for encrypting OIDC authorization code flow tokens in a session cookie is not configured, auto-generating it."
-                                + " Note that a new secret will be generated after a restart, thus making it impossible to decrypt the session cookie and requiring a user re-authentication."
-                                + " Use 'quarkus.oidc.token-state-manager.encryption-secret' to configure an encryption secret."
-                                + " Alternatively, disable session cookie encryption with 'quarkus.oidc.token-state-manager.encryption-required=false'"
-                                + " but only if it is considered to be safe in your application's network.");
-                return OidcCommonUtils.generateSecretKey();
-            } catch (Exception ex) {
-                throw new OIDCException(ex);
-            }
-        }
-        return null;
-    }
-
-    private static SecretKey generateIdTokenSecretKey(OidcTenantConfig config, OidcProvider provider) {
-        try {
-            return (!config.authentication.idTokenRequired.orElse(true)
-                    && OidcCommonUtils.getClientOrJwtSecret(config.credentials) == null
-                    && provider.client.getClientJwtKey() == null) ? OidcCommonUtils.generateSecretKey() : null;
-        } catch (Exception ex) {
-            throw new OIDCException(ex);
-        }
-    }
-
-    public OidcTenantConfig getOidcTenantConfig() {
-        return oidcConfig;
-    }
-
-    public OidcConfigurationMetadata getOidcMetadata() {
-        return provider != null ? provider.getMetadata() : null;
-    }
-
-    public OidcProviderClient getOidcProviderClient() {
-        return provider != null ? provider.client : null;
-    }
-
-    public SecretKey getStateEncryptionKey() {
-        return stateSecretKey;
-    }
-
-    public SecretKey getTokenEncSecretKey() {
-        return tokenEncSecretKey;
-    }
-
-    public SecretKey getInternalIdTokenSecretKey() {
-        return this.internalIdTokenGeneratedKey;
-    }
-
-    private static Map<Redirect.Location, List<OidcRedirectFilter>> getRedirectFiltersMap(List<OidcRedirectFilter> filters) {
-        Map<Redirect.Location, List<OidcRedirectFilter>> map = new HashMap<>();
-        for (OidcRedirectFilter filter : filters) {
-            Redirect redirect = ClientProxy.unwrap(filter).getClass().getAnnotation(Redirect.class);
-            if (redirect != null) {
-                for (Redirect.Location loc : redirect.value()) {
-                    map.computeIfAbsent(loc, k -> new ArrayList<OidcRedirectFilter>()).add(filter);
-                }
-            } else {
-                map.computeIfAbsent(Redirect.Location.ALL, k -> new ArrayList<OidcRedirectFilter>()).add(filter);
-            }
-        }
-        return map;
-    }
-
-    List<OidcRedirectFilter> getOidcRedirectFilters(Redirect.Location loc) {
-        List<OidcRedirectFilter> typeSpecific = redirectFilters.get(loc);
-        List<OidcRedirectFilter> all = redirectFilters.get(Redirect.Location.ALL);
-        if (typeSpecific == null && all == null) {
-            return List.of();
-        }
-        if (typeSpecific != null && all == null) {
-            return typeSpecific;
-        } else if (typeSpecific == null && all != null) {
-            return all;
-        } else {
-            List<OidcRedirectFilter> combined = new ArrayList<>(typeSpecific.size() + all.size());
-            combined.addAll(typeSpecific);
-            combined.addAll(all);
-            return combined;
-        }
+    static TenantConfigContext createNotReady(OidcProvider provider, OidcTenantConfig config,
+            Supplier<Uni<TenantConfigContext>> staticTenantCreator) {
+        var notReadyContext = new TenantConfigContextImpl(provider, config, false);
+        return new LazyTenantConfigContext(notReadyContext, staticTenantCreator);
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContextImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContextImpl.java
@@ -1,0 +1,256 @@
+package io.quarkus.oidc.runtime;
+
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.oidc.OIDCException;
+import io.quarkus.oidc.OidcConfigurationMetadata;
+import io.quarkus.oidc.OidcRedirectFilter;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.Redirect;
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.runtime.configuration.ConfigurationException;
+
+final class TenantConfigContextImpl implements TenantConfigContext {
+    private static final Logger LOG = Logger.getLogger(TenantConfigContextImpl.class);
+
+    /**
+     * OIDC Provider
+     */
+    private final OidcProvider provider;
+
+    /**
+     * Tenant configuration
+     */
+    private final OidcTenantConfig oidcConfig;
+
+    private final Map<Redirect.Location, List<OidcRedirectFilter>> redirectFilters;
+
+    /**
+     * PKCE Secret Key
+     */
+    private final SecretKey stateSecretKey;
+
+    /**
+     * Token Encryption Secret Key
+     */
+    private final SecretKey tokenEncSecretKey;
+
+    /**
+     * Internal ID token generated key
+     */
+    private final SecretKey internalIdTokenGeneratedKey;
+
+    private final boolean ready;
+
+    TenantConfigContextImpl(OidcProvider client, OidcTenantConfig config) {
+        this(client, config, true);
+    }
+
+    TenantConfigContextImpl(OidcProvider provider, OidcTenantConfig config, boolean ready) {
+        this.provider = provider;
+        this.oidcConfig = config;
+        this.redirectFilters = getRedirectFiltersMap(TenantFeatureFinder.find(config, OidcRedirectFilter.class));
+        this.ready = ready;
+
+        boolean isService = OidcUtils.isServiceApp(config);
+        stateSecretKey = !isService && provider != null && provider.client != null ? createStateSecretKey(config) : null;
+        tokenEncSecretKey = !isService && provider != null && provider.client != null
+                ? createTokenEncSecretKey(config, provider)
+                : null;
+        internalIdTokenGeneratedKey = !isService && provider != null && provider.client != null
+                ? generateIdTokenSecretKey(config, provider)
+                : null;
+    }
+
+    private static SecretKey createStateSecretKey(OidcTenantConfig config) {
+        if (config.authentication.pkceRequired.orElse(false) || config.authentication.nonceRequired) {
+            String stateSecret = null;
+            if (config.authentication.pkceSecret.isPresent() && config.authentication.getStateSecret().isPresent()) {
+                throw new ConfigurationException(
+                        "Both 'quarkus.oidc.authentication.state-secret' and 'quarkus.oidc.authentication.pkce-secret' are configured");
+            }
+            if (config.authentication.getStateSecret().isPresent()) {
+                stateSecret = config.authentication.getStateSecret().get();
+            } else if (config.authentication.pkceSecret.isPresent()) {
+                stateSecret = config.authentication.pkceSecret.get();
+            }
+
+            if (stateSecret == null) {
+                LOG.debug("'quarkus.oidc.authentication.state-secret' is not configured");
+                String possiblePkceSecret = OidcCommonUtils.getClientOrJwtSecret(config.credentials);
+                if (possiblePkceSecret != null && possiblePkceSecret.length() < 32) {
+                    LOG.debug("Client secret is less than 32 characters long, the state secret will be generated");
+                } else {
+                    stateSecret = possiblePkceSecret;
+                }
+            }
+            try {
+                if (stateSecret == null) {
+                    LOG.debug("Secret key for encrypting state cookie is missing, auto-generating it");
+                    SecretKey key = OidcCommonUtils.generateSecretKey();
+                    return key;
+                }
+                byte[] secretBytes = stateSecret.getBytes(StandardCharsets.UTF_8);
+                if (secretBytes.length < 32) {
+                    String errorMessage = "Secret key for encrypting state cookie should be at least 32 characters long"
+                            + " for the strongest state cookie encryption to be produced."
+                            + " Please update 'quarkus.oidc.authentication.state-secret' or update the configured client secret.";
+                    if (secretBytes.length < 16) {
+                        throw new ConfigurationException(
+                                "Secret key for encrypting state cookie is less than 16 characters long");
+                    } else {
+                        LOG.debug(errorMessage);
+                    }
+                }
+                return new SecretKeySpec(OidcUtils.getSha256Digest(secretBytes), "AES");
+            } catch (Exception ex) {
+                throw new OIDCException(ex);
+            }
+        }
+        return null;
+    }
+
+    private static SecretKey createTokenEncSecretKey(OidcTenantConfig config, OidcProvider provider) {
+        if (config.tokenStateManager.encryptionRequired) {
+            String encSecret = null;
+            if (config.tokenStateManager.encryptionSecret.isPresent()) {
+                encSecret = config.tokenStateManager.encryptionSecret.get();
+            } else {
+                LOG.debug("'quarkus.oidc.token-state-manager.encryption-secret' is not configured");
+                encSecret = OidcCommonUtils.getClientOrJwtSecret(config.credentials);
+            }
+            try {
+                if (encSecret != null) {
+                    byte[] secretBytes = encSecret.getBytes(StandardCharsets.UTF_8);
+                    if (secretBytes.length < 32) {
+                        String errorMessage = "Secret key for encrypting tokens in a session cookie should be at least 32 characters long"
+                                + " for the strongest cookie encryption to be produced."
+                                + " Please configure 'quarkus.oidc.token-state-manager.encryption-secret'"
+                                + " or update the configured client secret. You can disable the session cookie"
+                                + " encryption with 'quarkus.oidc.token-state-manager.encryption-required=false'"
+                                + " but only if it is considered to be safe in your application's network.";
+                        if (secretBytes.length < 16) {
+                            LOG.warn(errorMessage);
+                        } else {
+                            LOG.debug(errorMessage);
+                        }
+                    }
+                    return OidcUtils.createSecretKeyFromDigest(secretBytes);
+                } else if (provider.client.getClientJwtKey() instanceof PrivateKey) {
+                    return OidcUtils.createSecretKeyFromDigest(((PrivateKey) provider.client.getClientJwtKey()).getEncoded());
+                }
+
+                LOG.warn(
+                        "Secret key for encrypting OIDC authorization code flow tokens in a session cookie is not configured, auto-generating it."
+                                + " Note that a new secret will be generated after a restart, thus making it impossible to decrypt the session cookie and requiring a user re-authentication."
+                                + " Use 'quarkus.oidc.token-state-manager.encryption-secret' to configure an encryption secret."
+                                + " Alternatively, disable session cookie encryption with 'quarkus.oidc.token-state-manager.encryption-required=false'"
+                                + " but only if it is considered to be safe in your application's network.");
+                return OidcCommonUtils.generateSecretKey();
+            } catch (Exception ex) {
+                throw new OIDCException(ex);
+            }
+        }
+        return null;
+    }
+
+    private static SecretKey generateIdTokenSecretKey(OidcTenantConfig config, OidcProvider provider) {
+        try {
+            return (!config.authentication.idTokenRequired.orElse(true)
+                    && OidcCommonUtils.getClientOrJwtSecret(config.credentials) == null
+                    && provider.client.getClientJwtKey() == null) ? OidcCommonUtils.generateSecretKey() : null;
+        } catch (Exception ex) {
+            throw new OIDCException(ex);
+        }
+    }
+
+    @Override
+    public OidcTenantConfig oidcConfig() {
+        return oidcConfig;
+    }
+
+    @Override
+    public OidcProvider provider() {
+        return provider;
+    }
+
+    @Override
+    public boolean ready() {
+        return ready;
+    }
+
+    @Override
+    public OidcTenantConfig getOidcTenantConfig() {
+        return oidcConfig;
+    }
+
+    @Override
+    public OidcConfigurationMetadata getOidcMetadata() {
+        return provider != null ? provider.getMetadata() : null;
+    }
+
+    @Override
+    public OidcProviderClient getOidcProviderClient() {
+        return provider != null ? provider.client : null;
+    }
+
+    @Override
+    public SecretKey getStateEncryptionKey() {
+        return stateSecretKey;
+    }
+
+    @Override
+    public SecretKey getTokenEncSecretKey() {
+        return tokenEncSecretKey;
+    }
+
+    @Override
+    public SecretKey getInternalIdTokenSecretKey() {
+        return this.internalIdTokenGeneratedKey;
+    }
+
+    private static Map<Redirect.Location, List<OidcRedirectFilter>> getRedirectFiltersMap(List<OidcRedirectFilter> filters) {
+        Map<Redirect.Location, List<OidcRedirectFilter>> map = new HashMap<>();
+        for (OidcRedirectFilter filter : filters) {
+            Redirect redirect = ClientProxy.unwrap(filter).getClass().getAnnotation(Redirect.class);
+            if (redirect != null) {
+                for (Redirect.Location loc : redirect.value()) {
+                    map.computeIfAbsent(loc, k -> new ArrayList<OidcRedirectFilter>()).add(filter);
+                }
+            } else {
+                map.computeIfAbsent(Redirect.Location.ALL, k -> new ArrayList<OidcRedirectFilter>()).add(filter);
+            }
+        }
+        return map;
+    }
+
+    @Override
+    public List<OidcRedirectFilter> getOidcRedirectFilters(Redirect.Location loc) {
+        List<OidcRedirectFilter> typeSpecific = redirectFilters.get(loc);
+        List<OidcRedirectFilter> all = redirectFilters.get(Redirect.Location.ALL);
+        if (typeSpecific == null && all == null) {
+            return List.of();
+        }
+        if (typeSpecific != null && all == null) {
+            return typeSpecific;
+        } else if (typeSpecific == null && all != null) {
+            return all;
+        } else {
+            List<OidcRedirectFilter> combined = new ArrayList<>(typeSpecific.size() + all.size());
+            combined.addAll(typeSpecific);
+            combined.addAll(all);
+            return combined;
+        }
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
@@ -11,6 +11,7 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.ext.web.RoutingContext;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -20,6 +21,9 @@ public class AdminResource {
 
     @Inject
     SecurityIdentity identity;
+
+    @Inject
+    RoutingContext routingContext;
 
     @Path("bearer")
     @GET
@@ -51,6 +55,14 @@ public class AdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     public String adminNoIntrospection() {
         return "granted:" + identity.getRoles();
+    }
+
+    @Path("bearer-issuer-resolver/issuer") // don't change the path, avoid default tenant resolver
+    @GET
+    @RolesAllowed("admin")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String adminIssuerTest() {
+        return "static.tenant.id=" + routingContext.get("static.tenant.id");
     }
 
     @Path("bearer-certificate-full-chain")

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -254,3 +254,10 @@ quarkus.native.additional-build-args=-H:IncludeResources=private.*\\.*,-H:Includ
 quarkus.grpc.clients.hello.host=localhost
 quarkus.grpc.clients.hello.port=8081
 quarkus.grpc.server.use-separate-server=false
+
+%issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver.auth-server-url=http://localhost:8185/auth/realms/quarkus2
+%issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver.client-id=quarkus-app
+%issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver.credentials.secret=secret
+%issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver.token.audience=https://correct-issuer.edu
+%issuer-based-resolver.quarkus.oidc.bearer-issuer-resolver.token.allow-jwt-introspection=false
+%issuer-based-resolver.quarkus.oidc.resolve-tenants-with-issuer=true

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/StaticTenantIssuerResolverTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/StaticTenantIssuerResolverTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Set;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import io.smallrye.jwt.build.Jwt;
+
+@TestProfile(StaticTenantIssuerResolverTest.IssuerResolverProfile.class)
+@QuarkusTest
+public class StaticTenantIssuerResolverTest {
+
+    @Test
+    public void testOidcServerUnavailableOnAppStartup() {
+        WiremockTestResource server = new WiremockTestResource("https://correct-issuer.edu", 8185);
+        server.start();
+        try {
+            // 500 because default tenant has unavailable OIDC server (otherwise it assumes our issuer)
+            requestAdminRoles("https://wrong-issuer.edu").statusCode(500);
+
+            requestAdminRoles("https://correct-issuer.edu").statusCode(200)
+                    .body(Matchers.is("static.tenant.id=bearer-issuer-resolver"));
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static ValidatableResponse requestAdminRoles(String issuer) {
+        return RestAssured.given().auth().oauth2(getAdminTokenWithRole(issuer))
+                .when().get("/api/admin/bearer-issuer-resolver/issuer").then();
+    }
+
+    public static class IssuerResolverProfile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "issuer-based-resolver";
+        }
+    }
+
+    private static String getAdminTokenWithRole(String issuer) {
+        return Jwt.preferredUserName("alice")
+                .groups(Set.of("admin"))
+                .issuer(issuer)
+                .audience(issuer)
+                .jws()
+                .keyId("1")
+                .sign("privateKey.jwk");
+    }
+}

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
@@ -7,6 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.not;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.quarkus.oidc.OidcConfigurationMetadata.ISSUER;
 
 import org.jboss.logging.Logger;
 
@@ -16,13 +17,25 @@ public class WiremockTestResource {
 
     private static final Logger LOG = Logger.getLogger(WiremockTestResource.class);
 
+    private final String issuer;
+    private final int port;
     private WireMockServer server;
+
+    public WiremockTestResource() {
+        this.issuer = null;
+        this.port = 8180;
+    }
+
+    public WiremockTestResource(String issuer, int port) {
+        this.issuer = issuer;
+        this.port = port;
+    }
 
     public void start() {
 
         server = new WireMockServer(
                 wireMockConfig()
-                        .port(8180));
+                        .port(port));
         server.start();
 
         server.stubFor(
@@ -32,6 +45,7 @@ public class WiremockTestResource {
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +
+                                        (issuer == null ? "" : " \"" + ISSUER + "\": " + "\"" + issuer + "\",\n") +
                                         "    \"jwks_uri\": \"" + server.baseUrl()
                                         + "/auth/realms/quarkus2/protocol/openid-connect/certs\""
                                         + "}")));


### PR DESCRIPTION
- Closes: https://github.com/quarkusio/quarkus/issues/42497

Issuer-based tenant resolver has chicken-egg problem when static tenants are not available on startup. Before this PR, static tenants were only lazily initialized when tenant was resolved. And they leaked to the dynamic tenants. This caused me a problem in the Issuer-based tenant resolver because the original static tenants would be simply replaced (provided the issuer-based resolver could initialize it, which it could not) with dynamic tenants. The dynamic tenants are not supported for issuer-based tenant resolution. 

So, what this PR does:

- issuer-based tenant resolver tries to initialize static tenants that were not ready on application startup exactly once; because of that:
  - static tenant resolvers are moved to dedicated class (another level of abstraction solves it all :-)) because I had to switch String to Uni<String> and thought it's unnecessary to change TenantResolver interface, users don't seem to need it and issuer-based resolver is a special case
- fixes static tenants leaking into dynamic tenants; required by the issuer-based tenant resolver, because:
  - right now, if static tenant is not ready, the TenantConfigContext that represents it is left as it was and if late initialization of the static tenant context succeeds, the new one is added to the dynamic tenants; but the issuer-based resolver kept the original contexts that were never initialized; keeping polling dynamic tenants for changes is IMO bad solution, so I made sure that static tenants can be lazily initialized (switched)