### PR TITLE
[3.15] Adding an attribute for the TLS registry reference guide

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -63,6 +63,7 @@
 :vault-datasource-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/vault-datasource.html
 :micrometer-registry-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-micrometer-registry/dev/index.html
 :quarkus-migration-guide: https://github.com/quarkusio/quarkus/wiki/Migration-Guides[Migration Guides]
+:quarkus-tls-registry-reference-guide: TLS registry reference
 // .
 :create-app-group-id: org.acme
 :create-cli-group-id: {create-app-group-id}

--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="tls-registry-reference"]
-= TLS registry reference
+= {quarkus-tls-registry-reference-guide}
 include::_attributes.adoc[]
 :categories: web
 :summary: TLS registry configuration and usage


### PR DESCRIPTION
Adding an attribute for the TLS registry reference guide.
Cherry-pick of c265a8b8d624001b83d13882d44c2b7c79c1043b of https://github.com/quarkusio/quarkus/pull/43446