### PR TITLE
Agroal is not optional when/if we want dev services to be fired up when any JDBC driver is provided

### DIFF
--- a/extensions/jdbc/jdbc-db2/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-db2/deployment/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal-deployment</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-db2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-db2/runtime/pom.xml
@@ -25,7 +25,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-derby/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-derby/deployment/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal-deployment</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-derby/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-derby/runtime/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>

--- a/extensions/jdbc/jdbc-mariadb/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mariadb/deployment/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal-deployment</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>

--- a/extensions/jdbc/jdbc-mssql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/deployment/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal-deployment</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-mssql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/runtime/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>

--- a/extensions/jdbc/jdbc-mysql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mysql/deployment/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal-deployment</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-mysql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mysql/runtime/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.mysql</groupId>

--- a/extensions/jdbc/jdbc-oracle/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-oracle/deployment/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal-deployment</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-oracle/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-oracle/runtime/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>

--- a/extensions/jdbc/jdbc-postgresql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/deployment/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal-deployment</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -22,6 +22,16 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-oracle-deployment</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-agroal-deployment</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-agroal</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/reactive-oracle-client/runtime/pom.xml
+++ b/extensions/reactive-oracle-client/runtime/pom.xml
@@ -18,6 +18,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-oracle</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-agroal</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>


### PR DESCRIPTION
Fixes #43428 agroal is not optional when/if we want dev services to be fired up when any JDBC driver is provided

per @yrodiere suggestion, make agroal mandatory for JDBC extensions.

I kept I mind @gsmet comment : 

> "I'm not really sure how practical it would be for someone to come up with an extension for another pooling solution in the Quarkiverse. If we are already too tied to Agroal for it to happen, we could probably go one step further."

At my current employer we migrated several HikariCP DataSources to Agroal ones when we switched part of our microservices stack to Quarkus, it went smoothly, so I believe being coupled to Agroal is OK.