### PR TITLE
OIDC: Encapsulate static/dynamic tenants maps in `TenantConfigBean`

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -112,7 +112,7 @@ public class DefaultTenantConfigResolver {
                         final String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
 
                         if (tenantId != null && !isTenantSetByAnnotation(context, tenantId)) {
-                            TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                            TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                             if (tenantContext != null) {
                                 return Uni.createFrom().item(tenantContext.getOidcTenantConfig());
                             }
@@ -197,7 +197,7 @@ public class DefaultTenantConfigResolver {
     }
 
     private TenantConfigContext getStaticTenantContext(String tenantId) {
-        TenantConfigContext configContext = tenantId != null ? tenantConfigBean.getStaticTenantsConfig().get(tenantId) : null;
+        var configContext = tenantId != null ? tenantConfigBean.getStaticTenant(tenantId) : null;
         if (configContext == null) {
             if (tenantId != null && !tenantId.isEmpty()) {
                 LOG.debugf(
@@ -261,18 +261,18 @@ public class DefaultTenantConfigResolver {
             @Override
             public Uni<? extends TenantConfigContext> apply(OidcTenantConfig tenantConfig) {
                 if (tenantConfig != null) {
-                    String tenantId = tenantConfig.getTenantId()
+                    var tenantId = tenantConfig.getTenantId()
                             .orElseThrow(() -> new OIDCException("Tenant configuration must have tenant id"));
-                    TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                    var tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                     if (tenantContext == null) {
-                        return tenantConfigBean.getTenantConfigContextFactory().apply(tenantConfig);
+                        return tenantConfigBean.createDynamicTenantContext(tenantConfig);
                     } else {
                         return Uni.createFrom().item(tenantContext);
                     }
                 } else {
                     final String tenantId = context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
                     if (tenantId != null && !isTenantSetByAnnotation(context, tenantId)) {
-                        TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenantsConfig().get(tenantId);
+                        TenantConfigContext tenantContext = tenantConfigBean.getDynamicTenant(tenantId);
                         if (tenantContext != null) {
                             return Uni.createFrom().item(tenantContext);
                         }
@@ -304,14 +304,11 @@ public class DefaultTenantConfigResolver {
             return tenantConfigBean.getDefaultTenant().getOidcTenantConfig();
         }
 
-        if (tenantConfigBean.getStaticTenantsConfig().containsKey(sessionTenantId)) {
-            return tenantConfigBean.getStaticTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
+        var tenant = tenantConfigBean.getStaticTenant(sessionTenantId);
+        if (tenant == null) {
+            tenant = tenantConfigBean.getDynamicTenant(sessionTenantId);
         }
-
-        if (tenantConfigBean.getDynamicTenantsConfig().containsKey(sessionTenantId)) {
-            return tenantConfigBean.getDynamicTenantsConfig().get(sessionTenantId).getOidcTenantConfig();
-        }
-        return null;
+        return tenant != null ? tenant.getOidcTenantConfig() : null;
     }
 
     public String getRootPath() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
@@ -92,7 +92,7 @@ final class StaticTenantResolver {
             String[] pathSegments = context.request().path().split("/");
             if (pathSegments.length > 0) {
                 String lastPathSegment = pathSegments[pathSegments.length - 1];
-                if (tenantConfigBean.getStaticTenantsConfig().containsKey(lastPathSegment)) {
+                if (tenantConfigBean.getStaticTenant(lastPathSegment) != null) {
                     LOG.debugf(
                             "Tenant id '%s' is selected on the '%s' request path", lastPathSegment, context.normalizedPath());
                     return lastPathSegment;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -1,6 +1,5 @@
 package io.quarkus.oidc.runtime;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -17,7 +16,6 @@ public class TenantConfigBean {
     private final Map<String, TenantConfigContext> dynamicTenantsConfig;
     private final TenantConfigContext defaultTenant;
     private final TenantContextFactory tenantContextFactory;
-    private final Map<String, TenantConfigContext> unmodifiableDynamicTenants;
 
     @FunctionalInterface
     public interface TenantContextFactory {
@@ -30,7 +28,6 @@ public class TenantConfigBean {
             TenantContextFactory tenantContextFactory) {
         this.staticTenantsConfig = Map.copyOf(staticTenantsConfig);
         this.dynamicTenantsConfig = new ConcurrentHashMap<>();
-        this.unmodifiableDynamicTenants = Collections.unmodifiableMap(dynamicTenantsConfig);
         this.defaultTenant = defaultTenant;
         this.tenantContextFactory = tenantContextFactory;
     }
@@ -63,11 +60,6 @@ public class TenantConfigBean {
 
     public TenantConfigContext getDefaultTenant() {
         return defaultTenant;
-    }
-
-    @SuppressWarnings("unused") // retained for ABI compatibility
-    public Map<String, TenantConfigContext> getDynamicTenantsConfig() {
-        return unmodifiableDynamicTenants;
     }
 
     public TenantConfigContext getDynamicTenant(String tenantId) {

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -62,7 +62,7 @@ public class ProtectedResource {
     }
 
     private String getClientName() {
-        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenantsConfig().get(session.getTenantId())
+        OidcTenantConfig oidcConfig = tenantConfigBean.getDynamicTenant(session.getTenantId())
                 .getOidcTenantConfig();
         return oidcConfig.getClientName().get();
     }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
@@ -39,7 +39,7 @@ public class TenantRefresh {
             // Cookie format: jwt|<tenant id>
 
             String[] pair = sessionExpired.split("\\|");
-            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenantsConfig().get(pair[1]).getOidcTenantConfig();
+            OidcTenantConfig oidcConfig = tenantConfig.getStaticTenant(pair[1]).getOidcTenantConfig();
             JsonWebToken jwt = new DefaultJWTParser().decrypt(pair[0], oidcConfig.credentials.secret.get());
 
             OidcUtils.removeCookie(context, oidcConfig, "session_expired");


### PR DESCRIPTION
Lets `TenantConfigBean` be the sole "owner" of the static/dynamic tenants maps, adds/changes accessor methods for tenants. Also introduces a functional interface to create tenants.

No functional change, only moving code around.