### PR TITLE
SmallRye Fault Tolerance: upgrade to 6.6.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -53,7 +53,7 @@
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>3.13.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.11.0</smallrye-graphql.version>
-        <smallrye-fault-tolerance.version>6.5.0</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>6.6.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.0</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.1.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>


### PR DESCRIPTION
- https://smallrye.io/blog/fault-tolerance-6-6-0/