### PR TITLE
Add option to skip logging invalid recipients when sending emails

### DIFF
--- a/extensions/mailer/deployment/pom.xml
+++ b/extensions/mailer/deployment/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/InvalidEmailTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/InvalidEmailTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.mailer;
+
+import java.time.Duration;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.mailer.reactive.ReactiveMailer;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class InvalidEmailTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Sender.class));
+
+    @Inject
+    MockMailbox mockMailbox;
+
+    @Inject
+    Sender sender;
+
+    @Test
+    public void testInvalidTo() {
+        List<String> to = List.of("clement@test.io", "inv alid@quarkus.io", "max@test.io");
+        List<String> cc = List.of();
+        List<String> bcc = List.of();
+        Assertions.assertThatThrownBy(() -> sender.send(to, cc, bcc).await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unable to send an email, an email address is invalid")
+                .hasMessageNotContaining("@");
+        Assertions.assertThat(mockMailbox.getTotalMessagesSent()).isEqualTo(0);
+    }
+
+    @Test
+    public void testInvalidCC() {
+        List<String> cc = List.of("clement@test.io", "inv alid@quarkus.io", "max@test.io");
+        List<String> to = List.of();
+        List<String> bcc = List.of();
+        Assertions.assertThatThrownBy(() -> sender.send(to, cc, bcc).await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unable to send an email, an email address is invalid")
+                .hasMessageNotContaining("@");
+        Assertions.assertThat(mockMailbox.getTotalMessagesSent()).isEqualTo(0);
+    }
+
+    @Test
+    public void testInvalidBCC() {
+        List<String> bcc = List.of("clement@test.io", "inv alid@quarkus.io", "max@test.io");
+        List<String> to = List.of();
+        List<String> cc = List.of();
+        Assertions.assertThatThrownBy(() -> sender.send(to, cc, bcc).await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unable to send an email, an email address is invalid")
+                .hasMessageNotContaining("@");
+        Assertions.assertThat(mockMailbox.getTotalMessagesSent()).isEqualTo(0);
+    }
+
+    @Singleton
+    static class Sender {
+
+        @Inject
+        ReactiveMailer mailer;
+
+        Uni<Void> send(List<String> to, List<String> cc, List<String> bcc) {
+            Mail mail = new Mail()
+                    .setTo(to)
+                    .setCc(cc)
+                    .setBcc(bcc)
+                    .setSubject("Test")
+                    .setText("Hello!");
+            return mailer.send(mail);
+        }
+    }
+}

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/LoggedInvalidEmailTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/LoggedInvalidEmailTest.java
@@ -1,0 +1,86 @@
+package io.quarkus.mailer;
+
+import java.time.Duration;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.mailer.reactive.ReactiveMailer;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class LoggedInvalidEmailTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Sender.class))
+            .overrideRuntimeConfigKey("quarkus.mailer.log-invalid-recipients", "true");
+
+    @Inject
+    MockMailbox mockMailbox;
+
+    @Inject
+    Sender sender;
+
+    @Test
+    public void testInvalidTo() {
+        List<String> to = List.of("clement@test.io", "inv alid@quarkus.io", "max@test.io");
+        List<String> cc = List.of();
+        List<String> bcc = List.of();
+        Assertions.assertThatThrownBy(() -> sender.send(to, cc, bcc).await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unable to send an email")
+                .hasStackTraceContaining("inv alid@quarkus.io")
+                .hasMessageNotContaining("@text.io");
+        Assertions.assertThat(mockMailbox.getTotalMessagesSent()).isEqualTo(0);
+    }
+
+    @Test
+    public void testInvalidCC() {
+        List<String> cc = List.of("clement@test.io", "inv alid@quarkus.io", "max@test.io");
+        List<String> to = List.of();
+        List<String> bcc = List.of();
+        Assertions.assertThatThrownBy(() -> sender.send(to, cc, bcc).await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unable to send an email")
+                .hasStackTraceContaining("inv alid@quarkus.io")
+                .hasMessageNotContaining("@text.io");
+        Assertions.assertThat(mockMailbox.getTotalMessagesSent()).isEqualTo(0);
+    }
+
+    @Test
+    public void testInvalidBCC() {
+        List<String> bcc = List.of("clement@test.io", "inv alid@quarkus.io", "max@test.io");
+        List<String> to = List.of();
+        List<String> cc = List.of();
+        Assertions.assertThatThrownBy(() -> sender.send(to, cc, bcc).await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unable to send an email")
+                .hasStackTraceContaining("inv alid@quarkus.io")
+                .hasMessageNotContaining("@text.io");
+        Assertions.assertThat(mockMailbox.getTotalMessagesSent()).isEqualTo(0);
+    }
+
+    @Singleton
+    static class Sender {
+
+        @Inject
+        ReactiveMailer mailer;
+
+        Uni<Void> send(List<String> to, List<String> cc, List<String> bcc) {
+            Mail mail = new Mail()
+                    .setTo(to)
+                    .setCc(cc)
+                    .setBcc(bcc)
+                    .setSubject("Test")
+                    .setText("Hello!");
+            return mailer.send(mail);
+        }
+    }
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
@@ -272,4 +272,13 @@ public class MailerRuntimeConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean logRejectedRecipients = false;
+
+    /**
+     * Log invalid recipients as warnings.
+     * <p>
+     * If false, the invalid recipients will not be logged and the thrown exception will not contain the invalid email address.
+     *
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean logInvalidRecipients = false;
 }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
@@ -75,7 +75,8 @@ public class Mailers {
                             mailersRuntimeConfig.defaultMailer.mock.orElse(launchMode.isDevOrTest()),
                             mailersRuntimeConfig.defaultMailer.approvedRecipients.orElse(List.of()).stream()
                                     .filter(Objects::nonNull).collect(Collectors.toList()),
-                            mailersRuntimeConfig.defaultMailer.logRejectedRecipients));
+                            mailersRuntimeConfig.defaultMailer.logRejectedRecipients,
+                            mailersRuntimeConfig.defaultMailer.logInvalidRecipients));
         }
 
         for (String name : mailerSupport.namedMailers) {
@@ -97,7 +98,8 @@ public class Mailers {
                             namedMailerRuntimeConfig.mock.orElse(false),
                             namedMailerRuntimeConfig.approvedRecipients.orElse(List.of()).stream()
                                     .filter(p -> p != null).collect(Collectors.toList()),
-                            namedMailerRuntimeConfig.logRejectedRecipients));
+                            namedMailerRuntimeConfig.logRejectedRecipients,
+                            namedMailerRuntimeConfig.logInvalidRecipients));
         }
 
         this.clients = Collections.unmodifiableMap(localClients);

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MockMailboxImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MockMailboxImpl.java
@@ -9,6 +9,7 @@ import io.quarkus.mailer.Mail;
 import io.quarkus.mailer.MockMailbox;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.mail.MailMessage;
+import io.vertx.ext.mail.mailencoder.EmailAddress;
 
 /**
  * Mock mailbox bean, will be populated if mocking emails.
@@ -22,20 +23,28 @@ public class MockMailboxImpl implements MockMailbox {
     Uni<Void> send(Mail email, MailMessage mailMessage) {
         if (email.getTo() != null) {
             for (String to : email.getTo()) {
+                validateEmailAddress(to);
                 send(email, mailMessage, to);
             }
         }
         if (email.getCc() != null) {
             for (String to : email.getCc()) {
+                validateEmailAddress(to);
                 send(email, mailMessage, to);
             }
         }
         if (email.getBcc() != null) {
             for (String to : email.getBcc()) {
+                validateEmailAddress(to);
                 send(email, mailMessage, to);
             }
         }
         return Uni.createFrom().item(() -> null);
+    }
+
+    private void validateEmailAddress(String to) {
+        // Just here to validate the email address.
+        new EmailAddress(to);
     }
 
     private void send(Mail sentMail, MailMessage sentMailMessage, String to) {

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerImplTest.java
@@ -59,7 +59,7 @@ class MailerImplTest {
         mailer = new MutinyMailerImpl(vertx,
                 MailClient.createShared(vertx,
                         new MailConfig().setPort(wiser.getServer().getPort())),
-                null, FROM, null, false, List.of(), false);
+                null, FROM, null, false, List.of(), false, false);
 
         wiser.getMessages().clear();
     }

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerWithMultipartImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerWithMultipartImplTest.java
@@ -62,7 +62,7 @@ class MailerWithMultipartImplTest {
     void init() {
         mailer = new MutinyMailerImpl(vertx, MailClient.createShared(vertx,
                 new MailConfig().setPort(wiser.getServer().getPort()).setMultiPartOnly(true)), null,
-                FROM, null, false, List.of(), false);
+                FROM, null, false, List.of(), false, false);
 
         wiser.getMessages().clear();
     }

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MockMailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MockMailerImplTest.java
@@ -35,7 +35,7 @@ class MockMailerImplTest {
     @BeforeEach
     void init() {
         mockMailbox = new MockMailboxImpl();
-        mailer = new MutinyMailerImpl(vertx, null, mockMailbox, FROM, null, true, List.of(), false);
+        mailer = new MutinyMailerImpl(vertx, null, mockMailbox, FROM, null, true, List.of(), false, false);
     }
 
     @Test


### PR DESCRIPTION
This commits detects and prevents logging invalid recipients before delegating to the underlying SMTP client, avoiding the overhead of processing attachments for emails that won’t be sent as well as acquiring an unnecessary connection.

When the option is enabled (default), the invalid recipients is not logged and not part of the thrown exception.
