### PR TITLE
Support for single same uri redirects for OIDC WebClient

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1679,6 +1679,15 @@ In such cases, the endpoint might report an issuer verification failure and redi
 If you work with Keycloak, then start it with a `KEYCLOAK_FRONTEND_URL` system property set to the externally-accessible base URL.
 If you work with other OIDC providers, check the documentation of your provider.
 
+=== OIDC HTTP client redirects
+
+OIDC providers behind a firewall may redirect Quarkus OIDC HTTP client's GET requests to some of its endpoints such as a well-known configuration endpoint.
+By default, Quarkus OIDC HTTP client follows HTTP redirects automatically, excluding cookies which may have been set during the redirect request for security reasons.
+
+If you would like, you can disable it with `quarkus.oidc.follow-redirects=false`.
+
+When following redirects automatically is disabled, and Quarkus OIDC HTTP client receives a redirect request, it will attempt to recover only once by following the redirect URI, but only if it is exactly the same as the original request URI, and as long as one or more cookies were set during the redirect request.
+
 [[oidc-saml-broker]]
 == OIDC SAML identity broker
 

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
@@ -117,7 +117,7 @@ public class OidcClientRegistrationRecorder {
         }
 
         WebClientOptions options = new WebClientOptions();
-
+        options.setFollowRedirects(oidcConfig.followRedirects);
         OidcCommonUtils.setHttpClientOptions(oidcConfig, options, tlsSupport.forConfig(oidcConfig.tls));
 
         final io.vertx.mutiny.core.Vertx vertx = new io.vertx.mutiny.core.Vertx(vertxSupplier.get());

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -130,7 +130,7 @@ public class OidcClientRecorder {
         }
 
         WebClientOptions options = new WebClientOptions();
-
+        options.setFollowRedirects(oidcConfig.followRedirects);
         OidcCommonUtils.setHttpClientOptions(oidcConfig, options, tlsSupport.forConfig(oidcConfig.tls));
 
         var mutinyVertx = new io.vertx.mutiny.core.Vertx(vertx.get());

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientRedirectException.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientRedirectException.java
@@ -1,0 +1,37 @@
+package io.quarkus.oidc.common.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("serial")
+public class OidcClientRedirectException extends RuntimeException {
+
+    private final String location;
+    private final List<String> cookies;
+
+    public OidcClientRedirectException(String location, List<String> setCookies) {
+        this.location = location;
+        this.cookies = getCookies(setCookies);
+    }
+
+    private static List<String> getCookies(List<String> setCookies) {
+        if (setCookies != null && !setCookies.isEmpty()) {
+            List<String> cookies = new ArrayList<>();
+            for (String setCookie : setCookies) {
+                int index = setCookie.indexOf(";");
+                cookies.add(setCookie.substring(0, index));
+            }
+            return cookies;
+        }
+        return List.of();
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public List<String> getCookies() {
+        return cookies;
+    }
+
+}

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -72,6 +72,14 @@ public class OidcCommonConfig {
     public OptionalInt maxPoolSize = OptionalInt.empty();
 
     /**
+     * Follow redirects automatically when WebClient gets HTTP 302.
+     * When this property is disabled only a single redirect to exactly the same original URI
+     * is allowed but only if one or more cookies were set during the redirect request.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean followRedirects = true;
+
+    /**
      * Options to configure the proxy the OIDC adapter uses to talk with the OIDC server.
      */
     @ConfigItem

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -533,7 +533,7 @@ public class OidcRecorder {
         String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcConfig);
 
         WebClientOptions options = new WebClientOptions();
-
+        options.setFollowRedirects(oidcConfig.followRedirects);
         OidcCommonUtils.setHttpClientOptions(oidcConfig, options, tlsSupport.forConfig(oidcConfig.tls));
         var mutinyVertx = new io.vertx.mutiny.core.Vertx(vertx);
         WebClient client = WebClient.create(mutinyVertx, options);

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantRedirectLoop.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantRedirectLoop.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.oidc.Tenant;
+import io.quarkus.security.Authenticated;
+
+@Tenant("redirect-loop")
+@Path("/api-redirect-loop")
+@Authenticated
+public class TenantRedirectLoop {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getTenant() {
+        return "redirect-loop";
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantRedirectLoop2.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantRedirectLoop2.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.oidc.Tenant;
+import io.quarkus.security.Authenticated;
+
+@Tenant("redirect-loop2")
+@Path("/api-redirect-loop2")
+@Authenticated
+public class TenantRedirectLoop2 {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getTenant() {
+        return "redirect-loop2";
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantRedirectLoop3.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantRedirectLoop3.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.oidc.Tenant;
+import io.quarkus.security.Authenticated;
+
+@Tenant("redirect-loop3")
+@Path("/api-redirect-loop3")
+@Authenticated
+public class TenantRedirectLoop3 {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getTenant() {
+        return "redirect-loop3";
+    }
+}

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
@@ -34,6 +34,7 @@ public class AnnotationBasedTenantTest {
                     Map.entry("quarkus.oidc.hr.credentials.secret", "secret"),
                     Map.entry("quarkus.oidc.hr.tenant-paths", "/api/tenant-echo/http-security-policy-applies-all-same"),
                     Map.entry("quarkus.oidc.hr.token.audience", "http://hr.service"),
+                    Map.entry("quarkus.oidc.hr.follow-redirects", "false"),
                     Map.entry("quarkus.http.auth.policy.roles1.roles-allowed", "role1"),
                     Map.entry("quarkus.http.auth.policy.roles2.roles-allowed", "role2"),
                     Map.entry("quarkus.http.auth.policy.roles3.roles-allowed", "role3,role2"),
@@ -68,7 +69,13 @@ public class AnnotationBasedTenantTest {
                     Map.entry("quarkus.http.auth.permission.tenant-annotation-applies-all.paths",
                             "/api/tenant-echo/http-security-policy-applies-all-diff,/api/tenant-echo/http-security-policy-applies-all-same"),
                     Map.entry("quarkus.http.auth.permission.tenant-annotation-applies-all.policy", "admin-role"),
-                    Map.entry("quarkus.http.auth.policy.admin-role.roles-allowed", "admin"));
+                    Map.entry("quarkus.http.auth.policy.admin-role.roles-allowed", "admin"),
+                    Map.entry("quarkus.oidc.redirect-loop.auth-server-url", "http://localhost:8180/auth/realms/quarkus3/"),
+                    Map.entry("quarkus.oidc.redirect-loop.follow-redirects", "false"),
+                    Map.entry("quarkus.oidc.redirect-loop2.auth-server-url", "http://localhost:8180/auth/realms/quarkus4/"),
+                    Map.entry("quarkus.oidc.redirect-loop2.follow-redirects", "false"),
+                    Map.entry("quarkus.oidc.redirect-loop3.auth-server-url", "http://localhost:8180/auth/realms/quarkus5/"),
+                    Map.entry("quarkus.oidc.redirect-loop3.follow-redirects", "false"));
         }
 
         @Override
@@ -100,6 +107,18 @@ public class AnnotationBasedTenantTest {
                     .then().statusCode(200)
                     .body(Matchers.equalTo(("tenant-id=hr, static.tenant.id=hr, name=alice, "
                             + OidcUtils.TENANT_ID_SET_BY_ANNOTATION + "=hr")));
+
+            RestAssured.given().auth().oauth2(token)
+                    .when().get("/api-redirect-loop")
+                    .then().statusCode(500);
+
+            RestAssured.given().auth().oauth2(token)
+                    .when().get("/api-redirect-loop2")
+                    .then().statusCode(500);
+
+            RestAssured.given().auth().oauth2(token)
+                    .when().get("/api-redirect-loop3")
+                    .then().statusCode(500);
 
         } finally {
             server.stop();

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
@@ -41,6 +41,17 @@ public class WiremockTestResource {
         server.stubFor(
                 get(urlEqualTo("/auth/realms/quarkus2/.well-known/openid-configuration"))
                         .withHeader("Filter", equalTo("OK"))
+                        .withHeader("Cookie", absent())
+                        .willReturn(aResponse()
+                                .withStatus(302)
+                                .withHeader("Location", "http://localhost:" + port
+                                        + "/auth/realms/quarkus2/.well-known/openid-configuration")
+                                .withHeader("Set-Cookie", "redirect=true; Path=/; Domain=some.domain.com")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus2/.well-known/openid-configuration"))
+                        .withHeader("Cookie", equalTo("redirect=true"))
+                        .withHeader("Filter", equalTo("OK"))
                         .withHeader("tenant-id", not(absent()))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
@@ -52,6 +63,125 @@ public class WiremockTestResource {
 
         server.stubFor(
                 get(urlEqualTo("/auth/realms/quarkus2/protocol/openid-connect/certs"))
+                        .withHeader("Filter", equalTo("OK"))
+                        .withHeader("tenant-id", not(absent()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "  \"keys\" : [\n" +
+                                        "    {\n" +
+                                        "      \"kid\": \"1\",\n" +
+                                        "      \"kty\":\"RSA\",\n" +
+                                        "      \"n\":\"iJw33l1eVAsGoRlSyo-FCimeOc-AaZbzQ2iESA3Nkuo3TFb1zIkmt0kzlnWVGt48dkaIl13Vdefh9hqw_r9yNF8xZqX1fp0PnCWc5M_TX_ht5fm9y0TpbiVmsjeRMWZn4jr3DsFouxQ9aBXUJiu26V0vd2vrECeeAreFT4mtoHY13D2WVeJvboc5mEJcp50JNhxRCJ5UkY8jR_wfUk2Tzz4-fAj5xQaBccXnqJMu_1C6MjoCEiB7G1d13bVPReIeAGRKVJIF6ogoCN8JbrOhc_48lT4uyjbgnd24beatuKWodmWYhactFobRGYo5551cgMe8BoxpVQ4to30cGA0qjQ\",\n"
+                                        +
+                                        "      \"e\":\"AQAB\"\n" +
+                                        "    }\n" +
+                                        "  ]\n" +
+                                        "}")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus3/.well-known/openid-configuration"))
+                        .withHeader("Filter", equalTo("OK"))
+                        .withHeader("Cookie", absent())
+                        .willReturn(aResponse()
+                                .withStatus(302)
+                                .withHeader("Location", "http://localhost:" + port
+                                        + "/auth/realms/quarkus3/.well-known/openid-configuration")
+                                .withHeader("Set-Cookie", "redirect1=true; Path=/; Domain=some.domain.com")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus3/.well-known/openid-configuration"))
+                        .withHeader("Filter", equalTo("OK"))
+                        .withHeader("Cookie", equalTo("redirect1=true"))
+                        .willReturn(aResponse()
+                                .withStatus(302)
+                                .withHeader("Location", "http://localhost:" + port
+                                        + "/auth/realms/quarkus3/.well-known/openid-configuration")
+                                .withHeader("Set-Cookie", "redirect2=true; Path=/; Domain=some.domain.com")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus3/.well-known/openid-configuration"))
+                        .withHeader("Cookie", equalTo("redirect2=true"))
+                        .withHeader("Filter", equalTo("OK"))
+                        .withHeader("tenant-id", not(absent()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        (issuer == null ? "" : " \"" + ISSUER + "\": " + "\"" + issuer + "\",\n") +
+                                        "    \"jwks_uri\": \"" + server.baseUrl()
+                                        + "/auth/realms/quarkus3/protocol/openid-connect/certs\""
+                                        + "}")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus3/protocol/openid-connect/certs"))
+                        .withHeader("Filter", equalTo("OK"))
+                        .withHeader("tenant-id", not(absent()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "  \"keys\" : [\n" +
+                                        "    {\n" +
+                                        "      \"kid\": \"1\",\n" +
+                                        "      \"kty\":\"RSA\",\n" +
+                                        "      \"n\":\"iJw33l1eVAsGoRlSyo-FCimeOc-AaZbzQ2iESA3Nkuo3TFb1zIkmt0kzlnWVGt48dkaIl13Vdefh9hqw_r9yNF8xZqX1fp0PnCWc5M_TX_ht5fm9y0TpbiVmsjeRMWZn4jr3DsFouxQ9aBXUJiu26V0vd2vrECeeAreFT4mtoHY13D2WVeJvboc5mEJcp50JNhxRCJ5UkY8jR_wfUk2Tzz4-fAj5xQaBccXnqJMu_1C6MjoCEiB7G1d13bVPReIeAGRKVJIF6ogoCN8JbrOhc_48lT4uyjbgnd24beatuKWodmWYhactFobRGYo5551cgMe8BoxpVQ4to30cGA0qjQ\",\n"
+                                        +
+                                        "      \"e\":\"AQAB\"\n" +
+                                        "    }\n" +
+                                        "  ]\n" +
+                                        "}")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus4/.well-known/openid-configuration"))
+                        .withHeader("Filter", equalTo("OK"))
+                        .withHeader("Cookie", absent())
+                        .willReturn(aResponse()
+                                .withStatus(302)
+                                .withHeader("Location", "http://localhost:" + port
+                                        + "/auth/realms/quarkus4/.well-known/different-openid-configuration")
+                                .withHeader("Set-Cookie", "redirect=true; Path=/; Domain=some.domain.com")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus4/.well-known/different-openid-configuration"))
+                        .withHeader("Cookie", equalTo("redirect=true"))
+                        .withHeader("Filter", equalTo("OK"))
+                        .withHeader("tenant-id", not(absent()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        (issuer == null ? "" : " \"" + ISSUER + "\": " + "\"" + issuer + "\",\n") +
+                                        "    \"jwks_uri\": \"" + server.baseUrl()
+                                        + "/auth/realms/quarkus4/protocol/openid-connect/certs\""
+                                        + "}")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus4/protocol/openid-connect/certs"))
+                        .withHeader("Filter", equalTo("OK"))
+                        .withHeader("tenant-id", not(absent()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "  \"keys\" : [\n" +
+                                        "    {\n" +
+                                        "      \"kid\": \"1\",\n" +
+                                        "      \"kty\":\"RSA\",\n" +
+                                        "      \"n\":\"iJw33l1eVAsGoRlSyo-FCimeOc-AaZbzQ2iESA3Nkuo3TFb1zIkmt0kzlnWVGt48dkaIl13Vdefh9hqw_r9yNF8xZqX1fp0PnCWc5M_TX_ht5fm9y0TpbiVmsjeRMWZn4jr3DsFouxQ9aBXUJiu26V0vd2vrECeeAreFT4mtoHY13D2WVeJvboc5mEJcp50JNhxRCJ5UkY8jR_wfUk2Tzz4-fAj5xQaBccXnqJMu_1C6MjoCEiB7G1d13bVPReIeAGRKVJIF6ogoCN8JbrOhc_48lT4uyjbgnd24beatuKWodmWYhactFobRGYo5551cgMe8BoxpVQ4to30cGA0qjQ\",\n"
+                                        +
+                                        "      \"e\":\"AQAB\"\n" +
+                                        "    }\n" +
+                                        "  ]\n" +
+                                        "}")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus5/.well-known/openid-configuration"))
+                        .withHeader("Filter", equalTo("OK"))
+                        .withHeader("Cookie", absent())
+                        .willReturn(aResponse()
+                                .withStatus(302)
+                                .withHeader("Location", "http://localhost:" + port
+                                        + "/auth/realms/quarkus5/.well-known/openid-configuration")));
+
+        server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus5/protocol/openid-connect/certs"))
                         .withHeader("Filter", equalTo("OK"))
                         .withHeader("tenant-id", not(absent()))
                         .willReturn(aResponse()


### PR DESCRIPTION
Fixes #43937.

This PR enables a single time redirect support when one of GET OidcProvider endpoints (discovery, JWK, or UserInfo) request a redirect exactly to the same URI, as long as one or more cookies are available during such redirect.

it is impossible to avoid adding a property in this case. Some users may already depending on the auto-redirect feature  without cookies.