### PR TITLE
Configure HAL links for user defined REST resources in REST Data Panache

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceGetMethodTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceGetMethodTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -28,6 +29,16 @@ class PanacheEntityResourceGetMethodTest extends AbstractGetMethodTest {
                 .then().statusCode(200)
                 .and().body("id", is("full"))
                 .and().body("name", is("full collection"));
+    }
+
+    @Test
+    void shouldAdditionalMethodsSupportHal() {
+        given().accept("application/hal+json")
+                .when().get("/collections/name/full collection")
+                .then().statusCode(200)
+                .and().body("id", is("full"))
+                .and().body("name", is("full collection"))
+                .and().body("_links.addByName.href", containsString("/name/full"));
     }
 
     @Test

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/AbstractGetMethodTest.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/AbstractGetMethodTest.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.reactive.rest.data.panache.deployment;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
@@ -76,7 +77,8 @@ public abstract class AbstractGetMethodTest {
                 .and().body("_links.list.href", endsWith("/collections"))
                 .and().body("_links.self.href", endsWith("/collections/full"))
                 .and().body("_links.update.href", endsWith("/collections/full"))
-                .and().body("_links.remove.href", endsWith("/collections/full"));
+                .and().body("_links.remove.href", endsWith("/collections/full"))
+                .and().body("_links.addByName.href", containsString("/name/full"));
     }
 
     @Test

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/PanacheEntityResourceGetMethodTest.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/PanacheEntityResourceGetMethodTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
@@ -27,5 +28,15 @@ class PanacheEntityResourceGetMethodTest extends AbstractGetMethodTest {
                 .then().statusCode(200)
                 .and().body("id", is("full"))
                 .and().body("name", is("full collection"));
+    }
+
+    @Test
+    void shouldAdditionalMethodsSupportHal() {
+        given().accept("application/hal+json")
+                .when().get("/collections/name/full collection")
+                .then().statusCode(200)
+                .and().body("id", is("full"))
+                .and().body("name", is("full collection"))
+                .and().body("_links.addByName.href", containsString("/name/full"));
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
@@ -49,7 +49,7 @@ class JaxRsResourceImplementor {
                 new AddMethodImplementor(capabilities),
                 new UpdateMethodImplementor(capabilities),
                 new DeleteMethodImplementor(capabilities),
-                new UserMethodsWithAnnotationsImplementor(),
+                new UserMethodsWithAnnotationsImplementor(capabilities),
                 // The list hal endpoint needs to be added for both resteasy classic and resteasy reactive
                 // because the pagination links are programmatically added.
                 new ListHalMethodImplementor(capabilities));

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/OverrideUserMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/OverrideUserMethodImplementor.java
@@ -1,0 +1,112 @@
+package io.quarkus.rest.data.panache.deployment.methods;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.gizmo.AnnotatedElement;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
+import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
+
+/**
+ * Override the user method defined in the interface to propagate the annotations.
+ * In case of the method is also a REST resource, it will be configured to support the rest-data features like hal.
+ */
+public class OverrideUserMethodImplementor extends StandardMethodImplementor {
+
+    static final DotName REST_PATH = DotName.createSimple(Path.class);
+    static final DotName REST_PRODUCES = DotName.createSimple(Produces.class);
+
+    private final MethodInfo methodInfo;
+
+    protected OverrideUserMethodImplementor(MethodInfo methodInfo, Capabilities capabilities) {
+        super(capabilities);
+
+        this.methodInfo = methodInfo;
+    }
+
+    @Override
+    protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
+            ResourceProperties resourceProperties, FieldDescriptor resourceField) {
+        MethodCreator methodCreator = classCreator.getMethodCreator(MethodDescriptor.of(methodInfo));
+        methodCreator.setSignature(methodInfo.genericSignatureIfRequired());
+        Set<String> produces = new HashSet<>();
+        for (var annotation : methodInfo.annotations()) {
+            if (annotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {
+                short position = annotation.target().asMethodParameter().position();
+                methodCreator.getParameterAnnotations(position).addAnnotation(annotation);
+            }
+
+            if (annotation.target().kind() == AnnotationTarget.Kind.METHOD) {
+                if (REST_PRODUCES.equals(annotation.name())) {
+                    var annotationValue = annotation.value();
+                    if (annotationValue != null) {
+                        produces.addAll(List.of(annotationValue.asStringArray()));
+                    }
+                } else {
+                    methodCreator.addAnnotation(annotation);
+                }
+            }
+        }
+
+        ResultHandle[] params = new ResultHandle[methodInfo.parametersCount()];
+        for (int paramIdx = 0; paramIdx < methodInfo.parametersCount(); paramIdx++) {
+            params[paramIdx] = methodCreator.getMethodParam(paramIdx);
+        }
+
+        // Special handling for user-defined REST methods
+        if (methodInfo.hasAnnotation(REST_PATH)) {
+            addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), getResourceMethodName());
+            addSecurityAnnotations(methodCreator, resourceProperties);
+            addProducesAnnotation(produces, methodCreator, resourceProperties);
+        }
+
+        methodCreator.returnValue(
+                methodCreator.invokeSpecialInterfaceMethod(methodInfo, methodCreator.getThis(), params));
+        methodCreator.close();
+    }
+
+    @Override
+    protected String getResourceMethodName() {
+        return methodInfo.name();
+    }
+
+    @Override
+    protected void addLinksAnnotation(AnnotatedElement element, ResourceProperties resourceProperties, String entityClassName,
+            String rel) {
+        if (!resourceProperties.isHal()) {
+            return;
+        }
+
+        String linksAnnotationName = isResteasyClassic() ? "org.jboss.resteasy.links.LinkResource"
+                : "io.quarkus.resteasy.reactive.links.RestLink";
+        // Add the links annotation if and only if the user didn't add it.
+        if (!methodInfo.hasAnnotation(linksAnnotationName)) {
+            super.addLinksAnnotation(element, resourceProperties, entityClassName, rel);
+        }
+    }
+
+    private void addProducesAnnotation(Set<String> definedProduces, MethodCreator methodCreator,
+            ResourceProperties resourceProperties) {
+        Set<String> produces = new HashSet<>(definedProduces);
+        produces.add(APPLICATION_JSON);
+        if (resourceProperties.isHal()) {
+            produces.add(APPLICATION_HAL_JSON);
+        }
+
+        addProducesAnnotation(methodCreator, produces.toArray(new String[0]));
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UserMethodsWithAnnotationsImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UserMethodsWithAnnotationsImplementor.java
@@ -1,49 +1,33 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
-import org.jboss.jandex.AnnotationTarget;
-
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
 
 /**
- * Propagate all the user methods that have annotations.
- *
- * This is necessary when users use annotations with an interceptor binding like `@Transactional`.
+ * Loop over all the user-defined methods in the interface. These methods will be overridden in the generated resource
+ * if and only if it uses annotations.
  */
 public final class UserMethodsWithAnnotationsImplementor implements MethodImplementor {
+
+    private final Capabilities capabilities;
+
+    public UserMethodsWithAnnotationsImplementor(Capabilities capabilities) {
+        this.capabilities = capabilities;
+    }
 
     @Override
     public void implement(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         if (resourceMetadata.getResourceInterface() != null) {
             for (var methodInfo : resourceMetadata.getResourceInterface().methods()) {
+                // propagate only the default methods with annotations (needed for `@Transactional` annotations).
                 if (methodInfo.isDefault() && !methodInfo.annotations().isEmpty()) {
-                    MethodCreator methodCreator = classCreator.getMethodCreator(MethodDescriptor.of(methodInfo));
-                    methodCreator.setSignature(methodInfo.genericSignatureIfRequired());
-                    for (var annotation : methodInfo.annotations()) {
-                        if (annotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {
-                            short position = annotation.target().asMethodParameter().position();
-                            methodCreator.getParameterAnnotations(position).addAnnotation(annotation);
-                        }
-
-                        if (annotation.target().kind() == AnnotationTarget.Kind.METHOD) {
-                            methodCreator.addAnnotation(annotation);
-                        }
-                    }
-
-                    ResultHandle[] params = new ResultHandle[methodInfo.parametersCount()];
-                    for (int paramIdx = 0; paramIdx < methodInfo.parametersCount(); paramIdx++) {
-                        params[paramIdx] = methodCreator.getMethodParam(paramIdx);
-                    }
-
-                    methodCreator.returnValue(
-                            methodCreator.invokeSpecialInterfaceMethod(methodInfo, methodCreator.getThis(), params));
-                    methodCreator.close();
+                    OverrideUserMethodImplementor implementor = new OverrideUserMethodImplementor(methodInfo,
+                            capabilities);
+                    implementor.implement(classCreator, resourceMetadata, resourceProperties, resourceField);
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/43842

When adding user-defined methods in REST Data Panache like:

```java
@ResourceProperties
public interface PeopleResource extends PanacheEntityResource<Person, Long> {
    @GET
    @Path("/name/{name}")
    default List<Person> findByName(@PathParam("name") String name) {
        return Person.find("name = :name", Collections.singletonMap("name", name)).list();
    }
}
```

Since the HAL support is enabled by default in the `@ResourcesProperties` annotation, the user-defined resource "findByName" should support HAL as well. 

After these changes, these resources will be automatically configured for HAL support and also won't need to use the `@Produces` annotation to add the "application/hal+json" media type.

The link for the above method will be:
```json
{
    "id": "full",
    "name": "full collection",
    "type": 100,
    "items": [
        {
            "id": 1,
            "name": "first"
        },
        {
            "id": 2,
            "name": "second"
        }
    ],
    "_links": {
        "add": {
            "href": "http://localhost:8081/collections"
        },
        "addByName": {
            "href": "http://localhost:8081/collections/name/full"
        },
        "self": {
            "href": "http://localhost:8081/collections/full"
        },
        "update": {
            "href": "http://localhost:8081/collections/full"
        },
        "findByName": {
            "href": "http://localhost:8081/collections/name/full"
        },
        "list": {
            "href": "http://localhost:8081/collections"
        },
        "remove": {
            "href": "http://localhost:8081/collections/full"
        }
    }
}
```

Note the `_links.addByName` link. 