### PR TITLE
Add Native Image Native Memory Tracking (NMT) option and update docs

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -315,6 +315,7 @@ public interface NativeConfig {
      * <li><code>heapdump</code> for heampdump support</li>
      * <li><code>jmxclient</code> for JMX client support (experimental)</li>
      * <li><code>jmxserver</code> for JMX server support (experimental)</li>
+     * <li><code>nmt</code> for native memory tracking support</li>
      * <li><code>all</code> for all monitoring features</li>
      * </ul>
      */
@@ -552,6 +553,7 @@ public interface NativeConfig {
         JFR,
         JMXSERVER,
         JMXCLIENT,
+        NMT,
         ALL
     }
 

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -896,7 +896,7 @@ For a more detailed guide about debugging native images please refer to the xref
 
 == Using Monitoring Options
 
-Monitoring options such as JDK flight recorder, jvmstat, heap dumps, and remote JMX (experimental in Mandrel 23)
+Monitoring options such as JDK flight recorder, jvmstat, heap dumps, NMT (starting with Mandrel 24.1 for JDK 23), and remote JMX 
 can be added to the native executable build. Simply supply a comma separated list of the monitoring options you wish to
 include at build time.
 [source,bash]
@@ -926,6 +926,10 @@ include at build time.
 |jmxserver
 |Adds support for accepting connections from JMX clients.
 |GraalVM for JDK 17/20 Mandrel 23.0 (17.0.7)
+
+|nmt
+|Adds support for native memory tracking.
+|GraalVM for JDK 23 Mandrel 24.1
 
 |all
 |Adds all monitoring options.

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -2447,6 +2447,13 @@ The following table outlines Native Image JFR support and limitations by version
 * Event streaming
 |* No old object sampling
 
+|GraalVM CE for JDK 23 and Mandrel 24.1
+|* Everything from GraalVM CE for JDK 17/20 and Mandrel 23.0
+* Additional events
+* Always on allocation profiling (event throttling)
+* Partial support for old object sampling (no tracking paths to GC roots)
+* Support for `-XX:FlightRecorderOptions`
+| * Old object sampling is missing path to GC root support
 |===
 
 


### PR DESCRIPTION
### Summary
This is a small PR to update the monitoring options to include the new native memory tracking support in Native Image. It's another monitoring option similar to JFR or JMX. I've also done a small corresponding update to the documentation as well.  
Users will then be able to include the feature at build time with:  `-Dquarkus.native.monitoring=nmt`

In addition, I updated the JFR docs with a section on the new functionality in GraalVM for JDK 23.

See here for more info: https://www.graalvm.org/latest/reference-manual/native-image/debugging-and-diagnostics/NMT/