### PR TITLE
Adapt locales support for GraalVM >= 24.2

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -105,7 +105,7 @@
         {
             "category": "Misc2",
             "timeout": 75,
-            "test-modules": "hibernate-validator, test-extension/tests, logging-gelf, mailer, native-config-profile, locales/all, locales/some",
+            "test-modules": "hibernate-validator, test-extension/tests, logging-gelf, mailer, native-config-profile, locales/all, locales/some, locales/default",
             "os-name": "ubuntu-latest"
         },
         {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -88,7 +88,8 @@ public interface NativeConfig {
 
     /**
      * Defines the user language used for building the native executable.
-     * It also serves as the default Locale language for the native executable application runtime.
+     * With GraalVM versions prior to GraalVM for JDK 24 it also serves as the default Locale language for the native executable
+     * application runtime.
      * e.g. en or cs as defined by IETF BCP 47 language tags.
      * <p>
      *
@@ -100,7 +101,8 @@ public interface NativeConfig {
 
     /**
      * Defines the user country used for building the native executable.
-     * It also serves as the default Locale country for the native executable application runtime.
+     * With GraalVM versions prior to GraalVM for JDK 24 it also serves as the default Locale country for the native executable
+     * application runtime.
      * e.g. US or FR as defined by ISO 3166-1 alpha-2 codes.
      * <p>
      *

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -191,6 +191,8 @@ public final class GraalVM {
         public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", "22", Distribution.GRAALVM);
         public static final Version VERSION_24_0_999 = new Version("GraalVM 24.0.999", "24.0.999", "22", Distribution.GRAALVM);
         public static final Version VERSION_24_1_0 = new Version("GraalVM 24.1.0", "24.1.0", "23", Distribution.GRAALVM);
+        public static final Version VERSION_24_1_999 = new Version("GraalVM 24.1.999", "24.1.999", "23", Distribution.GRAALVM);
+        public static final Version VERSION_24_2_0 = new Version("GraalVM 24.2.0", "24.2.0", "24", Distribution.GRAALVM);
 
         /**
          * The minimum version of GraalVM supported by Quarkus.

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -746,15 +746,6 @@ public class NativeImageBuildStep {
                         }
                     }
                 }
-
-                final String userLanguage = LocaleProcessor.nativeImageUserLanguage(nativeConfig, localesBuildTimeConfig);
-                if (!userLanguage.isEmpty()) {
-                    nativeImageArgs.add("-J-Duser.language=" + userLanguage);
-                }
-                final String userCountry = LocaleProcessor.nativeImageUserCountry(nativeConfig, localesBuildTimeConfig);
-                if (!userCountry.isEmpty()) {
-                    nativeImageArgs.add("-J-Duser.country=" + userCountry);
-                }
                 final String includeLocales = LocaleProcessor.nativeImageIncludeLocales(nativeConfig, localesBuildTimeConfig);
                 if (!includeLocales.isEmpty()) {
                     if ("all".equals(includeLocales)) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/LocaleProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/LocaleProcessor.java
@@ -14,6 +14,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
@@ -60,6 +61,23 @@ public class LocaleProcessor {
     }
 
     /**
+     * These exports are only required for GraalVM for JDK < 24, but don't cause any issues for newer versions.
+     * To be removed once we drop support for GraalVM for JDK < 24.
+     */
+    @BuildStep(onlyIf = NativeBuild.class)
+    void setDefaults(BuildProducer<NativeImageSystemPropertyBuildItem> buildtimeSystemProperties,
+            NativeConfig nativeConfig, LocalesBuildTimeConfig localesBuildTimeConfig) {
+        String language = nativeImageUserLanguage(nativeConfig, localesBuildTimeConfig);
+        if (!language.isEmpty()) {
+            buildtimeSystemProperties.produce(new NativeImageSystemPropertyBuildItem("user.language", language));
+        }
+        String country = nativeImageUserCountry(nativeConfig, localesBuildTimeConfig);
+        if (!country.isEmpty()) {
+            buildtimeSystemProperties.produce(new NativeImageSystemPropertyBuildItem("user.country", country));
+        }
+    }
+
+    /**
      * We activate additional resources in native-image executable only if user opts
      * for anything else than what is already the system default.
      */
@@ -80,7 +98,8 @@ public class LocaleProcessor {
                     (nativeConfig.userCountry().isPresent()
                             && !Locale.getDefault().getCountry().equals(nativeConfig.userCountry().get()))
                     ||
-                    !Locale.getDefault().equals(localesBuildTimeConfig.defaultLocale)
+                    (localesBuildTimeConfig.defaultLocale.isPresent() &&
+                            !Locale.getDefault().equals(localesBuildTimeConfig.defaultLocale.get()))
                     ||
                     localesBuildTimeConfig.locales.stream().anyMatch(l -> !Locale.getDefault().equals(l));
         }
@@ -93,9 +112,14 @@ public class LocaleProcessor {
      * @param localesBuildTimeConfig
      * @return User language set by 'quarkus.default-locale' or by deprecated 'quarkus.native.user-language' or
      *         effectively LocalesBuildTimeConfig.DEFAULT_LANGUAGE if none of the aforementioned is set.
+     * @Deprecated
      */
+    @Deprecated
     public static String nativeImageUserLanguage(NativeConfig nativeConfig, LocalesBuildTimeConfig localesBuildTimeConfig) {
-        String language = localesBuildTimeConfig.defaultLocale.getLanguage();
+        String language = System.getProperty("user.language", "en");
+        if (localesBuildTimeConfig.defaultLocale.isPresent()) {
+            language = localesBuildTimeConfig.defaultLocale.get().getLanguage();
+        }
         if (nativeConfig.userLanguage().isPresent()) {
             log.warn(DEPRECATED_USER_LANGUAGE_WARNING);
             // The deprecated option takes precedence for users who are already using it.
@@ -112,9 +136,14 @@ public class LocaleProcessor {
      * @return User country set by 'quarkus.default-locale' or by deprecated 'quarkus.native.user-country' or
      *         effectively LocalesBuildTimeConfig.DEFAULT_COUNTRY (could be an empty string) if none of the aforementioned is
      *         set.
+     * @Deprecated
      */
+    @Deprecated
     public static String nativeImageUserCountry(NativeConfig nativeConfig, LocalesBuildTimeConfig localesBuildTimeConfig) {
-        String country = localesBuildTimeConfig.defaultLocale.getCountry();
+        String country = System.getProperty("user.country", "");
+        if (localesBuildTimeConfig.defaultLocale.isPresent()) {
+            country = localesBuildTimeConfig.defaultLocale.get().getCountry();
+        }
         if (nativeConfig.userCountry().isPresent()) {
             log.warn(DEPRECATED_USER_COUNTRY_WARNING);
             // The deprecated option takes precedence for users who are already using it.
@@ -124,7 +153,7 @@ public class LocaleProcessor {
     }
 
     /**
-     * Additional locales to be included in native-image executable.
+     * Locales to be included in native-image executable.
      *
      * @param nativeConfig
      * @param localesBuildTimeConfig
@@ -139,17 +168,18 @@ public class LocaleProcessor {
             return "all";
         }
 
-        // We subtract what we already declare for native-image's user.language or user.country.
-        // Note the deprecated options still count.
-        additionalLocales.remove(localesBuildTimeConfig.defaultLocale);
+        // GraalVM for JDK 24 doesn't include the default locale used at build time. We must explicitly include the
+        // specified locales - including the build-time locale if set by the user.
+        // Note the deprecated options still count and take precedence.
         if (nativeConfig.userCountry().isPresent() && nativeConfig.userLanguage().isPresent()) {
-            additionalLocales.remove(new Locale(nativeConfig.userLanguage().get(), nativeConfig.userCountry().get()));
+            additionalLocales.add(new Locale(nativeConfig.userLanguage().get(), nativeConfig.userCountry().get()));
         } else if (nativeConfig.userLanguage().isPresent()) {
-            additionalLocales.remove(new Locale(nativeConfig.userLanguage().get()));
+            additionalLocales.add(new Locale(nativeConfig.userLanguage().get()));
+        } else if (localesBuildTimeConfig.defaultLocale.isPresent()) {
+            additionalLocales.add(localesBuildTimeConfig.defaultLocale.get());
         }
 
         return additionalLocales.stream()
-                .filter(l -> !Locale.getDefault().equals(l))
                 .map(l -> l.getLanguage() + (l.getCountry().isEmpty() ? "" : "-" + l.getCountry()))
                 .collect(Collectors.joining(","));
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -240,8 +240,9 @@ public class MainClassBuildStep {
             createAppCDS.returnValue(null);
         }
 
-        // very first thing is to set system props (for run time, which use substitutions for a different
-        // storage from build-time)
+        // Make sure we set properties in doStartup as well. This is necessary because setting them in the static-init
+        // sets them at build-time, on the host JVM, while SVM has substitutions for System. get/ setProperty at
+        // run-time which will never see those properties unless we also set them at run-time.
         for (SystemPropertyBuildItem i : properties) {
             mv.invokeStaticMethod(ofMethod(System.class, "setProperty", String.class, String.class, String.class),
                     mv.load(i.getKey()), mv.load(i.getValue()));

--- a/core/runtime/src/main/java/io/quarkus/runtime/LocalesBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LocalesBuildTimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.runtime;
 
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
 import io.quarkus.runtime.annotations.ConfigDocPrefix;
@@ -44,8 +45,10 @@ public class LocalesBuildTimeConfig {
      * For instance, the Hibernate Validator extension makes use of it.
      * <p>
      * Native-image build uses this property to derive {@code user.language} and {@code user.country} for the application's
-     * runtime.
+     * runtime. Starting with GraalVM for JDK 24 {@code user.language} and {@code user.country} can also be overridden at
+     * runtime, provided the selected locale was included at image build time.
      */
-    @ConfigItem(defaultValue = DEFAULT_LANGUAGE + "-" + DEFAULT_COUNTRY, defaultValueDocumentation = "Build system locale")
-    public Locale defaultLocale;
+    @ConfigItem(defaultValueDocumentation = "Defaults to the JVM's default locale if not set. "
+            + "Starting with GraalVM for JDK 24, it defaults to en-US for native executables.")
+    public Optional<Locale> defaultLocale;
 }

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -86,7 +86,7 @@ public class HibernateValidatorRecorder {
                         // Locales, Locale ROOT means all locales in this setting.
                         .locales(localesBuildTimeConfig.locales.contains(Locale.ROOT) ? Set.of(Locale.getAvailableLocales())
                                 : localesBuildTimeConfig.locales)
-                        .defaultLocale(localesBuildTimeConfig.defaultLocale)
+                        .defaultLocale(localesBuildTimeConfig.defaultLocale.orElse(Locale.getDefault()))
                         .beanMetaDataClassNormalizer(new ArcProxyBeanMetaDataClassNormalizer());
 
                 if (hibernateValidatorBuildTimeConfig.expressionLanguage().constraintExpressionFeatureLevel().isPresent()) {

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -1417,7 +1418,7 @@ public class MessageBundleProcessor {
         AnnotationValue localeValue = bundleAnnotation.value(BUNDLE_LOCALE);
         String defaultLocale;
         if (localeValue == null || localeValue.asString().equals(MessageBundle.DEFAULT_LOCALE)) {
-            defaultLocale = locales.defaultLocale.toLanguageTag();
+            defaultLocale = locales.defaultLocale.orElse(Locale.getDefault()).toLanguageTag();
         } else {
             defaultLocale = localeValue.asString();
         }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
@@ -97,7 +97,7 @@ public class EngineProducer {
         this.templateContents = Map.copyOf(context.getTemplateContents());
         this.tags = context.getTags();
         this.templatePathExclude = config.templatePathExclude;
-        this.defaultLocale = locales.defaultLocale;
+        this.defaultLocale = locales.defaultLocale.orElse(Locale.getDefault());
         this.defaultCharset = config.defaultCharset;
         this.container = Arc.container();
 

--- a/integration-tests/locales/all/src/test/resources/application.properties
+++ b/integration-tests/locales/all/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.locales=all
 quarkus.native.resources.includes=AppMessages_*.properties
+quarkus.test.env.LC_ALL=mt_MT.UTF-8

--- a/integration-tests/locales/default/pom.xml
+++ b/integration-tests/locales/default/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-test-locales-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-integration-test-locales-default</artifactId>
+    <name>Quarkus - Integration Tests - Locales - Default</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-locales-app</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/locales/default/src/main/java/io/quarkus/locales/it/DefaultLocaleResource.java
+++ b/integration-tests/locales/default/src/main/java/io/quarkus/locales/it/DefaultLocaleResource.java
@@ -1,0 +1,26 @@
+package io.quarkus.locales.it;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.logging.Logger;
+
+@Path("")
+public class DefaultLocaleResource extends LocalesResource {
+    private static final Logger LOG = Logger.getLogger(DefaultLocaleResource.class);
+
+    // @Pattern validation does nothing when placed in LocalesResource.
+    @GET
+    @Path("/hibernate-validator-test-validation-message-locale/{id}/")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response validationMessageLocale(
+            @Pattern(regexp = "A.*", message = "{pattern.message}") @PathParam("id") String id) {
+        LOG.infof("Triggering test: id: %s", id);
+        return Response.ok(id).build();
+    }
+}

--- a/integration-tests/locales/default/src/test/java/io/quarkus/locales/it/LocalesIT.java
+++ b/integration-tests/locales/default/src/test/java/io/quarkus/locales/it/LocalesIT.java
@@ -1,0 +1,59 @@
+package io.quarkus.locales.it;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
+
+/**
+ * For the Native test cases to function, the operating system has to have locales support installed. A barebone system with
+ * only C.UTF-8 default locale available won't be able to pass the tests.
+ * <p>
+ * For example, this package satisfies the dependency on a RHEL 9 type of OS: glibc-all-langpacks
+ */
+@QuarkusIntegrationTest
+public class LocalesIT {
+
+    @Test
+    public void testDefaultLocale() {
+        RestAssured.given().when()
+                .get("/default/de-CH")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                /*
+                 * "l-Iżvizzera" is the correct name for Switzerland in Maltese language.
+                 * Maltese is the default language as per quarkus.default-locale=mt-MT.
+                 */
+                .body(is("l-Iżvizzera"))
+                .log().all();
+    }
+
+    /**
+     * @see integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+     */
+    @ParameterizedTest
+    @CsvSource(value = {
+            // French locale is included, so it's used, because Croatian locale is not included
+            // and thus its property file ValidationMessages_hr_HR.properties is ignored.
+            "en-US;q=0.25,hr-HR;q=0.9,fr-FR;q=0.5,uk-UA;q=0.1|La valeur ne correspond pas à l'échantillon",
+            // Silent fallback to lingua franca.
+            "invalid string|Value is not in line with the pattern",
+            // French locale is available and included.
+            "en-US;q=0.25,hr-HR;q=1,fr-FR;q=0.5|La valeur ne correspond pas à l'échantillon"
+    }, delimiter = '|')
+    public void testValidationMessageLocale(String acceptLanguage, String expectedMessage) {
+        RestAssured.given()
+                .header("Accept-Language", acceptLanguage)
+                .when()
+                .get("/hibernate-validator-test-validation-message-locale/1")
+                .then()
+                .body(containsString(expectedMessage));
+    }
+
+}

--- a/integration-tests/locales/default/src/test/java/io/quarkus/locales/it/LocalesTest.java
+++ b/integration-tests/locales/default/src/test/java/io/quarkus/locales/it/LocalesTest.java
@@ -1,0 +1,7 @@
+package io.quarkus.locales.it;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class LocalesTest {
+}

--- a/integration-tests/locales/default/src/test/resources/ValidationMessages.properties
+++ b/integration-tests/locales/default/src/test/resources/ValidationMessages.properties
@@ -1,0 +1,1 @@
+pattern.message=Value is not in line with the pattern

--- a/integration-tests/locales/default/src/test/resources/ValidationMessages_fr_FR.properties
+++ b/integration-tests/locales/default/src/test/resources/ValidationMessages_fr_FR.properties
@@ -1,0 +1,1 @@
+pattern.message=La valeur ne correspond pas à l'échantillon

--- a/integration-tests/locales/default/src/test/resources/ValidationMessages_hr_HR.properties
+++ b/integration-tests/locales/default/src/test/resources/ValidationMessages_hr_HR.properties
@@ -1,0 +1,1 @@
+pattern.message=Vrijednost ne zadovoljava uzorak

--- a/integration-tests/locales/default/src/test/resources/application.properties
+++ b/integration-tests/locales/default/src/test/resources/application.properties
@@ -1,7 +1,4 @@
 quarkus.locales=de,fr-FR,ja,uk-UA
 # Note that quarkus.native.user-language is deprecated and solely quarkus.default-locale should be
 # used in your application properties. This test uses it only to verify compatibility.
-quarkus.native.user-language=cs
-quarkus.default-locale=en-US
-quarkus.test.arg-line=-Duser.language=de
-quarkus.test.env.LC_ALL=mt_MT.UTF-8
+quarkus.default-locale=mt-MT

--- a/integration-tests/locales/pom.xml
+++ b/integration-tests/locales/pom.xml
@@ -14,6 +14,7 @@
     <modules>
         <module>app</module>
         <module>all</module>
+        <module>default</module>
         <module>some</module>
     </modules>
 </project>

--- a/integration-tests/locales/some/src/test/java/io/quarkus/locales/it/LocalesIT.java
+++ b/integration-tests/locales/some/src/test/java/io/quarkus/locales/it/LocalesIT.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import io.quarkus.test.junit.DisableIfBuiltWithGraalVMNewerThan;
+import io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan;
 import io.quarkus.test.junit.GraalVMVersion;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
@@ -43,9 +44,6 @@ public class LocalesIT {
                 .log().all();
     }
 
-    // Disable test with GraalVM 24.2 for JDK 24 and later till we reach a conclusion in
-    // https://github.com/quarkusio/quarkus/discussions/43533
-    @DisableIfBuiltWithGraalVMNewerThan(value = GraalVMVersion.GRAALVM_24_1_0)
     @ParameterizedTest
     @CsvSource(value = {
             "en-US|en|US Dollar",
@@ -65,9 +63,6 @@ public class LocalesIT {
                 .log().all();
     }
 
-    // Disable test with GraalVM 24.2 for JDK 24 and later till we reach a conclusion in
-    // https://github.com/quarkusio/quarkus/discussions/43533
-    @DisableIfBuiltWithGraalVMNewerThan(value = GraalVMVersion.GRAALVM_24_1_0)
     @ParameterizedTest
     @CsvSource(value = {
             "Asia/Tokyo|fr|heure normale du Japon",
@@ -88,20 +83,35 @@ public class LocalesIT {
                 .log().all();
     }
 
-    // Disable test with GraalVM 24.2 for JDK 24 and later till we reach a conclusion in
-    // https://github.com/quarkusio/quarkus/discussions/43533
     @Test
-    @DisableIfBuiltWithGraalVMNewerThan(value = GraalVMVersion.GRAALVM_24_1_0)
-    public void testDefaultLocale() {
+    @DisableIfBuiltWithGraalVMNewerThan(value = GraalVMVersion.GRAALVM_24_1_999)
+    public void testDefaultLocalePre24_2() {
         RestAssured.given().when()
                 .get("/default/de-CH")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 /*
+                 * Prior to GraalVM 24.2, the locale could not be changed at runtime.
                  * "Švýcarsko" is the correct name for Switzerland in Czech language.
                  * Czech is the default language as per quarkus.native.user-language=cs.
                  */
                 .body(is("Švýcarsko"))
+                .log().all();
+    }
+
+    @Test
+    @DisableIfBuiltWithGraalVMOlderThan(value = GraalVMVersion.GRAALVM_24_2_0)
+    public void testDefaultLocalePost24_1() {
+        RestAssured.given().when()
+                .get("/default/de-CH")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                /*
+                 * Starting with GraalVM 24.2, the locale can be set at runtime.
+                 * "Schweiz" is the correct name for Switzerland in German.
+                 * German is the default language as per the `quarkus.test.arg-line` in application.properties.
+                 */
+                .body(is("Schweiz"))
                 .log().all();
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
@@ -7,7 +7,9 @@ public enum GraalVMVersion {
     GRAALVM_23_1_3(GraalVM.Version.VERSION_23_1_3),
     GRAALVM_24_0_0(GraalVM.Version.VERSION_24_0_0),
     GRAALVM_24_0_999(GraalVM.Version.VERSION_24_0_999),
-    GRAALVM_24_1_0(GraalVM.Version.VERSION_24_1_0);
+    GRAALVM_24_1_0(GraalVM.Version.VERSION_24_1_0),
+    GRAALVM_24_1_999(GraalVM.Version.VERSION_24_1_999),
+    GRAALVM_24_2_0(GraalVM.Version.VERSION_24_2_0);
 
     private final GraalVM.Version version;
 


### PR DESCRIPTION
Starting with GraalVM for JDK 24 (24.2) native image will no longer set the locale default at build time. As a result, the default locale won't be included by default in the native image unless explicitly specified and it will also not be set implicitly.

As discussed in https://github.com/quarkusio/quarkus/discussions/43533#discussioncomment-10797019 this PR updates the locales support so that:

- [x] if neither `quarkus.locales` nor `quarkus.default-locale` is set, the Quarkus applications should default to English (`en_US`), instead of the build systems locale (which is the current behavior), at run-time.
- [X] if `quarkus.default-locale` is set but `quarkus.locales` is not set, then we should only include the locale `quarkus.default-locale` is set to. This is the current behavior with GraalVM for JDK 21.
- [X] if both `quarkus.default-locale` and `quarkus.locales` are set, then we should include only the locales from `quarkus.locales` and the one from `quarkus.default-locale` (this is the current behavior).
- [X] if `quarkus.locales` is set but `quarkus.default-locale` is not set, then we should include only the locales from `quarkus.locales` and default to English, instead of the build systems locale (which is the current behavior), at run-time (similarly to point 1).
- [x] if `quarkus.default-locale` (which is build time fixed) is set, it is used to set the default `user.language` and `user.country` values at run-time, while users may still override them. 

For points 2 and 3 starting with graalVM for JDK 24 we will also include `en_US` which shouldn't be a big issue as mentioned in https://github.com/quarkusio/quarkus/discussions/43533#discussioncomment-10795928,

> [!CAUTION]
> Point 1 changes the current behavior, meaning we need to clearly document and communicate it.

The PR also updates the Locales integration tests accordingly.

See https://github.com/oracle/graal/pull/9694

Closes https://github.com/quarkusio/quarkus/issues/43436

Depends on https://github.com/quarkusio/quarkus/pull/43696