### PR TITLE
Apply the required claims restriction to OIDC introspections

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -378,6 +378,27 @@ public class OidcProvider implements Closeable {
                             throw new AuthenticationFailedException(ex);
                         }
 
+                        if (requiredClaims != null && !requiredClaims.isEmpty()) {
+                            for (Map.Entry<String, String> requiredClaim : requiredClaims.entrySet()) {
+                                String introspectionClaimValue = null;
+                                try {
+                                    introspectionClaimValue = introspectionResult.getString(requiredClaim.getKey());
+                                } catch (ClassCastException ex) {
+                                    LOG.debugf("Introspection claim %s is not String", requiredClaim.getKey());
+                                    throw new AuthenticationFailedException();
+                                }
+                                if (introspectionClaimValue == null) {
+                                    LOG.debugf("Introspection claim %s is missing", requiredClaim.getKey());
+                                    throw new AuthenticationFailedException();
+                                }
+                                if (!introspectionClaimValue.equals(requiredClaim.getValue())) {
+                                    LOG.debugf("Value of the introspection claim %s does not match required value of %s",
+                                            requiredClaim.getKey(), requiredClaim.getValue());
+                                    throw new AuthenticationFailedException();
+                                }
+                            }
+                        }
+
                         return introspectionResult;
                     }
 

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.keycloak;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -35,6 +36,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
 
                 String path = context.request().path();
                 String tenantId = path.split("/")[2];
+
                 if ("tenant-d".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();
                     config.setTenantId("tenant-c");
@@ -70,7 +72,20 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.setJwksPath("jwks");
                     // try the absolute URI
                     config.setIntrospectionPath(authServerUri + "/introspect");
+                    return config;
+                } else if ("tenant-introspection-required-claims".equals(tenantId)) {
 
+                    OidcTenantConfig config = new OidcTenantConfig();
+                    config.setTenantId("tenant-introspection-required-claims");
+                    config.token.setRequiredClaims(Map.of("required_claim", "1"));
+                    String uri = context.request().absoluteURI();
+                    String authServerUri = uri.replace("/tenant-introspection/tenant-introspection-required-claims",
+                            "/oidc");
+                    config.setAuthServerUrl(authServerUri);
+                    config.setDiscoveryEnabled(false);
+                    config.setClientId("client");
+                    config.setIntrospectionPath(authServerUri + "/introspect");
+                    config.setAllowTokenIntrospectionCache(false);
                     return config;
                 } else if ("tenant-oidc-no-discovery".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantIntrospectionRequiredClaimsResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantIntrospectionRequiredClaimsResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.oidc.TokenIntrospection;
+import io.quarkus.security.Authenticated;
+
+@Path("/tenant-introspection")
+@Authenticated
+public class TenantIntrospectionRequiredClaimsResource {
+
+    @Inject
+    TokenIntrospection token;
+
+    @GET
+    @Path("tenant-introspection-required-claims")
+    public String userPermission() {
+        return token.getUsername() + ", required_claim:" + token.getString("required_claim");
+    }
+}


### PR DESCRIPTION
Fixes #43975.

The configured OIDC required claims provide a simple option for enforcing that the token contains some expected String claims, however, at the moment, it is only enforced for tokens in the JWT format.

If the token is remotely introspected, the required claims restriction is not applied to the token introspection response.

This PR makes it effective for the token introspection responses too. Additional checks can be made directly with the injected `TokenIntrospection`

