### PR TITLE
Move brotli native library handling to a feature

### DIFF
--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -79,10 +79,6 @@
             <artifactId>nativeimage</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devtools-utilities</artifactId>
-        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -74,6 +74,15 @@
             <groupId>com.aayushatharva.brotli4j</groupId>
             <artifactId>brotli4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devtools-utilities</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/graal/Brotli4jFeature.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/graal/Brotli4jFeature.java
@@ -1,3 +1,19 @@
+/*
+ *    Copyright (c) 2020-2023, Aayush Atharva
+ *
+ *    Brotli4j licenses this file to you under the
+ *    Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package io.quarkus.vertx.http.runtime.graal;
 
 import org.graalvm.nativeimage.hosted.Feature;
@@ -5,50 +21,25 @@ import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
 
 import io.quarkus.runtime.graal.GraalVM;
-import io.quarkus.utilities.OS;
 
 public class Brotli4jFeature implements Feature {
 
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
-        // TODO reuse Brotli4jLoader's code instead of reinventing the wheel?
-        final String arch = System.getProperty("os.arch");
-        final boolean amd64 = arch.matches("^(amd64|x64|x86_64)$");
-        final boolean aarch64 = "aarch64".equals(arch);
-        final String lib;
-        if (OS.determineOS() == OS.LINUX) {
-            if (amd64) {
-                lib = "linux-x86_64/libbrotli.so";
-            } else if (aarch64) {
-                lib = "linux-aarch64/libbrotli.so";
-            } else {
-                throw new IllegalStateException("Brotli compressor: No library for linux-" + arch);
-            }
-        } else if (OS.determineOS() == OS.WINDOWS) {
-            if (amd64) {
-                lib = "windows-x86_64/brotli.dll";
-            } else if (aarch64) {
-                lib = "windows-aarch64/brotli.dll";
-            } else {
-                throw new IllegalStateException("Brotli compressor: No library for windows-" + arch);
-            }
-        } else if (OS.determineOS() == OS.MAC) {
-            if (amd64) {
-                lib = "osx-x86_64/libbrotli.dylib";
-            } else if (aarch64) {
-                lib = "osx-aarch64/libbrotli.dylib";
-            } else {
-                throw new IllegalStateException("Brotli compressor: No library for osx-" + arch);
-            }
+        // We reuse Brotli4jLoader's code and logic instead of reinventing the wheel
+        String customPath = System.getProperty("brotli4j.library.path");
+        if (customPath != null && !customPath.isEmpty()) {
+            RuntimeResourceAccess.addResource(Brotli4jFeature.class.getModule(), customPath);
         } else {
-            throw new IllegalStateException("Brotli compressor: Your platform is not supported.");
+            String nativeLibName = System.mapLibraryName("brotli");
+            String platform = getPlatform();
+            String libPath = "lib/" + platform + '/' + nativeLibName;
+            RuntimeResourceAccess.addResource(Brotli4jFeature.class.getModule(), libPath);
         }
 
         // We do have Brotli4J on classpath thanks to Vert.X -> Netty dependencies.
         RuntimeResourceAccess.addResource(Brotli4jFeature.class.getModule(),
                 "META-INF/services/com.aayushatharva.brotli4j.service.BrotliNativeProvider");
-        // Register the Native library. We pick only the one relevant to our system.
-        RuntimeResourceAccess.addResource(Brotli4jFeature.class.getModule(), "lib/" + lib);
 
         // Static initializer tries to load the native library in Brotli4jLoader; must be done at runtime.
         RuntimeClassInitialization.initializeAtRunTime("com.aayushatharva.brotli4j.Brotli4jLoader");
@@ -60,4 +51,38 @@ public class Brotli4jFeature implements Feature {
         }
     }
 
+    // Verbatim copy from https://github.com/hyperxpro/Brotli4j/blob/32e3d3827fa3124ca945b75ae2138492c9c775b3/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java#L118C1-L150C6
+    private static String getPlatform() {
+        String osName = System.getProperty("os.name");
+        String archName = System.getProperty("os.arch");
+
+        if ("Linux".equalsIgnoreCase(osName)) {
+            if ("amd64".equalsIgnoreCase(archName)) {
+                return "linux-x86_64";
+            } else if ("aarch64".equalsIgnoreCase(archName)) {
+                return "linux-aarch64";
+            } else if ("arm".equalsIgnoreCase(archName)) {
+                return "linux-armv7";
+            } else if ("s390x".equalsIgnoreCase(archName)) {
+                return "linux-s390x";
+            } else if ("ppc64le".equalsIgnoreCase(archName)) {
+                return "linux-ppc64le";
+            } else if ("riscv64".equalsIgnoreCase(archName)) {
+                return "linux-riscv64";
+            }
+        } else if (osName.startsWith("Windows")) {
+            if ("amd64".equalsIgnoreCase(archName)) {
+                return "windows-x86_64";
+            } else if ("aarch64".equalsIgnoreCase(archName)) {
+                return "windows-aarch64";
+            }
+        } else if (osName.startsWith("Mac")) {
+            if ("x86_64".equalsIgnoreCase(archName)) {
+                return "osx-x86_64";
+            } else if ("aarch64".equalsIgnoreCase(archName)) {
+                return "osx-aarch64";
+            }
+        }
+        throw new UnsupportedOperationException("Unsupported OS and Architecture: " + osName + ", " + archName);
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/graal/Brotli4jFeature.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/graal/Brotli4jFeature.java
@@ -1,0 +1,63 @@
+package io.quarkus.vertx.http.runtime.graal;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
+import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
+
+import io.quarkus.runtime.graal.GraalVM;
+import io.quarkus.utilities.OS;
+
+public class Brotli4jFeature implements Feature {
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        // TODO reuse Brotli4jLoader's code instead of reinventing the wheel?
+        final String arch = System.getProperty("os.arch");
+        final boolean amd64 = arch.matches("^(amd64|x64|x86_64)$");
+        final boolean aarch64 = "aarch64".equals(arch);
+        final String lib;
+        if (OS.determineOS() == OS.LINUX) {
+            if (amd64) {
+                lib = "linux-x86_64/libbrotli.so";
+            } else if (aarch64) {
+                lib = "linux-aarch64/libbrotli.so";
+            } else {
+                throw new IllegalStateException("Brotli compressor: No library for linux-" + arch);
+            }
+        } else if (OS.determineOS() == OS.WINDOWS) {
+            if (amd64) {
+                lib = "windows-x86_64/brotli.dll";
+            } else if (aarch64) {
+                lib = "windows-aarch64/brotli.dll";
+            } else {
+                throw new IllegalStateException("Brotli compressor: No library for windows-" + arch);
+            }
+        } else if (OS.determineOS() == OS.MAC) {
+            if (amd64) {
+                lib = "osx-x86_64/libbrotli.dylib";
+            } else if (aarch64) {
+                lib = "osx-aarch64/libbrotli.dylib";
+            } else {
+                throw new IllegalStateException("Brotli compressor: No library for osx-" + arch);
+            }
+        } else {
+            throw new IllegalStateException("Brotli compressor: Your platform is not supported.");
+        }
+
+        // We do have Brotli4J on classpath thanks to Vert.X -> Netty dependencies.
+        RuntimeResourceAccess.addResource(Brotli4jFeature.class.getModule(),
+                "META-INF/services/com.aayushatharva.brotli4j.service.BrotliNativeProvider");
+        // Register the Native library. We pick only the one relevant to our system.
+        RuntimeResourceAccess.addResource(Brotli4jFeature.class.getModule(), "lib/" + lib);
+
+        // Static initializer tries to load the native library in Brotli4jLoader; must be done at runtime.
+        RuntimeClassInitialization.initializeAtRunTime("com.aayushatharva.brotli4j.Brotli4jLoader");
+        final GraalVM.Version v = GraalVM.Version.getCurrent();
+        // Newer 23.1+ GraalVM/Mandrel does not need this explicitly marked for runtime init thanks
+        // to a different strategy: https://github.com/oracle/graal/blob/vm-23.1.0/substratevm/CHANGELOG.md?plain=1#L10
+        if (v.compareTo(GraalVM.Version.VERSION_23_1_0) <= 0) {
+            RuntimeClassInitialization.initializeAtRunTime("io.netty.handler.codec.compression.Brotli");
+        }
+    }
+
+}


### PR DESCRIPTION
Always registers the correct native library as the logic runs on the
same architecture we are targeting (even when using containers).

Related to https://github.com/quarkusio/quarkus/pull/43782
