### PR TITLE
Fix faulty class loader

### DIFF
--- a/core/launcher/src/main/java/io/quarkus/launcher/RuntimeLaunchClassLoader.java
+++ b/core/launcher/src/main/java/io/quarkus/launcher/RuntimeLaunchClassLoader.java
@@ -1,6 +1,5 @@
 package io.quarkus.launcher;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -18,20 +17,14 @@ public class RuntimeLaunchClassLoader extends ClassLoader {
 
     @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
-        String resourceName = name.replace(".", "/") + ".class";
+        String resourceName = "META-INF/ide-deps/" + name.replace(".", "/") + ".class.ide-launcher-res";
         try {
-            try (InputStream is = getResourceAsStream(resourceName)) {
+            try (InputStream is = getParent().getResourceAsStream(resourceName)) {
                 if (is == null) {
                     throw new ClassNotFoundException(name);
                 }
                 definePackage(name);
-                byte[] buf = new byte[1024];
-                int r;
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                while ((r = is.read(buf)) > 0) {
-                    out.write(buf, 0, r);
-                }
-                byte[] bytes = out.toByteArray();
+                byte[] bytes = is.readAllBytes();
 
                 return defineClass(name, bytes, 0, bytes.length);
             }


### PR DESCRIPTION
The class loader as it is written will always delegate to the parent class loader first looking for the bytes of the class. This is very bad if the parent class loader happens to have the class, as is the case when a JBang library overlaps with a Quarkus one. This results in the `RuntimeLauncherClassLoader` defining the class as if it found it in its own set of resources, however the class bytes actually came from the JBang class loader (all of the class loaders involved are parent-first, so it goes right up to the top).

A class loader should never search for class resources outside of its own search path (particularly in parent class loaders). So, the fix is to look for the `ide-launcher-res` resource *exclusively*. If it's not found there, we can safely fail because the class loader is parent-first, so there'd be nothing left to search anyway.

Should fix #43648, which should be rebased after this. Fixes #43681.