### PR TITLE
Allow adding and removing extensions from Dev UI

### DIFF
--- a/extensions/smallrye-health/deployment/pom.xml
+++ b/extensions/smallrye-health/deployment/pom.xml
@@ -66,6 +66,16 @@
             <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/PathHandler.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/PathHandler.java
@@ -1,0 +1,29 @@
+package io.quarkus.smallrye.health.test;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class PathHandler {
+
+    public void setup(@Observes Router router) {
+        router.route().handler(new Handler<RoutingContext>() {
+            @Override
+            public void handle(RoutingContext event) {
+                QuarkusHttpUser user = (QuarkusHttpUser) event.user();
+                StringBuilder ret = new StringBuilder();
+                if (user != null) {
+                    ret.append(user.getSecurityIdentity().getPrincipal().getName());
+                }
+                ret.append(":");
+                ret.append(event.normalizedPath());
+                event.response().end(ret.toString());
+            }
+        });
+    }
+}

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/PathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/PathMatchingHttpSecurityPolicyTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.smallrye.health.test;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URL;
+import java.time.Duration;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+
+public class PathMatchingHttpSecurityPolicyTest {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
+    private static final String APP_PROPS = """
+            quarkus.http.auth.permission.management.paths=/q/*
+            quarkus.http.auth.permission.management.policy=authenticated
+            """;
+    private static WebClient client;
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestIdentityController.class, TestIdentityProvider.class, PathHandler.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles()
+                .add("test", "test", "test");
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource
+    URL url;
+
+    private WebClient getClient() {
+        if (client == null) {
+            client = WebClient.create(vertx);
+        }
+        return client;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/q/health", "/q/health/live", "/q/health/ready", "//q/health", "///q/health", "///q///health",
+            "/q/health/", "/q///health/", "/q///health////live"
+    })
+    public void testHealthCheckPaths(String path) {
+        assurePath(path, 401);
+        assurePathAuthenticated(path, "UP");
+    }
+
+    private void assurePath(String path, int expectedStatusCode) {
+        assurePath(path, expectedStatusCode, null, null, null);
+    }
+
+    private void assurePathAuthenticated(String path, String body) {
+        assurePath(path, 200, body, "test", null);
+    }
+
+    private void assurePath(String path, int expectedStatusCode, String body, String auth, String header) {
+        var req = getClient().get(url.getPort(), url.getHost(), path);
+        if (auth != null) {
+            req.basicAuthentication(auth, auth);
+        }
+        if (header != null) {
+            req.putHeader(header, header);
+        }
+        var result = req.send();
+        await().atMost(REQUEST_TIMEOUT).until(result::isComplete);
+        assertEquals(expectedStatusCode, result.result().statusCode(), path);
+
+        if (body != null) {
+            Assertions.assertTrue(result.result().bodyAsString().contains(body), path);
+        }
+    }
+}

--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -79,6 +79,16 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/PathHandler.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/PathHandler.java
@@ -1,0 +1,29 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class PathHandler {
+
+    public void setup(@Observes Router router) {
+        router.route().handler(new Handler<RoutingContext>() {
+            @Override
+            public void handle(RoutingContext event) {
+                QuarkusHttpUser user = (QuarkusHttpUser) event.user();
+                StringBuilder ret = new StringBuilder();
+                if (user != null) {
+                    ret.append(user.getSecurityIdentity().getPrincipal().getName());
+                }
+                ret.append(":");
+                ret.append(event.normalizedPath());
+                event.response().end(ret.toString());
+            }
+        });
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/PathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/PathMatchingHttpSecurityPolicyTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URL;
+import java.time.Duration;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+
+public class PathMatchingHttpSecurityPolicyTest {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
+    private static final String APP_PROPS = """
+            quarkus.http.auth.permission.management.paths=/q/*
+            quarkus.http.auth.permission.management.policy=authenticated
+            """;
+    private static WebClient client;
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestIdentityController.class, TestIdentityProvider.class, PathHandler.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles()
+                .add("test", "test", "test");
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource
+    URL url;
+
+    private WebClient getClient() {
+        if (client == null) {
+            client = WebClient.create(vertx);
+        }
+        return client;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/q/openapi", "///q/openapi", "/q///openapi", "/q/openapi/", "/q/openapi///"
+    })
+    public void testOpenApiPath(String path) {
+        assurePath(path, 401);
+        assurePathAuthenticated(path, "openapi");
+    }
+
+    private void assurePath(String path, int expectedStatusCode) {
+        assurePath(path, expectedStatusCode, null, null, null);
+    }
+
+    private void assurePathAuthenticated(String path, String body) {
+        assurePath(path, 200, body, "test", null);
+    }
+
+    private void assurePath(String path, int expectedStatusCode, String body, String auth, String header) {
+        var req = getClient().get(url.getPort(), url.getHost(), path);
+        if (auth != null) {
+            req.basicAuthentication(auth, auth);
+        }
+        if (header != null) {
+            req.putHeader(header, header);
+        }
+        var result = req.send();
+        await().atMost(REQUEST_TIMEOUT).until(result::isComplete);
+        assertEquals(expectedStatusCode, result.result().statusCode(), path);
+
+        if (body != null) {
+            Assertions.assertTrue(result.result().bodyAsString().contains(body), path);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -76,7 +76,17 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devtools-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven.resolver</groupId>
+                    <artifactId>maven-resolver-connector-basic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
@@ -1,14 +1,31 @@
 package io.quarkus.devui.deployment.menu;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.dev.spi.DevModeType;
+import io.quarkus.devtools.commands.AddExtensions;
+import io.quarkus.devtools.commands.ListCategories;
+import io.quarkus.devtools.commands.ListExtensions;
+import io.quarkus.devtools.commands.RemoveExtensions;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devui.deployment.ExtensionsBuildItem;
 import io.quarkus.devui.deployment.InternalPageBuildItem;
 import io.quarkus.devui.deployment.extension.Extension;
 import io.quarkus.devui.deployment.extension.ExtensionGroup;
+import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.devui.spi.page.Page;
 
 /**
@@ -30,11 +47,160 @@ public class ExtensionsProcessor {
 
         // Page
         extensionsPages.addPage(Page.webComponentPageBuilder()
-                .namespace("devui-extensions")
+                .namespace(NAMESPACE)
                 .title("Extensions")
                 .icon("font-awesome-solid:puzzle-piece")
                 .componentLink("qwc-extensions.js"));
 
         return extensionsPages;
     }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void createBuildTimeActions(BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer,
+            LaunchModeBuildItem launchModeBuildItem) {
+
+        if (launchModeBuildItem.getDevModeType().isPresent()
+                && launchModeBuildItem.getDevModeType().get().equals(DevModeType.LOCAL)) {
+
+            BuildTimeActionBuildItem buildTimeActions = new BuildTimeActionBuildItem(NAMESPACE);
+
+            getCategories(buildTimeActions);
+            getInstallableExtensions(buildTimeActions);
+            getInstalledNamespaces(buildTimeActions);
+            removeExtension(buildTimeActions);
+            addExtension(buildTimeActions);
+            buildTimeActionProducer.produce(buildTimeActions);
+        }
+    }
+
+    private void getCategories(BuildTimeActionBuildItem buildTimeActions) {
+        buildTimeActions.addAction(new Object() {
+        }.getClass().getEnclosingMethod().getName(), ignored -> {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    QuarkusCommandOutcome outcome = new ListCategories(getQuarkusProject())
+                            .format("object")
+                            .execute();
+
+                    if (outcome.isSuccess()) {
+                        return outcome.getResult();
+                    }
+                } catch (QuarkusCommandException ex) {
+                    throw new RuntimeException(ex);
+                }
+                return null;
+            });
+        });
+    }
+
+    private void getInstallableExtensions(BuildTimeActionBuildItem buildTimeActions) {
+        buildTimeActions.addAction(new Object() {
+        }.getClass().getEnclosingMethod().getName(), ignored -> {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    QuarkusCommandOutcome outcome = new ListExtensions(getQuarkusProject())
+                            .installed(false)
+                            .all(false)
+                            .format("object")
+                            .execute();
+
+                    if (outcome.isSuccess()) {
+                        return outcome.getResult();
+                    }
+
+                    return null;
+                } catch (QuarkusCommandException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+    }
+
+    private void getInstalledNamespaces(BuildTimeActionBuildItem buildTimeActions) {
+        buildTimeActions.addAction(new Object() {
+        }.getClass().getEnclosingMethod().getName(), ignored -> {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    QuarkusCommandOutcome outcome = new ListExtensions(getQuarkusProject())
+                            .installed(true)
+                            .all(false)
+                            .format("object")
+                            .execute();
+
+                    if (outcome.isSuccess()) {
+
+                        List<io.quarkus.registry.catalog.Extension> extensionList = (List<io.quarkus.registry.catalog.Extension>) outcome
+                                .getResult();
+
+                        List<String> namespaceList = new ArrayList<>();
+
+                        if (!extensionList.isEmpty()) {
+                            for (io.quarkus.registry.catalog.Extension e : extensionList) {
+                                String groupId = e.getArtifact().getGroupId();
+                                String artifactId = e.getArtifact().getArtifactId();
+                                namespaceList.add(groupId + "." + artifactId);
+                            }
+                        }
+                        return namespaceList;
+                    }
+
+                    return null;
+                } catch (QuarkusCommandException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+    }
+
+    private void removeExtension(BuildTimeActionBuildItem buildTimeActions) {
+        buildTimeActions.addAction(new Object() {
+        }.getClass().getEnclosingMethod().getName(), params -> {
+            return CompletableFuture.supplyAsync(() -> {
+                String extensionArtifactId = params.get("extensionArtifactId");
+                try {
+                    QuarkusCommandOutcome outcome = new RemoveExtensions(getQuarkusProject())
+                            .extensions(Set.of(extensionArtifactId))
+                            .execute();
+
+                    if (outcome.isSuccess()) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                } catch (QuarkusCommandException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+    }
+
+    private void addExtension(BuildTimeActionBuildItem buildTimeActions) {
+        buildTimeActions.addAction(new Object() {
+        }.getClass().getEnclosingMethod().getName(), params -> {
+            return CompletableFuture.supplyAsync(() -> {
+                String extensionArtifactId = params.get("extensionArtifactId");
+
+                try {
+                    QuarkusCommandOutcome outcome = new AddExtensions(getQuarkusProject())
+                            .extensions(Set.of(extensionArtifactId))
+                            .execute();
+
+                    if (outcome.isSuccess()) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                } catch (QuarkusCommandException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+    }
+
+    private QuarkusProject getQuarkusProject() {
+        Path projectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        return QuarkusProjectHelper.getCachedProject(projectRoot);
+    }
+
+    private static final String NAMESPACE = "devui-extensions";
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathMatchingHttpSecurityPolicyTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URL;
 import java.time.Duration;
-import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -23,8 +22,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import io.quarkus.builder.Version;
-import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.test.utils.TestIdentityController;
@@ -95,9 +92,7 @@ public class PathMatchingHttpSecurityPolicyTest {
             .addClasses(TestIdentityController.class, TestIdentityProvider.class, PathHandler.class,
                     RouteHandler.class, CustomNamedPolicy.class)
             .addAsResource("static-file.html", "META-INF/resources/static-file.html")
-            .addAsResource(new StringAsset(APP_PROPS), "application.properties")).setForcedDependencies(List.of(
-                    Dependency.of("io.quarkus", "quarkus-smallrye-health", Version.getVersion()),
-                    Dependency.of("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion())));
+            .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
 
     @BeforeAll
     public static void setup() {
@@ -188,25 +183,6 @@ public class PathMatchingHttpSecurityPolicyTest {
     public void testStaticResource(String path) {
         assurePath(path, 401);
         assurePathAuthenticated(path);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "///q/openapi", "/q///openapi", "/q/openapi/", "/q/openapi///"
-    })
-    public void testOpenApiPath(String path) {
-        assurePath(path, 401);
-        assurePathAuthenticated(path, "openapi");
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "/q/health", "/q/health/live", "/q/health/ready", "//q/health", "///q/health", "///q///health",
-            "/q/health/", "/q///health/", "/q///health////live"
-    })
-    public void testHealthCheckPaths(String path) {
-        assurePath(path, 401);
-        assurePathAuthenticated(path, "UP");
     }
 
     @Test

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
@@ -252,9 +252,9 @@ export class QwcConfiguration extends observeState(LitElement) {
         return html`<vaadin-grid .items="${this._filtered}" style="width: 100%;" class="${className}" theme="row-stripes"
                                 .detailsOpenedItems="${this._detailsOpenedItem}"
                                 @active-item-changed="${(event) => {
-                                const prop = event.detail.value;
-                                this._detailsOpenedItem = prop ? [prop] : [];
-                            }}"
+                                    const prop = event.detail.value;
+                                    this._detailsOpenedItem = prop ? [prop] : [];
+                                }}"
                             ${gridRowDetailsRenderer(this._descriptionRenderer, [])}
                         >
                         <vaadin-grid-sort-column auto-width class="cell" flex-grow="0" path="configPhase" header='Phase'

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extension-add.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extension-add.js
@@ -1,0 +1,371 @@
+import { QwcHotReloadElement, html, css} from 'qwc-hot-reload-element';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/text-field';
+import '@vaadin/icon';
+import '@vaadin/progress-bar';
+import '@vaadin/horizontal-layout';
+import '@vaadin/combo-box';
+import '@vaadin/details';
+import '@vaadin/grid';
+import '@vaadin/grid/vaadin-grid-sort-column.js';
+import '@qomponent/qui-badge';
+import { gridRowDetailsRenderer } from '@vaadin/grid/lit.js';
+
+/**
+ * This component create the add extensions screen
+ */
+export class QwcExtensionAdd extends QwcHotReloadElement {
+    jsonRpc = new JsonRpc("devui-extensions", false);
+    
+    static styles = css`
+        .dialogContent {
+            display: flex;
+            width: 75vw;
+            height: 80vh;
+            flex-direction: column;
+        }
+    
+        .grid {
+            width: 100%;
+            height: 100%;
+        }
+    
+        .descriptionPane{
+            display: flex;
+            padding-left: 30px;
+            padding-right: 30px;
+            padding-top: 10px;
+            padding-bottom: 10px;
+            justify-content: space-between;
+            gap: 10px;
+        }
+    
+        .description {
+            display: flex;
+            flex-direction: column;
+            color: var(--lumo-contrast-60pct);
+            width: 100%;
+        }
+    
+        a, a:visited {
+            text-decoration: none;
+            color: var(--lumo-contrast-60pct);
+        }
+        a:hover {
+            color: var(--lumo-primary-color);
+        }
+        
+        .line{
+            padding-bottom: 3px;
+        }
+        .list{
+            display: flex;
+            align-items: center;
+        }
+        .install {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+        }
+        .filterbar {
+            display: flex;
+            gap: 10px;
+            justify-content: space-between;
+        }
+        .loading {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            padding: 20px;
+        }
+    `;
+
+    static properties = {
+        _extensions: {state: true, type: Array},
+        _categories: {state: true, type: Array},
+        _filteredExtensions: {state: true, type: Array},
+        _filteredValue: {state: true},
+        _filteredCategory: {state: true},
+        _detailsOpenedItem: {state: true, type: Array},
+    }
+
+    constructor() {
+        super();
+        this._extensions = null;
+        this._categories = null;
+        this._filteredExtensions = null;
+        this._filteredValue = null;
+        this._filteredCategory = null;
+        this._detailsOpenedItem = [];
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        
+        this.jsonRpc.getCategories().then(jsonRpcResponse => {
+            this._categories = jsonRpcResponse.result;
+            this._categories.push({name:'Uncategorised', id: 'uncategorised'});
+        });
+        
+        if(!this._extensions){
+            this.hotReload();
+        }
+    }
+
+    hotReload(){
+        this.jsonRpc.getInstallableExtensions().then(jsonRpcResponse => {
+            this._extensions = jsonRpcResponse.result;
+            this._filteredExtensions = this._extensions;
+        });
+    }
+
+    render() {
+        if(this._filteredExtensions){
+            return html`<div class="dialogContent">
+                            ${this._renderFilterBar()}
+                            ${this._renderGrid()}
+                        </div>`;
+        }else{
+            return html`<div class="loading">
+                            <vaadin-horizontal-layout style="justify-content: space-between;">
+                                <label class="text-secondary" id="pblabel">Loading installable extensions</label>
+                            </vaadin-horizontal-layout>
+                            <vaadin-progress-bar class="progress" aria-labelledby="pblabel" indeterminate></vaadin-progress-bar>
+                        </div>`;
+        }
+    }
+
+    _renderGrid(){
+        return html`<vaadin-grid .items="${this._filteredExtensions}" class="grid" theme="row-stripes"
+                        .detailsOpenedItems="${this._detailsOpenedItem}"
+                            @active-item-changed="${(event) => {
+                                const prop = event.detail.value;
+                                this._detailsOpenedItem = prop ? [prop] : [];
+                            }}"
+                            ${gridRowDetailsRenderer(this._descriptionRenderer, [])}>
+                            <vaadin-grid-sort-column header="Name" path="name" auto-width flex-grow="0" resizable></vaadin-grid-sort-column>
+                            <vaadin-grid-sort-column header="Description" path="description" resizable></vaadin-grid-sort-column>
+                        </vaadin-grid>`;
+    }
+
+    _renderFilterBar(){
+        return html`<div class="filterbar">
+                        <vaadin-text-field style="width: 100%;"
+                                placeholder="Filter"
+                                value="${this._filteredValue}"
+                                @value-changed="${(e) => this._filterTextChanged(e)}">
+                            <vaadin-icon slot="prefix" icon="font-awesome-solid:filter"></vaadin-icon>
+                            <qui-badge slot="suffix"><span>${this._filteredExtensions.length}</span></qui-badge>
+                        </vaadin-text-field>
+                        ${this._renderCategoryDropdown()}
+                    </div>`;
+        
+    }
+
+    _renderCategoryDropdown(){
+        if(this._categories){
+            return html`<vaadin-combo-box
+                            placeholder="Category"
+                            item-label-path="name"
+                            item-value-path="id"
+                            .items="${this._categories}"
+                            @value-changed="${(e) => this._filterCategoryChanged(e)}"
+                            clear-button-visible
+                        ></vaadin-combo-box>`;
+        }
+    }
+
+    _filterCategoryChanged(e){
+        this._filteredCategory = (e.detail.value || '').trim();
+        return this._filterGrid();
+    }
+
+    _filterTextChanged(e) {
+        this._filteredValue = (e.detail.value || '').trim();
+        return this._filterGrid();
+    }
+
+    _filterGrid(){
+        this._filteredExtensions = this._extensions.filter((prop) => {
+            if(this._filteredValue && this._filteredValue !== '' && this._filteredCategory && this._filteredCategory !== ''){
+                return this._filterByTerm(prop) && this._filterByCategory(prop);
+            }else if(this._filteredValue && this._filteredValue !== ''){
+                 return this._filterByTerm(prop);
+            }else if(this._filteredCategory && this._filteredCategory !== ''){
+                return this._filterByCategory(prop);
+            }else{
+                return true;
+            }
+        });
+    }
+
+    _filterByTerm(prop){
+        if(prop.metadata && prop.metadata.keywords){
+            return this._match(prop.name, this._filteredValue) || this._match(prop.description, this._filteredValue) || prop.metadata.keywords.includes(this._filteredValue);
+        }else{
+            return this._match(prop.name, this._filteredValue) || this._match(prop.description, this._filteredValue);
+        }
+    }
+
+    _filterByCategory(prop){
+        if(prop.metadata && prop.metadata.categories){
+            return prop.metadata.categories.includes(this._filteredCategory);
+        }else if(this._filteredCategory === "uncategorised"){
+            return true;
+        }else {
+            return false;
+        }
+    }
+
+    _match(value, term) {
+        if (! value) {
+            return false;
+        }
+        
+        return value.toLowerCase().includes(term.toLowerCase());
+    }
+
+    _descriptionRenderer(prop) {
+        
+        return html`<div class="descriptionPane">
+                        <div class="description">
+                            <span class="line"><b>Artifact:</b> ${prop.artifact.groupId}:${prop.artifact.artifactId}</span>
+                            <span class="line"><b>Version:</b> ${prop.artifact.version}</span>
+                            ${this._renderIsPlatform(prop)}
+                            ${this._renderMetadata1(prop)}
+                        </div>
+                        <div class="description">
+                            ${this._renderMetadata2(prop)}
+                        </div>
+                    </div>
+                    <vaadin-button class="install" theme="secondary success" @click="${() => this._install(prop)}">
+                        <vaadin-icon icon="font-awesome-solid:download" slot="prefix"></vaadin-icon>
+                        Add Extension
+                    </vaadin-button>    
+                    `;
+    }
+
+    _renderMetadata1(prop){
+        if(prop.metadata){
+            return html`${this._renderGuide(prop.metadata)}
+                        ${this._renderScmUrl(prop.metadata)}
+                        ${this._renderStatus(prop.metadata)}
+                        ${this._renderMinJavaVersion(prop.metadata)}`;
+        }
+    }
+
+    _renderIsPlatform(prop){
+        if (prop.origins && prop.origins.some(str => str.startsWith("io.quarkus:quarkus-bom-quarkus-platform"))){
+            return html`<span class="line"><b>Platform:</b> <vaadin-icon style="height: var(--lumo-icon-size-s); width: var(--lumo-icon-size-s);" icon="font-awesome-solid:check"></vaadin-icon></span>`;
+        } else {
+            return html`<span class="line"><b>Platform:</b> <vaadin-icon style="height: var(--lumo-icon-size-s); width: var(--lumo-icon-size-s);" icon="font-awesome-solid:xmark"></vaadin-icon></span>`;
+        } 
+    }
+
+    _renderGuide(metadata){
+       if (metadata.guide){
+           return html`<span class="line"><b>Guide:</b> <a target="_blank" href="${metadata.guide}">${metadata.guide}</a></span>`;
+        } 
+    }
+
+    _renderScmUrl(metadata){
+        if (metadata['scm-url']){
+           return html`<span class="line"><b>SCM:</b> <a target="_blank" href="${metadata['scm-url']}">${metadata['scm-url']}</a></span>`;     
+        }
+    }
+    
+    _renderStatus(metadata){
+        if(metadata.status){
+            return html`<span class="line"><b>Status:</b> <qui-badge level="${this._statusLevel(metadata.status)}" small><span>${metadata.status.toUpperCase()}</span></qui-badge></span>`;     
+        }
+    }
+    
+    _renderMinJavaVersion(metadata){
+        if(metadata['minimum-java-version']){
+           return html`<span class="line"><b>Minimum Java version:</b> ${metadata['minimum-java-version']}</span>`;     
+        }
+    }
+
+    _renderMetadata2(prop){
+        if(prop.metadata){
+            return html`${this._renderKeywords(prop.metadata)}
+                        ${this._renderCategories(prop.metadata)}
+                        ${this._renderExtensionDependencies(prop.metadata)}`;
+        }
+    }
+
+    
+
+    
+    
+    _statusLevel(s){
+        if(s === "stable") {
+            return "success";
+        } else if(s === "experimental") {
+            return "warning";
+        } else if(s === "preview") {
+            return "contrast";   
+        }
+        return null;
+    }
+    
+    _renderCategories(metadata){
+        if(metadata.categories){
+           return this._renderList("Categories", metadata.categories);
+        }
+    }
+    
+    _renderKeywords(metadata){
+        if(metadata.keywords){
+           return this._renderList("Keywords", metadata.keywords);
+        }
+    }
+    
+    _renderExtensionDependencies(metadata){
+        if(metadata['extension-dependencies']){
+           return html`<vaadin-details summary="Extension dependencies">
+                            <vaadin-vertical-layout>
+                                ${this._renderExtensionDependenciesLines(metadata['extension-dependencies'])}
+                            </vaadin-vertical-layout>
+                        </vaadin-details>`;     
+        }
+    }
+    
+    _renderExtensionDependenciesLines(lines){
+        return html`
+            ${lines.map((line) =>
+                html`<span>${line}</span>`
+            )}
+        `;
+    }
+    
+    _renderList(heading, list) {
+        return html`<span class="list"><b>${heading}:</b> ${this._renderListLines(list)}</span>`;
+    }
+    
+    _renderListLines(list) {
+        return html`
+          <ul>
+            ${list.map((item) =>
+                html`<li>${item}</li>`
+            )}
+          </ul>
+        `;
+    }
+    
+    _install(prop){
+        let extensionArtifactId = prop.artifact.groupId + ':' + prop.artifact.artifactId;
+        this.jsonRpc.addExtension({extensionArtifactId:extensionArtifactId}).then(jsonRpcResponse => {
+            let outcome = jsonRpcResponse.result;
+            
+            const options = {
+                detail: {outcome: outcome, name: prop.name},
+                bubbles: true,
+                composed: true,
+            };
+            this.dispatchEvent(new CustomEvent('inprogress', options));
+            
+        });   
+    }
+}
+customElements.define('qwc-extension-add', QwcExtensionAdd);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extension.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extension.js
@@ -1,14 +1,19 @@
 import { LitElement, html, css} from 'lit';
+import { observeState } from 'lit-element-state';
 import '@vaadin/icon';
 import '@vaadin/dialog';
 import { dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import '@qomponent/qui-badge';
+import { JsonRpc } from 'jsonrpc';
+import { notifier } from 'notifier';
+import { connectionState } from 'connection-state';
 
 /**
  * This component represent one extension
  * It's a card on the extension board
  */
-export class QwcExtension extends LitElement {
+export class QwcExtension extends observeState(LitElement) {
+    jsonRpc = new JsonRpc("devui-extensions", false);
 
     static styles = css`
         .card {
@@ -95,13 +100,15 @@ export class QwcExtension extends LitElement {
         builtWith: {type: String},
         providesCapabilities: {},
         extensionDependencies: {}, 
-        favourite: {type: Boolean},   
+        favourite: {type: Boolean},
+        installed: {type: Boolean},
     };
     
     constructor() {
         super();
         this._dialogOpened = false;
         this.favourite = false;
+        this.installed = false;
     }
 
     render() {
@@ -260,7 +267,28 @@ export class QwcExtension extends LitElement {
                     <td>${this._renderExtensionDependencies()}</td>
                 </tr>
             </table>
+            ${this._renderUninstallButton()}
         `;
+    }
+
+    _renderUninstallButton(){
+        if(connectionState.current.isConnected && this.installed){
+            return html`<vaadin-button style="width: 100%;" theme="secondary error" @click="${this._uninstall}">
+                        <vaadin-icon icon="font-awesome-solid:trash-can" slot="prefix"></vaadin-icon>
+                        Remove this extension
+                    </vaadin-button>`;
+        }
+    }
+
+    _uninstall(){
+        this._dialogOpened = false;
+        notifier.showInfoMessage(this.name + " removal in progress");
+        this.jsonRpc.removeExtension({extensionArtifactId:this.artifact}).then(jsonRpcResponse => {
+            let outcome = jsonRpcResponse.result;
+            if(!outcome){
+                notifier.showErrorMessage(name + " removal failed");
+            }
+        });
     }
 
     _renderGuideDetails() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/data/QuarkusCommandOutcome.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/data/QuarkusCommandOutcome.java
@@ -2,25 +2,32 @@ package io.quarkus.devtools.commands.data;
 
 import java.util.Objects;
 
-public class QuarkusCommandOutcome extends ValueMap<QuarkusCommandOutcome> {
+public class QuarkusCommandOutcome<T> extends ValueMap<QuarkusCommandOutcome<T>> {
 
-    public static QuarkusCommandOutcome success() {
-        return new QuarkusCommandOutcome(true, null);
+    public static <T> QuarkusCommandOutcome<T> success() {
+        return new QuarkusCommandOutcome<>(true, null, null);
     }
 
-    public static QuarkusCommandOutcome failure(String message) {
+    public static <T> QuarkusCommandOutcome<T> success(T result) {
+        return new QuarkusCommandOutcome<>(true, null, result);
+    }
+
+    public static QuarkusCommandOutcome<Void> failure(String message) {
         Objects.requireNonNull(message, "Message may not be null in case of a failure");
 
-        return new QuarkusCommandOutcome(false, message);
+        return new QuarkusCommandOutcome(false, message, null);
     }
 
     private final boolean success;
 
     private final String message;
 
-    private QuarkusCommandOutcome(boolean success, String message) {
+    private final T result;
+
+    private QuarkusCommandOutcome(boolean success, String message, T result) {
         this.success = success;
         this.message = message;
+        this.result = result;
     }
 
     public boolean isSuccess() {
@@ -29,5 +36,9 @@ public class QuarkusCommandOutcome extends ValueMap<QuarkusCommandOutcome> {
 
     public String getMessage() {
         return message;
+    }
+
+    public T getResult() {
+        return result;
     }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
@@ -61,11 +61,13 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
                         .getExtensions();
 
         if (extensions.isEmpty()) {
-            log.info("No extension found with pattern '%s'", search);
+            if (!format.equalsIgnoreCase("object")) {
+                log.info("No extension found with pattern '%s'", search);
+            }
             return QuarkusCommandOutcome.success();
         }
 
-        if (!batchMode) {
+        if (!batchMode && !format.equalsIgnoreCase("object")) {
             String extensionStatus = all ? "available" : "installable";
             if (installedOnly)
                 extensionStatus = "installed";
@@ -75,6 +77,9 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
 
         BiConsumer<MessageWriter, DisplayData> currentFormatter;
         switch (format.toLowerCase()) {
+            case "object":
+                currentFormatter = null;
+                break;
             case "id":
             case "name":
                 currentFormatter = this::idFormatter;
@@ -110,11 +115,30 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
             categoryFilter = e -> true;
         }
 
-        extensions.stream()
-                .filter(e -> !ExtensionProcessor.of(e).isUnlisted())
-                .filter(categoryFilter)
-                .sorted(Comparator.comparing(e -> e.getArtifact().getArtifactId()))
-                .forEach(e -> display(log, e, installedByKey.get(toKey(e)), all, installedOnly, currentFormatter));
+        if (currentFormatter != null) {
+            extensions.stream()
+                    .filter(e -> !ExtensionProcessor.of(e).isUnlisted())
+                    .filter(categoryFilter)
+                    .sorted(Comparator.comparing(e -> e.getArtifact().getArtifactId()))
+                    .forEach(e -> display(log, e, installedByKey.get(toKey(e)), all, installedOnly, currentFormatter));
+        } else {
+            List<Extension> filteredExtensions = extensions.stream()
+                    .filter(e -> !ExtensionProcessor.of(e).isUnlisted())
+                    .filter(categoryFilter)
+                    .filter(e -> {
+                        ArtifactCoords installed = installedByKey.get(toKey(e));
+                        if (installedOnly && installed == null) {
+                            return false;
+                        }
+                        if (!installedOnly && !all && installed != null) {
+                            return false;
+                        }
+                        return true;
+                    })
+                    .sorted(Comparator.comparing(e -> e.getArtifact().getArtifactId()))
+                    .collect(Collectors.toList());
+            return QuarkusCommandOutcome.success(filteredExtensions);
+        }
 
         return QuarkusCommandOutcome.success();
     }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/CompileOnlyDependencyFlagsTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/CompileOnlyDependencyFlagsTest.java
@@ -86,7 +86,8 @@ public class CompileOnlyDependencyFlagsTest {
                 DependencyFlags.COMPILE_ONLY);
         assertOnlyFlagsSet(bootstrapResolver, compileOnly.get(bootstrapResolver),
                 DependencyFlags.COMPILE_ONLY,
-                DependencyFlags.CLASSLOADER_PARENT_FIRST);
+                DependencyFlags.CLASSLOADER_PARENT_FIRST,
+                DependencyFlags.DEPLOYMENT_CP);
 
         compileOnly = compileOnlyDeps.get(LaunchMode.NORMAL.name());
         assertEqual(compileOnly, expectedCompileOnly);
@@ -99,7 +100,8 @@ public class CompileOnlyDependencyFlagsTest {
                 DependencyFlags.COMPILE_ONLY);
         assertOnlyFlagsSet(bootstrapResolver, compileOnly.get(bootstrapResolver),
                 DependencyFlags.COMPILE_ONLY,
-                DependencyFlags.CLASSLOADER_PARENT_FIRST);
+                DependencyFlags.CLASSLOADER_PARENT_FIRST,
+                DependencyFlags.DEPLOYMENT_CP);
     }
 
     private static void assertOnlyFlagsSet(String coords, int flags, int... expectedFlags) {


### PR DESCRIPTION
This PR add the "quarkus add" and "quarkus remove" to Dev UI. It allows you to browse (and search) for installable extensions in Dev UI and install them from Dev UI. It also adds a remove button on the details screen on the extension if it can be uninstalled.

![extension_management_dev_ui](https://github.com/user-attachments/assets/cacfa079-0792-4e1e-b702-2f686f7e2107)
