### PR TITLE
Add testcase for dynamic tests and Jackson classloading

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/DynamicTestWithJacksonTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/DynamicTestWithJacksonTestCase.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.main;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class DynamicTestWithJacksonTestCase {
+
+    @TestFactory
+    public DynamicTest test() {
+        return dynamicTest("restAssuredExample", () -> given()
+                .body(new Data()) // Uses TCCL to load Jackson
+        );
+    }
+
+    static class Data {
+        public String data;
+    }
+}


### PR DESCRIPTION
#10435 shared a reproducer, but we didn't include the reproducer in our codebase when we did the fix. This strikes me as the kind of thing that could regress, so I've added it. I couldn't definitively confirm that the reproducer, as I've added it to the codebase, fails on 1.15.2.Final, because the shape of our codebase has changed too much. The risk is that classloading is sometimes different in a `@QuarkusTest` executed as part of the main build and one done in a standalone `resources` project, and this is a classloading problem. But the standalone sub-projects are expensive to execute, and since we didn't even have a test before, I didn't want to slow down our build too much, especially if the top-level test actually would catch the problem.

I could confirm that in a standalone project, the reproducer test case failed for 1.15.2.Final and passes now, which I think is a good enough level of confidence in the test case.

Fixes #10435 (technically speaking, it doesn't, since #10435 is already fixed, but this adds a test case, which means there's no barrier at all to closing #10435 once this merges).