### PR TITLE
Add dev-mode setting for forcing the use of C2

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
@@ -68,6 +68,12 @@ public abstract class QuarkusDevModeLauncher {
         }
 
         @SuppressWarnings("unchecked")
+        public B forceC2(boolean force) {
+            forceC2 = force;
+            return (B) this;
+        }
+
+        @SuppressWarnings("unchecked")
         public B jvmArgs(String jvmArgs) {
             args.add(jvmArgs);
             return (B) this;
@@ -316,6 +322,7 @@ public abstract class QuarkusDevModeLauncher {
     private String targetJavaVersion;
     private Set<Path> buildFiles = new HashSet<>(0);
     private boolean deleteDevJar = true;
+    private boolean forceC2 = false;
     private String baseName;
     private Consumer<DevModeContext> entryPointCustomizer;
     private String applicationArgs;
@@ -335,7 +342,7 @@ public abstract class QuarkusDevModeLauncher {
     protected void prepare() throws Exception {
         JBossVersion.disableVersionLogging();
 
-        if (!JavaVersionUtil.isGraalvmJdk()) {
+        if (!JavaVersionUtil.isGraalvmJdk() && !forceC2) {
             // prevent C2 compiler for kicking in - makes startup a little faster
             // it only makes sense in dev-mode but it is not available when GraalVM is used as the JDK
             args.add("-XX:TieredStopAtLevel=1");

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -93,6 +93,7 @@ public abstract class QuarkusDev extends QuarkusTask {
     private final MapProperty<String, String> environmentVariables;
 
     private final Property<Boolean> preventNoVerify;
+    private final Property<Boolean> forceC2;
     private final Property<Boolean> shouldPropagateJavaCompilerArgs;
     private final ListProperty<String> args;
     private final ListProperty<String> jvmArgs;
@@ -127,6 +128,9 @@ public abstract class QuarkusDev extends QuarkusTask {
 
         preventNoVerify = objectFactory.property(Boolean.class);
         preventNoVerify.convention(false);
+
+        forceC2 = objectFactory.property(Boolean.class);
+        forceC2.convention(false);
 
         shouldPropagateJavaCompilerArgs = objectFactory.property(Boolean.class);
         shouldPropagateJavaCompilerArgs.convention(true);
@@ -220,6 +224,11 @@ public abstract class QuarkusDev extends QuarkusTask {
     @Internal
     public boolean isPreventnoverify() {
         return getPreventNoVerify().get();
+    }
+
+    @Input
+    public Property<Boolean> getForceC2() {
+        return forceC2;
     }
 
     /**
@@ -414,6 +423,7 @@ public abstract class QuarkusDev extends QuarkusTask {
         }
         GradleDevModeLauncher.Builder builder = GradleDevModeLauncher.builder(getLogger(), java)
                 .preventnoverify(getPreventNoVerify().getOrElse(false))
+                .forceC2(getForceC2().getOrElse(false))
                 .projectDir(projectDir)
                 .buildDir(buildDir)
                 .outputDir(buildDir)

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -297,6 +297,15 @@ public class DevMojo extends AbstractMojo {
     private boolean preventnoverify = false;
 
     /**
+     * This value is intended to be set to true when we want to require C2 compilation instead of preventing it from
+     * ever kicking in.
+     * Setting this will likely have a small negative effect on startup time and should only be done when it absolutely
+     * makes sense.
+     */
+    @Parameter(defaultValue = "${forceC2}")
+    private boolean forceC2 = false;
+
+    /**
      * Whether changes in the projects that appear to be dependencies of the project containing the application to be launched
      * should trigger hot-reload. By default, they do.
      */
@@ -1247,6 +1256,7 @@ public class DevMojo extends AbstractMojo {
 
         final MavenDevModeLauncher.Builder builder = MavenDevModeLauncher.builder(java, getLog())
                 .preventnoverify(preventnoverify)
+                .forceC2(forceC2)
                 .buildDir(buildDir)
                 .outputDir(outputDirectory)
                 .suspend(suspend)


### PR DESCRIPTION
This setting allows users to opt-in to C2 when it makes sense (for example when running LLM inference via Jlama or Llama3.java)