### PR TITLE
Realign JUnit versions and update to 5.10.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -133,7 +133,7 @@
         <db2-jdbc.version>11.5.8.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->
-        <junit.jupiter.version>5.10.3</junit.jupiter.version>
+        <junit.jupiter.version>5.10.5</junit.jupiter.version>
         <infinispan.version>15.0.10.Final</infinispan.version>
         <infinispan.protostream.version>5.0.12.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ plugin-publish = "1.3.0"
 kotlin = "2.0.21"
 smallrye-config = "3.9.1"
 
-junit5 = "5.11.0"
+junit5 = "5.10.3"
 assertj = "3.26.3"
 
 [plugins]

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ plugin-publish = "1.3.0"
 kotlin = "2.0.21"
 smallrye-config = "3.9.1"
 
-junit5 = "5.11.1"
+junit5 = "5.11.0"
 assertj = "3.26.3"
 
 [plugins]

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ plugin-publish = "1.3.0"
 kotlin = "2.0.21"
 smallrye-config = "3.9.1"
 
-junit5 = "5.10.3"
+junit5 = "5.10.5"
 assertj = "3.26.3"
 
 [plugins]

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -51,7 +51,7 @@
         <version.bridger>1.6.Final</version.bridger>
         <!-- test versions -->
         <version.assertj>3.26.3</version.assertj>
-        <version.junit5>5.10.3</version.junit5>
+        <version.junit5>5.10.5</version.junit5>
         <version.kotlin>2.0.21</version.kotlin>
         <version.kotlin-coroutines>1.9.0</version.kotlin-coroutines>
         <version.mockito>5.14.2</version.mockito>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -41,7 +41,7 @@
         <assertj.version>3.26.3</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <junit.jupiter.version>5.10.3</junit.jupiter.version>
+        <junit.jupiter.version>5.10.5</junit.jupiter.version>
         <maven-core.version>3.9.9</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.9.0.M3</sisu.version><!-- Keep in sync with maven-core.version -->
         <maven-plugin-annotations.version>3.13.1</maven-plugin-annotations.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -41,7 +41,7 @@
         <assertj.version>3.26.3</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <junit.jupiter.version>5.11.0</junit.jupiter.version>
+        <junit.jupiter.version>5.10.3</junit.jupiter.version>
         <maven-core.version>3.9.9</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.9.0.M3</sisu.version><!-- Keep in sync with maven-core.version -->
         <maven-plugin-annotations.version>3.13.1</maven-plugin-annotations.version>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -361,7 +361,7 @@
         <dependency>
             <groupId>uk.org.webcompere</groupId>
             <artifactId>system-stubs-jupiter</artifactId>
-            <version>2.1.6</version>
+            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -40,7 +40,7 @@
         <maven-core.version>3.9.9</maven-core.version>
         <jackson-bom.version>2.18.0</jackson-bom.version>
         <smallrye-beanbag.version>1.5.2</smallrye-beanbag.version>
-        <junit.jupiter.version>5.10.3</junit.jupiter.version>
+        <junit.jupiter.version>5.10.5</junit.jupiter.version>
     </properties>
     <build>
         <testResources>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -40,7 +40,7 @@
         <maven-core.version>3.9.9</maven-core.version>
         <jackson-bom.version>2.18.0</jackson-bom.version>
         <smallrye-beanbag.version>1.5.2</smallrye-beanbag.version>
-        <junit.jupiter.version>5.11.0</junit.jupiter.version>
+        <junit.jupiter.version>5.10.3</junit.jupiter.version>
     </properties>
     <build>
         <testResources>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -43,7 +43,7 @@
         <surefire.plugin.version>3.5.0</surefire.plugin.version>
         <jandex.version>3.2.2</jandex.version>
 
-        <junit.jupiter.version>5.10.3</junit.jupiter.version>
+        <junit.jupiter.version>5.10.5</junit.jupiter.version>
         <junit.testkit.version>1.10.3</junit.testkit.version>
         <assertj.version>3.26.3</assertj.version>
     </properties>

--- a/independent-projects/junit5-virtual-threads/pom.xml
+++ b/independent-projects/junit5-virtual-threads/pom.xml
@@ -43,7 +43,7 @@
         <surefire.plugin.version>3.5.0</surefire.plugin.version>
         <jandex.version>3.2.2</jandex.version>
 
-        <junit.jupiter.version>5.11.0</junit.jupiter.version>
+        <junit.jupiter.version>5.10.3</junit.jupiter.version>
         <junit.testkit.version>1.10.3</junit.testkit.version>
         <assertj.version>3.26.3</assertj.version>
     </properties>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.junit>5.10.3</version.junit>
+        <version.junit>5.10.5</version.junit>
         <version.assertj>3.26.3</version.assertj>
         <version.jandex>3.2.2</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -47,7 +47,7 @@
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <jandex.version>3.2.2</jandex.version>
         <bytebuddy.version>1.14.11</bytebuddy.version>
-        <junit5.version>5.10.3</junit5.version>
+        <junit5.version>5.10.5</junit5.version>
         <maven.version>3.9.9</maven.version>
         <assertj.version>3.26.3</assertj.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -51,7 +51,7 @@
         <assertj.version>3.26.3</assertj.version>
         <jackson-bom.version>2.18.0</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
-        <junit.version>5.11.0</junit.version>
+        <junit.version>5.10.3</junit.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <mockito.version>5.14.2</mockito.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -51,7 +51,7 @@
         <assertj.version>3.26.3</assertj.version>
         <jackson-bom.version>2.18.0</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
-        <junit.version>5.10.3</junit.version>
+        <junit.version>5.10.5</junit.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <mockito.version>5.14.2</mockito.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -58,7 +58,7 @@
         <quarkus.version>${project.version}</quarkus.version>
         <maven-model-helper.version>37</maven-model-helper.version>
         <jandex.version>3.2.2</jandex.version>
-        <system-stubs-jupiter.version>2.1.6</system-stubs-jupiter.version>
+        <system-stubs-jupiter.version>2.0.2</system-stubs-jupiter.version>
         <awaitility.version>4.2.2</awaitility.version>
         <java-properties.version>0.0.7</java-properties.version>
     </properties>


### PR DESCRIPTION
For now, we can't upgrade to 5.11 due to how they changed hierarchy handling.
So let's make sure we are aligned on 5.10.3 everywhere by reverting the upgrades that went in.