### PR TITLE
Disable locales/some testDefaultLocale with GraalVM >= 24.2

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -195,6 +195,7 @@ public final class GraalVM {
         public static final Version VERSION_23_1_3 = new Version("GraalVM 23.1.3", "23.1.3", "21", Distribution.GRAALVM);
         public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", "22", Distribution.GRAALVM);
         public static final Version VERSION_24_0_999 = new Version("GraalVM 24.0.999", "24.0.999", "22", Distribution.GRAALVM);
+        public static final Version VERSION_24_1_0 = new Version("GraalVM 24.1.0", "24.1.0", "23", Distribution.GRAALVM);
 
         /**
          * The minimum version of GraalVM supported by Quarkus.

--- a/integration-tests/locales/some/src/test/java/io/quarkus/locales/it/LocalesIT.java
+++ b/integration-tests/locales/some/src/test/java/io/quarkus/locales/it/LocalesIT.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import io.quarkus.test.junit.DisableIfBuiltWithGraalVMNewerThan;
+import io.quarkus.test.junit.GraalVMVersion;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 
@@ -80,7 +82,10 @@ public class LocalesIT {
                 .log().all();
     }
 
+    // Disable test with GraalVM 24.2 for JDK 24 and later till we reach a conclusion in
+    // https://github.com/quarkusio/quarkus/discussions/43533
     @Test
+    @DisableIfBuiltWithGraalVMNewerThan(value = GraalVMVersion.GRAALVM_24_1_0)
     public void testDefaultLocale() {
         RestAssured.given().when()
                 .get("/default/de-CH")

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
@@ -6,7 +6,8 @@ public enum GraalVMVersion {
     GRAALVM_23_1_2(GraalVM.Version.VERSION_23_1_2),
     GRAALVM_23_1_3(GraalVM.Version.VERSION_23_1_3),
     GRAALVM_24_0_0(GraalVM.Version.VERSION_24_0_0),
-    GRAALVM_24_0_999(GraalVM.Version.VERSION_24_0_999);
+    GRAALVM_24_0_999(GraalVM.Version.VERSION_24_0_999),
+    GRAALVM_24_1_0(GraalVM.Version.VERSION_24_1_0);
 
     private final GraalVM.Version version;
 


### PR DESCRIPTION
Disable test with GraalVM 24.2 for JDK 24 and later till we reach a conclusion in https://github.com/quarkusio/quarkus/discussions/43533 on how to handle the new behaviour
