### PR TITLE
Tweaking the Datasource guide content conditionals

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -66,9 +66,7 @@ For more details and optional configurations, see xref:databases-dev-services.ad
 * `quarkus-jdbc-db2`
 * `quarkus-jdbc-derby`
 +
-ifdef::note-quarkus-derby[]
-include::resources/snippets/snip-note-derby.adoc[]
-endif::note-quarkus-derby[]
+include::_includes/snip-note-derby.adoc[]
 * `quarkus-jdbc-h2`
 * `quarkus-jdbc-mariadb`
 * `quarkus-jdbc-mssql`
@@ -156,9 +154,7 @@ Quarkus currently includes the following built-in database kinds:
 * DB2: `db2`
 * Derby: `derby`
 +
-ifdef::note-quarkus-derby[]
-include::resources/snippets/snip-note-derby.adoc[]
-endif::note-quarkus-derby[]
+include::_includes/snip-note-derby.adoc[]
 * H2: `h2`
 * MariaDB: `mariadb`
 * Microsoft SQL Server: `mssql`
@@ -200,9 +196,7 @@ JDBC is the most common database connection pattern, typically needed when used 
 +
 * Derby - `quarkus-jdbc-derby`
 +
-ifdef::note-quarkus-derby[]
-include::resources/snippets/snip-note-derby.adoc[]
-endif::note-quarkus-derby[]
+include::_includes/snip-note-derby.adoc[]
 * H2 - `quarkus-jdbc-h2`
 +
 [NOTE]

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -66,11 +66,9 @@ For more details and optional configurations, see xref:databases-dev-services.ad
 * `quarkus-jdbc-db2`
 * `quarkus-jdbc-derby`
 +
---
 ifdef::note-quarkus-derby[]
 include::resources/snippets/snip-note-derby.adoc[]
 endif::note-quarkus-derby[]
---
 * `quarkus-jdbc-h2`
 * `quarkus-jdbc-mariadb`
 * `quarkus-jdbc-mssql`
@@ -158,11 +156,9 @@ Quarkus currently includes the following built-in database kinds:
 * DB2: `db2`
 * Derby: `derby`
 +
---
 ifdef::note-quarkus-derby[]
 include::resources/snippets/snip-note-derby.adoc[]
 endif::note-quarkus-derby[]
---
 * H2: `h2`
 * MariaDB: `mariadb`
 * Microsoft SQL Server: `mssql`
@@ -204,11 +200,9 @@ JDBC is the most common database connection pattern, typically needed when used 
 +
 * Derby - `quarkus-jdbc-derby`
 +
---
 ifdef::note-quarkus-derby[]
 include::resources/snippets/snip-note-derby.adoc[]
 endif::note-quarkus-derby[]
---
 * H2 - `quarkus-jdbc-h2`
 +
 [NOTE]

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -65,10 +65,12 @@ For more details and optional configurations, see xref:databases-dev-services.ad
 
 * `quarkus-jdbc-db2`
 * `quarkus-jdbc-derby`
-ifdef::note-quarkus-derby[]
 +
-{note-quarkus-derby}
+--
+ifdef::note-quarkus-derby[]
+include::resources/snippets/snip-note-derby.adoc[]
 endif::note-quarkus-derby[]
+--
 * `quarkus-jdbc-h2`
 * `quarkus-jdbc-mariadb`
 * `quarkus-jdbc-mssql`
@@ -155,10 +157,12 @@ Quarkus currently includes the following built-in database kinds:
 +
 * DB2: `db2`
 * Derby: `derby`
-ifdef::note-quarkus-derby[]
 +
-{note-quarkus-derby}
+--
+ifdef::note-quarkus-derby[]
+include::resources/snippets/snip-note-derby.adoc[]
 endif::note-quarkus-derby[]
+--
 * H2: `h2`
 * MariaDB: `mariadb`
 * Microsoft SQL Server: `mssql`
@@ -199,10 +203,12 @@ JDBC is the most common database connection pattern, typically needed when used 
 .. For use with a built-in JDBC driver, choose and add the Quarkus extension for your relational database driver from the list below:
 +
 * Derby - `quarkus-jdbc-derby`
-ifdef::note-quarkus-derby[]
 +
-{note-quarkus-derby}
+--
+ifdef::note-quarkus-derby[]
+include::resources/snippets/snip-note-derby.adoc[]
 endif::note-quarkus-derby[]
+--
 * H2 - `quarkus-jdbc-h2`
 +
 [NOTE]


### PR DESCRIPTION
This is the tweaking PR for the better reusability of the TLS guide content.
These changes are being made based on QE feedback. CC Georgii Troitskii.
The visualization of the Quarkus TLS guide remains unchanged.

The issue now is that in order to render something correctly in RHBQ, I have to include a snippet that exists only in the RHBQ repository. Since we follow an "Upstream first" policy, I need to mention this include in the Quarkus documentation as well, even though it's wrapped in an `ifdef` condition, ensuring it doesn't affect Quarkus documentation (since the attribute that triggers the condition and the snippet itself are defined only in product repo).

Unfortunately, the GitHub docs preview bot fails because it attempts to locate the snippet that doesn’t exist in Quarkus, even though it’s not required.
```
Caused by: java.nio.file.NoSuchFileException: target/asciidoc/sources/resources/snippets/snip-note-derby.adoc
```

In my opinion, some changes will need to be made in `io.quarkus.docs.generation.AssembleDownstreamDocumentation`, which was likely written by @gsmet , whom I am kindly asking for advice/opinion/workaround.
Fix could be something like: When it is all about loading a file from the `resources/snippets/` folder, ignore it in the check.

This is not a blocker, but something that would be great to have.

