### PR TITLE
Move brotli4j dependency from netty to vertx-http

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -122,8 +122,11 @@ class NettyProcessor {
                     .addRuntimeInitializedClass("io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder")
                     .addRuntimeInitializedClass("io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder")
                     .addRuntimeInitializedClass("io.netty.handler.codec.compression.ZstdOptions")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.compression.ZstdConstants")
-                    .addRuntimeInitializedClass("io.netty.handler.codec.compression.BrotliOptions");
+                    .addRuntimeInitializedClass("io.netty.handler.codec.compression.ZstdConstants");
+            // Brotli is an optional dependency
+            if (QuarkusClassLoader.isClassPresentAtRuntime("io.netty.handler.codec.compression.BrotliOptions")) {
+                builder.addRuntimeInitializedClass("io.netty.handler.codec.compression.BrotliOptions");
+            }
         } else {
             log.debug("Not registering Netty HTTP classes as they were not found");
         }

--- a/extensions/netty/runtime/pom.xml
+++ b/extensions/netty/runtime/pom.xml
@@ -61,15 +61,6 @@
             <classifier>osx-x86_64</classifier>
             <optional>true</optional>
         </dependency>
-
-        <!--
-        The recent version of Netty have a hard dependency on brotli,
-        without this dependency, it's not possible to compile to native
-        -->
-        <dependency>
-            <groupId>com.aayushatharva.brotli4j</groupId>
-            <artifactId>brotli4j</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -69,6 +69,11 @@
             <groupId>io.github.crac</groupId>
             <artifactId>org-crac</artifactId>
         </dependency>
+        <!-- needed when quarkus.http.compressors contains "br" see https://github.com/quarkusio/quarkus/issues/43556 -->
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>brotli4j</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Brotli4J is necessary only when using `vertx-http` (for now), no need to
bring it in for every app using `quarkus-netty`

See https://github.com/quarkusio/quarkus/issues/43556 for more details

Marked as draft till the tests complete in my fork: https://github.com/zakkak/quarkus/actions/runs/11067441368