### PR TITLE
Fix AsciiDoc links syntax

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -463,12 +463,12 @@ customElements.define('qwc-arc-beans', QwcArcBeans);
 
 ===== Qomponent
 
-We also include all components from the [Qomponent](https://github.com/qomponent) library
+We also include all components from the https://github.com/qomponent[Qomponent] library
 
-- [Card](https://www.npmjs.com/package/@qomponent/qui-card)
-- [Badge](https://www.npmjs.com/package/@qomponent/qui-badge)
-- [Alert](https://www.npmjs.com/package/@qomponent/qui-alert)
-- [Code block](https://www.npmjs.com/package/@qomponent/qui-code-block)
+- https://www.npmjs.com/package/@qomponent/qui-card[Card]
+- https://www.npmjs.com/package/@qomponent/qui-badge[Badge]
+- https://www.npmjs.com/package/@qomponent/qui-alert[Alert]
+- https://www.npmjs.com/package/@qomponent/qui-code-block[Code block]
 
 ====== Card
 

--- a/docs/src/main/asciidoc/rest-migration.adoc
+++ b/docs/src/main/asciidoc/rest-migration.adoc
@@ -225,7 +225,7 @@ extension is used by a specific set of users / applications.
 When opting for supporting both extensions, the deployment module of the custom extension will usually depend on the SPI modules - `quarkus-jaxrs-spi-deployment`, `quarkus-resteasy-common-spi`, `quarkus-rest-spi-deployment`,
 while the runtime modules will have `optional` dependencies on the runtime modules of both RESTEasy flavors.
 
-A couple good examples of how Quarkus uses this strategy to support both RESTEasy flavors in the core repository can be seen [here](https://github.com/quarkusio/quarkus/pull/21089) and [here](https://github.com/quarkusio/quarkus/pull/20874).
+A couple good examples of how Quarkus uses this strategy to support both RESTEasy flavors in the core repository can be seen https://github.com/quarkusio/quarkus/pull/21089[here] and https://github.com/quarkusio/quarkus/pull/20874[here].
 
 In general, it should not be needed to have two different versions of the custom extension to support both flavors. Such a choice is only strictly necessary if it is desired for the extension consumers (i.e. Quarkus applications) to not have to select a RESTEasy version themselves.
 

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -635,7 +635,7 @@ public class CustomTenantPolicyConfigResolver implements TenantPolicyConfigResol
 
 == Configuration reference
 
-This configuration adheres to the official [Keycloak Policy Enforcer Configuration](https://www.keycloak.org/docs/latest/authorization_services/index.html#_enforcer_filter) guidelines.
+This configuration adheres to the official https://www.keycloak.org/docs/latest/authorization_services/index.html#_enforcer_filter[Keycloak Policy Enforcer Configuration] guidelines.
 For detailed insights into various configuration options, see the following documentation:
 
 include::{generated-dir}/config/quarkus-keycloak-authorization.adoc[opts=optional]


### PR DESCRIPTION
Change links from the Markdown syntax to the AsciiDoc syntax.