### PR TITLE
Document default connectionPoolSize of RestClient

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -143,6 +143,7 @@ public interface RestClientsConfig {
      * <p>
      * Can be overwritten by client-specific settings.
      */
+    @ConfigDocDefault("20")
     Optional<Integer> connectionPoolSize();
 
     /**


### PR DESCRIPTION
provided by org.jboss.resteasy.reactive.client.impl.ClientImpl.DEFAULT_CONNECTION_POOL_SIZE