### PR TITLE
Add equals and hashcode method to MemorySize configuration class to fix unnecessary Keycloak Dev Service reloading

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySize.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySize.java
@@ -1,6 +1,7 @@
 package io.quarkus.runtime.configuration;
 
 import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * A type representing data sizes.
@@ -24,5 +25,20 @@ public final class MemorySize {
      */
     public BigInteger asBigInteger() {
         return value;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null || getClass() != object.getClass())
+            return false;
+        MemorySize that = (MemorySize) object;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
     }
 }


### PR DESCRIPTION
- Closes: https://github.com/quarkusio/quarkus/issues/43701

I have added also hashcode as it seems that configmapping generates hashcode as well https://smallrye.io/smallrye-config/Main/config/mappings/#tostring-equals-hashcode and this way it will be more precise.