### PR TITLE
Introduce @ConfigDocAttribute to inject asciidoc attributes in config root documentation

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigRoot.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigRoot.java
@@ -1,5 +1,7 @@
 package io.quarkus.annotation.processor.documentation.config.discovery;
 
+import java.util.Map;
+
 import io.quarkus.annotation.processor.documentation.config.model.ConfigPhase;
 import io.quarkus.annotation.processor.documentation.config.model.Extension;
 
@@ -14,16 +16,19 @@ public final class DiscoveryConfigRoot extends DiscoveryRootElement {
     private final String overriddenDocPrefix;
     private final ConfigPhase phase;
     private final String overriddenDocFileName;
+    private final Map<String, String> attributes;
 
     public DiscoveryConfigRoot(Extension extension, String prefix, String overriddenDocPrefix,
             String binaryName, String qualifiedName,
-            ConfigPhase configPhase, String overriddenDocFileName, boolean configMapping) {
+            ConfigPhase configPhase, String overriddenDocFileName, boolean configMapping,
+            Map<String, String> attributes) {
         super(extension, binaryName, qualifiedName, configMapping);
 
         this.prefix = prefix;
         this.overriddenDocPrefix = overriddenDocPrefix;
         this.phase = configPhase;
         this.overriddenDocFileName = overriddenDocFileName;
+        this.attributes = attributes;
     }
 
     public String getPrefix() {
@@ -42,6 +47,10 @@ public final class DiscoveryConfigRoot extends DiscoveryRootElement {
         return overriddenDocFileName;
     }
 
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
     public String toString() {
         return toString("");
     }
@@ -52,6 +61,9 @@ public final class DiscoveryConfigRoot extends DiscoveryRootElement {
         sb.append(prefix + "config = " + this.phase + "\n");
         if (overriddenDocFileName != null) {
             sb.append(prefix + "overriddenDocFileName = " + this.overriddenDocFileName + "\n");
+        }
+        if (!attributes.isEmpty()) {
+            sb.append(prefix + "attributes = " + this.attributes + "\n");
         }
         sb.append(super.toString(prefix));
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigItemCollection.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigItemCollection.java
@@ -1,6 +1,7 @@
 package io.quarkus.annotation.processor.documentation.config.model;
 
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -32,6 +33,8 @@ public interface ConfigItemCollection {
     }
 
     void addItem(AbstractConfigItem item);
+
+    Map<String, String> getAttributes();
 
     boolean hasDurationType();
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigRoot.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigRoot.java
@@ -24,13 +24,18 @@ public class ConfigRoot implements ConfigItemCollection {
     private final String topLevelPrefix;
 
     private final String overriddenDocFileName;
+    private final Map<String, String> attributes = new HashMap<>();
     private final List<AbstractConfigItem> items = new ArrayList<>();
     private final Set<String> qualifiedNames = new HashSet<>();
 
-    public ConfigRoot(Extension extension, String prefix, String overriddenDocPrefix, String overriddenDocFileName) {
+    public ConfigRoot(Extension extension, String prefix, String overriddenDocPrefix, String overriddenDocFileName,
+            Map<String, String> attributes) {
         this.extension = extension;
         this.prefix = prefix;
         this.overriddenDocFileName = overriddenDocFileName;
+        if (attributes != null) {
+            this.attributes.putAll(attributes);
+        }
         this.topLevelPrefix = overriddenDocPrefix != null ? buildTopLevelPrefix(overriddenDocPrefix)
                 : buildTopLevelPrefix(prefix);
     }
@@ -45,6 +50,11 @@ public class ConfigRoot implements ConfigItemCollection {
 
     public String getOverriddenDocFileName() {
         return overriddenDocFileName;
+    }
+
+    @Override
+    public Map<String, String> getAttributes() {
+        return attributes;
     }
 
     public void addQualifiedName(String qualifiedName) {
@@ -92,6 +102,8 @@ public class ConfigRoot implements ConfigItemCollection {
         }
 
         Collections.sort(this.items);
+
+        this.attributes.putAll(other.getAttributes());
     }
 
     private void collectConfigSections(Map<String, ConfigSection> configSections, ConfigItemCollection configItemCollection) {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigSection.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ConfigSection.java
@@ -29,6 +29,11 @@ public final class ConfigSection extends AbstractConfigItem implements ConfigIte
     }
 
     @Override
+    public Map<String, String> getAttributes() {
+        return Map.of(); // Sections can't have attributes at the moment.
+    }
+
+    @Override
     public int compareTo(AbstractConfigItem o) {
         if (o instanceof ConfigProperty) {
             return 1;

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/resolver/ConfigResolver.java
@@ -71,7 +71,8 @@ public class ConfigResolver {
 
         for (DiscoveryConfigRoot discoveryConfigRoot : configCollector.getConfigRoots()) {
             ConfigRoot configRoot = new ConfigRoot(discoveryConfigRoot.getExtension(), discoveryConfigRoot.getPrefix(),
-                    discoveryConfigRoot.getOverriddenDocPrefix(), discoveryConfigRoot.getOverriddenDocFileName());
+                    discoveryConfigRoot.getOverriddenDocPrefix(), discoveryConfigRoot.getOverriddenDocFileName(),
+                    discoveryConfigRoot.getAttributes());
             Map<String, ConfigSection> existingRootConfigSections = new HashMap<>();
 
             configRoot.addQualifiedName(discoveryConfigRoot.getQualifiedName());

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigAnnotationScanner.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigAnnotationScanner.java
@@ -166,7 +166,8 @@ public class ConfigAnnotationScanner {
                 DiscoveryConfigRoot discoveryConfigRoot = new DiscoveryConfigRoot(config.getExtension(), "dummy", "dummy",
                         utils.element().getBinaryName(configMappingWithoutConfigRoot),
                         configMappingWithoutConfigRoot.getQualifiedName().toString(),
-                        ConfigPhase.BUILD_TIME, null, true);
+                        ConfigPhase.BUILD_TIME, null, true,
+                        Map.of());
                 scanElement(configMappingWithoutConfigRootListeners, discoveryConfigRoot, configMappingWithoutConfigRoot);
             } catch (Exception e) {
                 throw new IllegalStateException(

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/Types.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/util/Types.java
@@ -32,6 +32,7 @@ public final class Types {
     public static final String ANNOTATION_CONFIG_DOC_FILE_NAME = "io.quarkus.runtime.annotations.ConfigDocFilename";
     public static final String ANNOTATION_CONFIG_DOC_PREFIX = "io.quarkus.runtime.annotations.ConfigDocPrefix";
     public static final String ANNOTATION_CONFIG_DOC_ENUM = "io.quarkus.runtime.annotations.ConfigDocEnum";
+    public static final String ANNOTATION_CONFIG_DOC_ATTRIBUTE = "io.quarkus.runtime.annotations.ConfigDocAttribute";
 
     public static final String ANNOTATION_CONFIG_WITH_CONVERTER = "io.smallrye.config.WithConverter";
     public static final String ANNOTATION_CONFIG_WITH_NAME = "io.smallrye.config.WithName";

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigDocAttribute.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigDocAttribute.java
@@ -1,0 +1,39 @@
+package io.quarkus.runtime.annotations;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * A way to set <a href="https://docs.asciidoctor.org/asciidoc/latest/attributes/attribute-entries/" asciidoc attributes}
+ * (variables) at the start of generated documentation.
+ * <p>
+ * Only taken into account on config roots.
+ * <p>
+ * Each attribute will be rendered as a single line: {@code :name: value}.
+ * <p>
+ * Especially useful for injecting content (e.g. link roots) into documentation
+ * of config groups reused from another extension.
+ * For example a declaration such as {@code @ConfigDocAttribute(name = "myname", value = "myvalue")}
+ * can be referenced in Javadoc that uses {@code @asciidoclet}
+ * with the attribute reference {@code {myname}}.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@Documented
+public @interface ConfigDocAttribute {
+
+    /**
+     * @return The name of the attribute in generated documentation.
+     */
+    String name();
+
+    /**
+     * @return The value of the attribute in generated documentation.
+     */
+    String value();
+
+}

--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/allConfig.qute.adoc
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/allConfig.qute.adoc
@@ -9,12 +9,18 @@ h|Type
 h|Default
 
 {#for configRootEntry in extensionConfigRootsEntry.value}
+
 {#if configRootEntry.value.nonDeprecatedItems}
 {#let displayConfigRootDescription=configRootEntry.key.displayConfigRootDescription(extensionConfigRootsEntry.value.size)}
 {#if displayConfigRootDescription}
 h|[.configroot-name]##{configRootEntry.key.description.escapeCellContent}##
 h|Type
 h|Default
+
+{! TODO: Asciidoc only supports defining attributes outside of delimited blocks, so this won't work. !}
+{#for attributeEntry in configRootEntry.value.attributes}
+:{attributeEntry.key}: {attributeEntry.value}
+{/for}
 
 {/if}
 {#for item in configRootEntry.value.items}

--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/configReference.qute.adoc
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/configReference.qute.adoc
@@ -1,3 +1,8 @@
+{! Asciidoc only supports defining attributes outside of delimited blocks !}
+{#for attributeEntry in configItemCollection.attributes}
+:{attributeEntry.key}: {attributeEntry.value}
+{/for}
+
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference{#if searchable}.searchable{/if}, cols="80,.^10,.^10"]


### PR DESCRIPTION
The problem is the following:

1. I have a config group defined in extension A.
2. Extensions B and C each have a config root, which uses the config group from extension A.
3. The documentation of that config group needs to link to a section of a guide.
4. The link to the guide of extension B and C would be different, since each has its own guide.

You can take the example of #39416.

Ideally, I'd just use `xref:#someanchor` and all would be fine: the link would be to the same page, no need to alter it based on context.

But... we allow listing the documentation of configuration properties in other contexts than the extensions' main guide; for example in `all-config.adoc`. In such context, a link to the same page would not work.

In this PR I tried to solve the problem by adding a `@ConfigDocAttribute` annotation. The idea would be that the config group in extension A references an AsciiDoc attribute (variable) to build its links, and each config root in extensions B and C would assign a different value to that attribute. You can see how it's used in practice in the last commit of #39416: https://github.com/quarkusio/quarkus/pull/39416/commits/44d8359e439583abf086c3ed5a6980e98a1f3628

It worked well... until I noticed that you can only ever assign values to attributes outside of an asciidoc block. Critically, you cannot change attribute values in the middle of a table, which completely breaks the approach for `all-config.adoc`.

So, submitting this for discussion... how would you rather we solve it, @gsmet?

At this point the only viable option seems to be some custom variable definition/replacement in the Quarkus tool suite: we'd still use something similar to `@ConfigDocAttribute`, but would substitute attribute references ourselves, either when rendering the Qute templates (e.g. in `io.quarkus.maven.config.doc.generator.AbstractFormatter#formatDescription`), or (even better) when we generate `quarkus-config-javadoc.yaml`.

Alternatively we could have something less flexible, that doesn't allow custom attributes, but allows inserting links to the guide of the extension of the config root, with a parameterized anchor. That would still need to be handled by our own tools, though.