### PR TITLE
Do not fallback @RegisterRestClient#configKey if it matches the Rest Client class name

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
@@ -74,19 +74,22 @@ public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
             quarkusFallbacks.put(restClient.getSimpleName(), quotedSimpleName);
             relocates.put(quotedSimpleName, quotedFullName);
 
-            if (restClient.getConfigKey() != null) {
-                String quotedConfigKey = "\"" + restClient.getConfigKey() + "\"";
-                if (restClient.isConfigKeyComposed()) {
-                    // Quoted Simple Name -> Quoted Config Key
-                    quarkusFallbacks.put(quotedSimpleName, quotedConfigKey);
-                    relocates.put(quotedConfigKey, quotedFullName);
-                } else {
-                    // Quoted Simple Name -> Config Key
-                    quarkusFallbacks.put(quotedSimpleName, restClient.getConfigKey());
-                    relocates.put(restClient.getConfigKey(), quotedFullName);
-                    // Config Key -> Quoted Config Key
-                    quarkusFallbacks.put(restClient.getConfigKey(), quotedConfigKey);
-                    relocates.put(quotedConfigKey, quotedFullName);
+            String configKey = restClient.getConfigKey();
+            if (configKey != null && !restClient.isConfigKeyEqualsNames()) {
+                String quotedConfigKey = "\"" + configKey + "\"";
+                if (!quotedConfigKey.equals(quotedFullName) && !quotedConfigKey.equals(quotedSimpleName)) {
+                    if (restClient.isConfigKeyComposed()) {
+                        // Quoted Simple Name -> Quoted Config Key
+                        quarkusFallbacks.put(quotedSimpleName, quotedConfigKey);
+                        relocates.put(quotedConfigKey, quotedFullName);
+                    } else {
+                        // Quoted Simple Name -> Config Key
+                        quarkusFallbacks.put(quotedSimpleName, configKey);
+                        relocates.put(configKey, quotedFullName);
+                        // Config Key -> Quoted Config Key
+                        quarkusFallbacks.put(configKey, quotedConfigKey);
+                        relocates.put(quotedConfigKey, quotedFullName);
+                    }
                 }
             }
 
@@ -94,8 +97,8 @@ public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
             String mpRestFullName = restClient.getFullName() + "/mp-rest/";
             microProfileFallbacks.put(quotedFullName, mpRestFullName);
             relocates.put(mpRestFullName, quotedFullName);
-            if (restClient.getConfigKey() != null) {
-                String mpConfigKey = restClient.getConfigKey() + "/mp-rest/";
+            if (configKey != null && !restClient.isConfigKeyEqualsNames()) {
+                String mpConfigKey = configKey + "/mp-rest/";
                 microProfileFallbacks.put(mpRestFullName, mpConfigKey);
                 relocates.put(mpConfigKey, quotedFullName);
             }

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RegisteredRestClient.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RegisteredRestClient.java
@@ -35,6 +35,14 @@ public class RegisteredRestClient {
         return configKey;
     }
 
+    public boolean isConfigKeyEqualsNames() {
+        if (configKey == null) {
+            return false;
+        }
+
+        return configKey.equals(fullName) || configKey.equals(simpleName);
+    }
+
     public boolean isConfigKeyComposed() {
         if (configKey == null) {
             throw new IllegalStateException("configKey is null");

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
@@ -2,6 +2,7 @@ package io.quarkus.restclient.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
@@ -65,6 +66,43 @@ class RestClientConfigTest {
         assertEquals(1, restClientsConfig.clients().size());
         assertTrue(restClientsConfig.clients().containsKey(ConfigKeyRestClient.class.getName()));
         verifyConfig(restClientsConfig.getClient(ConfigKeyRestClient.class));
+    }
+
+    @Test
+    void restClientConfigKeyMatchName() {
+        SmallRyeConfig config = ConfigUtils.emptyConfigBuilder()
+                .withMapping(RestClientsConfig.class)
+                .withCustomizers(new SmallRyeConfigBuilderCustomizer() {
+                    @Override
+                    public void configBuilder(final SmallRyeConfigBuilder builder) {
+                        new AbstractRestClientConfigBuilder() {
+                            @Override
+                            public List<RegisteredRestClient> getRestClients() {
+                                return List.of(new RegisteredRestClient(ConfigKeyRestClient.class,
+                                        ConfigKeyRestClient.class.getName()));
+                            }
+                        }.configBuilder(builder);
+                    }
+                })
+                .build();
+        assertNotNull(config);
+
+        config = ConfigUtils.emptyConfigBuilder()
+                .withMapping(RestClientsConfig.class)
+                .withCustomizers(new SmallRyeConfigBuilderCustomizer() {
+                    @Override
+                    public void configBuilder(final SmallRyeConfigBuilder builder) {
+                        new AbstractRestClientConfigBuilder() {
+                            @Override
+                            public List<RegisteredRestClient> getRestClients() {
+                                return List.of(new RegisteredRestClient(ConfigKeyRestClient.class,
+                                        ConfigKeyRestClient.class.getSimpleName()));
+                            }
+                        }.configBuilder(builder);
+                    }
+                })
+                .build();
+        assertNotNull(config);
     }
 
     @Test
@@ -147,6 +185,43 @@ class RestClientConfigTest {
         assertTrue(clientConfig.proxyAddress().isPresent());
         assertTrue(clientConfig.queryParamStyle().isPresent());
         assertThat(clientConfig.queryParamStyle().get()).isEqualTo(QueryParamStyle.COMMA_SEPARATED);
+    }
+
+    @Test
+    void restClientMicroProfileConfigKeyMatchName() {
+        SmallRyeConfig config = ConfigUtils.emptyConfigBuilder()
+                .withMapping(RestClientsConfig.class)
+                .withCustomizers(new SmallRyeConfigBuilderCustomizer() {
+                    @Override
+                    public void configBuilder(final SmallRyeConfigBuilder builder) {
+                        new AbstractRestClientConfigBuilder() {
+                            @Override
+                            public List<RegisteredRestClient> getRestClients() {
+                                return List.of(new RegisteredRestClient(MPConfigKeyRestClient.class,
+                                        MPConfigKeyRestClient.class.getName()));
+                            }
+                        }.configBuilder(builder);
+                    }
+                })
+                .build();
+        assertNotNull(config);
+
+        config = ConfigUtils.emptyConfigBuilder()
+                .withMapping(RestClientsConfig.class)
+                .withCustomizers(new SmallRyeConfigBuilderCustomizer() {
+                    @Override
+                    public void configBuilder(final SmallRyeConfigBuilder builder) {
+                        new AbstractRestClientConfigBuilder() {
+                            @Override
+                            public List<RegisteredRestClient> getRestClients() {
+                                return List.of(new RegisteredRestClient(MPConfigKeyRestClient.class,
+                                        MPConfigKeyRestClient.class.getSimpleName()));
+                            }
+                        }.configBuilder(builder);
+                    }
+                })
+                .build();
+        assertNotNull(config);
     }
 
     private void verifyConfig(RestClientConfig config) {


### PR DESCRIPTION
- Fixes #44067

The fix is not related to the reported issue, but since it was found while discussing it, I am marking it here as fixed.