### PR TITLE
[3.15] (Do not merge yet) Applying a conditionalized attribute to fix the issue with the included snippet

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -65,11 +65,9 @@ For more details and optional configurations, see xref:databases-dev-services.ad
 
 * `quarkus-jdbc-db2`
 * `quarkus-jdbc-derby`
-+
 ifdef::note-quarkus-derby[]
-====
++
 {note-quarkus-derby}
-====
 endif::note-quarkus-derby[]
 * `quarkus-jdbc-h2`
 * `quarkus-jdbc-mariadb`
@@ -156,11 +154,9 @@ Quarkus currently includes the following built-in database kinds:
 +
 * DB2: `db2`
 * Derby: `derby`
-+
 ifdef::note-quarkus-derby[]
-====
++
 {note-quarkus-derby}
-====
 endif::note-quarkus-derby[]
 * H2: `h2`
 * MariaDB: `mariadb`
@@ -202,11 +198,9 @@ JDBC is the most common database connection pattern, typically needed when used 
 .. For use with a built-in JDBC driver, choose and add the Quarkus extension for your relational database driver from the list below:
 +
 * Derby - `quarkus-jdbc-derby`
-+
 ifdef::note-quarkus-derby[]
-====
++
 {note-quarkus-derby}
-====
 endif::note-quarkus-derby[]
 * H2 - `quarkus-jdbc-h2`
 +

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -66,7 +66,11 @@ For more details and optional configurations, see xref:databases-dev-services.ad
 * `quarkus-jdbc-db2`
 * `quarkus-jdbc-derby`
 +
-include::_includes/snip-note-derby.adoc[]
+ifdef::note-quarkus-derby[]
+====
+{note-quarkus-derby}
+====
+endif::note-quarkus-derby[]
 * `quarkus-jdbc-h2`
 * `quarkus-jdbc-mariadb`
 * `quarkus-jdbc-mssql`
@@ -153,7 +157,11 @@ Quarkus currently includes the following built-in database kinds:
 * DB2: `db2`
 * Derby: `derby`
 +
-include::_includes/snip-note-derby.adoc[]
+ifdef::note-quarkus-derby[]
+====
+{note-quarkus-derby}
+====
+endif::note-quarkus-derby[]
 * H2: `h2`
 * MariaDB: `mariadb`
 * Microsoft SQL Server: `mssql`
@@ -195,7 +203,11 @@ JDBC is the most common database connection pattern, typically needed when used 
 +
 * Derby - `quarkus-jdbc-derby`
 +
-include::_includes/snip-note-derby.adoc[]
+ifdef::note-quarkus-derby[]
+====
+{note-quarkus-derby}
+====
+endif::note-quarkus-derby[]
 * H2 - `quarkus-jdbc-h2`
 +
 [NOTE]


### PR DESCRIPTION
The current use of included snippets is not reusable for the downstream documentation, thus I am reverting this change back to the use of an attribute and conditionalization.
If this will work as expected, I will merge https://github.com/quarkusio/quarkus/pull/44252 to `main`, and this can be merged directly or backported.