### PR TITLE
[native-image] Adds -H:+ForeignAPISupport for all GraalVM 24.2+

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -834,6 +834,16 @@ public class NativeImageBuildStep {
 
                 addExperimentalVMOption(nativeImageArgs, "-H:+AllowFoldMethods");
 
+                /*
+                 * Foreign Function and Memory API in Native Image, JDK's JEP 454
+                 * This is needed for JDK 24+ internal native calls due to AWT,
+                 * e.g. JDK-8337237 et al.
+                 *
+                 */
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_24_2_0) >= 0) {
+                    addExperimentalVMOption(nativeImageArgs, "-H:+ForeignAPISupport");
+                }
+
                 if (nativeConfig.headless()) {
                     nativeImageArgs.add("-J-Djava.awt.headless=true");
                 }


### PR DESCRIPTION
fixes #44001
enables a disabled test, discussed in #43997

Due to the AWT test being disabled it has been slipping under the radar that latest JDK, i.e. JDK 24+ uses [JEP 454](https://openjdk.org/jeps/454) API internally at places previously catered to by plain JNI. The fonts detection and fonts loading is such a place. We reflected this change in Mandrel test suite https://github.com/Karm/mandrel-integration-tests/pull/277, but it is finding its way to Quarkus only now with this PR.

See GraalVM notes on the support of this API in Native-image: [foreign-interface](https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/)

I tested this PR with latest JDK 24 based Mandrel dev build `Mandrel-24.2.0-dev59c335af5b8 (build 24-beta+20-ea)`
and the current GA `Mandrel-24.1.1.0-Final (build 23.0.1+11)`.

## Question:
Do we enable the API unconditionally for JDK 24+ based native-image? Or do we detect AWT extension usage? Which other use cases might trigger this in the JDK code?

## Explanation of the debug 
...for posterity.

The error message is cryptic for information leakage reasons as discussed on https://github.com/openjdk/jdk/pull/20169#issuecomment-2381602619. 

```
Caused by: java.io.IOException: Problem reading font data.
	at java.desktop@24-beta/java.awt.Font.createFont0(Font.java:1205)
	at java.desktop@24-beta/java.awt.Font.createFont(Font.java:1076)
	at io.quarkus.awt.it.Application.init(Application.java:63)
	at io.quarkus.awt.it.Application_Bean.doCreate(Unknown Source)
	... 26 more
```

So the root cause became apparent to me during a `gdb` session:

```
(gdb) p *(t->cause->detailMessage->value)
$1054 = {<byte []> = {<java.lang.Object> = {<_objhdr> = {
        hub = 0xe093b8 <io.netty.handler.codec.http2.DefaultHttp2FrameReader::readHeadersFrame(io.netty.channel.ChannelHandlerContext*, 
io.netty.buffer.ByteBuf*, io.netty.handler.codec.http2.Http2FrameListener*)+1096>}, <No data fields>}, len = 101, 
data = 0x7fffed638eb0 "Support for the Java Foreign Function and Memory API is not active: enable with -H:+ForeignAPISupport"}, <No data fields>}
(gdb) 
```

...and only then I recalled the old https://github.com/Karm/mandrel-integration-tests/pull/277.

