### PR TITLE
Move rocksdb native library resource registration to a feature

### DIFF
--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/graal/KafkaStreamsFeature.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/graal/KafkaStreamsFeature.java
@@ -1,0 +1,15 @@
+package io.quarkus.kafka.streams.runtime.graal;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
+import org.rocksdb.util.Environment;
+
+public class KafkaStreamsFeature implements Feature {
+
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        String libraryFileName = Environment.getJniLibraryFileName("rocksdb");
+        RuntimeResourceAccess.addResource(Environment.class.getModule(), libraryFileName);
+    }
+
+}


### PR DESCRIPTION
Always registers the correct native library as the logic runs on the same architecture we are targeting (even when using containers).

Closes https://github.com/quarkusio/quarkus/issues/43319