### PR TITLE
Bump smallrye-open-api to 4.0.1; Avoid Windows JAR locking

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <smallrye-config.version>3.10.0</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>4.0.0</smallrye-open-api.version>
+        <smallrye-open-api.version>4.0.1</smallrye-open-api.version>
         <smallrye-graphql.version>2.11.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.6.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.0</smallrye-jwt.version>

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -935,10 +935,18 @@ public class SmallRyeOpenApiProcessor {
             }
         });
 
-        @SuppressWarnings("deprecation")
+        openApiDocumentProducer.produce(new OpenApiDocumentBuildItem(toOpenApiDocument(finalOpenAPI)));
+    }
+
+    /**
+     * We need to use the deprecated OpenApiDocument as long as
+     * OpenApiDocumentBuildItem needs to be produced.
+     */
+    @SuppressWarnings("deprecation")
+    OpenApiDocument toOpenApiDocument(SmallRyeOpenAPI finalOpenAPI) {
         OpenApiDocument output = OpenApiDocument.newInstance();
         output.set(finalOpenAPI.model());
-        openApiDocumentProducer.produce(new OpenApiDocumentBuildItem(output));
+        return output;
     }
 
     @BuildStep
@@ -1099,16 +1107,24 @@ public class SmallRyeOpenApiProcessor {
     }
 
     private InputStream loadResource(String path, URL url) {
-        try (InputStream inputStream = url.openStream()) {
-            if (inputStream != null) {
-                byte[] contents = IoUtil.readBytes(inputStream);
-                return new ByteArrayInputStream(contents);
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException("An error occurred while processing %s for %s".formatted(url, path), e);
-        }
+        Supplier<String> msg = () -> "An error occurred while processing %s for %s".formatted(url, path);
 
-        return null;
+        try {
+            return ClassPathUtils.readStream(url, inputStream -> {
+                if (inputStream != null) {
+                    try {
+                        byte[] contents = IoUtil.readBytes(inputStream);
+                        return new ByteArrayInputStream(contents);
+                    } catch (IOException ioe) {
+                        throw new UncheckedIOException(msg.get(), ioe);
+                    }
+                }
+
+                return null;
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException(msg.get(), e);
+        }
     }
 
     private boolean shouldIgnore(List<Pattern> ignorePatterns, String url) {
@@ -1136,6 +1152,7 @@ public class SmallRyeOpenApiProcessor {
             }
         } else {
             ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            // QuarkusClassLoader will return a ByteArrayInputStream of directory entry names
             try (InputStream inputStream = cl.getResourceAsStream(resourceName)) {
                 if (inputStream != null) {
                     try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {


### PR DESCRIPTION
- Fixes: #43940