### PR TITLE
Remove Dev UI and other Dev Mode classes from prod

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevModeCleanupBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevModeCleanupBuildItem.java
@@ -1,0 +1,61 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * This allows you to define one or more packages or set of classes that should be removed on Prod Build
+ */
+public final class DevModeCleanupBuildItem extends MultiBuildItem {
+    private final Set<Class> classes;
+    private final Set<String> packageNames;
+
+    public DevModeCleanupBuildItem(Class c) {
+        this(c, false);
+    }
+
+    public DevModeCleanupBuildItem(Class c, boolean wholePackage) {
+        this(Set.of(c), wholePackage);
+    }
+
+    public DevModeCleanupBuildItem(Set<Class> c, boolean wholePackage) {
+        super();
+        if (wholePackage) {
+            this.classes = null;
+            this.packageNames = c.stream()
+                    .map(clazz -> clazz.getPackage().getName())
+                    .collect(Collectors.toSet());
+        } else {
+            this.classes = c;
+            this.packageNames = null;
+        }
+    }
+
+    public DevModeCleanupBuildItem(Set<Class> classes) {
+        super();
+        this.classes = classes;
+        this.packageNames = null;
+    }
+
+    public DevModeCleanupBuildItem(String... packageName) {
+        super();
+        this.packageNames = Set.of(packageName);
+        this.classes = null;
+
+    }
+
+    public Set<String> getPackageNames() {
+        return packageNames;
+    }
+
+    public Set<Class> getClasses() {
+        return classes;
+    }
+
+    public boolean isWholePackage() {
+        return this.classes == null;
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/RemovedResourceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/RemovedResourceBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.builditem;
 
+import java.nio.file.Path;
 import java.util.Set;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -11,12 +12,14 @@ import io.quarkus.maven.dependency.GACT;
  */
 public final class RemovedResourceBuildItem extends MultiBuildItem {
 
+    private final Path artifactPath;
     private final ArtifactKey artifact;
     private final Set<String> resources;
 
     public RemovedResourceBuildItem(ArtifactKey artifact, Set<String> resources) {
         this.artifact = artifact;
         this.resources = resources;
+        this.artifactPath = null;
     }
 
     /**
@@ -26,8 +29,15 @@ public final class RemovedResourceBuildItem extends MultiBuildItem {
      */
     @Deprecated(forRemoval = true)
     public RemovedResourceBuildItem(GACT artifact, Set<String> resources) {
+        this.artifactPath = null;
         this.artifact = artifact;
         this.resources = resources;
+    }
+
+    public RemovedResourceBuildItem(Path artifactPath, Set<String> resources) {
+        this.artifact = null;
+        this.resources = resources;
+        this.artifactPath = artifactPath;
     }
 
     public ArtifactKey getArtifact() {
@@ -36,5 +46,13 @@ public final class RemovedResourceBuildItem extends MultiBuildItem {
 
     public Set<String> getResources() {
         return resources;
+    }
+
+    public Path getArtifactPath() {
+        return this.artifactPath;
+    }
+
+    public boolean hasArtifact() {
+        return this.artifact != null;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeCleanupProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeCleanupProcessor.java
@@ -1,0 +1,95 @@
+package io.quarkus.deployment.dev;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
+import io.quarkus.deployment.builditem.RemovedResourceBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+/**
+ * Cleans up classes that is not needed in Prod
+ */
+public class DevModeCleanupProcessor {
+
+    /**
+     * This makes sure the Dev Mode Classes are not included in the prod build
+     */
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<RemovedResourceBuildItem> producer,
+            List<DevModeCleanupBuildItem> devUIItemsToRemove,
+            CurateOutcomeBuildItem curateOutcomeBuildItem) {
+
+        Set<String> classNames = new HashSet<>();
+        Set<String> packageNames = new HashSet<>();
+        for (DevModeCleanupBuildItem devUIRemoveItemBuildItem : devUIItemsToRemove) {
+            if (devUIRemoveItemBuildItem.isWholePackage()) {
+                packageNames.addAll(devUIRemoveItemBuildItem.getPackageNames());
+            } else {
+                for (Class c : devUIRemoveItemBuildItem.getClasses()) {
+                    classNames.add(c.getName());
+                }
+            }
+        }
+
+        List<RemovedResourceBuildItem> removedResourceBuildItems = getRemoveResourceBuildItemList(classNames, packageNames,
+                curateOutcomeBuildItem);
+        producer.produce(removedResourceBuildItems);
+    }
+
+    private List<RemovedResourceBuildItem> getRemoveResourceBuildItemList(Set<String> classNames, Set<String> packageNames,
+            CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        List<RemovedResourceBuildItem> buildItems = new ArrayList<>();
+
+        ApplicationModel applicationModel = curateOutcomeBuildItem.getApplicationModel();
+        Collection<ResolvedDependency> runtimeDependencies = applicationModel.getRuntimeDependencies();
+        List<ResolvedDependency> allArtifacts = new ArrayList<>(runtimeDependencies.size() + 1);
+        allArtifacts.addAll(runtimeDependencies);
+        allArtifacts.add(applicationModel.getAppArtifact());
+        for (ResolvedDependency i : allArtifacts) {
+            for (Path path : i.getResolvedPaths()) {
+                if (path.toString().endsWith(".jar") && path.toFile().isFile()) {
+                    Set<String> foundClasses = new HashSet<>();
+                    try (JarFile jarFile = new JarFile(path.toFile())) {
+                        Enumeration<JarEntry> entries = jarFile.entries();
+                        while (entries.hasMoreElements()) {
+                            JarEntry entry = entries.nextElement();
+                            if (entry.getName().endsWith(".class")) {
+                                String entryClassName = entry.getName()
+                                        .replace('/', '.')
+                                        .replace(".class", "");
+                                if (classNames.contains(entryClassName)) {
+                                    foundClasses.add(entry.getName());
+                                } else if (packageNames.stream().anyMatch(entryClassName::startsWith)) {
+                                    foundClasses.add(entry.getName());
+                                }
+                            }
+                        }
+                    } catch (IOException ex) {
+                        throw new UncheckedIOException(ex);
+                    }
+                    if (!foundClasses.isEmpty()) {
+                        buildItems.add(new RemovedResourceBuildItem(path, foundClasses));
+                    }
+                }
+            }
+        }
+
+        return buildItems;
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
@@ -318,7 +318,14 @@ public class ClassTransformingBuildStep {
             removed.put(new GACT(entry.getKey().split(":")), entry.getValue());
         }
         for (RemovedResourceBuildItem i : removedResourceBuildItems) {
-            removed.computeIfAbsent(i.getArtifact(), k -> new HashSet<>()).addAll(i.getResources());
+            if (i.hasArtifact()) {
+                removed.computeIfAbsent(i.getArtifact(), k -> new HashSet<>()).addAll(i.getResources());
+            } else {
+                transformedClassesByJar.computeIfAbsent(i.getArtifactPath(), s -> new HashSet<>())
+                        .addAll(i.getResources().stream()
+                                .map(file -> new TransformedClassesBuildItem.TransformedClass(null, null, file))
+                                .collect(Collectors.toSet()));
+            }
         }
         if (!removed.isEmpty()) {
             ApplicationModel applicationModel = curateOutcomeBuildItem.getApplicationModel();
@@ -332,7 +339,7 @@ public class ClassTransformingBuildStep {
                     for (Path path : i.getResolvedPaths()) {
                         transformedClassesByJar.computeIfAbsent(path, s -> new HashSet<>())
                                 .addAll(filtered.stream()
-                                        .map(file -> new TransformedClassesBuildItem.TransformedClass(null, null, file, false))
+                                        .map(file -> new TransformedClassesBuildItem.TransformedClass(null, null, file))
                                         .collect(Collectors.toSet()));
                     }
                 }

--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -887,6 +887,19 @@ JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {// <2>
 
 https://github.com/quarkusio/quarkus/blob/main/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devui/CacheDevUiProcessor.java[Example code]
 
+Also cleanup this in Prod mode, so when the app build in prod mode, we remove all dev-ui related runtime classes:
+
+[source,java]
+----
+@BuildStep(onlyIf = IsNormal.class)// <1>
+DevModeCleanupBuildItem cleanProd() {// <2>
+    return new DevModeCleanupBuildItem(CacheJsonRPCService.class, true);// <3>
+}
+----
+<1> Always only do this in Normal (Prod) Mode
+<2> Produce or return a `DevModeCleanupBuildItem`
+<3> Define the class or classes in your runtime module that will be removed. You can also clean the whole package of that class in case you used more than just the JSON-RPC Service
+
 Now, in your Runtime module, create the JsonRPC Service. This class will default to an application-scoped bean, except if you explicitly scope the bean. All public methods that return something will be made available to call from the Web component Javascript.
 
 The return object in these methods can be:

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevUIProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevUIProcessor.java
@@ -20,8 +20,10 @@ import io.quarkus.arc.runtime.devconsole.Monitored;
 import io.quarkus.arc.runtime.devmode.EventsMonitor;
 import io.quarkus.arc.runtime.devui.ArcJsonRPCService;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -100,6 +102,14 @@ public class ArcDevUIProcessor {
         }
 
         return pageBuildItem;
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<DevModeCleanupBuildItem> producer) {
+        producer.produce(new DevModeCleanupBuildItem(
+                "io.quarkus.arc.runtime.devconsole",
+                "io.quarkus.arc.runtime.devmode",
+                "io.quarkus.arc.runtime.devui"));
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devui/CacheDevUiProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devui/CacheDevUiProcessor.java
@@ -2,7 +2,9 @@ package io.quarkus.cache.deployment.devui;
 
 import io.quarkus.cache.runtime.devui.CacheJsonRPCService;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
@@ -24,5 +26,10 @@ public class CacheDevUiProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(CacheJsonRPCService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(CacheJsonRPCService.class, true);
     }
 }

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/devui/ContainerImageDevUiProcessor.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/devui/ContainerImageDevUiProcessor.java
@@ -13,7 +13,9 @@ import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.container.image.runtime.devui.ContainerBuilderJsonRpcService;
 import io.quarkus.container.spi.AvailableContainerImageExtensionBuildItem;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.dev.console.TempSystemProperties;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
@@ -41,6 +43,11 @@ public class ContainerImageDevUiProcessor {
     JsonRPCProvidersBuildItem createJsonRPCServiceForContainerBuild() {
         DevConsoleManager.register("container-image-build-action", build());
         return new JsonRPCProvidersBuildItem(ContainerBuilderJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(ContainerBuilderJsonRpcService.class, true);
     }
 
     private Function<Map<String, String>, String> build() {

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devui/DevUIDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devui/DevUIDatasourceProcessor.java
@@ -7,7 +7,9 @@ import java.util.List;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.datasource.runtime.devui.DatasourceJsonRpcService;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -35,4 +37,8 @@ public class DevUIDatasourceProcessor {
         return new JsonRPCProvidersBuildItem(DatasourceJsonRpcService.class);
     }
 
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(DatasourceJsonRpcService.class, true);
+    }
 }

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/devui/FlywayDevUIProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/devui/FlywayDevUIProcessor.java
@@ -9,8 +9,10 @@ import java.util.function.Supplier;
 
 import io.quarkus.agroal.spi.JdbcInitialSQLGeneratorBuildItem;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
@@ -48,5 +50,10 @@ public class FlywayDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(FlywayJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(FlywayJsonRpcService.class, true);
     }
 }

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devui/GrpcDevUIProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devui/GrpcDevUIProcessor.java
@@ -35,9 +35,11 @@ import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
@@ -229,6 +231,11 @@ public class GrpcDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(GrpcJsonRPCService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<DevModeCleanupBuildItem> producer) {
+        producer.produce(new DevModeCleanupBuildItem(GrpcJsonRPCService.class, true));
     }
 
     private Collection<Class<?>> getGrpcServices(IndexView index) throws ClassNotFoundException {

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
@@ -6,9 +6,11 @@ import io.quarkus.agroal.spi.JdbcInitialSQLGeneratorBuildItem;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -46,6 +48,11 @@ public class HibernateOrmDevUIProcessor {
     @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(HibernateOrmDevJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<DevModeCleanupBuildItem> producer) {
+        producer.produce(new DevModeCleanupBuildItem(HibernateOrmDevJsonRpcService.class, true));
     }
 
     @BuildStep

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/dev/HibernateSearchElasticsearchDevUIProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/dev/HibernateSearchElasticsearchDevUIProcessor.java
@@ -9,9 +9,11 @@ import java.util.stream.Collectors;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -57,5 +59,10 @@ public class HibernateSearchElasticsearchDevUIProcessor {
     @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(HibernateSearchElasticsearchDevJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(HibernateSearchElasticsearchDevJsonRpcService.class, true);
     }
 }

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/dev/HibernateSearchStandaloneDevUIProcessor.java
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/standalone/elasticsearch/deployment/dev/HibernateSearchStandaloneDevUIProcessor.java
@@ -7,9 +7,11 @@ import java.util.Optional;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -52,5 +54,10 @@ public class HibernateSearchStandaloneDevUIProcessor {
     @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(HibernateSearchStandaloneDevJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(HibernateSearchStandaloneDevJsonRpcService.class, true);
     }
 }

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devui/InfinispanDevUIProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devui/InfinispanDevUIProcessor.java
@@ -5,7 +5,9 @@ import org.infinispan.commons.util.Version;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -46,6 +48,11 @@ public class InfinispanDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     public JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(InfinispanJsonRPCService.class, BuiltinScope.SINGLETON.getName());
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(InfinispanJsonRPCService.class, true);
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/devui/KafkaDevUIProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/devui/KafkaDevUIProcessor.java
@@ -3,7 +3,9 @@ package io.quarkus.kafka.client.deployment.devui;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -51,5 +53,10 @@ public class KafkaDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(KafkaJsonRPCService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(KafkaJsonRPCService.class, true);
     }
 }

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/devui/KafkaStreamsDevUIProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/devui/KafkaStreamsDevUIProcessor.java
@@ -1,11 +1,16 @@
 package io.quarkus.kafka.streams.deployment.devui;
 
+import java.util.Set;
+
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
+import io.quarkus.kafka.streams.runtime.devmode.KafkaStreamsHotReplacementSetup;
 import io.quarkus.kafka.streams.runtime.devui.KafkaStreamsJsonRPCService;
 
 public class KafkaStreamsDevUIProcessor {
@@ -26,5 +31,11 @@ public class KafkaStreamsDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     public void createJsonRPCService(BuildProducer<JsonRPCProvidersBuildItem> jsonRPCServiceProducer) {
         jsonRPCServiceProducer.produce(new JsonRPCProvidersBuildItem(KafkaStreamsJsonRPCService.class));
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<DevModeCleanupBuildItem> producer) {
+        producer.produce(new DevModeCleanupBuildItem(
+                Set.of(KafkaStreamsHotReplacementSetup.class, KafkaStreamsJsonRPCService.class), true));
     }
 }

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/devui/LiquibaseDevUIProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/devui/LiquibaseDevUIProcessor.java
@@ -5,8 +5,10 @@ import java.net.URL;
 import java.util.jar.Manifest;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -43,6 +45,11 @@ public class LiquibaseDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(LiquibaseJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(LiquibaseJsonRpcService.class, true);
     }
 
     private static Manifest getManifest(Class<?> clz) {

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
@@ -9,6 +9,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
@@ -16,6 +17,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
@@ -135,6 +137,11 @@ public class OidcDevUIProcessor extends AbstractDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem produceOidcDevJsonRpcService() {
         return new JsonRPCProvidersBuildItem(OidcDevJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(OidcDevJsonRpcService.class, true);
     }
 
     private boolean checkProviderUserInfoRequired(OidcTenantConfig providerConfig) {

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
@@ -7,12 +7,14 @@ import java.util.Optional;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ConfigurationBuildItem;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.devservices.keycloak.KeycloakDevServicesConfigBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
@@ -81,5 +83,10 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem produceOidcDevJsonRpcService() {
         return new JsonRPCProvidersBuildItem(OidcDevJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(OidcDevJsonRpcService.class, true);
     }
 }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -80,12 +80,14 @@ import io.quarkus.arc.processor.QualifierRegistrar;
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.IsTest;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
@@ -149,6 +151,7 @@ import io.quarkus.qute.runtime.QuteConfig;
 import io.quarkus.qute.runtime.QuteRecorder;
 import io.quarkus.qute.runtime.QuteRecorder.QuteContext;
 import io.quarkus.qute.runtime.TemplateProducer;
+import io.quarkus.qute.runtime.devmode.QuteErrorPageSetup;
 import io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions;
 import io.quarkus.qute.runtime.extensions.ConfigTemplateExtensions;
 import io.quarkus.qute.runtime.extensions.MapTemplateExtensions;
@@ -787,6 +790,11 @@ public class QuteProcessor {
         LOGGER.debugf("Finished analysis of %s templates in %s ms", analysis.size(),
                 TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
         return new TemplatesAnalysisBuildItem(analysis);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(QuteErrorPageSetup.class, true);
     }
 
     private String templatePathWithoutSuffix(String path, QuteConfig config) {

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
@@ -1,8 +1,10 @@
 package io.quarkus.resteasy.reactive.server.deployment.devui;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -49,5 +51,10 @@ public class ResteasyReactiveDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     public void createJsonRPCService(BuildProducer<JsonRPCProvidersBuildItem> jsonRPCServiceProducer) {
         jsonRPCServiceProducer.produce(new JsonRPCProvidersBuildItem(ResteasyReactiveJsonRPCService.class));
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<DevModeCleanupBuildItem> producer) {
+        producer.produce(new DevModeCleanupBuildItem(ResteasyReactiveJsonRPCService.class, true));
     }
 }

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/devui/SchedulerDevUIProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/devui/SchedulerDevUIProcessor.java
@@ -3,8 +3,10 @@ package io.quarkus.scheduler.deployment.devui;
 import java.util.List;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.FooterPageBuildItem;
@@ -38,6 +40,11 @@ public class SchedulerDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem rpcProvider() {
         return new JsonRPCProvidersBuildItem(SchedulerJsonRPCService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<DevModeCleanupBuildItem> producer) {
+        producer.produce(new DevModeCleanupBuildItem(SchedulerJsonRPCService.class, true));
     }
 
 }

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/devui/FaultToleranceDevUIProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/devui/FaultToleranceDevUIProcessor.java
@@ -1,7 +1,10 @@
 package io.quarkus.smallrye.faulttolerance.deployment.devui;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -25,5 +28,10 @@ public class FaultToleranceDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem jsonRPCService() {
         return new JsonRPCProvidersBuildItem(FaultToleranceJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<DevModeCleanupBuildItem> producer) {
+        producer.produce(new DevModeCleanupBuildItem(FaultToleranceJsonRpcService.class, true));
     }
 }

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/devui/RabbitDevUIProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/devui/RabbitDevUIProcessor.java
@@ -2,8 +2,10 @@ package io.quarkus.smallrye.reactivemessaging.rabbitmq.deployment.devui;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime.devui.RabbitHttpPortFinder;
@@ -26,5 +28,10 @@ public class RabbitDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(RabbitMqJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(RabbitMqJsonRpcService.class, true);
     }
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/devui/ReactiveMessagingDevUIProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/devui/ReactiveMessagingDevUIProcessor.java
@@ -4,6 +4,7 @@ import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.jandex.AnnotationInstance;
 
@@ -11,11 +12,14 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
 import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames;
+import io.quarkus.smallrye.reactivemessaging.runtime.devmode.ReactiveMessagingHotReplacementSetup;
 import io.quarkus.smallrye.reactivemessaging.runtime.devui.Connectors;
 import io.quarkus.smallrye.reactivemessaging.runtime.devui.DevConsoleRecorder;
 import io.quarkus.smallrye.reactivemessaging.runtime.devui.ReactiveMessagingJsonRpcService;
@@ -67,5 +71,11 @@ public class ReactiveMessagingDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(ReactiveMessagingJsonRpcService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    DevModeCleanupBuildItem cleanProd() {
+        return new DevModeCleanupBuildItem(
+                Set.of(ReactiveMessagingJsonRpcService.class, ReactiveMessagingHotReplacementSetup.class), true);
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -34,12 +34,14 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
@@ -260,6 +262,11 @@ public class DevUIProcessor {
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<DevModeCleanupBuildItem> producer) {
+        producer.produce(new DevModeCleanupBuildItem("io.quarkus.devui.runtime"));
     }
 
     /**

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/devui/WebSocketServerDevUIProcessor.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/devui/WebSocketServerDevUIProcessor.java
@@ -15,8 +15,10 @@ import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevModeCleanupBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -48,6 +50,11 @@ public class WebSocketServerDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     JsonRPCProvidersBuildItem rpcProvider() {
         return new JsonRPCProvidersBuildItem(WebSocketNextJsonRPCService.class);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    void cleanProd(BuildProducer<DevModeCleanupBuildItem> producer) {
+        producer.produce(new DevModeCleanupBuildItem(WebSocketNextJsonRPCService.class, true));
     }
 
     private List<Map<String, Object>> createEndpointsJson(List<WebSocketEndpointBuildItem> endpoints,


### PR DESCRIPTION
This PR add removing all the non-relevant dev mode classes from Prod (Dev UI Json RPC Services and HotReloadSetup etc.)

The way that you add a JSON-RPC Service in Dev UI:

```
@BuildStep(onlyIf = IsDevelopment.class)
JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
    return new JsonRPCProvidersBuildItem(CacheJsonRPCService.class);
}
```

You will do a similar thing in Prod mode only:

```
@BuildStep(onlyIf = IsNormal.class)
DevModeCleanupBuildItem cleanProd() {
    return new DevModeCleanupBuildItem(CacheJsonRPCService.class, true);
}
```

This will remove the JsonRPC service when Prod mode is build, and (due to the true) also any other classes in that package.