### PR TITLE
Fix ObservabilityDevServicesConfigBuildItem usage - can be multiple, fix dup logging output

### DIFF
--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
@@ -145,7 +145,9 @@ class ObservabilityDevServiceProcessor {
                     consoleInstalledBuildItem,
                     loggingSetupBuildItem,
                     s -> false,
-                    s -> s.contains(getClass().getSimpleName())); // log if it comes from this class
+                    s -> s.contains(getClass().getSimpleName()) ||
+                            s.contains("Resource") ||
+                            s.contains("Container")); // log if it comes from this class or Resource / Container
             try {
                 DevServicesResultBuildItem.RunningDevService newDevService = startContainer(
                         devId,

--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/devui/ObservabilityDevServicesConfigBuildItem.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/devui/ObservabilityDevServicesConfigBuildItem.java
@@ -2,12 +2,12 @@ package io.quarkus.observability.deployment.devui;
 
 import java.util.Map;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * Build item used to carry running DevService values to Dev UI.
  */
-public final class ObservabilityDevServicesConfigBuildItem extends SimpleBuildItem {
+public final class ObservabilityDevServicesConfigBuildItem extends MultiBuildItem {
 
     private final Map<String, String> config;
 

--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/devui/ObservabilityDevUIProcessor.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/devui/ObservabilityDevUIProcessor.java
@@ -1,7 +1,7 @@
 package io.quarkus.observability.deployment.devui;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -26,45 +26,46 @@ public class ObservabilityDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     void createVersion(BuildProducer<CardPageBuildItem> cardPageBuildItemBuildProducer,
             BuildProducer<FooterPageBuildItem> footerProducer,
-            Optional<ObservabilityDevServicesConfigBuildItem> configProps) {
+            List<ObservabilityDevServicesConfigBuildItem> configProps) {
 
-        // LGTM
-        if (configProps.isPresent()) {
-            Map<String, String> runtimeConfig = configProps.get().getConfig();
-            String grafanaUrl = runtimeConfig.getOrDefault("grafana.endpoint", "");
+        if (configProps != null) {
+            configProps.forEach(cp -> {
+                Map<String, String> runtimeConfig = cp.getConfig();
 
-            if (StringUtils.isNotEmpty(grafanaUrl)) {
-                final CardPageBuildItem card = new CardPageBuildItem();
+                // LGTM
+                String grafanaUrl = runtimeConfig.getOrDefault("grafana.endpoint", "");
+                if (StringUtils.isNotEmpty(grafanaUrl)) {
+                    final CardPageBuildItem card = new CardPageBuildItem();
 
-                // Grafana
-                grafanaUrl = StringUtils.prependIfMissing(grafanaUrl, "http://");
-                card.addPage(Page.externalPageBuilder("Grafana UI")
-                        .url(grafanaUrl, grafanaUrl)
-                        .doNotEmbed()
-                        .isHtmlContent()
-                        .icon("font-awesome-solid:chart-line"));
+                    // Grafana
+                    grafanaUrl = StringUtils.prependIfMissing(grafanaUrl, "http://");
+                    card.addPage(Page.externalPageBuilder("Grafana UI")
+                            .url(grafanaUrl, grafanaUrl)
+                            .doNotEmbed()
+                            .isHtmlContent()
+                            .icon("font-awesome-solid:chart-line"));
 
-                // Open Telemetry
-                final ExternalPageBuilder otelPage = Page.externalPageBuilder("OpenTelemetry Port")
-                        .icon("font-awesome-solid:binoculars")
-                        .doNotEmbed()
-                        .url("https://opentelemetry.io/")
-                        .staticLabel(StringUtils
-                                .substringAfterLast(runtimeConfig.getOrDefault("otel-collector.url", "0"), ":"));
-                card.addPage(otelPage);
+                    // Open Telemetry
+                    final ExternalPageBuilder otelPage = Page.externalPageBuilder("OpenTelemetry Port")
+                            .icon("font-awesome-solid:binoculars")
+                            .doNotEmbed()
+                            .url("https://opentelemetry.io/")
+                            .staticLabel(StringUtils
+                                    .substringAfterLast(runtimeConfig.getOrDefault("otel-collector.url", "0"), ":"));
+                    card.addPage(otelPage);
 
-                card.setCustomCard("qwc-lgtm-card.js");
-                cardPageBuildItemBuildProducer.produce(card);
+                    card.setCustomCard("qwc-lgtm-card.js");
+                    cardPageBuildItemBuildProducer.produce(card);
 
-                // LGTM Container Log Console
-                WebComponentPageBuilder mailLogPageBuilder = Page.webComponentPageBuilder()
-                        .icon("font-awesome-solid:chart-line")
-                        .title("LGTM")
-                        .componentLink("qwc-lgtm-log.js");
+                    // LGTM Container Log Console
+                    WebComponentPageBuilder mailLogPageBuilder = Page.webComponentPageBuilder()
+                            .icon("font-awesome-solid:chart-line")
+                            .title("LGTM")
+                            .componentLink("qwc-lgtm-log.js");
 
-                footerProducer.produce(new FooterPageBuildItem(mailLogPageBuilder));
-            }
+                    footerProducer.produce(new FooterPageBuildItem(mailLogPageBuilder));
+                }
+            });
         }
-
     }
 }

--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/devui/ObservabilityDevUIProcessor.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/devui/ObservabilityDevUIProcessor.java
@@ -28,44 +28,42 @@ public class ObservabilityDevUIProcessor {
             BuildProducer<FooterPageBuildItem> footerProducer,
             List<ObservabilityDevServicesConfigBuildItem> configProps) {
 
-        if (configProps != null) {
-            configProps.forEach(cp -> {
-                Map<String, String> runtimeConfig = cp.getConfig();
+        for (ObservabilityDevServicesConfigBuildItem cp : configProps) {
+            Map<String, String> runtimeConfig = cp.getConfig();
 
-                // LGTM
-                String grafanaUrl = runtimeConfig.getOrDefault("grafana.endpoint", "");
-                if (StringUtils.isNotEmpty(grafanaUrl)) {
-                    final CardPageBuildItem card = new CardPageBuildItem();
+            // LGTM
+            String grafanaUrl = runtimeConfig.getOrDefault("grafana.endpoint", "");
+            if (StringUtils.isNotEmpty(grafanaUrl)) {
+                final CardPageBuildItem card = new CardPageBuildItem();
 
-                    // Grafana
-                    grafanaUrl = StringUtils.prependIfMissing(grafanaUrl, "http://");
-                    card.addPage(Page.externalPageBuilder("Grafana UI")
-                            .url(grafanaUrl, grafanaUrl)
-                            .doNotEmbed()
-                            .isHtmlContent()
-                            .icon("font-awesome-solid:chart-line"));
+                // Grafana
+                grafanaUrl = StringUtils.prependIfMissing(grafanaUrl, "http://");
+                card.addPage(Page.externalPageBuilder("Grafana UI")
+                        .url(grafanaUrl, grafanaUrl)
+                        .doNotEmbed()
+                        .isHtmlContent()
+                        .icon("font-awesome-solid:chart-line"));
 
-                    // Open Telemetry
-                    final ExternalPageBuilder otelPage = Page.externalPageBuilder("OpenTelemetry Port")
-                            .icon("font-awesome-solid:binoculars")
-                            .doNotEmbed()
-                            .url("https://opentelemetry.io/")
-                            .staticLabel(StringUtils
-                                    .substringAfterLast(runtimeConfig.getOrDefault("otel-collector.url", "0"), ":"));
-                    card.addPage(otelPage);
+                // Open Telemetry
+                final ExternalPageBuilder otelPage = Page.externalPageBuilder("OpenTelemetry Port")
+                        .icon("font-awesome-solid:binoculars")
+                        .doNotEmbed()
+                        .url("https://opentelemetry.io/")
+                        .staticLabel(StringUtils
+                                .substringAfterLast(runtimeConfig.getOrDefault("otel-collector.url", "0"), ":"));
+                card.addPage(otelPage);
 
-                    card.setCustomCard("qwc-lgtm-card.js");
-                    cardPageBuildItemBuildProducer.produce(card);
+                card.setCustomCard("qwc-lgtm-card.js");
+                cardPageBuildItemBuildProducer.produce(card);
 
-                    // LGTM Container Log Console
-                    WebComponentPageBuilder mailLogPageBuilder = Page.webComponentPageBuilder()
-                            .icon("font-awesome-solid:chart-line")
-                            .title("LGTM")
-                            .componentLink("qwc-lgtm-log.js");
+                // LGTM Container Log Console
+                WebComponentPageBuilder mailLogPageBuilder = Page.webComponentPageBuilder()
+                        .icon("font-awesome-solid:chart-line")
+                        .title("LGTM")
+                        .componentLink("qwc-lgtm-log.js");
 
-                    footerProducer.produce(new FooterPageBuildItem(mailLogPageBuilder));
-                }
-            });
+                footerProducer.produce(new FooterPageBuildItem(mailLogPageBuilder));
+            }
         }
     }
 }

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
@@ -5,20 +5,13 @@ import java.util.Set;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 import org.testcontainers.utility.MountableFile;
 
-import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.observability.common.ContainerConstants;
 import io.quarkus.observability.common.config.AbstractGrafanaConfig;
 import io.quarkus.observability.common.config.LgtmConfig;
 
 public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
-    /**
-     * Logger which will be used to capture container STDOUT and STDERR.
-     */
-    private static final Logger log = Logger.getLogger(LgtmContainer.class);
-
     protected static final String LGTM_NETWORK_ALIAS = "ltgm.testcontainer.docker";
 
     protected static final String PROMETHEUS_CONFIG = """
@@ -47,7 +40,6 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
         // cannot override grafana-dashboards.yaml in the container because it's on a version dependent path:
         // ./grafana-v11.0.0/conf/provisioning/dashboards/grafana-dashboards.yaml
         // will replace contents of current dashboards
-        withLogConsumer(new JBossLoggingConsumer(log).withPrefix("LGTM"));
         withCopyFileToContainer(
                 MountableFile.forClasspathResource("/grafana-dashboard-quarkus-micrometer-prometheus.json"),
                 "/otel-lgtm/grafana-dashboard-red-metrics-classic.json");
@@ -59,6 +51,11 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
                 "/otel-lgtm/grafana-dashboard-jvm-metrics.json");
         addFileToContainer(getPrometheusConfig().getBytes(), "/otel-lgtm/prometheus.yaml");
 
+    }
+
+    @Override
+    protected String prefix() {
+        return "LGTM";
     }
 
     public String getOtlpProtocol() {

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/ObservabilityContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/ObservabilityContainer.java
@@ -8,21 +8,21 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.observability.common.config.ContainerConfig;
 
 @SuppressWarnings("resource")
 public abstract class ObservabilityContainer<T extends ObservabilityContainer<T, C>, C extends ContainerConfig>
         extends GenericContainer<T> {
-    private final Logger log = LoggerFactory.getLogger(getClass());
-    private final Logger dockerLog = LoggerFactory.getLogger(getClass().getName() + ".docker");
+
+    protected final Logger log = Logger.getLogger(getClass());
 
     public ObservabilityContainer(C config) {
         super(DockerImageName.parse(config.imageName()));
@@ -35,8 +35,10 @@ public abstract class ObservabilityContainer<T extends ObservabilityContainer<T,
         }
     }
 
+    protected abstract String prefix();
+
     protected Consumer<OutputFrame> frameConsumer() {
-        return frame -> logger().debug(frame.getUtf8String().stripTrailing());
+        return new JBossLoggingConsumer(log).withPrefix(prefix());
     }
 
     protected byte[] getResourceAsBytes(String resource) {
@@ -54,19 +56,14 @@ public abstract class ObservabilityContainer<T extends ObservabilityContainer<T,
     }
 
     @Override
-    protected Logger logger() {
-        return dockerLog;
-    }
-
-    @Override
     public void start() {
-        log.info("Starting {} ...", getClass().getSimpleName());
+        log.infof("Starting %s ...", prefix());
         super.start();
     }
 
     @Override
     public void stop() {
-        log.info("Stopping {}...", getClass().getSimpleName());
+        log.infof("Stopping %s...", prefix());
         super.stop();
     }
 }

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/ObservabilityContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/ObservabilityContainer.java
@@ -51,7 +51,7 @@ public abstract class ObservabilityContainer<T extends ObservabilityContainer<T,
 
     @SuppressWarnings("OctalInteger")
     protected void addFileToContainer(byte[] content, String pathInContainer) {
-        log.infof("Content [%s]: \n{}", pathInContainer, new String(content, StandardCharsets.UTF_8));
+        log.infof("Content [%s]: \n%s", pathInContainer, new String(content, StandardCharsets.UTF_8));
         withCopyToContainer(Transferable.of(content, 0777), pathInContainer);
     }
 

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/ObservabilityContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/ObservabilityContainer.java
@@ -51,7 +51,7 @@ public abstract class ObservabilityContainer<T extends ObservabilityContainer<T,
 
     @SuppressWarnings("OctalInteger")
     protected void addFileToContainer(byte[] content, String pathInContainer) {
-        logger().info("Content [{}]: \n{}", pathInContainer, new String(content, StandardCharsets.UTF_8));
+        log.infof("Content [%s]: \n{}", pathInContainer, new String(content, StandardCharsets.UTF_8));
         withCopyToContainer(Transferable.of(content, 0777), pathInContainer);
     }
 


### PR DESCRIPTION
There can (and probably will be) multiple ObservabilityDevServicesConfigBuildItem instances,
since there can be multiple DevResources instances.
Currently only the last one would probably be used with this `Optional<ObservabilityDevServicesConfigBuildItem>` parameter?
This fixes ObservabilityDevServicesConfigBuildItem usage, so all are checked for potential DevUI contribution.