### PR TITLE
Add overflow-x scroll

### DIFF
--- a/core/runtime/src/main/resources/META-INF/template-html-builder.css
+++ b/core/runtime/src/main/resources/META-INF/template-html-builder.css
@@ -123,6 +123,8 @@ h3 {
     font-size: 1.3em;
     line-height: 1.5;
     color: hsla(3, 89%, 42%, 1.0);
+    overflow-x: scroll;
+    display: block;
 }
 
 .rel-stacktrace-item {


### PR DESCRIPTION
# Changes

Apply `overflow-x: scroll` and `display: block` to `.stacktrace` class.

## Old behavior

<img width="1782" alt="image" src="https://github.com/user-attachments/assets/5248288a-7d8d-47d8-b9fd-66f21065944f">

## New behavior
Now the container is not overflowing:

<img width="1792" alt="Screenshot 2024-09-27 at 00 25 53" src="https://github.com/user-attachments/assets/f3b229f9-b9af-4519-9fc3-bb2a4dbd54c7">

Fixes #43551 