### PR TITLE
Allow to populate Spring @RestQuery Map<String, String> with request parameter values

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CustomResourceProducersGenerator.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CustomResourceProducersGenerator.java
@@ -154,8 +154,8 @@ final class CustomResourceProducersGenerator {
                         m.getThis());
                 ResultHandle extractorHandle = m.newInstance(
                         MethodDescriptor.ofConstructor(QueryParamExtractor.class, String.class, boolean.class, boolean.class,
-                                String.class),
-                        m.getMethodParam(0), m.load(true), m.load(false), m.loadNull());
+                                String.class, boolean.class),
+                        m.getMethodParam(0), m.load(true), m.load(false), m.loadNull(), m.load(false));
                 ResultHandle resultHandle = m.invokeVirtualMethod(MethodDescriptor.ofMethod(QueryParamExtractor.class,
                         "extractParameter", Object.class, ResteasyReactiveRequestContext.class), extractorHandle,
                         quarkusRestContextHandle);

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/test/MapControllerTest.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/test/MapControllerTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.spring.web.test;
+
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class MapControllerTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MapControllerTest.MapControllers.class));
+
+    @Test
+    void ok() {
+        RestAssured.when().get("/another/ok?framework=quarkus")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("quarkus"));
+    }
+
+    @RestController
+    @RequestMapping("/another")
+    public static class MapControllers {
+        @GetMapping("/ok")
+        public String ok(@RequestParam Map<String, String> queryParams) {
+            return queryParams.get("framework");
+        }
+    }
+}

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/test/MapControllerWithExceptionTest.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/test/MapControllerWithExceptionTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.spring.web.test;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MapControllerWithExceptionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MapControllerWithExceptionTest.MapControllers.class))
+            .assertException(throwable -> {
+                Assertions.assertThat(throwable.getCause().getCause().getMessage())
+                        .contains(
+                                "Could not create converter for java.util.Map for method java.lang.String ok(java.util.Map<java.lang.String, "
+                                        +
+                                        "java.lang.String> queryParams) on class");
+            });
+
+    @Test
+    void failure() {
+    }
+
+    @RestController
+    @RequestMapping("/another")
+    public static class MapControllers {
+        @GetMapping("/ok")
+        // there is no mapping for @RestQuery with name
+        public String ok(@RequestParam(name = "failing") Map<String, String> queryParams) {
+            return queryParams.get("framework");
+        }
+    }
+}

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/test/MapResourceTest.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/test/MapResourceTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.spring.web.test;
+
+import java.util.Map;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.RestQuery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class MapResourceTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MapResourceTest.MapControllers.class));
+
+    @Test
+    void ok() {
+        RestAssured.when().get("/another/ok?framework=quarkus")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("quarkus"));
+    }
+
+    @Path("/quarkus")
+    public static class MapControllers {
+        @GET
+        public String ok(@RestQuery Map<String, String> queryParams) {
+            return queryParams.get("framework");
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
@@ -164,7 +164,7 @@ public class ClientEndpointIndexer
                 elementType, declaredTypes.getDeclaredType(), declaredTypes.getDeclaredUnresolvedType(), signature, type,
                 single,
                 defaultValue, parameterResult.isObtainedAsCollection(), parameterResult.isOptional(), encoded,
-                mimePart, partFileName, null);
+                mimePart, partFileName, null, false);
     }
 
     private String getPartFileName(Map<DotName, AnnotationInstance> annotations) {

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -31,6 +31,7 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.LOCAL_DATE_TIME;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.LOCAL_TIME;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.LONG;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MAP;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MATRIX_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MULTI;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MULTI_PART_DATA_INPUT;
@@ -1212,7 +1213,8 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                 .setField(field)
                 .setHasRuntimeConverters(hasRuntimeConverters)
                 .setPathParameters(pathParameters)
-                .setSourceName(sourceName);
+                .setSourceName(sourceName)
+                .setRestQueryMap(false);
 
         AnnotationInstance beanParam = anns.get(BEAN_PARAM);
         AnnotationInstance multiPartFormParam = anns.get(MULTI_PART_FORM_PARAM);
@@ -1388,6 +1390,14 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                             genericElementType, currentMethodInfo);
                 }
                 builder.setOptional(true);
+            } else if (isEligibleForMapAsQuery(anns, pt)) {
+                typeHandled = true;
+                builder.setSingle(false);
+                elementType = String.class.getName();
+                builder.setRestQueryMap(true);
+                handleMapParam(existingConverters, errorLocation, hasRuntimeConverters, builder,
+                        elementType,
+                        currentMethodInfo);
             } else if (convertible) {
                 typeHandled = true;
                 elementType = toClassName(pt, currentClassInfo, actualEndpointInfo, index);
@@ -1472,6 +1482,23 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         return builder;
     }
 
+    private boolean isEligibleForMapAsQuery(Map<DotName, AnnotationInstance> annotations, ParameterizedType type) {
+        AnnotationInstance annotation = annotations.get(REST_QUERY_PARAM);
+        return type.name().equals(MAP) && annotation != null &&
+                (annotation.value("name") == null ||
+                        annotation.value("name").asString().isBlank())
+                &&
+                isAValidMapStringString(type);
+    }
+
+    private boolean isAValidMapStringString(ParameterizedType parameterizedType) {
+        boolean invalidMapForInjectingQuery = parameterizedType.arguments().size() != 2;
+        if (invalidMapForInjectingQuery) {
+            return false;
+        }
+        return parameterizedType.arguments().stream().allMatch(item -> item.name().equals(DotName.createSimple(String.class)));
+    }
+
     private boolean isFormParamConvertible(Type paramType) {
         // let's not call the array converter for byte[] for multipart
         if (paramType.kind() == Kind.ARRAY
@@ -1521,6 +1548,10 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
 
     protected void handleSortedSetParam(Map<String, String> existingConverters, String errorLocation,
             boolean hasRuntimeConverters, PARAM builder, String elementType, MethodInfo currentMethodInfo) {
+    }
+
+    protected void handleMapParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,
+            PARAM builder, String elementType, MethodInfo currentMethodInfo) {
     }
 
     protected void handleOptionalParam(Map<String, String> existingConverters,

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/IndexedParameter.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/IndexedParameter.java
@@ -30,6 +30,7 @@ public class IndexedParameter<T extends IndexedParameter<T>> {
     protected boolean single;
     protected boolean optional;
     protected String separator;
+    private boolean restQueryMap;
 
     public boolean isObtainedAsCollection() {
         return !single
@@ -217,5 +218,14 @@ public class IndexedParameter<T extends IndexedParameter<T>> {
     public T setSeparator(String separator) {
         this.separator = separator;
         return (T) this;
+    }
+
+    public T setRestQueryMap(boolean restQueryMap) {
+        this.restQueryMap = restQueryMap;
+        return (T) this;
+    }
+
+    public boolean getRestQueryMap() {
+        return restQueryMap;
     }
 }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -4,7 +4,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/MethodParameter.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/MethodParameter.java
@@ -26,6 +26,7 @@ public class MethodParameter {
     public String mimeType;
     public String partFileName;
     public String separator;
+    public boolean restQueryMap;
 
     public MethodParameter() {
     }
@@ -34,7 +35,7 @@ public class MethodParameter {
             ParameterType parameterType,
             boolean single,
             String defaultValue, boolean isObtainedAsCollection, boolean optional, boolean encoded,
-            String mimeType, String partFileName, String separator) {
+            String mimeType, String partFileName, String separator, boolean restQueryMap) {
         this.name = name;
         this.type = type;
         this.declaredType = declaredType;
@@ -49,6 +50,7 @@ public class MethodParameter {
         this.mimeType = mimeType;
         this.partFileName = partFileName;
         this.separator = separator;
+        this.restQueryMap = restQueryMap;
     }
 
     public String getName() {
@@ -117,6 +119,10 @@ public class MethodParameter {
     public MethodParameter setObtainedAsCollection(boolean isObtainedAsCollection) {
         this.isObtainedAsCollection = isObtainedAsCollection;
         return this;
+    }
+
+    public boolean isRestQueryMap() {
+        return restQueryMap;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -74,6 +74,7 @@ import org.jboss.resteasy.reactive.server.core.parameters.converters.LoadedParam
 import org.jboss.resteasy.reactive.server.core.parameters.converters.LocalDateParamConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.LocalDateTimeParamConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.LocalTimeParamConverter;
+import org.jboss.resteasy.reactive.server.core.parameters.converters.MapConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.NoopParameterConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.OffsetDateTimeParamConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.OffsetTimeParamConverter;
@@ -464,7 +465,8 @@ public class ServerEndpointIndexer
                 elementType, declaredType, declaredTypes.getDeclaredUnresolvedType(),
                 type, single, signature,
                 converter, defaultValue, parameterResult.isObtainedAsCollection(), parameterResult.isOptional(), encoded,
-                parameterResult.getCustomParameterExtractor(), mimeType, parameterResult.getSeparator());
+                parameterResult.getCustomParameterExtractor(), mimeType, parameterResult.getSeparator(),
+                parameterResult.getRestQueryMap());
     }
 
     @Override
@@ -528,6 +530,14 @@ public class ServerEndpointIndexer
         ParameterConverterSupplier converter = extractConverter(elementType, index,
                 existingConverters, errorLocation, hasRuntimeConverters, builder.getAnns(), currentMethodInfo);
         builder.setConverter(new SetConverter.SetSupplier(converter));
+    }
+
+    @Override
+    protected void handleMapParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,
+            ServerIndexedParameter builder, String elementType, MethodInfo currentMethodInfo) {
+        ParameterConverterSupplier converter = extractConverter(elementType, index,
+                existingConverters, errorLocation, hasRuntimeConverters, builder.getAnns(), currentMethodInfo);
+        builder.setConverter(new MapConverter.MapSupplier(converter));
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -838,18 +839,22 @@ public abstract class ResteasyReactiveRequestContext
         }
     }
 
-    public Object getQueryParameter(String name, boolean single, boolean encoded) {
-        return getQueryParameter(name, single, encoded, null);
-    }
-
     @Override
-    public Object getQueryParameter(String name, boolean single, boolean encoded, String separator) {
+    public Object getQueryParameter(String name, boolean single, boolean encoded, String separator, boolean restQueryMap) {
         if (single) {
             String val = serverRequest().getQueryParam(name);
             if (encoded && val != null) {
                 val = Encode.encodeQueryParam(val);
             }
             return val;
+        }
+
+        if (restQueryMap) {
+            HashMap<String, String> allQueryAsMap = new HashMap<>();
+            serverRequest().queryParamNames().forEach(n -> {
+                allQueryAsMap.put(n, serverRequest().getQueryParam(n));
+            });
+            return allQueryAsMap;
         }
 
         // empty collections must not be turned to null

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/QueryParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/QueryParamExtractor.java
@@ -9,16 +9,18 @@ public class QueryParamExtractor implements ParameterExtractor {
     private final boolean single;
     private final boolean encoded;
     private final String separator;
+    private final boolean restQueryMap;
 
-    public QueryParamExtractor(String name, boolean single, boolean encoded, String separator) {
+    public QueryParamExtractor(String name, boolean single, boolean encoded, String separator, boolean restQueryMap) {
         this.name = name;
         this.single = single;
         this.encoded = encoded;
         this.separator = separator;
+        this.restQueryMap = restQueryMap;
     }
 
     @Override
     public Object extractParameter(ResteasyReactiveRequestContext context) {
-        return context.getQueryParameter(name, single, encoded, separator);
+        return context.getQueryParameter(name, single, encoded, separator, restQueryMap);
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/converters/MapConverter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/converters/MapConverter.java
@@ -1,0 +1,56 @@
+package org.jboss.resteasy.reactive.server.core.parameters.converters;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
+
+public record MapConverter(ParameterConverter delegate) implements ParameterConverter {
+
+    @Override
+    public Object convert(Object parameter) {
+        if (parameter instanceof Map) {
+            return parameter;
+        }
+
+        return Map.of();
+    }
+
+    @Override
+    public void init(ParamConverterProviders deployment, Class<?> rawType, Type genericType, Annotation[] annotations) {
+        if (delegate != null)
+            delegate.init(deployment, rawType, genericType, annotations);
+    }
+
+    public static class MapSupplier implements DelegatingParameterConverterSupplier {
+        private ParameterConverterSupplier delegate;
+
+        public MapSupplier() {
+        }
+
+        public MapSupplier(ParameterConverterSupplier converter) {
+            this.delegate = converter;
+        }
+
+        @Override
+        public ParameterConverterSupplier getDelegate() {
+            return delegate;
+        }
+
+        @Override
+        public String getClassName() {
+            return MapConverter.class.getName();
+        }
+
+        @Override
+        public ParameterConverter get() {
+            return delegate == null ? new MapConverter(null) : new MapConverter(delegate.get());
+        }
+
+        public MapConverter.MapSupplier setDelegate(ParameterConverterSupplier delegate) {
+            this.delegate = delegate;
+            return this;
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/reflection/ReflectiveContextInjectedBeanFactory.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/reflection/ReflectiveContextInjectedBeanFactory.java
@@ -90,7 +90,10 @@ public class ReflectiveContextInjectedBeanFactory<T> implements BeanFactory<T> {
                 //we need better SPI's around this
                 //we don't handle conversion at all
                 QueryParam param = i.getAnnotation(QueryParam.class);
-                constructorParams.add(() -> CurrentRequestManager.get().getQueryParameter(param.value(), true, false));
+
+                constructorParams
+                        .add(() -> CurrentRequestManager.get().getQueryParameter(param.value(), true, false, null, false));
+
             } else if (i.isAnnotationPresent(HeaderParam.class)) {
                 HeaderParam param = i.getAnnotation(HeaderParam.class);
                 constructorParams.add(() -> CurrentRequestManager.get().getHeader(param.value(), true));

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -707,7 +707,8 @@ public class RuntimeResourceDeployment {
             case ASYNC_RESPONSE:
                 return AsyncResponseExtractor.INSTANCE;
             case QUERY:
-                extractor = new QueryParamExtractor(param.name, param.isSingle(), param.encoded, param.separator);
+                extractor = new QueryParamExtractor(param.name, param.isSingle(), param.encoded, param.separator,
+                        param.restQueryMap);
                 return extractor;
             case BODY:
                 return BodyParamExtractor.INSTANCE;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionContext.java
@@ -3,7 +3,7 @@ package org.jboss.resteasy.reactive.server.injection;
 public interface ResteasyReactiveInjectionContext {
     Object getHeader(String name, boolean single);
 
-    Object getQueryParameter(String name, boolean single, boolean encoded, String separator);
+    Object getQueryParameter(String name, boolean single, boolean encoded, String separator, boolean restQueryMap);
 
     String getPathParameter(String name, boolean encoded);
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
@@ -21,10 +21,10 @@ public class ServerMethodParameter extends MethodParameter {
             ParameterConverterSupplier converter, String defaultValue, boolean obtainedAsCollection, boolean optional,
             boolean encoded,
             ParameterExtractor customParameterExtractor,
-            String mimeType, String separator) {
+            String mimeType, String separator, boolean mapAsQuery) {
         super(name, type, declaredType, declaredUnresolvedType, signature, parameterType, single, defaultValue,
                 obtainedAsCollection, optional,
-                encoded, mimeType, null /* not useful for server params */, separator);
+                encoded, mimeType, null /* not useful for server params */, separator, mapAsQuery);
         this.converter = converter;
         this.customParameterExtractor = customParameterExtractor;
     }


### PR DESCRIPTION
Fixes #43705 

## What

This pull request allows to populate a `@RequestParam() MultivaluedMap<String, String> queryParams` with the request parameter values, this is aimed to work only for Spring Boot.  

## Current behavior for `@RestQuery` using `Map<String, String>`

Actually, when the user aims to use a `MultivaluedMap<String, String>` in the server side with `@RestQuery` there is no way to convert the incoming request to the Map<String, String> object, causing an error. You can see more details in [here](https://github.com/quarkusio/quarkus/blob/40b6c912fce6a7fa95c8f4712aef2e18faa658b3/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/test/MapResourceWithExceptionTest.java) (Behind the scenes spring-web extension converts `@RequestParam Map<String, String>` to `@RestQuery`).

## Problems with this draft solution

### Problem
We are adding Spring annotation at `independents/resteasy-common`, I think that it is a not good idea because we are adding spring stuff inside resteasy modules (because it I did not add support for Spring [MultiValueMap](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/MultiValueMap.html) for now). 

### Solution

To have a intermediate annotation like `@QueryMap` inside `resteasy-common` for serving as a intermediate indicating that the argument `Map<String, String> should be populated as the request parameter values.

The problem with this solution is that the user will be able to add it in a no Spring resource, with pure Java specification. 

With this point in mind, I would like to know if it makes sense for us to implement this for pure resteasy resources. If not, would be great to show a better message error to the final user, indicating that use of the annotation is not permitted/not supported.


## Questions

- Should I add the same behavior for pure resteasy resources?
- Do you have another better solution?
- What do you think about show a better message on mapping error (`@RestQuery Map<String, String> query`)?

Any suggestions are welcome! 

cc: @geoand 