### PR TITLE
Update and enable testLambdaCapturing test for GraalVM/Mandrel 23.1 for JDK 21

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -191,6 +191,8 @@ public final class GraalVM {
         static final Version VERSION_21_3_0 = new Version("GraalVM 21.3.0", "21.3.0", Distribution.GRAALVM);
         public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", "17", Distribution.GRAALVM);
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", "21", Distribution.GRAALVM);
+        public static final Version VERSION_23_1_2 = new Version("GraalVM 23.1.2", "23.1.2", "21", Distribution.GRAALVM);
+        public static final Version VERSION_23_1_3 = new Version("GraalVM 23.1.3", "23.1.3", "21", Distribution.GRAALVM);
         public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", "22", Distribution.GRAALVM);
         public static final Version VERSION_24_0_999 = new Version("GraalVM 24.0.999", "24.0.999", "22", Distribution.GRAALVM);
 

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RegisterForReflectionITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RegisterForReflectionITCase.java
@@ -59,18 +59,18 @@ public class RegisterForReflectionITCase {
     }
 
     @Test
-    @DisableIfBuiltWithGraalVMNewerThan(GraalVMVersion.GRAALVM_23_1_0)
-    public void testLambdaCapturingPre24_0() {
+    @DisableIfBuiltWithGraalVMNewerThan(GraalVMVersion.GRAALVM_23_1_2)
+    public void testLambdaCapturingPre23_1_3() {
         // Starting with GraalVM 22.1 support Lambda functions serialization
         // (see https://github.com/oracle/graal/issues/3756)
         RestAssured.given().when().get("/reflection/lambda").then().body(startsWith("Comparator$$Lambda$"));
     }
 
     @Test
-    @DisableIfBuiltWithGraalVMOlderThan(GraalVMVersion.GRAALVM_24_0_0)
-    public void testLambdaCapturingPost23_1() {
-        // Starting with GraalVM 24.0 lambda class names match the ones from HotSpot
-        // (see https://github.com/oracle/graal/pull/7775)
+    @DisableIfBuiltWithGraalVMOlderThan(GraalVMVersion.GRAALVM_23_1_3)
+    public void testLambdaCapturingPost23_1_2() {
+        // Starting with GraalVM 23.1.3 lambda class names match the ones from HotSpot
+        // (see https://github.com/oracle/graal/pull/7775 and https://github.com/oracle/graal/commit/7d158e5c141e2f5c84f27095d8718189ab4953c2)
         RestAssured.given().when().get("/reflection/lambda").then().body(startsWith("Comparator$$Lambda/"));
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
@@ -3,7 +3,8 @@ package io.quarkus.test.junit;
 import io.quarkus.deployment.pkg.steps.GraalVM;
 
 public enum GraalVMVersion {
-    GRAALVM_23_1_0(GraalVM.Version.VERSION_23_1_0),
+    GRAALVM_23_1_2(GraalVM.Version.VERSION_23_1_2),
+    GRAALVM_23_1_3(GraalVM.Version.VERSION_23_1_3),
     GRAALVM_24_0_0(GraalVM.Version.VERSION_24_0_0),
     GRAALVM_24_0_999(GraalVM.Version.VERSION_24_0_999);
 


### PR DESCRIPTION
The previous conditions were wrong and the test was not run with GraalVM/Mandrel 23.1 for JDK 21

Lambda naming change has been backported to GraalVM/Mandrel 23.1.3 for JDK 21 with https://github.com/oracle/graal/commit/7d158e5c141e2f5c84f27095d8718189ab4953c2 so now we need a different version for <= 23.1.2 and another for >= 23.1.3
