### PR TITLE
ArC: register synthetic injection points in a separate phase

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -460,10 +460,12 @@ public class ArcProcessor {
             configurator.getValues().forEach(BeanConfigurator::done);
         }
 
-        // Initialize the type -> bean map
-        beanRegistrationPhase.getBeanProcessor().getBeanDeployment().initBeanByTypeMap();
-
         BeanProcessor beanProcessor = beanRegistrationPhase.getBeanProcessor();
+        beanProcessor.registerSyntheticInjectionPoints(beanRegistrationPhase.getContext());
+
+        // Initialize the type -> bean map
+        beanProcessor.getBeanDeployment().initBeanByTypeMap();
+
         ObserverRegistrar.RegistrationContext registrationContext = beanProcessor.registerSyntheticObservers();
 
         return new ObserverRegistrationPhaseBuildItem(registrationContext, beanProcessor);

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnremovableSyntheticInjectionPointTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnremovableSyntheticInjectionPointTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.arc.test.unused;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Consumer;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Vetoed;
+
+import org.jboss.jandex.ClassType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UnremovableSyntheticInjectionPointTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(UnremovableSyntheticInjectionPointTest.class, Alpha.class, Gama.class, GamaCreator.class))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+
+                    @Override
+                    public void execute(BuildContext context) {
+                        context.produce(SyntheticBeanBuildItem.configure(Gama.class)
+                                .scope(BuiltinScope.SINGLETON.getInfo())
+                                .unremovable()
+                                .addInjectionPoint(ClassType.create(Alpha.class))
+                                .creator(GamaCreator.class)
+                                .done());
+                    }
+                }).produces(SyntheticBeanBuildItem.class).build();
+            }
+        };
+    }
+
+    @Test
+    public void testBeans() {
+        ArcContainer container = Arc.container();
+        InstanceHandle<Alpha> alpha = container.instance(Alpha.class);
+        assertTrue(alpha.isAvailable());
+        assertTrue(alpha.get().ping());
+        InstanceHandle<Gama> gama = container.instance(Gama.class);
+        assertTrue(gama.isAvailable());
+        assertTrue(gama.get().ping());
+    }
+
+    // unused bean injected into a synthetic injection point
+    @ApplicationScoped
+    public static class Alpha {
+
+        volatile boolean flag;
+
+        @PostConstruct
+        void init() {
+            flag = true;
+        }
+
+        public boolean ping() {
+            return flag;
+        }
+
+    }
+
+    @Vetoed
+    public static class Gama {
+
+        private final Alpha alpha;
+
+        private Gama(Alpha alpha) {
+            this.alpha = alpha;
+        }
+
+        public boolean ping() {
+            return alpha.ping();
+        }
+
+    }
+
+    public static class GamaCreator implements BeanCreator<Gama> {
+
+        @Override
+        public Gama create(SyntheticCreationalContext<Gama> context) {
+            return new Gama(context.getInjectedReference(Alpha.class));
+        }
+
+    }
+
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1503,8 +1503,15 @@ public class BeanDeployment {
             buildCompatibleExtensions.runSynthesis(beanArchiveComputingIndex);
             buildCompatibleExtensions.registerSyntheticBeans(context, applicationClassPredicate);
         }
-        this.injectionPoints.addAll(context.syntheticInjectionPoints);
         return context;
+    }
+
+    void registerSyntheticInjectionPoints(RegistrationContext context) {
+        if (context instanceof BeanRegistrationContextImpl beanRegistrationContext) {
+            this.injectionPoints.addAll(beanRegistrationContext.syntheticInjectionPoints);
+        } else {
+            throw new IllegalArgumentException("Invalid registration context found:" + context.getClass());
+        }
     }
 
     io.quarkus.arc.processor.ObserverRegistrar.RegistrationContext registerSyntheticObservers(

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -33,6 +33,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.processor.BeanDeploymentValidator.ValidationContext;
+import io.quarkus.arc.processor.BeanRegistrar.RegistrationContext;
 import io.quarkus.arc.processor.BuildExtension.BuildContext;
 import io.quarkus.arc.processor.BuildExtension.Key;
 import io.quarkus.arc.processor.CustomAlterableContexts.CustomAlterableContextInfo;
@@ -51,6 +52,7 @@ import io.quarkus.gizmo.ResultHandle;
  * <li>{@link #registerCustomContexts()}</li>
  * <li>{@link #registerScopes()}</li>
  * <li>{@link #registerBeans()}</li>
+ * <li>{@link #registerSyntheticInjectionPoints(io.quarkus.arc.processor.BeanRegistrar.RegistrationContext)}</li>
  * <li>{@link BeanDeployment#initBeanByTypeMap()}</li>
  * <li>{@link #registerSyntheticObservers()}</li>
  * <li>{@link #initialize(Consumer, List)}</li>
@@ -151,6 +153,15 @@ public class BeanProcessor {
      */
     public BeanRegistrar.RegistrationContext registerBeans() {
         return beanDeployment.registerBeans(beanRegistrars);
+    }
+
+    /**
+     * Register synthetic injection points from all synthetic beans.
+     *
+     * @param context
+     */
+    public void registerSyntheticInjectionPoints(BeanRegistrar.RegistrationContext context) {
+        beanDeployment.registerSyntheticInjectionPoints(context);
     }
 
     public ObserverRegistrar.RegistrationContext registerSyntheticObservers() {
@@ -560,7 +571,8 @@ public class BeanProcessor {
         };
         registerCustomContexts();
         registerScopes();
-        registerBeans();
+        RegistrationContext registrationContext = registerBeans();
+        registerSyntheticInjectionPoints(registrationContext);
         beanDeployment.initBeanByTypeMap();
         registerSyntheticObservers();
         initialize(unsupportedBytecodeTransformer, Collections.emptyList());

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedBeansTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedBeansTest.java
@@ -36,7 +36,7 @@ public class RemoveUnusedBeansTest extends RemoveUnusedComponentsTest {
             .beanClasses(HasObserver.class, Foo.class, FooAlternative.class, HasName.class, UnusedProducers.class,
                     InjectedViaInstance.class, InjectedViaInstanceWithWildcard.class, InjectedViaProvider.class, Excluded.class,
                     UsedProducers.class, UnusedProducerButInjected.class, UsedViaInstanceWithUnusedProducer.class,
-                    UsesBeanViaInstance.class, UsedViaAllList.class)
+                    UsesBeanViaInstance.class, UsedViaAllList.class, UnusedBean.class, OnlyInjectedInUnusedBean.class)
             .removeUnusedBeans(true)
             .addRemovalExclusion(b -> b.getBeanClass().toString().equals(Excluded.class.getName()))
             .build();


### PR DESCRIPTION
- this fixes the problem where an synthetic injection point from a SyntheticBeanBuiltItem was not considered when detecting unused beans

Thanks for reporting the problem @michalvavrik!