### PR TITLE
Use SelectionQuery#getResultCount() in Panache entity count operations

### DIFF
--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -323,22 +323,19 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
     public long count(Class<?> entityClass) {
         return getSession(entityClass)
-                .createSelectionQuery("SELECT COUNT(*) FROM " + PanacheJpaUtil.getEntityName(entityClass), Long.class)
-                .getSingleResult();
+                .createSelectionQuery("FROM " + PanacheJpaUtil.getEntityName(entityClass), entityClass)
+                .getResultCount();
     }
 
     public long count(Class<?> entityClass, String panacheQuery, Object... params) {
         if (PanacheJpaUtil.isNamedQuery(panacheQuery)) {
-            SelectionQuery namedQuery = extractNamedSelectionQuery(entityClass, panacheQuery);
+            SelectionQuery<?> namedQuery = extractNamedSelectionQuery(entityClass, panacheQuery);
             return (long) bindParameters(namedQuery, params).getSingleResult();
         }
 
         try {
-            return bindParameters(
-                    getSession(entityClass)
-                            .createSelectionQuery(
-                                    PanacheJpaUtil.createCountQuery(entityClass, panacheQuery, paramCount(params)), Long.class),
-                    params).getSingleResult();
+            String query = PanacheJpaUtil.createQueryForCount(entityClass, panacheQuery, paramCount(params));
+            return bindParameters(getSession(entityClass).createSelectionQuery(query, Object.class), params).getResultCount();
         } catch (RuntimeException x) {
             throw NamedQueryUtil.checkForNamedQueryMistake(x, panacheQuery);
         }
@@ -346,16 +343,13 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
     public long count(Class<?> entityClass, String panacheQuery, Map<String, Object> params) {
         if (PanacheJpaUtil.isNamedQuery(panacheQuery)) {
-            SelectionQuery namedQuery = extractNamedSelectionQuery(entityClass, panacheQuery);
+            SelectionQuery<?> namedQuery = extractNamedSelectionQuery(entityClass, panacheQuery);
             return (long) bindParameters(namedQuery, params).getSingleResult();
         }
 
         try {
-            return bindParameters(
-                    getSession(entityClass)
-                            .createSelectionQuery(
-                                    PanacheJpaUtil.createCountQuery(entityClass, panacheQuery, paramCount(params)), Long.class),
-                    params).getSingleResult();
+            String query = PanacheJpaUtil.createQueryForCount(entityClass, panacheQuery, paramCount(params));
+            return bindParameters(getSession(entityClass).createSelectionQuery(query, Object.class), params).getResultCount();
         } catch (RuntimeException x) {
             throw NamedQueryUtil.checkForNamedQueryMistake(x, panacheQuery);
         }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
@@ -198,8 +198,8 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
     public Uni<Long> count(Class<?> entityClass) {
         return getSession()
                 .chain(session -> session
-                        .createSelectionQuery("SELECT COUNT(*) FROM " + PanacheJpaUtil.getEntityName(entityClass), Long.class)
-                        .getSingleResult());
+                        .createSelectionQuery("FROM " + PanacheJpaUtil.getEntityName(entityClass), entityClass)
+                        .getResultCount());
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -213,9 +213,9 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
             });
 
         return getSession().chain(session -> bindParameters(
-                session.createSelectionQuery(PanacheJpaUtil.createCountQuery(entityClass, panacheQuery, paramCount(params)),
-                        Long.class),
-                params).getSingleResult())
+                session.createSelectionQuery(PanacheJpaUtil.createQueryForCount(entityClass, panacheQuery, paramCount(params)),
+                        Object.class),
+                params).getResultCount())
                 .onFailure(RuntimeException.class)
                 .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((RuntimeException) x, panacheQuery));
     }
@@ -230,9 +230,9 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
             });
 
         return getSession().chain(session -> bindParameters(
-                session.createSelectionQuery(PanacheJpaUtil.createCountQuery(entityClass, panacheQuery, paramCount(params)),
-                        Long.class),
-                params).getSingleResult())
+                session.createSelectionQuery(PanacheJpaUtil.createQueryForCount(entityClass, panacheQuery, paramCount(params)),
+                        Object.class),
+                params).getResultCount())
                 .onFailure(RuntimeException.class)
                 .transform(x -> NamedQueryUtil.checkForNamedQueryMistake((RuntimeException) x, panacheQuery));
     }

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -86,33 +86,31 @@ public class PanacheJpaUtil {
         return query.charAt(0) == '#';
     }
 
-    public static String createCountQuery(Class<?> entityClass, String query, int paramCount) {
-        if (query == null)
-            return "SELECT COUNT(*) FROM " + getEntityName(entityClass);
+    public static String createQueryForCount(Class<?> entityClass, String query, int paramCount) {
+        if (query == null || query.isEmpty())
+            return "FROM " + getEntityName(entityClass);
 
         String trimmedForAnalysis = trimForAnalysis(query);
         if (trimmedForAnalysis.isEmpty())
-            return "SELECT COUNT(*) FROM " + getEntityName(entityClass);
+            return "FROM " + getEntityName(entityClass);
 
         // assume these have valid select clauses and let them through
         if (trimmedForAnalysis.startsWith("select ")
-                || trimmedForAnalysis.startsWith("with ")) {
+                || trimmedForAnalysis.startsWith("with ")
+                || trimmedForAnalysis.startsWith("from ")) {
             return query;
         }
-        if (trimmedForAnalysis.startsWith("from ")) {
-            return "SELECT COUNT(*) " + query;
-        }
         if (trimmedForAnalysis.startsWith("where ")) {
-            return "SELECT COUNT(*) FROM " + getEntityName(entityClass) + " " + query;
+            return "FROM " + getEntityName(entityClass) + " " + query;
         }
         if (trimmedForAnalysis.startsWith("order by ")) {
             // ignore it
-            return "SELECT COUNT(*) FROM " + getEntityName(entityClass);
+            return "FROM " + getEntityName(entityClass);
         }
         if (trimmedForAnalysis.indexOf(' ') == -1 && trimmedForAnalysis.indexOf('=') == -1 && paramCount == 1) {
             query += " = ?1";
         }
-        return "SELECT COUNT(*) FROM " + getEntityName(entityClass) + " WHERE " + query;
+        return "FROM " + getEntityName(entityClass) + " WHERE " + query;
     }
 
     public static String createUpdateQuery(Class<?> entityClass, String query, int paramCount) {


### PR DESCRIPTION
Since Hibernate [introduced](https://hibernate.atlassian.net/browse/HHH-16931) a standard method of getting the count of a query, we should also align Panache entities `count()` operations to take advantage of this. The API allows to automatically manipulates the generated query to avoid getting the wrong result count and optimizes it for this purpose.