### PR TITLE
Avoid getting the GraalVM version at deployment time for AWT

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
@@ -12,6 +12,7 @@ public class JavaVersionUtil {
     private static boolean IS_GRAALVM_JDK;
     private static boolean IS_JAVA_16_OR_OLDER;
     private static boolean IS_JAVA_17_OR_NEWER;
+    private static boolean IS_JAVA_19_OR_NEWER;
 
     static {
         performChecks();
@@ -26,11 +27,13 @@ public class JavaVersionUtil {
             IS_JAVA_13_OR_NEWER = (first >= 13);
             IS_JAVA_16_OR_OLDER = (first <= 16);
             IS_JAVA_17_OR_NEWER = (first >= 17);
+            IS_JAVA_19_OR_NEWER = (first >= 19);
         } else {
             IS_JAVA_11_OR_NEWER = false;
             IS_JAVA_13_OR_NEWER = false;
             IS_JAVA_16_OR_OLDER = false;
             IS_JAVA_17_OR_NEWER = false;
+            IS_JAVA_19_OR_NEWER = false;
         }
 
         String vmVendor = System.getProperty("java.vm.vendor");
@@ -51,6 +54,10 @@ public class JavaVersionUtil {
 
     public static boolean isJava17OrHigher() {
         return IS_JAVA_17_OR_NEWER;
+    }
+
+    public static boolean isJava19OrHigher() {
+        return IS_JAVA_19_OR_NEWER;
     }
 
     public static boolean isGraalvmJdk() {

--- a/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/AwtFeature.java
+++ b/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/AwtFeature.java
@@ -1,0 +1,24 @@
+package io.quarkus.awt.runtime.graal;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeJNIAccess;
+
+import io.quarkus.runtime.util.JavaVersionUtil;
+
+public class AwtFeature implements Feature {
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        // Added for JDK 19+ due to: https://github.com/openjdk/jdk20/commit/9bc023220 calling FontUtilities
+        if (JavaVersionUtil.isJava19OrHigher()) {
+            try {
+                Class<?> fontUtilitiesClass = Class.forName("sun.font.FontUtilities");
+                RuntimeJNIAccess.register(fontUtilitiesClass);
+                RuntimeJNIAccess.register(fontUtilitiesClass.getDeclaredFields());
+                RuntimeJNIAccess.register(fontUtilitiesClass.getDeclaredMethods());
+                RuntimeJNIAccess.register(fontUtilitiesClass.getDeclaredConstructors());
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reduces the times we start a container when using a builder-image