### PR TITLE
Undertow - Only load resources that are known

### DIFF
--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/KnownPathResourceManager.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/KnownPathResourceManager.java
@@ -66,6 +66,9 @@ public class KnownPathResourceManager implements ResourceManager {
         if (directories.contains(path)) {
             return new DirectoryResource(path);
         }
+        if (!files.contains(path)) {
+            return null;
+        }
         return underlying.getResource(path);
     }
 

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/KnownPathResourceManager.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/KnownPathResourceManager.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.NavigableSet;
 import java.util.Set;
 import java.util.SortedSet;
@@ -24,8 +23,6 @@ import io.undertow.util.ETag;
 import io.undertow.util.MimeMappings;
 
 public class KnownPathResourceManager implements ResourceManager {
-
-    public static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows");
 
     private final NavigableSet<String> files;
     private final NavigableSet<String> directories;
@@ -86,7 +83,7 @@ public class KnownPathResourceManager implements ResourceManager {
         }
 
         private String evaluatePath(String path) {
-            return path.replaceAll("\\\\", "/");
+            return path.replace('\\', '/');
         }
 
         @Override
@@ -127,9 +124,7 @@ public class KnownPathResourceManager implements ResourceManager {
         public List<Resource> list() {
             List<Resource> ret = new ArrayList<>();
             String slashPath = path.isEmpty() ? path : path + "/";
-            if (IS_WINDOWS) {
-                slashPath = slashPath.replaceAll("/", "\\\\"); // correct Windows paths
-            }
+
             SortedSet<String> fileSet = files.tailSet(slashPath);
             SortedSet<String> dirSet = directories.tailSet(slashPath);
 

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -168,7 +168,7 @@ public class UndertowDeploymentRecorder {
         hotDeploymentResourcePaths = resources;
     }
 
-    public RuntimeValue<DeploymentInfo> createDeployment(String name, Set<String> knownFile, Set<String> knownDirectories,
+    public RuntimeValue<DeploymentInfo> createDeployment(String name, Set<String> knownFiles, Set<String> knownDirectories,
             LaunchMode launchMode, ShutdownContext context, String mountPoint, String defaultCharset,
             String requestCharacterEncoding, String responseCharacterEncoding, boolean proactiveAuth,
             List<String> welcomeFiles, final boolean hasSecurityCapability) {
@@ -188,7 +188,7 @@ public class UndertowDeploymentRecorder {
         //TODO: we need better handling of static resources
         ResourceManager resourceManager;
         if (hotDeploymentResourcePaths == null) {
-            resourceManager = new KnownPathResourceManager(knownFile, knownDirectories,
+            resourceManager = new KnownPathResourceManager(knownFiles, knownDirectories,
                     new ClassPathResourceManager(d.getClassLoader(), "META-INF/resources"));
         } else {
             List<ResourceManager> managers = new ArrayList<>();

--- a/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/UndertowStaticResourcesBuildStep.java
+++ b/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/UndertowStaticResourcesBuildStep.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.runtime.LaunchMode;
+import io.smallrye.common.os.OS;
 
 /**
  * NOTE: Shared with Resteasy standalone!
@@ -103,18 +104,26 @@ public class UndertowStaticResourcesBuildStep {
     private void collectKnownPaths(Path resource, Set<String> knownFiles, Set<String> knownDirectories) {
         try {
             Files.walkFileTree(resource, new SimpleFileVisitor<Path>() {
+
                 @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                public FileVisitResult visitFile(Path path, BasicFileAttributes attrs)
                         throws IOException {
-                    knownFiles.add(resource.relativize(file).toString());
+                    knownFiles.add(normalizePath(resource.relativize(path).toString()));
                     return FileVisitResult.CONTINUE;
                 }
 
                 @Override
-                public FileVisitResult preVisitDirectory(Path file, BasicFileAttributes attrs)
+                public FileVisitResult preVisitDirectory(Path path, BasicFileAttributes attrs)
                         throws IOException {
-                    knownDirectories.add(resource.relativize(file).toString());
+                    knownDirectories.add(normalizePath(resource.relativize(path).toString()));
                     return FileVisitResult.CONTINUE;
+                }
+
+                private String normalizePath(String path) {
+                    if (OS.WINDOWS.isCurrent()) {
+                        path = path.replace('\\', '/');
+                    }
+                    return path;
                 }
             });
         } catch (IOException e) {


### PR DESCRIPTION
If we try to load every resource, we end up creating cache entries in the resourceCache CHM of the AppClassLoader, which is definitely not what we want in this case, given we are supposed to serve only known resources.

Now I must admit the fix looks a bit too simple to be true :).

Fixes #43676