### PR TITLE
Undertow: ignore missing servlet class in web.xml

### DIFF
--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -430,10 +430,14 @@ public class UndertowBuildStep {
         //add servlets
         if (webMetaData.getServlets() != null) {
             for (ServletMetaData servlet : webMetaData.getServlets()) {
+                String servletClass = servlet.getServletClass();
+                if (servletClass == null) {
+                    continue;
+                }
                 reflectiveClasses.accept(
-                        ReflectiveClassBuildItem.builder(servlet.getServletClass()).build());
+                        ReflectiveClassBuildItem.builder(servletClass).build());
                 RuntimeValue<ServletInfo> sref = recorder.registerServlet(deployment, servlet.getServletName(),
-                        context.classProxy(servlet.getServletClass()),
+                        context.classProxy(servletClass),
                         servlet.isAsyncSupported(),
                         servlet.getLoadOnStartupInt(),
                         bc.getValue(),
@@ -447,7 +451,7 @@ public class UndertowBuildStep {
                 if (webMetaData.getAnnotations() != null) {
                     for (AnnotationMetaData amd : webMetaData.getAnnotations()) {
                         final ServletSecurityMetaData ssmd = amd.getServletSecurity();
-                        if (ssmd != null && amd.getClassName().equals(servlet.getServletClass())) {
+                        if (ssmd != null && amd.getClassName().equals(servletClass)) {
                             // Process the @ServletSecurity into metadata
                             ServletSecurityInfo securityInfo = new ServletSecurityInfo();
                             securityInfo.setEmptyRoleSemantic(
@@ -471,7 +475,7 @@ public class UndertowBuildStep {
                         }
 
                         final MultipartConfigMetaData mcmd = amd.getMultipartConfig();
-                        if (mcmd != null && amd.getClassName().equals(servlet.getServletClass())) {
+                        if (mcmd != null && amd.getClassName().equals(servletClass)) {
                             servlet.setMultipartConfig(mcmd);
                         }
                     }

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/WebXmlParsingBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/WebXmlParsingBuildStep.java
@@ -79,7 +79,10 @@ public class WebXmlParsingBuildStep {
                     }
                     if (metadata.getServlets() != null) {
                         for (ServletMetaData i : metadata.getServlets()) {
-                            additionalBeans.add(i.getServletClass());
+                            String servletClass = i.getServletClass();
+                            if (servletClass != null) {
+                                additionalBeans.add(servletClass);
+                            }
                         }
                     }
                     if (metadata.getFilters() != null) {


### PR DESCRIPTION
Avoids writing a null bean name to the bean archive, which causes a later build failure.

Fixes #43825