### PR TITLE
Exclude uri from otel tracing

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -589,6 +589,81 @@ quarkus.otel.instrument.rest=false
 quarkus.otel.instrument.resteasy=false
 ----
 
+=== Disable specific REST endpoints
+
+There are two ways to disable tracing for a specific REST endpoint.
+
+You can use the `@io.quarkus.opentelemetry.runtime.tracing.Traceless` (or simply `@Traceless`) annotation to disable tracing for a specific endpoint.
+
+Examples:
+
+==== `@Traceless` annotation on a class
+
+[source,java]
+.PingResource.java
+----
+@Path("/health")
+public class PingResource {
+
+    @Path("/ping")
+    public String ping() {
+        return "pong";
+    }
+}
+----
+
+When the `@Traceless` annotation is placed on a class, all methods annotated with `@Path` will be excluded from tracing.
+
+==== `@Traceless` annotation on a method
+
+[source,java]
+.TraceResource.java
+----
+@Path("/trace")
+@Traceless
+public class TraceResource {
+
+    @Path("/no")
+    @GET
+    @Traceless
+    public String noTrace() {
+        return "no";
+    }
+
+    @Path("/yes")
+    @GET
+    public String withTrace() {
+        return "yes";
+    }
+}
+----
+
+In the example above, only `GET /trace/yes` will be included in tracing.
+
+==== Disable using configuration
+
+If you do not want to modify the source code, you can use your `application.properties` to disable a specific endpoint through the `quarkus.otel.traces.suppress-application-uris` property.
+
+Example:
+
+[source,properties]
+.application.properties
+----
+quarkus.otel.traces.suppress-application-uris=trace,ping,people*
+----
+
+This configuration will:
+
+- Disable tracing for the `/trace` URI;
+- Disable tracing for the `/ping` URI;
+- Disable tracing for the `/people` URI and all other URIs under it, e.g., `/people/1`, `/people/1/cars`.
+
+[NOTE]
+====
+If you are using `quarkus.http.root-path`, you need to remember to include the root path in the configuration. Unlike `@Traceless`, this configuration does not automatically add the root path.
+====
+
+
 [[configuration-reference]]
 == OpenTelemetry Configuration Reference
 

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/DropApplicationUrisBuildItem.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/DropApplicationUrisBuildItem.java
@@ -1,0 +1,19 @@
+package io.quarkus.opentelemetry.deployment.tracing;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Represents an application uri that must be ignored for tracing.
+ */
+public final class DropApplicationUrisBuildItem extends MultiBuildItem {
+
+    private final String uri;
+
+    public DropApplicationUrisBuildItem(String uri) {
+        this.uri = uri;
+    }
+
+    public String uri() {
+        return uri;
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressAppUrisTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressAppUrisTest.java
@@ -1,0 +1,87 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.TracerRouter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryMetricExporterProvider;
+import io.quarkus.opentelemetry.deployment.common.traces.TraceMeResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenTelemetrySuppressAppUrisTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(InMemoryExporter.class.getPackage())
+                    .addAsResource("resource-config/application.properties", "application.properties")
+                    .addAsResource(
+                            "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                    .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                    .addClasses(TracerRouter.class, TraceMeResource.class))
+            .overrideConfigKey("quarkus.otel.traces.suppress-application-uris", "tracer,/hello/Itachi");
+
+    @Inject
+    InMemoryExporter exporter;
+
+    @BeforeEach
+    void setup() {
+        exporter.reset();
+    }
+
+    @Test
+    @DisplayName("Should not trace when the using configuration quarkus.otel.traces.suppress-application-uris without slash")
+    void testingSuppressAppUrisWithoutSlash() {
+        RestAssured.when()
+                .get("/tracer").then()
+                .statusCode(200)
+                .body(is("Hello Tracer!"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the using configuration quarkus.otel.traces.suppress-application-uris with slash")
+    void testingSuppressAppUrisWithSlash() {
+        RestAssured.when()
+                .get("/hello/Itachi").then()
+                .statusCode(200)
+                .body(is("Amaterasu!"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTracelessOnMethodWithoutPathTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTracelessOnMethodWithoutPathTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.ws.rs.core.Response;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryExporter;
+import io.quarkus.opentelemetry.runtime.tracing.Traceless;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenTelemetryTracelessOnMethodWithoutPathTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(InMemoryExporter.class.getPackage())
+                    .addAsResource(new StringAsset(
+                            ""), "application.properties")
+                    .addClasses(TracelessWithoutPath.class))
+            .assertException(throwable -> {
+                assertThat(throwable).isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("The class")
+                        .hasMessageContaining(
+                                "contains a method annotated with @Traceless but is missing the required @Path annotation. Please ensure that the class is properly annotated with @Path annotation.");
+            });
+
+    @Test
+    void testClassAnnotatedWithTracelessMissingPath() {
+        Assertions.fail();
+    }
+
+    public static class TracelessWithoutPath {
+
+        @Traceless
+        public Response hello() {
+            return Response.ok("hello").build();
+        }
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTracelessTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTracelessTest.java
@@ -1,0 +1,141 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryMetricExporterProvider;
+import io.quarkus.opentelemetry.deployment.common.traces.TraceMeResource;
+import io.quarkus.opentelemetry.deployment.common.traces.TracelessClassLevelResource;
+import io.quarkus.opentelemetry.deployment.common.traces.TracelessHelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenTelemetryTracelessTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(InMemoryExporter.class.getPackage())
+                    .addAsResource("resource-config/application.properties", "application.properties")
+                    .addAsResource(
+                            "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                    .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                    .addClasses(TracelessHelloResource.class, TracelessClassLevelResource.class, TraceMeResource.class));
+
+    @Inject
+    InMemoryExporter exporter;
+
+    @BeforeEach
+    void setup() {
+        exporter.reset();
+    }
+
+    @Test
+    @DisplayName("Should not trace when the method @Path uses @PathParam")
+    void testingWithPathParam() {
+        RestAssured.when()
+                .get("/hello/mask/1").then()
+                .statusCode(200)
+                .body(is("mask-1"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the annotation @Traceless is at method level")
+    void testingTracelessHelloHi() {
+
+        RestAssured.when()
+                .get("/hello").then()
+                .statusCode(200)
+                .body(is("hello"));
+
+        RestAssured.when()
+                .get("/hello/hi").then()
+                .statusCode(200)
+                .body(is("hi"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the method @Path is without '/'")
+    void testingHelloNoSlash() {
+        RestAssured.when()
+                .get("/hello/no-slash").then()
+                .statusCode(200)
+                .body(is("no-slash"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the annotation is at class level")
+    void testingTracelessAtClassLevel() {
+
+        RestAssured.when()
+                .get("class-level").then()
+                .statusCode(200)
+                .body(is("class-level"));
+
+        RestAssured.when()
+                .get("/class-level/first-method").then()
+                .statusCode(200)
+                .body(is("first-method"));
+
+        RestAssured.when()
+                .get("/class-level/second-method").then()
+                .statusCode(200)
+                .body(is("second-method"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTracelessWithRootPathTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTracelessWithRootPathTest.java
@@ -1,0 +1,146 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryMetricExporterProvider;
+import io.quarkus.opentelemetry.deployment.common.traces.TraceMeResource;
+import io.quarkus.opentelemetry.deployment.common.traces.TracelessClassLevelResource;
+import io.quarkus.opentelemetry.deployment.common.traces.TracelessHelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenTelemetryTracelessWithRootPathTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(InMemoryExporter.class.getPackage())
+                    .addAsResource("resource-config/application.properties", "application.properties")
+                    .addAsResource(
+                            "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                    .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                    .addClasses(TracelessHelloResource.class, TracelessClassLevelResource.class, TraceMeResource.class))
+            .overrideConfigKey("quarkus.http.root-path", "/api");
+
+    @Inject
+    InMemoryExporter exporter;
+
+    @BeforeEach
+    void setup() {
+        exporter.reset();
+    }
+
+    @Test
+    @DisplayName("Should not trace when the annotation @Traceless is at method level")
+    void testingTracelessHelloHi() {
+
+        RestAssured.when()
+                .get("/hello").then()
+                .statusCode(200)
+                .body(is("hello"));
+
+        RestAssured.when()
+                .get("/hello/hi").then()
+                .statusCode(200)
+                .body(is("hi"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the method @Path uses @PathParam")
+    void testingWithPathParam() {
+        RestAssured.when()
+                .get("/hello/mask/1").then()
+                .statusCode(200)
+                .body(is("mask-1"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the method @Path is without '/'")
+    void testingHelloNoSlash() {
+        RestAssured.when()
+                .get("/hello/no-slash").then()
+                .statusCode(200)
+                .body(is("no-slash"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the annotation is at class level")
+    void testingTracelessAtClassLevel() {
+
+        RestAssured.when()
+                .get("class-level").then()
+                .statusCode(200)
+                .body(is("class-level"));
+
+        RestAssured.when()
+                .get("/class-level/first-method").then()
+                .statusCode(200)
+                .body(is("first-method"));
+
+        RestAssured.when()
+                .get("/class-level/second-method").then()
+                .statusCode(200)
+                .body(is("second-method"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTracelessWithoutPathTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryTracelessWithoutPathTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryExporter;
+import io.quarkus.opentelemetry.runtime.tracing.Traceless;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenTelemetryTracelessWithoutPathTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(InMemoryExporter.class.getPackage())
+                    .addAsResource(new StringAsset(
+                            ""), "application.properties")
+                    .addClasses(TracelessWithoutPath.class))
+            .assertException(throwable -> {
+                assertThat(throwable).isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("The class")
+                        .hasMessageContaining(
+                                "is annotated with @Traceless but is missing the required @Path annotation. Please ensure that the class is properly annotated with @Path annotation.");
+            });
+
+    @Test
+    void testClassAnnotatedWithTracelessMissingPath() {
+        Assertions.fail();
+    }
+
+    @Traceless
+    public static class TracelessWithoutPath {
+
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/TracerRouter.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/TracerRouter.java
@@ -27,6 +27,8 @@ public class TracerRouter {
             String name = rc.pathParam("name");
             if (name.equals("Naruto")) {
                 rc.response().end("hello " + name);
+            } else if (name.equals("Itachi")) {
+                rc.response().end("Amaterasu!");
             } else {
                 rc.response().setStatusCode(404).end();
             }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/traces/TraceMeResource.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/traces/TraceMeResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.opentelemetry.deployment.common.traces;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.opentelemetry.api.metrics.Meter;
+
+@Path("/trace-me")
+public class TraceMeResource {
+
+    @Inject
+    Meter meter;
+
+    @GET
+    public String traceMe() {
+        meter.counterBuilder("trace-me").build().add(1);
+        return "trace-me";
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/traces/TracelessClassLevelResource.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/traces/TracelessClassLevelResource.java
@@ -1,0 +1,36 @@
+package io.quarkus.opentelemetry.deployment.common.traces;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.opentelemetry.api.metrics.Meter;
+import io.quarkus.opentelemetry.runtime.tracing.Traceless;
+
+@Path("/class-level")
+@Traceless
+public class TracelessClassLevelResource {
+
+    @Inject
+    Meter meter;
+
+    @GET
+    public String classLevel() {
+        meter.counterBuilder("class-level").build().add(1);
+        return "class-level";
+    }
+
+    @GET
+    @Path("/first-method")
+    public String firstMethod() {
+        meter.counterBuilder("first-method").build().add(1);
+        return "first-method";
+    }
+
+    @Path("/second-method")
+    @GET
+    public String secondMethod() {
+        meter.counterBuilder("second-method").build().add(1);
+        return "second-method";
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/traces/TracelessHelloResource.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/traces/TracelessHelloResource.java
@@ -1,0 +1,47 @@
+package io.quarkus.opentelemetry.deployment.common.traces;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import io.opentelemetry.api.metrics.Meter;
+import io.quarkus.opentelemetry.runtime.tracing.Traceless;
+
+@Path("/hello")
+public class TracelessHelloResource {
+
+    @Inject
+    Meter meter;
+
+    @GET
+    @Traceless
+    public String hello() {
+        meter.counterBuilder("hello").build().add(1);
+        return "hello";
+    }
+
+    @Path("/hi")
+    @GET
+    @Traceless
+    public String hi() {
+        meter.counterBuilder("hi").build().add(1);
+        return "hi";
+    }
+
+    @Path("no-slash")
+    @GET
+    @Traceless
+    public String noSlash() {
+        meter.counterBuilder("no-slash").build().add(1);
+        return "no-slash";
+    }
+
+    @GET
+    @Path("/mask/{number}")
+    @Traceless
+    public String mask(@PathParam("number") String number) {
+        meter.counterBuilder("mask").build().add(Integer.parseInt(number));
+        return "mask-" + number;
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySuppressAppUrisTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySuppressAppUrisTest.java
@@ -1,0 +1,87 @@
+package io.quarkus.opentelemetry.deployment.traces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.TracerRouter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryMetricExporterProvider;
+import io.quarkus.opentelemetry.deployment.common.traces.TraceMeResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenTelemetrySuppressAppUrisTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(InMemoryExporter.class.getPackage())
+                    .addAsResource("resource-config/application.properties", "application.properties")
+                    .addAsResource(
+                            "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                    .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                    .addClasses(TracerRouter.class, TraceMeResource.class))
+            .overrideConfigKey("quarkus.otel.traces.suppress-application-uris", "tracer,/hello/Itachi");
+
+    @Inject
+    InMemoryExporter exporter;
+
+    @BeforeEach
+    void setup() {
+        exporter.reset();
+    }
+
+    @Test
+    @DisplayName("Should not trace when the using configuration quarkus.otel.traces.suppress-application-uris without slash")
+    void testingSuppressAppUrisWithoutSlash() {
+        RestAssured.when()
+                .get("/tracer").then()
+                .statusCode(200)
+                .body(is("Hello Tracer!"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the using configuration quarkus.otel.traces.suppress-application-uris with slash")
+    void testingSuppressAppUrisWithSlash() {
+        RestAssured.when()
+                .get("/hello/Itachi").then()
+                .statusCode(200)
+                .body(is("Amaterasu!"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracelessTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracelessTest.java
@@ -1,0 +1,141 @@
+package io.quarkus.opentelemetry.deployment.traces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryMetricExporterProvider;
+import io.quarkus.opentelemetry.deployment.common.traces.TraceMeResource;
+import io.quarkus.opentelemetry.deployment.common.traces.TracelessClassLevelResource;
+import io.quarkus.opentelemetry.deployment.common.traces.TracelessHelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenTelemetryTracelessTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(InMemoryExporter.class.getPackage())
+                    .addAsResource("resource-config/application.properties", "application.properties")
+                    .addAsResource(
+                            "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                    .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                    .addClasses(TracelessHelloResource.class, TracelessClassLevelResource.class, TraceMeResource.class));
+
+    @Inject
+    InMemoryExporter exporter;
+
+    @BeforeEach
+    void setup() {
+        exporter.reset();
+    }
+
+    @Test
+    @DisplayName("Should not trace when the method @Path uses @PathParam")
+    void testingWithPathParam() {
+        RestAssured.when()
+                .get("/hello/mask/1").then()
+                .statusCode(200)
+                .body(is("mask-1"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the annotation @Traceless is at method level")
+    void testingTracelessHelloHi() {
+
+        RestAssured.when()
+                .get("/hello").then()
+                .statusCode(200)
+                .body(is("hello"));
+
+        RestAssured.when()
+                .get("/hello/hi").then()
+                .statusCode(200)
+                .body(is("hi"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the method @Path is without '/'")
+    void testingHelloNoSlash() {
+        RestAssured.when()
+                .get("/hello/no-slash").then()
+                .statusCode(200)
+                .body(is("no-slash"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the annotation is at class level")
+    void testingTracelessAtClassLevel() {
+
+        RestAssured.when()
+                .get("class-level").then()
+                .statusCode(200)
+                .body(is("class-level"));
+
+        RestAssured.when()
+                .get("/class-level/first-method").then()
+                .statusCode(200)
+                .body(is("first-method"));
+
+        RestAssured.when()
+                .get("/class-level/second-method").then()
+                .statusCode(200)
+                .body(is("second-method"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracelessWithRootPathTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryTracelessWithRootPathTest.java
@@ -1,0 +1,146 @@
+package io.quarkus.opentelemetry.deployment.traces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryMetricExporterProvider;
+import io.quarkus.opentelemetry.deployment.common.traces.TraceMeResource;
+import io.quarkus.opentelemetry.deployment.common.traces.TracelessClassLevelResource;
+import io.quarkus.opentelemetry.deployment.common.traces.TracelessHelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenTelemetryTracelessWithRootPathTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(InMemoryExporter.class.getPackage())
+                    .addAsResource("resource-config/application.properties", "application.properties")
+                    .addAsResource(
+                            "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                    .addAsResource(new StringAsset(InMemoryMetricExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider")
+                    .addClasses(TracelessHelloResource.class, TracelessClassLevelResource.class, TraceMeResource.class))
+            .overrideConfigKey("quarkus.http.root-path", "/api");
+
+    @Inject
+    InMemoryExporter exporter;
+
+    @BeforeEach
+    void setup() {
+        exporter.reset();
+    }
+
+    @Test
+    @DisplayName("Should not trace when the annotation @Traceless is at method level")
+    void testingTracelessHelloHi() {
+
+        RestAssured.when()
+                .get("/hello").then()
+                .statusCode(200)
+                .body(is("hello"));
+
+        RestAssured.when()
+                .get("/hello/hi").then()
+                .statusCode(200)
+                .body(is("hi"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the method @Path uses @PathParam")
+    void testingWithPathParam() {
+        RestAssured.when()
+                .get("/hello/mask/1").then()
+                .statusCode(200)
+                .body(is("mask-1"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the method @Path is without '/'")
+    void testingHelloNoSlash() {
+        RestAssured.when()
+                .get("/hello/no-slash").then()
+                .statusCode(200)
+                .body(is("no-slash"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+    @Test
+    @DisplayName("Should not trace when the annotation is at class level")
+    void testingTracelessAtClassLevel() {
+
+        RestAssured.when()
+                .get("class-level").then()
+                .statusCode(200)
+                .body(is("class-level"));
+
+        RestAssured.when()
+                .get("/class-level/first-method").then()
+                .statusCode(200)
+                .body(is("first-method"));
+
+        RestAssured.when()
+                .get("/class-level/second-method").then()
+                .statusCode(200)
+                .body(is("second-method"));
+
+        RestAssured.when()
+                .get("/trace-me").then()
+                .statusCode(200)
+                .body(is("trace-me"));
+
+        List<SpanData> spans = exporter.getSpanExporter().getFinishedSpanItems(1);
+
+        assertThat(spans)
+                .hasSize(1)
+                .satisfiesOnlyOnce(span -> assertThat(span.getName()).containsOnlyOnce("trace-me"));
+    }
+
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/TracesRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/TracesRuntimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.opentelemetry.runtime.config.runtime;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -24,6 +25,17 @@ public interface TracesRuntimeConfig {
     @WithName("suppress-non-application-uris")
     @WithDefault("true")
     Boolean suppressNonApplicationUris();
+
+    /**
+     * Comma-separated, suppress application uris from trace collection.
+     * <p>
+     * This will suppress all uris set by this property.
+     * <p>
+     * If you are using <code>quarkus.http.root-path</code>, you need to consider it when setting your uris, in
+     * other words, you need to configure it using the root-path if necessary.
+     */
+    @WithName("suppress-application-uris")
+    Optional<List<String>> suppressApplicationUris();
 
     /**
      * Include static resources from trace collection.

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/Traceless.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/Traceless.java
@@ -1,0 +1,16 @@
+package io.quarkus.opentelemetry.runtime.tracing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Identifies that the current path should not be select for tracing.
+ * <p>
+ * Used together with {@code jakarta.ws.rs.Path} annotation.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Traceless {
+}

--- a/integration-tests/opentelemetry/src/main/java/io/quarkus/it/opentelemetry/SimpleResource.java
+++ b/integration-tests/opentelemetry/src/main/java/io/quarkus/it/opentelemetry/SimpleResource.java
@@ -17,6 +17,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.context.Scope;
+import io.quarkus.opentelemetry.runtime.tracing.Traceless;
 
 @Path("")
 @Produces(MediaType.APPLICATION_JSON)
@@ -149,5 +150,22 @@ public class SimpleResource {
         exception.setStackTrace(trimmedStackTrace);
         LOG.error("Oh no {}", exception.getMessage(), exception);
         return "Oh no! An exception";
+    }
+
+    @GET
+    @Path("/suppress-app-uri")
+    public TraceData suppressAppUri() {
+        TraceData traceData = new TraceData();
+        traceData.message = "Suppress me!";
+        return traceData;
+    }
+
+    @GET
+    @Path("/traceless")
+    @Traceless
+    public TraceData traceless() {
+        TraceData traceData = new TraceData();
+        traceData.message = "@Traceless";
+        return traceData;
     }
 }

--- a/integration-tests/opentelemetry/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry/src/main/resources/application.properties
@@ -21,4 +21,7 @@ quarkus.security.users.embedded.plain-text=true
 quarkus.security.users.embedded.enabled=true
 quarkus.http.auth.basic=true
 
+quarkus.otel.traces.suppress-application-uris=/suppress-app-uri
+
 quarkus.native.monitoring=jfr
+

--- a/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/TracingTest.java
+++ b/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/TracingTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.awaitility.core.ConditionTimeoutException;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -741,6 +743,34 @@ public class TracingTest {
                 .filter(e -> ("attr_" + SemanticAttributes.ENDUSER_ID.getKey()).equals(e.getKey())
                         || ("attr_" + SemanticAttributes.ENDUSER_ROLE.getKey()).equals(e.getKey()))
                 .findAny().isEmpty());
+    }
+
+    @Test
+    public void testSuppressAppUri() {
+        RestAssured.given()
+                .when().get("/suppress-app-uri")
+                .then()
+                .statusCode(200)
+                .body("message", Matchers.is("Suppress me!"));
+
+        // should throw because there are a configuration quarkus.otel.traces.suppress-app-uris=/suppress-app-uri
+        assertThrows(ConditionTimeoutException.class, () -> {
+            await().atMost(5, SECONDS).until(() -> !getSpans().isEmpty());
+        });
+    }
+
+    @Test
+    public void testTracelessResource() {
+        RestAssured.given()
+                .when().get("/traceless")
+                .then()
+                .statusCode(200)
+                .body("message", Matchers.is("@Traceless"));
+
+        // should throw because there is no span
+        assertThrows(ConditionTimeoutException.class, () -> {
+            await().atMost(5, SECONDS).until(() -> !getSpans().isEmpty());
+        });
     }
 
     private void verifyResource(Map<String, Object> spanData) {


### PR DESCRIPTION
## What

This pull request creates a new `BuildItem` that is used for drop uri from tracing when using `quarkus-opentelemetry` extension. The `DropApplicationUrisBuildItem`  is generated from the scanning of the `@Traceless`  annotation.

The `@Traceless` annotation is used with the `jakarta.ws.rs.Path` annotation. If annotated at class level all uri below will be ignored for tracing.

If your `@Path` annotation contains expression like `@Path("/cars/{carId}")` the extension will ignore all thing after `cars` using, e.g. `cars*`.

## Why

You can see the issue below, or directly this [Stackoverflow](https://stackoverflow.com/questions/78742740/how-to-disable-trace-ids-for-specific-rest-clients-invocations/78748952) discussion.


Fixes #42659