### PR TITLE
Add @WithConverter for Level in LogConfig

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
@@ -7,6 +7,7 @@ import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
@@ -27,6 +28,7 @@ public interface LogBuildTimeConfig {
      * The default minimum log level.
      */
     @WithDefault("DEBUG")
+    @WithConverter(LevelConverter.class)
     Level minLevel();
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
@@ -50,6 +50,7 @@ public interface LogRuntimeConfig {
      * @asciidoclet
      */
     @WithDefault("INFO")
+    @WithConverter(LevelConverter.class)
     Level level();
 
     /**
@@ -171,6 +172,7 @@ public interface LogRuntimeConfig {
          * The level of logs to be written into the file.
          */
         @WithDefault("ALL")
+        @WithConverter(LevelConverter.class)
         Level level();
 
         /**
@@ -262,6 +264,7 @@ public interface LogRuntimeConfig {
          * The console log level.
          */
         @WithDefault("ALL")
+        @WithConverter(LevelConverter.class)
         Level level();
 
         /**
@@ -368,6 +371,7 @@ public interface LogRuntimeConfig {
          * The log level specifying what message levels will be logged by the Syslog logger
          */
         @WithDefault("ALL")
+        @WithConverter(LevelConverter.class)
         Level level();
 
         /**
@@ -400,6 +404,7 @@ public interface LogRuntimeConfig {
          * The new log level for the filtered message. Defaults to DEBUG.
          */
         @WithDefault("DEBUG")
+        @WithConverter(LevelConverter.class)
         Level targetLevel();
     }
 


### PR DESCRIPTION
In the cases where the Log config is created manually, the builder may not have registered the `LevelConverter`, so let's just add the converter directly.