### PR TITLE
Docs typo fix - use proper SmallRye, RESTEasy and PostgreSQL names

### DIFF
--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -158,7 +158,7 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.devservices.volumes."/local/test/data"=/var/lib/postgresql/data
 ----
 
-The appropriate in-container location varies depending on the database vendor. For PostgresSQL is "/var/lib/postgresql/data", but for MySQL, you would need this configuration instead:
+The appropriate in-container location varies depending on the database vendor. For PostgreSQL is "/var/lib/postgresql/data", but for MySQL, you would need this configuration instead:
 
 [source,properties]
 ----

--- a/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
@@ -165,7 +165,7 @@ It uses Cloud Build to build your Docker image and deploy it to Google Container
 When done, the output will display the URL of your application (target url), you can use it with curl or directly open it in your browser using `gcloud app browse`.
 
 NOTE: App Engine Flexible custom runtimes support link:https://cloud.google.com/appengine/docs/flexible/reference/app-yaml?tab=java#updated_health_checks[health checks],
-it is strongly advised to provide them thanks to Quarkus xref:smallrye-health.adoc[Smallrye Health] support.
+it is strongly advised to provide them thanks to Quarkus xref:smallrye-health.adoc[SmallRye Health] support.
 
 == Deploying to Google Cloud Run
 
@@ -221,7 +221,7 @@ After you answer to these questions, it will deploy your application.
 When the deployment is done, the output will display the URL to access your application.
 
 NOTE: Cloud Run supports link:https://cloud.google.com/run/docs/configuring/healthchecks[health checks],
-it is strongly advised to provide them thanks to Quarkus xref:smallrye-health.adoc[Smallrye Health] support.
+it is strongly advised to provide them thanks to Quarkus xref:smallrye-health.adoc[SmallRye Health] support.
 
 == Using Cloud SQL
 

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -627,7 +627,7 @@ quarkus.kubernetes.config-map-volumes.my-volume.config-map-name=my-config-map
 
 ==== Passing application configuration
 
-Quarkus supports passing configuration from external locations (via Smallrye Config). This usually requires setting an additional environment variable or system property.
+Quarkus supports passing configuration from external locations (via SmallRye Config). This usually requires setting an additional environment variable or system property.
 When you need to use a secret or a config map for the purpose of application configuration, you need to:
 
 - define a volume

--- a/docs/src/main/asciidoc/flyway.adoc
+++ b/docs/src/main/asciidoc/flyway.adoc
@@ -63,7 +63,7 @@ In your build file, add the following dependencies:
     <artifactId>flyway-database-oracle</artifactId>
 </dependency>
 
-<!-- Flyway Postgres specific dependencies -->
+<!-- Flyway PostgreSQL specific dependencies -->
 <dependency>
     <groupId>org.flywaydb</groupId>
     <artifactId>flyway-database-postgresql</artifactId>
@@ -156,7 +156,7 @@ implementation("org.flywaydb:flyway-sqlserver")
 implementation("org.flywaydb:flyway-mysql")
 // Flyway Oracle specific dependencies
 implementation("org.flywaydb:flyway-database-oracle")
-// Flyway Postgres specific dependencies
+// Flyway PostgreSQL specific dependencies
 implementation("org.flywaydb:flyway-database-postgresql")
 // Flyway DB2 specific dependencies
 implementation("org.flywaydb:flyway-database-db2")

--- a/docs/src/main/asciidoc/grpc-kubernetes.adoc
+++ b/docs/src/main/asciidoc/grpc-kubernetes.adoc
@@ -65,7 +65,7 @@ You can find more information about how to deploy the application in Kubernetes 
 
 == Using gRPC Health probes
 
-By default, the Kubernetes resources do not contain readiness and liveness probes. To add them, import the Smallrye Health extension to your build file:
+By default, the Kubernetes resources do not contain readiness and liveness probes. To add them, import the SmallRye Health extension to your build file:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -65,9 +65,9 @@ implementation("io.quarkus:quarkus-messaging-kafka")
 The extension includes `kafka-clients` version 3.2.1 as a transitive dependency and is compatible with Kafka brokers version 2.x.
 ====
 
-== Configuring Smallrye Kafka Connector
+== Configuring SmallRye Kafka Connector
 
-Because Smallrye Reactive Messaging framework supports different messaging backends like Apache Kafka, AMQP, Apache Camel, JMS, MQTT, etc., it employs a generic vocabulary:
+Because SmallRye Reactive Messaging framework supports different messaging backends like Apache Kafka, AMQP, Apache Camel, JMS, MQTT, etc., it employs a generic vocabulary:
 
 - Applications send and receive *messages*. A message wraps a _payload_ and can be extended with some _metadata_. With the Kafka connector, a _message_ corresponds to a Kafka _record_.
 - Messages transit on *channels*. Application components connect to channels to publish and consume messages. The Kafka connector maps _channels_ to Kafka _topics_.
@@ -381,7 +381,7 @@ If high throughput is important for you, and you are not limited by the downstre
 - or set `enable.auto.commit` to true and annotate the consuming method with `@Acknowledgment(Acknowledgment.Strategy.NONE)`.
 ====
 
-Smallrye Reactive Messaging enables implementing custom commit strategies.
+SmallRye Reactive Messaging enables implementing custom commit strategies.
 See https://smallrye.io/smallrye-reactive-messaging/latest/kafka/receiving-kafka-records/#acknowledgement[SmallRye Reactive Messaging documentation] for more information.
 
 [[error-handling]]
@@ -409,7 +409,7 @@ The record written on the dead letter queue contains a set of additional headers
 - *dead-letter-partition*: the original partition of the record (integer mapped to String)
 - *dead-letter-offset*: the original offset of the record (long mapped to String)
 
-Smallrye Reactive Messaging enables implementing custom failure strategies.
+SmallRye Reactive Messaging enables implementing custom failure strategies.
 See https://smallrye.io/smallrye-reactive-messaging/latest/kafka/receiving-kafka-records/#acknowledgement[SmallRye Reactive Messaging documentation] for more information.
 
 ==== Retrying processing
@@ -537,7 +537,7 @@ Therefore, it is important to think about how records are partitioned inside a t
 The default partitioner uses record key hash to compute the partition for a record, or when the key is not defined, chooses a partition randomly per batch or records.
 
 During normal operation, a Kafka consumer preserves the order of records inside each partition assigned to it.
-Smallrye Reactive Messaging keeps this order for processing, unless `@Blocking(ordered = false)` is used (see <<blocking-processing>>).
+SmallRye Reactive Messaging keeps this order for processing, unless `@Blocking(ordered = false)` is used (see <<blocking-processing>>).
 
 Note that due to consumer rebalances, Kafka consumers only guarantee at-least-once processing of single records, meaning that uncommitted records _can_ be processed again by consumers.
 ====
@@ -761,7 +761,7 @@ You can configure batch mode explicitly with `mp.messaging.incoming.$channel.bat
 The `checkpoint` commit strategy is an experimental feature and can change in the future.
 ====
 
-Smallrye Reactive Messaging `checkpoint` commit strategy allows consumer applications to process messages in a stateful manner, while also respecting Kafka consumer scalability.
+SmallRye Reactive Messaging `checkpoint` commit strategy allows consumer applications to process messages in a stateful manner, while also respecting Kafka consumer scalability.
 An incoming channel with `checkpoint` commit strategy persists consumer offsets on an external
 <<state-stores,state store>>, such as a relational database or a key-value store.
 As a result of processing consumed records, the consumer application can accumulate an internal state for each topic-partition assigned to the Kafka consumer.
@@ -1469,7 +1469,7 @@ which it expects to be sent back in the reply record.
 The replier can be implemented using a Reactive Messaging processor (see <<processing-messages>>).
 
 For more information on Kafka Request Reply feature and advanced configuration options,
-see the https://smallrye.io/smallrye-reactive-messaging/latest/kafka/request-reply/[Smallrye Reactive Messaging Documentation].
+see the https://smallrye.io/smallrye-reactive-messaging/latest/kafka/request-reply/[SmallRye Reactive Messaging Documentation].
 
 [[processing-messages]]
 == Processing Messages
@@ -3092,7 +3092,7 @@ perform database updates and commit the Kafka transaction only if the database t
 The following example demonstrates:
 
 * Receive a payload by serving HTTP requests using Quarkus REST,
-* Limit concurrency of that HTTP endpoint using Smallrye Fault Tolerance,
+* Limit concurrency of that HTTP endpoint using SmallRye Fault Tolerance,
 * Start a Kafka transaction and send the payload to Kafka record,
 * Store the payload in the database using Hibernate Reactive with Panache,
 * Commit the Kafka transaction only if the entity is persisted successfully.

--- a/docs/src/main/asciidoc/messaging.adoc
+++ b/docs/src/main/asciidoc/messaging.adoc
@@ -41,7 +41,7 @@ Some of these extensions are maintained in the core Quarkus repository:
 
 Some extensions are contributed and maintained by the community:
 
-* link:{camel-smallrye-reactive-messaging}[Camel Smallrye Reactive Messaging]
+* link:{camel-smallrye-reactive-messaging}[Camel SmallRye Reactive Messaging]
 * link:{nats-jetstream}[Nats Jetstream Connector]
 * link:{solace-quarkus}[Solace Messaging Connector]
 * link:{http-websocket-connector}[Reactive HTTP and WebSocket Connector]
@@ -562,7 +562,7 @@ This is the case, for example, for Kafka, where multiple consumers can consume d
 
 == Health Checks
 
-Together with the Smallrye Health extension, Quarkus Messaging extensions provide health check support per channel.
+Together with the SmallRye Health extension, Quarkus Messaging extensions provide health check support per channel.
 The implementation of _startup_, _readiness_ and _liveness_ checks depends on the connector.
 Some connectors allow configuring the health check behavior or disabling them completely or per channel.
 

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -162,7 +162,7 @@ public class FruitResourceTest {
 
 == Expose OpenAPI Specifications
 
-Quarkus provides the https://github.com/smallrye/smallrye-open-api/[Smallrye OpenAPI] extension compliant with the
+Quarkus provides the https://github.com/smallrye/smallrye-open-api/[SmallRye OpenAPI] extension compliant with the
 https://github.com/eclipse/microprofile-open-api/[MicroProfile OpenAPI]
 specification in order to generate your API
 https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md[OpenAPI v3 specification].

--- a/docs/src/main/asciidoc/resteasy.adoc
+++ b/docs/src/main/asciidoc/resteasy.adoc
@@ -776,7 +776,7 @@ Configuration via an application-supplied subclass of `Application` is supported
 
 === Only a single Jakarta REST application
 
-In contrast to Jakarta REST (and RESTeasy) running in a standard servlet container, Quarkus only supports the deployment of a single Jakarta REST application.
+In contrast to Jakarta REST (and RESTEasy) running in a standard servlet container, Quarkus only supports the deployment of a single Jakarta REST application.
 If multiple Jakarta REST `Application` classes are defined, the build will fail with the message `Multiple classes have been annotated with @ApplicationPath which is currently not supported`.
 
 If multiple Jakarta REST applications are defined, the property `quarkus.resteasy.ignore-application-classes=true` can be used to ignore all explicit `Application` classes.

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -36,7 +36,7 @@ SmallRye JWT Build provides an API for securing JWT claims using all of these op
 implementation("io.quarkus:quarkus-smallrye-jwt-build")
 ----
 
-Note you can use Smallrye JWT Build API without having to create MicroProfile JWT endpoints supported by `quarkus-smallrye-jwt`.
+Note you can use SmallRye JWT Build API without having to create MicroProfile JWT endpoints supported by `quarkus-smallrye-jwt`.
 It can also be excluded from `quarkus-smallrye-jwt` if MP JWT endpoints do not need to generate JWT tokens.
 
 == Create JwtClaimsBuilder and set the claims
@@ -349,5 +349,5 @@ SmallRye JWT supports the following properties which can be used to customize th
 * link:https://tools.ietf.org/html/rfc7518[JSON Web Algorithms]
 * link:https://bitbucket.org/b_c/jose4j/wiki/Home[Jose4J]
 * xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
-* xref:security-jwt.adoc[Using Smallrye JWT to Protect Service Applications]
+* xref:security-jwt.adoc[Using SmallRye JWT to Protect Service Applications]
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -905,7 +905,7 @@ public class OidcClientRequestCustomFilter extends AbstractOidcClientRequestReac
 }
 ----
 
-Here is an example of the RestEasy Classic custom filter:
+Here is an example of the RESTEasy Classic custom filter:
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/security-vulnerability-detection.adoc
+++ b/docs/src/main/asciidoc/security-vulnerability-detection.adoc
@@ -92,7 +92,7 @@ To detect less severe issues, adjust the value of `failBuildOnCVSS` to suppress 
     <suppress>
         <notes>
             <![CDATA[
-                Suppress the false positive CPE for Smallrye Mutiny to mutiny:mutiny
+                Suppress the false positive CPE for SmallRye Mutiny to mutiny:mutiny
             ]]>
         </notes>
         <gav regex="true">^io\.smallrye\.reactive:mutiny.*:.*$</gav>
@@ -101,7 +101,7 @@ To detect less severe issues, adjust the value of `failBuildOnCVSS` to suppress 
     <suppress>
         <notes>
             <![CDATA[
-                Suppress the false positive CPE for Smallrye Mutiny to mutiny:mutiny
+                Suppress the false positive CPE for SmallRye Mutiny to mutiny:mutiny
             ]]>
         </notes>
         <gav regex="true">^io\.smallrye\.reactive:smallrye-mutiny.*:.*$</gav>
@@ -110,7 +110,7 @@ To detect less severe issues, adjust the value of `failBuildOnCVSS` to suppress 
     <suppress>
         <notes>
             <![CDATA[
-                Suppress the false positive CPE for Smallrye Mutiny to mutiny:mutiny
+                Suppress the false positive CPE for SmallRye Mutiny to mutiny:mutiny
             ]]>
         </notes>
         <gav regex="true">^io\.smallrye\.reactive:vertx-mutiny.*:.*$</gav>


### PR DESCRIPTION
Docs typo fix - use proper SmallRye, RESTEasy and PostgreSQL names