### PR TITLE
Update MP REST Client to 4.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -26,7 +26,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.inject.version>1</javax.inject.version>
         <parsson.version>1.1.7</parsson.version>
-        <resteasy-microprofile.version>2.1.5.Final</resteasy-microprofile.version>
+        <resteasy-microprofile.version>3.0.0.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.1.3.Final</resteasy-spring-web.version>
         <resteasy.version>6.2.10.Final</resteasy.version>
         <opentracing.version>0.33.0</opentracing.version>
@@ -48,7 +48,7 @@
         <microprofile-opentracing-api.version>3.0</microprofile-opentracing-api.version>
         <microprofile-fault-tolerance-api.version>4.1.1</microprofile-fault-tolerance-api.version>
         <microprofile-reactive-streams-operators.version>3.0.1</microprofile-reactive-streams-operators.version>
-        <microprofile-rest-client.version>3.0.1</microprofile-rest-client.version>
+        <microprofile-rest-client.version>4.0</microprofile-rest-client.version>
         <microprofile-jwt.version>2.1</microprofile-jwt.version>
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>3.1.2</microprofile-openapi.version>

--- a/extensions/resteasy-classic/resteasy-client/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-client/runtime/pom.xml
@@ -59,6 +59,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.interceptor</groupId>
             <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/DefaultBuilderHeadersTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/DefaultBuilderHeadersTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.rest.client.reactive.headers;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class DefaultBuilderHeadersTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().withApplicationRoot(jar -> {
+    });
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void headers() {
+        RestClientBuilder builder = RestClientBuilder.newBuilder().baseUri("http://localhost:8080/");
+        builder.register(ReturnWithAllDuplicateClientHeadersFilter.class);
+        builder.header("InterfaceAndBuilderHeader", "builder");
+        ClientBuilderHeaderMethodClient client = builder.build(ClientBuilderHeaderMethodClient.class);
+
+        checkHeaders(client.getAllHeaders("headerparam"), "method");
+    }
+
+    @Path("/")
+    public interface ClientBuilderHeaderMethodClient {
+        @GET
+        @ClientHeaderParam(name = "InterfaceAndBuilderHeader", value = "method")
+        JsonObject getAllHeaders(@HeaderParam("HeaderParam") String param);
+    }
+
+    public static class ReturnWithAllDuplicateClientHeadersFilter implements ClientRequestFilter {
+
+        @Override
+        public void filter(ClientRequestContext clientRequestContext) throws IOException {
+            JsonObjectBuilder allClientHeaders = Json.createObjectBuilder();
+            MultivaluedMap<String, Object> clientHeaders = clientRequestContext.getHeaders();
+            for (String headerName : clientHeaders.keySet()) {
+                List<Object> header = clientHeaders.get(headerName);
+                final JsonArrayBuilder headerValues = Json.createArrayBuilder();
+                header.forEach(h -> headerValues.add(h.toString()));
+                allClientHeaders.add(headerName, headerValues);
+            }
+            clientRequestContext.abortWith(Response.ok(allClientHeaders.build()).build());
+        }
+    }
+
+    private static void checkHeaders(final JsonObject headers, final String clientHeaderParamName) {
+        final List<String> clientRequestHeaders = headerValues(headers, "InterfaceAndBuilderHeader");
+
+        assertTrue(clientRequestHeaders.contains("builder"),
+                "Header InterfaceAndBuilderHeader did not container \"builder\": " + clientRequestHeaders);
+        assertTrue(clientRequestHeaders.contains(clientHeaderParamName),
+                "Header InterfaceAndBuilderHeader did not container \"" + clientHeaderParamName + "\": "
+                        + clientRequestHeaders);
+
+        final List<String> headerParamHeaders = headerValues(headers, "HeaderParam");
+        assertTrue(headerParamHeaders.contains("headerparam"),
+                "Header HeaderParam did not container \"headerparam\": " + headerParamHeaders);
+    }
+
+    private static List<String> headerValues(final JsonObject headers, final String headerName) {
+        final JsonArray headerValues = headers.getJsonArray(headerName);
+        assertNotNull(headerValues,
+                String.format("Expected header '%s' to be present in %s", headerName, headers));
+        return headerValues.stream().map(
+                v -> (v.getValueType() == JsonValue.ValueType.STRING ? ((JsonString) v).getString() : v.toString()))
+                .collect(Collectors.toList());
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/DefaultClientHeadersRequestFilter.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/DefaultClientHeadersRequestFilter.java
@@ -1,0 +1,31 @@
+package io.quarkus.rest.client.reactive.runtime;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
+
+@Priority(Integer.MIN_VALUE + 10)
+public class DefaultClientHeadersRequestFilter implements ClientRequestFilter {
+    private final MultivaluedMap<String, Object> defaultHeaders;
+
+    public DefaultClientHeadersRequestFilter(final MultivaluedMap<String, Object> defaultHeaders) {
+        this.defaultHeaders = new CaseInsensitiveMap<>();
+        this.defaultHeaders.putAll(defaultHeaders);
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        this.defaultHeaders.forEach(new BiConsumer<String, List<Object>>() {
+            @Override
+            public void accept(final String name, final List<Object> values) {
+                requestContext.getHeaders().addAll(name, values);
+            }
+        });
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -41,6 +41,7 @@ import org.jboss.resteasy.reactive.client.spi.MultipartResponseData;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.util.MultivaluedTreeMap;
 
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
@@ -384,10 +385,10 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                 .onFailure(new Handler<>() {
                     @Override
                     public void handle(Throwable failure) {
-                        if (failure instanceof HttpClosedException) {
+                        if (failure instanceof HttpClosedException || failure instanceof DecoderException) {
                             // This is because of the Rest Client TCK
-                            // HttpClosedException is a runtime exception. If we complete with that exception, it gets
-                            // unwrapped by the rest client proxy and thus fails the TCK.
+                            // HttpClosedException / DecoderException are runtime exceptions. If we complete with that
+                            // exception, it gets unwrapped by the rest client proxy and thus fails the TCK.
                             // By creating an IOException, we avoid that and provide a meaningful exception (because
                             // it's an I/O exception)
                             requestContext.resume(new ProcessingException(new IOException(failure.getMessage())));

--- a/tcks/microprofile-rest-client-reactive/pom.xml
+++ b/tcks/microprofile-rest-client-reactive/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <wiremock.server.port>8766</wiremock.server.port>
-        <microprofile-rest-client-tck.version>3.0.1</microprofile-rest-client-tck.version>
+        <microprofile-rest-client-tck.version>4.0</microprofile-rest-client-tck.version>
         <!--
         Disabling the enforcer because of:
 
@@ -80,6 +80,9 @@
 
                         <!-- TODO fix this-->
                         <exclude>org.eclipse.microprofile.rest.client.tck.jsonb.InvokeWithJsonBProviderTest</exclude>
+
+                        <!-- Missing implementation - See org.jboss.resteasy.reactive.common.jaxrs.RuntimeDelegateImpl.createEntityPartBuilder -->
+                        <exclude>**/EntityPartTest</exclude>
 
                         <!-- These are flaky -->
                         <exclude>org.eclipse.microprofile.rest.client.tck.FollowRedirectsTest</exclude>

--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -14,7 +14,7 @@
     <name>Quarkus - TCK - MicroProfile REST Client</name>
 
     <properties>
-        <microprofile-rest-client-tck.version>3.0.1</microprofile-rest-client-tck.version>
+        <microprofile-rest-client-tck.version>4.0</microprofile-rest-client-tck.version>
         <!--
         Disabling the enforcer because of:
 


### PR DESCRIPTION
<summary>MicroProfile REST Client Release notes:</summary>
<br>
<blockquote>
    <h2>4.0</h2>
    <ul>
        <li>New overloaded `baseUri(String uri)` method so users don’t have to call URI.create()</li>
        <li>New `header(String name, Object value)` method for adding headers to Client instances</li>
        <li>Clarify specification CDI support (`@RestClient` qualifier is not optional)</li>
        <li>Add multi-part processing example to specification.</li>
        <li>Clarify the specification that when a client injected as a CDI bean falls out of scope, the client is closed</li>
    </ul>
</blockquote>

[MicroProfile Rest Client Spec PDF](https://download.eclipse.org/microprofile/microprofile-rest-client-4.0/microprofile-rest-client-spec-4.0.pdf)
[MicroProfile Rest Client Spec HTML](http://download.eclipse.org/microprofile/microprofile-rest-client-4.0/microprofile-rest-client-spec-4.0.html)
[MicroProfile Rest Client Spec Javadocs](http://download.eclipse.org/microprofile/microprofile-rest-client-4.0/apidocs/)