### PR TITLE
Dev UI custom side menu

### DIFF
--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoDevUIProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoDevUIProcessor.java
@@ -5,7 +5,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
-import io.quarkus.devui.spi.page.MenuPageBuildItem;
+import io.quarkus.devui.spi.page.ExternalPageBuilder;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.devui.spi.page.WebComponentPageBuilder;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
@@ -17,8 +17,7 @@ import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConf
 public class InfoDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    void create(BuildProducer<MenuPageBuildItem> menuPageProducer,
-            BuildProducer<CardPageBuildItem> cardPageProducer,
+    void create(BuildProducer<CardPageBuildItem> cardPageProducer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             InfoBuildTimeConfig config,
             ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
@@ -27,25 +26,20 @@ public class InfoDevUIProcessor {
         var path = nonApplicationRootPathBuildItem.resolveManagementPath(config.path(),
                 managementInterfaceBuildTimeConfig, launchModeBuildItem);
 
-        MenuPageBuildItem menuBuildItem = new MenuPageBuildItem();
-
-        menuBuildItem.addBuildTimeData("infoUrl", path);
-
         WebComponentPageBuilder infoPage = Page.webComponentPageBuilder()
                 .title("Information")
                 .icon("font-awesome-solid:circle-info")
                 .componentLink("qwc-info.js");
 
-        menuBuildItem.addPage(infoPage);
-        menuBuildItem.addPage(Page.externalPageBuilder("Raw")
+        ExternalPageBuilder rawPage = Page.externalPageBuilder("Raw")
                 .url(path)
                 .icon("font-awesome-solid:circle-info")
-                .isJsonContent());
-
-        menuPageProducer.produce(menuBuildItem);
+                .isJsonContent();
 
         CardPageBuildItem cardBuildItem = new CardPageBuildItem();
+        cardBuildItem.addBuildTimeData("infoUrl", path);
         cardBuildItem.addPage(infoPage);
+        cardBuildItem.addPage(rawPage);
         cardPageProducer.produce(cardBuildItem);
     }
 

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/devui/SmallRyeGraphQLDevUIProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/devui/SmallRyeGraphQLDevUIProcessor.java
@@ -35,8 +35,8 @@ public class SmallRyeGraphQLDevUIProcessor {
                 .doNotEmbed()
                 .url("https://graphql.org/");
 
-        cardPageBuildItem.addPage(schemaPage);
         cardPageBuildItem.addPage(uiPage);
+        cardPageBuildItem.addPage(schemaPage);
         cardPageBuildItem.addPage(learnLink);
 
         return cardPageBuildItem;

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/devui/OpenApiDevUIProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/devui/OpenApiDevUIProcessor.java
@@ -27,6 +27,11 @@ public class OpenApiDevUIProcessor {
 
         CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
 
+        cardPageBuildItem.addPage(Page.externalPageBuilder("Swagger UI")
+                .url(uiPath + "/index.html?embed=true", uiPath)
+                .isHtmlContent()
+                .icon("font-awesome-solid:signs-post"));
+
         cardPageBuildItem.addPage(Page.externalPageBuilder("Schema yaml")
                 .url(schemaPath, schemaPath)
                 .isYamlContent()
@@ -37,11 +42,6 @@ public class OpenApiDevUIProcessor {
                 .url(jsonSchema, jsonSchema)
                 .isJsonContent()
                 .icon("font-awesome-solid:file-code"));
-
-        cardPageBuildItem.addPage(Page.externalPageBuilder("Swagger UI")
-                .url(uiPath + "/index.html?embed=true", uiPath)
-                .isHtmlContent()
-                .icon("font-awesome-solid:signs-post"));
 
         return cardPageBuildItem;
     }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -42,8 +42,12 @@ export class QwcExtensions extends observeState(LitElement) {
             flex-flow: column wrap;
             padding-top: 5px;
         }
-         .float-right {
+        .float-right {
             align-self: flex-end;
+        }
+    
+        qwc-extension-link {
+            cursor: grab;
         }
        `;
 
@@ -199,9 +203,20 @@ export class QwcExtensions extends observeState(LitElement) {
                                 ?embed=${page.embed}
                                 externalUrl="${page.metadata.externalUrl}"
                                 dynamicUrlMethodName="${page.metadata.dynamicUrlMethodName}"
-                                webcomponent="${page.componentLink}" >
+                                webcomponent="${page.componentLink}" 
+                                draggable="true" @dragstart="${this._handleDragStart}">
                             </qwc-extension-link>
                         `)}`;
+    }
+
+    _handleDragStart(event) {
+        const extensionNamespace = event.currentTarget.getAttribute('namespace');
+        const pageId = event.currentTarget.getAttribute('path');
+
+        const extension = devuiState.cards.active.find(obj => obj.namespace === extensionNamespace);
+        const page = extension.cardPages.find(obj => obj.id === pageId);
+        const jsonData = JSON.stringify(page);
+        event.dataTransfer.setData('application/json', jsonData);
     }
 
     _renderInactive(extension){


### PR DESCRIPTION
Fix #43721

This PR Allows users to drag any link from an active card to the side menu to be used as a shortcut. It will remember the shortcut over all applications, and if an application does not have an extension that is added to the menu with another application, it will just be ignored. Right-click > Remove to remove it again.

![custom_menu](https://github.com/user-attachments/assets/b41424b1-0636-466d-91d2-4ae30190f960)

This PR also 
 - Removes the Information extension Menu (as this can now be added with above if the user wants it)
 - Re-order the card links on OpenAPI and GraphQL to put the (more popular) UI links first.

