### PR TITLE
Split Quarkiverse release into two workflows

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/pre-release.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/pre-release.yml
@@ -9,25 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    name: pre release
-
-    steps:
-      - uses: radcortez/project-metadata-action@master
-        name: retrieve project metadata
-        id: metadata
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          metadata-file-path: '.github/project.yml'
-
-      - name: Validate version
-        if: contains(steps.metadata.outputs.current-version, 'SNAPSHOT')
-        run: |
-          echo '::error::Cannot release a SNAPSHOT version.'
-          exit 1
+  pre-release:
+    name: Pre-Release
+    uses: quarkiverse/.github/.github/workflows/pre-release.yml@main
+    secrets: inherit

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/release-perform.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/release-perform.yml
@@ -1,0 +1,28 @@
+name: Quarkiverse Perform Release
+run-name: Perform ${{github.event.inputs.tag || github.ref_name}} Release
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+
+permissions:
+  attestations: write
+  id-token: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  perform-release:
+    name: Perform Release
+    uses: quarkiverse/.github/.github/workflows/perform-release.yml@main
+    secrets: inherit
+    with:
+      version: ${{github.event.inputs.tag || github.ref_name}}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/release-prepare.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/release-prepare.yml
@@ -1,4 +1,4 @@
-name: Quarkiverse Release
+name: Quarkiverse Prepare Release
 
 on:
   pull_request:
@@ -16,11 +16,3 @@ jobs:
     if: ${{ github.event.pull_request.merged == true}}
     uses: quarkiverse/.github/.github/workflows/prepare-release.yml@main
     secrets: inherit
-
-  perform-release:
-    name: Perform Release
-    needs: prepare-release
-    uses: quarkiverse/.github/.github/workflows/perform-release.yml@main
-    secrets: inherit
-    with:
-      version: ${{needs.prepare-release.outputs.release-version}}

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateExtensionMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateExtensionMojoIT.java
@@ -118,7 +118,8 @@ public class CreateExtensionMojoIT extends QuarkusPlatformAwareMojoTestBase {
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/.github/workflows/build.yml");
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/.github/workflows/pre-release.yml");
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/.github/workflows/quarkus-snapshot.yaml");
-        assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/.github/workflows/release.yml");
+        assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/.github/workflows/release-perform.yml");
+        assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/.github/workflows/release-prepare.yml");
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/docs/pom.xml");
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/docs/antora.yml");
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/docs/modules/ROOT/nav.adoc");

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/dir-tree.snapshot
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/dir-tree.snapshot
@@ -9,7 +9,8 @@ quarkus-my-quarkiverse-ext/.github/workflows/build.yml
 quarkus-my-quarkiverse-ext/.github/workflows/deploy-snapshots.yml.disabled
 quarkus-my-quarkiverse-ext/.github/workflows/pre-release.yml
 quarkus-my-quarkiverse-ext/.github/workflows/quarkus-snapshot.yaml
-quarkus-my-quarkiverse-ext/.github/workflows/release.yml
+quarkus-my-quarkiverse-ext/.github/workflows/release-perform.yml
+quarkus-my-quarkiverse-ext/.github/workflows/release-prepare.yml
 quarkus-my-quarkiverse-ext/.gitignore
 quarkus-my-quarkiverse-ext/LICENSE
 quarkus-my-quarkiverse-ext/README.md

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_.github_workflows_pre-release.yml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_.github_workflows_pre-release.yml
@@ -9,25 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    name: pre release
-
-    steps:
-      - uses: radcortez/project-metadata-action@master
-        name: retrieve project metadata
-        id: metadata
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          metadata-file-path: '.github/project.yml'
-
-      - name: Validate version
-        if: contains(steps.metadata.outputs.current-version, 'SNAPSHOT')
-        run: |
-          echo '::error::Cannot release a SNAPSHOT version.'
-          exit 1
+  pre-release:
+    name: Pre-Release
+    uses: quarkiverse/.github/.github/workflows/pre-release.yml@main
+    secrets: inherit

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_.github_workflows_release-perform.yml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_.github_workflows_release-perform.yml
@@ -1,0 +1,28 @@
+name: Quarkiverse Perform Release
+run-name: Perform ${{github.event.inputs.tag || github.ref_name}} Release
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+
+permissions:
+  attestations: write
+  id-token: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  perform-release:
+    name: Perform Release
+    uses: quarkiverse/.github/.github/workflows/perform-release.yml@main
+    secrets: inherit
+    with:
+      version: ${{github.event.inputs.tag || github.ref_name}}

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_.github_workflows_release-prepare.yml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_.github_workflows_release-prepare.yml
@@ -1,4 +1,4 @@
-name: Quarkiverse Release
+name: Quarkiverse Prepare Release
 
 on:
   pull_request:
@@ -16,11 +16,3 @@ jobs:
     if: ${{ github.event.pull_request.merged == true}}
     uses: quarkiverse/.github/.github/workflows/prepare-release.yml@main
     secrets: inherit
-
-  perform-release:
-    name: Perform Release
-    needs: prepare-release
-    uses: quarkiverse/.github/.github/workflows/perform-release.yml@main
-    secrets: inherit
-    with:
-      version: ${{needs.prepare-release.outputs.release-version}}


### PR DESCRIPTION
This changes the existing Quarkiverse release workflow to two files: one to prepare a release and another to perform it (triggered when a tag is created).

- Follow-up to https://github.com/quarkusio/quarkus/pull/43290/
- Needed for https://github.com/quarkiverse/quarkiverse-devops/issues/275
