### PR TITLE
Keycloak container consumes too much memory in devmode

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -10,6 +10,7 @@ import io.quarkus.oidc.deployment.DevUiConfig;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.configuration.MemorySize;
 
 @ConfigGroup
 public class DevServicesConfig {
@@ -254,6 +255,14 @@ public class DevServicesConfig {
     @ConfigDocMapKey("environment-variable-name")
     public Map<String, String> containerEnv;
 
+    /**
+     * Memory limit for Keycloak container
+     * </p>
+     * If not specified, 750MiB is the default memory limit.
+     */
+    @ConfigItem(defaultValue = "750M")
+    public MemorySize containerMemoryLimit;
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -271,11 +280,12 @@ public class DevServicesConfig {
                 && Objects.equals(users, that.users)
                 && Objects.equals(javaOpts, that.javaOpts)
                 && Objects.equals(roles, that.roles)
-                && Objects.equals(containerEnv, that.containerEnv);
+                && Objects.equals(containerEnv, that.containerEnv)
+                && Objects.equals(containerMemoryLimit, that.containerMemoryLimit);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, imageName, port, realmPath, realmName, users, roles, containerEnv);
+        return Objects.hash(enabled, imageName, port, realmPath, realmName, users, roles, containerEnv, containerMemoryLimit);
     }
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -65,6 +65,7 @@ import io.quarkus.oidc.deployment.devservices.OidcDevServicesBuildItem;
 import io.quarkus.oidc.runtime.devui.OidcDevServicesUtils;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
+import io.quarkus.runtime.configuration.MemorySize;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
@@ -377,6 +378,7 @@ public class KeycloakDevServicesProcessor {
                     capturedDevServicesConfiguration.javaOpts,
                     capturedDevServicesConfiguration.startCommand,
                     capturedDevServicesConfiguration.showLogs,
+                    capturedDevServicesConfiguration.containerMemoryLimit,
                     errors);
 
             timeout.ifPresent(oidcContainer::withStartupTimeout);
@@ -449,12 +451,13 @@ public class KeycloakDevServicesProcessor {
         private List<RealmRepresentation> realmReps = new LinkedList<>();
         private final Optional<String> startCommand;
         private final boolean showLogs;
+        private final MemorySize containerMemoryLimit;
         private final List<String> errors;
 
         public QuarkusOidcContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort, boolean useSharedNetwork,
                 List<String> realmPaths, Map<String, String> resources, String containerLabelValue,
                 boolean sharedContainer, Optional<String> javaOpts, Optional<String> startCommand, boolean showLogs,
-                List<String> errors) {
+                MemorySize containerMemoryLimit, List<String> errors) {
             super(dockerImageName);
 
             this.useSharedNetwork = useSharedNetwork;
@@ -475,6 +478,7 @@ public class KeycloakDevServicesProcessor {
             this.fixedExposedPort = fixedExposedPort;
             this.startCommand = startCommand;
             this.showLogs = showLogs;
+            this.containerMemoryLimit = containerMemoryLimit;
             this.errors = errors;
 
             super.setWaitStrategy(Wait.forLogMessage(".*Keycloak.*started.*", 1));
@@ -548,6 +552,13 @@ public class KeycloakDevServicesProcessor {
                     LOG.info("Keycloak: " + t.getUtf8StringWithoutLineEnding());
                 });
             }
+
+            super.withCreateContainerCmdModifier((container) -> Optional.ofNullable(container.getHostConfig())
+                    .ifPresent(hostConfig -> {
+                        final var limit = containerMemoryLimit.asLongValue();
+                        hostConfig.withMemory(limit);
+                        LOG.debug("Set container memory limit (bytes): " + limit);
+                    }));
 
             LOG.infof("Using %s powered Keycloak distribution", keycloakX ? "Quarkus" : "WildFly");
         }


### PR DESCRIPTION
- Fixes #41813

## Overview 

The unset container memory limit is the cause of the issue, for sure. 

In Keycloak 24, we introduced a different behavior for memory settings as these values are mostly relative to the whole available memory of the node/machine/agent (see [here](https://www.keycloak.org/2024/03/keycloak-2400-released#_different_jvm_memory_settings_when_running_in_container)). 

In that case, it is required to set the container limit for Keycloak, otherwise expect a rapid increase of memory consumption (see [here](https://www.keycloak.org/server/containers#_specifying_different_memory_settings)).

Since Keycloak 25, Argon2 is the new default password hashing algorithm, that requires more memory than the algorithm before.

Therefore, I'd propose to introduce the ability to set the container limit for Keycloak Dev service with some reasonable default value.

I would not amend the JVM options (as in https://github.com/quarkusio/quarkus/pull/41833), as they can be changed in the future and the maintainability would be worse.

cc: @sberyozkin @gsmet @fedinskiy 

------------------------------------
## Proposed changes

- Provide the config option for container memory limit
- Set 750MiB as the default container limit (should be sufficient for dev service like this --> see [here](https://www.keycloak.org/server/containers#_specifying_different_memory_settings))

### Verification
I cannot find an existing test case for new config options.

Memory consumption verification based on the `podman stats` and created 5 realms.

**OLD** (limit = node memory = 32GiB):
```
ID            NAME        CPU %       MEM USAGE / LIMIT  MEM %       NET IO            BLOCK IO           PIDS        CPU TIME      AVG CPU %
901f13e0f8d5  kind_kilby  83.04%      888.8MB / 33.34GB  2.67%       1.78kB / 22.19kB  92.58MB / 4.334MB  120         2m53.976208s  179.75%

```

**NEW** (limit = 750MiB):
```
ID            NAME             CPU %       MEM USAGE / LIMIT  MEM %       NET IO            BLOCK IO           PIDS        CPU TIME      AVG CPU %
185b7a567958  exciting_cannon  0.52%       611.7MB / 786.4MB  77.78%      1.64kB / 21.45kB  82.44MB / 3.654MB  118         1m45.389621s  161.24%
```

The **OLD** memory can grow until the container limit, so it should be limited.

@fedinskiy Could you please test this solution in your deployment? Same as you mentioned in the issue description? Thanks!