### PR TITLE
Add a cleanup SPI for the REST Client

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jackson/deployment/src/main/java/io/quarkus/rest/client/reactive/jackson/deployment/RestClientReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jackson/deployment/src/main/java/io/quarkus/rest/client/reactive/jackson/deployment/RestClientReactiveJacksonProcessor.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.RuntimeType;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.jandex.DotName;
+import org.jboss.resteasy.reactive.client.impl.RestClientClosingTask;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -18,10 +19,12 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.rest.client.reactive.deployment.AnnotationToRegisterIntoClientContextBuildItem;
 import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
 import io.quarkus.rest.client.reactive.jackson.runtime.serialisers.ClientJacksonMessageBodyReader;
 import io.quarkus.rest.client.reactive.jackson.runtime.serialisers.ClientJacksonMessageBodyWriter;
+import io.quarkus.rest.client.reactive.jackson.runtime.serialisers.JacksonCleanupRestClientClosingTask;
 import io.quarkus.resteasy.reactive.jackson.deployment.processor.ResteasyReactiveJacksonProviderDefinedBuildItem;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonArrayBasicMessageBodyReader;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonArrayBasicMessageBodyWriter;
@@ -115,5 +118,11 @@ public class RestClientReactiveJacksonProcessor {
                                 .setBuiltin(true)
                                 .setRuntimeType(RuntimeType.CLIENT)
                                 .build());
+    }
+
+    @BuildStep
+    void nativeSupport(BuildProducer<ServiceProviderBuildItem> serviceProviderProducer) {
+        serviceProviderProducer.produce(new ServiceProviderBuildItem(RestClientClosingTask.class.getName(),
+                JacksonCleanupRestClientClosingTask.class.getName()));
     }
 }

--- a/extensions/resteasy-reactive/rest-client-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/JacksonCleanupRestClientClosingTask.java
+++ b/extensions/resteasy-reactive/rest-client-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/JacksonCleanupRestClientClosingTask.java
@@ -1,0 +1,17 @@
+package io.quarkus.rest.client.reactive.jackson.runtime.serialisers;
+
+import org.jboss.resteasy.reactive.client.impl.RestClientClosingTask;
+
+import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
+
+/**
+ * Cleans up the mappings that is needed to support {@link ClientObjectMapper}
+ */
+public class JacksonCleanupRestClientClosingTask implements RestClientClosingTask {
+
+    @Override
+    public void close(Context context) {
+        JacksonUtil.contextResolverMap
+                .remove(new ResolverMapKey(context.baseTarget().getConfiguration(), context.restApiClass()));
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/JacksonUtil.java
+++ b/extensions/resteasy-reactive/rest-client-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/JacksonUtil.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 final class JacksonUtil {
 
-    private static final ConcurrentMap<ResolverMapKey, ObjectMapper> contextResolverMap = new ConcurrentHashMap<>();
+    static final ConcurrentMap<ResolverMapKey, ObjectMapper> contextResolverMap = new ConcurrentHashMap<>();
 
     private JacksonUtil() {
     }

--- a/extensions/resteasy-reactive/rest-client-jackson/runtime/src/main/resources/META-INF/services/org.jboss.resteasy.reactive.client.impl.RestClientClosingTask
+++ b/extensions/resteasy-reactive/rest-client-jackson/runtime/src/main/resources/META-INF/services/org.jboss.resteasy.reactive.client.impl.RestClientClosingTask
@@ -1,0 +1,1 @@
+io.quarkus.rest.client.reactive.jackson.runtime.serialisers.JacksonCleanupRestClientClosingTask

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientClosingTask.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientClosingTask.java
@@ -1,0 +1,30 @@
+package org.jboss.resteasy.reactive.client.impl;
+
+import java.util.ServiceLoader;
+
+import org.jboss.logging.Logger;
+
+/**
+ * This represents a task that will be called by the implementation class of the REST Client when the {@code close}
+ * method is called.
+ */
+public interface RestClientClosingTask {
+
+    Logger log = Logger.getLogger(RestClientClosingTask.class);
+
+    void close(Context context);
+
+    record Context(Class<?> restApiClass, WebTargetImpl baseTarget) {
+    }
+
+    @SuppressWarnings("unused") // this is called by the implementation class of the REST Client when the {@code close} method is called
+    static void invokeAll(Context context) {
+        for (RestClientClosingTask restClientClosingTask : ServiceLoader.load(RestClientClosingTask.class)) {
+            try {
+                restClientClosingTask.close(context);
+            } catch (Exception e) {
+                log.warn("Error running RestClientClosingTask", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, this is used to cleanup up the mappings that is needed to support `@ClientObjectMapper`.

The SPI is invoked when the `close` method of a REST Client is called.

- Resolves: #44180