### PR TITLE
Fix add command in getting-started-dev-services.adoc

### DIFF
--- a/docs/src/main/asciidoc/getting-started-dev-services.adoc
+++ b/docs/src/main/asciidoc/getting-started-dev-services.adoc
@@ -125,7 +125,7 @@ You should see in your terminal that the tests are now passing.
 
 1. To add the persistence libraries, run
 
-:add-extension-extensions: hibernate-orm-panache jdbc-postgresql
+:add-extension-extensions: hibernate-orm-panache,jdbc-postgresql
 include::{includes}/devtools/extension-add.adoc[]
 
 The application will record the names of people it greets. Define an Entity


### PR DESCRIPTION
While we might want to add support for spaces at some point, better have the command fixed.

Related to https://github.com/quarkusio/quarkus/discussions/41229