### PR TITLE
Fix HttpHeaders.getAcceptableLanguages() on empty headers

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/HeaderUtil.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/HeaderUtil.java
@@ -32,7 +32,7 @@ import org.jboss.resteasy.reactive.common.util.WeightedLanguage;
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class HeaderUtil {
-    private static final List<Locale> LANGUAGE_WILDCARD = List.of(Locale.ROOT);
+    private static final List<Locale> LANGUAGE_WILDCARD = List.of(new Locale("*"));
 
     private static final ClassValue<RuntimeDelegate.HeaderDelegate<?>> HEADER_DELEGATE_CACHE = new ClassValue<>() {
         @Override

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/HeaderUtil.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/HeaderUtil.java
@@ -32,6 +32,7 @@ import org.jboss.resteasy.reactive.common.util.WeightedLanguage;
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class HeaderUtil {
+    private static final List<Locale> LANGUAGE_WILDCARD = List.of(Locale.ROOT);
 
     private static final ClassValue<RuntimeDelegate.HeaderDelegate<?>> HEADER_DELEGATE_CACHE = new ClassValue<>() {
         @Override
@@ -293,7 +294,7 @@ public class HeaderUtil {
     public static List<Locale> getAcceptableLanguages(MultivaluedMap<String, ? extends Object> headers) {
         List<?> accepts = headers.get(HttpHeaders.ACCEPT_LANGUAGE);
         if (accepts == null || accepts.isEmpty())
-            return Collections.emptyList();
+            return LANGUAGE_WILDCARD;
         List<WeightedLanguage> languages = new ArrayList<WeightedLanguage>();
         for (Object obj : accepts) {
             if (obj instanceof Locale) {

--- a/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/headers/HeaderUtilTest.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/headers/HeaderUtilTest.java
@@ -1,0 +1,28 @@
+package org.jboss.resteasy.reactive.common.headers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Locale;
+
+import org.jboss.resteasy.reactive.common.util.MultivaluedTreeMap;
+import org.junit.jupiter.api.Test;
+
+class HeaderUtilTest {
+
+    @Test
+    void getAcceptableLanguages() {
+        MultivaluedTreeMap<String, String> emptyHeaders = new MultivaluedTreeMap<>();
+        Locale[] wildcardLocale = new Locale[] { new Locale("*") };
+        assertArrayEquals(wildcardLocale, HeaderUtil.getAcceptableLanguages(emptyHeaders).toArray());
+
+        MultivaluedTreeMap<String, String> singleLanguage = new MultivaluedTreeMap<>();
+        singleLanguage.add("Accept-Language", "de");
+        Locale[] singleLocale = new Locale[] { Locale.GERMAN };
+        assertArrayEquals(singleLocale, HeaderUtil.getAcceptableLanguages(singleLanguage).toArray());
+
+        MultivaluedTreeMap<String, String> multipleWeightedLanguages = new MultivaluedTreeMap<>();
+        multipleWeightedLanguages.add("Accept-Language", "da, en-gb;q=0.8, en;q=0.7");
+        Locale[] multipleWeightedLocales = new Locale[] { new Locale("da"), Locale.UK, Locale.ENGLISH };
+        assertArrayEquals(multipleWeightedLocales, HeaderUtil.getAcceptableLanguages(multipleWeightedLanguages).toArray());
+    }
+}


### PR DESCRIPTION
`jakarta.ws.rs.core.HttpHeaders.getAcceptableLanguages` requires that a wildcard locale is returned, if no acceptable language is specified. The previous behavior returned an empty list.

- Closes: #44253