### PR TITLE
Add missing OTLP gRPC test, simplify ports usage

### DIFF
--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
@@ -13,5 +13,6 @@ public final class ContainerConstants {
     public static final int OTEL_GRPC_EXPORTER_PORT = 4317;
     public static final int OTEL_HTTP_EXPORTER_PORT = 4318;
 
+    public static final String OTEL_GRPC_PROTOCOL = "grpc";
     public static final String OTEL_HTTP_PROTOCOL = "http/protobuf";
 }

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmGrpcTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmGrpcTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.observability.test;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Simple case were we use gRPC as a OTLP protocol
+ */
+@QuarkusTest
+@TestProfile(LgtmGrpcTest.GrpcTestProfileOnly.class)
+@DisabledOnOs(OS.WINDOWS)
+public class LgtmGrpcTest extends LgtmTestBase {
+
+    public static class GrpcTestProfileOnly implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.observability.lgtm.otlp-protocol", "grpc");
+        }
+    }
+}


### PR DESCRIPTION
Test the `quarkus.observability.lgtm.otlp-protocol` usage.
Expose both - http and grpc - ports with the LTM Testcontainer.