### PR TITLE
Add extension description for websockets next

### DIFF
--- a/extensions/websockets-next/pom.xml
+++ b/extensions/websockets-next/pom.xml
@@ -12,6 +12,8 @@
 
     <artifactId>quarkus-websockets-next-parent</artifactId>
     <name>Quarkus - WebSockets Next</name>
+    <description>Use a modern declarative API to define WebSocket server and client endpoints</description>
+
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>


### PR DESCRIPTION
Without a description, the project inherits its parent description:

<img width="248" alt="image" src="https://github.com/user-attachments/assets/7344d917-f935-495d-a7e6-903e981acb29">
