### PR TITLE
Fix how OTLP protocol and port are used in LGTM, upgrade LGTM image version

### DIFF
--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
@@ -4,7 +4,7 @@ public final class ContainerConstants {
 
     // Images
 
-    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.6.0";
+    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.7.5";
 
     // Ports
 
@@ -12,4 +12,6 @@ public final class ContainerConstants {
 
     public static final int OTEL_GRPC_EXPORTER_PORT = 4317;
     public static final int OTEL_HTTP_EXPORTER_PORT = 4318;
+
+    public static final String OTEL_HTTP_PROTOCOL = "http/protobuf";
 }

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
@@ -28,9 +28,13 @@ public interface LgtmConfig extends GrafanaConfig {
     @WithDefault("quarkus-dev-service-lgtm")
     String label();
 
+    // this is duplicated for a reason - not all collectors speak grpc,
+    // which is the default in OTEL exporter,
+    // where we want http as a default with LGTM
+
     /**
-     * The port on which LGTM's OTLP port will be exposed.
+     * The LGTM's OTLP protocol.
      */
-    @WithDefault("4318")
-    int otlpPort();
+    @WithDefault(ContainerConstants.OTEL_HTTP_PROTOCOL)
+    String otlpProtocol();
 }

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
@@ -41,7 +41,7 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
 
     public LgtmContainer(LgtmConfig config) {
         super(config);
-        addExposedPorts(config.otlpPort());
+        addExposedPorts(getOtlpPortInternal());
         // cannot override grafana-dashboards.yaml in the container because it's on a version dependent path:
         // ./grafana-v11.0.0/conf/provisioning/dashboards/grafana-dashboards.yaml
         // will replace contents of current dashboards
@@ -59,8 +59,18 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
 
     }
 
+    public String getOtlpProtocol() {
+        return config.otlpProtocol();
+    }
+
     public int getOtlpPort() {
-        return getMappedPort(config.otlpPort());
+        int port = getOtlpPortInternal();
+        return getMappedPort(port);
+    }
+
+    private int getOtlpPortInternal() {
+        return ContainerConstants.OTEL_HTTP_PROTOCOL.equals(getOtlpProtocol()) ? ContainerConstants.OTEL_HTTP_EXPORTER_PORT
+                : ContainerConstants.OTEL_GRPC_EXPORTER_PORT;
     }
 
     private String getPrometheusConfig() {
@@ -87,8 +97,8 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
         }
 
         @Override
-        public int otlpPort() {
-            return ContainerConstants.OTEL_HTTP_EXPORTER_PORT;
+        public String otlpProtocol() {
+            return ContainerConstants.OTEL_HTTP_PROTOCOL;
         }
     }
 }

--- a/extensions/observability-devservices/testlibs/devresource-lgtm/src/main/java/io/quarkus/observability/devresource/lgtm/LgtmResource.java
+++ b/extensions/observability-devservices/testlibs/devresource-lgtm/src/main/java/io/quarkus/observability/devresource/lgtm/LgtmResource.java
@@ -63,7 +63,7 @@ public class LgtmResource extends ContainerResource<LgtmContainer, LgtmConfig> {
         if (catalog != null && catalog.hasOpenTelemetry()) {
             containerConfigs.put("quarkus.otel.exporter.otlp.endpoint",
                     String.format("http://%s:%s", host, container.getOtlpPort()));
-            containerConfigs.put("quarkus.otel.exporter.otlp.protocol", "http/protobuf");
+            containerConfigs.put("quarkus.otel.exporter.otlp.protocol", container.getOtlpProtocol());
         }
         if (catalog != null && catalog.hasMicrometerOtlp()) {
             containerConfigs.put("quarkus.micrometer.export.otlp.url",


### PR DESCRIPTION
Map OTLP ports per protocol, so users can eventually even use gRPC as protocol -- currently this wasn't possible, HTTP was (too) hardcoded default.

Also uograde LGTM image version to 0.7.5.