### PR TITLE
Avoiding forcing resolution when configuring QuarkusApplicationModelTask

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -519,14 +519,12 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getProjectDescriptor().set(projectDescriptor);
         task.getLaunchMode().set(launchMode);
         task.getOriginalClasspath().setFrom(classpath.getOriginalRuntimeClasspathAsInput());
-        task.getAppClasspath().configureFrom(classpath.getRuntimeConfiguration());
+        task.getAppClasspath().configureFrom(classpath.getRuntimeConfigurationWithoutResolvingDeployment());
         task.getPlatformConfiguration().configureFrom(classpath.getPlatformConfiguration());
         task.getDeploymentClasspath().configureFrom(classpath.getDeploymentConfiguration());
-        task.getPlatformImportProperties().set(classpath.getPlatformImports().getPlatformProperties());
-        task.getApplicationModel().set(
-                project.getLayout().getBuildDirectory()
-                        .file(quarkusModelFile));
-
+        task.getDeploymentResolvedWorkaround().from(classpath.getDeploymentConfiguration().getIncoming().getFiles());
+        task.getPlatformImportProperties().set(classpath.getPlatformImportsWithoutResolvingPlatform().getPlatformProperties());
+        task.getApplicationModel().set(project.getLayout().getBuildDirectory().file(quarkusModelFile));
     }
 
     private static void configureQuarkusBuildTask(Project project, QuarkusPluginExtension quarkusExt, QuarkusBuildTask task,

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -48,6 +48,7 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
@@ -106,6 +107,9 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
      */
     @CompileClasspath
     public abstract ConfigurableFileCollection getOriginalClasspath();
+
+    @InputFiles
+    public abstract ConfigurableFileCollection getDeploymentResolvedWorkaround();
 
     @Nested
     public abstract QuarkusResolvedClasspath getPlatformConfiguration();

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -288,6 +288,10 @@ public class ApplicationDeploymentClasspathBuilder {
         return project.getConfigurations().getByName(this.runtimeConfigurationName);
     }
 
+    public Configuration getRuntimeConfigurationWithoutResolvingDeployment() {
+        return project.getConfigurations().getByName(this.runtimeConfigurationName);
+    }
+
     public Configuration getDeploymentConfiguration() {
         return project.getConfigurations().getByName(this.deploymentConfigurationName);
     }
@@ -305,6 +309,10 @@ public class ApplicationDeploymentClasspathBuilder {
      */
     public PlatformImports getPlatformImports() {
         this.getPlatformConfiguration().getResolvedConfiguration();
+        return platformImports.get(this.platformImportName);
+    }
+
+    public PlatformImports getPlatformImportsWithoutResolvingPlatform() {
         return platformImports.get(this.platformImportName);
     }
 

--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    java
+    id("io.quarkus")
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+
+dependencies {
+    implementation("io.quarkus:quarkus-rest")
+    implementation("io.quarkus:quarkus-arc")
+    implementation(enforcedPlatform(project(":lib")))
+    testImplementation("io.quarkus:quarkus-junit5")
+    testImplementation("io.rest-assured:rest-assured")
+}
+
+group = "org.acme"
+version = "1.0.0-SNAPSHOT"
+
+tasks.withType<Test> {
+    systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+}
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+    options.compilerArgs.add("-parameters")
+}
+
+tasks.all{}

--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 dependencies {
     implementation("io.quarkus:quarkus-rest")
     implementation("io.quarkus:quarkus-arc")
-    implementation(enforcedPlatform(project(":lib")))
+    implementation(enforcedPlatform(project(":library")))
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.rest-assured:rest-assured")
 }

--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/gradle.properties
@@ -1,0 +1,3 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus
+kotlinVersion=${kotlin.version}

--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/library/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/library/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `java-platform`
+}
+
+val quarkusPlatformGroupId: String by project
+val quarkusPlatformArtifactId: String by project
+val quarkusPlatformVersion: String by project
+
+javaPlatform.allowDependencies()
+dependencies{
+    api(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
+    constraints{
+        api("org.assertj:assertj-core:3.26.3")
+    }
+}

--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/settings.gradle
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+        id 'org.jetbrains.kotlin.jvm' version "${kotlinVersion}"
+        id 'org.jetbrains.kotlin.plugin.allopen' version "${kotlinVersion}"
+    }
+}
+rootProject.name='java-platform-with-eager-resolution-project'
+include(":lib")

--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/settings.gradle
@@ -16,4 +16,4 @@ pluginManagement {
     }
 }
 rootProject.name='java-platform-with-eager-resolution-project'
-include(":lib")
+include(":library")

--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/src/main/java/org/acme/GreetingResource.java
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/src/main/java/org/acme/GreetingResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from Quarkus REST";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/src/native-test/java/org/acme/GreetingResourceIT.java
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/src/native-test/java/org/acme/GreetingResourceIT.java
@@ -1,0 +1,8 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class GreetingResourceIT extends GreetingResourceTest {
+    // Execute the same tests but in packaged mode.
+}

--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/src/test/java/org/acme/GreetingResourceTest.java
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/src/test/java/org/acme/GreetingResourceTest.java
@@ -1,0 +1,20 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+class GreetingResourceTest {
+    @Test
+    void testHelloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("Hello from Quarkus REST"));
+    }
+
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/JavaPlatformWithEagerResolutionTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/JavaPlatformWithEagerResolutionTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class JavaPlatformWithEagerResolutionTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void shouldImportConditionalDependency() throws IOException, URISyntaxException, InterruptedException {
+
+        final File projectDir = getProjectDir("java-platform-with-eager-resolution-project");
+
+        runGradleWrapper(projectDir, "clean", ":quarkusBuild");
+
+        final File buildDir = new File(projectDir, "build");
+
+        final Path quarkusOutput = buildDir.toPath().resolve("quarkus-app");
+        assertThat(quarkusOutput.resolve("quarkus-run.jar")).exists();
+    }
+}


### PR DESCRIPTION
Issue #43258 describes a problem where a build using a Java platform module and an eager configuration call produces the following error:
```
Failed to apply plugin 'org.gradle.java-platform'.
> Project#afterEvaluate(Action) on project ':lib' cannot be executed in the current context.
```
The eager `tasks.all` will immediately create and configure any registered task. During the configuration of `QuarkusApplicationModelTask` is required to resolve various configurations, which happens within the lazy action of a task's register configure block, triggering the Quarkus resolution chain(Runtime Configuration → Forced Deployment Resolution → Conditional Helper). Resolving the configuration causes Gradle to configure the lib project, which applies the java-platform plugin. Applying this plugin triggers an afterEvaluate block—a lazy action—resulting in Gradle's restriction that you cannot perform a lazy action within another lazy action.
We were able to reproduce this behavior in Gradle without applying the Quarkus Plugin: https://github.com/cdsap/JavaPlatformIssue 

This PR proposes a fix that avoids forcing the resolution in ApplicationDeploymentClasspathBuilder for:
```
public Configuration getRuntimeConfiguration() {
    this.getDeploymentConfiguration().resolve();
    return project.getConfigurations().getByName(this.runtimeConfigurationName);
}
```
For the QuarkusApplicationModelTask, we set the required configurations using a new method that removes the forced resolution:
```
public Configuration getRuntimeConfigurationWithoutResolvingDeployment() {
    return project.getConfigurations().getByName(this.runtimeConfigurationName);
}
```
This fix addresses the Java platform issue, but as a side effect, it broke conditional dependencies, as we are no longer resolving the configuration, and the Quarkus deployment configuration is not informed about those conditional dependencies. This issue was identified during test executions.

To resolve this, we've created a new input for the model task that uses:
```
classpath.getDeploymentConfiguration().getIncoming().getFiles()
```
This allows us to retrieve the FileCollection from the incoming dependencies of the Quarkus deployment configuration without resolving the dependencies immediately.

This PR also adds a new integration test covering the use case of the original issue.

@aloubyansky @gnodet do you have in mind additional eager resolution edge cases I could add to the tests? 