### PR TITLE
Move RestClientReactiveConfig to use @ConfigMapping

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -2029,8 +2029,11 @@ To change this behavior, set the `quarkus.rest-client-reactive.scope` property t
 - it is not possible to set `HostnameVerifier` or `SSLContext`
 - a few things that don't make sense for a non-blocking implementations, such as setting the `ExecutorService`, don't work
 
-
-
 == Further reading
 
  * link:https://download.eclipse.org/microprofile/microprofile-rest-client-2.0/microprofile-rest-client-spec-2.0.html[MicroProfile Rest Client specification]
+
+== Configuration Reference
+
+include::{generated-dir}/config/quarkus-rest-client_quarkus.rest-client.adoc[opts=optional, leveloffset=+1]
+include::{generated-dir}/config/quarkus-rest-client-config.adoc[opts=optional, leveloffset=+1]

--- a/docs/src/main/asciidoc/resteasy-client.adoc
+++ b/docs/src/main/asciidoc/resteasy-client.adoc
@@ -670,3 +670,7 @@ describes how to set it up in detail.
 == Further reading
 
  * link:https://download.eclipse.org/microprofile/microprofile-rest-client-2.0/microprofile-rest-client-spec-2.0.html[MicroProfile Rest Client specification]
+
+== Configuration Reference
+
+include::{generated-dir}/config/quarkus-rest-client-config.adoc[opts=optional, leveloffset=+1]

--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -165,7 +165,7 @@ class RestClientReactiveProcessor {
             RestClientReactiveConfig config) {
         consumes.produce(new RestClientDefaultConsumesBuildItem(MediaType.APPLICATION_JSON, 10));
         produces.produce(new RestClientDefaultProducesBuildItem(MediaType.APPLICATION_JSON, 10));
-        if (config.disableSmartProduces) {
+        if (config.disableSmartProduces()) {
             disableSmartProduces.produce(new RestClientDisableSmartDefaultProduces());
         }
     }
@@ -286,7 +286,7 @@ class RestClientReactiveProcessor {
             constructor.invokeSpecialMethod(MethodDescriptor.ofConstructor(AnnotationRegisteredProviders.class),
                     constructor.getThis());
 
-            if (clientConfig.providerAutodiscovery) {
+            if (clientConfig.providerAutodiscovery()) {
                 for (AnnotationInstance instance : index.getAnnotations(ResteasyReactiveDotNames.PROVIDER)) {
                     ClassInfo providerClass = instance.target().asClass();
 

--- a/extensions/resteasy-reactive/rest-client/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client/runtime/pom.xml
@@ -108,9 +108,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfig.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfig.java
@@ -1,30 +1,34 @@
 package io.quarkus.rest.client.reactive.runtime;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * Build time REST client config.
  */
-@ConfigRoot(name = "rest-client", phase = ConfigPhase.BUILD_TIME)
-public class RestClientReactiveConfig {
+@ConfigMapping(prefix = "quarkus.rest-client")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface RestClientReactiveConfig {
 
     /**
      * By default, RESTEasy Reactive uses text/plain content type for String values
      * and application/json for everything else.
-     *
+     * <p>
      * MicroProfile Rest Client spec requires the implementations to always default to application/json.
      * This build item disables the "smart" behavior of RESTEasy Reactive to comply to the spec
      */
-    @Deprecated // Deprecated in favour of RestClientsConfig.disableSmartProduces
-    @ConfigItem(name = "disable-smart-produces", defaultValue = "false")
-    public boolean disableSmartProduces;
+    @WithName("disable-smart-produces")
+    @WithDefault("false")
+    boolean disableSmartProduces();
 
     /**
      * Whether providers (filters, etc.) annotated with {@link jakarta.ws.rs.ext.Provider} should be
      * automatically registered for all the clients in the application.
      */
-    @ConfigItem(name = "provider-autodiscovery", defaultValue = "true")
-    public boolean providerAutodiscovery = true;
+    @WithName("provider-autodiscovery")
+    @WithDefault("true")
+    boolean providerAutodiscovery();
 }


### PR DESCRIPTION
- Fixes #43748
- Undeprecates `quarkus.rest-client.disable-smart-produces`, due to https://github.com/quarkusio/quarkus/pull/39159
- Added Rest Client configuration references to docs