### PR TITLE
Introduce CurateOutcomeBuildItem.getApplicationModuleDirectory()

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CurateOutcomeBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CurateOutcomeBuildItem.java
@@ -1,11 +1,17 @@
 package io.quarkus.deployment.pkg.builditem;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.utils.BuildToolHelper;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
 import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class CurateOutcomeBuildItem extends SimpleBuildItem {
 
     private final ApplicationModel appModel;
+    private Path appModuleDir;
 
     public CurateOutcomeBuildItem(ApplicationModel appModel) {
         this.appModel = appModel;
@@ -13,5 +19,40 @@ public final class CurateOutcomeBuildItem extends SimpleBuildItem {
 
     public ApplicationModel getApplicationModel() {
         return appModel;
+    }
+
+    /**
+     * Returns the application module directory, if the application is built from a source project.
+     * For a single module project it will the project directory. For a multimodule project,
+     * it will the directory of the application module.
+     * <p>
+     * During re-augmentation of applications packaged as {@code mutable-jar} this method will return the current directory,
+     * since the source project might not be available anymore.
+     *
+     * @return application module directory, never null
+     */
+    public Path getApplicationModuleDirectory() {
+        if (appModuleDir == null) {
+            // modules are by default available in dev and test modes, and in prod mode if
+            // quarkus.bootstrap.workspace-discovery system or project property is true,
+            // otherwise it could be null
+            final WorkspaceModule module = appModel.getApplicationModule();
+            appModuleDir = module == null ? deriveModuleDirectoryFromArtifact() : module.getModuleDir().toPath();
+        }
+        return appModuleDir;
+    }
+
+    private Path deriveModuleDirectoryFromArtifact() {
+        var paths = appModel.getAppArtifact().getResolvedPaths();
+        for (var path : paths) {
+            if (Files.isDirectory(path)) {
+                var moduleDir = BuildToolHelper.getProjectDir(path);
+                if (moduleDir != null) {
+                    return moduleDir;
+                }
+            }
+        }
+        // the module isn't available, return the current directory
+        return Path.of("").toAbsolutePath();
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
@@ -59,7 +59,7 @@ public class BuildToolHelper {
             }
             currentPath = currentPath.getParent();
         }
-        log.warnv("Unable to find a project directory for {0}.", p);
+        log.warnv("Unable to find the project directory for {0}.", p);
         return null;
     }
 


### PR DESCRIPTION
Closes https://github.com/quarkusio/quarkus/issues/44013

FYI @ia3andy @melloware @mcruzdev 

I'm curious what this method will be used for.
There is a case when this project is actually not available, for example during re-augmentation of a mutable-jar (remote-dev being one of the use-cases), in which case I'm returning the current directory. Although that may not match the expectation. OTOH, if I return null instead, every caller of this method will have to check for null and do something about it. So it depends on what this will be used for.