### PR TITLE
Watch for index.html creation

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/StaticResourcesProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/StaticResourcesProcessor.java
@@ -14,9 +14,11 @@ import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
@@ -30,6 +32,12 @@ import io.quarkus.vertx.http.runtime.StaticResourcesRecorder;
  * Handles all static file resources found in {@code META-INF/resources} unless the servlet container is present.
  */
 public class StaticResourcesProcessor {
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    HotDeploymentWatchedFileBuildItem indexHtmlFile() {
+        String staticRoot = StaticResourcesRecorder.META_INF_RESOURCES + "/index.html";
+        return new HotDeploymentWatchedFileBuildItem(staticRoot, !QuarkusClassLoader.isResourcePresentAtRuntime(staticRoot));
+    }
 
     @BuildStep
     void collectStaticResources(Capabilities capabilities,

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-welcome.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-welcome.js
@@ -113,6 +113,9 @@ export class QwcWelcome extends LitElement {
             margin-top: 1rem;
             font-weight: 200;
         }
+        #quarkus-logo-svg {
+            cursor: pointer;
+        }
     `;
 
     static properties = {
@@ -133,7 +136,7 @@ export class QwcWelcome extends LitElement {
 
     render() {
         return html`<div class="fullscreen">
-                        <div class="header">
+                        <div class="header" @click=${this._reload}>
                             <svg id="quarkus-logo-svg" data-name="Quarkus Logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 195">
                                 <defs>
                                     <style>.cls-1 {
@@ -213,6 +216,10 @@ export class QwcWelcome extends LitElement {
                             </div>
                         </div>    
                     </div>`;
+    }
+    
+    _reload(){
+        window.location.href = '/';
     }
     
     _renderEndpoints(){

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUIBuildTimeStaticHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUIBuildTimeStaticHandler.java
@@ -61,7 +61,6 @@ public class DevUIBuildTimeStaticHandler implements Handler<RoutingContext> {
                             .putHeader(CONTENT_TYPE, getMimeType(fileName))
                             .end(Buffer.buffer(content));
                 } catch (IOException ex) {
-                    ex.printStackTrace();
                     event.next();
                 }
             } else {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUIWebSocket.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUIWebSocket.java
@@ -36,8 +36,12 @@ public class DevUIWebSocket implements Handler<RoutingContext> {
     }
 
     private void addSocket(ServerWebSocket session) {
-        JsonRpcRouter jsonRpcRouter = CDI.current().select(JsonRpcRouter.class).get();
-        jsonRpcRouter.addSocket(session);
+        try {
+            JsonRpcRouter jsonRpcRouter = CDI.current().select(JsonRpcRouter.class).get();
+            jsonRpcRouter.addSocket(session);
+        } catch (IllegalStateException ise) {
+            LOG.debug("Failed to connect to dev ui communication server, " + ise.getMessage());
+        }
     }
 
     private static final String UPGRADE = "Upgrade";

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/FileSystemStaticHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/FileSystemStaticHandler.java
@@ -130,7 +130,7 @@ public class FileSystemStaticHandler implements Handler<RoutingContext>, Closeab
         Path found = null;
         for (Path root : resolvedWebRoots) {
             Path resolved = root.resolve(path);
-            if (Files.exists(resolved)) {
+            if (resolved.getFileSystem().isOpen() && Files.exists(resolved)) {
                 found = resolved;
                 break;
             }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/StaticResourcesHotReplacementSetup.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/StaticResourcesHotReplacementSetup.java
@@ -1,6 +1,5 @@
 package io.quarkus.vertx.http.runtime.devmode;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,9 +33,7 @@ public class StaticResourcesHotReplacementSetup implements HotReplacementSetup {
 
     private void addPathIfContainsStaticResources(List<Path> resources, Path resourceDir) {
         Path resource = resourceDir.resolve(StaticResourcesRecorder.META_INF_RESOURCES);
-        if (Files.exists(resource)) {
-            resources.add(resource);
-        }
+        resources.add(resource);
     }
 
 }


### PR DESCRIPTION
Fix #40829

In this PR:

- Added a watch for index.html
- Make sure to always watch META-INF for changes
- Clean up some stacktraces that print in the log
- Make the logo in the welcome page clickable, so when you created your own index.html, you can click the logo to re-try

![index](https://github.com/user-attachments/assets/4edcf73f-b99e-4264-8d9c-6303ae13f3c2)
