### PR TITLE
Check self-signed ID token when access token is verified

### DIFF
--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowOpaqueAccessTokenResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowOpaqueAccessTokenResource.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.security.Authenticated;
+
+@Path("/code-flow-opaque-access-token")
+@Authenticated
+public class CodeFlowOpaqueAccessTokenResource {
+
+    @Inject
+    JsonWebToken jwtAccessToken;
+
+    @Inject
+    AccessTokenCredential accessTokenCredential;
+
+    @GET
+    public String getAccessTokenCredential() {
+        return accessTokenCredential.getToken();
+    }
+
+    @GET
+    @Path("/jwt-access-token")
+    public String getJwtAccessToken() {
+        return jwtAccessToken.getRawToken();
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -36,6 +36,15 @@ quarkus.oidc.code-flow-verify-id-and-access-tokens.credentials.secret=secret
 quarkus.oidc.code-flow-verify-id-and-access-tokens.application-type=web-app
 quarkus.oidc.code-flow-verify-id-and-access-tokens.token.audience=any
 
+quarkus.oidc.code-flow-opaque-access-token.provider=github
+quarkus.oidc.code-flow-opaque-access-token.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.code-flow-opaque-access-token.authorization-path=/
+quarkus.oidc.code-flow-opaque-access-token.token-path=${keycloak.url}/realms/quarkus/opaque-access-token
+quarkus.oidc.code-flow-opaque-access-token.user-info-path=protocol/openid-connect/userinfo
+quarkus.oidc.code-flow-opaque-access-token.client-id=quarkus-web-app
+quarkus.oidc.code-flow-opaque-access-token.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+quarkus.oidc.code-flow-opaque-access-token.tenant-paths=/code-flow-opaque-access-token/*
+
 quarkus.oidc.code-flow-encrypted-id-token-jwk.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-encrypted-id-token-jwk.client-id=quarkus-web-app
 quarkus.oidc.code-flow-encrypted-id-token-jwk.credentials.secret=secret

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -37,6 +38,7 @@ import javax.crypto.SecretKey;
 import org.awaitility.core.ThrowingRunnable;
 import org.eclipse.microprofile.jwt.Claims;
 import org.hamcrest.Matchers;
+import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.TextPage;
 import org.htmlunit.WebClient;
@@ -104,6 +106,33 @@ public class CodeFlowAuthorizationTest {
             assertEquals("Welcome, clientId: quarkus-web-app", textPage.getContent());
             assertNull(getSessionCookie(webClient, "code-flow"));
             // Clear the post logout cookie
+            webClient.getCookieManager().clearCookies();
+        }
+        clearCache();
+    }
+
+    @Test
+    public void testCodeFlowOpaqueAccessToken() throws IOException {
+        defineCodeFlowOpaqueAccessTokenStub();
+        try (final WebClient webClient = createWebClient()) {
+            webClient.getOptions().setRedirectEnabled(true);
+            HtmlPage page = webClient.getPage("http://localhost:8081/code-flow-opaque-access-token");
+
+            HtmlForm form = page.getFormByName("form");
+            form.getInputByName("username").type("alice");
+            form.getInputByName("password").type("alice");
+
+            TextPage textPage = form.getInputByValue("login").click();
+
+            assertEquals("alice", textPage.getContent());
+
+            try {
+                webClient.getPage("http://localhost:8081/code-flow-opaque-access-token/jwt-access-token");
+                fail("500 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(500, ex.getStatusCode());
+            }
+
             webClient.getCookieManager().clearCookies();
         }
         clearCache();
@@ -674,6 +703,16 @@ public class CodeFlowAuthorizationTest {
                                                 .jws()
                                                 .keyId("1").sign("privateKey.jwk"))));
 
+    }
+
+    private void defineCodeFlowOpaqueAccessTokenStub() {
+        wireMockServer
+                .stubFor(WireMock.post(urlPathMatching("/auth/realms/quarkus/opaque-access-token"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "  \"access_token\": \"alice\","
+                                        + "\"expires_in\": 299}")));
     }
 
     private String generateAlreadyExpiredRefreshToken() {


### PR DESCRIPTION
Fixes #43583.

This PR is about 

1) Avoiding an internal ID token verification when  `JsonWebToken` injected by mistake but `not accessed` from the code, even if the OAuth2 providers return binary/opaque access tokens 

2) Users getting a correct error message when they attempt to access the access token using `JsonWebToken` API but the OAuth2 providers return opaque/binary access tokens 

For example, in case of Github, when they have

```
class GithubService {
@Inject JsonWebToken jwt;
}
```
then any method which attempts to access the Githib binary access token as `jwt`, will get, instead of the confusing error such as:

```
2024-09-27 16:21:07,764 ERROR [io.qua.oid.run.CodeAuthenticationMechanism] (vert.x-eventloop-thread-2) ID token verification has failed:
Token issued to client 686026e8cf211de572f8 can not be introspected because the introspection endpoint address is unknown - please check if your OpenId Connect Provider supports the token introspection
```

a more appropriate, here in devmode:
```
Exception in GithubService.java:26
	  24      @Path("/login")
	  25      public String userinfo() {
	→ 26  	    return jwt.getName() + userInfo.getUserInfoString();
	  27  	}
	  28      

The stacktrace below has been reversed to show the root cause first. [See the original stacktrace](http://localhost:8080/login)

io.quarkus.oidc.OIDCException: Opaque access token can not be converted to JsonWebToken
	at io.quarkus.oidc.runtime.OidcJsonWebTokenProducer.getTokenCredential(OidcJsonWebTokenProducer.java:67)
```

It will make it possible nearly immediately identify the problem which is about the user attempting to use a wrong API to access the binary token. Unfortunately we can't detect it at build time, for ex, we know, Github returns binary access tokens, but this is not part of any contract, the format can change any time.

So PR just makes sure that a check for a self-signed ID token is done correctly in both of the code branches where an ID tokne verification is attempted, with and without the initial code flow access token verification.

The added test confirms that, with a provider returning an opaque access token (value = `alice` - to match the OidcWiremock stub rule), the endpoint method works as expected if an inject `JsonWebToken` is not accessed, but fails with the server error otherwise.

It all may be a bit confusing, but all in all, it is really about improving the user experience when they make a mistake with trying to access opaque access tokens as JSON web tokens. The fix is very simple - encapsulate the code which checks how to proceed with the ID token verification into  a utility method and call it from both places where it is necessary
