### PR TITLE
Prefer hosting-independent URL for quarkiverse docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/extension_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/extension_proposal.yml
@@ -41,7 +41,7 @@ body:
       description: >-
         A URL with more information about the technology this extension promotes (defaults to the Quarkiverse Docs repository)
       value:
-        https://quarkiverse.github.io/quarkiverse-docs/<REPOSITORY_NAME>/dev/
+        https://docs.quarkiverse.io/<REPOSITORY_NAME>/dev/
 
   - type: textarea
     id: repository_topics

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -55,13 +55,13 @@
 :hibernate-orm-dialect-docs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version-major-minor}/dialect/dialect.html
 :hibernate-search-docs-url: https://docs.jboss.org/hibernate/search/{hibernate-search-version-major-minor}/reference/en-US/html_single/
 // .
-:amazon-services-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/index.html
-:config-consul-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-extensions/dev/consul.html
-:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/dev/index.html
-:neo4j-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-neo4j/dev/index.html
-:vault-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html
-:vault-datasource-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/vault-datasource.html
-:micrometer-registry-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-micrometer-registry/dev/index.html
+:amazon-services-guide: https://docs.quarkiverse.io/quarkus-amazon-services/dev/index.html
+:config-consul-guide: https://docs.quarkiverse.io/quarkus-config-extensions/dev/consul.html
+:hibernate-search-orm-elasticsearch-aws-guide: https://docs.quarkiverse.io/quarkus-hibernate-search-extras/dev/index.html
+:neo4j-guide: https://docs.quarkiverse.io/quarkus-neo4j/dev/index.html
+:vault-guide: https://docs.quarkiverse.io/quarkus-vault/dev/index.html
+:vault-datasource-guide: https://docs.quarkiverse.io/quarkus-vault/dev/vault-datasource.html
+:micrometer-registry-guide: https://docs.quarkiverse.io/quarkus-micrometer-registry/dev/index.html
 :quarkus-migration-guide: https://github.com/quarkusio/quarkus/wiki/Migration-Guides[Migration Guides]
 // .
 :create-app-group-id: org.acme

--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -239,7 +239,7 @@ quarkus.container-image.builder=docker
 
 == Integrating with `systemd-notify`
 
-If you are building a container image in order to deploy your Quarkus application as a Linux service with Podman and Systemd, you might want to consider including the https://quarkiverse.github.io/quarkiverse-docs/quarkus-systemd-notify/dev/index.html[Quarkus Systemd Notify Extension] as part of your application, with:
+If you are building a container image in order to deploy your Quarkus application as a Linux service with Podman and Systemd, you might want to consider including the https://docs.quarkiverse.io/quarkus-systemd-notify/dev/index.html[Quarkus Systemd Notify Extension] as part of your application, with:
 
 :add-extension-extensions: io.quarkiverse.systemd.notify:quarkus-systemd-notify
 include::{includes}/devtools/extension-add.adoc[]

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -203,7 +203,7 @@ Read <<in-memory-databases,Testing with in-memory databases>> for suggestions re
 * MySQL - `quarkus-jdbc-mysql`
 * Oracle - `quarkus-jdbc-oracle`
 * PostgreSQL - `quarkus-jdbc-postgresql`
-* Other JDBC extensions, such as link:https://github.com/quarkiverse/quarkus-jdbc-sqlite[SQLite] and its link:https://quarkiverse.github.io/quarkiverse-docs/quarkus-jdbc-sqlite/dev/index.html[documentation], can be found in the https://github.com/quarkiverse[Quarkiverse].
+* Other JDBC extensions, such as link:https://github.com/quarkiverse/quarkus-jdbc-sqlite[SQLite] and its link:https://docs.quarkiverse.io/quarkus-jdbc-sqlite/dev/index.html[documentation], can be found in the https://github.com/quarkiverse[Quarkiverse].
 +
 For example, to add the PostgreSQL driver dependency:
 +

--- a/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
@@ -303,4 +303,4 @@ quarkus.native.additional-build-args=--initialize-at-run-time=jnr.ffi.provider.j
 You can find a set of extensions to access various Google Cloud Services in the Quarkiverse (a GitHub organization for Quarkus extensions maintained by the community),
 including PubSub, BigQuery, Storage, Spanner, Firestore, Secret Manager (visit the repository for an accurate list of supported services).
 
-You can find some documentation about them in the link:https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/index.html[Quarkiverse Google Cloud Services documentation].
+You can find some documentation about them in the link:https://docs.quarkiverse.io/quarkus-google-cloud-services/main/index.html[Quarkiverse Google Cloud Services documentation].

--- a/docs/src/main/asciidoc/extension-codestart.adoc
+++ b/docs/src/main/asciidoc/extension-codestart.adoc
@@ -194,7 +194,7 @@ tags: extension-codestart
 metadata:
   title: Aloha
   description: Start to code with the Aloha extension.
-  related-guide-section: https://quarkiverse.github.io/quarkiverse-docs/quarkus-aloha/dev/
+  related-guide-section: https://docs.quarkiverse.io/quarkus-aloha/dev/
   path: /aloha # (optional) for web extensions providing HTTP resources
 ----
 

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -390,5 +390,5 @@ With the Artemis properties configured, you can resume the steps above from <<ge
 
 === Configuration Reference
 
-To know more about how to configure the Artemis JMS client, have a look at https://quarkiverse.github.io/quarkiverse-docs/quarkus-artemis/dev/index.html[the documentation of the extension].
+To know more about how to configure the Artemis JMS client, have a look at https://docs.quarkiverse.io/quarkus-artemis/dev/index.html[the documentation of the extension].
 

--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -356,7 +356,7 @@ the only way to get the new value would be to restart the application.
 
 [NOTE]
 Do use Vault, you need the https://github.com/quarkiverse/quarkus-vault[Quarkus Vault] extension.
-More details about this extension and its configuration can be found in the https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html[extension documentation].
+More details about this extension and its configuration can be found in the https://docs.quarkiverse.io/quarkus-vault/dev/index.html[extension documentation].
 
 
 [TIP]

--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -49,7 +49,7 @@ ifndef::no-webauthn-authentication[]
 endif::no-webauthn-authentication[]
 
 ifndef::no-quarkus-kerberos[]
-|Kerberos ticket |link:https://quarkiverse.github.io/quarkiverse-docs/quarkus-kerberos/dev/index.html[Kerberos]
+|Kerberos ticket |link:https://docs.quarkiverse.io/quarkus-kerberos/dev/index.html[Kerberos]
 endif::no-quarkus-kerberos[]
 
 |====

--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -25,7 +25,7 @@ The configuration of such providers can become complex, very technical and diffi
 
 `quarkus.oidc.provider` configuration property has been introduced to refer to well-known OpenID Connect and OAuth2 providers. This property can be used to refer to a provider such as `github` with only a minimum number of customizations required, typically, an account specific `client id`, `client secret` and some properties have to be set to complete the configuration.
 
-This property can be used in `application.properties`, in xref:security-openid-connect-multitenancy.adoc[multi-tenant] set-ups if more than one provider has to be configured (for example, see https://quarkiverse.github.io/quarkiverse-docs/quarkus-renarde/dev/security.html#_using_oidc_for_login[Quarkus Renarde security documentation]), in custom xref:security-openid-connect-multitenancy.adoc#tenant-config-resolver[TenantConfigResolvers] if the tenant configurations are created dynamically.
+This property can be used in `application.properties`, in xref:security-openid-connect-multitenancy.adoc[multi-tenant] set-ups if more than one provider has to be configured (for example, see https://docs.quarkiverse.io/quarkus-renarde/dev/security.html#_using_oidc_for_login[Quarkus Renarde security documentation]), in custom xref:security-openid-connect-multitenancy.adoc#tenant-config-resolver[TenantConfigResolvers] if the tenant configurations are created dynamically.
 
 == Well Known Providers
 

--- a/docs/src/main/asciidoc/web.adoc
+++ b/docs/src/main/asciidoc/web.adoc
@@ -39,7 +39,7 @@ NOTE: *We recommend using a bundler for production* as it offers better control,
 There are two ways to bundle your web assets:
 
 a. Using https://docs.quarkiverse.io/quarkus-web-bundler/dev/[the Quarkus Web Bundler extension], which is the recommended way. Without any configuration, it puts everything together in an instant, and follows good practices such as dead-code elimination, minification, caching, and more.
-b. Using a custom bundler such as Webpack, Parcel, Rollup, etc. This can be easily integrated with Quarkus using the https://quarkiverse.github.io/quarkiverse-docs/quarkus-quinoa/dev/[Quarkus Quinoa extension].
+b. Using a custom bundler such as Webpack, Parcel, Rollup, etc. This can be easily integrated with Quarkus using the https://docs.quarkiverse.io/quarkus-quinoa/dev/[Quarkus Quinoa extension].
 
 image::web-bundle-transition.png[Web Bundle Transition]
 
@@ -159,7 +159,7 @@ public class Todos extends Controller {
 
 Quarkus provides very solid tools for creating or integrating Single Page Applications to Quarkus (React, Angular, Vue, …), here are 3 options:
 
-* https://quarkiverse.github.io/quarkiverse-docs/quarkus-quinoa/dev/[Quarkus Quinoa] bridges your npm-compatible web application and Quarkus for both dev and prod. No need to install Node.js or configure your framework, it will detect it and use sensible defaults.
+* https://docs.quarkiverse.io/quarkus-quinoa/dev/[Quarkus Quinoa] bridges your npm-compatible web application and Quarkus for both dev and prod. No need to install Node.js or configure your framework, it will detect it and use sensible defaults.
 * The https://docs.quarkiverse.io/quarkus-web-bundler/dev/[Quarkus Web Bundler] is also a good approach, it is closer to the Java ecosystem and removes a lot of boilerplate and configuration, it is fast and efficient. For examples of such SPAs, see https://github.com/quarkusio/code.quarkus.io[code.quarkus.io] and https://github.com/mvnpm/mvnpm[mvnpm.org].
 * Your automation using the https://github.com/eirslett/frontend-maven-plugin[maven-frontend-plugin] or similar tools.
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-codestart/java/runtime/src/main/codestarts/quarkus/{extension.id}-codestart/codestart.tpl.qute.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-codestart/java/runtime/src/main/codestarts/quarkus/{extension.id}-codestart/codestart.tpl.qute.yml
@@ -7,7 +7,7 @@ metadata:
   description: {#if extension.description}{extension.description}{#else}Start coding with {extension.name}{/if}
 #  path: /some-path
 {#if input.extra-codestarts.contains("quarkiverse")}
-  related-guide-section: https://quarkiverse.github.io/quarkiverse-docs/quarkus-quinoa/dev/index.html
+  related-guide-section: https://docs.quarkiverse.io/quarkus-quinoa/dev/index.html
 {#else}
 #  related-guide-section: TBD
 {/if}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
@@ -88,7 +88,7 @@ public class CreateExtension {
     public static final String DEFAULT_QUARKIVERSE_PARENT_ARTIFACT_ID = "quarkiverse-parent";
     public static final String DEFAULT_QUARKIVERSE_PARENT_VERSION = "17";
     public static final String DEFAULT_QUARKIVERSE_NAMESPACE_ID = "quarkus-";
-    public static final String DEFAULT_QUARKIVERSE_GUIDE_URL = "https://quarkiverse.github.io/quarkiverse-docs/%s/dev/";
+    public static final String DEFAULT_QUARKIVERSE_GUIDE_URL = "https://docs.quarkiverse.io/%s/dev/";
 
     private static final String DEFAULT_SUREFIRE_PLUGIN_VERSION = "3.5.0";
     private static final String DEFAULT_COMPILER_PLUGIN_VERSION = "3.13.0";

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
@@ -3,7 +3,7 @@ name: My Quarkiverse extension
 metadata:
 #  keywords:
 #    - my-quarkiverse-ext
-#  guide: https://quarkiverse.github.io/quarkiverse-docs/my-quarkiverse-ext/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+#  guide: https://docs.quarkiverse.io/my-quarkiverse-ext/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
 #  categories:
 #    - "miscellaneous"
 #  status: "preview"


### PR DESCRIPTION
I noticed new extensions are still being created with a docs url of the form http://quarkiverse.github.io/quarkiverse-docs. We should prefer the https://docs.quarkiverse.io url, partly because it's shorter and prettier, but also because it's not coupled to a hosting provider. 

I started out fixing just the extension templates, but then I decided that while I was searching I'd change the other occurrences, too. 