### PR TITLE
Fix IT / native test(s), add it to native-tests run

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -117,7 +117,7 @@
         {
             "category": "Misc4",
             "timeout": 130,
-            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, jaxb, opentelemetry, opentelemetry-jdbc-instrumentation, opentelemetry-mongodb-client-instrumentation, opentelemetry-redis-instrumentation, web-dependency-locator",
+            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, jaxb, observability-lgtm, opentelemetry, opentelemetry-jdbc-instrumentation, opentelemetry-mongodb-client-instrumentation, opentelemetry-redis-instrumentation, web-dependency-locator",
             "os-name": "ubuntu-latest"
         },
         {

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmConfigTestBase.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmConfigTestBase.java
@@ -1,0 +1,14 @@
+package io.quarkus.observability.test;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+public abstract class LgtmConfigTestBase extends LgtmTestBase {
+
+    @ConfigProperty(name = "grafana.endpoint")
+    String endpoint;
+
+    @Override
+    protected String grafanaEndpoint() {
+        return endpoint;
+    }
+}

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmGrpcTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmGrpcTest.java
@@ -15,7 +15,7 @@ import io.quarkus.test.junit.TestProfile;
 @QuarkusTest
 @TestProfile(LgtmGrpcTest.GrpcTestProfileOnly.class)
 @DisabledOnOs(OS.WINDOWS)
-public class LgtmGrpcTest extends LgtmTestBase {
+public class LgtmGrpcTest extends LgtmConfigTestBase {
 
     public static class GrpcTestProfileOnly implements QuarkusTestProfile {
         @Override

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmLifecycleTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmLifecycleTest.java
@@ -15,7 +15,7 @@ import io.quarkus.test.junit.TestProfile;
 @QuarkusTestResource(value = LgtmResource.class, restrictToAnnotatedClass = true)
 @TestProfile(LgtmLifecycleTest.TestResourceTestProfileOff.class)
 @DisabledOnOs(OS.WINDOWS)
-public class LgtmLifecycleTest extends LgtmTestBase {
+public class LgtmLifecycleTest extends LgtmConfigTestBase {
 
     public static class TestResourceTestProfileOff implements QuarkusTestProfile {
         @Override

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesIT.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesIT.java
@@ -1,11 +1,18 @@
 package io.quarkus.observability.test;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
 
 @QuarkusIntegrationTest
+@TestProfile(LgtmResourcesTest.DevResourcesTestProfileOnly.class)
 @DisabledOnOs(OS.WINDOWS)
-public class LgtmResourcesIT extends LgtmResourcesTest {
+public class LgtmResourcesIT extends LgtmTestBase {
+    @Override
+    protected String grafanaEndpoint() {
+        return ConfigProvider.getConfig().getValue("grafana.endpoint", String.class);
+    }
 }

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesTest.java
@@ -15,7 +15,7 @@ import io.quarkus.test.junit.TestProfile;
 @QuarkusTest
 @TestProfile(LgtmResourcesTest.DevResourcesTestProfileOnly.class)
 @DisabledOnOs(OS.WINDOWS)
-public class LgtmResourcesTest extends LgtmTestBase {
+public class LgtmResourcesTest extends LgtmConfigTestBase {
 
     public static class DevResourcesTestProfileOnly implements QuarkusTestProfile {
         @Override

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmServicesTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmServicesTest.java
@@ -7,5 +7,5 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @DisabledOnOs(OS.WINDOWS)
-public class LgtmServicesTest extends LgtmTestBase {
+public class LgtmServicesTest extends LgtmConfigTestBase {
 }

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestBase.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestBase.java
@@ -3,7 +3,6 @@ package io.quarkus.observability.test;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
@@ -13,15 +12,14 @@ import io.restassured.RestAssured;
 public abstract class LgtmTestBase {
     private final Logger log = Logger.getLogger(getClass());
 
-    @ConfigProperty(name = "grafana.endpoint")
-    String endpoint;
+    protected abstract String grafanaEndpoint();
 
     @Test
     public void testTracing() {
         log.info("Testing Grafana ...");
         String response = RestAssured.get("/api/poke?f=100").body().asString();
         log.info("Response: " + response);
-        GrafanaClient client = new GrafanaClient(endpoint, "admin", "admin");
+        GrafanaClient client = new GrafanaClient(grafanaEndpoint(), "admin", "admin");
         Awaitility.await().atMost(61, TimeUnit.SECONDS).until(
                 client::user,
                 u -> "admin".equals(u.login));


### PR DESCRIPTION
This removes ConfigProperty usage in IT test.
And it finally enables LGTM test(s) as native -- hence we didn't notice this failure before.