### PR TITLE
Fixed trust all option after reload (TlsRegistry)

### DIFF
--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -18,6 +18,7 @@ import javax.net.ssl.TrustManagerFactory;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TlsConfigUtils;
+import io.quarkus.tls.runtime.keystores.TrustAllOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.KeyCertOptions;
@@ -167,6 +168,8 @@ public class VertxCertificateHolder implements TlsConfiguration {
             } catch (Exception e) {
                 return false;
             }
+        } else if (config.trustAll()) {
+            trustStoreUpdateResult = new TrustStoreAndTrustOptions(null, TrustAllOptions.INSTANCE);
         }
 
         if (keyStoreUpdateResult == null && trustStoreUpdateResult == null) {


### PR DESCRIPTION
/cc @jmartisk @cescoffier 
I encountered a potential bug while working on TLS-Registry integration for SmallRye GraphQL.
When having a configuration property `quarkus.tls."TLS-BUCKET-NAME".trust-all=true` set after a successful manual reload, this trust-all option is not set.