### PR TITLE
generate flyway migrations from hibernate update scripts

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -888,7 +888,10 @@ Add the following in your properties file.
 ----
 
 [[flyway]]
-== Automatically transitioning to Flyway to Manage Schemas
+== Flyway integration
+
+[[flyway-transition-from-entities]]
+=== Automatically transitioning to Flyway to Manage Schemas
 
 If you have the xref:flyway.adoc[Flyway extension] installed when running in development mode,
 Quarkus provides a simple way to initialize your Flyway configuration
@@ -907,6 +910,19 @@ link in the Flyway pane. Hit the `Create Initial Migration` button and the follo
 
 WARNING: This button is simply a convenience to quickly get you started with Flyway, it is up to you to determine how you want to
 manage your database schemas in production. In particular the `migrate-at-start` setting may not be right for all environments.
+
+[[flyway-incremental-from-entities]]
+=== Incremental migrations from entity changes
+
+After the first migration is created, Quarkus can derive a draft migration from your updated entity model, so you don’t need to hand‑write a baseline for each change.
+To create a new migration, click the `Generate Migration File` button in the Dev UI Flyway pane.
+
+WARNING: Always review the suggested script. While Quarkus infers schema changes from your entities, domain‑specific data movements, concurrency considerations, and advanced index strategies still require human judgment.
+
+Generated migration files follow the following pattern:
+
+- Major version is extracted from the last existing migration in your project.
+- Minor version is the current timestamp at generation time.
 
 [[offline]]
 == Offline startup

--- a/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/JdbcUpdateSQLGeneratorBuildItem.java
+++ b/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/JdbcUpdateSQLGeneratorBuildItem.java
@@ -1,0 +1,29 @@
+package io.quarkus.agroal.spi;
+
+import java.util.function.Supplier;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Registers a JDBC generator that produces SQL update scripts for the specified database.
+ * <p>
+ * The generated SQL updates the database schema so it matches the current model.
+ */
+public final class JdbcUpdateSQLGeneratorBuildItem extends MultiBuildItem {
+
+    final String databaseName;
+    final Supplier<String> sqlSupplier;
+
+    public JdbcUpdateSQLGeneratorBuildItem(String databaseName, Supplier<String> sqlSupplier) {
+        this.databaseName = databaseName;
+        this.sqlSupplier = sqlSupplier;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public Supplier<String> getSqlSupplier() {
+        return sqlSupplier;
+    }
+}

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/devui/FlywayDevUIProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/devui/FlywayDevUIProcessor.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import io.quarkus.agroal.spi.JdbcInitialSQLGeneratorBuildItem;
+import io.quarkus.agroal.spi.JdbcUpdateSQLGeneratorBuildItem;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
@@ -24,17 +25,23 @@ public class FlywayDevUIProcessor {
     @BuildStep(onlyIf = IsLocalDevelopment.class)
     @Record(value = RUNTIME_INIT, optional = true)
     CardPageBuildItem create(FlywayDevUIRecorder recorder, FlywayBuildTimeConfig buildTimeConfig,
-            List<JdbcInitialSQLGeneratorBuildItem> generatorBuildItem,
+            List<JdbcInitialSQLGeneratorBuildItem> createGeneratorBuildItem,
+            List<JdbcUpdateSQLGeneratorBuildItem> updateGeneratorBuildItem,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
 
         Map<String, Supplier<String>> initialSqlSuppliers = new HashMap<>();
-        for (JdbcInitialSQLGeneratorBuildItem buildItem : generatorBuildItem) {
+        for (JdbcInitialSQLGeneratorBuildItem buildItem : createGeneratorBuildItem) {
             initialSqlSuppliers.put(buildItem.getDatabaseName(), buildItem.getSqlSupplier());
+        }
+
+        Map<String, Supplier<String>> updateSqlSuppliers = new HashMap<>();
+        for (JdbcUpdateSQLGeneratorBuildItem buildItem : updateGeneratorBuildItem) {
+            updateSqlSuppliers.put(buildItem.getDatabaseName(), buildItem.getSqlSupplier());
         }
 
         String artifactId = curateOutcomeBuildItem.getApplicationModel().getAppArtifact().getArtifactId();
 
-        recorder.setInitialSqlSuppliers(initialSqlSuppliers, artifactId);
+        recorder.setSqlSuppliers(initialSqlSuppliers, updateSqlSuppliers, artifactId);
 
         CardPageBuildItem card = new CardPageBuildItem();
 

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayDevModeUpdateFromHibernateTest.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayDevModeUpdateFromHibernateTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.flyway.test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.dev.console.DevConsoleManager;
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class FlywayDevModeUpdateFromHibernateTest extends DevUIJsonRPCTest {
+
+    public FlywayDevModeUpdateFromHibernateTest() {
+        super("io.quarkus.quarkus-flyway");
+    }
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(FlywayDevModeUpdateFromHibernateTest.class, Fruit.class)
+                    .addAsResource(new StringAsset(
+                            """
+                                    create sequence Fruit_SEQ start with 1 increment by 50;
+
+                                    create table Fruit (
+                                        id integer not null,
+                                        primary key (id)
+                                    );"""),
+                            "db/update/V2.0.0__Quarkus.sql")
+                    .addAsResource(new StringAsset(
+                            "quarkus.flyway.migrate-at-start=true\nquarkus.flyway.locations=db/update"),
+                            "application.properties"));
+
+    @Test
+    public void testGenerateMigrationFromHibernate() throws Exception {
+
+        Map<String, Object> params = Map.of("ds", "<default>");
+        JsonNode devuiresponse = super.executeJsonRPCMethod("update", params);
+
+        Assertions.assertNotNull(devuiresponse);
+        String type = devuiresponse.get("type").asText();
+        Assertions.assertNotNull(type);
+        Assertions.assertEquals("success", type);
+
+        File migrationsDir = DevConsoleManager.getHotReplacementContext().getResourcesDir().get(0).resolve("db/update")
+                .toFile();
+        File[] newMigrations = migrationsDir.listFiles((dir, name) -> !name.equals("V2.0.0__Quarkus.sql"));
+        Assertions.assertNotNull(newMigrations);
+        Assertions.assertEquals(1, newMigrations.length);
+        Assertions.assertTrue(newMigrations[0].getName().startsWith("V2."));
+
+        String content = Files.readString(newMigrations[0].toPath())
+                // Windows is weird.
+                .replaceAll("\\r\\n?", "\n");
+
+        Assertions.assertEquals("""
+
+                    alter table if exists Fruit\s
+                       add column name varchar(40);
+
+                    alter table if exists Fruit\s
+                       drop constraint if exists UKqn1mp5t3oovyl0h02glapi2iv;
+
+                    alter table if exists Fruit\s
+                       add constraint UKqn1mp5t3oovyl0h02glapi2iv unique (name);
+                """, content);
+    }
+
+}

--- a/extensions/flyway/runtime-dev/src/main/java/io/quarkus/flyway/runtime/dev/ui/FlywayDevUIRecorder.java
+++ b/extensions/flyway/runtime-dev/src/main/java/io/quarkus/flyway/runtime/dev/ui/FlywayDevUIRecorder.java
@@ -10,9 +10,11 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class FlywayDevUIRecorder {
 
-    public RuntimeValue<Boolean> setInitialSqlSuppliers(Map<String, Supplier<String>> initialSqlSuppliers, String artifactId) {
+    public RuntimeValue<Boolean> setSqlSuppliers(Map<String, Supplier<String>> initialSqlSuppliers,
+            Map<String, Supplier<String>> updateSuppliers, String artifactId) {
         FlywayJsonRpcService rpcService = Arc.container().instance(FlywayJsonRpcService.class).get();
         rpcService.setInitialSqlSuppliers(initialSqlSuppliers);
+        rpcService.setUpdateSqlSuppliers(updateSuppliers);
         rpcService.setArtifactId(artifactId);
         return new RuntimeValue<>(true);
     }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.orm.deployment.dev;
 import java.util.List;
 
 import io.quarkus.agroal.spi.JdbcInitialSQLGeneratorBuildItem;
+import io.quarkus.agroal.spi.JdbcUpdateSQLGeneratorBuildItem;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -14,6 +15,7 @@ import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmEnabled;
 import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
 import io.quarkus.hibernate.orm.dev.HibernateOrmDevInfoCreateDDLSupplier;
+import io.quarkus.hibernate.orm.dev.HibernateOrmDevInfoUpdateDDLSupplier;
 import io.quarkus.hibernate.orm.dev.ui.HibernateOrmDevJsonRpcService;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 
@@ -63,6 +65,17 @@ public class HibernateOrmDevUIProcessor {
             String dsName = puDescriptor.getConfig().getDataSource().orElse(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME);
             initialSQLGeneratorBuildItemBuildProducer
                     .produce(new JdbcInitialSQLGeneratorBuildItem(dsName, new HibernateOrmDevInfoCreateDDLSupplier(puName)));
+        }
+    }
+
+    @BuildStep
+    void handleUpdateSql(List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
+            BuildProducer<JdbcUpdateSQLGeneratorBuildItem> updateSQLGeneratorBuildItemBuildProducer) {
+        for (PersistenceUnitDescriptorBuildItem puDescriptor : persistenceUnitDescriptorBuildItems) {
+            String puName = puDescriptor.getPersistenceUnitName();
+            String dsName = puDescriptor.getConfig().getDataSource().orElse(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME);
+            updateSQLGeneratorBuildItemBuildProducer
+                    .produce(new JdbcUpdateSQLGeneratorBuildItem(dsName, new HibernateOrmDevInfoUpdateDDLSupplier(puName)));
         }
     }
 

--- a/extensions/hibernate-orm/runtime-dev/src/main/java/io/quarkus/hibernate/orm/dev/HibernateOrmDevInfoUpdateDDLSupplier.java
+++ b/extensions/hibernate-orm/runtime-dev/src/main/java/io/quarkus/hibernate/orm/dev/HibernateOrmDevInfoUpdateDDLSupplier.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.dev;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import io.quarkus.runtime.annotations.RecordableConstructor;
+
+public class HibernateOrmDevInfoUpdateDDLSupplier implements Supplier<String> {
+
+    private final String puName;
+
+    @RecordableConstructor
+    public HibernateOrmDevInfoUpdateDDLSupplier(String puName) {
+        this.puName = puName;
+    }
+
+    @Override
+    public String get() {
+        Collection<HibernateOrmDevInfo.PersistenceUnit> persistenceUnits = HibernateOrmDevController.get()
+                .getInfo().getPersistenceUnits();
+        for (var p : persistenceUnits) {
+            if (Objects.equals(puName, p.getName())) {
+                return p.getUpdateDDL();
+            }
+        }
+        return null;
+    }
+
+    public String getPuName() {
+        return puName;
+    }
+}


### PR DESCRIPTION
fix #43723 

Current Process: When creating a database migration, the workflow is quite cumbersome:

- Modify the entity.
- Check the update script in the dev UI (when accessible—sometimes the app doesn't even start, making it unavailable).
- Manually create a new migration file.
- Customize the update script as needed.

This process involves redundancy, as the entity already contains the necessary information to at least generate a draft migration.

New Workflow: With this pull request, the process is simplified to:

- Modify the entity.
- Customize the update script as needed.


Migration naming convention:

- major version is extracted from the previous migration
- minor version is the current timestamp (current format is yyyyMMddHHmmss, but I think flyway might support something more readable like yyyy_MM_dd_HH_mm_ss)