### PR TITLE
Add key property name to provide context

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/RunTimeConfigurationDefaultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/RunTimeConfigurationDefaultBuildItem.java
@@ -22,7 +22,7 @@ public final class RunTimeConfigurationDefaultBuildItem extends MultiBuildItem {
     public RunTimeConfigurationDefaultBuildItem(final String key, final String value) {
         Assert.checkNotNullParam("key", key);
         Assert.checkNotEmptyParam("key", key);
-        Assert.checkNotNullParam("value", value);
+        Assert.checkNotNullParam("value for key " + key, value);
         this.key = key;
         this.value = value;
     }


### PR DESCRIPTION
fixes #43866 

This change adds more diagnostic information for users. This provides context of the key name to accompany the value that was null. Which is helpful for users to efficiently diagnose trivial configuration mistakes.

This pull request includes:
[x] Change to an existing logging message
[ ] Additional test cases
[ ] Additional documentation
