### PR TITLE
Adding Scm-Revision to quarkus-core jars

### DIFF
--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -292,6 +292,7 @@
                                 <Scm-Url>${project.scm.url}</Scm-Url>
                                 <Scm-Connection>${project.scm.connection}</Scm-Connection>
                                 <Bundle-License>Apache License 2.0</Bundle-License>
+                                <Scm-Revision>${buildNumber}</Scm-Revision>
                             </manifestEntries>
                         </archive>
                     </configuration>


### PR DESCRIPTION
This is following https://github.com/quarkusio/quarkus/pull/33614 but re-introducing `Scm-Revision` back to quarkus-core jar.

The missing `Scm-Revision` information are making complex to track the buid hash while running our nightly perf regression tests.