### PR TITLE
Flyway Build Item (prerequisite for multitenant extension)

### DIFF
--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayBuildItem.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayBuildItem.java
@@ -1,0 +1,96 @@
+package io.quarkus.flyway.deployment;
+
+import org.jboss.jandex.AnnotationInstance;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.flyway.runtime.FlywayContainerProducer;
+import io.quarkus.flyway.runtime.FlywayDataSourceBuildTimeConfig;
+
+/**
+ * Represents a build item that configures and provides Flyway instances for managing database migrations.
+ *
+ * <p>
+ * This build item is responsible for initializing and configuring Flyway instances. This extension creates one instance
+ * per datasource. The instances are distinguished by the {@code FlywayDataSource} qualifier. Additional instances can also be
+ * added by
+ * other extensions if required.
+ *
+ * <p>
+ * Flyway instances are created by the {@code FlywayContainerProducer} implementation. Instances are differentiated by prefix
+ * and name.
+ * The name should be unique in the realm of an extension. The prefix is used to distinguish between different extensions.
+ *
+ * <p>
+ * The following parameters allow to distinguish between Flyway instances:
+ * <ul>
+ * <li><strong>Qualifier</strong> and <strong>priority</strong> - Define the CDI qualifier and priority for the Flyway
+ * instance.</li>
+ * <li><strong>containerBeanName</strong> and <strong>flywayBeanName</strong> - Set up the {@code Named} qualifier for the
+ * instance (can be null).</li>
+ * </ul>
+ *
+ * @see org.flywaydb.core.Flyway
+ */
+public final class FlywayBuildItem extends MultiBuildItem {
+
+    private final Class<? extends FlywayContainerProducer> producerClass;
+    private final FlywayDataSourceBuildTimeConfig buildTimeConfig;
+    private final String prefix;
+    private final String name;
+    private final String dataSourceName;
+    private final AnnotationInstance qualifier;
+    private final int priority;
+    private final String containerBeanName;
+    private final String flywayBeanName;
+
+    public FlywayBuildItem(Class<? extends FlywayContainerProducer> producerClass,
+            FlywayDataSourceBuildTimeConfig buildTimeConfig, String prefix, String name, String dataSourceName,
+            AnnotationInstance qualifier,
+            int priority, String containerBeanName, String flywayBeanName) {
+        this.producerClass = producerClass;
+        this.buildTimeConfig = buildTimeConfig;
+        this.prefix = prefix;
+        this.name = name;
+        this.dataSourceName = dataSourceName;
+        this.qualifier = qualifier;
+        this.priority = priority;
+        this.containerBeanName = containerBeanName;
+        this.flywayBeanName = flywayBeanName;
+    }
+
+    public Class<? extends FlywayContainerProducer> getProducerClass() {
+        return producerClass;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getId() {
+        return prefix + "." + name;
+    }
+
+    public String getDataSourceName() {
+        return dataSourceName;
+    }
+
+    public AnnotationInstance getQualifier() {
+        return qualifier;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public String getContainerBeanName() {
+        return containerBeanName;
+    }
+
+    public String getFlywayBeanName() {
+        return flywayBeanName;
+    }
+
+    public FlywayDataSourceBuildTimeConfig getBuildTimeConfig() {
+        return buildTimeConfig;
+    }
+}

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayProcessor.java
@@ -66,7 +66,7 @@ import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.flyway.FlywayDataSource;
 import io.quarkus.flyway.runtime.FlywayBuildTimeConfig;
 import io.quarkus.flyway.runtime.FlywayContainer;
-import io.quarkus.flyway.runtime.FlywayContainerProducer;
+import io.quarkus.flyway.runtime.FlywayContainerProducerImpl;
 import io.quarkus.flyway.runtime.FlywayDataSourceBuildTimeConfig;
 import io.quarkus.flyway.runtime.FlywayRecorder;
 import io.quarkus.flyway.runtime.FlywayRuntimeConfig;
@@ -107,6 +107,46 @@ class FlywayProcessor {
         }
     }
 
+    @BuildStep
+    void prepare(BuildProducer<FlywayBuildItem> flywayBuildItems, BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems,
+            FlywayBuildTimeConfig flywayBuildTimeConfig) {
+
+        // make a FlywayContainerProducer bean
+        additionalBeans
+                .produce(AdditionalBeanBuildItem.builder().addBeanClasses(FlywayContainerProducerImpl.class).setUnremovable()
+                        .setDefaultScope(DotNames.SINGLETON).build());
+        // add the @FlywayDataSource class otherwise it won't be registered as a qualifier
+        additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClass(FlywayDataSource.class).build());
+
+        for (JdbcDataSourceBuildItem item : jdbcDataSourceBuildItems) {
+            String dataSourceName = item.getName();
+            FlywayDataSourceBuildTimeConfig buildTimeConfig = flywayBuildTimeConfig
+                    .getConfigForDataSourceName(dataSourceName);
+            AnnotationInstance qualifier;
+            int priority;
+            String flywayBeanName = null;
+            String containerBeanName = null;
+
+            if (DataSourceUtil.isDefault(dataSourceName)) {
+                // Flyway containers used to be ordered with the default database coming first.
+                // Some multitenant tests are relying on this order.
+                priority = 10;
+                qualifier = AnnotationInstance.builder(Default.class).build();
+            } else {
+                priority = 5;
+                qualifier = AnnotationInstance.builder(FlywayDataSource.class).add("value", dataSourceName)
+                        .build();
+                flywayBeanName = FLYWAY_BEAN_NAME_PREFIX + dataSourceName;
+                containerBeanName = FLYWAY_CONTAINER_BEAN_NAME_PREFIX + dataSourceName;
+            }
+
+            flywayBuildItems
+                    .produce(new FlywayBuildItem(FlywayContainerProducerImpl.class, buildTimeConfig, "flyway", dataSourceName,
+                            dataSourceName, qualifier, priority, containerBeanName, flywayBeanName));
+        }
+    }
+
     @Record(STATIC_INIT)
     @BuildStep
     MigrationStateBuildItem build(BuildProducer<NativeImageResourceBuildItem> resourceProducer,
@@ -115,30 +155,28 @@ class FlywayProcessor {
             FlywayRecorder recorder,
             RecorderContext context,
             CombinedIndexBuildItem combinedIndexBuildItem,
-            List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems,
+            List<FlywayBuildItem> flywayBuildItems,
             FlywayBuildTimeConfig flywayBuildTimeConfig) throws Exception {
 
-        Collection<String> dataSourceNames = getDataSourceNames(jdbcDataSourceBuildItems);
-        Map<String, Collection<String>> applicationMigrationsToDs = new HashMap<>();
-        for (var dataSourceName : dataSourceNames) {
-            FlywayDataSourceBuildTimeConfig flywayDataSourceBuildTimeConfig = flywayBuildTimeConfig
-                    .getConfigForDataSourceName(dataSourceName);
+        Map<String, Collection<String>> applicationMigrationsToInstance = new HashMap<>();
+        for (var flywayBuildItem : flywayBuildItems) {
+            FlywayDataSourceBuildTimeConfig flywayDataSourceBuildTimeConfig = flywayBuildItem.getBuildTimeConfig();
 
             Collection<String> migrationLocations = discoverApplicationMigrations(
                     flywayDataSourceBuildTimeConfig.locations);
-            applicationMigrationsToDs.put(dataSourceName, migrationLocations);
+            applicationMigrationsToInstance.put(flywayBuildItem.getId(), migrationLocations);
         }
-        Set<String> datasourcesWithMigrations = new HashSet<>();
-        Set<String> datasourcesWithoutMigrations = new HashSet<>();
-        for (var e : applicationMigrationsToDs.entrySet()) {
+        Set<String> instancesWithMigrations = new HashSet<>();
+        Set<String> instancesWithoutMigrations = new HashSet<>();
+        for (var e : applicationMigrationsToInstance.entrySet()) {
             if (e.getValue().isEmpty()) {
-                datasourcesWithoutMigrations.add(e.getKey());
+                instancesWithoutMigrations.add(e.getKey());
             } else {
-                datasourcesWithMigrations.add(e.getKey());
+                instancesWithMigrations.add(e.getKey());
             }
         }
 
-        Collection<String> applicationMigrations = applicationMigrationsToDs.values().stream().collect(HashSet::new,
+        Collection<String> applicationMigrations = applicationMigrationsToInstance.values().stream().collect(HashSet::new,
                 AbstractCollection::addAll, HashSet::addAll);
         for (String applicationMigration : applicationMigrations) {
             Location applicationMigrationLocation = new Location(applicationMigration);
@@ -158,14 +196,13 @@ class FlywayProcessor {
         recorder.setApplicationMigrationClasses(javaMigrationClasses);
 
         final Map<String, Collection<Callback>> callbacks = FlywayCallbacksLocator.with(
-                dataSourceNames,
-                flywayBuildTimeConfig,
+                flywayBuildItems,
                 combinedIndexBuildItem,
                 reflectiveClassProducer).getCallbacks();
         recorder.setApplicationCallbackClasses(callbacks);
 
         resourceProducer.produce(new NativeImageResourceBuildItem(applicationMigrations.toArray(new String[0])));
-        return new MigrationStateBuildItem(datasourcesWithMigrations, datasourcesWithoutMigrations);
+        return new MigrationStateBuildItem(instancesWithMigrations, instancesWithoutMigrations);
     }
 
     @SuppressWarnings("unchecked")
@@ -187,25 +224,19 @@ class FlywayProcessor {
     @Consume(LoggingSetupBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void createBeans(FlywayRecorder recorder,
-            List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems,
-            List<JdbcInitialSQLGeneratorBuildItem> sqlGeneratorBuildItems,
-            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            List<FlywayBuildItem> flywayBuildItems,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
             MigrationStateBuildItem migrationsBuildItem,
+            List<JdbcInitialSQLGeneratorBuildItem> sqlGeneratorBuildItems,
             FlywayBuildTimeConfig flywayBuildTimeConfig) {
-        // make a FlywayContainerProducer bean
-        additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClasses(FlywayContainerProducer.class).setUnremovable()
-                .setDefaultScope(DotNames.SINGLETON).build());
-        // add the @FlywayDataSource class otherwise it won't be registered as a qualifier
-        additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClass(FlywayDataSource.class).build());
 
-        Collection<String> dataSourceNames = getDataSourceNames(jdbcDataSourceBuildItems);
+        for (FlywayBuildItem flywayBuildItem : flywayBuildItems) {
 
-        for (String dataSourceName : dataSourceNames) {
-            boolean hasMigrations = migrationsBuildItem.hasMigrations.contains(dataSourceName);
+            boolean hasMigrations = migrationsBuildItem.hasMigrations.contains(flywayBuildItem.getId());
             boolean createPossible = false;
             if (!hasMigrations) {
-                createPossible = sqlGeneratorBuildItems.stream().anyMatch(s -> s.getDatabaseName().equals(dataSourceName));
+                createPossible = sqlGeneratorBuildItems.stream()
+                        .anyMatch(s -> s.getDatabaseName().equals(flywayBuildItem.getDataSourceName()));
             }
 
             SyntheticBeanBuildItem.ExtendedBeanConfigurator flywayContainerConfigurator = SyntheticBeanBuildItem
@@ -213,34 +244,21 @@ class FlywayProcessor {
                     .scope(Singleton.class)
                     .setRuntimeInit()
                     .unremovable()
-                    .addInjectionPoint(ClassType.create(DotName.createSimple(FlywayContainerProducer.class)))
+                    .addQualifier(flywayBuildItem.getQualifier())
+                    .priority(flywayBuildItem.getPriority())
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(flywayBuildItem.getProducerClass())))
                     .addInjectionPoint(ClassType.create(DotName.createSimple(DataSource.class)),
-                            AgroalDataSourceBuildUtil.qualifier(dataSourceName))
+                            AgroalDataSourceBuildUtil.qualifier(flywayBuildItem.getDataSourceName()))
                     .startup()
-                    .checkActive(recorder.flywayCheckActiveSupplier(dataSourceName))
-                    .createWith(recorder.flywayContainerFunction(dataSourceName, hasMigrations, createPossible));
+                    .checkActive(recorder.flywayCheckActiveSupplier(flywayBuildItem.getDataSourceName()))
+                    .createWith(recorder.flywayContainerFunction(flywayBuildItem.getProducerClass(),
+                            flywayBuildItem.getDataSourceName(), flywayBuildItem.getName(), flywayBuildItem.getId(),
+                            hasMigrations, createPossible));
 
-            AnnotationInstance flywayContainerQualifier;
-
-            if (DataSourceUtil.isDefault(dataSourceName)) {
-                flywayContainerConfigurator.addQualifier(Default.class);
-
-                // Flyway containers used to be ordered with the default database coming first.
-                // Some multitenant tests are relying on this order.
-                flywayContainerConfigurator.priority(10);
-
-                flywayContainerQualifier = AnnotationInstance.builder(Default.class).build();
-            } else {
-                String beanName = FLYWAY_CONTAINER_BEAN_NAME_PREFIX + dataSourceName;
-                flywayContainerConfigurator.name(beanName);
-
-                flywayContainerConfigurator.addQualifier().annotation(DotNames.NAMED).addValue("value", beanName).done();
-                flywayContainerConfigurator.addQualifier().annotation(FlywayDataSource.class).addValue("value", dataSourceName)
-                        .done();
-                flywayContainerConfigurator.priority(5);
-
-                flywayContainerQualifier = AnnotationInstance.builder(FlywayDataSource.class).add("value", dataSourceName)
-                        .build();
+            if (flywayBuildItem.getContainerBeanName() != null) {
+                flywayContainerConfigurator.name(flywayBuildItem.getContainerBeanName());
+                flywayContainerConfigurator.addQualifier().annotation(DotNames.NAMED)
+                        .addValue("value", flywayBuildItem.getContainerBeanName()).done();
             }
 
             syntheticBeanBuildItemBuildProducer.produce(flywayContainerConfigurator.done());
@@ -250,21 +268,19 @@ class FlywayProcessor {
                     .scope(Singleton.class)
                     .setRuntimeInit()
                     .unremovable()
-                    .addInjectionPoint(ClassType.create(DotName.createSimple(FlywayContainer.class)), flywayContainerQualifier)
+                    .addQualifier(flywayBuildItem.getQualifier())
+                    .priority(flywayBuildItem.getPriority())
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(flywayBuildItem.getProducerClass())))
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(FlywayContainer.class)),
+                            flywayBuildItem.getQualifier())
                     .startup()
-                    .checkActive(recorder.flywayCheckActiveSupplier(dataSourceName))
-                    .createWith(recorder.flywayFunction(dataSourceName));
+                    .checkActive(recorder.flywayCheckActiveSupplier(flywayBuildItem.getDataSourceName()))
+                    .createWith(recorder.flywayFunction(flywayBuildItem.getProducerClass(), flywayBuildItem.getName()));
 
-            if (DataSourceUtil.isDefault(dataSourceName)) {
-                flywayConfigurator.addQualifier(Default.class);
-                flywayConfigurator.priority(10);
-            } else {
-                String beanName = FLYWAY_BEAN_NAME_PREFIX + dataSourceName;
-                flywayConfigurator.name(beanName);
-                flywayConfigurator.priority(5);
-
-                flywayConfigurator.addQualifier().annotation(DotNames.NAMED).addValue("value", beanName).done();
-                flywayConfigurator.addQualifier().annotation(FlywayDataSource.class).addValue("value", dataSourceName).done();
+            if (flywayBuildItem.getFlywayBeanName() != null) {
+                flywayConfigurator.name(flywayBuildItem.getFlywayBeanName());
+                flywayConfigurator.addQualifier().annotation(DotNames.NAMED)
+                        .addValue("value", flywayBuildItem.getFlywayBeanName()).done();
             }
 
             syntheticBeanBuildItemBuildProducer.produce(flywayConfigurator.done());
@@ -278,13 +294,11 @@ class FlywayProcessor {
             FlywayRuntimeConfig config,
             BuildProducer<JdbcDataSourceSchemaReadyBuildItem> schemaReadyBuildItem,
             BuildProducer<InitTaskCompletedBuildItem> initializationCompleteBuildItem,
-            List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems,
+            List<FlywayBuildItem> flywayBuildItems,
             MigrationStateBuildItem migrationsBuildItem) {
 
-        Collection<String> dataSourceNames = getDataSourceNames(jdbcDataSourceBuildItems);
-
-        for (String dataSourceName : dataSourceNames) {
-            recorder.doStartActions(dataSourceName);
+        for (FlywayBuildItem flywayBuildItem : flywayBuildItems) {
+            recorder.doStartActions(flywayBuildItem.getProducerClass(), flywayBuildItem.getDataSourceName(), flywayBuildItem.getName());
         }
 
         // once we are done running the migrations, we produce a build item indicating that the

--- a/extensions/flyway/deployment/src/main/resources/dev-ui/qwc-flyway-datasources.js
+++ b/extensions/flyway/deployment/src/main/resources/dev-ui/qwc-flyway-datasources.js
@@ -137,20 +137,20 @@ export class QwcFlywayDatasources extends QwcHotReloadElement {
 
     _clean(ds) {
         if (confirm('This will drop all objects (tables, views, procedures, triggers, ...) in the configured schema. Do you want to continue?')) {
-            this.jsonRpc.clean({ds: ds.name}).then(jsonRpcResponse => {
+            this.jsonRpc.clean({id: ds.id}).then(jsonRpcResponse => {
                 this._showResultNotification(jsonRpcResponse.result);
             });
         }
     }
     
     _migrate(ds) {
-        this.jsonRpc.migrate({ds: ds.name}).then(jsonRpcResponse => {
+        this.jsonRpc.migrate({id: ds.id}).then(jsonRpcResponse => {
             this._showResultNotification(jsonRpcResponse.result);
         });
     }
 
     _create(ds) {
-        this.jsonRpc.create({ds: ds.name}).then(jsonRpcResponse => {
+        this.jsonRpc.create({id: ds.id}).then(jsonRpcResponse => {
             this._showResultNotification(jsonRpcResponse.result);
             this._selectedDs = null;
             this._createDialogOpened = false;

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayDevModeCreateFromHibernateTest.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayDevModeCreateFromHibernateTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.flyway.test;
 
+import static org.hamcrest.Matchers.is;
+
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -45,7 +47,7 @@ public class FlywayDevModeCreateFromHibernateTest extends DevUIJsonRPCTest {
         RestAssured.get("fruit").then().statusCode(200)
                 .body("[0].name", CoreMatchers.is("Orange"));
 
-        Map<String, Object> params = Map.of("ds", "<default>");
+        Map<String, Object> params = Map.of("id", "flyway.<default>");
         JsonNode devuiresponse = super.executeJsonRPCMethod("create", params);
 
         Assertions.assertNotNull(devuiresponse);
@@ -66,7 +68,8 @@ public class FlywayDevModeCreateFromHibernateTest extends DevUIJsonRPCTest {
                 "        return this;\n" +
                 "    }"));
         //added a field, should now fail (if hibernate were still in charge this would work)
-        RestAssured.get("fruit").then().statusCode(500);
+        RestAssured.get("fruit").then()
+                .statusCode(500);
         //now update out sql
         config.modifyResourceFile("db/create/V1.0.0__quarkus-flyway-deployment.sql", new Function<String, String>() {
             @Override

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainer.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainer.java
@@ -1,6 +1,14 @@
 package io.quarkus.flyway.runtime;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.FlywayExecutor;
+import org.flywaydb.core.api.output.BaselineResult;
+import org.flywaydb.core.internal.callback.CallbackExecutor;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.core.internal.resolver.CompositeMigrationResolver;
+import org.flywaydb.core.internal.schemahistory.SchemaHistory;
 
 public class FlywayContainer {
 
@@ -13,13 +21,14 @@ public class FlywayContainer {
 
     private final boolean validateAtStart;
     private final String dataSourceName;
+    private final String name;
     private final boolean hasMigrations;
     private final boolean createPossible;
     private final String id;
 
     public FlywayContainer(Flyway flyway, boolean baselineAtStart, boolean cleanAtStart, boolean migrateAtStart,
             boolean repairAtStart, boolean validateAtStart,
-            String dataSourceName, boolean hasMigrations, boolean createPossible) {
+            String dataSourceName, String name, String id, boolean hasMigrations, boolean createPossible) {
         this.flyway = flyway;
         this.baselineAtStart = baselineAtStart;
         this.cleanAtStart = cleanAtStart;
@@ -27,9 +36,10 @@ public class FlywayContainer {
         this.repairAtStart = repairAtStart;
         this.validateAtStart = validateAtStart;
         this.dataSourceName = dataSourceName;
+        this.name = name;
         this.hasMigrations = hasMigrations;
         this.createPossible = createPossible;
-        this.id = dataSourceName.replace("<", "").replace(">", "");
+        this.id = id;
     }
 
     public Flyway getFlyway() {
@@ -56,6 +66,10 @@ public class FlywayContainer {
         return validateAtStart;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public String getDataSourceName() {
         return dataSourceName;
     }
@@ -70,5 +84,41 @@ public class FlywayContainer {
 
     public String getId() {
         return this.id;
+    }
+
+    public void doStartActions() {
+        if (isCleanAtStart()) {
+            getFlyway().clean();
+        }
+        if (isValidateAtStart()) {
+            getFlyway().validate();
+        }
+        if (isBaselineAtStart()) {
+            new FlywayExecutor(getFlyway().getConfiguration())
+                    .execute(new BaselineCommand(getFlyway()), true, null);
+        }
+        if (isRepairAtStart()) {
+            getFlyway().repair();
+        }
+        if (isMigrateAtStart()) {
+            getFlyway().migrate();
+        }
+    }
+
+    static class BaselineCommand implements FlywayExecutor.Command<BaselineResult> {
+        BaselineCommand(Flyway flyway) {
+            this.flyway = flyway;
+        }
+
+        final Flyway flyway;
+
+        @Override
+        public BaselineResult execute(CompositeMigrationResolver cmr, SchemaHistory schemaHistory, Database d,
+                Schema defaultSchema, Schema[] s, CallbackExecutor ce, StatementInterceptor si) {
+            if (!schemaHistory.exists()) {
+                return flyway.baseline();
+            }
+            return null;
+        }
     }
 }

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainerProducer.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainerProducer.java
@@ -1,89 +1,12 @@
 package io.quarkus.flyway.runtime;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 import javax.sql.DataSource;
 
-import org.flywaydb.core.Flyway;
-import org.flywaydb.core.api.callback.Callback;
+public interface FlywayContainerProducer {
+    FlywayContainer createFlyway(DataSource dataSource, String dataSourceName, String name, String id, boolean hasMigrations,
+            boolean createPossible);
 
-import io.quarkus.arc.All;
-import io.quarkus.arc.InstanceHandle;
-import io.quarkus.datasource.common.runtime.DataSourceUtil;
-import io.quarkus.flyway.FlywayConfigurationCustomizer;
-import io.quarkus.flyway.FlywayDataSource;
-
-/**
- * This class is sort of a producer for {@link Flyway}.
- *
- * It isn't a CDI producer in the literal sense, but it is marked as a bean
- * and it's {@code createFlyway} method is called at runtime in order to produce
- * the actual {@code Flyway} objects.
- *
- * CDI scopes and qualifiers are set up at build-time, which is why this class is devoid of
- * any CDI annotations
- *
- */
-public class FlywayContainerProducer {
-
-    private final FlywayRuntimeConfig flywayRuntimeConfig;
-    private final FlywayBuildTimeConfig flywayBuildConfig;
-
-    private final List<InstanceHandle<FlywayConfigurationCustomizer>> configCustomizerInstances;
-
-    public FlywayContainerProducer(FlywayRuntimeConfig flywayRuntimeConfig, FlywayBuildTimeConfig flywayBuildConfig,
-            @All List<InstanceHandle<FlywayConfigurationCustomizer>> configCustomizerInstances) {
-        this.flywayRuntimeConfig = flywayRuntimeConfig;
-        this.flywayBuildConfig = flywayBuildConfig;
-        this.configCustomizerInstances = configCustomizerInstances;
-    }
-
-    public FlywayContainer createFlyway(DataSource dataSource, String dataSourceName, boolean hasMigrations,
-            boolean createPossible) {
-        FlywayDataSourceRuntimeConfig matchingRuntimeConfig = flywayRuntimeConfig.getConfigForDataSourceName(dataSourceName);
-        FlywayDataSourceBuildTimeConfig matchingBuildTimeConfig = flywayBuildConfig.getConfigForDataSourceName(dataSourceName);
-        final Collection<Callback> callbacks = QuarkusPathLocationScanner.callbacksForDataSource(dataSourceName);
-        final Flyway flyway = new FlywayCreator(matchingRuntimeConfig, matchingBuildTimeConfig, matchingConfigCustomizers(
-                configCustomizerInstances, dataSourceName)).withCallbacks(callbacks)
-                .createFlyway(dataSource);
-        return new FlywayContainer(flyway, matchingRuntimeConfig.baselineAtStart, matchingRuntimeConfig.cleanAtStart,
-                matchingRuntimeConfig.migrateAtStart,
-                matchingRuntimeConfig.repairAtStart, matchingRuntimeConfig.validateAtStart,
-                dataSourceName, hasMigrations,
-                createPossible);
-    }
-
-    private List<FlywayConfigurationCustomizer> matchingConfigCustomizers(
-            List<InstanceHandle<FlywayConfigurationCustomizer>> configCustomizerInstances, String dataSourceName) {
-        if ((configCustomizerInstances == null) || configCustomizerInstances.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<FlywayConfigurationCustomizer> result = new ArrayList<>();
-        for (InstanceHandle<FlywayConfigurationCustomizer> instance : configCustomizerInstances) {
-            Set<Annotation> qualifiers = instance.getBean().getQualifiers();
-            boolean qualifierMatchesDS = false;
-            boolean hasFlywayDataSourceQualifier = false;
-            for (Annotation qualifier : qualifiers) {
-                if (qualifier.annotationType().equals(FlywayDataSource.class)) {
-                    hasFlywayDataSourceQualifier = true;
-                    if (dataSourceName.equals(((FlywayDataSource) qualifier).value())) {
-                        qualifierMatchesDS = true;
-                        break;
-                    }
-                }
-            }
-            if (qualifierMatchesDS) {
-                result.add(instance.get());
-            } else if (DataSourceUtil.isDefault(dataSourceName) && !hasFlywayDataSourceQualifier) {
-                // this is the case where a FlywayConfigurationCustomizer does not have a qualifier at all, therefore is applies to the default datasource
-                result.add(instance.get());
-            }
-        }
-        return result;
-    }
+    Annotation getFlywayContainerQualifier(String name);
 }

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainerProducerImpl.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainerProducerImpl.java
@@ -1,0 +1,96 @@
+package io.quarkus.flyway.runtime;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.callback.Callback;
+
+import io.quarkus.arc.All;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.flyway.FlywayConfigurationCustomizer;
+import io.quarkus.flyway.FlywayDataSource;
+
+/**
+ * This class is sort of a producer for {@link Flyway}.
+ *
+ * It isn't a CDI producer in the literal sense, but it is marked as a bean
+ * and it's {@code createFlyway} method is called at runtime in order to produce
+ * the actual {@code Flyway} objects.
+ *
+ * CDI scopes and qualifiers are set up at build-time, which is why this class is devoid of
+ * any CDI annotations
+ *
+ */
+public class FlywayContainerProducerImpl implements FlywayContainerProducer {
+
+    private final FlywayRuntimeConfig flywayRuntimeConfig;
+    private final FlywayBuildTimeConfig flywayBuildConfig;
+
+    private final List<InstanceHandle<FlywayConfigurationCustomizer>> configCustomizerInstances;
+
+    public FlywayContainerProducerImpl(FlywayRuntimeConfig flywayRuntimeConfig, FlywayBuildTimeConfig flywayBuildConfig,
+            @All List<InstanceHandle<FlywayConfigurationCustomizer>> configCustomizerInstances) {
+        this.flywayRuntimeConfig = flywayRuntimeConfig;
+        this.flywayBuildConfig = flywayBuildConfig;
+        this.configCustomizerInstances = configCustomizerInstances;
+    }
+
+    @Override
+    public FlywayContainer createFlyway(DataSource dataSource, String dataSourceName, String name, String id,
+            boolean hasMigrations,
+            boolean createPossible) {
+        FlywayDataSourceRuntimeConfig matchingRuntimeConfig = flywayRuntimeConfig.getConfigForDataSourceName(dataSourceName);
+        FlywayDataSourceBuildTimeConfig matchingBuildTimeConfig = flywayBuildConfig.getConfigForDataSourceName(dataSourceName);
+        final Collection<Callback> callbacks = QuarkusPathLocationScanner.callbacksForDataSource(id);
+        final Flyway flyway = new FlywayCreator(matchingRuntimeConfig, matchingBuildTimeConfig, matchingConfigCustomizers(
+                configCustomizerInstances, dataSourceName)).withCallbacks(callbacks)
+                .createFlyway(dataSource);
+        return new FlywayContainer(flyway, matchingRuntimeConfig.baselineAtStart, matchingRuntimeConfig.cleanAtStart,
+                matchingRuntimeConfig.migrateAtStart,
+                matchingRuntimeConfig.repairAtStart, matchingRuntimeConfig.validateAtStart,
+                dataSourceName, name, id, hasMigrations,
+                createPossible);
+    }
+
+    private List<FlywayConfigurationCustomizer> matchingConfigCustomizers(
+            List<InstanceHandle<FlywayConfigurationCustomizer>> configCustomizerInstances, String dataSourceName) {
+        if ((configCustomizerInstances == null) || configCustomizerInstances.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<FlywayConfigurationCustomizer> result = new ArrayList<>();
+        for (InstanceHandle<FlywayConfigurationCustomizer> instance : configCustomizerInstances) {
+            Set<Annotation> qualifiers = instance.getBean().getQualifiers();
+            boolean qualifierMatchesDS = false;
+            boolean hasFlywayDataSourceQualifier = false;
+            for (Annotation qualifier : qualifiers) {
+                if (qualifier.annotationType().equals(FlywayDataSource.class)) {
+                    hasFlywayDataSourceQualifier = true;
+                    if (dataSourceName.equals(((FlywayDataSource) qualifier).value())) {
+                        qualifierMatchesDS = true;
+                        break;
+                    }
+                }
+            }
+            if (qualifierMatchesDS) {
+                result.add(instance.get());
+            } else if (DataSourceUtil.isDefault(dataSourceName) && !hasFlywayDataSourceQualifier) {
+                // this is the case where a FlywayConfigurationCustomizer does not have a qualifier at all, therefore is applies to the default datasource
+                result.add(instance.get());
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Annotation getFlywayContainerQualifier(String name) {
+        return FlywayContainerUtil.getFlywayContainerQualifier(name);
+    }
+}

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainerUtil.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainerUtil.java
@@ -3,12 +3,12 @@ package io.quarkus.flyway.runtime;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.enterprise.inject.Default;
 
 import io.quarkus.agroal.runtime.AgroalDataSourceUtil;
 import io.quarkus.arc.Arc;
-import io.quarkus.arc.InstanceHandle;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.flyway.FlywayDataSource;
 
@@ -23,14 +23,10 @@ public final class FlywayContainerUtil {
 
     public static List<FlywayContainer> getActiveFlywayContainers() {
         List<FlywayContainer> result = new ArrayList<>();
-        for (String datasourceName : AgroalDataSourceUtil.activeDataSourceNames()) {
-            InstanceHandle<FlywayContainer> handle = Arc.container().instance(FlywayContainer.class,
-                    getFlywayContainerQualifier(datasourceName));
-            if (!handle.isAvailable()) {
-                continue;
-            }
-            result.add(handle.get());
-        }
+        Set<String> activeDs = AgroalDataSourceUtil.activeDataSourceNames();
+        Arc.container().select(FlywayContainer.class).stream()
+                .filter(container -> activeDs.contains(container.getDataSourceName()))
+                .forEach(result::add);
         return result;
     }
 

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/UnconfiguredDataSourceFlywayContainer.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/UnconfiguredDataSourceFlywayContainer.java
@@ -12,7 +12,7 @@ public class UnconfiguredDataSourceFlywayContainer extends FlywayContainer {
     private final Throwable cause;
 
     public UnconfiguredDataSourceFlywayContainer(String dataSourceName, String message, Throwable cause) {
-        super(null, false, false, false, false, false, dataSourceName, false, false);
+        super(null, false, false, false, false, false, dataSourceName, "flyway", dataSourceName, false, false);
         this.message = message;
         this.cause = cause;
     }


### PR DESCRIPTION
- Create Flyway build item to allow other extensions to create flyway instances
- Allow multiple flyway instances by datasources (add unique id attribute that is not the ds name)
- move startAction in flyway container to allow other extension to define different behavior