### PR TITLE
Update getting-started-reactive.adoc

### DIFF
--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -184,6 +184,10 @@ Create the `src/main/java/org/acme/hibernate/orm/panache/FruitResource.java` fil
 ----
 package org.acme.hibernate.orm.panache;
 
+import java.util.List;
+
+import io.quarkus.panache.common.Sort;
+import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.Path;
 


### PR DESCRIPTION
docs: To run the `/fruits` GET endpoint example, I required 3 more imports:
- java.util.List;
- io.quarkus.panache.common.Sort;
- io.smallrye.mutiny.Uni