### PR TITLE
Fix Keycloak test server account setup that results in invalid grant with 25

### DIFF
--- a/extensions/oidc-client-reactive-filter/deployment/pom.xml
+++ b/extensions/oidc-client-reactive-filter/deployment/pom.xml
@@ -107,7 +107,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.docker.image>${keycloak.docker.legacy.image}</keycloak.docker.image>
+                                <keycloak.version>${keycloak.version}</keycloak.version>
                                 <keycloak.use.https>false</keycloak.use.https>
                             </systemPropertyVariables>
                         </configuration>

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakContainer.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakContainer.java
@@ -95,4 +95,8 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
         return String.format("%s://keycloak:%d" + getAuthPath(),
                 useHttps ? "https" : "http", getPort());
     }
+
+    boolean isLegacy() {
+        return legacy;
+    }
 }

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakTestResourceLifecycleManager.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakTestResourceLifecycleManager.java
@@ -136,6 +136,10 @@ public class KeycloakTestResourceLifecycleManager implements QuarkusTestResource
         user.setCredentials(new ArrayList<>());
         user.setRealmRoles(realmRoles);
         user.setEmail(username + "@gmail.com");
+        if (!keycloak.isLegacy()) {
+            user.setFirstName(username + "_first_name");
+            user.setLastName(username + "_last_name");
+        }
 
         CredentialRepresentation credential = new CredentialRepresentation();
 


### PR DESCRIPTION
I was helping to my colleague to migrate from very old Keycloak 11 to 25 in the https://github.com/quarkus-qe/beefy-scenarios/pull/510 and I mentioned that `io.quarkus:quarkus-test-keycloak-server` doesn't work anymore because a first name and last name are not set. Maybe changes are forced by https://www.keycloak.org/docs/25.0.6/upgrading/#default-validations that describes that we will be forced to update invalid values of the first name and the last name from previous versions. And here https://www.keycloak.org/docs/25.0.6/upgrading/#changes-to-the-user-representation-in-both-admin-api-and-account-contexts it is described that last name and the first name were moved to a different base class.

```
2024-09-27 20:36:28,729 ERROR [io.qua.ver.htt.run.QuarkusErrorHandler] (executor-thread-1) HTTP Request to /oidc-client/annotation/user-name failed, error id: 87eabea9-9f6e-45c4-8c56-4dad3778f78e-1: io.quarkus.oidc.client.OidcClientException: {"error":"invalid_grant","error_description":"Account is not fully set up"}
	at io.quarkus.oidc.client.runtime.OidcClientImpl.emitGrantTokens(OidcClientImpl.java:261)
	at io.quarkus.oidc.client.runtime.OidcClientImpl$1.lambda$get$0(OidcClientImpl.java:158)
	at io.smallrye.context.impl.wrappers.SlowContextualFunction.apply(SlowContextualFunction.java:21)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransform$UniOnItemTransformProcessor.onItem(UniOnItemTransform.java:36)
	at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onItem(UniOperatorProcessor.java:47)
	at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onItem(UniOperatorProcessor.java:47)
	at io.smallrye.mutiny.vertx.AsyncResultUni.lambda$subscribe$1(AsyncResultUni.java:35)
	at io.smallrye.mutiny.vertx.DelegatingHandler.handle(DelegatingHandler.java:25)
	at io.vertx.ext.web.client.impl.HttpContext.handleDispatchResponse(HttpContext.java:402)
	at io.vertx.ext.web.client.impl.HttpContext.execute(HttpContext.java:384)
	at io.vertx.ext.web.client.impl.HttpContext.next(HttpContext.java:362)
	at io.vertx.ext.web.client.impl.HttpContext.fire(HttpContext.java:329)
	at io.vertx.ext.web.client.impl.HttpContext.dispatchResponse(HttpContext.java:291)
	at io.vertx.ext.web.client.impl.HttpContext.lambda$null$7(HttpContext.java:512)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:270)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:252)
	at io.vertx.core.impl.ContextInternal.lambda$runOnContext$0(ContextInternal.java:50)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

The changes I made in the `quarkus-rest-client-oidc-filter-deployment` (legacy to 25)  are reproducing the issue. Also it seems that setting these fields with the legacy image leads to failures. 