### PR TITLE
Remove Failsafe plugin config in AWT testing

### DIFF
--- a/integration-tests/awt/pom.xml
+++ b/integration-tests/awt/pom.xml
@@ -161,12 +161,6 @@
                     <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The plugin shouldn't be defined and disabled, it will be automatically enabled by the profile.

Fixes #43997