### PR TITLE
Propagate Security JPA security exceptions root cause in raised `AuthenticationFailedException`

### DIFF
--- a/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/PanacheEntitiesConfigurationTest.java
+++ b/extensions/security-jpa-reactive/deployment/src/test/java/io/quarkus/security/jpa/reactive/PanacheEntitiesConfigurationTest.java
@@ -1,10 +1,22 @@
 package io.quarkus.security.jpa.reactive;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.persistence.NonUniqueResultException;
+
+import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.spi.runtime.AuthenticationFailureEvent;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
@@ -20,8 +32,12 @@ public class PanacheEntitiesConfigurationTest extends JpaSecurityRealmTest {
                     .addClass(PanacheUserEntity.class)
                     .addClass(PanacheRoleEntity.class)
                     .addClass(UserResource.class)
+                    .addClass(AuthenticationFailureObserver.class)
                     .addAsResource("multiple-entities/import.sql", "import.sql")
                     .addAsResource("multiple-entities/application.properties", "application.properties"));
+
+    @Inject
+    AuthenticationFailureObserver authenticationFailureObserver;
 
     @Test
     void duplicateUsernameTest() {
@@ -34,8 +50,17 @@ public class PanacheEntitiesConfigurationTest extends JpaSecurityRealmTest {
         // one user
         getUsername().statusCode(200).body(is(DUPLICATE_USERNAME));
         createUser();
+
         // two users -> NonUniqueResultException -> 401
-        getUsername().statusCode(401);
+        authenticationFailureObserver.recordEvents(true);
+        getUsername().statusCode(401).body(Matchers.emptyOrNullString());
+        Awaitility.await().untilAsserted(() -> assertNotNull(authenticationFailureObserver.getEvent()));
+        var authFailureEvent = authenticationFailureObserver.getEvent();
+        assertInstanceOf(AuthenticationFailedException.class, authFailureEvent.getAuthenticationFailure());
+        var cause = authFailureEvent.getAuthenticationFailure().getCause();
+        assertInstanceOf(NonUniqueResultException.class, cause);
+        assertTrue(cause.getMessage().contains("Query did not return a unique result"));
+        authenticationFailureObserver.recordEvents(false);
     }
 
     private static void createUser() {
@@ -57,4 +82,27 @@ public class PanacheEntitiesConfigurationTest extends JpaSecurityRealmTest {
                 .then();
     }
 
+    @Singleton
+    public static class AuthenticationFailureObserver {
+
+        private volatile boolean record = false;
+        private volatile AuthenticationFailureEvent event;
+
+        void observerAuthFailure(@Observes AuthenticationFailureEvent event) {
+            if (record) {
+                this.event = event;
+            }
+        }
+
+        void recordEvents(boolean record) {
+            this.record = record;
+            if (!record) {
+                this.event = null;
+            }
+        }
+
+        AuthenticationFailureEvent getEvent() {
+            return event;
+        }
+    }
 }

--- a/extensions/security-jpa-reactive/runtime/src/main/java/io/quarkus/security/jpa/reactive/runtime/JpaReactiveIdentityProvider.java
+++ b/extensions/security-jpa-reactive/runtime/src/main/java/io/quarkus/security/jpa/reactive/runtime/JpaReactiveIdentityProvider.java
@@ -48,7 +48,7 @@ public abstract class JpaReactiveIdentityProvider implements IdentityProvider<Us
                             @Override
                             public Throwable apply(Throwable throwable) {
                                 LOG.debug("Authentication failed", throwable);
-                                return new AuthenticationFailedException();
+                                return new AuthenticationFailedException(throwable);
                             }
                         });
             }

--- a/extensions/security-jpa-reactive/runtime/src/main/java/io/quarkus/security/jpa/reactive/runtime/JpaReactiveTrustedIdentityProvider.java
+++ b/extensions/security-jpa-reactive/runtime/src/main/java/io/quarkus/security/jpa/reactive/runtime/JpaReactiveTrustedIdentityProvider.java
@@ -48,7 +48,7 @@ public abstract class JpaReactiveTrustedIdentityProvider implements IdentityProv
                             @Override
                             public Throwable apply(Throwable throwable) {
                                 LOG.debug("Authentication failed", throwable);
-                                return new AuthenticationFailedException();
+                                return new AuthenticationFailedException(throwable);
                             }
                         });
             }

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/runtime/JpaIdentityProvider.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/runtime/JpaIdentityProvider.java
@@ -60,7 +60,7 @@ public abstract class JpaIdentityProvider implements IdentityProvider<UsernamePa
             return authenticate(session, request);
         } catch (SecurityException e) {
             log.debug("Authentication failed", e);
-            throw new AuthenticationFailedException();
+            throw new AuthenticationFailedException(e);
         }
     }
 

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/runtime/JpaTrustedIdentityProvider.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/runtime/JpaTrustedIdentityProvider.java
@@ -60,7 +60,7 @@ public abstract class JpaTrustedIdentityProvider implements IdentityProvider<Tru
             return authenticate(session, request);
         } catch (SecurityException e) {
             log.debug("Authentication failed", e);
-            throw new AuthenticationFailedException();
+            throw new AuthenticationFailedException(e);
         }
     }
 


### PR DESCRIPTION
- Reported here https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/AuthorizationFailedException.20message.20is.20null.20in.20Exc.2EMapper.

Keeps root cause of a security failure (and non-unique result in JPA reactive case) in thrown `AuthenticationFailedException` because users may want to access it for example via security events and inspect it. This shouldn't introduce any security risk because we do not return a root cause with HTTP response. We only return exception message in DEV mode, which is not a case here.