### PR TITLE
Dev UI better reconnect

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/state/connection-state.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/state/connection-state.js
@@ -27,6 +27,7 @@ class ConnectionState extends LitState {
         newState.isConnecting = false;
         newState.isHotreloading = false;
         connectionState.current = newState;
+        document.body.style.cursor = 'wait';
     }
     
     connecting(serverUri){
@@ -41,6 +42,7 @@ class ConnectionState extends LitState {
         newState.isConnecting = true;
         newState.isHotreloading = false;
         connectionState.current = newState;
+        document.body.style.cursor = 'progress';
     }
     
     hotreload(serverUri){
@@ -55,6 +57,7 @@ class ConnectionState extends LitState {
         newState.isConnecting = false;
         newState.isHotreloading = true;
         connectionState.current = newState;
+        document.body.style.cursor = 'progress'; 
     }
     
     connected(serverUri){
@@ -69,6 +72,7 @@ class ConnectionState extends LitState {
         newState.isConnecting = false;
         newState.isHotreloading = false;
         connectionState.current = newState;
+        document.body.style.cursor = 'default';
     }
 }
 


### PR DESCRIPTION
This PR does 2 things:

- Change the mouse pointer to wait when the server is restarting. This gives the user some more indication that the server is offline (other than the icon on the bottom left corner)
- Exponential backoff the retry attempts, with a max of 10. If the server is not up by then, it's not a normal restart, so we display a popup to allow manual reconnect.

![dev_ui_reconnect](https://github.com/user-attachments/assets/48479c29-13b0-4a98-b483-320d703f81dd)
