### PR TITLE
Improve GitHub Actions cache usage

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -236,13 +236,13 @@ jobs:
           echo 'impacted_modules<<EOF' >> $GITHUB_OUTPUT
           echo "${GIB_IMPACTED}" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
-      - name: Tar .m2/repository/io/quarkus
-        run: tar -czf m2-io-quarkus.tgz -C ~ .m2/repository/io/quarkus
-      - name: Upload .m2/repository/io/quarkus
+      - name: Tar .m2 content pushed to subsequent jobs
+        run: tar -czf m2-content.tgz -C ~ .m2/repository/io/quarkus .m2/.develocity/build-cache
+      - name: Upload .m2 content pushed to subsequent jobs
         uses: actions/upload-artifact@v4
         with:
-          name: m2-io-quarkus
-          path: m2-io-quarkus.tgz
+          name: m2-content
+          path: m2-content.tgz
           retention-days: 7
       - name: Delete snapshots artifacts from cache
         run: find ~/.m2 -name \*-SNAPSHOT -type d -exec rm -rf {} +
@@ -402,13 +402,13 @@ jobs:
           restore-keys: |
             ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
-      - name: Download .m2/repository/io/quarkus
+      - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
-          name: m2-io-quarkus
+          name: m2-content
           path: .
-      - name: Extract .m2/repository/io/quarkus
-        run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
       - name: Cache Develocity local cache
         uses: actions/cache@v4
         if: github.event_name == 'pull_request'
@@ -527,13 +527,13 @@ jobs:
           restore-keys: |
             ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
-      - name: Download .m2/repository/io/quarkus
+      - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
-          name: m2-io-quarkus
+          name: m2-content
           path: .
-      - name: Extract .m2/repository/io/quarkus
-        run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
       - name: Set up JDK ${{ matrix.java.java-version }}
         uses: actions/setup-java@v4
         with:
@@ -629,13 +629,13 @@ jobs:
           restore-keys: |
             ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
-      - name: Download .m2/repository/io/quarkus
+      - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
-          name: m2-io-quarkus
+          name: m2-content
           path: .
-      - name: Extract .m2/repository/io/quarkus
-        run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
       - name: Set up JDK ${{ matrix.java.java-version }}
         uses: actions/setup-java@v4
         with:
@@ -721,13 +721,13 @@ jobs:
           restore-keys: |
             ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
-      - name: Download .m2/repository/io/quarkus
+      - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
-          name: m2-io-quarkus
+          name: m2-content
           path: .
-      - name: Extract .m2/repository/io/quarkus
-        run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
       - name: Set up JDK ${{ matrix.java.java-version }}
         uses: actions/setup-java@v4
         with:
@@ -817,13 +817,13 @@ jobs:
           restore-keys: |
             ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
-      - name: Download .m2/repository/io/quarkus
+      - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
-          name: m2-io-quarkus
+          name: m2-content
           path: .
-      - name: Extract .m2/repository/io/quarkus
-        run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
       - name: Set up JDK ${{ matrix.java.java-version }}
         uses: actions/setup-java@v4
         with:
@@ -900,13 +900,13 @@ jobs:
           restore-keys: |
             ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
-      - name: Download .m2/repository/io/quarkus
+      - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
-          name: m2-io-quarkus
+          name: m2-content
           path: .
-      - name: Extract .m2/repository/io/quarkus
-        run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
       - name: Set up JDK ${{ matrix.java.java-version }}
         uses: actions/setup-java@v4
         with:
@@ -989,13 +989,13 @@ jobs:
           restore-keys: |
             ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
-      - name: Download .m2/repository/io/quarkus
+      - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
-          name: m2-io-quarkus
+          name: m2-content
           path: .
-      - name: Extract .m2/repository/io/quarkus
-        run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -1073,13 +1073,13 @@ jobs:
           restore-keys: |
             ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
-      - name: Download .m2/repository/io/quarkus
+      - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
-          name: m2-io-quarkus
+          name: m2-content
           path: .
-      - name: Extract .m2/repository/io/quarkus
-        run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
       - name: Setup Develocity Build Scan capture
         uses: gradle/develocity-actions/maven-setup@v1
         with:
@@ -1186,13 +1186,13 @@ jobs:
           restore-keys: |
             ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
-      - name: Download .m2/repository/io/quarkus
+      - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
-          name: m2-io-quarkus
+          name: m2-content
           path: .
-      - name: Extract .m2/repository/io/quarkus
-        run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
       - name: Setup Develocity Build Scan capture
         uses: gradle/develocity-actions/maven-setup@v1
         with:

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -144,11 +144,23 @@ jobs:
       - name: Cache Maven Repository
         id: cache-maven
         uses: actions/cache@v4
+        # if it's not a pull request, we restore and save the cache
+        if: github.event_name != 'pull_request'
         with:
           path: ~/.m2/repository
           # A new cache will be stored daily. After that first store of the day, cache save actions will fail because the cache is immutable but it's not a problem.
           # The whole cache is dropped monthly to prevent unlimited growth.
           # The cache is per branch but in case we don't find a branch for a given branch, we will get a cache from another branch.
+          key: ${{ steps.cache-key.outputs.m2-cache-key }}
+          restore-keys: |
+            ${{ steps.cache-key.outputs.m2-monthly-branch-cache-key }}-
+            ${{ steps.cache-key.outputs.m2-monthly-cache-key }}-
+      - name: Restore Maven Repository
+        uses: actions/cache/restore@v4
+        # if it a pull request, we restore the cache but we don't save it
+        if: github.event_name == 'pull_request'
+        with:
+          path: ~/.m2/repository
           key: ${{ steps.cache-key.outputs.m2-cache-key }}
           restore-keys: |
             ${{ steps.cache-key.outputs.m2-monthly-branch-cache-key }}-

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -409,6 +409,14 @@ jobs:
           path: .
       - name: Extract .m2/repository/io/quarkus
         run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Cache Develocity local cache
+        uses: actions/cache@v4
+        if: github.event_name == 'pull_request'
+        with:
+          path: ~/.m2/.develocity/build-cache
+          key: develocity-cache-JVM Tests - JDK ${{matrix.java.name}}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          restore-keys: |
+            develocity-cache-JVM Tests - JDK ${{matrix.java.name}}-${{ github.event.pull_request.number }}-
       - name: Setup Develocity Build Scan capture
         uses: gradle/develocity-actions/maven-setup@v1
         with:

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -165,6 +165,14 @@ jobs:
           restore-keys: |
             ${{ steps.cache-key.outputs.m2-monthly-branch-cache-key }}-
             ${{ steps.cache-key.outputs.m2-monthly-cache-key }}-
+      - name: Cache Develocity local cache
+        uses: actions/cache@v4
+        if: github.event_name == 'pull_request'
+        with:
+          path: ~/.m2/.develocity/build-cache
+          key: develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          restore-keys: |
+            develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number }}-
       - name: Populate the cache
         run: |
           ./mvnw -T2C $COMMON_MAVEN_ARGS dependency:go-offline


### PR DESCRIPTION
This is related to #43559.

The idea is to avoid saving the .m2 cache for pull requests and to only restore the cache coming from the push events.
Also we want to experiment with caching the Develocity local cache but this might be a bit cumbersome given the number of jobs we have: experimenting with the Initial JDK build first.