### PR TITLE
Properly update the Platform for Maven

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -108,6 +108,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                         buildTool,
                         projectQuarkusPlatformBom.getVersion(),
                         targetPlatformVersion,
+                        platformUpdateInfo,
                         kotlinVersion,
                         updateJavaVersion,
                         extensionsUpdateInfo);

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectPlatformUpdateInfo.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectPlatformUpdateInfo.java
@@ -3,16 +3,14 @@ package io.quarkus.devtools.project.update;
 import java.util.List;
 import java.util.Map;
 
-import io.quarkus.maven.dependency.ArtifactKey;
-
 public class ProjectPlatformUpdateInfo {
-    private final Map<ArtifactKey, PlatformInfo> platformImports;
+    private final Map<String, PlatformInfo> platformImports;
     private final List<PlatformInfo> importVersionUpdates;
     private final List<PlatformInfo> newImports;
     private final boolean importsToBeRemoved;
     private final boolean platformUpdatesAvailable;
 
-    public ProjectPlatformUpdateInfo(Map<ArtifactKey, PlatformInfo> platformImports, List<PlatformInfo> importVersionUpdates,
+    public ProjectPlatformUpdateInfo(Map<String, PlatformInfo> platformImports, List<PlatformInfo> importVersionUpdates,
             List<PlatformInfo> newImports) {
         this.platformImports = platformImports;
         this.importVersionUpdates = importVersionUpdates;
@@ -29,7 +27,7 @@ public class ProjectPlatformUpdateInfo {
         return platformUpdatesAvailable;
     }
 
-    public Map<ArtifactKey, PlatformInfo> getPlatformImports() {
+    public Map<String, PlatformInfo> getPlatformImports() {
         return platformImports;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectUpdateInfos.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectUpdateInfos.java
@@ -15,7 +15,6 @@ import io.quarkus.devtools.project.state.ProjectState;
 import io.quarkus.devtools.project.state.TopExtensionDependency;
 import io.quarkus.devtools.project.update.ExtensionMapBuilder.ExtensionUpdateInfoBuilder;
 import io.quarkus.maven.dependency.ArtifactCoords;
-import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.ExtensionOrigin;
@@ -59,15 +58,17 @@ public final class ProjectUpdateInfos {
             ProjectState recommendedState) {
         checkProjectState(currentState, recommendedState);
 
-        final Map<ArtifactKey, PlatformInfo> platformImports = new LinkedHashMap<>();
+        // we map the platform by artifact id because a given platform can for instance be in the community Platform
+        // and in the Red Hat Build of Quarkus Platform and we need to be able to switch between the two
+        final Map<String, PlatformInfo> platformImports = new LinkedHashMap<>();
         for (ArtifactCoords c : currentState.getPlatformBoms()) {
             final PlatformInfo info = new PlatformInfo(c, null);
-            platformImports.put(c.getKey(), info);
+            platformImports.put(c.getArtifactId(), info);
         }
         List<PlatformInfo> importVersionUpdates = new ArrayList<>();
         List<PlatformInfo> newImports = new ArrayList<>(0);
         for (ArtifactCoords c : recommendedState.getPlatformBoms()) {
-            final PlatformInfo importInfo = platformImports.compute(c.getKey(), (k, v) -> {
+            final PlatformInfo importInfo = platformImports.compute(c.getArtifactId(), (k, v) -> {
                 if (v == null) {
                     return new PlatformInfo(null, c);
                 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
@@ -8,15 +8,22 @@ import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.update.ExtensionUpdateInfo;
+import io.quarkus.devtools.project.update.PlatformInfo;
 import io.quarkus.devtools.project.update.ProjectExtensionsUpdateInfo;
+import io.quarkus.devtools.project.update.ProjectPlatformUpdateInfo;
 import io.quarkus.devtools.project.update.rewrite.QuarkusUpdatesRepository.FetchResult;
+import io.quarkus.devtools.project.update.rewrite.operations.AddManagedDependencyOperation;
+import io.quarkus.devtools.project.update.rewrite.operations.ChangeDependencyOperation;
 import io.quarkus.devtools.project.update.rewrite.operations.DropDependencyVersionOperation;
+import io.quarkus.devtools.project.update.rewrite.operations.RemoveManagedDependencyOperation;
 import io.quarkus.devtools.project.update.rewrite.operations.UpdateDependencyVersionOperation;
 import io.quarkus.devtools.project.update.rewrite.operations.UpdateJavaVersionOperation;
 import io.quarkus.devtools.project.update.rewrite.operations.UpdatePropertyOperation;
 import io.quarkus.devtools.project.update.rewrite.operations.UpgradeGradlePluginOperation;
 
 public final class QuarkusUpdates {
+
+    private static final String IMPORT_SCOPE = "import";
 
     private QuarkusUpdates() {
     }
@@ -43,10 +50,35 @@ public final class QuarkusUpdates {
         }
         switch (request.buildTool) {
             case MAVEN:
-                recipe.addOperation(
-                        new UpdateDependencyVersionOperation("io.quarkus.platform", "quarkus-bom", request.targetVersion))
-                        .addOperation(new UpdateDependencyVersionOperation("io.quarkus", "quarkus-bom", request.targetVersion))
-                        .addOperation(new UpdateDependencyVersionOperation("io.quarkus", "quarkus-universe-bom",
+                // Properly handle the Platform updates
+                for (PlatformInfo platformInfo : request.platformUpdateInfo.getPlatformImports().values()) {
+                    if (platformInfo.getRecommended() == null) {
+                        recipe.addOperation(new RemoveManagedDependencyOperation(platformInfo.getImported().getGroupId(),
+                                platformInfo.getImported().getArtifactId()));
+                    } else if (platformInfo.getImported() == null) {
+                        // we need to add the Platform
+                        recipe.addOperation(new AddManagedDependencyOperation(platformInfo.getRecommended().getGroupId(),
+                                platformInfo.getRecommended().getArtifactId(), platformInfo.getRecommended().getVersion(),
+                                platformInfo.getRecommended().getType(), IMPORT_SCOPE));
+                        continue;
+                    } else {
+                        // usual case when we should update the Platform
+                        if (platformInfo.getRecommended().getKey().equals(platformInfo.getImported().getKey())) {
+                            // same Platform, we can just update the version
+                            recipe.addOperation(new UpdateDependencyVersionOperation("io.quarkus.platform", "quarkus-bom",
+                                    request.targetVersion));
+                        } else {
+                            // we need to update the Platform coordinates
+                            recipe.addOperation(new ChangeDependencyOperation(platformInfo.getImported().getGroupId(),
+                                    platformInfo.getImported().getArtifactId(),
+                                    platformInfo.getRecommended().getGroupId(), platformInfo.getRecommended().getArtifactId(),
+                                    platformInfo.getRecommended().getVersion()));
+                        }
+                    }
+                }
+
+                // last resort for projects not following conventions or using the old Universe BOM
+                recipe.addOperation(new UpdateDependencyVersionOperation("io.quarkus", "quarkus-universe-bom",
                                 request.targetVersion))
                         .addOperation(new UpdatePropertyOperation("quarkus.platform.version", request.targetVersion))
                         .addOperation(new UpdatePropertyOperation("quarkus.version", request.targetVersion))
@@ -57,6 +89,9 @@ public final class QuarkusUpdates {
                 break;
             case GRADLE:
             case GRADLE_KOTLIN_DSL:
+                // Unfortunately, for now we can't really handle Platforms properly in Gradle due to OpenRewrite limitations
+                // Using a naive approach to replace the properties
+
                 recipe.addOperation(new UpdatePropertyOperation("quarkusPlatformVersion", request.targetVersion))
                         .addOperation(new UpdatePropertyOperation("quarkusPluginVersion", request.targetVersion));
                 if (request.kotlinVersion != null) {
@@ -95,22 +130,26 @@ public final class QuarkusUpdates {
         public final BuildTool buildTool;
         public final String currentVersion;
         public final String targetVersion;
+        public final ProjectPlatformUpdateInfo platformUpdateInfo;
         public final String kotlinVersion;
         public final Optional<Integer> updateJavaVersion;
         public final ProjectExtensionsUpdateInfo projectExtensionsUpdateInfo;
 
-        public ProjectUpdateRequest(String currentVersion, String targetVersion, String kotlinVersion,
+        public ProjectUpdateRequest(String currentVersion, String targetVersion,
+                ProjectPlatformUpdateInfo platformUpdateInfo, String kotlinVersion,
                 Optional<Integer> updateJavaVersion, ProjectExtensionsUpdateInfo projectExtensionsUpdateInfo) {
-            this(BuildTool.MAVEN, currentVersion, targetVersion, kotlinVersion, updateJavaVersion,
+            this(BuildTool.MAVEN, currentVersion, targetVersion, platformUpdateInfo, kotlinVersion, updateJavaVersion,
                     projectExtensionsUpdateInfo);
         }
 
         public ProjectUpdateRequest(BuildTool buildTool, String currentVersion, String targetVersion,
+                ProjectPlatformUpdateInfo platformUpdateInfo,
                 String kotlinVersion,
                 Optional<Integer> updateJavaVersion, ProjectExtensionsUpdateInfo projectExtensionsUpdateInfo) {
             this.buildTool = buildTool;
             this.currentVersion = currentVersion;
             this.targetVersion = targetVersion;
+            this.platformUpdateInfo = platformUpdateInfo;
             this.kotlinVersion = kotlinVersion;
             this.updateJavaVersion = updateJavaVersion;
             this.projectExtensionsUpdateInfo = projectExtensionsUpdateInfo;

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/operations/AddManagedDependencyOperation.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/operations/AddManagedDependencyOperation.java
@@ -1,0 +1,43 @@
+package io.quarkus.devtools.project.update.rewrite.operations;
+
+import java.util.Map;
+
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.update.rewrite.RewriteOperation;
+
+public class AddManagedDependencyOperation implements RewriteOperation {
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+    private final String type;
+    private final String scope;
+
+    public AddManagedDependencyOperation(String groupId, String artifactId, String version, String type, String scope) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.type = type;
+        this.scope = scope;
+    }
+
+    @Override
+    public Map<String, Object> single(BuildTool buildTool) {
+        switch (buildTool) {
+            case GRADLE_KOTLIN_DSL:
+            case GRADLE:
+                throw new IllegalStateException("AddManagedDependencyOperation is not supported for Gradle at the moment");
+            case MAVEN:
+                return Map.of("org.openrewrite.maven.AddManagedDependency",
+                        Map.of(
+                                "groupId", groupId,
+                                "artifactId", artifactId,
+                                "version", version,
+                                "type", type,
+                                "scope", scope));
+            default:
+                return Map.of();
+        }
+    }
+
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/operations/ChangeDependencyOperation.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/operations/ChangeDependencyOperation.java
@@ -1,0 +1,43 @@
+package io.quarkus.devtools.project.update.rewrite.operations;
+
+import java.util.Map;
+
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.update.rewrite.RewriteOperation;
+
+public class ChangeDependencyOperation implements RewriteOperation {
+
+    private final String oldGroupId;
+    private final String oldArtifactId;
+    private final String newGroupId;
+    private final String newArtifactId;
+    private final String newVersion;
+
+    public ChangeDependencyOperation(String oldGroupId, String oldArtifactId, String newGroupId, String newArtifactId,
+            String newVersion) {
+        this.oldGroupId = oldGroupId;
+        this.oldArtifactId = oldArtifactId;
+        this.newGroupId = newGroupId;
+        this.newArtifactId = newArtifactId;
+        this.newVersion = newVersion;
+    }
+
+    @Override
+    public Map<String, Object> single(BuildTool buildTool) {
+        switch (buildTool) {
+            case GRADLE_KOTLIN_DSL:
+            case GRADLE:
+            case MAVEN:
+                return Map.of("org.openrewrite.java.dependencies.ChangeDependency",
+                        Map.of(
+                                "oldGroupId", oldGroupId,
+                                "oldArtifactId", oldArtifactId,
+                                "newGroupId", newGroupId,
+                                "newArtifactId", newArtifactId,
+                                "newVersion", newVersion));
+            default:
+                return Map.of();
+        }
+    }
+
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/operations/RemoveManagedDependencyOperation.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/operations/RemoveManagedDependencyOperation.java
@@ -1,0 +1,37 @@
+package io.quarkus.devtools.project.update.rewrite.operations;
+
+import java.util.Map;
+
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.update.rewrite.RewriteOperation;
+
+public class RemoveManagedDependencyOperation implements RewriteOperation {
+
+    private final String groupId;
+    private final String artifactId;
+
+    public RemoveManagedDependencyOperation(String groupId, String artifactId) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+    }
+
+    @Override
+    public Map<String, Object> single(BuildTool buildTool) {
+        switch (buildTool) {
+            case GRADLE_KOTLIN_DSL:
+            case GRADLE:
+                return Map.of("org.openrewrite.gradle.RemoveDependency",
+                        Map.of(
+                                "groupId", groupId,
+                                "artifactId", artifactId));
+            case MAVEN:
+                return Map.of("org.openrewrite.maven.RemoveManagedDependency",
+                        Map.of(
+                                "groupId", groupId,
+                                "artifactId", artifactId));
+            default:
+                return Map.of();
+        }
+    }
+
+}


### PR DESCRIPTION
For now, it doesn't work with Gradle due to OpenRewrite limitations but at least in the Maven case, we properly update the Platform groupId if we switch Platforms.

Also better handle adding new Platforms or removing Platforms.

Note that there is a big limitation to lift before merging this: OpenRewrite doesn't update the properties when updating the groupId/artifactId (it only does it for the version) which causes issues as we need to update the groupId for the plugin - and in any case, the current behavior is not very clean.

Another important thing to address before merging is the update of the Platform from io.quarkus to io.quarkus.platform which might not be what we want. We are using the io.quarkus Platform in very specific cases such as extension development and we want to keep this one when updating.

Fixes #42943 at least in the Maven case.