### PR TITLE
[3.15] (Do not merge)testing the proper use of the {includes} attribute when including a snippet

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -66,7 +66,7 @@ For more details and optional configurations, see xref:databases-dev-services.ad
 * `quarkus-jdbc-db2`
 * `quarkus-jdbc-derby`
 +
-include::_includes/snip-note-derby.adoc[]
+include::{includes}/snip-note-derby.adoc[]
 * `quarkus-jdbc-h2`
 * `quarkus-jdbc-mariadb`
 * `quarkus-jdbc-mssql`
@@ -153,7 +153,7 @@ Quarkus currently includes the following built-in database kinds:
 * DB2: `db2`
 * Derby: `derby`
 +
-include::_includes/snip-note-derby.adoc[]
+include::{includes}/snip-note-derby.adoc[]
 * H2: `h2`
 * MariaDB: `mariadb`
 * Microsoft SQL Server: `mssql`
@@ -195,7 +195,7 @@ JDBC is the most common database connection pattern, typically needed when used 
 +
 * Derby - `quarkus-jdbc-derby`
 +
-include::_includes/snip-note-derby.adoc[]
+include::{includes}/snip-note-derby.adoc[]
 * H2 - `quarkus-jdbc-h2`
 +
 [NOTE]

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -67,7 +67,7 @@ For more details and optional configurations, see xref:databases-dev-services.ad
 * `quarkus-jdbc-derby`
 +
 --
-include::{includes}/snip-note-derby.adoc[]
+include::_includes/snip-note-derby.adoc[]
 --
 * `quarkus-jdbc-h2`
 * `quarkus-jdbc-mariadb`

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -66,7 +66,9 @@ For more details and optional configurations, see xref:databases-dev-services.ad
 * `quarkus-jdbc-db2`
 * `quarkus-jdbc-derby`
 +
+--
 include::{includes}/snip-note-derby.adoc[]
+--
 * `quarkus-jdbc-h2`
 * `quarkus-jdbc-mariadb`
 * `quarkus-jdbc-mssql`


### PR DESCRIPTION
Current use of `include::_includes/snip-note-derby.adoc[]` instead of `include::{includes}/snip-note-derby.adoc[]`
causing an issue with the downstreaming pipeline. Here, I want to test if replacing this with an attribute solves the issue for us.
If this change does not fix it, I will revert the changes back to what they originally were, but I will wrap the whole include in between invisible blocks by using `--`.