### PR TITLE
Qute message bundles: change the way message templates are loaded

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templatelocator/CustomTemplateLocatorTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templatelocator/CustomTemplateLocatorTest.java
@@ -89,7 +89,7 @@ public class CustomTemplateLocatorTest {
 
     @Test
     public void testLocatorsAreRegisteredAsSingletons() {
-        assertEquals(4, locatorList.size());
+        assertEquals(5, locatorList.size());
     }
 
     @Singleton

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
@@ -10,8 +10,6 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 
-import org.jboss.logging.Logger;
-
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
@@ -30,8 +28,6 @@ public final class MessageBundles {
 
     public static final String ATTRIBUTE_LOCALE = TemplateInstance.LOCALE;
     public static final String DEFAULT_LOCALE = "<<default>>";
-
-    private static final Logger LOGGER = Logger.getLogger(MessageBundles.class);
 
     private MessageBundles() {
     }
@@ -62,11 +58,14 @@ public final class MessageBundles {
                 .render());
     }
 
-    static void setupNamespaceResolvers(@Observes EngineBuilder builder, BundleContext context) {
+    static void setupNamespaceResolvers(@Observes EngineBuilder builder, Instance<BundleContext> context) {
+        if (!context.isResolvable()) {
+            return;
+        }
         // Avoid injecting "Instance<Object> instance" which prevents unused beans removal
         ArcContainer container = Arc.container();
         // For every bundle register a new resolver
-        for (Entry<String, Map<String, Class<?>>> entry : context.getBundleInterfaces().entrySet()) {
+        for (Entry<String, Map<String, Class<?>>> entry : context.get().getBundleInterfaces().entrySet()) {
             final String bundleName = entry.getKey();
             final Map<String, Resolver> interfaces = new HashMap<>();
             Resolver resolver = null;
@@ -121,10 +120,15 @@ public final class MessageBundles {
         }
     }
 
-    static void setupMessageTemplates(@Observes Engine engine, BundleContext context) {
-        for (Entry<String, String> entry : context.getMessageTemplates().entrySet()) {
-            LOGGER.debugf("Register template for message [%s]", entry.getKey());
-            engine.putTemplate(entry.getKey(), engine.parse(entry.getValue()));
+    static void preloadMessageTemplates(@Observes Engine engine, Instance<BundleContext> context) {
+        if (!context.isResolvable()) {
+            return;
+        }
+        for (String key : context.get().getMessageTemplates().keySet()) {
+            Template messageTemplate = engine.getTemplate(key);
+            if (messageTemplate == null) {
+                throw new IllegalStateException("Unable to preload message template: " + key);
+            }
         }
     }
 

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageTemplateLocator.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageTemplateLocator.java
@@ -1,0 +1,59 @@
+package io.quarkus.qute.i18n;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Optional;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import io.quarkus.arc.WithCaching;
+import io.quarkus.qute.TemplateLocator;
+import io.quarkus.qute.Variant;
+import io.quarkus.qute.runtime.MessageBundleRecorder.BundleContext;
+
+@Singleton
+public class MessageTemplateLocator implements TemplateLocator {
+
+    @WithCaching // BundleContext is dependent
+    @Inject
+    Instance<BundleContext> bundleContext;
+
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY - 1;
+    }
+
+    @Override
+    public Optional<TemplateLocation> locate(String id) {
+        if (bundleContext.isResolvable()) {
+            String template = bundleContext.get().getMessageTemplates().get(id);
+            if (template != null) {
+                return Optional.of(new MessageTemplateLocation(template));
+            }
+        }
+        return Optional.empty();
+    }
+
+    static final class MessageTemplateLocation implements TemplateLocation {
+
+        private final String content;
+
+        private MessageTemplateLocation(String content) {
+            this.content = content;
+        }
+
+        @Override
+        public Reader read() {
+            return new StringReader(content);
+        }
+
+        @Override
+        public Optional<Variant> getVariant() {
+            return Optional.empty();
+        }
+
+    }
+
+}


### PR DESCRIPTION
- introduce a dedicated TemplateLocator so that the message templates can be reloaded automatically when a no-restart change occurs during the dev mode
- fixes #43944