### PR TITLE
Add JsonPropertyOrder annotations to prevent order-dependent test failures

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/CategoryImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/CategoryImpl.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.quarkus.registry.json.JsonBuilder;
 
@@ -20,6 +21,7 @@ import io.quarkus.registry.json.JsonBuilder;
  * @see JsonBuilder.JsonBuilderSerializer for building a builder before serializing it.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "id", "name", "description", "metadata" })
 public class CategoryImpl implements Category {
 
     private final String id;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/ExtensionImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/ExtensionImpl.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -32,6 +33,7 @@ import io.quarkus.registry.json.JsonBuilder;
  * @see JsonBuilder.JsonBuilderSerializer for building a builder before serializing it.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "name", "description", "metadata", "artifact", "origins" })
 public class ExtensionImpl implements Extension {
     private final String name;
     private final String description;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformCatalogImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformCatalogImpl.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -28,6 +29,7 @@ import io.quarkus.registry.json.JsonEntityWithAnySupport;
  * @see JsonBuilder.JsonBuilderSerializer for building a builder before serializing it.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "platforms", "metadata" })
 public class PlatformCatalogImpl extends JsonEntityWithAnySupport implements PlatformCatalog {
 
     private final Map<String, Platform> platforms;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformImpl.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -24,6 +25,7 @@ import io.quarkus.registry.json.JsonEntityWithAnySupport;
  * @see JsonBuilder.JsonBuilderSerializer for building a builder before serializing it.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "platformKey", "name", "streams", "metadata" })
 public class PlatformImpl extends JsonEntityWithAnySupport implements Platform {
 
     private final String platformKey;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformReleaseImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformReleaseImpl.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import io.quarkus.maven.dependency.ArtifactCoords;
@@ -23,6 +24,7 @@ import io.quarkus.registry.json.JsonEntityWithAnySupport;
  * @see JsonBuilder.JsonBuilderSerializer for building a builder before serializing it.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "version", "memberBoms", "quarkusCoreVersion", "upstreamQuarkusCoreVersion", "metadata" })
 public class PlatformReleaseImpl extends JsonEntityWithAnySupport implements PlatformRelease {
     private final PlatformReleaseVersion version;
     private final Collection<ArtifactCoords> memberBoms;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformStreamImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformStreamImpl.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.quarkus.registry.json.JsonBuilder;
@@ -23,6 +24,7 @@ import io.quarkus.registry.json.JsonEntityWithAnySupport;
  * @see JsonBuilder.JsonBuilderSerializer for building a builder before serializing it.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "id", "name", "releases", "metadata" })
 public class PlatformStreamImpl extends JsonEntityWithAnySupport implements PlatformStream {
     private final String id;
     private final String name;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryArtifactConfigImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryArtifactConfigImpl.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.json.JsonBuilder;
@@ -18,6 +19,7 @@ import io.quarkus.registry.json.JsonBuilder;
  * @see JsonBuilder.JsonBuilderSerializer for building a builder before serializing it.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "disabled", "artifact" })
 public class RegistryArtifactConfigImpl implements RegistryArtifactConfig {
 
     protected final boolean disabled;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryMavenRepoConfigImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryMavenRepoConfigImpl.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.quarkus.registry.json.JsonBuilder;
 
@@ -17,6 +18,7 @@ import io.quarkus.registry.json.JsonBuilder;
  * @see JsonBuilder.JsonBuilderSerializer for building a builder before serializing it.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "id", "url" })
 public class RegistryMavenRepoConfigImpl implements RegistryMavenRepoConfig {
 
     private final String id;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryQuarkusVersionsConfigImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryQuarkusVersionsConfigImpl.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.quarkus.registry.json.JsonBuilder;
 
@@ -19,6 +20,7 @@ import io.quarkus.registry.json.JsonBuilder;
  * @see JsonBuilder.JsonBuilderSerializer for building a builder before serializing it.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({ "recognizedVersionsExpression", "recognizedGroupIds", "exclusiveProvider" })
 public class RegistryQuarkusVersionsConfigImpl implements RegistryQuarkusVersionsConfig {
 
     private final String recognizedVersionsExpression;


### PR DESCRIPTION
`independent-projects/tools/registry-client` has many tests that compare serialization via a reference JSON or YAML file. JSON and YAML are inherently unordered, and thus, `jackson` needs to be explicitly told when we expect a certain property serialization order.

This is most likely to cause test failures if quarkus is compiled and tested with different JVM/JDK distributions running on different architectures, so is a preemptive measure. The tests can be shown to be flaky via [NonDex](https://github.com/TestingResearchIllinois/NonDex) and the following command:

```bash
# Should pass:
./mvnw test -f independent-projects/tools/registry-client -DnondexRuns=10
# Should fail before this PR, pass after this PR:
./mvnw edu.illinois:nondex-maven-plugin:2.1.7:nondex -f independent-projects/tools/registry-client -DnondexRuns=10
```

**Solution:** Simply annotating relevant objects with `@JsonPropertyOrder` ([doc](https://fasterxml.github.io/jackson-annotations/javadoc/2.8/com/fasterxml/jackson/annotation/JsonPropertyOrder.html))

Happy to iterate on this -- in theory the tests themselves could be modified to perform order-independent JSON/YAML equality.