### PR TITLE
Add HTTP Access Log to Dev UI

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DeploymentMethodBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DeploymentMethodBuildItem.java
@@ -1,8 +1,10 @@
 package io.quarkus.devui.deployment;
 
 import java.util.List;
+import java.util.Map;
 
 import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.runtime.RuntimeValue;
 
 /**
  * Hold add discovered build time methods that can be executed via json-rpc
@@ -11,10 +13,13 @@ public final class DeploymentMethodBuildItem extends SimpleBuildItem {
 
     private final List<String> methods;
     private final List<String> subscriptions;
+    private final Map<String, RuntimeValue> recordedValues;
 
-    public DeploymentMethodBuildItem(List<String> methods, List<String> subscriptions) {
+    public DeploymentMethodBuildItem(List<String> methods, List<String> subscriptions,
+            Map<String, RuntimeValue> recordedValues) {
         this.methods = methods;
         this.subscriptions = subscriptions;
+        this.recordedValues = recordedValues;
     }
 
     public List<String> getMethods() {
@@ -31,5 +36,13 @@ public final class DeploymentMethodBuildItem extends SimpleBuildItem {
 
     public boolean hasSubscriptions() {
         return this.subscriptions != null && !this.subscriptions.isEmpty();
+    }
+
+    public Map<String, RuntimeValue> getRecordedValues() {
+        return this.recordedValues;
+    }
+
+    public boolean hasRecordedValues() {
+        return this.recordedValues != null && !this.recordedValues.isEmpty();
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxDevUILogBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxDevUILogBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.vertx.http.deployment;
+
+import java.util.concurrent.SubmissionPublisher;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+
+/**
+ * Used to create the publisher for the vertx access log in dev ui
+ */
+public final class VertxDevUILogBuildItem extends SimpleBuildItem {
+
+    private final RuntimeValue<SubmissionPublisher<String>> publisher;
+
+    public VertxDevUILogBuildItem(RuntimeValue<SubmissionPublisher<String>> publisher) {
+        this.publisher = publisher;
+    }
+
+    public RuntimeValue<SubmissionPublisher<String>> getPublisher() {
+        return this.publisher;
+    }
+}

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/jsonrpc.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/jsonrpc.js
@@ -156,6 +156,9 @@ export class JsonRpc {
                         var jsonrpcpayload = JSON.stringify(message);
 
                         if (jsonRPCSubscriptions.includes(method)) {
+                            if(JsonRpc.observerQueue.has(uid)){
+                                JsonRpc.observerQueue.get(uid).observer.cancel();
+                            }
                             // Observer
                             var observer = new Observer(uid);
                             JsonRpc.observerQueue.set(uid, {
@@ -163,7 +166,7 @@ export class JsonRpc {
                                 log: this._logTraffic
                             });
                             JsonRpc.sendJsonRPCMessage(jsonrpcpayload, this._logTraffic);
-                            return observer;
+                            return observer;                
                         } else if(jsonRPCMethods.includes(method)){
                             // Promise
                             var _resolve, _reject;

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/log-controller.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/log-controller.js
@@ -4,14 +4,14 @@
 export class LogController {
     static _controllers = new Map();
     static listener;
-
+    
     host;
     tab;
     items = [];
     
     constructor(host) {
         (this.host = host).addController(this);
-        this.tab = host.tagName.toLowerCase();
+        this.tab = host.title;
     }
 
     hostConnected() {

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer-log.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer-log.js
@@ -41,7 +41,7 @@ export class QwcFooterLog extends QwcAbstractLogElement {
     
     constructor() {
         super();
-
+         
         this.logControl
                 .addToggle("On/off switch", true, (e) => {
                     this._toggleOnOffClicked(e);
@@ -130,6 +130,7 @@ export class QwcFooterLog extends QwcAbstractLogElement {
     hotReload(){
         this._clearLog();
         if(this._observer != null){
+            this._toggleOnOff(false);
             this._toggleOnOff(true);
         }
     }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer.js
@@ -309,9 +309,9 @@ export class QwcFooter extends observeState(LitElement) {
         this._selectedTab = index;
         var selectedComponentName = devuiState.footer[this._selectedTab];
         if(selectedComponentName){
-            this._controlButtons = LogController.getItemsForTab(devuiState.footer[this._selectedTab].componentName);
+            this._controlButtons = LogController.getItemsForTab(devuiState.footer[this._selectedTab].title);
         }else{
-            this._controlButtons = LogController.getItemsForTab(devuiState.footer[0].componentName);
+            this._controlButtons = LogController.getItemsForTab(devuiState.footer[0].title);
             this._selectedTab = 0;
         }
         this.storageControl.set('selected-tab', this._selectedTab);

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeAction.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeAction.java
@@ -3,6 +3,8 @@ package io.quarkus.devui.spi.buildtime;
 import java.util.Map;
 import java.util.function.Function;
 
+import io.quarkus.runtime.RuntimeValue;
+
 /**
  * Define a action that can be executed against the deployment classpath in runtime
  * This means a call will still be make with Json-RPC to the backend, but fall through to this action
@@ -11,13 +13,22 @@ public class BuildTimeAction {
 
     private final String methodName;
     private final Function<Map<String, String>, ?> action;
+    private final RuntimeValue runtimeValue;
 
     protected <T> BuildTimeAction(String methodName,
             Function<Map<String, String>, T> action) {
 
         this.methodName = methodName;
         this.action = action;
+        this.runtimeValue = null;
+    }
 
+    protected <T> BuildTimeAction(String methodName,
+            RuntimeValue runtimeValue) {
+
+        this.methodName = methodName;
+        this.action = null;
+        this.runtimeValue = runtimeValue;
     }
 
     public String getMethodName() {
@@ -26,5 +37,13 @@ public class BuildTimeAction {
 
     public Function<Map<String, String>, ?> getAction() {
         return action;
+    }
+
+    public RuntimeValue getRuntimeValue() {
+        return runtimeValue;
+    }
+
+    public boolean hasRuntimeValue() {
+        return this.runtimeValue != null;
     }
 }

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import io.quarkus.devui.spi.AbstractDevUIBuildItem;
+import io.quarkus.runtime.RuntimeValue;
 
 /**
  * Holds any Build time actions for Dev UI the extension has
@@ -32,6 +33,11 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
         this.addAction(new BuildTimeAction(methodName, action));
     }
 
+    public <T> void addAction(String methodName,
+            RuntimeValue runtimeValue) {
+        this.addAction(new BuildTimeAction(methodName, runtimeValue));
+    }
+
     public List<BuildTimeAction> getActions() {
         return actions;
     }
@@ -43,6 +49,11 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
     public <T> void addSubscription(String methodName,
             Function<Map<String, String>, T> action) {
         this.addSubscription(new BuildTimeAction(methodName, action));
+    }
+
+    public <T> void addSubscription(String methodName,
+            RuntimeValue runtimeValue) {
+        this.addSubscription(new BuildTimeAction(methodName, runtimeValue));
     }
 
     public List<BuildTimeAction> getSubscriptions() {

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/FooterLogBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/buildtime/FooterLogBuildItem.java
@@ -1,9 +1,11 @@
 package io.quarkus.devui.spi.buildtime;
 
 import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
 import java.util.function.Supplier;
 
 import io.quarkus.devui.spi.AbstractDevUIBuildItem;
+import io.quarkus.runtime.RuntimeValue;
 
 /**
  * Add a log to the footer of dev ui
@@ -12,11 +14,24 @@ public final class FooterLogBuildItem extends AbstractDevUIBuildItem {
 
     private final String name;
     private final Supplier<Flow.Publisher<String>> publisherSupplier;
+    private final RuntimeValue<SubmissionPublisher<String>> runtimePublisher;
 
     public FooterLogBuildItem(String name, Supplier<Flow.Publisher<String>> publisherSupplier) {
         super(DEV_UI);
         this.name = name;
         this.publisherSupplier = publisherSupplier;
+        this.runtimePublisher = null;
+    }
+
+    public FooterLogBuildItem(String name, RuntimeValue<SubmissionPublisher<String>> runtimePublisher) {
+        super(DEV_UI);
+        this.name = name;
+        this.runtimePublisher = runtimePublisher;
+        this.publisherSupplier = null;
+    }
+
+    public boolean hasRuntimePublisher() {
+        return runtimePublisher != null;
     }
 
     public String getName() {
@@ -25,5 +40,9 @@ public final class FooterLogBuildItem extends AbstractDevUIBuildItem {
 
     public Flow.Publisher<String> getPublisher() {
         return publisherSupplier.get();
+    }
+
+    public RuntimeValue<SubmissionPublisher<String>> getRuntimePublisher() {
+        return runtimePublisher;
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
@@ -25,6 +25,7 @@ import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
 import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethodName;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonTypeAdapter;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.devmode.FileSystemStaticHandler;
@@ -47,10 +48,14 @@ public class DevUIRecorder {
     public void createJsonRpcRouter(BeanContainer beanContainer,
             Map<String, Map<JsonRpcMethodName, JsonRpcMethod>> extensionMethodsMap,
             List<String> deploymentMethods,
-            List<String> deploymentSubscriptions) {
+            List<String> deploymentSubscriptions,
+            Map<String, RuntimeValue> recordedValues) {
         JsonRpcRouter jsonRpcRouter = beanContainer.beanInstance(JsonRpcRouter.class);
         jsonRpcRouter.populateJsonRPCRuntimeMethods(extensionMethodsMap);
         jsonRpcRouter.setJsonRPCDeploymentActions(deploymentMethods, deploymentSubscriptions);
+        if (recordedValues != null && !recordedValues.isEmpty()) {
+            jsonRpcRouter.setRecordedValues(recordedValues);
+        }
         jsonRpcRouter.initializeCodec(createJsonMapper());
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -318,6 +319,10 @@ public class VertxHttpRecorder {
         return new RuntimeValue<>(new io.vertx.mutiny.ext.web.Router(router.getValue()));
     }
 
+    public RuntimeValue<SubmissionPublisher<String>> createAccessLogPublisher() {
+        return new RuntimeValue<>(new SubmissionPublisher<>());
+    }
+
     public void startServer(Supplier<Vertx> vertx, ShutdownContext shutdown,
             LaunchMode launchMode,
             boolean startVirtual, boolean startSocket, Supplier<Integer> ioThreads, List<String> websocketSubProtocols,
@@ -388,7 +393,8 @@ public class VertxHttpRecorder {
             LogBuildTimeConfig logBuildTimeConfig,
             String srcMainJava,
             List<String> knowClasses,
-            List<ErrorPageAction> actions) {
+            List<ErrorPageAction> actions,
+            Optional<RuntimeValue<SubmissionPublisher<String>>> publisher) {
         HttpConfiguration httpConfiguration = this.httpConfiguration.getValue();
         // install the default route at the end
         Router httpRouteRouter = httpRouterRuntimeValue.getValue();
@@ -483,22 +489,25 @@ public class VertxHttpRecorder {
             } else {
                 receiver = new JBossLoggingAccessLogReceiver(accessLog.category);
             }
-            AccessLogHandler handler = new AccessLogHandler(receiver, accessLog.pattern, accessLog.consolidateReroutedRequests,
-                    getClass().getClassLoader(),
-                    accessLog.excludePattern);
-            if (rootPath.equals("/") || nonRootPath.equals("/")) {
-                mainRouterRuntimeValue.orElse(httpRouterRuntimeValue).getValue().route()
-                        .order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER)
-                        .handler(handler);
-            } else if (nonRootPath.startsWith(rootPath)) {
-                httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
-            } else if (rootPath.startsWith(nonRootPath)) {
-                frameworkRouter.getValue().route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
-            } else {
-                httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
-                frameworkRouter.getValue().route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
-            }
+            setupAccessLogHandler(mainRouterRuntimeValue, httpRouterRuntimeValue, frameworkRouter, receiver, rootPath,
+                    nonRootPath, accessLog.pattern, accessLog.consolidateReroutedRequests, accessLog.excludePattern);
+            quarkusWrapperNeeded = true;
+        }
 
+        // Add an access log for Dev UI
+
+        if (publisher.isPresent()) {
+            SubmissionPublisher<String> logPublisher = publisher.get().getValue();
+            AccessLogReceiver receiver = new AccessLogReceiver() {
+                @Override
+                public void logMessage(String message) {
+                    logPublisher.submit(message);
+                }
+            };
+
+            setupAccessLogHandler(mainRouterRuntimeValue, httpRouterRuntimeValue, frameworkRouter, receiver, rootPath,
+                    nonRootPath, accessLog.pattern, accessLog.consolidateReroutedRequests,
+                    accessLog.excludePattern.or(() -> Optional.of("^" + nonRootPath + ".*")));
             quarkusWrapperNeeded = true;
         }
 
@@ -583,6 +592,34 @@ public class VertxHttpRecorder {
                     };
                 }
             }
+        }
+    }
+
+    private void setupAccessLogHandler(Optional<RuntimeValue<Router>> mainRouterRuntimeValue,
+            RuntimeValue<Router> httpRouterRuntimeValue,
+            RuntimeValue<Router> frameworkRouter,
+            AccessLogReceiver receiver,
+            String rootPath,
+            String nonRootPath,
+            String pattern,
+            boolean consolidateReroutedRequests,
+            Optional<String> excludePattern) {
+
+        Router httpRouteRouter = httpRouterRuntimeValue.getValue();
+        AccessLogHandler handler = new AccessLogHandler(receiver, pattern, consolidateReroutedRequests,
+                getClass().getClassLoader(),
+                excludePattern);
+        if (rootPath.equals("/") || nonRootPath.equals("/")) {
+            mainRouterRuntimeValue.orElse(httpRouterRuntimeValue).getValue().route()
+                    .order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER)
+                    .handler(handler);
+        } else if (nonRootPath.startsWith(rootPath)) {
+            httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
+        } else if (rootPath.startsWith(nonRootPath)) {
+            frameworkRouter.getValue().route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
+        } else {
+            httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
+            frameworkRouter.getValue().route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
         }
     }
 


### PR DESCRIPTION
Build on the new feature (#43402) I added a HTTP Access log in Dev UI.

I had to add a new feature in Dev UI to allow for this, namely that a JsonRPC Method can now return a recorded value in a method.  I also had to fix the log controllers for the log files added in this new way, as the web component we use are the same for all logs, I had to change to identify by title and not component name.

![access_log](https://github.com/user-attachments/assets/2dc2183b-1d7b-497b-b04d-6c8c518cd0b0)
