### PR TITLE
Avoid duplication descriptors in PlatformImportsImpl

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImportsImpl.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImportsImpl.java
@@ -81,8 +81,10 @@ public class PlatformImportsImpl implements PlatformImports, Serializable {
                 artifactId.substring(0,
                         artifactId.length() - BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX.length()),
                 version);
-        platformImports.computeIfAbsent(bomCoords, c -> new PlatformImport()).descriptorFound = true;
-        platformBoms.add(bomCoords);
+        platformImports.computeIfAbsent(bomCoords, c -> {
+            platformBoms.add(bomCoords);
+            return new PlatformImport();
+        }).descriptorFound = true;
     }
 
     public void addPlatformProperties(String groupId, String artifactId, String classifier, String type, String version,
@@ -92,21 +94,24 @@ public class PlatformImportsImpl implements PlatformImports, Serializable {
                         artifactId.length() - BootstrapConstants.PLATFORM_PROPERTIES_ARTIFACT_ID_SUFFIX.length()),
                 version);
         platformImports.computeIfAbsent(bomCoords, c -> new PlatformImport());
-        importedPlatformBoms.computeIfAbsent(groupId, g -> new ArrayList<>()).add(bomCoords);
+        importedPlatformBoms.computeIfAbsent(groupId, g -> new ArrayList<>());
+        if (!importedPlatformBoms.get(groupId).contains(bomCoords)) {
+            importedPlatformBoms.get(groupId).add(bomCoords);
 
-        final Properties props = new Properties();
-        try (InputStream is = Files.newInputStream(propsPath)) {
-            props.load(is);
-        } catch (IOException e) {
-            throw new AppModelResolverException("Failed to read properties from " + propsPath, e);
-        }
-        for (Map.Entry<?, ?> prop : props.entrySet()) {
-            final String name = String.valueOf(prop.getKey());
-            if (name.startsWith(BootstrapConstants.PLATFORM_PROPERTY_PREFIX)) {
-                if (isPlatformReleaseInfo(name)) {
-                    addPlatformRelease(name, String.valueOf(prop.getValue()));
-                } else {
-                    collectedProps.putIfAbsent(name, String.valueOf(prop.getValue().toString()));
+            final Properties props = new Properties();
+            try (InputStream is = Files.newInputStream(propsPath)) {
+                props.load(is);
+            } catch (IOException e) {
+                throw new AppModelResolverException("Failed to read properties from " + propsPath, e);
+            }
+            for (Map.Entry<?, ?> prop : props.entrySet()) {
+                final String name = String.valueOf(prop.getKey());
+                if (name.startsWith(BootstrapConstants.PLATFORM_PROPERTY_PREFIX)) {
+                    if (isPlatformReleaseInfo(name)) {
+                        addPlatformRelease(name, String.valueOf(prop.getValue()));
+                    } else {
+                        collectedProps.putIfAbsent(name, String.valueOf(prop.getValue().toString()));
+                    }
                 }
             }
         }

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/bootstrap/model/PlatformImportsTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/bootstrap/model/PlatformImportsTest.java
@@ -114,6 +114,14 @@ public class PlatformImportsTest {
                         GACTV.fromString("io.playground:acme-bom::pom:2.2.2")))));
     }
 
+    @Test
+    public void duplicatePlatformDescriptorsAreIgnored() {
+        final PlatformImportsImpl pi = new PlatformImportsImpl();
+        pi.addPlatformDescriptor("io.playground", "acme-bom-quarkus-platform-descriptor", "", "", "1.1");
+        pi.addPlatformDescriptor("io.playground", "acme-bom-quarkus-platform-descriptor", "", "", "1.1");
+        assertEquals(1, pi.getImportedPlatformBoms().size());
+    }
+
     private PlatformProps newPlatformProps() throws IOException {
         final PlatformProps p = new PlatformProps();
         platformProps.add(p);


### PR DESCRIPTION
As we discussed in issue #44146, to use `PlatformImportsImpl` as input for `GradleApplicationModelTask`, we need to prevent the duplications generated during configuration resolution. This PR addresses the duplication issue and includes a test to cover platform descriptor duplications