### PR TITLE
Add Support for Trusted Proxy Detection on Forwarded Requests

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHandlerInitializer.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHandlerInitializer.java
@@ -19,6 +19,17 @@ public class ForwardedHandlerInitializer {
                         + "|" + rc.request().remoteAddress().toString()
                         + "|" + rc.request().uri()
                         + "|" + rc.request().absoluteURI()));
+        router.route("/trusted-proxy").handler(rc -> rc.response()
+                .end(rc.request().scheme() + "|" + rc.request().getHeader(HttpHeaders.HOST) + "|"
+                        + rc.request().remoteAddress().toString()
+                        + "|" + rc.request().getHeader("X-Forwarded-Trusted-Proxy")));
+        router.route("/path-trusted-proxy").handler(rc -> rc.response()
+                .end(rc.request().scheme()
+                        + "|" + rc.request().getHeader(HttpHeaders.HOST)
+                        + "|" + rc.request().remoteAddress().toString()
+                        + "|" + rc.request().uri()
+                        + "|" + rc.request().absoluteURI()
+                        + "|" + rc.request().getHeader("X-Forwarded-Trusted-Proxy")));
     }
 
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyHeaderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyHeaderTest.java
@@ -11,46 +11,44 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.vertx.http.ForwardedHandlerInitializer;
 import io.restassured.RestAssured;
 
-public class TrustedForwarderProxyTest {
+/**
+ * Test the trusted-proxy header
+ */
+public class TrustedProxyHeaderTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(ForwardedHandlerInitializer.class)
-                    .addAsResource(new StringAsset("quarkus.http.proxy.proxy-address-forwarding=true\n" +
-                            "quarkus.http.proxy.allow-forwarded=true\n" +
-                            "quarkus.http.proxy.enable-forwarded-host=true\n" +
-                            "quarkus.http.proxy.enable-forwarded-prefix=true\n" +
-                            "quarkus.http.proxy.trusted-proxies=localhost"),
+                    .addAsResource(new StringAsset("""
+                            quarkus.http.proxy.proxy-address-forwarding=true
+                            quarkus.http.proxy.allow-forwarded=true
+                            quarkus.http.proxy.enable-forwarded-host=true
+                            quarkus.http.proxy.enable-forwarded-prefix=true
+                            quarkus.http.proxy.allow-forwarded=true
+                            quarkus.http.proxy.enable-trusted-proxy-header=true
+                            quarkus.http.proxy.trusted-proxies=localhost
+                            """),
                             "application.properties"));
 
     @Test
     public void testHeadersAreUsed() {
         RestAssured.given()
                 .header("Forwarded", "proto=http;for=backend2:5555;host=somehost2")
-                .get("/path")
-                .then()
-                .body(Matchers.equalTo("http|somehost2|backend2:5555|/path|http://somehost2/path"));
-    }
-
-    @Test
-    public void testHeadersAreUsedWithTrustedProxyHeader() {
-        RestAssured.given()
-                .header("Forwarded", "proto=http;for=backend2:5555;host=somehost2")
                 .get("/path-trusted-proxy")
                 .then()
                 .body(Matchers
-                        .equalTo("http|somehost2|backend2:5555|/path-trusted-proxy|http://somehost2/path-trusted-proxy|null"));
+                        .equalTo("http|somehost2|backend2:5555|/path-trusted-proxy|http://somehost2/path-trusted-proxy|true"));
     }
 
     @Test
-    public void testWithoutTrustedProxyHeader() {
+    public void testTrustedProxyHeader() {
         assertThat(RestAssured.get("/forward").asString()).startsWith("http|");
         RestAssured.given()
                 .header("Forwarded", "by=proxy;for=backend:4444;host=somehost;proto=https")
                 .get("/trusted-proxy")
                 .then()
-                .body(Matchers.equalTo("https|somehost|backend:4444|null"));
+                .body(Matchers.equalTo("https|somehost|backend:4444|true"));
     }
 
     @Test
@@ -61,21 +59,21 @@ public class TrustedForwarderProxyTest {
                 .header("X-Forwarded-Trusted-Proxy", "true")
                 .get("/trusted-proxy")
                 .then()
-                .body(Matchers.equalTo("https|somehost|backend:4444|null"));
+                .body(Matchers.equalTo("https|somehost|backend:4444|true"));
 
         RestAssured.given()
                 .header("Forwarded", "by=proxy;for=backend:4444;host=somehost;proto=https")
                 .header("X-Forwarded-Trusted-Proxy", "hello")
                 .get("/trusted-proxy")
                 .then()
-                .body(Matchers.equalTo("https|somehost|backend:4444|null"));
+                .body(Matchers.equalTo("https|somehost|backend:4444|true"));
 
         RestAssured.given()
                 .header("Forwarded", "by=proxy;for=backend:4444;host=somehost;proto=https")
                 .header("X-Forwarded-Trusted-Proxy", "false")
                 .get("/trusted-proxy")
                 .then()
-                .body(Matchers.equalTo("https|somehost|backend:4444|null"));
+                .body(Matchers.equalTo("https|somehost|backend:4444|true"));
     }
 
     /**
@@ -89,8 +87,9 @@ public class TrustedForwarderProxyTest {
     public void testHeadersAreUsedWhenUsingCasedCharacters() {
         RestAssured.given()
                 .header("Forwarded", "Proto=http;For=backend2:5555;Host=somehost2")
-                .get("/path")
+                .get("/path-trusted-proxy")
                 .then()
-                .body(Matchers.equalTo("http|somehost2|backend2:5555|/path|http://somehost2/path"));
+                .body(Matchers
+                        .equalTo("http|somehost2|backend2:5555|/path-trusted-proxy|http://somehost2/path-trusted-proxy|true"));
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
@@ -15,14 +15,16 @@ public class ForwardingProxyOptions {
     final AsciiString forwardedHostHeader;
     final AsciiString forwardedPrefixHeader;
     public final TrustedProxyCheckBuilder trustedProxyCheckBuilder;
+    final boolean enableTrustedProxyHeader;
 
     public ForwardingProxyOptions(final boolean proxyAddressForwarding,
-            final boolean allowForwarded,
-            final boolean allowXForwarded,
-            final boolean enableForwardedHost,
-            final AsciiString forwardedHostHeader,
-            final boolean enableForwardedPrefix,
-            final AsciiString forwardedPrefixHeader,
+            boolean allowForwarded,
+            boolean allowXForwarded,
+            boolean enableForwardedHost,
+            boolean enableTrustedProxyHeader,
+            AsciiString forwardedHostHeader,
+            boolean enableForwardedPrefix,
+            AsciiString forwardedPrefixHeader,
             TrustedProxyCheckBuilder trustedProxyCheckBuilder) {
         this.proxyAddressForwarding = proxyAddressForwarding;
         this.allowForwarded = allowForwarded;
@@ -32,15 +34,16 @@ public class ForwardingProxyOptions {
         this.forwardedHostHeader = forwardedHostHeader;
         this.forwardedPrefixHeader = forwardedPrefixHeader;
         this.trustedProxyCheckBuilder = trustedProxyCheckBuilder;
+        this.enableTrustedProxyHeader = enableTrustedProxyHeader;
     }
 
     public static ForwardingProxyOptions from(ProxyConfig proxy) {
         final boolean proxyAddressForwarding = proxy.proxyAddressForwarding;
         final boolean allowForwarded = proxy.allowForwarded;
         final boolean allowXForwarded = proxy.allowXForwarded.orElse(!allowForwarded);
-
         final boolean enableForwardedHost = proxy.enableForwardedHost;
         final boolean enableForwardedPrefix = proxy.enableForwardedPrefix;
+        final boolean enableTrustedProxyHeader = proxy.enableTrustedProxyHeader;
         final AsciiString forwardedPrefixHeader = AsciiString.cached(proxy.forwardedPrefixHeader);
         final AsciiString forwardedHostHeader = AsciiString.cached(proxy.forwardedHostHeader);
 
@@ -50,6 +53,7 @@ public class ForwardingProxyOptions {
                 || parts.isEmpty() ? null : TrustedProxyCheckBuilder.builder(parts);
 
         return new ForwardingProxyOptions(proxyAddressForwarding, allowForwarded, allowXForwarded, enableForwardedHost,
-                forwardedHostHeader, enableForwardedPrefix, forwardedPrefixHeader, proxyCheckBuilder);
+                enableTrustedProxyHeader, forwardedHostHeader, enableForwardedPrefix, forwardedPrefixHeader,
+                proxyCheckBuilder);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -77,6 +77,18 @@ public class ProxyConfig {
     public String forwardedPrefixHeader;
 
     /**
+     * Adds the header `X-Forwarded-Trusted-Proxy` if the request is forwarded by a trusted proxy.
+     * The value is `true` if the request is forwarded by a trusted proxy, otherwise `null`.
+     * <p>
+     * The forwarded parser detects forgery attempts and if the incoming request contains this header, it will be removed
+     * from the request.
+     * <p>
+     * The `X-Forwarded-Trusted-Proxy` header is a custom header, not part of the standard `Forwarded` header.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enableTrustedProxyHeader;
+
+    /**
      * Configure the list of trusted proxy addresses.
      * Received `Forwarded`, `X-Forwarded` or `X-Forwarded-*` headers from any other proxy address will be ignored.
      * The trusted proxy address should be specified as the IP address (IPv4 or IPv6), hostname or Classless Inter-Domain


### PR DESCRIPTION
This PR introduces a way to determine if a trusted proxy has forwarded a request behind a proxy. It implements a custom header (`X-Forwarded-Trusted-Proxy`) that allows request processing to verify the presence of this header, indicating the request originated from a trusted source.

To prevent forgery, any incoming request containing this custom header has it removed before further processing.


CC @shawkins  