### PR TITLE
Do not throw NPE in AfterAll interceptor if application didn't start

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -888,7 +888,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
     @Override
     public void interceptAfterAllMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext,
             ExtensionContext extensionContext) throws Throwable {
-        if (isNativeOrIntegrationTest(extensionContext.getRequiredTestClass())) {
+        if (runningQuarkusApplication == null || isNativeOrIntegrationTest(extensionContext.getRequiredTestClass())) {
             invocation.proceed();
             return;
         }


### PR DESCRIPTION
This is to solve an issue that we can see from time to time in the CI:

```
java.lang.NullPointerException: Cannot invoke "io.quarkus.bootstrap.app.RunningQuarkusApplication.getClassLoader()" because "io.quarkus.test.junit.QuarkusTestExtension.runningQuarkusApplication" is null
	at io.quarkus.test.junit.QuarkusTestExtension.runExtensionMethod(QuarkusTestExtension.java:909)
	at io.quarkus.test.junit.QuarkusTestExtension.runExtensionMethod(QuarkusTestExtension.java:901)
	at io.quarkus.test.junit.QuarkusTestExtension.interceptAfterAllMethod(QuarkusTestExtension.java:895)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1116)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	Suppressed: org.opentest4j.TestAbortedException: Boot failed
```

For instance here:
https://github.com/quarkusio/quarkus/pull/43448#issuecomment-2430017790 in the `io.quarkus.it.mongodb.BookResourceTest` failure.

Created as draft to get a full CI run.