### PR TITLE
Micrometer to OpenTelemetry Bridge

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -117,7 +117,7 @@
         {
             "category": "Misc4",
             "timeout": 130,
-            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, jaxb, observability-lgtm, opentelemetry, opentelemetry-jdbc-instrumentation, opentelemetry-mongodb-client-instrumentation, opentelemetry-redis-instrumentation, web-dependency-locator",
+            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, jaxb, observability-lgtm, opentelemetry, opentelemetry-jdbc-instrumentation, opentelemetry-mongodb-client-instrumentation, opentelemetry-redis-instrumentation, web-dependency-locator, micrometer-opentelemetry",
             "os-name": "ubuntu-latest"
         },
         {

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3201,6 +3201,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-micrometer-opentelemetry-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -1593,6 +1593,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1604,6 +1604,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-to-opentelemetry.adoc
@@ -1,0 +1,236 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id=telemetry-micrometer-opentelemetry]
+= Micrometer and OpenTelemetry extension
+include::_attributes.adoc[]
+:extension-status: preview
+:diataxis-type: reference
+:categories: observability
+:summary: Guide to send Micrometer data to OpenTelemetry.
+:topics: observability,opentelemetry,metrics,micrometer,tracing,logs
+:extensions: io.quarkus:quarkus-micrometer-opentelemetry
+
+This extension provides support for both Micrometer and OpenTelemetry in Quarkus applications. It streamlines integration by incorporating both extensions along with a bridge that enables sending Micrometer metrics via OpenTelemetry.
+
+include::{includes}/extension-status.adoc[]
+
+[NOTE]
+====
+- The xref:telemetry-micrometer.adoc[Micrometer Guide] is available for detailed information about the Micrometer extension.
+- The xref:opentelemetry.adoc[OpenTelemetry Guide] provides information about the OpenTelemetry extension.
+====
+
+The extension allows the normal use of the Micrometer API, but have the metrics handled by the OpenTelemetry extension.
+
+As an example, the `@Timed` annotation from Micrometer is used to measure the execution time of a method:
+[source,java]
+----
+import io.micrometer.core.annotation.Timed;
+//...
+@Timed(name = "timer_metric")
+public String timer() {
+    return "OK";
+}
+----
+The output telemetry data is handled by the OpenTelemetry SDK and sent by the `quarkus-opentelemetry` extension exporter using the OTLP protocol.
+
+This reduces the overhead of having an independent Micrometer registry plus the OpenTelemetry SDK in memory for the same application when both `quarkus-micrometer` and `quarkus-opentelemetry` extensions are used independently.
+
+*The OpenTelemetry SDK will handle all metrics.* Either Micrometer metrics (manual or automatic) and OpenTelemetry Metrics can be used. All are available with this single extension.
+
+All the configurations from the OpenTelemetry and Micrometer extensions are available with `quarkus-micrometer-opentelemetry`.
+
+The bridge is more than the simple OTLP registry found in Quarkiverse. In this extension, the OpenTelemetry SDK provides a Micrometer registry implementation based on the https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/micrometer/micrometer-1.5/library[`micrometer/micrometer-1.5`] OpenTelemetry instrumentation library.
+
+== Usage
+
+If you already have your Quarkus project configured, you can add the `quarkus-micrometer-opentelemetry` extension to your project by running the following command in your project base directory:
+
+:add-extension-extensions: micrometer-opentelemetry
+include::{includes}/devtools/extension-add.adoc[]
+
+This will add the following to your build file:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-micrometer-opentelemetry")
+----
+
+== Configuration
+
+When the extension is present, Micrometer is enabled by default as are OpenTelemetry tracing, metrics and logs.
+
+OpenTelemetry metrics auto-instrumentation for HTTP server and JVM metrics are disabled by default because those metrics can be  collected by Micrometer.
+
+Specific automatic Micrometer metrics are all disabled by default and can be enabled by setting, for example in the case of JVM metrics:
+[source,properties]
+----
+quarkus.micrometer.binder.jvm=true
+----
+in the `application.properties` file.
+
+For this and other properties you can use with the extension, Please refer to:
+
+* xref:telemetry-micrometer.adoc#configuration-reference[Micrometer metrics configuration properties]
+* xref:opentelemetry.adoc#configuration-reference[OpenTelemetry configuration properties]
+
+== Metric differences between Micrometer and OpenTelemetry
+
+=== API differences
+The metrics produced with each framework follow different APIs and the mapping is not 1:1.
+
+One fundamental API difference is that Micrometer uses a https://docs.micrometer.io/micrometer/reference/concepts/timers.html[Timer] and OpenTelemetry uses a https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram[Histogram] to record latency (execution time) metrics and the frequency of the events.
+
+When using the `@Timed` annotation with Micrometer, 2 different metrics are https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/324fdbdd452ddffaf2da2c5bf004d8bb3fdfa1dd/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java#L31[created on the OpenTelemetry side], one `Gauge` for the `max` value and one `Histogram`.
+
+The `DistributionSummary` from Micrometer is transformed into a `Histogram` and a `DoubleGauge` for the `max` value. If service level objectives (slo) are set to `true` when creating a `DistributionSummary`, an additional histogram is created for them.
+
+This table shows the differences between the two frameworks:
+
+|===
+|Micrometer |OpenTelemetry
+
+|DistributionSummary
+|`<Metric name>` (Histogram), `<Metric name>.max` (DoubleGauge)
+
+|DistributionSummary with SLOs
+|`<Metric name>` (Histogram), `<Metric name>.max` (DoubleGauge), `<Metric name>.histogram` (DoubleGauge)
+
+|LongTaskTimer
+|`<Metric name>.active` (ObservableLongUpDownCounter), `<Metric name>.duration` (ObservableDoubleUpDownCounter)
+
+|Timer
+|`<Metric name>` (Histogram), `<Metric name>.max` (ObservableDoubleGauge)
+|===
+
+
+=== Semantic convention differences
+
+The 2 frameworks follow different semantic conventions. The OpenTelemetry Metrics are based on the https://opentelemetry.io/docs/concepts/semantic-conventions/[OpenTelemetry Semantic Conventions] and are still under active development (early 2025). Micrometer metrics convention format is around for a long time and has not changed much.
+
+When these 2 configurations are set in the `application.properties` file:
+
+[source,properties]
+----
+quarkus.micrometer.binder.jvm=true
+quarkus.micrometer.binder.http-server.enabled=true
+----
+
+The JVM and HTTP server metrics are collected by Micrometer.
+
+Next, are examples of the metrics collected by Micrometer and a comparison of what would be the `quarkus-micrometer-registry-prometheus` output vs the one on this bridge. A link to the equivalent OpenTelemetry Semantic Convention is also provided for reference and is not currently used in the bridge.
+
+|===
+|Micrometer Meter |Quarkus Micrometer Prometheus output | This bridge OpenTelemetry output name | Related OpenTelemetry Semantic Convention (not applied)
+
+|Using the @Timed interceptor.
+|
+|method.timed (Histogram), method.timed.max (DoubleGauge)
+|NA
+
+|Using the @Counted interceptor.
+|
+|method.counted (DoubleSum)
+|NA
+
+|`http.server.active.requests` (Gauge)
+|`http_server_active_requests` (Gauge)
+|`http.server.active.requests` (DoubleGauge)
+|https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserveractive_requests[`http.server.active_requests`] (UpDownCounter)
+
+|`http.server.requests` (Timer)
+|`http_server_requests_seconds_count`, `http_server_requests_seconds_sum`, `http_server_requests_seconds_max` (Gauge)
+|`http.server.requests` (Histogram), `http.server.requests.max` (DoubleGauge)
+|https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration[`http.server.request.duration`] (Histogram)
+
+|`http.server.bytes.read` (DistributionSummary)
+|`http_server_bytes_read_count`, `http_server_bytes_read_sum` , `http_server_bytes_read_max` (Gauge)
+|`http.server.bytes.read` (Histogram), `http.server.bytes.read.max` (DoubleGauge)
+|https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestbodysize[`http.server.request.body.size`] (Histogram)
+
+|`http.server.bytes.write` (DistributionSummary)
+|`http_server_bytes_write_count`, `http_server_bytes_write_sum` , `http_server_bytes_write_max` (Gauge)
+|`http.server.bytes.write` (Histogram), `http.server.bytes.write.max` (DoubleGauge)
+|https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverresponsebodysize[`http.server.response.body.size`] (Histogram)
+
+|`http.server.connections` (LongTaskTimer)
+|`http_server_connections_seconds_active_count`, `http_server_connections_seconds_duration_sum` `http_server_connections_seconds_max` (Gauge)
+|`http.server.connections.active` (LongSum), `http.server.connections.duration` (DoubleGauge)
+| N/A
+
+|`jvm.threads.live` (Gauge)
+|`jvm_threads_live_threads` (Gauge)
+|`jvm.threads.live` (DoubleGauge)
+|https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmthreadcount[`jvm.threads.live`] (UpDownCounter)
+
+|`jvm.threads.started` (FunctionCounter)
+|`jvm_threads_started_threads_total` (Counter)
+|`jvm.threads.started` (DoubleSum)
+|https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmthreadcount[`jvm.threads.live`] (UpDownCounter)
+
+|`jvm.threads.daemon` (Gauge)
+|`jvm_threads_daemon_threads` (Gauge)
+|`jvm.threads.daemon` (DoubleGauge)
+|https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmthreadcount[`jvm.threads.live`] (UpDownCounter)
+
+|`jvm.threads.peak` (Gauge)
+|`jvm_threads_peak_threads` (Gauge)
+|`jvm.threads.peak` (DoubleGauge)
+|N/A
+
+|`jvm.threads.states` (Gauge per state)
+|`jvm_threads_states_threads` (Gauge)
+|`jvm.threads.states` (DoubleGauge)
+|https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmthreadcount[`jvm.threads.live`] (UpDownCounter)
+|===
+
+
+[NOTE]
+====
+Some metrics might be missing from the output if they contain no data.
+====
+
+== See the output
+
+=== Grafana-OTel-LGTM Dev Service
+You can use the xref:observability-devservices-lgtm.adoc[Grafana-OTel-LGTM] Dev Service.
+
+This Dev Service includes Grafana for visualizing data, Loki to store logs, Tempo to store traces and Prometheus to store metrics.
+It also provides an OTel collector to receive the data
+
+=== Logging exporter
+
+You can output all metrics to the console by setting the exporter to `logging` in the `application.properties` file:
+[source, properties]
+----
+quarkus.otel.metrics.exporter=logging <1>
+quarkus.otel.metric.export.interval=10000ms <2>
+----
+
+<1> Set the exporter to `logging`.
+Normally you don't need to set this.
+The default is `cdi`.
+<2> Set the interval to export the metrics.
+The default is `1m`, which is too long for debugging.
+
+Also add this dependency to your project:
+[source,xml]
+----
+<dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-exporter-logging</artifactId>
+</dependency>
+----

--- a/extensions/micrometer-opentelemetry/deployment/pom.xml
+++ b/extensions/micrometer-opentelemetry/deployment/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-micrometer-opentelemetry-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-micrometer-opentelemetry-deployment</artifactId>
+    <name>Quarkus - Micrometer to OpenTelemetry Bridge - Deployment</name>
+    <description>Micrometer registry implemented by the OpenTelemetry SDK</description>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-deployment</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-deployment</artifactId>
+        </dependency>
+
+        <!--TESTS-->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-routes-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <quarkus.log.level>INFO</quarkus.log.level>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/micrometer-opentelemetry/deployment/src/main/java/io/quarkus/micrometer/opentelemetry/deployment/MicrometerOTelBridgeConfigBuilderCustomizer.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/main/java/io/quarkus/micrometer/opentelemetry/deployment/MicrometerOTelBridgeConfigBuilderCustomizer.java
@@ -1,0 +1,18 @@
+package io.quarkus.micrometer.opentelemetry.deployment;
+
+import java.util.Map;
+
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+
+public class MicrometerOTelBridgeConfigBuilderCustomizer implements SmallRyeConfigBuilderCustomizer {
+    @Override
+    public void configBuilder(final SmallRyeConfigBuilder builder) {
+        // use a priority of 50 to make sure that this is overridable by any of the standard methods
+        builder.withSources(
+                new PropertiesConfigSource(Map.of(
+                        "quarkus.otel.metrics.enabled", "true",
+                        "quarkus.otel.logs.enabled", "true"), "quarkus-micrometer-opentelemetry", 1));
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/main/java/io/quarkus/micrometer/opentelemetry/deployment/MicrometerOtelBridgeProcessor.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/main/java/io/quarkus/micrometer/opentelemetry/deployment/MicrometerOtelBridgeProcessor.java
@@ -1,0 +1,91 @@
+package io.quarkus.micrometer.opentelemetry.deployment;
+
+import java.util.Locale;
+import java.util.function.BooleanSupplier;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Singleton;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.logmanager.Level;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.LogCategoryBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
+import io.quarkus.micrometer.deployment.MicrometerProcessor;
+import io.quarkus.micrometer.opentelemetry.runtime.MicrometerOtelBridgeRecorder;
+import io.quarkus.opentelemetry.deployment.OpenTelemetryEnabled;
+import io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig;
+import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
+
+@BuildSteps(onlyIf = {
+        MicrometerProcessor.MicrometerEnabled.class,
+        OpenTelemetryEnabled.class,
+        MicrometerOtelBridgeProcessor.OtlpMetricsExporterEnabled.class })
+public class MicrometerOtelBridgeProcessor {
+
+    @BuildStep
+    public void disableOTelAutoInstrumentedMetrics(BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeConfigProducer) {
+        runtimeConfigProducer.produce(
+                new RunTimeConfigurationDefaultBuildItem("quarkus.otel.instrument.http-server-metrics", "false"));
+        runtimeConfigProducer.produce(
+                new RunTimeConfigurationDefaultBuildItem("quarkus.otel.instrument.jvm-metrics", "false"));
+    }
+
+    @BuildStep
+    public void tuneDefaultConfigs(BuildProducer<LogCategoryBuildItem> logCategoryProducer) {
+        // Suppress noisy logs from Micrometer:
+        // ...A MeterFilter is being configured after a Meter has been registered to this registry...
+        logCategoryProducer.produce(new LogCategoryBuildItem(
+                "io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry",
+                Level.ERROR));
+        logCategoryProducer.produce(new LogCategoryBuildItem(
+                "io.micrometer.core.instrument.composite.CompositeMeterRegistry",
+                Level.ERROR));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void createBridgeBean(OTelRuntimeConfig otelRuntimeConfig,
+            MicrometerOtelBridgeRecorder recorder,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeanProducer) {
+
+        if (otelRuntimeConfig.sdkDisabled()) {
+            return; // No point in creating the bridge if the SDK is disabled
+        }
+
+        syntheticBeanProducer.produce(SyntheticBeanBuildItem.configure(MeterRegistry.class)
+                .defaultBean()
+                .setRuntimeInit()
+                .unremovable()
+                .scope(Singleton.class)
+                .addInjectionPoint(ParameterizedType.create(DotName.createSimple(Instance.class),
+                        new Type[] { ClassType.create(DotName.createSimple(OpenTelemetry.class.getName())) }, null))
+                .createWith(recorder.createBridge(otelRuntimeConfig))
+                .done());
+    }
+
+    /**
+     * No point in activating the bridge if the OTel metrics if off or the exporter is none.
+     */
+    static class OtlpMetricsExporterEnabled implements BooleanSupplier {
+        OTelBuildConfig otelBuildConfig;
+
+        public boolean getAsBoolean() {
+            return otelBuildConfig.metrics().enabled().orElse(Boolean.TRUE) &&
+                    !otelBuildConfig.metrics().exporter().stream()
+                            .map(exporter -> exporter.toLowerCase(Locale.ROOT))
+                            .anyMatch(exporter -> exporter.contains("none"));
+        }
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
+++ b/extensions/micrometer-opentelemetry/deployment/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
@@ -1,0 +1,1 @@
+io.quarkus.micrometer.opentelemetry.deployment.MicrometerOTelBridgeConfigBuilderCustomizer

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/DistributionSummaryTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/DistributionSummaryTest.java
@@ -1,0 +1,129 @@
+package io.quarkus.micrometer.opentelemetry.deployment;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporter;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporterProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DistributionSummaryTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(ManualHistogramBean.class)
+                            .addClasses(InMemoryMetricExporter.class, InMemoryMetricExporterProvider.class)
+                            .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                                    "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                            .add(new StringAsset("""
+                                    quarkus.otel.metrics.enabled=true\n
+                                    quarkus.otel.traces.exporter=none\n
+                                    quarkus.otel.logs.exporter=none\n
+                                    quarkus.otel.metrics.exporter=in-memory\n
+                                    quarkus.otel.metric.export.interval=300ms\n
+                                    quarkus.micrometer.binder-enabled-default=false\n
+                                    quarkus.micrometer.binder.http-client.enabled=true\n
+                                    quarkus.micrometer.binder.http-server.enabled=true\n
+                                    quarkus.micrometer.binder.http-server.match-patterns=/one=/two\n
+                                    quarkus.micrometer.binder.http-server.ignore-patterns=/two\n
+                                    quarkus.micrometer.binder.vertx.enabled=true\n
+                                    pingpong/mp-rest/url=${test.url}\n
+                                    quarkus.redis.devservices.enabled=false\n
+                                    """),
+                                    "application.properties"));
+
+    @Inject
+    ManualHistogramBean manualHistogramBean;
+
+    @Inject
+    InMemoryMetricExporter exporter;
+
+    @Test
+    void histogramTest() {
+        manualHistogramBean.recordHistogram();
+
+        MetricData testSummary = exporter.getLastFinishedHistogramItem("testSummary", 4);
+        assertNotNull(testSummary);
+        assertThat(testSummary)
+                .hasDescription("This is a test distribution summary")
+                .hasUnit("things")
+                .hasHistogramSatisfying(
+                        histogram -> histogram.hasPointsSatisfying(
+                                points -> points
+                                        .hasSum(555.5)
+                                        .hasCount(4)
+                                        .hasAttributes(attributeEntry("tag", "value"))));
+
+        MetricData textSummaryMax = exporter.getFinishedMetricItem("testSummary.max");
+        assertNotNull(textSummaryMax);
+        assertThat(textSummaryMax)
+                .hasDescription("This is a test distribution summary")
+                .hasDoubleGaugeSatisfying(
+                        gauge -> gauge.hasPointsSatisfying(
+                                point -> point
+                                        .hasValue(500)
+                                        .hasAttributes(attributeEntry("tag", "value"))));
+
+        MetricData testSummaryHistogram = exporter.getFinishedMetricItem("testSummary.histogram"); // present when SLOs are set
+        assertNotNull(testSummaryHistogram);
+        assertThat(testSummaryHistogram)
+                .hasDoubleGaugeSatisfying(
+                        gauge -> gauge.hasPointsSatisfying(
+                                point -> point
+                                        .hasValue(1)
+                                        .hasAttributes(
+                                                attributeEntry("le", "1"),
+                                                attributeEntry("tag", "value")),
+                                point -> point
+                                        .hasValue(2)
+                                        .hasAttributes(
+                                                attributeEntry("le", "10"),
+                                                attributeEntry("tag", "value")),
+                                point -> point
+                                        .hasValue(3)
+                                        .hasAttributes(
+                                                attributeEntry("le", "100"),
+                                                attributeEntry("tag", "value")),
+                                point -> point
+                                        .hasValue(4)
+                                        .hasAttributes(
+                                                attributeEntry("le", "1000"),
+                                                attributeEntry("tag", "value"))));
+    }
+
+    @ApplicationScoped
+    public static class ManualHistogramBean {
+        @Inject
+        MeterRegistry registry;
+
+        public void recordHistogram() {
+            DistributionSummary summary = DistributionSummary.builder("testSummary")
+                    .description("This is a test distribution summary")
+                    .baseUnit("things")
+                    .tags("tag", "value")
+                    .serviceLevelObjectives(1, 10, 100, 1000)
+                    .distributionStatisticBufferLength(10)
+                    .register(registry);
+
+            summary.record(0.5);
+            summary.record(5);
+            summary.record(50);
+            summary.record(500);
+        }
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/MetricsDisabledTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/MetricsDisabledTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.micrometer.opentelemetry.deployment;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.restassured.RestAssured.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporter;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporterProvider;
+import io.quarkus.micrometer.opentelemetry.deployment.common.PingPongResource;
+import io.quarkus.micrometer.opentelemetry.deployment.common.Util;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class MetricsDisabledTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(Util.class,
+                                    PingPongResource.class)
+                            .addClasses(InMemoryMetricExporter.class, InMemoryMetricExporterProvider.class)
+                            .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                                    "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                            .add(new StringAsset("""
+                                    quarkus.otel.sdk.disabled=true\n
+                                    quarkus.otel.metrics.enabled=true\n
+                                    quarkus.otel.traces.exporter=none\n
+                                    quarkus.otel.logs.exporter=none\n
+                                    quarkus.otel.metrics.exporter=in-memory\n
+                                    quarkus.otel.metric.export.interval=300ms\n
+                                    quarkus.micrometer.binder.http-client.enabled=true\n
+                                    quarkus.micrometer.binder.http-server.enabled=true\n
+                                    pingpong/mp-rest/url=${test.url}\n
+                                    quarkus.redis.devservices.enabled=false\n
+                                    """),
+                                    "application.properties"));
+
+    @Inject
+    protected InMemoryMetricExporter metricExporter;
+
+    protected static String mapToString(Map<AttributeKey<?>, ?> map) {
+        return (String) map.keySet().stream()
+                .map(key -> "" + key.getKey() + "=" + map.get(key))
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    @BeforeEach
+    void setUp() {
+        metricExporter.reset();
+    }
+
+    @Test
+    void disabledTest() throws InterruptedException {
+        // The otel metrics are disabled
+        RestAssured.basePath = "/";
+        when().get("/ping/one").then().statusCode(200);
+
+        Thread.sleep(200);
+
+        List<MetricData> metricData = metricExporter.getFinishedMetricItems();
+        assertThat(metricData).isEmpty();
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/CountedResource.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/CountedResource.java
@@ -1,0 +1,64 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import static io.quarkus.micrometer.opentelemetry.deployment.compatibility.MicrometerCounterInterceptorTest.*;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.aop.MeterTag;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class CountedResource {
+    @Counted(value = "metric.none", recordFailuresOnly = true)
+    public void onlyCountFailures() {
+    }
+
+    @Counted(value = "metric.all", extraTags = { "extra", "tag" })
+    public void countAllInvocations(@MeterTag(key = "do_fail", resolver = TestValueResolver.class) boolean fail) {
+        if (fail) {
+            throw new NullPointerException("Failed on purpose");
+        }
+    }
+
+    @Counted(description = "nice description")
+    public void emptyMetricName(@MeterTag boolean fail) {
+        if (fail) {
+            throw new NullPointerException("Failed on purpose");
+        }
+    }
+
+    @Counted(value = "async.none", recordFailuresOnly = true)
+    public CompletableFuture<?> onlyCountAsyncFailures(GuardedResult guardedResult) {
+        return supplyAsync(guardedResult::get);
+    }
+
+    @Counted(value = "async.all", extraTags = { "extra", "tag" })
+    public CompletableFuture<?> countAllAsyncInvocations(GuardedResult guardedResult) {
+        return supplyAsync(guardedResult::get);
+    }
+
+    @Counted
+    public CompletableFuture<?> emptyAsyncMetricName(GuardedResult guardedResult) {
+        return supplyAsync(guardedResult::get);
+    }
+
+    @Counted(value = "uni.none", recordFailuresOnly = true)
+    public Uni<?> onlyCountUniFailures(GuardedResult guardedResult) {
+        return Uni.createFrom().item(guardedResult::get);
+    }
+
+    @Counted(value = "uni.all", extraTags = { "extra", "tag" })
+    public Uni<?> countAllUniInvocations(GuardedResult guardedResult) {
+        return Uni.createFrom().item(guardedResult::get);
+    }
+
+    @Counted
+    public Uni<?> emptyUniMetricName(GuardedResult guardedResult) {
+        return Uni.createFrom().item(guardedResult::get);
+    }
+
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/GuardedResult.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/GuardedResult.java
@@ -1,0 +1,34 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+public class GuardedResult {
+
+    private boolean complete;
+    private NullPointerException withException;
+
+    public synchronized Object get() {
+        while (!complete) {
+            try {
+                wait();
+            } catch (InterruptedException e) {
+                // Intentionally empty
+            }
+        }
+
+        if (withException == null) {
+            return new Object();
+        }
+
+        throw withException;
+    }
+
+    public synchronized void complete() {
+        complete(null);
+    }
+
+    public synchronized void complete(NullPointerException withException) {
+        this.complete = true;
+        this.withException = withException;
+        notifyAll();
+    }
+
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/HelloResource.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/HelloResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("/hello")
+@Singleton
+public class HelloResource {
+    @GET
+    @Path("{message}")
+    public String hello(@PathParam("message") String message) {
+        return "hello " + message;
+    }
+
+    @OPTIONS
+    @Path("{message}")
+    public String helloOptions(@PathParam("message") String message) {
+        return "hello " + message;
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/InMemoryMetricExporter.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/InMemoryMetricExporter.java
@@ -1,0 +1,180 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.quarkus.arc.Unremovable;
+
+@Unremovable
+@ApplicationScoped
+public class InMemoryMetricExporter implements MetricExporter {
+
+    private final Queue<MetricData> finishedMetricItems = new ConcurrentLinkedQueue<>();
+    private final AggregationTemporality aggregationTemporality = AggregationTemporality.CUMULATIVE;
+    private boolean isStopped = false;
+
+    public MetricDataFilter metrics(final String name) {
+        return new MetricDataFilter(this, name);
+    }
+
+    public MetricDataFilter get(final String name) {
+        return new MetricDataFilter(this, name);
+    }
+
+    public MetricDataFilter find(final String name) {
+        return new MetricDataFilter(this, name);
+    }
+
+    /*
+     * ignore points with /export in the route
+     */
+    private static boolean notExporterPointData(PointData pointData) {
+        return pointData.getAttributes().asMap().entrySet().stream()
+                .noneMatch(entry -> entry.getKey().getKey().equals("uri") &&
+                        entry.getValue().toString().contains("/export"));
+    }
+
+    private static boolean isPathFound(String path, Attributes attributes) {
+        if (path == null) {
+            return true;// any match
+        }
+        Object value = attributes.asMap().get(AttributeKey.stringKey("uri"));
+        if (value == null) {
+            return false;
+        }
+        return value.toString().equals(path);
+    }
+
+    public MetricData getLastFinishedHistogramItem(String testSummary, int count) {
+        Awaitility.await().atMost(5, SECONDS)
+                .untilAsserted(() -> Assertions.assertEquals(count, getFinishedMetricItems(testSummary, null).size()));
+        List<MetricData> metricData = getFinishedMetricItems(testSummary, null);
+        return metricData.get(metricData.size() - 1);// get last added entry which will be the most recent
+    }
+
+    public void assertCountDataPointsAtLeast(final String name, final String target, final int count) {
+        Awaitility.await().atMost(5, SECONDS)
+                .untilAsserted(() -> Assertions.assertTrue(count < countMaxPoints(name, target)));
+    }
+
+    public void assertCountDataPointsAtLeastOrEqual(final String name, final String target, final int count) {
+        Awaitility.await().atMost(5, SECONDS)
+                .untilAsserted(() -> Assertions.assertTrue(count <= countMaxPoints(name, target)));
+    }
+
+    public void assertCountDataPointsAtLeastOrEqual(Supplier<MetricDataFilter> tag, int count) {
+        Awaitility.await().atMost(50, SECONDS)
+                .untilAsserted(() -> Assertions.assertTrue(count <= tag.get().lastReadingPointsSize()));
+    }
+
+    private Integer countMaxPoints(String name, String target) {
+        List<MetricData> metricData = getFinishedMetricItems(name, target);
+        if (metricData.isEmpty()) {
+            return 0;
+        }
+        int size = metricData.get(metricData.size() - 1).getData().getPoints().size();
+        return size;
+    }
+
+    /**
+     * Returns a {@code List} of the finished {@code Metric}s, represented by {@code MetricData}.
+     *
+     * @return a {@code List} of the finished {@code Metric}s.
+     */
+    public List<MetricData> getFinishedMetricItems() {
+        return Collections.unmodifiableList(new ArrayList<>(finishedMetricItems));
+    }
+
+    public MetricData getFinishedMetricItem(String metricName) {
+        List<MetricData> metricData = getFinishedMetricItems(metricName, null);
+        if (metricData.isEmpty()) {
+            return null;
+        }
+        return metricData.get(metricData.size() - 1);// get last added entry which will be the most recent
+    }
+
+    public List<MetricData> getFinishedMetricItems(final String name, final String target) {
+        return Collections.unmodifiableList(new ArrayList<>(
+                finishedMetricItems.stream()
+                        .filter(metricData -> metricData.getName().equals(name))
+                        .filter(metricData -> metricData.getData().getPoints().stream()
+                                .anyMatch(point -> isPathFound(target, point.getAttributes())))
+                        .collect(Collectors.toList())));
+    }
+
+    /**
+     * Clears the internal {@code List} of finished {@code Metric}s.
+     *
+     * <p>
+     * Does not reset the state of this exporter if already shutdown.
+     */
+    public void reset() {
+        finishedMetricItems.clear();
+    }
+
+    @Override
+    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+        return aggregationTemporality;
+    }
+
+    /**
+     * Exports the collection of {@code Metric}s into the inmemory queue.
+     *
+     * <p>
+     * If this is called after {@code shutdown}, this will return {@code ResultCode.FAILURE}.
+     */
+    @Override
+    public CompletableResultCode export(Collection<MetricData> metrics) {
+        if (isStopped) {
+            return CompletableResultCode.ofFailure();
+        }
+        finishedMetricItems.addAll(metrics);
+        return CompletableResultCode.ofSuccess();
+    }
+
+    /**
+     * The InMemory exporter does not batch metrics, so this method will immediately return with
+     * success.
+     *
+     * @return always Success
+     */
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    /**
+     * Clears the internal {@code List} of finished {@code Metric}s.
+     *
+     * <p>
+     * Any subsequent call to export() function on this MetricExporter, will return {@code
+     * CompletableResultCode.ofFailure()}
+     */
+    @Override
+    public CompletableResultCode shutdown() {
+        isStopped = true;
+        finishedMetricItems.clear();
+        return CompletableResultCode.ofSuccess();
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/InMemoryMetricExporterProvider.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/InMemoryMetricExporterProvider.java
@@ -1,0 +1,19 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+
+public class InMemoryMetricExporterProvider implements ConfigurableMetricExporterProvider {
+    @Override
+    public MetricExporter createExporter(ConfigProperties configProperties) {
+        return CDI.current().select(InMemoryMetricExporter.class).get();
+    }
+
+    @Override
+    public String getName() {
+        return "in-memory";
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/MetricDataFilter.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/MetricDataFilter.java
@@ -1,0 +1,247 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.Data;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class MetricDataFilter {
+    private Stream<MetricData> metricData;
+
+    public MetricDataFilter(final InMemoryMetricExporter metricExporter, final String name) {
+        metricData = metricExporter.getFinishedMetricItems()
+                .stream()
+                .filter(metricData -> metricData.getName().equals(name));
+    }
+
+    public MetricDataFilter route(final String route) {
+        metricData = metricData.map(new Function<MetricData, MetricData>() {
+            @Override
+            public MetricData apply(final MetricData metricData) {
+                return new MetricData() {
+                    @Override
+                    public Resource getResource() {
+                        return metricData.getResource();
+                    }
+
+                    @Override
+                    public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+                        return metricData.getInstrumentationScopeInfo();
+                    }
+
+                    @Override
+                    public String getName() {
+                        return metricData.getName();
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return metricData.getDescription();
+                    }
+
+                    @Override
+                    public String getUnit() {
+                        return metricData.getUnit();
+                    }
+
+                    @Override
+                    public MetricDataType getType() {
+                        return metricData.getType();
+                    }
+
+                    @Override
+                    public Data<?> getData() {
+                        return new Data<PointData>() {
+                            @Override
+                            public Collection<PointData> getPoints() {
+                                return metricData.getData().getPoints().stream().filter(new Predicate<PointData>() {
+                                    @Override
+                                    public boolean test(final PointData pointData) {
+                                        String value = pointData.getAttributes().get(HTTP_ROUTE);
+                                        return value != null && value.equals(route);
+                                    }
+                                }).collect(Collectors.toSet());
+                            }
+                        };
+                    }
+                };
+            }
+        });
+        return this;
+    }
+
+    public MetricDataFilter path(final String path) {
+        metricData = metricData.map(new Function<MetricData, MetricData>() {
+            @Override
+            public MetricData apply(final MetricData metricData) {
+                return new MetricData() {
+                    @Override
+                    public Resource getResource() {
+                        return metricData.getResource();
+                    }
+
+                    @Override
+                    public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+                        return metricData.getInstrumentationScopeInfo();
+                    }
+
+                    @Override
+                    public String getName() {
+                        return metricData.getName();
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return metricData.getDescription();
+                    }
+
+                    @Override
+                    public String getUnit() {
+                        return metricData.getUnit();
+                    }
+
+                    @Override
+                    public MetricDataType getType() {
+                        return metricData.getType();
+                    }
+
+                    @Override
+                    public Data<?> getData() {
+                        return new Data<PointData>() {
+                            @Override
+                            public Collection<PointData> getPoints() {
+                                return metricData.getData().getPoints().stream().filter(new Predicate<PointData>() {
+                                    @Override
+                                    public boolean test(final PointData pointData) {
+                                        String value = pointData.getAttributes().get(URL_PATH);
+                                        return value != null && value.equals(path);
+                                    }
+                                }).collect(Collectors.toSet());
+                            }
+                        };
+                    }
+                };
+            }
+        });
+        return this;
+    }
+
+    public MetricDataFilter tag(final String key, final String value) {
+        return stringAttribute(key, value);
+    }
+
+    public MetricDataFilter stringAttribute(final String key, final String value) {
+        metricData = metricData.map(new Function<MetricData, MetricData>() {
+            @Override
+            public MetricData apply(final MetricData metricData) {
+                return new MetricData() {
+                    @Override
+                    public Resource getResource() {
+                        return metricData.getResource();
+                    }
+
+                    @Override
+                    public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+                        return metricData.getInstrumentationScopeInfo();
+                    }
+
+                    @Override
+                    public String getName() {
+                        return metricData.getName();
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return metricData.getDescription();
+                    }
+
+                    @Override
+                    public String getUnit() {
+                        return metricData.getUnit();
+                    }
+
+                    @Override
+                    public MetricDataType getType() {
+                        return metricData.getType();
+                    }
+
+                    @Override
+                    public Data<?> getData() {
+                        return new Data<PointData>() {
+                            @Override
+                            public Collection<PointData> getPoints() {
+                                return metricData.getData().getPoints().stream().filter(new Predicate<PointData>() {
+                                    @Override
+                                    public boolean test(final PointData pointData) {
+                                        String v = pointData.getAttributes().get(AttributeKey.stringKey(key));
+                                        boolean result = v != null && v.equals(value);
+                                        if (!result) {
+                                            System.out.println(
+                                                    "\nNot Matching. Expected: " + key + " = " + value + " -> Found: " + v);
+                                        }
+                                        return result;
+                                    }
+                                }).collect(Collectors.toSet());
+                            }
+                        };
+                    }
+                };
+            }
+        });
+        return this;
+    }
+
+    public List<MetricData> getAll() {
+        return metricData.collect(Collectors.toList());
+    }
+
+    public MetricData lastReading() {
+        return metricData.reduce((first, second) -> second)
+                .orElseThrow(() -> new IllegalArgumentException("Stream has no elements"));
+    }
+
+    public int lastReadingPointsSize() {
+        return metricData.reduce((first, second) -> second)
+                .map(data -> data.getData().getPoints().size())
+                .orElseThrow(() -> new IllegalArgumentException("Stream has no elements"));
+    }
+
+    /**
+     * Returns the first point data of the last reading.
+     * Assumes only one data point can be present.
+     *
+     * @param pointDataClass
+     * @param <T>
+     * @return
+     */
+    public <T extends PointData> T lastReadingDataPoint(Class<T> pointDataClass) {
+        List<T> list = lastReading().getData().getPoints().stream()
+                .map(pointData -> (T) pointData)
+                .toList();
+
+        if (list.size() == 0) {
+            throw new IllegalArgumentException("Stream has no elements");
+        }
+        if (list.size() > 1) {
+            throw new IllegalArgumentException("Stream has more than one element");
+        }
+        return list.get(0);
+    }
+
+    public int countPoints(final MetricData metricData) {
+        return metricData.getData().getPoints().size();
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/PingPongResource.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/PingPongResource.java
@@ -1,0 +1,75 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("/")
+@Singleton
+public class PingPongResource {
+    @RegisterRestClient(configKey = "pingpong")
+    public interface PingPongRestClient {
+        @GET
+        @Path("pong/{message}")
+        String pingpong(@PathParam("message") String message);
+
+        @GET
+        @Path("pong/{message}")
+        CompletionStage<String> asyncPingPong(@PathParam("message") String message);
+    }
+
+    @Inject
+    @RestClient
+    PingPongRestClient pingRestClient;
+
+    @GET
+    @Path("pong/{message}")
+    public Response pong(@PathParam("message") String message) {
+        if (message.equals("500")) {
+            return Response.status(500).build();
+        } else if (message.equals("400")) {
+            return Response.status(400).build();
+        }
+        return Response.ok(message, "text/plain").build();
+    }
+
+    @GET
+    @Path("ping/{message}")
+    public String ping(@PathParam("message") String message) {
+        try {
+            return pingRestClient.pingpong(message);
+        } catch (Exception ex) {
+            if (!"400".equals(message) && !"500".equals(message)) {
+                throw ex;
+            }
+            // expected exception
+        }
+        return message;
+    }
+
+    @GET
+    @Path("async-ping/{message}")
+    public CompletionStage<String> asyncPing(@PathParam("message") String message) {
+        return pingRestClient.asyncPingPong(message);
+    }
+
+    @GET
+    @Path("one")
+    public String one() {
+        return "OK";
+    }
+
+    @GET
+    @Path("two")
+    public String two() {
+        return "OK";
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/ServletEndpoint.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/ServletEndpoint.java
@@ -1,0 +1,18 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet(name = "ServletEndpoint", urlPatterns = "/servlet/*")
+public class ServletEndpoint extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        resp.getWriter().println("OK");
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/TimedResource.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/TimedResource.java
@@ -1,0 +1,66 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.micrometer.core.annotation.Timed;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class TimedResource {
+    @Timed(value = "call", extraTags = { "extra", "tag" })
+    public void call(boolean fail) {
+        if (fail) {
+            throw new NullPointerException("Failed on purpose");
+        }
+
+    }
+
+    @Timed(value = "longCall", extraTags = { "extra", "tag" }, longTask = true)
+    public void longCall(boolean fail) {
+        try {
+            Thread.sleep(3);
+        } catch (InterruptedException e) {
+        }
+        if (fail) {
+            throw new NullPointerException("Failed on purpose");
+        }
+    }
+
+    @Timed(value = "async.call", extraTags = { "extra", "tag" })
+    public CompletableFuture<?> asyncCall(GuardedResult guardedResult) {
+        return supplyAsync(guardedResult::get);
+    }
+
+    @Timed(value = "uni.call", extraTags = { "extra", "tag" })
+    public Uni<?> uniCall(GuardedResult guardedResult) {
+        return Uni.createFrom().item(guardedResult::get);
+    }
+
+    @Timed(value = "async.longCall", extraTags = { "extra", "tag" }, longTask = true)
+    public CompletableFuture<?> longAsyncCall(GuardedResult guardedResult) {
+        try {
+            Thread.sleep(3);
+        } catch (InterruptedException e) {
+        }
+        return supplyAsync(guardedResult::get);
+    }
+
+    @Timed(value = "uni.longCall", extraTags = { "extra", "tag" }, longTask = true)
+    public Uni<?> longUniCall(GuardedResult guardedResult) {
+        return Uni.createFrom().item(guardedResult::get).onItem().delayIt().by(Duration.of(3, ChronoUnit.MILLIS));
+    }
+
+    @Timed(value = "alpha", extraTags = { "extra", "tag" })
+    @Timed(value = "bravo", extraTags = { "extra", "tag" })
+    public void repeatableCall(boolean fail) {
+        if (fail) {
+            throw new NullPointerException("Failed on purpose");
+        }
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/Util.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/Util.java
@@ -1,0 +1,75 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+public class Util {
+    private Util() {
+    }
+
+    static void assertMessage(String attribute, List<LogRecord> records) {
+        // look through log records and make sure there is a message about the specific attribute
+        long i = records.stream().filter(x -> Arrays.stream(x.getParameters()).anyMatch(y -> y.equals(attribute)))
+                .count();
+        Assertions.assertEquals(1, i);
+    }
+
+    static String stackToString(Throwable t) {
+        StringBuilder sb = new StringBuilder().append("\n");
+        while (t.getCause() != null) {
+            t = t.getCause();
+        }
+        sb.append(t.getClass()).append(": ").append(t.getMessage()).append("\n");
+        Arrays.asList(t.getStackTrace()).forEach(x -> sb.append("\t").append(x.toString()).append("\n"));
+        return sb.toString();
+    }
+
+    public static String foundServerRequests(MeterRegistry registry, String message) {
+        return message + "\nFound:\n" + Util.listMeters(registry, "http.server.requests");
+    }
+
+    public static String foundClientRequests(MeterRegistry registry, String message) {
+        return message + "\nFound:\n" + Util.listMeters(registry, "http.client.requests");
+    }
+
+    public static String listMeters(MeterRegistry registry, String meterName) {
+        return registry.find(meterName).meters().stream()
+                .map(x -> {
+                    return x.getId().toString();
+                })
+                .collect(Collectors.joining("\n"));
+    }
+
+    public static String listMeters(MeterRegistry registry, String meterName, final String tag) {
+        return registry.find(meterName).meters().stream()
+                .map(x -> {
+                    return x.getId().getTag(tag);
+                })
+                .collect(Collectors.joining(","));
+    }
+
+    public static <T> void waitForMeters(Collection<T> collection, int count) throws InterruptedException {
+        int i = 0;
+        do {
+            Thread.sleep(3);
+        } while (collection.size() < count && i++ < 10);
+    }
+
+    public static void assertTags(Tag tag, Meter... meters) {
+        for (Meter meter : meters) {
+            assertThat(meter.getId().getTags().contains(tag));
+        }
+    }
+
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/VertxWebEndpoint.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/common/VertxWebEndpoint.java
@@ -1,0 +1,24 @@
+package io.quarkus.micrometer.opentelemetry.deployment.common;
+
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
+import io.quarkus.vertx.web.RouteBase;
+
+@RouteBase(path = "/vertx")
+public class VertxWebEndpoint {
+    @Route(path = "item/:id", methods = HttpMethod.GET)
+    public String item(@Param("id") Integer id) {
+        return "message with id " + id;
+    }
+
+    @Route(path = "item/:id/:sub", methods = HttpMethod.GET)
+    public String item(@Param("id") Integer id, @Param("sub") Integer sub) {
+        return "message with id " + id + " and sub " + sub;
+    }
+
+    @Route(path = "echo/:msg", methods = { HttpMethod.HEAD, HttpMethod.GET, HttpMethod.OPTIONS })
+    public String echo(@Param("msg") String msg) {
+        return "echo " + msg;
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/HttpCompatibilityTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/HttpCompatibilityTest.java
@@ -1,0 +1,241 @@
+package io.quarkus.micrometer.opentelemetry.deployment.compatibility;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.restassured.RestAssured.when;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.Comparator;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.awaitility.Awaitility;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.quarkus.micrometer.opentelemetry.deployment.common.HelloResource;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporter;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporterProvider;
+import io.quarkus.micrometer.opentelemetry.deployment.common.PingPongResource;
+import io.quarkus.micrometer.opentelemetry.deployment.common.ServletEndpoint;
+import io.quarkus.micrometer.opentelemetry.deployment.common.Util;
+import io.quarkus.micrometer.opentelemetry.deployment.common.VertxWebEndpoint;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Copy of io.quarkus.micrometer.deployment.binder.UriTagTest
+ */
+public class HttpCompatibilityTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(Util.class,
+                                    PingPongResource.class,
+                                    PingPongResource.PingPongRestClient.class,
+                                    ServletEndpoint.class,
+                                    VertxWebEndpoint.class,
+                                    HelloResource.class)
+                            .addClasses(InMemoryMetricExporter.class, InMemoryMetricExporterProvider.class)
+                            .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                                    "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                            .add(new StringAsset("""
+                                    quarkus.otel.metrics.exporter=in-memory\n
+                                    quarkus.otel.metric.export.interval=100ms\n
+                                    quarkus.micrometer.binder-enabled-default=false\n
+                                    quarkus.micrometer.binder.http-client.enabled=true\n
+                                    quarkus.micrometer.binder.http-server.enabled=true\n
+                                    quarkus.micrometer.binder.http-server.match-patterns=/one=/two\n
+                                    quarkus.micrometer.binder.http-server.ignore-patterns=/two\n
+                                    quarkus.micrometer.binder.vertx.enabled=true\n
+                                    pingpong/mp-rest/url=${test.url}\n
+                                    quarkus.redis.devservices.enabled=false\n
+                                    """),
+                                    "application.properties"));
+    public static final AttributeKey<String> URI = AttributeKey.stringKey("uri");
+    public static final AttributeKey<String> METHOD = AttributeKey.stringKey("method");
+    public static final AttributeKey<String> STATUS = AttributeKey.stringKey("status");
+
+    @Inject
+    protected InMemoryMetricExporter metricExporter;
+
+    @BeforeEach
+    void setUp() {
+        metricExporter.reset();
+    }
+
+    /**
+     * Same as io.quarkus.micrometer.deployment.binder.UriTagTest.
+     * Makes sure we are getting equivalent results in OTel.
+     * Micrometer uses timers and OTel uses histograms.
+     */
+    @Test
+    void testHttpTimerToHistogramCompatibility() {
+        RestAssured.basePath = "/";
+
+        // Server GET vs. HEAD methods -- templated
+        when().get("/hello/one").then().statusCode(200);
+        when().get("/hello/two").then().statusCode(200);
+        when().head("/hello/three").then().statusCode(200);
+        when().head("/hello/four").then().statusCode(200);
+        when().get("/vertx/echo/thing1").then().statusCode(200);
+        when().get("/vertx/echo/thing2").then().statusCode(200);
+        when().head("/vertx/echo/thing3").then().statusCode(200);
+        when().head("/vertx/echo/thing4").then().statusCode(200);
+
+        // Server -> Rest client -> Server (templated)
+        when().get("/ping/one").then().statusCode(200);
+        when().get("/ping/two").then().statusCode(200);
+        when().get("/ping/three").then().statusCode(200);
+        when().get("/ping/400").then().statusCode(200);
+        when().get("/ping/500").then().statusCode(200);
+        when().get("/async-ping/one").then().statusCode(200);
+        when().get("/async-ping/two").then().statusCode(200);
+        when().get("/async-ping/three").then().statusCode(200);
+
+        // Server paths (templated)
+        when().get("/one").then().statusCode(200);
+        when().get("/two").then().statusCode(200);
+        when().get("/vertx/item/123").then().statusCode(200);
+        when().get("/vertx/item/1/123").then().statusCode(200);
+        //        when().get("/servlet/12345").then().statusCode(200);
+
+        Awaitility.await().atMost(10, SECONDS)
+                .untilAsserted(() -> {
+                    final List<MetricData> metricDataList = metricExporter.getFinishedMetricItems("http.server.requests", null);
+                    final MetricData metricData = metricDataList.get(metricDataList.size() - 1); // get last collected
+                    assertServerMetrics(metricData);
+                });
+
+        final List<MetricData> metricDataList = metricExporter.getFinishedMetricItems("http.server.requests", null);
+        final MetricData metricData = metricDataList.stream()
+                .max(Comparator.comparingInt(data -> data.getData().getPoints().size()))
+                .get();
+
+        assertThat(metricData.getInstrumentationScopeInfo().getName())
+                .isEqualTo("io.opentelemetry.micrometer-1.5");
+
+        // /one should map to /two, which is ignored.
+        // Neither should exist w/ timers because they were disabled in the configuration.
+        assertThat(metricData.getHistogramData().getPoints().stream()
+                .anyMatch(point -> point.getAttributes().get(URI).equals("/one") ||
+                        point.getAttributes().get(URI).equals("/two")))
+                .isFalse();
+
+        // OTel metrics are not enabled
+        assertThat(metricExporter.getFinishedMetricItem("http.server.request.duration")).isNull();
+
+        metricExporter.assertCountDataPointsAtLeast("http.client.requests", null, 2);
+        final List<MetricData> clientMetricDataList = metricExporter.getFinishedMetricItems("http.client.requests", null);
+
+        Awaitility.await().atMost(10, SECONDS)
+                .untilAsserted(() -> {
+                    final MetricData clientMetricData = clientMetricDataList.get(clientMetricDataList.size() - 1); // get last collected
+                    assertThat(clientMetricData.getInstrumentationScopeInfo().getName())
+                            .isEqualTo("io.opentelemetry.micrometer-1.5");
+                    assertThat(clientMetricData)
+                            .hasName("http.client.requests") // in OTel it should be "http.server.request.duration"
+                            .hasDescription("") // in OTel it should be "Duration of HTTP client requests."
+                            .hasUnit("ms") // OTel has seconds
+                            .hasHistogramSatisfying(histogram -> histogram.isCumulative()
+                                    .hasPointsSatisfying(
+                                            // valid entries
+                                            point -> point.hasCount(1)
+                                                    .hasAttributesSatisfying(
+                                                            // "uri" not following conventions and should be "http.route"
+                                                            equalTo(URI, "/pong/{message}"),
+                                                            // Method not following conventions and should be "http.request.method"
+                                                            equalTo(METHOD, "GET"),
+                                                            // status_code not following conventions and should be
+                                                            // "http.response.status_code" and it should use a long key and not a string key
+                                                            equalTo(STATUS, "400")),
+                                            point -> point.hasCount(1)
+                                                    .hasAttributesSatisfying(
+                                                            equalTo(URI, "/pong/{message}"),
+                                                            equalTo(METHOD, "GET"),
+                                                            equalTo(STATUS, "500")),
+                                            point -> point.hasCount(6) // 3 sync requests and 3 async requests
+                                                    .hasAttributesSatisfying(
+                                                            equalTo(URI, "/pong/{message}"),
+                                                            equalTo(METHOD, "GET"),
+                                                            equalTo(STATUS, "200"))));
+                });
+    }
+
+    private static void assertServerMetrics(MetricData metricData) {
+        assertThat(metricData)
+                .hasName("http.server.requests") // in OTel it should be "http.server.request.duration"
+                .hasDescription("HTTP server request processing time") // in OTel it should be "Duration of HTTP server requests."
+                .hasUnit("ms") // OTel has seconds
+                .hasHistogramSatisfying(histogram -> histogram.isCumulative()
+                        .hasPointsSatisfying(
+                                // valid entries
+                                point -> point.hasCount(1)
+                                        .hasAttributesSatisfying(
+                                                // "uri" not following conventions and should be "http.route"
+                                                equalTo(URI, "/vertx/item/{id}"),
+                                                // method not following conventions and should be "http.request.method"
+                                                equalTo(METHOD, "GET"),
+                                                // status_code not following conventions and should be
+                                                // "http.response.status_code" and it should use a long key and not a string key
+                                                equalTo(STATUS, "200")),
+                                point -> point.hasCount(1)
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/vertx/item/{id}/{sub}"),
+                                                equalTo(METHOD, "GET"),
+                                                equalTo(STATUS, "200")),
+                                point -> point.hasCount(2)
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/hello/{message}"),
+                                                equalTo(METHOD, "HEAD"),
+                                                equalTo(STATUS, "200")),
+                                point -> point.hasCount(2)
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/hello/{message}"),
+                                                equalTo(METHOD, "GET"),
+                                                equalTo(STATUS, "200")),
+                                point -> point.hasCount(2)
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/vertx/echo/{msg}"),
+                                                equalTo(METHOD, "HEAD"),
+                                                equalTo(STATUS, "200")),
+                                point -> point.hasCount(2)
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/vertx/echo/{msg}"),
+                                                equalTo(METHOD, "GET"),
+                                                equalTo(STATUS, "200")),
+                                point -> point.hasCount(5) // 3 x 200 + 400 + 500 status codes
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/ping/{message}"),
+                                                equalTo(METHOD, "GET"),
+                                                equalTo(STATUS, "200")),
+                                point -> point.hasCount(3)
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/async-ping/{message}"),
+                                                equalTo(METHOD, "GET"),
+                                                equalTo(STATUS, "200")),
+                                point -> point.hasCount(6) // 3 sync requests and 3 async requests
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/pong/{message}"),
+                                                equalTo(METHOD, "GET"),
+                                                equalTo(STATUS, "200")),
+                                point -> point.hasCount(1)
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/pong/{message}"),
+                                                equalTo(METHOD, "GET"),
+                                                equalTo(STATUS, "500")),
+                                point -> point.hasCount(1)
+                                        .hasAttributesSatisfying(
+                                                equalTo(URI, "/pong/{message}"),
+                                                equalTo(METHOD, "GET"),
+                                                equalTo(STATUS, "400"))));
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/JvmCompatibilityTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/JvmCompatibilityTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.micrometer.opentelemetry.deployment.compatibility;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import java.util.Comparator;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporter;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporterProvider;
+import io.quarkus.micrometer.opentelemetry.deployment.common.PingPongResource;
+import io.quarkus.micrometer.opentelemetry.deployment.common.Util;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JvmCompatibilityTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(Util.class,
+                                    PingPongResource.class,
+                                    PingPongResource.PingPongRestClient.class)
+                            .addClasses(InMemoryMetricExporter.class, InMemoryMetricExporterProvider.class)
+                            .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                                    "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                            .add(new StringAsset("""
+                                    quarkus.otel.metrics.exporter=in-memory\n
+                                    quarkus.otel.metric.export.interval=300ms\n
+                                    quarkus.micrometer.binder-enabled-default=false\n
+                                    quarkus.micrometer.binder.jvm=true\n
+                                    quarkus.redis.devservices.enabled=false\n
+                                    """),
+                                    "application.properties"));
+
+    @Inject
+    protected InMemoryMetricExporter metricExporter;
+
+    // No need to reset tests for JVM
+
+    @Test
+    void testDoubleSum() {
+        metricExporter.assertCountDataPointsAtLeastOrEqual("jvm.threads.started", null, 1);
+        final List<MetricData> metricDataList = metricExporter.getFinishedMetricItems("jvm.threads.started", null);
+
+        metricDataList.forEach(System.out::println);
+
+        final MetricData metricData = metricDataList.stream()
+                .max(Comparator.comparingInt(data -> data.getData().getPoints().size()))
+                .get();
+
+        assertThat(metricData.getInstrumentationScopeInfo().getName())
+                .isEqualTo("io.opentelemetry.micrometer-1.5");
+
+        assertThat(metricData)
+                .hasName("jvm.threads.started")
+                .hasDescription("The total number of application threads started in the JVM")
+                .hasUnit("threads")
+                .hasDoubleSumSatisfying(doubleSumAssert -> doubleSumAssert
+                        .isMonotonic()
+                        .isCumulative()
+                        .hasPointsSatisfying(point -> point
+                                .satisfies(actual -> assertThat(actual.getValue()).isGreaterThanOrEqualTo(1.0))
+                                .hasAttributesSatisfying(attributes -> attributes.isEmpty())));
+    }
+
+    @Test
+    void testDoubleGauge() {
+        metricExporter.assertCountDataPointsAtLeastOrEqual("jvm.classes.loaded", null, 1);
+        final List<MetricData> metricDataList = metricExporter.getFinishedMetricItems("jvm.classes.loaded", null);
+
+        metricDataList.forEach(System.out::println);
+
+        final MetricData metricData = metricDataList.stream()
+                .max(Comparator.comparingInt(data -> data.getData().getPoints().size()))
+                .get();
+
+        assertThat(metricData.getInstrumentationScopeInfo().getName())
+                .isEqualTo("io.opentelemetry.micrometer-1.5");
+
+        assertThat(metricData)
+                .hasName("jvm.classes.loaded")
+                .hasDescription("The number of classes that are currently loaded in the Java virtual machine")
+                .hasUnit("classes")
+                .hasDoubleGaugeSatisfying(doubleSumAssert -> doubleSumAssert
+                        .hasPointsSatisfying(point -> point
+                                .satisfies(actual -> assertThat(actual.getValue()).isGreaterThanOrEqualTo(1.0))
+                                .hasAttributesSatisfying(attributes -> attributes.isEmpty())));
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/MicrometerCounterInterceptorTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/MicrometerCounterInterceptorTest.java
@@ -1,0 +1,125 @@
+package io.quarkus.micrometer.opentelemetry.deployment.compatibility;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.common.annotation.ValueResolver;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.aop.MeterTag;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporter;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporterProvider;
+import io.quarkus.micrometer.opentelemetry.deployment.common.Util;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Copy of io.quarkus.micrometer.runtime.MicrometerCounterInterceptorTest
+ */
+public class MicrometerCounterInterceptorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(Util.class, CountedBean.class, TestValueResolver.class)
+                            .addClasses(InMemoryMetricExporter.class, InMemoryMetricExporterProvider.class)
+                            .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                                    "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                            .add(new StringAsset("""
+                                    quarkus.otel.metrics.exporter=in-memory\n
+                                    quarkus.otel.metric.export.interval=300ms\n
+                                    quarkus.micrometer.binder.http-client.enabled=true\n
+                                    quarkus.micrometer.binder.http-server.enabled=true\n
+                                    quarkus.redis.devservices.enabled=false\n
+                                    """),
+                                    "application.properties"));
+
+    @Inject
+    CountedBean countedBean;
+
+    @Inject
+    InMemoryMetricExporter exporter;
+
+    @BeforeEach
+    void setup() {
+        exporter.reset();
+    }
+
+    @Test
+    void testCountAllMetrics() {
+        countedBean.countAllInvocations(false);
+        Assertions.assertThrows(NullPointerException.class, () -> countedBean.countAllInvocations(true));
+
+        exporter.assertCountDataPointsAtLeastOrEqual("metric.all", null, 2);
+
+        MetricData metricAll = exporter.getFinishedMetricItem("metric.all");
+        assertThat(metricAll)
+                .isNotNull()
+                .hasName("metric.all")
+                .hasDescription("")// currently empty
+                .hasUnit("")// currently empty
+                .hasDoubleSumSatisfying(sum -> sum.hasPointsSatisfying(
+                        point -> point
+                                .hasValue(1d)
+                                .hasAttributes(attributeEntry(
+                                        "class",
+                                        "io.quarkus.micrometer.opentelemetry.deployment.compatibility.MicrometerCounterInterceptorTest$CountedBean"),
+                                        attributeEntry("method", "countAllInvocations"),
+                                        attributeEntry("extra", "tag"),
+                                        attributeEntry("do_fail", "prefix_false"),
+                                        attributeEntry("exception", "none"),
+                                        attributeEntry("result", "success")),
+                        point -> point
+                                .hasValue(1d)
+                                .hasAttributes(attributeEntry(
+                                        "class",
+                                        "io.quarkus.micrometer.opentelemetry.deployment.compatibility.MicrometerCounterInterceptorTest$CountedBean"),
+                                        attributeEntry("method", "countAllInvocations"),
+                                        attributeEntry("extra", "tag"),
+                                        attributeEntry("do_fail", "prefix_true"),
+                                        attributeEntry("exception", "NullPointerException"),
+                                        attributeEntry("result", "failure"))));
+    }
+
+    @ApplicationScoped
+    public static class CountedBean {
+        @Counted(value = "metric.none", recordFailuresOnly = true)
+        public void onlyCountFailures() {
+        }
+
+        @Counted(value = "metric.all", extraTags = { "extra", "tag" })
+        public void countAllInvocations(@MeterTag(key = "do_fail", resolver = TestValueResolver.class) boolean fail) {
+            if (fail) {
+                throw new NullPointerException("Failed on purpose");
+            }
+        }
+
+        @Counted(description = "nice description")
+        public void emptyMetricName(@MeterTag boolean fail) {
+            if (fail) {
+                throw new NullPointerException("Failed on purpose");
+            }
+        }
+    }
+
+    @Singleton
+    public static class TestValueResolver implements ValueResolver {
+        @Override
+        public String resolve(Object parameter) {
+            return "prefix_" + parameter;
+        }
+    }
+
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/MicrometerTimedInterceptorTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/MicrometerTimedInterceptorTest.java
@@ -1,0 +1,321 @@
+package io.quarkus.micrometer.opentelemetry.deployment.compatibility;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.quarkus.micrometer.opentelemetry.deployment.common.CountedResource;
+import io.quarkus.micrometer.opentelemetry.deployment.common.GuardedResult;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporter;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporterProvider;
+import io.quarkus.micrometer.opentelemetry.deployment.common.MetricDataFilter;
+import io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Copy of io.quarkus.micrometer.runtime.MicrometerTimedInterceptorTest
+ */
+public class MicrometerTimedInterceptorTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.metrics.exporter", "in-memory")
+            .overrideConfigKey("quarkus.otel.metric.export.interval", "100ms")
+            .overrideConfigKey("quarkus.micrometer.binder.mp-metrics.enabled", "false")
+            .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "false")
+            .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .withApplicationRoot((jar) -> jar
+                    .addClass(CountedResource.class)
+                    .addClass(TimedResource.class)
+                    .addClass(GuardedResult.class)
+                    .addClasses(InMemoryMetricExporter.class, InMemoryMetricExporterProvider.class, MetricDataFilter.class)
+                    .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider"));
+
+    @Inject
+    TimedResource timed;
+
+    @Inject
+    InMemoryMetricExporter metricExporter;
+
+    @BeforeEach
+    void setUp() {
+        metricExporter.reset();
+    }
+
+    @Test
+    void testTimeMethod() {
+        timed.call(false);
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("call", null, 1);
+        assertEquals(1, metricExporter.get("call")
+                .tag("method", "call")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "none")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(HistogramPointData.class).getCount());
+
+        assertThat(metricExporter.get("call.max")
+                .tag("method", "call")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "none")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(DoublePointData.class).getValue())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    void testTimeMethod_Failed() {
+        assertThrows(NullPointerException.class, () -> timed.call(true));
+
+        Supplier<MetricDataFilter> metricFilterSupplier = () -> metricExporter.get("call")
+                .tag("method", "call")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "NullPointerException")
+                .tag("extra", "tag");
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual(metricFilterSupplier, 1);
+        assertEquals(1, metricFilterSupplier.get()
+                .lastReadingDataPoint(HistogramPointData.class).getCount());
+
+        assertThat(metricExporter.get("call.max")
+                .tag("method", "call")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "NullPointerException")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(DoublePointData.class).getValue())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    void testTimeMethod_Async() {
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = timed.asyncCall(guardedResult);
+        guardedResult.complete();
+        completableFuture.join();
+
+        Supplier<MetricDataFilter> metricFilterSupplier = () -> metricExporter.get("async.call")
+                .tag("method", "asyncCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "none")
+                .tag("extra", "tag");
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual(metricFilterSupplier, 1);
+        assertEquals(1, metricFilterSupplier.get()
+                .lastReadingDataPoint(HistogramPointData.class).getCount());
+
+        assertThat(metricExporter.get("async.call.max")
+                .tag("method", "asyncCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "none")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(DoublePointData.class).getValue())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    void testTimeMethod_AsyncFailed() {
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = timed.asyncCall(guardedResult);
+        guardedResult.complete(new NullPointerException());
+        assertThrows(java.util.concurrent.CompletionException.class, () -> completableFuture.join());
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("async.call", null, 1);
+        assertEquals(1, metricExporter.get("async.call")
+                .tag("method", "asyncCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "NullPointerException")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(HistogramPointData.class).getCount());
+
+        assertThat(metricExporter.get("async.call.max")
+                .tag("method", "asyncCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "NullPointerException")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(DoublePointData.class).getValue())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    void testTimeMethod_Uni() {
+        GuardedResult guardedResult = new GuardedResult();
+        Uni<?> uni = timed.uniCall(guardedResult);
+        guardedResult.complete();
+        uni.subscribe().asCompletionStage().join();
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("uni.call", null, 1);
+        assertEquals(1, metricExporter.get("uni.call")
+                .tag("method", "uniCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "none")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(HistogramPointData.class).getCount());
+
+        assertThat(metricExporter.get("uni.call.max")
+                .tag("method", "uniCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "none")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(DoublePointData.class).getValue())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    void testTimeMethod_UniFailed() throws InterruptedException {
+        GuardedResult guardedResult = new GuardedResult();
+        Uni<?> uni = timed.uniCall(guardedResult);
+        guardedResult.complete(new NullPointerException());
+        assertThrows(java.util.concurrent.CompletionException.class,
+                () -> uni.subscribe().asCompletionStage().join());
+
+        // this needs to be executed inline, otherwise the results will be old.
+        Supplier<MetricDataFilter> metricFilterSupplier = () -> metricExporter.get("uni.call")
+                .tag("method", "uniCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "NullPointerException")
+                .tag("extra", "tag");
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual(metricFilterSupplier, 1);
+        assertEquals(1, metricFilterSupplier.get()
+                .lastReadingDataPoint(HistogramPointData.class).getCount());
+
+        assertThat(metricExporter.get("uni.call.max")
+                .tag("method", "uniCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "NullPointerException")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(DoublePointData.class).getValue())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    void testTimeMethod_LongTaskTimer() {
+        timed.longCall(false);
+        metricExporter.assertCountDataPointsAtLeastOrEqual("longCall.active", null, 1);
+        assertEquals(0, metricExporter.get("longCall.active")
+                .tag("method", "longCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(LongPointData.class).getValue());
+    }
+
+    @Test
+    void testTimeMethod_LongTaskTimer_Failed() {
+        assertThrows(NullPointerException.class, () -> timed.longCall(true));
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("longCall.active", null, 1);
+        assertEquals(0, metricExporter.get("longCall.active")
+                .tag("method", "longCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(LongPointData.class).getValue());
+    }
+
+    @Test
+    void testTimeMethod_LongTaskTimer_Async() {
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = timed.longAsyncCall(guardedResult);
+        guardedResult.complete();
+        completableFuture.join();
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("async.longCall.active", null, 1);
+        assertEquals(0, metricExporter.get("async.longCall.active")
+                .tag("method", "longAsyncCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(LongPointData.class).getValue());
+    }
+
+    @Test
+    void testTimeMethod_LongTaskTimer_AsyncFailed() {
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = timed.longAsyncCall(guardedResult);
+        guardedResult.complete(new NullPointerException());
+        assertThrows(java.util.concurrent.CompletionException.class, () -> completableFuture.join());
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("async.longCall.active", null, 1);
+        assertEquals(0, metricExporter.get("async.longCall.active")
+                .tag("method", "longAsyncCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(LongPointData.class).getValue());
+    }
+
+    @Test
+    void testTimeMethod_LongTaskTimer_Uni() {
+        GuardedResult guardedResult = new GuardedResult();
+        Uni<?> uni = timed.longUniCall(guardedResult);
+        guardedResult.complete();
+        uni.subscribe().asCompletionStage().join();
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("uni.longCall.active", null, 1);
+        assertEquals(0, metricExporter.get("uni.longCall.active")
+                .tag("method", "longUniCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(LongPointData.class).getValue());
+    }
+
+    @Test
+    void testTimeMethod_LongTaskTimer_UniFailed() throws InterruptedException {
+        GuardedResult guardedResult = new GuardedResult();
+        Uni<?> uni = timed.longUniCall(guardedResult);
+        guardedResult.complete(new NullPointerException());
+        assertThrows(java.util.concurrent.CompletionException.class,
+                () -> uni.subscribe().asCompletionStage().join());
+
+        // Was "uni.longCall" Now is "uni.longCall.active" and "uni.longCall.duration"
+        // Metric was executed but now there are no active tasks
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("uni.longCall.active", null, 1);
+        assertEquals(0, metricExporter.get("uni.longCall.active")
+                .tag("method", "longUniCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(LongPointData.class).getValue());
+
+        assertEquals(0, metricExporter.get("uni.longCall.duration")
+                .tag("method", "longUniCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("extra", "tag")
+                .lastReadingDataPoint(DoublePointData.class).getValue());
+
+    }
+
+    @Test
+    void testTimeMethod_repeatable() {
+        timed.repeatableCall(false);
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("alpha", null, 1);
+
+        assertEquals(1, metricExporter.get("alpha")
+                .tag("method", "repeatableCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "none")
+                .tag("extra", "tag")
+                .lastReadingPointsSize());
+
+        assertEquals(1, metricExporter.get("bravo")
+                .tag("method", "repeatableCall")
+                .tag("class", "io.quarkus.micrometer.opentelemetry.deployment.common.TimedResource")
+                .tag("exception", "none")
+                .tag("extra", "tag")
+                .lastReadingPointsSize());
+    }
+
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/RestClientUriParameterTest.java
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/java/io/quarkus/micrometer/opentelemetry/deployment/compatibility/RestClientUriParameterTest.java
@@ -1,0 +1,94 @@
+package io.quarkus.micrometer.opentelemetry.deployment.compatibility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporter;
+import io.quarkus.micrometer.opentelemetry.deployment.common.InMemoryMetricExporterProvider;
+import io.quarkus.micrometer.opentelemetry.deployment.common.MetricDataFilter;
+import io.quarkus.rest.client.reactive.Url;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RestClientUriParameterTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(
+                    jar -> jar.addClasses(Resource.class, Client.class)
+                            .addClasses(InMemoryMetricExporter.class,
+                                    InMemoryMetricExporterProvider.class,
+                                    MetricDataFilter.class)
+                            .addClasses(InMemoryMetricExporter.class, InMemoryMetricExporterProvider.class,
+                                    MetricDataFilter.class)
+                            .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                                    "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider"))
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.otel.metrics.exporter", "in-memory")
+            .overrideConfigKey("quarkus.otel.metric.export.interval", "300ms")
+            .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.rest-client.\"client\".url", "http://does-not-exist.io");
+
+    @Inject
+    InMemoryMetricExporter metricExporter;
+
+    @RestClient
+    Client client;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    Integer testPort;
+
+    @Test
+    public void testOverride() {
+        String result = client.getById("http://localhost:" + testPort, "bar");
+        assertEquals("bar", result);
+
+        metricExporter.assertCountDataPointsAtLeastOrEqual("http.client.requests", null, 1);
+        assertEquals(1, metricExporter.find("http.client.requests")
+                .tag("uri", "/example/{id}")
+                .lastReadingDataPoint(HistogramPointData.class).getCount());
+    }
+
+    @Path("/example")
+    @RegisterRestClient(baseUri = "http://dummy")
+    public interface Client {
+
+        @GET
+        @Path("/{id}")
+        String getById(@Url String baseUri, @PathParam("id") String id);
+    }
+
+    @Path("/example")
+    public static class Resource {
+
+        @RestClient
+        Client client;
+
+        @GET
+        @Path("/{id}")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String example() {
+            return "bar";
+        }
+
+        @GET
+        @Path("/call")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String call() {
+            return client.getById("http://localhost:8080", "1");
+        }
+    }
+}

--- a/extensions/micrometer-opentelemetry/deployment/src/test/resources/test-logging.properties
+++ b/extensions/micrometer-opentelemetry/deployment/src/test/resources/test-logging.properties
@@ -1,0 +1,4 @@
+#quarkus.log.category."io.quarkus.micrometer".level=DEBUG
+quarkus.log.category."io.quarkus.bootstrap".level=INFO
+#quarkus.log.category."io.quarkus.arc".level=DEBUG
+quarkus.log.category."io.netty".level=INFO

--- a/extensions/micrometer-opentelemetry/pom.xml
+++ b/extensions/micrometer-opentelemetry/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-micrometer-opentelemetry-parent</artifactId>
+    <name>Quarkus - Micrometer to OpenTelemetry Bridge - Parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/extensions/micrometer-opentelemetry/runtime/pom.xml
+++ b/extensions/micrometer-opentelemetry/runtime/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-micrometer-opentelemetry-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+    <name>Quarkus - Micrometer to OpenTelemetry Bridge - Runtime</name>
+    <description>Micrometer registry implemented by the OpenTelemetry SDK</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-micrometer-1.5</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/micrometer-opentelemetry/runtime/src/main/java/io/quarkus/micrometer/opentelemetry/runtime/MicrometerOtelBridgeRecorder.java
+++ b/extensions/micrometer-opentelemetry/runtime/src/main/java/io/quarkus/micrometer/opentelemetry/runtime/MicrometerOtelBridgeRecorder.java
@@ -1,0 +1,45 @@
+package io.quarkus.micrometer.opentelemetry.runtime;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class MicrometerOtelBridgeRecorder {
+
+    public Function<SyntheticCreationalContext<MeterRegistry>, MeterRegistry> createBridge(
+            OTelRuntimeConfig otelRuntimeConfig) {
+
+        return new Function<>() {
+            @Override
+            public MeterRegistry apply(SyntheticCreationalContext<MeterRegistry> context) {
+                Instance<OpenTelemetry> openTelemetry = context.getInjectedReference(new TypeLiteral<>() {
+                });
+
+                if (openTelemetry.isUnsatisfied()) {
+                    throw new IllegalStateException("OpenTelemetry instance not found");
+                }
+
+                MeterRegistry meterRegistry = OpenTelemetryMeterRegistry.builder(openTelemetry.get())
+                        .setPrometheusMode(false)
+                        .setMicrometerHistogramGaugesEnabled(true)
+                        .setBaseTimeUnit(TimeUnit.MILLISECONDS)
+                        .setClock(Clock.SYSTEM)
+                        .build();
+                Metrics.addRegistry(meterRegistry);
+                return meterRegistry;
+            }
+        };
+    }
+}

--- a/extensions/micrometer-opentelemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/micrometer-opentelemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,17 @@
+name: "Micrometer OpenTelemetry Bridge"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  keywords:
+  - "micrometer"
+  - "metrics"
+  - "metric"
+  - "opentelemetry"
+  - "tracing"
+  - "logging"
+  - "monitoring"
+  guide: "https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry"
+  categories:
+  - "observability"
+  status: "preview"
+  config:
+  - "quarkus.micrometer.otel."

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -39,6 +39,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.metrics.MetricsFactoryConsumerBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
@@ -213,6 +214,7 @@ public class MicrometerProcessor {
 
     @BuildStep
     @Consume(RootMeterRegistryBuildItem.class)
+    @Consume(LoggingSetupBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void configureRegistry(MicrometerRecorder recorder,
             MicrometerConfig config,

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/metric/MetricProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/metric/MetricProcessor.java
@@ -36,7 +36,12 @@ public class MetricProcessor {
     private static final DotName METRIC_PROCESSOR = DotName.createSimple(MetricProcessor.class.getName());
 
     @BuildStep
-    void addNativeMonitoring(BuildProducer<NativeMonitoringBuildItem> nativeMonitoring) {
+    void startJvmMetrics(BuildProducer<NativeMonitoringBuildItem> nativeMonitoring,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        additionalBeans.produce(AdditionalBeanBuildItem.builder()
+                .setUnremovable()
+                .addBeanClass(JvmMetricsService.class)
+                .build());
         nativeMonitoring.produce(new NativeMonitoringBuildItem(NativeConfig.MonitoringOption.JFR));
     }
 
@@ -48,7 +53,6 @@ public class MetricProcessor {
         additionalBeans.produce(AdditionalBeanBuildItem.builder()
                 .setUnremovable()
                 .addBeanClass(MetricsProducer.class)
-                .addBeanClass(JvmMetricsService.class)
                 .build());
 
         IndexView index = indexBuildItem.getIndex();

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -51,6 +51,7 @@
         <module>smallrye-fault-tolerance</module>
         <module>micrometer</module>
         <module>micrometer-registry-prometheus</module>
+        <module>micrometer-opentelemetry</module>
         <module>opentelemetry</module>
         <module>info</module>
         <module>observability-devservices</module>

--- a/integration-tests/micrometer-opentelemetry/pom.xml
+++ b/integration-tests/micrometer-opentelemetry/pom.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-micrometer-opentelemetry</artifactId>
+    <name>Quarkus - Integration Tests - Micrometer to OpenTelemetry Bridge</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+
+        <!-- Verify that the client can co-exist with the server -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Needed for InMemorySpanExporter to verify captured traces -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry-deployment</artifactId>
+            <version>999-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>
+                                            ${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/AppResource.java
+++ b/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/AppResource.java
@@ -1,0 +1,26 @@
+package io.quarkus.micrometer.opentelemetry;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkus.micrometer.opentelemetry.services.CountedBean;
+
+@Path("")
+@Produces(MediaType.APPLICATION_JSON)
+public class AppResource {
+
+    @Inject
+    CountedBean countedBean;
+
+    @Path("/count")
+    @GET
+    public Response count(@QueryParam("fail") boolean fail) {
+        countedBean.countAllInvocations(fail);
+        return Response.ok().build();
+    }
+}

--- a/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/ExporterResource.java
+++ b/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/ExporterResource.java
@@ -1,0 +1,125 @@
+package io.quarkus.micrometer.opentelemetry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.SemanticAttributes;
+
+@Path("")
+public class ExporterResource {
+    @Inject
+    InMemorySpanExporter inMemorySpanExporter;
+    @Inject
+    InMemoryMetricExporter inMemoryMetricExporter;
+    @Inject
+    InMemoryLogRecordExporter inMemoryLogRecordExporter;
+
+    @GET
+    @Path("/reset")
+    public Response reset() {
+        inMemorySpanExporter.reset();
+        inMemoryMetricExporter.reset();
+        inMemoryLogRecordExporter.reset();
+        return Response.ok().build();
+    }
+
+    /**
+     * Will exclude export endpoint related traces
+     */
+    @GET
+    @Path("/export")
+    public List<SpanData> exportTraces() {
+        return inMemorySpanExporter.getFinishedSpanItems()
+                .stream()
+                .filter(sd -> !sd.getName().contains("export") && !sd.getName().contains("reset"))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Export metrics with optional filtering by name and target
+     */
+    @GET
+    @Path("/export/metrics")
+    public List<MetricData> exportMetrics(@QueryParam("name") String name, @QueryParam("target") String target) {
+        return Collections.unmodifiableList(new ArrayList<>(
+                inMemoryMetricExporter.getFinishedMetricItems().stream()
+                        .filter(metricData -> name == null ? true : metricData.getName().equals(name))
+                        .filter(metricData -> target == null ? true
+                                : metricData.getData()
+                                        .getPoints().stream()
+                                        .anyMatch(point -> isPathFound(target, point.getAttributes())))
+                        .collect(Collectors.toList())));
+    }
+
+    /**
+     * Will exclude Quarkus startup logs
+     */
+    @GET
+    @Path("/export/logs")
+    public List<LogRecordData> exportLogs(@QueryParam("body") String message) {
+        if (message == null) {
+            return inMemoryLogRecordExporter.getFinishedLogRecordItems().stream()
+                    .collect(Collectors.toList());
+        }
+        return inMemoryLogRecordExporter.getFinishedLogRecordItems().stream()
+                .filter(logRecordData -> logRecordData.getBody().asString().equals(message))
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isPathFound(String path, Attributes attributes) {
+        if (path == null) {
+            return true;// any match
+        }
+        Object value = attributes.asMap().get(AttributeKey.stringKey(SemanticAttributes.HTTP_ROUTE.getKey()));
+        if (value == null) {
+            return false;
+        }
+        return value.toString().equals(path);
+    }
+
+    @ApplicationScoped
+    static class InMemorySpanExporterProducer {
+        @Produces
+        @Singleton
+        InMemorySpanExporter inMemorySpanExporter() {
+            return InMemorySpanExporter.create();
+        }
+    }
+
+    @ApplicationScoped
+    static class InMemoryMetricExporterProducer {
+        @Produces
+        @Singleton
+        InMemoryMetricExporter inMemoryMetricsExporter() {
+            return InMemoryMetricExporter.create();
+        }
+    }
+
+    @ApplicationScoped
+    static class InMemoryLogRecordExporterProducer {
+        @Produces
+        @Singleton
+        public InMemoryLogRecordExporter createInMemoryExporter() {
+            return InMemoryLogRecordExporter.create();
+        }
+    }
+}

--- a/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/SimpleResource.java
+++ b/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/SimpleResource.java
@@ -1,0 +1,163 @@
+package io.quarkus.micrometer.opentelemetry;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.context.Scope;
+import io.quarkus.micrometer.opentelemetry.services.TraceData;
+import io.quarkus.micrometer.opentelemetry.services.TracedService;
+
+@Path("")
+@Produces(MediaType.APPLICATION_JSON)
+public class SimpleResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleResource.class);
+
+    @RegisterRestClient(configKey = "simple")
+    public interface SimpleClient {
+        @Path("")
+        @GET
+        TraceData noPath();
+
+        @Path("/")
+        @GET
+        TraceData slashPath();
+
+        @Path("/from-baggage")
+        @GET
+        TraceData fromBaggagePath();
+    }
+
+    @Inject
+    TracedService tracedService;
+
+    @Inject
+    @RestClient
+    SimpleClient simpleClient;
+
+    @Inject
+    Baggage baggage;
+
+    @Inject
+    Meter meter;
+
+    @GET
+    public TraceData noPath() {
+        TraceData data = new TraceData();
+        data.message = "No path trace";
+        return data;
+    }
+
+    @GET
+    @Path("/nopath")
+    public TraceData noPathClient() {
+        return simpleClient.noPath();
+    }
+
+    @GET
+    @Path("/slashpath")
+    public TraceData slashPathClient() {
+        return simpleClient.slashPath();
+    }
+
+    @GET
+    @Path("/slashpath-baggage")
+    public TraceData slashPathBaggageClient() {
+        try (Scope scope = baggage.toBuilder()
+                .put("baggage-key", "baggage-value")
+                .build()
+                .makeCurrent()) {
+            return simpleClient.fromBaggagePath();
+        }
+    }
+
+    @GET
+    @Path("/from-baggage")
+    public TraceData fromBaggageValue() {
+        TraceData data = new TraceData();
+        data.message = baggage.getEntryValue("baggage-key");
+        return data;
+    }
+
+    @GET
+    @Path("/direct")
+    public TraceData directTrace() {
+        LOG.info("directTrace called");
+        TraceData data = new TraceData();
+        data.message = "Direct trace";
+        return data;
+    }
+
+    @GET
+    @Path("/direct-metrics")
+    public TraceData directTraceWithMetrics() {
+        meter.counterBuilder("direct-trace-counter")
+                .setUnit("items")
+                .setDescription("A counter of direct traces")
+                .build()
+                .add(1, Attributes.of(AttributeKey.stringKey("key"), "low-cardinality-value"));
+        TraceData data = new TraceData();
+        data.message = "Direct trace";
+        return data;
+    }
+
+    @GET
+    @Path("/chained")
+    public TraceData chainedTrace() {
+        LOG.info("chainedTrace called");
+        TraceData data = new TraceData();
+        data.message = tracedService.call();
+
+        return data;
+    }
+
+    @GET
+    @Path("/deep/path")
+    public TraceData deepUrlPathTrace() {
+        TraceData data = new TraceData();
+        data.message = "Deep url path";
+
+        return data;
+    }
+
+    @GET
+    @Path("/param/{paramId}")
+    public TraceData pathParameters(@PathParam("paramId") String paramId) {
+        TraceData data = new TraceData();
+        data.message = "ParameterId: " + paramId;
+
+        return data;
+    }
+
+    @GET
+    @Path("/exception")
+    public String exception() {
+        var exception = new RuntimeException("Exception!");
+        StackTraceElement[] trimmedStackTrace = new StackTraceElement[2];
+        System.arraycopy(exception.getStackTrace(), 0, trimmedStackTrace, 0, trimmedStackTrace.length);
+        exception.setStackTrace(trimmedStackTrace);
+        LOG.error("Oh no {}", exception.getMessage(), exception);
+        return "Oh no! An exception";
+    }
+
+    @GET
+    @Path("/suppress-app-uri")
+    public TraceData suppressAppUri() {
+        TraceData traceData = new TraceData();
+        traceData.message = "Suppress me!";
+        return traceData;
+    }
+}

--- a/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/CountedBean.java
+++ b/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/CountedBean.java
@@ -1,0 +1,27 @@
+package io.quarkus.micrometer.opentelemetry.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.aop.MeterTag;
+
+@ApplicationScoped
+public class CountedBean {
+    @Counted(value = "metric.none", recordFailuresOnly = true)
+    public void onlyCountFailures() {
+    }
+
+    @Counted(value = "metric.all", extraTags = { "extra", "tag" })
+    public void countAllInvocations(@MeterTag(key = "do_fail", resolver = TestValueResolver.class) boolean fail) {
+        if (fail) {
+            throw new NullPointerException("Failed on purpose");
+        }
+    }
+
+    @Counted(description = "nice description")
+    public void emptyMetricName(@MeterTag boolean fail) {
+        if (fail) {
+            throw new NullPointerException("Failed on purpose");
+        }
+    }
+}

--- a/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/ManualHistogram.java
+++ b/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/ManualHistogram.java
@@ -1,0 +1,28 @@
+package io.quarkus.micrometer.opentelemetry.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@ApplicationScoped
+public class ManualHistogram {
+    @Inject
+    MeterRegistry registry;
+
+    public void recordHistogram() {
+        DistributionSummary summary = DistributionSummary.builder("testSummary")
+                .description("This is a test distribution summary")
+                .baseUnit("things")
+                .tags("tag", "value")
+                .serviceLevelObjectives(1, 10, 100, 1000)
+                .distributionStatisticBufferLength(10)
+                .register(registry);
+
+        summary.record(0.5);
+        summary.record(5);
+        summary.record(50);
+        summary.record(500);
+    }
+}

--- a/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/TestValueResolver.java
+++ b/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/TestValueResolver.java
@@ -1,0 +1,13 @@
+package io.quarkus.micrometer.opentelemetry.services;
+
+import jakarta.inject.Singleton;
+
+import io.micrometer.common.annotation.ValueResolver;
+
+@Singleton
+public class TestValueResolver implements ValueResolver {
+    @Override
+    public String resolve(Object parameter) {
+        return "prefix_" + parameter;
+    }
+}

--- a/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/TraceData.java
+++ b/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/TraceData.java
@@ -1,0 +1,5 @@
+package io.quarkus.micrometer.opentelemetry.services;
+
+public class TraceData {
+    public String message;
+}

--- a/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/TracedService.java
+++ b/integration-tests/micrometer-opentelemetry/src/main/java/io/quarkus/micrometer/opentelemetry/services/TracedService.java
@@ -1,0 +1,20 @@
+package io.quarkus.micrometer.opentelemetry.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+
+@ApplicationScoped
+public class TracedService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TracedService.class);
+
+    @WithSpan
+    public String call() {
+        LOG.info("Chained trace called");
+        return "Chained trace";
+    }
+}

--- a/integration-tests/micrometer-opentelemetry/src/main/resources/application.properties
+++ b/integration-tests/micrometer-opentelemetry/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+# Setting these for tests explicitly. Not required in normal application
+quarkus.application.name=micrometer-opentelemetry-integration-test
+quarkus.application.version=999-SNAPSHOT
+
+# speed up tests
+quarkus.otel.bsp.schedule.delay=100
+quarkus.otel.bsp.export.timeout=5s
+quarkus.otel.metric.export.interval=100ms
+
+
+

--- a/integration-tests/micrometer-opentelemetry/src/test/java/io/quarkus/micrometer/opentelemetry/MicrometerCounterInterceptorTest.java
+++ b/integration-tests/micrometer-opentelemetry/src/test/java/io/quarkus/micrometer/opentelemetry/MicrometerCounterInterceptorTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.micrometer.opentelemetry;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.common.mapper.TypeRef;
+
+@QuarkusTest
+public class MicrometerCounterInterceptorTest {
+
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        given().get("/reset").then().statusCode(HTTP_OK);
+    }
+
+    @Test
+    void testCountAllMetrics_MetricsOnSuccess() {
+        given()
+                .when()
+                .get("/count")
+                .then()
+                .statusCode(200);
+
+        await().atMost(5, SECONDS).until(() -> getMetrics("metric.all").size() > 1);
+
+        List<Map<String, Object>> metrics = getMetrics("metric.all");
+
+        Double value = (Double) ((Map) ((List) ((Map) (getMetrics("metric.all")
+                .get(metrics.size() - 1)
+                .get("data")))
+                .get("points"))
+                .get(0))
+                .get("value");
+        assertThat(value).isEqualTo(1d);
+    }
+
+    private List<Map<String, Object>> getMetrics(String metricName) {
+        return given()
+                .when()
+                .queryParam("name", metricName)
+                .get("/export/metrics")
+                .body().as(new TypeRef<>() {
+                });
+    }
+
+    private List<Map<String, Object>> getSpans() {
+        return get("/export").body().as(new TypeRef<>() {
+        });
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -359,6 +359,7 @@
                 <module>micrometer-mp-metrics</module>
                 <module>micrometer-prometheus</module>
                 <module>micrometer-security</module>
+                <module>micrometer-opentelemetry</module>
                 <module>opentelemetry</module>
                 <module>opentelemetry-quickstart</module>
                 <module>opentelemetry-spi</module>


### PR DESCRIPTION
solves https://github.com/quarkusio/quarkus/issues/43621

The implementation uses the [opentelemetry-micrometer-1.5](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/micrometer/micrometer-1.5/library) library.

This allows us to create a Micrometer registry implemented with the OpenTelemetry SDK and APIs.

All telemetry data created with both Micrometer and OpenTelemetry will be processed by the same OpenTelemetry SDK instance from the `quarkus-opentelemetry` extension and will use it's configuration and exporters.

`quarkus-micrometer` extension configurations should also work, as verified on some tests.

Missing:

- [x] Native tests
- [ ] Tests with exemplars using OTel Tracing. 
- [x] Documentation updates
- [x] Decide what to do with the OTel metrics auto instrumentation
- [x] Move the code to the OTel extension? No.
- [x] Disable x.histogram in DistributionSummary
- [x] Silence `io.ope.ins.mic.v1_.OpenTelemetryMeterRegistry] (main) A MeterFilter is being configured ...`
- [x] Enable otel metrics and disable otel metrics instrumentation

