### PR TITLE
An option to resolve only the runtime part of the ApplicationModel

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
@@ -83,6 +83,12 @@ public class DependencySbomMojo extends AbstractMojo {
     @Parameter(property = "quarkus.dependency.sbom.schema-version")
     String schemaVersion;
 
+    /**
+     * Whether to limit application dependencies to only those that are included in the runtime
+     */
+    @Parameter(property = "quarkus.dependency.sbom.runtime-only")
+    boolean runtimeOnly;
+
     protected MavenArtifactResolver resolver;
 
     @Override
@@ -111,7 +117,8 @@ public class DependencySbomMojo extends AbstractMojo {
                 project.getVersion());
         final BootstrapAppModelResolver modelResolver;
         try {
-            modelResolver = new BootstrapAppModelResolver(getResolver());
+            modelResolver = new BootstrapAppModelResolver(getResolver())
+                    .setRuntimeModelOnly(runtimeOnly);
             if (mode != null) {
                 if (mode.equalsIgnoreCase("test")) {
                     modelResolver.setTest(true);

--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
@@ -85,6 +85,12 @@ public class DependencyTreeMojo extends AbstractMojo {
     @Parameter(property = "appendOutput", required = false, defaultValue = "false")
     boolean appendOutput;
 
+    /**
+     * Whether to log only the runtime dependencies of the Quarkus application
+     */
+    @Parameter(property = "runtimeOnly")
+    boolean runtimeOnly;
+
     protected MavenArtifactResolver resolver;
 
     @Override
@@ -134,7 +140,8 @@ public class DependencyTreeMojo extends AbstractMojo {
                 project.getVersion());
         final BootstrapAppModelResolver modelResolver;
         try {
-            modelResolver = new BootstrapAppModelResolver(resolver());
+            modelResolver = new BootstrapAppModelResolver(resolver())
+                    .setRuntimeModelOnly(runtimeOnly);
             if (mode != null) {
                 if (mode.equalsIgnoreCase("test")) {
                     modelResolver.setTest(true);

--- a/devtools/maven/src/test/java/io/quarkus/maven/ConditionalDependencyTreeMojoRuntimeOnlyTest.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/ConditionalDependencyTreeMojoRuntimeOnlyTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.maven;
+
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+
+public class ConditionalDependencyTreeMojoRuntimeOnlyTest extends DependencyTreeMojoTestBase {
+    @Override
+    protected String mode() {
+        return "prod";
+    }
+
+    @Override
+    protected boolean isIncubatingModelResolver() {
+        return true;
+    }
+
+    @Override
+    protected boolean isRuntimeOnly() {
+        return true;
+    }
+
+    @Override
+    protected void initRepo() {
+
+        final TsQuarkusExt coreExt = new TsQuarkusExt("test-core-ext");
+
+        var tomatoExt = new TsQuarkusExt("quarkus-tomato").addDependency(coreExt);
+        var mozzarellaExt = new TsQuarkusExt("quarkus-mozzarella").addDependency(coreExt);
+        var basilExt = new TsQuarkusExt("quarkus-basil").addDependency(coreExt);
+
+        var oilJar = TsArtifact.jar("quarkus-oil");
+
+        var capreseExt = new TsQuarkusExt("quarkus-caprese")
+                .setDependencyCondition(tomatoExt, mozzarellaExt, basilExt)
+                .addDependency(coreExt);
+        capreseExt.getDeployment().addDependency(oilJar);
+        capreseExt.install(repoBuilder);
+
+        var saladExt = new TsQuarkusExt("quarkus-salad")
+                .setConditionalDeps(capreseExt)
+                .addDependency(coreExt);
+
+        app = TsArtifact.jar("app-with-conditional-deps")
+                .addDependency(tomatoExt)
+                .addDependency(mozzarellaExt)
+                .addDependency(basilExt)
+                .addDependency(saladExt)
+                .addDependency(oilJar);
+
+        appModel = app.getPomModel();
+        app.install(repoBuilder);
+    }
+}

--- a/devtools/maven/src/test/java/io/quarkus/maven/DependencyTreeMojoTestBase.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/DependencyTreeMojoTestBase.java
@@ -65,6 +65,10 @@ abstract class DependencyTreeMojoTestBase {
         return false;
     }
 
+    protected boolean isRuntimeOnly() {
+        return false;
+    }
+
     @Test
     public void test() throws Exception {
 
@@ -81,6 +85,7 @@ abstract class DependencyTreeMojoTestBase {
         mojo.resolver = mvnResolver;
         mojo.mode = mode();
         mojo.graph = isGraph();
+        mojo.runtimeOnly = isRuntimeOnly();
 
         final Path mojoLog = workDir.resolve(getClass().getName() + ".log");
         final PrintStream defaultOut = System.out;
@@ -92,8 +97,12 @@ abstract class DependencyTreeMojoTestBase {
             System.setOut(defaultOut);
         }
 
+        String expectedFileName = app.getArtifactFileName() + "." + mode();
+        if (isRuntimeOnly()) {
+            expectedFileName += ".rt";
+        }
         assertThat(mojoLog).hasSameTextualContentAs(
                 Path.of("").normalize().toAbsolutePath()
-                        .resolve("target").resolve("test-classes").resolve(app.getArtifactFileName() + "." + mode()));
+                        .resolve("target").resolve("test-classes").resolve(expectedFileName));
     }
 }

--- a/devtools/maven/src/test/resources/app-with-conditional-deps-1.jar.prod.rt
+++ b/devtools/maven/src/test/resources/app-with-conditional-deps-1.jar.prod.rt
@@ -1,0 +1,9 @@
+[info] Quarkus application PROD mode build dependency tree:
+[info] io.quarkus.bootstrap.test:app-with-conditional-deps:pom:1
+[info] ├─ io.quarkus.bootstrap.test:quarkus-tomato:1 (compile)
+[info] │  └─ io.quarkus.bootstrap.test:test-core-ext:1 (compile)
+[info] ├─ io.quarkus.bootstrap.test:quarkus-mozzarella:1 (compile)
+[info] ├─ io.quarkus.bootstrap.test:quarkus-basil:1 (compile)
+[info] ├─ io.quarkus.bootstrap.test:quarkus-salad:1 (compile)
+[info] │  └─ io.quarkus.bootstrap.test:quarkus-caprese:1 (compile)
+[info] └─ io.quarkus.bootstrap.test:quarkus-oil:1 (compile)

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/RuntimeOnlyApplicationModelTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/RuntimeOnlyApplicationModelTestCase.java
@@ -1,0 +1,82 @@
+package io.quarkus.bootstrap.resolver.test;
+
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import io.quarkus.maven.dependency.DependencyFlags;
+
+public class RuntimeOnlyApplicationModelTestCase extends CollectDependenciesBase {
+
+    private static final boolean runtimeOnly = true;
+
+    @Override
+    protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
+        var resolver = super.newAppModelResolver(currentProject);
+        resolver.setIncubatingModelResolver(false);
+        resolver.setRuntimeModelOnly(runtimeOnly);
+        return resolver;
+    }
+
+    @Override
+    protected void setupDependencies() {
+
+        final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        install(extA, false);
+        if (!runtimeOnly) {
+            addCollectedDeploymentDep(extA.getDeployment());
+        }
+
+        installAsDep(extA.getRuntime(),
+                DependencyFlags.DIRECT
+                        | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT
+                        | DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
+
+        final TsQuarkusExt extB = new TsQuarkusExt("ext-b");
+        install(extB, false);
+
+        final TsQuarkusExt extC = new TsQuarkusExt("ext-c");
+        extC.setDependencyCondition(extB);
+        install(extC, false);
+
+        final TsQuarkusExt extD = new TsQuarkusExt("ext-d");
+        install(extD, false);
+        installAsDep(extD.getRuntime(),
+                DependencyFlags.DIRECT
+                        | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT
+                        | DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
+        if (!runtimeOnly) {
+            addCollectedDeploymentDep(extD.getDeployment());
+        }
+
+        final TsArtifact libE = TsArtifact.jar("lib-e");
+        install(libE, true);
+        final TsArtifact libEBuildTIme = TsArtifact.jar("lib-e-build-time");
+        install(libEBuildTIme);
+        if (!runtimeOnly) {
+            addCollectedDeploymentDep(libEBuildTIme);
+        }
+
+        final TsQuarkusExt extE = new TsQuarkusExt("ext-e");
+        extE.setDependencyCondition(extD);
+        extE.getRuntime().addDependency(libE);
+        extE.getDeployment().addDependency(libEBuildTIme);
+        install(extE, false);
+        addCollectedDep(extE.getRuntime(), DependencyFlags.RUNTIME_EXTENSION_ARTIFACT);
+        if (!runtimeOnly) {
+            addCollectedDeploymentDep(extE.getDeployment());
+        }
+
+        final TsQuarkusExt extF = new TsQuarkusExt("ext-f");
+        extF.setConditionalDeps(extC, extE);
+        install(extF, false);
+        installAsDep(extF.getRuntime(),
+                DependencyFlags.DIRECT
+                        | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT
+                        | DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
+        if (!runtimeOnly) {
+            addCollectedDeploymentDep(extF.getDeployment());
+        }
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -62,6 +62,7 @@ public class BootstrapAppModelResolver implements AppModelResolver {
     protected boolean test;
     private boolean collectReloadableDeps = true;
     private boolean incubatingModelResolver;
+    private boolean runtimeModelOnly;
 
     public BootstrapAppModelResolver(MavenArtifactResolver mvn) {
         this.mvn = mvn;
@@ -107,6 +108,11 @@ public class BootstrapAppModelResolver implements AppModelResolver {
 
     public BootstrapAppModelResolver setCollectReloadableDependencies(boolean collectReloadableDeps) {
         this.collectReloadableDeps = collectReloadableDeps;
+        return this;
+    }
+
+    public BootstrapAppModelResolver setRuntimeModelOnly(boolean runtimeModelOnly) {
+        this.runtimeModelOnly = runtimeModelOnly;
         return this;
     }
 
@@ -371,6 +377,7 @@ public class BootstrapAppModelResolver implements AppModelResolver {
                         .setCollectReloadableModules(collectReloadableDeps && reloadableModules.isEmpty())
                         .setCollectCompileOnly(filteredProvidedDeps)
                         .setDependencyLogging(depLogConfig)
+                        .setRuntimeModelOnly(runtimeModelOnly)
                         .resolve(collectRtDepsRequest);
             } else {
                 ApplicationDependencyTreeResolver.newInstance()
@@ -379,6 +386,7 @@ public class BootstrapAppModelResolver implements AppModelResolver {
                         .setCollectReloadableModules(collectReloadableDeps && reloadableModules.isEmpty())
                         .setCollectCompileOnly(filteredProvidedDeps)
                         .setBuildTreeConsumer(depLogConfig == null ? null : depLogConfig.getMessageConsumer())
+                        .setRuntimeModelOnly(runtimeModelOnly)
                         .resolve(collectRtDepsRequest);
             }
             if (logTime) {


### PR DESCRIPTION
This can be useful in cases when a runtime extension dependency model (including the conditional dependencies) needs to be resolved. Basically, collecting information about all the extensions and their runtime dependencies of an application for analysis by the dev tools.

This change also adds an options to log only the runtime dependency trees to the `quarkus:dependency-tree` and an option to generate an SBOM only for the Quarkus runtime dependencies to the `quarkus:dependency-sbom`.