### PR TITLE
Fix NoClassDefFoundError when using vertx without http

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagExemplarTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagExemplarTest.java
@@ -1,0 +1,154 @@
+package io.quarkus.micrometer.deployment.binder;
+
+import static io.restassured.RestAssured.when;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.micrometer.test.HelloResource;
+import io.quarkus.micrometer.test.PingPongResource;
+import io.quarkus.micrometer.test.ServletEndpoint;
+import io.quarkus.micrometer.test.Util;
+import io.quarkus.micrometer.test.VertxWebEndpoint;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class UriTagExemplarTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.binder.http-server.match-patterns", "/one=/two")
+            .overrideConfigKey("quarkus.micrometer.binder.http-server.ignore-patterns", "/two")
+            .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "true")
+            .overrideConfigKey("pingpong/mp-rest/url", "${test.url}")
+            .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Util.class,
+                            PingPongResource.class,
+                            PingPongResource.PingPongRestClient.class,
+                            ServletEndpoint.class,
+                            VertxWebEndpoint.class,
+                            HelloResource.class));
+
+    static SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeAll
+    static void setRegistry() {
+        registry = new SimpleMeterRegistry();
+        Metrics.addRegistry(registry);
+    }
+
+    @AfterAll()
+    static void removeRegistry() {
+        Metrics.removeRegistry(registry);
+    }
+
+    @Test
+    public void testRequestUris() throws Exception {
+        RestAssured.basePath = "/";
+
+        // Server paths (templated)
+        when().get("/one").then().statusCode(200);
+        when().get("/two").then().statusCode(200);
+        when().get("/vertx/item/123").then().statusCode(200);
+        when().get("/vertx/item/1/123").then().statusCode(200);
+        when().get("/servlet/12345").then().statusCode(200);
+
+        // Server GET vs. HEAD methods -- templated
+        when().get("/hello/one").then().statusCode(200);
+        when().get("/hello/two").then().statusCode(200);
+        when().head("/hello/three").then().statusCode(200);
+        when().head("/hello/four").then().statusCode(200);
+        when().get("/vertx/echo/thing1").then().statusCode(200);
+        when().get("/vertx/echo/thing2").then().statusCode(200);
+        when().head("/vertx/echo/thing3").then().statusCode(200);
+        when().head("/vertx/echo/thing4").then().statusCode(200);
+
+        // Server -> Rest client -> Server (templated)
+        when().get("/ping/one").then().statusCode(200);
+        when().get("/ping/two").then().statusCode(200);
+        when().get("/ping/three").then().statusCode(200);
+        when().get("/ping/400").then().statusCode(200);
+        when().get("/ping/500").then().statusCode(200);
+        when().get("/async-ping/one").then().statusCode(200);
+        when().get("/async-ping/two").then().statusCode(200);
+        when().get("/async-ping/three").then().statusCode(200);
+
+        // Try to let metrics gathering finish.
+        // Looking for server request timers: /vertx/item/{id}, /vertx/item/{id}/{sub}, /servlet/,
+        //   /ping/{message}, /async-ping/{message}, /pong/{message}, and 2 of both /hello/{message} and /vertx/echo/{msg}
+        // Looking for client request: /pong/{message}
+        Util.waitForMeters(registry.find("http.server.requests").timers(), 10);
+        Util.waitForMeters(registry.find("http.client.requests").timers(), 1);
+
+        System.out.println("Server paths\n" + Util.listMeters(registry, "http.server.requests"));
+        System.out.println("Client paths\n" + Util.listMeters(registry, "http.client.requests"));
+
+        // /one should map to /two, which is ignored. Neither should exist w/ timers
+        Assertions.assertEquals(0, registry.find("http.server.requests").tag("uri", "/one").timers().size(),
+                Util.foundServerRequests(registry, "/one is mapped to /two, which should be ignored."));
+        Assertions.assertEquals(0, registry.find("http.server.requests").tag("uri", "/two").timers().size(),
+                Util.foundServerRequests(registry, "/two should be ignored."));
+
+        // URIs for server: /vertx/item/{id}, /vertx/item/{id}/{sub}, /servlet/
+        Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "/vertx/item/{id}").timers().size(),
+                Util.foundServerRequests(registry,
+                        "Vert.x Web template path (/vertx/item/:id) should be detected/translated to /vertx/item/{id}."));
+        Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "/vertx/item/{id}/{sub}").timers().size(),
+                Util.foundServerRequests(registry,
+                        "Vert.x Web template path (/vertx/item/:id/:sub) should be detected/translated to /vertx/item/{id}/{sub}."));
+        Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "/servlet").timers().size(),
+                Util.foundServerRequests(registry, "Servlet path (/servlet) should be used for servlet"));
+
+        // GET and HEAD are two different methods, there should be two timers for each of these URI tag values
+        Assertions.assertEquals(2, registry.find("http.server.requests").tag("uri", "/hello/{message}").timers().size(),
+                Util.foundServerRequests(registry, "/hello/{message} should have two timers (GET and HEAD)."));
+        Assertions.assertEquals(2, registry.find("http.server.requests").tag("uri", "/vertx/echo/{msg}").timers().size(),
+                Util.foundServerRequests(registry, "/vertx/echo/{msg} should have two timers (GET and HEAD)."));
+
+        // URIs to trigger REST request: /ping/{message}, /async-ping/{message},
+        Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "/ping/{message}").timers().size(),
+                Util.foundServerRequests(registry, "/ping/{message} should be returned by JAX-RS."));
+        Assertions.assertEquals(1, registry.find("http.server.requests").tag("uri", "/async-ping/{message}").timers().size(),
+                Util.foundServerRequests(registry, "/async-ping/{message} should be returned by JAX-RS."));
+
+        // Server response for /pong/{message}
+        Assertions.assertEquals(1,
+                registry.find("http.server.requests").tag("uri", "/pong/{message}").tag("outcome", "SUCCESS").timers().size(),
+                Util.foundServerRequests(registry, "/pong/{message} with tag outcome=SUCCESS should be returned by JAX-RS."));
+        Assertions.assertEquals(1,
+                registry.find("http.server.requests").tag("uri", "/pong/{message}").tag("outcome", "CLIENT_ERROR").timers()
+                        .size(),
+                Util.foundServerRequests(registry,
+                        "/pong/{message} with tag outcome=CLIENT_ERROR should be returned by JAX-RS."));
+        Assertions.assertEquals(1,
+                registry.find("http.server.requests").tag("uri", "/pong/{message}").tag("outcome", "SERVER_ERROR").timers()
+                        .size(),
+                Util.foundServerRequests(registry,
+                        "/pong/{message} with tag outcome=SERVER_ERROR should be returned by JAX-RS."));
+
+        // URI for outbound client request: /pong/{message}
+        Assertions.assertEquals(1,
+                registry.find("http.client.requests").tag("uri", "/pong/{message}").tag("outcome", "SUCCESS").timers().size(),
+                Util.foundClientRequests(registry,
+                        "/pong/{message} with tag outcome=SUCCESS should be returned by Rest client."));
+        Assertions.assertEquals(1,
+                registry.find("http.client.requests").tag("uri", "/pong/{message}").tag("outcome", "CLIENT_ERROR").timers()
+                        .size(),
+                Util.foundClientRequests(registry,
+                        "/pong/{message} with tag outcome=CLIENT_ERROR should be returned by Rest client."));
+        Assertions.assertEquals(1,
+                registry.find("http.client.requests").tag("uri", "/pong/{message}").tag("outcome", "SERVER_ERROR").timers()
+                        .size(),
+                Util.foundClientRequests(registry,
+                        "/pong/{message} with tag outcome=SERVER_ERROR should be returned by Rest client."));
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/InstrumentationRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/InstrumentationRecorder.java
@@ -11,6 +11,7 @@ import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.EventBusInstrumenterVertxTracer;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.HttpInstrumenterVertxTracer;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.InstrumenterVertxTracer;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxHttpMetricsFactory;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxMetricsFactory;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxTracer;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxTracingFactory;
@@ -74,7 +75,15 @@ public class InstrumentationRecorder {
     }
 
     /* STATIC INIT */
-    public Consumer<VertxOptions> getVertxTracingMetricsOptions() {
+    public Consumer<VertxOptions> getVertxHttpMetricsOptions() {
+        MetricsOptions metricsOptions = new MetricsOptions()
+                .setEnabled(true)
+                .setFactory(new OpenTelemetryVertxHttpMetricsFactory());
+        return vertxOptions -> vertxOptions.setMetricsOptions(metricsOptions);
+    }
+
+    /* STATIC INIT */
+    public Consumer<VertxOptions> getVertxMetricsOptions() {
         MetricsOptions metricsOptions = new MetricsOptions()
                 .setEnabled(true)
                 .setFactory(new OpenTelemetryVertxMetricsFactory());

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/MetricRequest.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/MetricRequest.java
@@ -1,0 +1,27 @@
+package io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx;
+
+import java.util.Optional;
+
+import io.vertx.core.Context;
+import io.vertx.core.http.impl.HttpServerRequestInternal;
+import io.vertx.core.spi.observability.HttpRequest;
+
+public final class MetricRequest {
+    private final HttpRequest request;
+
+    MetricRequest(final HttpRequest request) {
+        this.request = request;
+    }
+
+    Optional<Context> getContext() {
+        if (request instanceof HttpServerRequestInternal) {
+            return Optional.of(((HttpServerRequestInternal) request).context());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    static MetricRequest request(final HttpRequest httpRequest) {
+        return new MetricRequest(httpRequest);
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/OpenTelemetryVertxHttpMetricsFactory.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/OpenTelemetryVertxHttpMetricsFactory.java
@@ -1,5 +1,6 @@
 package io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx;
 
+import io.quarkus.vertx.http.runtime.ExtendedQuarkusVertxHttpMetrics;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.SocketAddress;
@@ -12,26 +13,28 @@ import io.vertx.core.spi.observability.HttpRequest;
  * This is used to retrieve the route name from Vert.x. This is useful for OpenTelemetry to generate the Span name and
  * <code>http.route</code> attribute. Right now, there is no other way to retrieve the route name from Vert.x using the
  * Telemetry SPI, so we need to rely on the Metrics SPI.
- *
+ * <p>
  * Right now, it is not possible to register multiple <code>VertxMetrics</code>, meaning that only a single one is
  * available per Quarkus instance. To avoid clashing with other extensions that provide Metrics data (like the
- * Micrometer extension), we only register the {@link OpenTelemetryVertxMetricsFactory} if the
+ * Micrometer extension), we only register the {@link OpenTelemetryVertxHttpMetricsFactory} if the
  * <code>VertxHttpServerMetrics</code> is not available in the runtime.
  */
-public class OpenTelemetryVertxMetricsFactory implements VertxMetricsFactory {
+public class OpenTelemetryVertxHttpMetricsFactory implements VertxMetricsFactory {
     @Override
     public VertxMetrics metrics(final VertxOptions options) {
-        return new VertxMetrics() {
-            @Override
-            public HttpServerMetrics<?, ?, ?> createHttpServerMetrics(final HttpServerOptions options,
-                    final SocketAddress localAddress) {
-                return new OpenTelemetryVertxServerMetrics();
-            }
-        };
+        return new OpenTelemetryVertxHttpServerMetrics();
     }
 
-    public static class OpenTelemetryVertxServerMetrics
-            implements HttpServerMetrics<MetricRequest, Object, Object> {
+    public static class OpenTelemetryVertxHttpServerMetrics
+            implements HttpServerMetrics<MetricRequest, Object, Object>,
+            VertxMetrics, ExtendedQuarkusVertxHttpMetrics {
+
+        @Override
+        public HttpServerMetrics<?, ?, ?> createHttpServerMetrics(final HttpServerOptions options,
+                final SocketAddress localAddress) {
+            return this;
+        }
+
         @Override
         public MetricRequest requestBegin(final Object socketMetric, final HttpRequest request) {
             return MetricRequest.request(request);
@@ -42,6 +45,12 @@ public class OpenTelemetryVertxMetricsFactory implements VertxMetricsFactory {
             if (route != null) {
                 requestMetric.getContext().ifPresent(context -> context.putLocal("VertxRoute", route));
             }
+        }
+
+        @Override
+        public ConnectionTracker getHttpConnectionTracker() {
+            // To be implemented if we decide to instrument with OpenTelemetry. See VertxMeterBinderAdapter for an example.
+            return ExtendedQuarkusVertxHttpMetrics.NOOP_CONNECTION_TRACKER;
         }
     }
 }

--- a/integration-tests/opentelemetry-minimal/pom.xml
+++ b/integration-tests/opentelemetry-minimal/pom.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-opentelemetry-minimal</artifactId>
+    <name>Quarkus - Integration Tests - OpenTelemetry minimal (No HTTP)</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+
+            <artifactId>quarkus-vertx-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <vertx.disableWebsockets>false</vertx.disableWebsockets>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                            <systemPropertyVariables>
+                                <vertx.disableWebsockets>false</vertx.disableWebsockets>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <vertx.disableWebsockets>false</vertx.disableWebsockets>
+                                        <native.image.path>
+                                            ${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/opentelemetry-minimal/src/main/java/io/quarkus/it/opentelemetry/minimal/HelloService.java
+++ b/integration-tests/opentelemetry-minimal/src/main/java/io/quarkus/it/opentelemetry/minimal/HelloService.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.opentelemetry.minimal;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+
+@ApplicationScoped
+public class HelloService {
+
+    @Inject
+    Vertx vertx;
+
+    @Inject
+    InMemoryMetricExporter inMemoryMetricExporter;
+
+    void onStart(@Observes StartupEvent ev) {
+        // Code executed during application startup
+        System.out.println("Application is starting...");
+    }
+
+    public Uni<Integer> getMetricCount() {
+        return Uni.createFrom().emitter(e -> {
+            vertx.setTimer(100, x -> e.complete(inMemoryMetricExporter.getFinishedMetricItems().size()));
+        });
+    }
+
+    @ApplicationScoped
+    static class InMemoryMetricExporterProducer {
+        @Produces
+        @Singleton
+        InMemoryMetricExporter inMemoryMetricsExporter() {
+            return InMemoryMetricExporter.create();
+        }
+    }
+}

--- a/integration-tests/opentelemetry-minimal/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-minimal/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+# Setting these for tests explicitly. Not required in normal application
+quarkus.application.name=opentelemetry-minimal
+# speed up build
+quarkus.otel.bsp.schedule.delay=100
+quarkus.otel.bsp.export.timeout=5s
+quarkus.otel.metrics.enabled=true
+quarkus.otel.metric.export.interval=100ms
+#quarkus.otel.logs.enabled=true

--- a/integration-tests/opentelemetry-minimal/src/test/java/io/quarkus/it/opentelemetry/minimal/HelloServiceIT.java
+++ b/integration-tests/opentelemetry-minimal/src/test/java/io/quarkus/it/opentelemetry/minimal/HelloServiceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.opentelemetry.minimal;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class HelloServiceIT extends HelloServiceTest {
+
+}

--- a/integration-tests/opentelemetry-minimal/src/test/java/io/quarkus/it/opentelemetry/minimal/HelloServiceTest.java
+++ b/integration-tests/opentelemetry-minimal/src/test/java/io/quarkus/it/opentelemetry/minimal/HelloServiceTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.opentelemetry.minimal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+import java.time.Duration;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class HelloServiceTest {
+
+    @Inject
+    HelloService helloService;
+
+    @Test
+    public void testHello() {
+        Integer result = helloService.getMetricCount().await().atMost(Duration.ofSeconds(5));
+        System.out.println("Metric count: " + result);
+        assertThat(result, greaterThanOrEqualTo(1));
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -360,6 +360,7 @@
                 <module>opentelemetry-quickstart</module>
                 <module>opentelemetry-spi</module>
                 <module>opentelemetry-jdbc-instrumentation</module>
+                <module>opentelemetry-minimal</module>
                 <module>opentelemetry-mongodb-client-instrumentation</module>
                 <module>opentelemetry-quartz</module>
                 <module>opentelemetry-scheduler</module>


### PR DESCRIPTION
This is a follow up to https://github.com/quarkusio/quarkus/pull/43919

Added a new IT test with minimal setup because all other tests use HTTP to retrieve the telemetry, therefore causing a blank spot in the coverage. 