### PR TITLE
Upgrade to Hibernate Commons Annotations 7.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <hibernate-orm.version>6.6.1.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.14.18</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-commons-annotations.version>7.0.1.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
+        <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>2.4.2.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <hibernate-search.version>7.2.1.Final</hibernate-search.version>


### PR DESCRIPTION
No change at runtime, as 7.0.3.Final is identical to 7.0.1.Final except for some build plugins.

This is mainly useful to allow rebuilding Quarkus and all its dependencies from source, as 7.0.1.Final has build-time dependencies on artifacts that were hosted on JCenter and are no longer available.

cc @tqvarnst