### PR TITLE
MultiStage Docker instructions needed `chmod ./mvnw`

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -579,7 +579,7 @@ Sample Dockerfile for building with Maven:
 ----
 ## Stage 1 : build with maven builder image with native capabilities
 FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
-COPY --chown=quarkus:quarkus mvnw /code/mvnw
+COPY --chown=quarkus:quarkus --chmod=0755 mvnw /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn
 COPY --chown=quarkus:quarkus pom.xml /code/
 USER quarkus


### PR DESCRIPTION
I used these instructions to deploy to Koyeb and it would fail saying `/bin.sh` could not run `mvnw` so I had to add

```shell
RUN chmod +x ./mvnw
```

And then it worked.  You can see my Koyeb deploy script here: https://github.com/melloware/quarkus-faces/blob/main/Dockerfile.koyeb