### PR TITLE
Amazon Lambda - Support decorators

### DIFF
--- a/extensions/amazon-lambda/deployment/pom.xml
+++ b/extensions/amazon-lambda/deployment/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -3,13 +3,13 @@ package io.quarkus.amazon.lambda.deployment;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import jakarta.inject.Named;
 
@@ -29,6 +29,7 @@ import io.quarkus.amazon.lambda.runtime.FunctionError;
 import io.quarkus.amazon.lambda.runtime.LambdaBuildTimeConfig;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.processor.DotNames;
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -58,6 +59,18 @@ public final class AmazonLambdaProcessor {
     private static final DotName NAMED = DotName.createSimple(Named.class.getName());
     private static final Logger log = Logger.getLogger(AmazonLambdaProcessor.class);
 
+    private static final Predicate<ClassInfo> INCLUDE_HANDLER_PREDICATE = new Predicate<>() {
+
+        @Override
+        public boolean test(ClassInfo classInfo) {
+            if (classInfo.isAbstract() || classInfo.hasAnnotation(DotNames.DECORATOR)) {
+                return false;
+            }
+
+            return true;
+        }
+    };
+
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.AMAZON_LAMBDA);
@@ -75,11 +88,13 @@ public final class AmazonLambdaProcessor {
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer) throws BuildException {
 
-        Collection<ClassInfo> allKnownImplementors = combinedIndexBuildItem.getIndex().getAllKnownImplementors(REQUEST_HANDLER);
+        List<ClassInfo> allKnownImplementors = new ArrayList<>(
+                combinedIndexBuildItem.getIndex().getAllKnownImplementors(REQUEST_HANDLER)
+                        .stream().filter(INCLUDE_HANDLER_PREDICATE).toList());
         allKnownImplementors.addAll(combinedIndexBuildItem.getIndex()
-                .getAllKnownImplementors(REQUEST_STREAM_HANDLER));
+                .getAllKnownImplementors(REQUEST_STREAM_HANDLER).stream().filter(INCLUDE_HANDLER_PREDICATE).toList());
         allKnownImplementors.addAll(combinedIndexBuildItem.getIndex()
-                .getAllKnownSubclasses(SKILL_STREAM_HANDLER));
+                .getAllKnownSubclasses(SKILL_STREAM_HANDLER).stream().filter(INCLUDE_HANDLER_PREDICATE).toList());
 
         if (allKnownImplementors.size() > 0 && providedLambda.isPresent()) {
             throw new BuildException(

--- a/extensions/amazon-lambda/deployment/src/test/java/io/quarkus/amazon/lambda/deployment/testing/LambdaWithDecoratorTest.java
+++ b/extensions/amazon-lambda/deployment/src/test/java/io/quarkus/amazon/lambda/deployment/testing/LambdaWithDecoratorTest.java
@@ -1,0 +1,83 @@
+package io.quarkus.amazon.lambda.deployment.testing;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import io.quarkus.amazon.lambda.deployment.testing.model.InputPerson;
+import io.quarkus.test.QuarkusUnitTest;
+
+class LambdaWithDecoratorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(LambdaWithDecorator.class, RequestHandlerDecorator.class, InputPerson.class))
+            .setLogRecordPredicate(record -> record.getLevel().intValue() == Level.INFO.intValue()
+                    && record.getMessage().contains("handling request with id"))
+            .assertLogRecords(records -> assertThat(records)
+                    .extracting(LogRecord::getMessage)
+                    .isNotEmpty());
+
+    @Test
+    public void testLambdaWithDecorator() throws Exception {
+        // you test your lambdas by invoking on http://localhost:8081
+        // this works in dev mode too
+
+        InputPerson in = new InputPerson("Stu");
+        given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body(in)
+                .when()
+                .post()
+                .then()
+                .statusCode(200)
+                .body(containsString("Hey Stu"));
+    }
+
+    public static class LambdaWithDecorator implements RequestHandler<InputPerson, String> {
+
+        @Override
+        public String handleRequest(InputPerson input, Context context) {
+            return "Hey " + input.getName();
+        }
+    }
+
+    @Priority(10)
+    @Decorator
+    public static class RequestHandlerDecorator<I, O> implements RequestHandler<I, O> {
+
+        @Inject
+        Logger logger;
+
+        @Inject
+        @Any
+        @Delegate
+        RequestHandler<I, O> delegate;
+
+        @Override
+        public O handleRequest(I i, Context context) {
+            logger.info("handling request with id " + context.getAwsRequestId());
+            return delegate.handleRequest(i, context);
+        }
+    }
+}


### PR DESCRIPTION
We need to ignore decorators and abstract classes when selecting the request handlers.

Fixes #34824