### PR TITLE
Skip kafka-oauth-keycloak test with GraalVM >= 24.1

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -192,6 +192,7 @@ public final class GraalVM {
         public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", "17", Distribution.GRAALVM);
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", "21", Distribution.GRAALVM);
         public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", "22", Distribution.GRAALVM);
+        public static final Version VERSION_24_0_999 = new Version("GraalVM 24.0.999", "24.0.999", "22", Distribution.GRAALVM);
 
         /**
          * The minimum version of GraalVM supported by Quarkus.

--- a/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaOauthTest.java
+++ b/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaOauthTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.DisableIfBuiltWithGraalVMNewerThan;
+import io.quarkus.test.junit.GraalVMVersion;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.common.mapper.TypeRef;
 
@@ -20,6 +22,7 @@ public class KafkaOauthTest {
     };
 
     @Test
+    @DisableIfBuiltWithGraalVMNewerThan(GraalVMVersion.GRAALVM_24_0_999) // See https://github.com/quarkusio/quarkus/issues/39634
     public void test() {
         await().untilAsserted(() -> Assertions.assertEquals(2, get("/kafka").as(TYPE_REF).size()));
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMNewerThan.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMNewerThan.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Used to signal that a test class or method should be disabled if the version of GraalVM used to build the native binary
- * under test was older than the supplied version.
+ * under test was newer than the supplied version.
  *
  * This annotation should only be used on a test classes annotated with {@link QuarkusIntegrationTest}.
  * If it is used on other test classes, it will have no effect.

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
@@ -4,7 +4,8 @@ import io.quarkus.deployment.pkg.steps.GraalVM;
 
 public enum GraalVMVersion {
     GRAALVM_23_1_0(GraalVM.Version.VERSION_23_1_0),
-    GRAALVM_24_0_0(GraalVM.Version.VERSION_24_0_0);
+    GRAALVM_24_0_0(GraalVM.Version.VERSION_24_0_0),
+    GRAALVM_24_0_999(GraalVM.Version.VERSION_24_0_999);
 
     private final GraalVM.Version version;
 


### PR DESCRIPTION
The test is known to fail for quite some time generating a lot of CI
noise. Let's skip it till https://github.com/quarkusio/quarkus/issues/39634 is resolved.

cc @jerboaa 