### PR TITLE
Include proto unzip directory as proto import directory argument for protoc

### DIFF
--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
@@ -368,9 +368,7 @@ public class GrpcCodeGen implements CodeGenProvider {
                                         .normalize().toAbsolutePath();
                                 try {
                                     Files.createDirectories(protoUnzipDir);
-                                    if (filesToInclude.isEmpty()) {
-                                        protoDirectories.add(protoUnzipDir.toString());
-                                    }
+                                    protoDirectories.add(protoUnzipDir.toString());
                                 } catch (IOException e) {
                                     throw new GrpcCodeGenException("Failed to create directory: " + protoUnzipDir, e);
                                 }

--- a/integration-tests/grpc-external-proto-test/src/main/proto/extended.proto
+++ b/integration-tests/grpc-external-proto-test/src/main/proto/extended.proto
@@ -8,7 +8,7 @@ option optimize_for = CODE_SIZE;
 package org.acme.proto.extended;
 
 // Import the base proto file
-import "base.proto";
+import "protobuf/base.proto";
 
 // A message representing detailed user information
 message DetailedUser {

--- a/integration-tests/grpc-external-proto/src/main/resources/protobuf/base.proto
+++ b/integration-tests/grpc-external-proto/src/main/resources/protobuf/base.proto
@@ -6,7 +6,7 @@ option java_outer_classname = "BASEProtos";
 option optimize_for = CODE_SIZE;
 
 // Import the extra proto file
-import "role.proto";
+import "protobuf/role.proto";
 
 package org.acme.protos.base;
 


### PR DESCRIPTION
Relevant issue: https://github.com/quarkusio/quarkus/issues/43539

This is to fix code gen issue where `quarkus.generate-code.grpc.scan-for-proto-include` option is used and `.proto` files use imports relative to the root directory.