### PR TITLE
Add information about 'from' in mailer docs

### DIFF
--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -66,9 +66,9 @@ To send a simple email, proceed as follows:
 [source, java]
 ----
 // Imperative API:
-mailer.send(Mail.withText("to@acme.org", "A simple email from quarkus", "This is my body."));
+mailer.send(Mail.withText("to@acme.org", "A simple email from quarkus", "This is my body.").setFrom("from@acme.org"));
 // Reactive API:
-Uni<Void> stage = reactiveMailer.send(Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body."));
+Uni<Void> stage = reactiveMailer.send(Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body.").setFrom("from@acme.org"));
 ----
 
 For example, you can use the `Mailer` in an HTTP endpoint as follows:
@@ -78,14 +78,14 @@ For example, you can use the `Mailer` in an HTTP endpoint as follows:
 @GET
 @Path("/imperative")
 public void sendASimpleEmail() {
-    mailer.send(Mail.withText("to@acme.org", "A simple email from quarkus", "This is my body"));
+    mailer.send(Mail.withText("to@acme.org", "A simple email from quarkus", "This is my body").setFrom("from@acme.org"));
 }
 
 @GET
 @Path("/reactive")
 public Uni<Void> sendASimpleEmailAsync() {
     return reactiveMailer.send(
-            Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body"));
+            Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body").setFrom("from@acme.org"));
 }
 ----
 
@@ -95,6 +95,20 @@ The mailer lets you send `io.quarkus.mailer.Mail` objects.
 You can create new `io.quarkus.mailer.Mail` instances from the constructor or from the `Mail.withText` and
 `Mail.withHtml` helper methods.
 The `Mail` instance lets you add recipients (to, cc, or bcc), set the subject, headers, sender (from) address...
+
+Most of these properties are optional, but the sender address is required. It can either be set on an individual `Mail` instances using
+
+[source,java]
+----
+.setFrom("from@acme.org");
+----
+
+or a global default can be configured, using
+
+[source,properties]
+----
+quarkus.mailer.from=from@acme.org
+----
 
 You can also send several `Mail` objects in one call:
 


### PR DESCRIPTION
Direct preview link: https://quarkus-pr-main-44164-preview.surge.sh/version/main/guides/mailer-reference

-----

I recently used the mailer extension. When I copied and pasted the example from the [docs](https://quarkus.io/guides/mailer-reference), it didn't work. 

```
mailer.send(Mail.withText("to@acme.org", "A simple email from quarkus", "This is my body."));
```

I got a nasty exception:

```
 java.util.concurrent.CompletionException: io.vertx.core.impl.NoStackTraceThrowable: sender address is not present
        at io.smallrye.mutiny.operators.uni.UniBlockingAwait.await(UniBlockingAwait.java:79)
        at io.smallrye.mutiny.groups.UniAwait.atMost(UniAwait.java:65)
        at io.smallrye.mutiny.groups.UniAwait.indefinitely(UniAwait.java:46)
        at io.quarkus.mailer.runtime.BlockingMailerImpl.send(BlockingMailerImpl.java:20)
        at org.acme.MailThing.doMail(MailThing.java:16)
...
Caused by: io.vertx.core.impl.NoStackTraceThrowable: sender address is not present
```

(The error was hidden, which didn't help, but that's a different issue.)

I worked out I needed to set the from address, but https://quarkus.io/guides/mailer-reference didn't give enough information how to do that. It says 

> The Mail instance lets you add recipients (to, cc, or bcc), set the subject, headers, sender (from) address…​

I tried a few variations, like `addSender`, `addHeader(`from`...`), `addFrom`, before I found `setFrom`. Since users have to use this method (or do it by config), we should make sure to include it in the reference. 

I've updated the opening examples so they work out of the box, and also added a bit of text to explain that a sender is required, and describe the two ways of doing it. 