### PR TITLE
Take regexps into account when setting access-control-allow-credentials

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSRegexTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSRegexTestCase.java
@@ -22,7 +22,8 @@ public class CORSRegexTestCase {
                 .when()
                 .get("/test").then()
                 .statusCode(200)
-                .header("Access-Control-Allow-Origin", "https://asdf.domain.com");
+                .header("Access-Control-Allow-Origin", "https://asdf.domain.com")
+                .header("Access-Control-Allow-Credentials", "true");
     }
 
     @Test
@@ -31,7 +32,8 @@ public class CORSRegexTestCase {
                 .when()
                 .get("/test").then()
                 .statusCode(200)
-                .header("Access-Control-Allow-Origin", "https://abc-123.app.mydomain.com");
+                .header("Access-Control-Allow-Origin", "https://abc-123.app.mydomain.com")
+                .header("Access-Control-Allow-Credentials", "true");
     }
 
     @Test
@@ -40,7 +42,8 @@ public class CORSRegexTestCase {
                 .when()
                 .get("/test").then()
                 .statusCode(403)
-                .header("Access-Control-Allow-Origin", nullValue());
+                .header("Access-Control-Allow-Origin", nullValue())
+                .header("Access-Control-Allow-Credentials", nullValue());
     }
 
     @Test
@@ -49,6 +52,7 @@ public class CORSRegexTestCase {
                 .when()
                 .get("/test").then()
                 .statusCode(403)
-                .header("Access-Control-Allow-Origin", nullValue());
+                .header("Access-Control-Allow-Origin", nullValue())
+                .header("Access-Control-Allow-Credentials", nullValue());
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSRegexWildcardTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSRegexWildcardTestCase.java
@@ -1,0 +1,27 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CORSRegexWildcardTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanRegisteringRoute.class)
+                    .addAsResource("conf/cors-regex-wildcard.properties", "application.properties"));
+
+    @Test
+    public void corsRegexValidOriginTest() {
+        given().header("Origin", "https://asdf.domain.com")
+                .when()
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", "https://asdf.domain.com")
+                .header("Access-Control-Allow-Credentials", "false");
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
@@ -57,7 +57,8 @@ public class CORSWildcardSecurityTestCase {
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
                 .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Headers", headers)
+                .header("Access-Control-Allow-Credentials", "false");
 
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -68,7 +69,8 @@ public class CORSWildcardSecurityTestCase {
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
                 .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Headers", headers)
+                .header("Access-Control-Allow-Credentials", "false");
 
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -79,7 +81,8 @@ public class CORSWildcardSecurityTestCase {
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
                 .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Headers", headers)
+                .header("Access-Control-Allow-Credentials", "false");
 
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -90,20 +93,20 @@ public class CORSWildcardSecurityTestCase {
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
                 .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Headers", headers)
+                .header("Access-Control-Allow-Credentials", "false");
     }
 
     @Test
     @DisplayName("Handles a direct CORS request correctly")
     public void corsNoPreflightTest() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET, POST";
-        String headers = "X-Custom";
         given().header("Origin", origin)
                 .when()
                 .get("/test").then()
                 .statusCode(401)
-                .header("Access-Control-Allow-Origin", origin);
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Credentials", "false");
 
         given().header("Origin", origin)
                 .when()
@@ -111,20 +114,23 @@ public class CORSWildcardSecurityTestCase {
                 .get("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .body(Matchers.equalTo("test:/test"));
+                .body(Matchers.equalTo("test:/test"))
+                .header("Access-Control-Allow-Credentials", "false");
 
         given().header("Origin", origin)
                 .when()
                 .auth().basic("test", "wrongpassword")
                 .get("/test").then()
                 .statusCode(401)
-                .header("Access-Control-Allow-Origin", origin);
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Credentials", "false");
 
         given().header("Origin", origin)
                 .when()
                 .auth().basic("user", "user")
                 .get("/test").then()
                 .statusCode(403)
-                .header("Access-Control-Allow-Origin", origin);
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Credentials", "false");
     }
 }

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-regex-wildcard.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-regex-wildcard.properties
@@ -1,0 +1,2 @@
+quarkus.http.cors=true
+quarkus.http.cors.origins=/.*/

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -146,7 +146,7 @@ public class CORSFilter implements Handler<RoutingContext> {
 
             //for both normal and preflight requests we need to check the origin
             boolean allowsOrigin = wildcardOrigin;
-            boolean originMatches = corsConfig.origins.isPresent() &&
+            boolean originMatches = !wildcardOrigin && corsConfig.origins.isPresent() &&
                     (corsConfig.origins.get().contains(origin) || isOriginAllowedByRegex(allowedOriginsRegex, origin));
             if (!allowsOrigin) {
                 if (corsConfig.origins.isPresent()) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -83,7 +83,13 @@ public class CORSFilter implements Handler<RoutingContext> {
     }
 
     private static boolean isOriginConfiguredWithWildcard(Optional<List<String>> origins) {
-        return !origins.isEmpty() && origins.get().size() == 1 && "*".equals(origins.get().get(0));
+        if (origins.isEmpty() || origins.get().size() != 1) {
+            return false;
+        }
+
+        String origin = origins.get().get(0);
+
+        return "*".equals(origin) || "/.*/".equals(origin);
     }
 
     /**


### PR DESCRIPTION
We used to only consider exact matches which looks like an oversight.

Fixes #43736