### PR TITLE
Add io.netty.versions.properties to native image resources

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
@@ -369,6 +370,14 @@ class NettyProcessor {
     LogCleanupFilterBuildItem cleanupMacDNSInLog() {
         return new LogCleanupFilterBuildItem(DnsServerAddressStreamProviders.class.getName(), Level.WARN,
                 "Can not find io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider in the classpath");
+    }
+
+    /**
+     * `Version.identify()` in netty-common uses the resource to determine the version of netty.
+     */
+    @BuildStep
+    NativeImageResourceBuildItem nettyVersions() {
+        return new NativeImageResourceBuildItem("META-INF/io.netty.versions.properties");
     }
 
     private String calculateMaxOrder(OptionalInt userConfig, List<MinNettyAllocatorMaxOrderBuildItem> minMaxOrderBuildItems,


### PR DESCRIPTION
netty-common `Version.identify` uses `META-INF/io.netty.versions.properties` to determine the netty version.

Seen in https://github.com/SolaceLabs/solace-quarkus/pull/77