### PR TITLE
Upgrade to gradle/develocity-actions@v1.2

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Verify virtual-threads-tests.json
         run: ./.github/verify-tests-json.sh virtual-threads-tests.json integration-tests/virtual-threads/
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Initial JDK 17 Build"
@@ -418,7 +418,7 @@ jobs:
           restore-keys: |
             develocity-cache-JVM Tests - JDK ${{matrix.java.name}}-${{ github.event.pull_request.number }}-
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "JVM Tests - JDK ${{matrix.java.name}}"
@@ -540,7 +540,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java.java-version }}
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Maven Tests - JDK ${{matrix.java.name}}"
@@ -647,7 +647,7 @@ jobs:
         if: "!startsWith(matrix.java.os-name, 'windows')"
         run: ./integration-tests/gradle/update-dependencies.sh $COMMON_MAVEN_ARGS -Dscan=false
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Gradle Tests - JDK ${{matrix.java.name}}"
@@ -734,7 +734,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java.java-version }}
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Devtools Tests - JDK ${{matrix.java.name}}"
@@ -830,7 +830,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java.java-version }}
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Kubernetes Tests - JDK ${{matrix.java.name}}"
@@ -913,7 +913,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java.java-version }}
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Quickstarts Compilation - JDK ${{matrix.java.name}}"
@@ -1008,7 +1008,7 @@ jobs:
             cat <<< $(jq '.HttpHeaders += {"User-Agent": "Quarkus-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
           fi
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Native Tests - Virtual Thread - ${{matrix.category}}"
@@ -1081,7 +1081,7 @@ jobs:
       - name: Extract previously uploaded .m2 content
         run: tar -xzf m2-content.tgz -C ~
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "MicroProfile TCKs Tests"
@@ -1194,7 +1194,7 @@ jobs:
       - name: Extract previously uploaded .m2 content
         run: tar -xzf m2-content.tgz -C ~
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Native Tests - ${{matrix.category}}"

--- a/.github/workflows/develocity-publish-build-scans.yml
+++ b/.github/workflows/develocity-publish-build-scans.yml
@@ -20,13 +20,13 @@ jobs:
     steps:
       - name: Setup Build Scan link capture
         id: setup
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           add-pr-comment: false
           add-job-summary: true
       - name: Publish Maven Build Scans
         id: publish
-        uses: gradle/develocity-actions/maven-publish-build-scan@v1
+        uses: gradle/develocity-actions/maven-publish-build-scan@v1.2
         with:
           develocity-url: 'https://ge.quarkus.io'
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/native-it-selected-graalvm.yml
+++ b/.github/workflows/native-it-selected-graalvm.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Verify virtual-threads-tests.json
         run: ./.github/verify-tests-json.sh virtual-threads-tests.json integration-tests/virtual-threads/
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Initial JDK 17 Build"
@@ -266,7 +266,7 @@ jobs:
             cat <<< $(jq '.HttpHeaders += {"User-Agent": "Quarkus-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
           fi
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Native Tests - Virtual Thread - ${{matrix.category}}"
@@ -353,7 +353,7 @@ jobs:
       - name: Extract .m2/repository/io/quarkus
         run: tar -xzf m2-io-quarkus.tgz -C ~
       - name: Setup Develocity Build Scan capture
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/setup-maven@v1.2
         with:
           capture-strategy: ON_DEMAND
           job-name: "Native Tests - ${{matrix.category}}"


### PR DESCRIPTION
Bumping up from v1 to v1.2 to
- Rename `maven-setup` action to `setup-maven`
- Add run attempt number to the artifact name containing the build scan data and metadata
- Add Develocity extensions injection

Check the release notes [there](https://github.com/gradle/develocity-actions/releases) for more details