### PR TITLE
WebSockets Next: Security cleanup

### DIFF
--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
@@ -88,7 +88,6 @@ import io.quarkus.security.spi.SecurityTransformerUtils;
 import io.quarkus.security.spi.runtime.SecurityCheck;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HandlerType;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.websockets.next.HttpUpgradeCheck;
 import io.quarkus.websockets.next.InboundProcessingMode;
 import io.quarkus.websockets.next.WebSocketClientConnection;
@@ -445,18 +444,11 @@ public class WebSocketProcessor {
     @Record(RUNTIME_INIT)
     @BuildStep
     public void registerRoutes(WebSocketServerRecorder recorder, List<GeneratedEndpointBuildItem> generatedEndpoints,
-            HttpBuildTimeConfig httpConfig, Capabilities capabilities,
             BuildProducer<RouteBuildItem> routes) {
         for (GeneratedEndpointBuildItem endpoint : generatedEndpoints.stream().filter(GeneratedEndpointBuildItem::isServer)
                 .toList()) {
-            RouteBuildItem.Builder builder = RouteBuildItem.builder();
-            if (capabilities.isPresent(Capability.SECURITY) && !httpConfig.auth.proactive) {
-                // Add a special handler so that it's possible to capture the SecurityIdentity before the HTTP upgrade
-                builder.routeFunction(endpoint.path, recorder.initializeSecurityHandler());
-            } else {
-                builder.route(endpoint.path);
-            }
-            builder
+            RouteBuildItem.Builder builder = RouteBuildItem.builder()
+                    .route(endpoint.path)
                     .displayOnNotFoundPage("WebSocket Endpoint")
                     .handlerType(HandlerType.NORMAL)
                     .handler(recorder.createEndpointHandler(endpoint.generatedClassName, endpoint.endpointId));

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/HttpUpgradeCheck.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/HttpUpgradeCheck.java
@@ -48,7 +48,7 @@ public interface HttpUpgradeCheck {
      * @param securityIdentity {@link SecurityIdentity}; the identity is null if the Quarkus Security extension is absent
      * @param endpointId {@link WebSocket#endpointId()}
      */
-    record HttpUpgradeContext(HttpServerRequest httpRequest, SecurityIdentity securityIdentity, String endpointId) {
+    record HttpUpgradeContext(HttpServerRequest httpRequest, Uni<SecurityIdentity> securityIdentity, String endpointId) {
     }
 
     final class CheckResult {

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/SecurityHttpUpgradeCheck.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/SecurityHttpUpgradeCheck.java
@@ -26,11 +26,10 @@ public class SecurityHttpUpgradeCheck implements HttpUpgradeCheck {
 
     @Override
     public Uni<CheckResult> perform(HttpUpgradeContext context) {
-        return endpointToCheck
-                .get(context.endpointId())
-                .nonBlockingApply(context.securityIdentity(), (MethodDescription) null, null)
+        return context.securityIdentity().chain(identity -> endpointToCheck.get(context.endpointId())
+                .nonBlockingApply(identity, (MethodDescription) null, null)
                 .replaceWith(CheckResult::permitUpgradeSync)
-                .onFailure(SecurityException.class).recoverWithItem(this::rejectUpgrade);
+                .onFailure(SecurityException.class).recoverWithItem(this::rejectUpgrade));
     }
 
     @Override


### PR DESCRIPTION
- do not force authentication in a dedicted handler so that it's possible to capture the SecurityIdentity before the HTTP upgrade but use the deferred identity instead
- also change the HttpUpgradeContext to consume Uni<SecurityIdentity> instead of SecurityIdentity