### PR TITLE
OIDC: Cosmetic code changes

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -51,6 +51,7 @@ public class BackChannelLogoutHandler {
         }
     }
 
+    @SuppressWarnings("Convert2Lambda")
     class RouteHandler implements Handler<RoutingContext> {
         private final OidcTenantConfig oidcTenantConfig;
 
@@ -60,7 +61,7 @@ public class BackChannelLogoutHandler {
 
         @Override
         public void handle(RoutingContext context) {
-            LOG.debugf("Back channel logout request for the tenant %s received", oidcTenantConfig.getTenantId().get());
+            LOG.debugf("Back channel logout request for the tenant %s received", oidcTenantConfig.getTenantId().orElseThrow());
             final String requestPath = context.request().path();
             final TenantConfigContext tenantContext = getTenantConfigContext(requestPath);
             if (tenantContext == null) {
@@ -75,7 +76,7 @@ public class BackChannelLogoutHandler {
 
             if (OidcUtils.isFormUrlEncodedRequest(context)) {
                 OidcUtils.getFormUrlEncodedData(context)
-                        .subscribe().with(new Consumer<MultiMap>() {
+                        .subscribe().with(new Consumer<>() {
                             @Override
                             public void accept(MultiMap form) {
 
@@ -94,7 +95,7 @@ public class BackChannelLogoutHandler {
                                             String key = result.localVerificationResult
                                                     .getString(oidcTenantConfig.logout.backchannel.logoutTokenKey);
                                             BackChannelLogoutTokenCache tokens = resolver
-                                                    .getBackChannelLogoutTokens().get(oidcTenantConfig.tenantId.get());
+                                                    .getBackChannelLogoutTokens().get(oidcTenantConfig.tenantId.orElseThrow());
                                             if (tokens == null) {
                                                 tokens = new BackChannelLogoutTokenCache(oidcTenantConfig, context.vertx());
                                                 resolver.getBackChannelLogoutTokens().put(oidcTenantConfig.tenantId.get(),
@@ -163,7 +164,7 @@ public class BackChannelLogoutHandler {
 
         private boolean isMatchingTenant(String requestPath, TenantConfigContext tenant) {
             return tenant.oidcConfig().isTenantEnabled()
-                    && tenant.oidcConfig().getTenantId().get().equals(oidcTenantConfig.getTenantId().get())
+                    && tenant.oidcConfig().getTenantId().orElseThrow().equals(oidcTenantConfig.getTenantId().orElseThrow())
                     && requestPath.equals(getRootPath() + tenant.oidcConfig().logout.backchannel.path.orElse(null));
         }
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LazyTenantConfigContext.java
@@ -29,7 +29,7 @@ final class LazyTenantConfigContext implements TenantConfigContext {
     public Uni<TenantConfigContext> initialize() {
         if (!delegate.ready()) {
             LOG.debugf("Tenant '%s' is not initialized yet, trying to create OIDC connection now",
-                    delegate.oidcConfig().tenantId.get());
+                    delegate.oidcConfig().tenantId.orElseThrow());
             return staticTenantCreator.get().invoke(ctx -> LazyTenantConfigContext.this.delegate = ctx);
         }
         return Uni.createFrom().item(delegate);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -68,6 +68,7 @@ public class TenantConfigBean {
 
     public static class Destroyer implements BeanDestroyer<TenantConfigBean> {
 
+        @SuppressWarnings("resource") // TenantConfigContext.provider is an AutoCloseable
         @Override
         public void destroy(TenantConfigBean instance, CreationalContext<TenantConfigBean> creationalContext,
                 Map<String, Object> params) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContextImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContextImpl.java
@@ -98,8 +98,7 @@ final class TenantConfigContextImpl implements TenantConfigContext {
             try {
                 if (stateSecret == null) {
                     LOG.debug("Secret key for encrypting state cookie is missing, auto-generating it");
-                    SecretKey key = OidcCommonUtils.generateSecretKey();
-                    return key;
+                    return OidcCommonUtils.generateSecretKey();
                 }
                 byte[] secretBytes = stateSecret.getBytes(StandardCharsets.UTF_8);
                 if (secretBytes.length < 32) {
@@ -123,7 +122,7 @@ final class TenantConfigContextImpl implements TenantConfigContext {
 
     private static SecretKey createTokenEncSecretKey(OidcTenantConfig config, OidcProvider provider) {
         if (config.tokenStateManager.encryptionRequired) {
-            String encSecret = null;
+            String encSecret;
             if (config.tokenStateManager.encryptionSecret.isPresent()) {
                 encSecret = config.tokenStateManager.encryptionSecret.get();
             } else {
@@ -226,10 +225,10 @@ final class TenantConfigContextImpl implements TenantConfigContext {
             Redirect redirect = ClientProxy.unwrap(filter).getClass().getAnnotation(Redirect.class);
             if (redirect != null) {
                 for (Redirect.Location loc : redirect.value()) {
-                    map.computeIfAbsent(loc, k -> new ArrayList<OidcRedirectFilter>()).add(filter);
+                    map.computeIfAbsent(loc, k -> new ArrayList<>()).add(filter);
                 }
             } else {
-                map.computeIfAbsent(Redirect.Location.ALL, k -> new ArrayList<OidcRedirectFilter>()).add(filter);
+                map.computeIfAbsent(Redirect.Location.ALL, k -> new ArrayList<>()).add(filter);
             }
         }
         return map;
@@ -244,7 +243,7 @@ final class TenantConfigContextImpl implements TenantConfigContext {
         }
         if (typeSpecific != null && all == null) {
             return typeSpecific;
-        } else if (typeSpecific == null && all != null) {
+        } else if (typeSpecific == null) {
             return all;
         } else {
             List<OidcRedirectFilter> combined = new ArrayList<>(typeSpecific.size() + all.size());


### PR DESCRIPTION
Cosmetic code changes to reduce the number of warnings in IDEs.

* Some `@SuppressWarning`s
* `Optional.get()` -> `Optional.orElseThrow()`
* `Optional.isEmpty()` intead of `!isPresent()`
* Inline variables
* Cast instead of `Class.cast`
* One less `Arc.container.instance().get()`
* Remove unnecessary assignments
* Remove unnecessary (always true) `if` condition