### PR TITLE
Properly handle `@ApplicationPath` and `Application` in RESTEasy Classic

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/ApplicationTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/ApplicationTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.container.*;
@@ -310,6 +311,7 @@ class ApplicationTest {
         }
     }
 
+    @ApplicationPath("whatever")
     public static abstract class AppTest2 extends Application {
 
     }


### PR DESCRIPTION
`@ApplicationPath` is only taken into account for the single `Application` class that is selected (if any).

- Fixes: #42963