### PR TITLE
Mailer: register default mailer beans correctly

### DIFF
--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateRecordNoInjectionTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateRecordNoInjectionTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.mailer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.mailer.MailTemplate.MailTemplateInstance;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.ext.mail.MailMessage;
+
+public class MailTemplateRecordNoInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(confirmation.class)
+                    .addAsResource("mock-config.properties", "application.properties")
+                    .addAsResource(new StringAsset(""
+                            + "<html>{name}</html>"), "templates/MailTemplateRecordNoInjectionTest/confirmation.html"));
+
+    @Test
+    public void testMailTemplateRecord() {
+        // Intentionally use programmatic lookup to obtain the MockMailbox
+        MockMailbox mockMailbox = Arc.container().instance(MockMailbox.class).get();
+        new confirmation("Ondrej").to("quarkus-reactive@quarkus.io").from("from-record@quarkus.io").subject("test mailer")
+                .send().await().indefinitely();
+        assertEquals(1, mockMailbox.getMailMessagesSentTo("quarkus-reactive@quarkus.io").size());
+        MailMessage message = mockMailbox.getMailMessagesSentTo("quarkus-reactive@quarkus.io").get(0);
+        assertEquals("from-record@quarkus.io", message.getFrom());
+        assertEquals("<html>Ondrej</html>", message.getHtml());
+    }
+
+    record confirmation(String name) implements MailTemplateInstance {
+    }
+
+}

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateRecordNoInjectionTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateRecordNoInjectionTest.java
@@ -26,7 +26,7 @@ public class MailTemplateRecordNoInjectionTest {
         // Intentionally use programmatic lookup to obtain the MockMailbox
         MockMailbox mockMailbox = Arc.container().instance(MockMailbox.class).get();
         new confirmation("Ondrej").to("quarkus-reactive@quarkus.io").from("from-record@quarkus.io").subject("test mailer")
-                .send().await().indefinitely();
+                .sendAndAwait();
         assertEquals(1, mockMailbox.getMailMessagesSentTo("quarkus-reactive@quarkus.io").size());
         MailMessage message = mockMailbox.getMailMessagesSentTo("quarkus-reactive@quarkus.io").get(0);
         assertEquals("from-record@quarkus.io", message.getFrom());

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
@@ -4,6 +4,7 @@ import java.io.File;
 
 import io.quarkus.mailer.reactive.ReactiveMailer;
 import io.quarkus.qute.TemplateInstance;
+import io.smallrye.common.annotation.CheckReturnValue;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -117,8 +118,18 @@ public interface MailTemplate {
          * @return a {@link Uni} indicating when the mails have been sent
          * @see ReactiveMailer#send(Mail...)
          */
+        @CheckReturnValue
         default Uni<Void> send() {
             throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Sends all e-mail definitions and blocks the current thread while waiting for the result.
+         *
+         * @see #send()
+         */
+        default void sendAndAwait() {
+            send().await().indefinitely();
         }
 
         /**


### PR DESCRIPTION
- even if only mail template record is used
- get rid of unnecessary programmatic lookup in MailTemplateProducer
- fixes #43518