### PR TITLE
Add stork-configuration-generator as an annotationProcessorPath

### DIFF
--- a/integration-tests/rest-client-reactive-stork/pom.xml
+++ b/integration-tests/rest-client-reactive-stork/pom.xml
@@ -44,11 +44,6 @@
             <groupId>io.smallrye.stork</groupId>
             <artifactId>stork-service-discovery-static-list</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.smallrye.stork</groupId>
-            <artifactId>stork-configuration-generator</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -121,6 +116,17 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.smallrye.stork</groupId>
+                            <artifactId>stork-configuration-generator</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>


### PR DESCRIPTION
This fixes the warning when building, which makes the build fail in some environments: 
```
[INFO] --- compiler:3.13.0:compile (default-compile) @ quarkus-integration-test-rest-client-reactive-stork ---
[WARNING] The following annotation processors were found on the classpath:
[io.smallrye.stork.config.generator.ConfigurationGenerator], provided by /Users/ggastald/.m2/repository/io/smallrye/stork/stork-configuration-generator/2.7.0/stork-configuration-generator-2.7.0.jar
Compile avoidance has been deactivated.
Please use the maven-compiler-plugin version 3.5 or above and use the <annotationProcessorPaths> configuration element to declare the processors instead.
If you did not intend to use the processors above (e.g. they were leaked by a dependency), you can use the <proc>none</proc> option to disable annotation processing.

For more information see https://gradle.com/help/maven-extension-compile-avoidance.
```

See https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Compilation.20Error.20in.20main for more details