### PR TITLE
Add Brotli4J Native Dependencies to the BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -286,6 +286,51 @@
                 <artifactId>native-linux-x86_64</artifactId>
                 <version>${brotli4j.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-s390x</artifactId>
+                <version>${brotli4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-ppc64le</artifactId>
+                <version>${brotli4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-aarch64</artifactId>
+                <version>${brotli4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-armv7</artifactId>
+                <version>${brotli4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-riscv64</artifactId>
+                <version>${brotli4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-windows-x86_64</artifactId>
+                <version>${brotli4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-windows-aarch64</artifactId>
+                <version>${brotli4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-osx-x86_64</artifactId>
+                <version>${brotli4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-osx-aarch64</artifactId>
+                <version>${brotli4j.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>io.smallrye.certs</groupId>

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -1243,4 +1243,34 @@ public class MyCustomizer implements VertxOptionsCustomizer {
 
 The _customizer_ beans received the `VertxOptions` (coming from the application configuration), and can modify them.
 
+== Brotli4J and cross-platform support
 
+Brotli4J is a native library that provides support for the Brotli compression algorithm.
+By default, Quarkus includes the Brotli native library matching the platform you are running on.
+But sometimes, you need to include the native library for a different platform.
+
+In this case, you need to explicitly add a dependency to your project.
+For example, if you need to include the native library for `linux-aarch64`, you can add the following dependency:
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.aayushatharva.brotli4j</groupId>
+    <artifactId>native-linux-aarch64</artifactId>
+</dependency>
+----
+
+This will include the native library for `linux-aarch64` in your project, in addition to the one matching your machine.
+
+Here is the list of available brotli4j artifacts for the different platforms:
+
+* `native-linux-x86_64`
+* `native-linux-s390x`
+* `native-linux-ppc64le`
+* `native-linux-aarch64`
+* `native-linux-armv7`
+* `native-linux-riscv64`
+* `native-windows-x86_64`
+* `native-windows-aarch64`
+* `native-macos-x86_64`
+* `native-macos-aarch64`


### PR DESCRIPTION
Quarkus automatically includes the Brotli native dependency corresponding to the platform on which the application is built. However, this approach doesn’t work when the application needs to support multiple platforms. In such cases, users must manually include the appropriate dependencies.

This PR adds Brotli4J native dependencies to the BOM and updates the documentation to guide users on which dependencies to add for various platforms.
