### PR TITLE
Add support for vhosts in RabbitMQ Dev Services topology

### DIFF
--- a/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
+++ b/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
@@ -230,6 +230,7 @@ swap:
   Qdmanage|QDMANAGE: qdmanage
   Qdstat|QDSTAT: qdstat
   Qeth|QETH: qeth
+  Rabbit\sMQ|rabbitMQ|Rabbitmq|Rabbit-mq: RabbitMQ
   RAMdisk|ramdisk|RAM-disk: RAM disk
   Ram|ram: RAM
   RAW: raw

--- a/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
@@ -13,7 +13,7 @@ Dev Services for RabbitMQ automatically starts a RabbitMQ broker in dev mode and
 So, you don't have to start a broker manually.
 The application is configured automatically.
 
-== Enabling / Disabling Dev Services for RabbitMQ
+== Enabling / disabling Dev Services for RabbitMQ
 
 Dev Services for RabbitMQ is automatically enabled unless:
 
@@ -22,15 +22,15 @@ Dev Services for RabbitMQ is automatically enabled unless:
 - all the Reactive Messaging RabbitMQ channels have the `host` or `port` attributes set
 
 Dev Services for RabbitMQ relies on Docker to start the broker.
-If your environment does not support Docker, you will need to start the broker manually, or connect to an already running broker.
-You can configure the broker access using the `rabbitmq-host`, `rabbitmq-port`, `rabbitmq-username` and `rabbitmq-password` properties.
+If your environment does not support Docker, you must start the broker manually, or connect to an already running broker.
+You can configure the broker access by using the `rabbitmq-host`, `rabbitmq-port`, `rabbitmq-username` and `rabbitmq-password` properties.
 
 == Shared broker
 
-Most of the time you need to share the broker between applications.
+Most of the time you want to share the broker between applications.
 Dev Services for RabbitMQ implements a _service discovery_ mechanism for your multiple Quarkus applications running in _dev_ mode to share a single broker.
 
-NOTE: Dev Services for RabbitMQ starts the container with the `quarkus-dev-service-rabbitmq` label which is used to identify the container.
+NOTE: Dev Services for RabbitMQ starts the container with the `quarkus-dev-service-rabbitmq` label, which is used to identify the container.
 
 If you need multiple (shared) brokers, you can configure the `quarkus.rabbitmq.devservices.service-name` attribute and indicate the broker name.
 It looks for a container with the same value, or starts a new one if none can be found.
@@ -48,7 +48,7 @@ You can set the port by configuring the `quarkus.rabbitmq.devservices.port` prop
 == Configuring the image
 
 Dev Services for RabbitMQ uses official images available at https://hub.docker.com/_/rabbitmq.
-You can configure the image and version using the `quarkus.rabbitmq.devservices.image-name` property:
+You can configure the image and version with the `quarkus.rabbitmq.devservices.image-name` property:
 
 [source, properties]
 ----
@@ -58,14 +58,24 @@ quarkus.rabbitmq.devservices.image-name=rabbitmq:latest
 == Access the management UI
 
 By default, Dev Services for RabbitMQ use the official image with the `management` tag. This means you have the https://github.com/docker-library/docs/tree/master/rabbitmq#management-plugin[management plugin] available. You can use the xref:dev-ui.adoc[Dev UI] to find the HTTP port randomly affected
-or configure a static one via `quarkus.rabbitmq.devservices.http-port`.
+or configure a static one by using `quarkus.rabbitmq.devservices.http-port`.
 
-== Predefined Topology
+== Predefined topology
 
-Dev Services for RabbitMQ supports defining topology upon broker start. You can define Exchanges, Queues, and
-Bindings using standard Quarkus configuration.
+Dev Services for RabbitMQ supports defining topology upon broker start. You can define Virtual Hosts, Exchanges, Queues,
+and Bindings through standard Quarkus configuration.
 
-=== Defining Exchanges
+=== Defining virtual hosts
+
+RabbitMQ uses a default virtual host of `/`. To define additional RabbitMQ virtual hosts, provide the names
+of the virtual hosts in the `quarkus.rabbitmq.devservices.vhosts` key:
+
+[source, properties]
+----
+quarkus.rabbitmq.devservices.exchanges.vhosts=my-vhost-1,my-vhost-2
+----
+
+=== Defining exchanges
 
 To define a RabbitMQ exchange you provide the exchange's name after the `quarkus.rabbitmq.devservices.exchanges` key,
 followed by one (or more) of the exchange's properties:
@@ -75,16 +85,17 @@ followed by one (or more) of the exchange's properties:
 quarkus.rabbitmq.devservices.exchanges.my-exchange.type=topic            # defaults to 'direct'
 quarkus.rabbitmq.devservices.exchanges.my-exchange.auto-delete=false     # defaults to 'false'
 quarkus.rabbitmq.devservices.exchanges.my-exchange.durable=true          # defaults to 'false'
+quarkus.rabbitmq.devservices.exchanges.my-exchange.vhost=my-vhost        # defaults to '/'
 ----
 
-Additionally, any additional arguments may be provided to the exchange's definition by using the `arguments` key:
+Additionally, any additional arguments can be provided to the exchange's definition by using the `arguments` key:
 
 [source, properties]
 ----
 quarkus.rabbitmq.devservices.exchanges.my-exchange.arguments.alternate-exchange=another-exchange
 ----
 
-=== Defining Queues
+=== Defining queues
 
 To define a RabbitMQ queue you provide the queue's name after the `quarkus.rabbitmq.devservices.queues` key,
 followed by one (or more) of the queue's properties:
@@ -93,16 +104,17 @@ followed by one (or more) of the queue's properties:
 ----
 quarkus.rabbitmq.devservices.queues.my-queue.auto-delete=false          # defaults to 'false'
 quarkus.rabbitmq.devservices.queues.my-queue.durable=true               # defaults to 'false'
+quarkus.rabbitmq.devservices.queues.my-queue.vhost=my-vhost             # defaults to '/'
 ----
 
-Additionally, any additional arguments may be provided to the queue's definition by using the `arguments` key:
+Additionally, any additional arguments can be provided to the queue's definition by using the `arguments` key:
 
 [source, properties]
 ----
 quarkus.rabbitmq.devservices.queues.my-queue.arguments.x-dead-letter-exchange=another-exchange
 ----
 
-=== Defining Bindings
+=== Defining bindings
 
 To define a RabbitMQ binding you provide the binding's name after the `quarkus.rabbitmq.devservices.bindings` key,
 followed by one (or more) of the binding's properties:
@@ -113,12 +125,13 @@ quarkus.rabbitmq.devservices.bindings.a-binding.source=my-exchange      # defaul
 quarkus.rabbitmq.devservices.bindings.a-binding.routing-key=some-key    # defaults to '#'
 quarkus.rabbitmq.devservices.bindings.a-binding.destination=my-queue    # defaults to name of binding
 quarkus.rabbitmq.devservices.bindings.a-binding.destination-type=queue  # defaults to 'queue'
+quarkus.rabbitmq.devservices.bindings.a-binding.vhost=my-vhost          # defaults to '/'
 ----
 
 NOTE: The name of the binding is only used for the purposes of the Dev Services configuration and is not part of the
 binding defined in RabbitMQ.
 
-Additionally, any additional arguments may be provided to the binding's definition by using the `arguments` key:
+Additionally, any additional arguments can be provided to the binding's definition by using the `arguments` key:
 
 [source, properties]
 ----

--- a/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
@@ -72,7 +72,7 @@ of the virtual hosts in the `quarkus.rabbitmq.devservices.vhosts` key:
 
 [source, properties]
 ----
-quarkus.rabbitmq.devservices.exchanges.vhosts=my-vhost-1,my-vhost-2
+quarkus.rabbitmq.devservices.vhosts=my-vhost-1,my-vhost-2
 ----
 
 === Defining exchanges

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.reactivemessaging.rabbitmq.deployment;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -33,6 +34,12 @@ public class RabbitMQDevServicesBuildTimeConfig {
         public Boolean durable;
 
         /**
+         * What virtual host should the exchange be associated with?
+         */
+        @ConfigItem(defaultValue = "/")
+        public String vhost;
+
+        /**
          * Extra arguments for the exchange definition.
          */
         @ConfigItem
@@ -54,6 +61,12 @@ public class RabbitMQDevServicesBuildTimeConfig {
          */
         @ConfigItem(defaultValue = "false")
         public Boolean durable;
+
+        /**
+         * What virtual host should the queue be associated with?
+         */
+        @ConfigItem(defaultValue = "/")
+        public String vhost;
 
         /**
          * Extra arguments for the queue definition.
@@ -89,6 +102,12 @@ public class RabbitMQDevServicesBuildTimeConfig {
          */
         @ConfigItem(defaultValue = "queue")
         public String destinationType;
+
+        /**
+         * What virtual host should the binding be associated with?
+         */
+        @ConfigItem(defaultValue = "/")
+        public String vhost;
 
         /**
          * Extra arguments for the binding definition.
@@ -179,6 +198,12 @@ public class RabbitMQDevServicesBuildTimeConfig {
     @ConfigItem
     @ConfigDocMapKey("binding-name")
     public Map<String, Binding> bindings;
+
+    /**
+     * Virtual hosts that should be predefined after starting the RabbitMQ broker.
+     */
+    @ConfigItem
+    public Optional<List<String>> vhosts;
 
     /**
      * Environment variables that are passed to the container.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -332,6 +332,7 @@
                 <module>reactive-messaging-pulsar</module>
                 <module>reactive-messaging-mqtt</module>
                 <module>reactive-messaging-rabbitmq</module>
+                <module>reactive-messaging-rabbitmq-devservices</module>
                 <module>reactive-messaging-rabbitmq-dyn</module>
                 <module>reactive-messaging-hibernate-reactive</module>
                 <module>reactive-messaging-hibernate-orm</module>

--- a/integration-tests/reactive-messaging-rabbitmq-devservices/pom.xml
+++ b/integration-tests/reactive-messaging-rabbitmq-devservices/pom.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-reactive-messaging-rabbitmq-devservices</artifactId>
+    <name>Quarkus - Integration Tests - Reactive Messaging - RabbitMQ Dev Services</name>
+    <description>The RabbitMQ Reactive Messaging Dev Services integration tests module</description>
+
+    <properties>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-shared-library</artifactId>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+
+        <!-- Health -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-rabbitmq</artifactId>
+        </dependency>
+
+
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-rabbitmq-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-rabbitmq</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/integration-tests/reactive-messaging-rabbitmq-devservices/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-rabbitmq-devservices/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+quarkus.rabbitmq.devservices.vhosts=my-vhost-1,my-vhost-2
+quarkus.rabbitmq.devservices.exchanges.my-exchange-1.vhost=my-vhost-1
+quarkus.rabbitmq.devservices.exchanges.my-exchange-1.type=fanout
+quarkus.rabbitmq.devservices.queues.my-queue-1.vhost=my-vhost-1
+quarkus.rabbitmq.devservices.bindings.my-binding-1.vhost=my-vhost-1
+quarkus.rabbitmq.devservices.bindings.my-binding-1.source=my-exchange-1
+quarkus.rabbitmq.devservices.bindings.my-binding-1.destination=my-queue-1
+
+

--- a/integration-tests/reactive-messaging-rabbitmq-devservices/src/test/java/io/quarkus/it/rabbitmq/RabbitMQDevServiceTopologyIT.java
+++ b/integration-tests/reactive-messaging-rabbitmq-devservices/src/test/java/io/quarkus/it/rabbitmq/RabbitMQDevServiceTopologyIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.rabbitmq;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class RabbitMQDevServiceTopologyIT extends RabbitMQDevServiceTopologyTest {
+
+}

--- a/integration-tests/reactive-messaging-rabbitmq-devservices/src/test/java/io/quarkus/it/rabbitmq/RabbitMQDevServiceTopologyTest.java
+++ b/integration-tests/reactive-messaging-rabbitmq-devservices/src/test/java/io/quarkus/it/rabbitmq/RabbitMQDevServiceTopologyTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.it.rabbitmq;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class RabbitMQDevServiceTopologyTest {
+
+    @ConfigProperty(name = "rabbitmq-username")
+    String username;
+
+    @ConfigProperty(name = "rabbitmq-password")
+    String password;
+
+    @ConfigProperty(name = "rabbitmq-http-port")
+    int rabbitMqHttpPort;
+
+    @Test
+    public void testVhosts() {
+        RestAssured.given()
+                .port(rabbitMqHttpPort)
+                .auth().preemptive().basic(username, password)
+                .when().get("/api/vhosts")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("name", containsInAnyOrder("/", "my-vhost-1", "my-vhost-2"));
+    }
+
+    @Test
+    public void testExchanges() {
+        RestAssured.given()
+                .port(rabbitMqHttpPort)
+                .auth().preemptive().basic(username, password)
+                .when().get("/api/exchanges/my-vhost-1/my-exchange-1")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("name", equalTo("my-exchange-1"), "vhost", equalTo("my-vhost-1"));
+    }
+
+    @Test
+    public void testQueues() {
+        RestAssured.given()
+                .port(rabbitMqHttpPort)
+                .auth().preemptive().basic(username, password)
+                .when().get("/api/queues/my-vhost-1/my-queue-1")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("name", equalTo("my-queue-1"), "vhost", equalTo("my-vhost-1"));
+    }
+
+    @Test
+    public void testBindings() {
+        RestAssured.given()
+                .port(rabbitMqHttpPort)
+                .auth().preemptive().basic(username, password)
+                .when().get("/api/bindings/my-vhost-1/e/my-exchange-1/q/my-queue-1")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("source[0]", equalTo("my-exchange-1"), "vhost[0]", equalTo("my-vhost-1"), "destination[0]",
+                        equalTo("my-queue-1"));
+    }
+}


### PR DESCRIPTION
RabbitMQ has a concept of a [virtual host (vhost)](https://www.rabbitmq.com/docs/vhosts). Adding support so the RabbitMQ dev service topology builder can include virtual host information.