### PR TITLE
Avoid double wrapping of RuntimeExceptions in QuarkusUnitTest

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -732,6 +732,8 @@ public class QuarkusUnitTest
                     throw e;
                 }
             }
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Noticed while working on https://github.com/quarkusio/quarkus/issues/43926#issuecomment-2426893248