### PR TITLE
Prototype System -> Log

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
@@ -33,6 +33,12 @@ public class LogBuildTimeConfig {
     public Boolean decorateStacktraces;
 
     /**
+     * Capture System messages.
+     */
+    @ConfigItem(name = "system.enabled", defaultValue = "true")
+    public boolean systemEnabled;
+
+    /**
      * Minimum logging categories.
      * <p>
      * Logging is done on a per-category basis. Each category can be configured independently.

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -253,6 +253,11 @@ public class LoggingSetupRecorder {
         addNamedHandlersToRootHandlers(config.handlers, namedHandlers, handlers, errorManager);
         InitialConfigurator.DELAYED_HANDLER.setAutoFlush(false);
         InitialConfigurator.DELAYED_HANDLER.setHandlers(handlers.toArray(LogContextInitializer.NO_HANDLERS));
+
+        if (buildConfig.systemEnabled) {
+            SystemPublisher.init();
+        }
+
         return shutdownNotifier;
     }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/SystemPublisher.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/SystemPublisher.java
@@ -1,0 +1,76 @@
+package io.quarkus.runtime.logging;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.PrintStream;
+
+import org.jboss.logging.Logger;
+
+/**
+ * System.(out/err) -> Logging
+ */
+public class SystemPublisher {
+    private static final Logger LOG = Logger.getLogger("System");
+    private final PipedOutputStream outPos;
+    private final PipedInputStream outPis;
+    private final PrintStream out;
+
+    private final PipedOutputStream errPos;
+    private final PipedInputStream errPis;
+    private final PrintStream err;
+
+    private SystemPublisher() throws IOException {
+        outPos = new PipedOutputStream();
+        outPis = new PipedInputStream(outPos);
+        out = new PrintStream(outPos, true);
+
+        errPos = new PipedOutputStream();
+        errPis = new PipedInputStream(errPos);
+        err = new PrintStream(errPos, true);
+
+        this.startPublishing();
+    }
+
+    private void startPublishing() {
+        System.setOut(out);
+        System.setErr(err);
+
+        capture(outPis, Logger.Level.INFO);
+        capture(errPis, Logger.Level.ERROR);
+    }
+
+    private void capture(PipedInputStream pis, Logger.Level level) {
+        new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(pis))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    LOG.log(level, line);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            } finally {
+                closeStreams();
+            }
+        }).start();
+    }
+
+    private void closeStreams() {
+        try {
+            outPis.close();
+            outPos.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void init() {
+        try {
+            new SystemPublisher();
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
OK I don't know if this is a good idea or not. After chatting to @yrodiere yesterday about the Hibernate SQL Log, that is currently using System.out, and the issue that we have that System.out is not captured in the Dev UI Log, I was wondering if we can redirect System.(out/err) to a Log. This is the prototype, and it is working nicely:

![image](https://github.com/user-attachments/assets/f3ee8bec-e6f5-4975-a21a-adeb49b825f0)

However, like I said, I am not 100% sure on this idea ? Leaving it as draft so we can discuss. I am happy to just close it if it's a bad idea :)

/cc @dmlloyd @cescoffier @yrodiere @geoand 