### PR TITLE
Update getting-started.adoc

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -252,6 +252,7 @@ package org.acme;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
@@ -262,9 +263,8 @@ public class GreetingResource {
     GreetingService service;
 
     @GET
-    @Produces(MediaType.TEXT_PLAIN)
     @Path("/greeting/{name}")
-    public String greeting(String name) {
+    public String greeting(@PathParam("name") String name) {
         return service.greeting(name);
     }
 


### PR DESCRIPTION
Fix greetings endpoint.
1) From swagger GET endpoint sends a body
![image](https://github.com/user-attachments/assets/7148e2f3-f477-40a3-9b21-18f78f941a52)

2) @Pathparam is missing and the incoming path param is not handled at all
`@Path("/greeting/{name}")
    public String greeting(String name) {
        return service.greeting(name);
    }`