### PR TITLE
Missing space in code example for OpenTracing to OpenTelemetry mapping

### DIFF
--- a/docs/src/main/asciidoc/telemetry-opentracing-to-otel-tutorial.adoc
+++ b/docs/src/main/asciidoc/telemetry-opentracing-to-otel-tutorial.adoc
@@ -281,7 +281,7 @@ The OpenTelemetry tracer is not compatible with the OpenTracing API. The main ch
 
 |1
 |`@Inject io.opentracing.Tracer legacyTracer;`
-|`@Injectio.opentelemetry.api.trace.Tracer otelTracer;`
+|`@Inject io.opentelemetry.api.trace.Tracer otelTracer;`
 
 |2
 |`@Traced`


### PR DESCRIPTION
Missing space in code example for OpenTracing to OpenTelemetry mapping