### PR TITLE
Codestarts - Do not reference ITs module if extension without ITs

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/pom.tpl.qute.xml
@@ -21,6 +21,7 @@
         </pluginManagement>
     </build>
     {/if}
+    {#if has-integration-tests-module}
     <profiles>
         <profile>
             <id>it</id>
@@ -35,4 +36,5 @@
             </modules>
         </profile>
     </profiles>
+    {/if}
 </project>

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartCatalog.java
@@ -50,7 +50,8 @@ public final class QuarkusExtensionCodestartCatalog extends GenericCodestartCata
         IT_PARENT_RELATIVE_PATH("it-parent.relative-path"),
         MAVEN_QUARKUS_EXTENSION_PLUGIN("maven.quarkus-extension-plugin"),
         MAVEN_COMPILER_PLUGIN_VERSION("maven.compiler-plugin-version"),
-        HAS_DOCS_MODULE("has-docs-module");
+        HAS_DOCS_MODULE("has-docs-module"),
+        HAS_INTEGRATION_TESTS_MODULE("has-integration-tests-module");
 
         private final String key;
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
@@ -8,6 +8,7 @@ import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestart
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.EXTENSION_NAME;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.GROUP_ID;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.HAS_DOCS_MODULE;
+import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.HAS_INTEGRATION_TESTS_MODULE;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.IT_PARENT_ARTIFACT_ID;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.IT_PARENT_GROUP_ID;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.IT_PARENT_RELATIVE_PATH;
@@ -105,6 +106,7 @@ public class CreateExtension {
     private String extensionsRelativeDir = "extensions";
     private boolean withCodestart;
     private String javaVersion;
+    private boolean hasIntegrationTestsModule;
 
     public CreateExtension(final Path baseDir) {
         this.baseDir = requireNonNull(baseDir, "extensionDirPath is required");
@@ -218,6 +220,7 @@ public class CreateExtension {
     }
 
     public CreateExtension withoutIntegrationTests(boolean withoutIntegrationTest) {
+        hasIntegrationTestsModule = !withoutIntegrationTest;
         this.builder.withoutIntegrationTests(withoutIntegrationTest);
         return this;
     }
@@ -263,6 +266,7 @@ public class CreateExtension {
         data.putIfAbsent(CLASS_NAME_BASE, toCapCamelCase(extensionId));
         data.put(EXTENSION_FULL_NAME,
                 data.getRequiredStringValue(NAMESPACE_NAME) + data.getRequiredStringValue(EXTENSION_NAME));
+        data.put(HAS_INTEGRATION_TESTS_MODULE, hasIntegrationTestsModule);
 
         // for now, we only support Java extensions
         data.put(JAVA_VERSION, javaVersion == null ? JavaVersion.DEFAULT_JAVA_VERSION_FOR_EXTENSION


### PR DESCRIPTION
When creating a project without ITs, we don't generate the ITs module so we shouldn't reference it in the parent POM.

Fixes #37216