### PR TITLE
Unwrap tooltips in the downstream configuration reference docs

### DIFF
--- a/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
@@ -62,6 +62,7 @@ public class AssembleDownstreamDocumentation {
     private static final String SOURCE_BLOCK_PREFIX = "[source";
     private static final String SOURCE_BLOCK_DELIMITER = "--";
     private static final Pattern FOOTNOTE_PATTERN = Pattern.compile("footnote:([a-z0-9_-]+)\\[(\\])?");
+    private static final Pattern TOOLTIP_PATTERN = Pattern.compile("tooltip:([a-z0-9_-]+)\\[(.*?)\\]");
 
     private static final String PROJECT_NAME_ATTRIBUTE = "{project-name}";
     private static final String RED_HAT_BUILD_OF_QUARKUS = "Red Hat build of Quarkus";
@@ -481,6 +482,10 @@ public class AssembleDownstreamDocumentation {
             }
 
             return "footnoteref:[" + mr.group(1) + ", ";
+        });
+
+        content = TOOLTIP_PATTERN.matcher(content).replaceAll(mr -> {
+            return "*" + mr.group(1) + "*: " + mr.group(2);
         });
 
         return content;

--- a/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
@@ -62,7 +62,7 @@ public class AssembleDownstreamDocumentation {
     private static final String SOURCE_BLOCK_PREFIX = "[source";
     private static final String SOURCE_BLOCK_DELIMITER = "--";
     private static final Pattern FOOTNOTE_PATTERN = Pattern.compile("footnote:([a-z0-9_-]+)\\[(\\])?");
-    private static final Pattern TOOLTIP_PATTERN = Pattern.compile("tooltip:([a-z0-9_-]+)\\[(.*?)\\]");
+    private static final Pattern TOOLTIP_PATTERN = Pattern.compile("tooltip:([a-z0-9_-]+)\\[(.*?)\\](, ?)?");
 
     private static final String PROJECT_NAME_ATTRIBUTE = "{project-name}";
     private static final String RED_HAT_BUILD_OF_QUARKUS = "Red Hat build of Quarkus";
@@ -485,7 +485,14 @@ public class AssembleDownstreamDocumentation {
         });
 
         content = TOOLTIP_PATTERN.matcher(content).replaceAll(mr -> {
-            return "*" + mr.group(1) + "*: " + mr.group(2);
+            // group(1) is the enum value, group(2) is the tooltip text for the value
+            if (mr.group(3) != null) {
+                // group(3) is a comma that means there are still more values after this one
+                // So in this case, replace it with two newlines to visually separate items
+                return "*" + mr.group(1) + "*: " + mr.group(2) + "\n\n";
+            } else {
+                return "*" + mr.group(1) + "*: " + mr.group(2);
+            }
         });
 
         return content;

--- a/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
@@ -62,7 +62,14 @@ public class AssembleDownstreamDocumentation {
     private static final String SOURCE_BLOCK_PREFIX = "[source";
     private static final String SOURCE_BLOCK_DELIMITER = "--";
     private static final Pattern FOOTNOTE_PATTERN = Pattern.compile("footnote:([a-z0-9_-]+)\\[(\\])?");
+
     private static final Pattern TOOLTIP_PATTERN = Pattern.compile("tooltip:([a-z0-9_-]+)\\[(.*?)\\](, ?)?");
+    // A tooltip that is detected to be in the third column of a configuration reference table
+    // (a default value for a configuration property) - in this case, let's strip out the description from it.
+    // We assume it's in the third column if it follows right after a | at the beginning of a line (if it's in
+    // the second column, it would be preceded by a|, not just |).
+    private static final Pattern TOOLTIP_PATTERN_DEFAULT_COLUMN = Pattern.compile("^\\|tooltip:([a-z0-9_-]+)\\[(.*?)\\](, ?)?",
+            Pattern.MULTILINE);
 
     private static final String PROJECT_NAME_ATTRIBUTE = "{project-name}";
     private static final String RED_HAT_BUILD_OF_QUARKUS = "Red Hat build of Quarkus";
@@ -482,6 +489,12 @@ public class AssembleDownstreamDocumentation {
             }
 
             return "footnoteref:[" + mr.group(1) + ", ";
+        });
+
+        content = TOOLTIP_PATTERN_DEFAULT_COLUMN.matcher(content).replaceAll(mr -> {
+            // for tooltips in the third column of the configuration reference table (the default values),
+            // don't include the description, just the plain value
+            return "|*" + mr.group(1) + "*";
         });
 
         content = TOOLTIP_PATTERN.matcher(content).replaceAll(mr -> {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/QDOCS-978

The downstream docs engine is unable to render `tooltip`-s, so we need to unwrap the tooltips in the configuration reference into regular text within the table

Example for the `quarkus.datasource."datasource-name".jdbc.transactions` config property:

Before this PR:
```
tooltip:enabled[Integrate the JDBC Datasource with the JTA TransactionManager of Quarkus. This is the default.], tooltip:xa[Similarly to `enabled`, also enables integration with the JTA TransactionManager of Quarkus, but enabling XA transactions as well. Requires a JDBC driver implementing `javax.sql.XADataSource`], tooltip:disabled[Disables the Agroal integration with the Narayana TransactionManager. This is typically a bad idea, and is only useful in special cases\: make sure to not use this without having a deep understanding of the implications.]
```

After this PR:
```
*enabled*: Integrate the JDBC Datasource with the JTA TransactionManager of Quarkus. This is the default.

*xa*: Similarly to `enabled`, also enables integration with the JTA TransactionManager of Quarkus, but enabling XA transactions as well. Requires a JDBC driver implementing `javax.sql.XADataSource`

*disabled*: Disables the Agroal integration with the Narayana TransactionManager. This is typically a bad idea, and is only useful in special cases: make sure to not use this without having a deep understanding of the implications.
```

@MichalMaler please check