### PR TITLE
Platform imports as input parameter for GradleApplicationModelTask

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -522,8 +522,7 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getAppClasspath().configureFrom(classpath.getRuntimeConfigurationWithoutResolvingDeployment());
         task.getPlatformConfiguration().configureFrom(classpath.getPlatformConfiguration());
         task.getDeploymentClasspath().configureFrom(classpath.getDeploymentConfiguration());
-        task.getDeploymentResolvedWorkaround().from(classpath.getDeploymentConfiguration().getIncoming().getFiles());
-        task.getPlatformImportProperties().set(classpath.getPlatformImportsWithoutResolvingPlatform().getPlatformProperties());
+        task.getPlatformImports().set(classpath.getPlatformImportsWithoutResolvingPlatform());
         task.getApplicationModel().set(project.getLayout().getBuildDirectory().file(quarkusModelFile));
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImportsImpl.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImportsImpl.java
@@ -81,8 +81,10 @@ public class PlatformImportsImpl implements PlatformImports, Serializable {
                 artifactId.substring(0,
                         artifactId.length() - BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX.length()),
                 version);
-        platformImports.computeIfAbsent(bomCoords, c -> new PlatformImport()).descriptorFound = true;
-        platformBoms.add(bomCoords);
+        platformImports.computeIfAbsent(bomCoords, c -> {
+            platformBoms.add(bomCoords);
+            return new PlatformImport();
+        }).descriptorFound = true;
     }
 
     public void addPlatformProperties(String groupId, String artifactId, String classifier, String type, String version,
@@ -92,8 +94,10 @@ public class PlatformImportsImpl implements PlatformImports, Serializable {
                         artifactId.length() - BootstrapConstants.PLATFORM_PROPERTIES_ARTIFACT_ID_SUFFIX.length()),
                 version);
         platformImports.computeIfAbsent(bomCoords, c -> new PlatformImport());
-        importedPlatformBoms.computeIfAbsent(groupId, g -> new ArrayList<>()).add(bomCoords);
-
+        importedPlatformBoms.computeIfAbsent(groupId, g -> new ArrayList<>());
+        if (!importedPlatformBoms.get(groupId).contains(bomCoords)) {
+            importedPlatformBoms.get(groupId).add(bomCoords);
+        }
         final Properties props = new Properties();
         try (InputStream is = Files.newInputStream(propsPath)) {
             props.load(is);

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/bootstrap/model/PlatformImportsTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/bootstrap/model/PlatformImportsTest.java
@@ -114,6 +114,14 @@ public class PlatformImportsTest {
                         GACTV.fromString("io.playground:acme-bom::pom:2.2.2")))));
     }
 
+    @Test
+    public void duplicatePlatformDescriptorsAreIgnored() {
+        final PlatformImportsImpl pi = new PlatformImportsImpl();
+        pi.addPlatformDescriptor("io.playground", "acme-bom-quarkus-platform-descriptor", "", "", "1.1");
+        pi.addPlatformDescriptor("io.playground", "acme-bom-quarkus-platform-descriptor", "", "", "1.1");
+        assertEquals(1, pi.getImportedPlatformBoms().size());
+    }
+
     private PlatformProps newPlatformProps() throws IOException {
         final PlatformProps p = new PlatformProps();
         platformProps.add(p);


### PR DESCRIPTION
**Note**
This PR includes a commit from [PR #44147](https://github.com/quarkusio/quarkus/pull/44147) to demonstrate the full workflow keeping the caching of the tasks. If the changes in the previous PR are approved and merged, I can open a new PR for clarity.

**Current Issue**
In the current implementation of `GradleApplicationModelTask`, we create a new `PlatformImportsImpl` instance by manually configuring properties and descriptors. However, when testing the `QuarkusInfo` task using the new ApplicationModel provided by GradleApplicationModelTask, the output indicates "no BOM or extensions are found."

The issue arises because we aren’t enforcing the resolution of the Platform Configuration, which is why the platform BOMs aren’t being retrieved.

**Proposal**
This PR proposes to add PlatformImports from ApplicationDeploymentClasspathBuilder as an input parameter for GradleApplicationModelTask:
```
@Input
public abstract Property<PlatformImports> getPlatformImports();
```
This change simplifies the ApplicationModel creation logic:
```
final ApplicationModelBuilder modelBuilder = new ApplicationModelBuilder()
        .setAppArtifact(appArtifact)
        .setPlatformImports(getPlatformImports().get())
        .addReloadableWorkspaceModule(appArtifact.getKey());
```
To prevent issues like [#43258](https://github.com/quarkusio/quarkus/issues/43258), we use the same approach as in [PR #44032](https://github.com/quarkusio/quarkus/pull/44032), retrieving the FileCollection from the incoming dependencies of the Quarkus deployment configuration without immediate resolution. This allows us to retrieve the Platform Configuration as needed. Consequently, we removed the getDeploymentResolvedWorkaround as input, as the file collection is now accessed during the Quarkus task configuration phase.

**Additional Fix**
This PR also addresses another issue observed when testing the QuarkusInfo task. With this configuration:
```
implementation("io.quarkus:quarkus-rest")
implementation("io.quarkus:quarkus-arc")
```
Only the quarkus-rest extension was displayed:
```
io.quarkus:quarkus-rest ✔
```
The reason is that quarkus-arc is a dependency of quarkus-rest, causing it not to display as a direct dependency. To resolve this, we introduce directDependencies to avoid duplicating Application Model dependencies that are indirect.

If these changes are approved, I’ll create a new PR to migrate QuarkusInfo to use the updated ApplicationModel provider.