### PR TITLE
Check expiry of the cached OIDC token introspections

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
@@ -2,12 +2,15 @@ package io.quarkus.oidc.runtime;
 
 import jakarta.enterprise.event.Observes;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.oidc.TokenIntrospectionCache;
 import io.quarkus.oidc.UserInfo;
 import io.quarkus.oidc.UserInfoCache;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.runtime.ShutdownEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
@@ -23,6 +26,7 @@ import io.vertx.core.Vertx;
  * which has been introspected which will be used to request UserInfo.
  */
 public class DefaultTokenIntrospectionUserInfoCache implements TokenIntrospectionCache, UserInfoCache {
+    private static final Logger LOG = Logger.getLogger(DefaultTokenIntrospectionUserInfoCache.class);
     private static final Uni<TokenIntrospection> NULL_INTROSPECTION_UNI = Uni.createFrom().nullItem();
     private static final Uni<UserInfo> NULL_USERINFO_UNI = Uni.createFrom().nullItem();
 
@@ -50,7 +54,22 @@ public class DefaultTokenIntrospectionUserInfoCache implements TokenIntrospectio
     public Uni<TokenIntrospection> getIntrospection(String token, OidcTenantConfig oidcConfig,
             OidcRequestContext<TokenIntrospection> requestContext) {
         CacheEntry entry = cache.get(token);
-        return entry == null ? NULL_INTROSPECTION_UNI : Uni.createFrom().item(entry.introspection);
+        if (entry == null || entry.introspection == null) {
+            return NULL_INTROSPECTION_UNI;
+        }
+        if (isTokenExpired(entry.introspection.getLong(OidcConstants.INTROSPECTION_TOKEN_EXP), oidcConfig)) {
+            LOG.debug("Introspected token has expired, removing it from the token introspection cache");
+            cache.remove(token);
+            return NULL_INTROSPECTION_UNI;
+        }
+
+        return Uni.createFrom().item(entry.introspection);
+    }
+
+    private static boolean isTokenExpired(Long exp, OidcTenantConfig oidcConfig) {
+        final long lifespanGrace = oidcConfig != null ? oidcConfig.token.lifespanGrace.orElse(0) : 0;
+        return exp != null
+                && System.currentTimeMillis() / 1000 > (exp + lifespanGrace);
     }
 
     @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/MemoryCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/MemoryCache.java
@@ -26,7 +26,7 @@ public class MemoryCache<T> {
     }
 
     private void init(Vertx vertx, Optional<Duration> cleanUpTimerInterval) {
-        if (cleanUpTimerInterval.isPresent()) {
+        if (vertx != null && cleanUpTimerInterval.isPresent()) {
             timerId = vertx.setPeriodic(cleanUpTimerInterval.get().toMillis(), new Handler<Long>() {
                 @Override
                 public void handle(Long event) {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TokenIntrospectionCacheTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TokenIntrospectionCacheTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.oidc.runtime;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.TokenIntrospection;
+import io.quarkus.oidc.TokenIntrospectionCache;
+
+public class TokenIntrospectionCacheTest {
+    TokenIntrospectionCache cache = new DefaultTokenIntrospectionUserInfoCache(createOidcConfig(), null);
+
+    @Test
+    public void testExpiredIntrospection() {
+
+        TokenIntrospection introspectionValidFor10secs = new TokenIntrospection(
+                "{\"active\": true,"
+                        + "\"exp\":" + (System.currentTimeMillis() / 1000 + 10) + "}");
+        TokenIntrospection introspectionValidFor3secs = new TokenIntrospection(
+                "{\"active\": true,"
+                        + "\"exp\":" + (System.currentTimeMillis() / 1000 + 3) + "}");
+        cache.addIntrospection("tokenValidFor10secs", introspectionValidFor10secs, null, null);
+        cache.addIntrospection("tokenValidFor3secs", introspectionValidFor3secs, null, null);
+
+        assertNotNull(cache.getIntrospection("tokenValidFor10secs", null, null).await().indefinitely());
+        assertNotNull(cache.getIntrospection("tokenValidFor3secs", null, null).await().indefinitely());
+
+        await().atMost(Duration.ofSeconds(5)).pollInterval(1, TimeUnit.SECONDS)
+                .until(new Callable<Boolean>() {
+
+                    @Override
+                    public Boolean call() throws Exception {
+                        return cache.getIntrospection("tokenValidFor3secs", null, null).await().indefinitely() == null;
+                    }
+
+                });
+
+        assertNotNull(cache.getIntrospection("tokenValidFor10secs", null, null).await().indefinitely());
+        assertNull(cache.getIntrospection("tokenValidFor3secs", null, null).await().indefinitely());
+    }
+
+    private static OidcConfig createOidcConfig() {
+        OidcConfig cfg = new OidcConfig();
+        cfg.tokenCache.maxSize = 2;
+        return cfg;
+    }
+}


### PR DESCRIPTION
When the opaque token is introspected remotely, its expiry time is checked and then it can be optionally saved in the token introspection cache. If it goes to the cache then its validity period becomes equal to the cache entry time to live.

This PR checks the token introspection expiry time even when it is cached, and removes it from the cache eagerly if the introspection has expired.

Right now this is only done at the default token introspection cache level, custom ones should be managing expired token introspections themselves. 
I've tried to make this PR work even for custom token introspection caches to make it easier for custom caches, but the PR becomes more involved and may not be backportable, as a new TokenIntospectionCache.remove method is required so I'll deal with it later.

Added a test to confirm that when the token introspection has expired, with the cache entry time to live beng significantly larger (tokens are valid for 10 or 3 secs, the cache entry for 3 mins), then the token introspection which is valid for 3 secs will be removed after 5 secs.