### PR TITLE
Set JDBC Oracle Extension as stable

### DIFF
--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,4 +9,4 @@ metadata:
   guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"
-  status: "preview"
+  status: "stable"


### PR DESCRIPTION
Since it's been in preview for some years already, I believe it's time to promote it to stable