### PR TITLE
Dev UI: Change the endpoints to navigate to Swagger UI if included

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/EndpointsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/EndpointsProcessor.java
@@ -1,7 +1,10 @@
 package io.quarkus.devui.deployment.menu;
 
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.devui.deployment.InternalPageBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -16,13 +19,24 @@ public class EndpointsProcessor {
     private static final String DEVUI = "dev-ui";
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    InternalPageBuildItem createEndpointsPage(NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem) {
+    InternalPageBuildItem createEndpointsPage(Capabilities capabilities, ConfigurationBuildItem configurationBuildItem,
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem) {
+
+        final boolean swaggerIsAvailable = capabilities.isPresent(Capability.SMALLRYE_OPENAPI);
+        final String swaggerUiPath;
+        if (swaggerIsAvailable) {
+            swaggerUiPath = nonApplicationRootPathBuildItem.resolvePath(
+                    getProperty(configurationBuildItem, "quarkus.swagger-ui.path"));
+        } else {
+            swaggerUiPath = "";
+        }
 
         String basepath = nonApplicationRootPathBuildItem.resolvePath(DEVUI);
 
         InternalPageBuildItem endpointsPage = new InternalPageBuildItem("Endpoints", 25);
 
         endpointsPage.addBuildTimeData("basepath", basepath);
+        endpointsPage.addBuildTimeData("swaggerUiPath", swaggerUiPath);
 
         // Page
         endpointsPage.addPage(Page.webComponentPageBuilder()
@@ -43,5 +57,32 @@ public class EndpointsProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(NAMESPACE, ResourceNotFoundData.class);
+    }
+
+    private static String getProperty(ConfigurationBuildItem configurationBuildItem,
+            String propertyKey) {
+
+        String propertyValue = configurationBuildItem
+                .getReadResult()
+                .getAllBuildTimeValues()
+                .get(propertyKey);
+
+        if (propertyValue == null) {
+            propertyValue = configurationBuildItem
+                    .getReadResult()
+                    .getBuildTimeRunTimeValues()
+                    .get(propertyKey);
+        } else {
+            return propertyValue;
+        }
+
+        if (propertyValue == null) {
+            propertyValue = configurationBuildItem
+                    .getReadResult()
+                    .getRunTimeDefaultValues()
+                    .get(propertyKey);
+        }
+
+        return propertyValue;
     }
 }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-endpoints.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-endpoints.js
@@ -4,6 +4,7 @@ import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
 import { JsonRpc } from 'jsonrpc';
+import { swaggerUiPath } from 'devui-data';
 
 /**
  * This component show all available endpoints
@@ -37,12 +38,14 @@ export class QwcEndpoints extends LitElement {
     `;
 
     static properties = {
+        filter: {type: String},
         _info: {state: true}
     }
 
     constructor() {
         super();
         this._info = null;
+        this.filter = null;
     }
 
     connectedCallback() {
@@ -56,7 +59,9 @@ export class QwcEndpoints extends LitElement {
         if (this._info) {
             const typeTemplates = [];
             for (const [type, list] of Object.entries(this._info)) {
-                typeTemplates.push(html`${this._renderType(type,list)}`);
+                if(!this.filter || this.filter === type){
+                    typeTemplates.push(html`${this._renderType(type,list)}`);
+                }
             }
             return html`${typeTemplates}`;
         }else{
@@ -86,8 +91,12 @@ export class QwcEndpoints extends LitElement {
     }
 
     _uriRenderer(endpoint) {
-        if (endpoint.uri) {
+        if (endpoint.uri && endpoint.description && endpoint.description.startsWith("GET")) {
             return html`<a href="${endpoint.uri}" target="_blank">${endpoint.uri}</a>`;
+        }else if(swaggerUiPath!==""){
+            return html`<a href="${swaggerUiPath}" title="Test this Swagger UI" target="_blank">${endpoint.uri}</a>`;
+        }else{
+            return html`<span>${endpoint.uri}</span>`;
         }
     }
 

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-welcome.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-welcome.js
@@ -1,17 +1,11 @@
 import { LitElement, html, css } from 'lit';
 import { devuiState } from 'devui-state';
-import { JsonRpc } from 'jsonrpc';
-import '@vaadin/progress-bar';
-import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import '@vaadin/grid/vaadin-grid-sort-column.js';
+import 'qwc/qwc-endpoints.js';
 
 /**
  * This component shows the welcome screen
  */
 export class QwcWelcome extends LitElement {
-    jsonRpc = new JsonRpc("devui-endpoints");
-
     static styles = css`
         a { color: inherit; } 
 
@@ -118,22 +112,6 @@ export class QwcWelcome extends LitElement {
         }
     `;
 
-    static properties = {
-        _info: {state: true}
-    };
-
-    constructor() {
-        super();
-        this._info = null;
-    }
-
-    connectedCallback() {
-        super.connectedCallback();
-        this.jsonRpc.getJsonContent().then(jsonRpcResponse => {
-            this._info = jsonRpcResponse.result;
-        });
-    }
-
     render() {
         return html`<div class="fullscreen">
                         <div class="header" @click=${this._reload}>
@@ -202,7 +180,7 @@ export class QwcWelcome extends LitElement {
                                     <span>Static assets: <code>${devuiState.welcomeData.resourcesDir}/META-INF/resources/</code></span>
                                     <span>Code: <code>${devuiState.welcomeData.sourceDir}</code></span>
                                 </div>
-                                ${this._renderEndpoints()}
+                                <qwc-endpoints filter="Resource Endpoints"></qwc-endpoints>
                             </div>
                             <div class="right-column">
                                 ${this._renderSelectedExtensions()}
@@ -220,52 +198,6 @@ export class QwcWelcome extends LitElement {
     
     _reload(){
         window.location.href = '/';
-    }
-    
-    _renderEndpoints(){
-        if (this._info) {
-            const typeTemplates = [];
-            for (const [type, list] of Object.entries(this._info)) {
-                if(type !== "Additional endpoints")
-                typeTemplates.push(html`${this._renderType(type,list)}`);
-            }
-            return html`${typeTemplates}`;
-        }else{
-            return html`
-            <div style="color: var(--lumo-secondary-text-color);width: 95%;" >
-                <div>Fetching information...</div>
-                <vaadin-progress-bar indeterminate></vaadin-progress-bar>
-            </div>
-            `;
-        }
-    }
-    
-    _renderType(type, items){
-        return html`<h3>${type}</h3>
-                    <vaadin-grid .items="${items}" class="infogrid" all-rows-visible>
-                        <vaadin-grid-sort-column header='URL'
-                                                path="uri" 
-                                            ${columnBodyRenderer(this._uriRenderer, [])}>
-                        </vaadin-grid-sort-column>
-
-                        <vaadin-grid-sort-column 
-                                            header="Description" 
-                                            path="description"
-                                            ${columnBodyRenderer(this._descriptionRenderer, [])}>
-                        </vaadin-grid-sort-column>
-                    </vaadin-grid>`;
-    }
-    
-    _uriRenderer(endpoint) {
-        if (endpoint.uri) {
-            return html`<a href="${endpoint.uri}" target="_blank">${endpoint.uri}</a>`;
-        }
-    }
-
-    _descriptionRenderer(endpoint) {
-        if (endpoint.description) {
-            return html`<span>${endpoint.description}</span>`;
-        }
     }
     
     _renderSelectedExtensions(){


### PR DESCRIPTION
Fix #43445

As discussed, when Swagger UI is included, the non GET endpoints will point to go there (rather than a new window that will just result in an error)

![endpoints-swagger](https://github.com/user-attachments/assets/da621cef-d4f9-4cb3-af40-84bb2026ba2f)

This also change the welcome screen to rather use the endpoints web component, then to repeat the same code.