### PR TITLE
Add RESTEasy Class Multipart capability

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -68,6 +68,8 @@ public interface Capability {
     String RESTEASY_REACTIVE_JSON_JACKSON = RESTEASY_REACTIVE_JSON + ".jackson";
     String RESTEASY_REACTIVE_JSON_JSONB = RESTEASY_REACTIVE_JSON + ".jsonb";
 
+    String RESTEASY_MULTIPART = RESTEASY + ".multipart";
+
     String JWT = QUARKUS_PREFIX + ".jwt";
 
     /**

--- a/extensions/resteasy-classic/resteasy-multipart/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-multipart/runtime/pom.xml
@@ -59,6 +59,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.resteasy.multipart</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Actually on https://github.com/quarkiverse/quarkus-openapi-generator we need to verify if the capability `RESTEasy Classic Multipart` exists.