### PR TITLE
Introduce `JBossLoggingConsumer`

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/JBossLoggingConsumer.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/JBossLoggingConsumer.java
@@ -1,4 +1,4 @@
-package io.quarkus.observability.testcontainers;
+package io.quarkus.devservices.common;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,7 +11,7 @@ import org.testcontainers.containers.output.OutputFrame;
 /**
  * A TestContainers consumer for container output that logs output to an JBoss logger.
  */
-public class LgtmContainerLogConsumer extends BaseConsumer<LgtmContainerLogConsumer> {
+public class JBossLoggingConsumer extends BaseConsumer<JBossLoggingConsumer> {
 
     private final Logger logger;
 
@@ -21,31 +21,31 @@ public class LgtmContainerLogConsumer extends BaseConsumer<LgtmContainerLogConsu
 
     private String prefix = "";
 
-    public LgtmContainerLogConsumer(Logger logger) {
+    public JBossLoggingConsumer(Logger logger) {
         this(logger, false);
     }
 
-    public LgtmContainerLogConsumer(Logger logger, boolean separateOutputStreams) {
+    public JBossLoggingConsumer(Logger logger, boolean separateOutputStreams) {
         this.logger = logger;
         this.separateOutputStreams = separateOutputStreams;
     }
 
-    public LgtmContainerLogConsumer withPrefix(String prefix) {
+    public JBossLoggingConsumer withPrefix(String prefix) {
         this.prefix = "[" + prefix + "] ";
         return this;
     }
 
-    public LgtmContainerLogConsumer withMdc(String key, String value) {
+    public JBossLoggingConsumer withMdc(String key, String value) {
         mdc.put(key, value);
         return this;
     }
 
-    public LgtmContainerLogConsumer withMdc(Map<String, String> mdc) {
+    public JBossLoggingConsumer withMdc(Map<String, String> mdc) {
         this.mdc.putAll(mdc);
         return this;
     }
 
-    public LgtmContainerLogConsumer withSeparateOutputStreams() {
+    public JBossLoggingConsumer withSeparateOutputStreams() {
         this.separateOutputStreams = true;
         return this;
     }

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
@@ -8,6 +8,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import org.testcontainers.utility.MountableFile;
 
+import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.observability.common.ContainerConstants;
 import io.quarkus.observability.common.config.AbstractGrafanaConfig;
 import io.quarkus.observability.common.config.LgtmConfig;
@@ -46,7 +47,7 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
         // cannot override grafana-dashboards.yaml in the container because it's on a version dependent path:
         // ./grafana-v11.0.0/conf/provisioning/dashboards/grafana-dashboards.yaml
         // will replace contents of current dashboards
-        withLogConsumer(new LgtmContainerLogConsumer(log).withPrefix("LGTM"));
+        withLogConsumer(new JBossLoggingConsumer(log).withPrefix("LGTM"));
         withCopyFileToContainer(
                 MountableFile.forClasspathResource("/grafana-dashboard-quarkus-micrometer-prometheus.json"),
                 "/otel-lgtm/grafana-dashboard-red-metrics-classic.json");


### PR DESCRIPTION
This utility class outputs the logging from TestContainer containers to JBoss Logging. Useful for extensions exposing devservices.
