### PR TITLE
Fix flaky test due to nondeterministic serialization order

### DIFF
--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -30,7 +31,8 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
     }
 
     @Override
-    public void process(Path targetDirectory, String relativePath, List<TargetFile> codestartFiles, Map<String, Object> data)
+    public void process(Path targetDirectory, String relativePath, List<TargetFile> codestartFiles,
+            Map<String, Object> data)
             throws IOException {
         checkNotEmptyCodestartFiles(codestartFiles);
 
@@ -63,7 +65,8 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
 
     private void writePropertiesConfig(Path targetPath, Map<String, Object> config) throws IOException {
         final StringBuilder builder = new StringBuilder();
-        final HashMap<String, String> flat = new HashMap<>();
+        // Enforce properties are in consistent order.
+        final TreeMap<String, String> flat = new TreeMap<>();
         flatten("", flat, config);
         for (Map.Entry<String, String> entry : flat.entrySet()) {
             final String key = entry.getKey().replaceAll("\\.~$", "");

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_main_resources_application.properties
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_main_resources_application.properties
@@ -1,2 +1,2 @@
-mp.messaging.outgoing.words-out.address=words
 mp.messaging.incoming.words-in.address=words
+mp.messaging.outgoing.words-out.address=words

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_main_resources_application.properties
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_main_resources_application.properties
@@ -1,3 +1,3 @@
+mp.messaging.incoming.words-in.auto.offset.reset=earliest
 mp.messaging.incoming.words-in.topic=words
 mp.messaging.outgoing.words-out.topic=words
-mp.messaging.incoming.words-in.auto.offset.reset=earliest


### PR DESCRIPTION
In `independent-projects/tools/codestarts`, I've observed flaky tests at [`CodestartProjectGenerationTest#checkDefaultProject`](https://github.com/quarkusio/quarkus/blob/558857764e4ea9657082b879b8efa4e2bf56e616/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/CodestartProjectGenerationTest.java#L65). Specifically, assertions like the following will fail:
```java
assertThat(targetDirectory.resolve("config.properties")).hasContent("foo.bar=baz\nfoo.foo=bar\n");
```
Why? Here's `config.properties` after an unsuccessful test run:
```
foo.foo=bar
foo.bar=baz
```
The issue is that the config data is not being serialized in a deterministic/sorted order, which the test relies upon.

**How to reproduce this issue?** I found this via the use of [NonDex](https://github.com/TestingResearchIllinois/NonDex), which internally swaps out implementations of Java builtins, notably in this case, `HashMap`, to make finding flaky tests easier. You can reproduce this issue via the following maven command:

```
./mvnw edu.illinois:nondex-maven-plugin:2.1.7:nondex -f independent-projects/tools/codestarts -Dtest=io.quarkus.devtools.codestarts.CodestartProjectGenerationTest#checkDefaultProject -DnondexSeed=933178 -DnondexRuns=10
```

The test relies upon HashMap iteration order, which is something we cannot rely upon. (technically, most standard HashMap implementations retain iteration order if unmodified between two iterations, but that is not the case here.)

**Proposed Fix**:
Simply swapping out the configuration data into a `TreeMap` such that the `config.properties` objects are in a sorted order will work. This change also makes logical sense, as flattened map key-values should be next to each other in the file, e.g.:

```
// Don't want this interleaved scenario
foo.bar=qux
foo.baz=quux
foo.bar=baz
foo.baz=bar
```

Happy to iterate on this if it's not acceptable in the current form.