### PR TITLE
Bump org.hibernate.reactive:hibernate-reactive-core from 2.4.1.Final to 2.4.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.14.18</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>7.0.1.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>2.4.1.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>2.4.2.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <hibernate-search.version>7.2.1.Final</hibernate-search.version>
 


### PR DESCRIPTION
This update fixes a couple of bugs with `@IdClass` and JSON mapping that we missed in 2.4.1.Final
See https://in.relation.to/2024/10/04/hibernate-reactive-2_4_2_Final/

FIY: @yrodiere 