### PR TITLE
Support Keycloak Dev Services for standalone OIDC Client Registration extension

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakAdminPageBuildItem.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakAdminPageBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.devservices.keycloak;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+
+/**
+ * Extensions should produce this build item if a DEV UI card with
+ * the Keycloak Admin link should be created for the extension.
+ */
+public final class KeycloakAdminPageBuildItem extends MultiBuildItem {
+
+    final CardPageBuildItem cardPage;
+
+    /**
+     * @param cardPage created inside extension that requires Keycloak Dev Service, this way, card page
+     *        custom identifier deduced from a stacktrace walker will identify the extension correctly
+     */
+    public KeycloakAdminPageBuildItem(CardPageBuildItem cardPage) {
+        this.cardPage = cardPage;
+    }
+}

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfigBuildItem.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfigBuildItem.java
@@ -1,6 +1,9 @@
 package io.quarkus.devservices.keycloak;
 
+import static io.quarkus.devservices.keycloak.KeycloakDevServicesProcessor.KEYCLOAK_URL_KEY;
+
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
@@ -27,5 +30,12 @@ public final class KeycloakDevServicesConfigBuildItem extends SimpleBuildItem {
 
     public boolean isContainerRestarted() {
         return containerRestarted;
+    }
+
+    public static String getKeycloakUrl(Optional<KeycloakDevServicesConfigBuildItem> configBuildItem) {
+        return configBuildItem
+                .map(KeycloakDevServicesConfigBuildItem::getConfig)
+                .map(config -> config.get(KEYCLOAK_URL_KEY))
+                .orElse(null);
     }
 }

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfigurator.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfigurator.java
@@ -1,0 +1,17 @@
+package io.quarkus.devservices.keycloak;
+
+import java.util.Map;
+
+import org.keycloak.representations.idm.RealmRepresentation;
+
+public interface KeycloakDevServicesConfigurator {
+
+    record ConfigPropertiesContext(String authServerInternalUrl, String oidcClientId, String oidcClientSecret) {
+    }
+
+    Map<String, String> createProperties(ConfigPropertiesContext context);
+
+    default void customizeDefaultRealm(RealmRepresentation realmRepresentation) {
+    }
+
+}

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesRequiredBuildItem.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesRequiredBuildItem.java
@@ -1,9 +1,16 @@
 package io.quarkus.devservices.keycloak;
 
-import static io.quarkus.devservices.keycloak.KeycloakDevServicesProcessor.OIDC_CLIENT_AUTH_SERVER_URL_CONFIG_KEY;
-import static io.quarkus.devservices.keycloak.KeycloakDevServicesProcessor.OIDC_CLIENT_TOKEN_PATH_CONFIG_KEY;
+import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jboss.logging.Logger;
+import org.keycloak.representations.idm.RealmRepresentation;
 
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.runtime.configuration.ConfigUtils;
@@ -15,33 +22,65 @@ import io.quarkus.runtime.configuration.ConfigUtils;
  */
 public final class KeycloakDevServicesRequiredBuildItem extends MultiBuildItem {
 
-    enum Capability {
-        OIDC,
-        OIDC_CLIENT
+    private static final Logger LOG = Logger.getLogger(KeycloakDevServicesProcessor.class);
+    public static final String OIDC_AUTH_SERVER_URL_CONFIG_KEY = "quarkus.oidc.auth-server-url";
+
+    private final KeycloakDevServicesConfigurator devServicesConfigurator;
+    private final String authServerUrl;
+
+    private KeycloakDevServicesRequiredBuildItem(KeycloakDevServicesConfigurator devServicesConfigurator,
+            String authServerUrl) {
+        this.devServicesConfigurator = requireNonNull(devServicesConfigurator);
+        this.authServerUrl = requireNonNull(authServerUrl);
     }
 
-    private final Capability capability;
-
-    private KeycloakDevServicesRequiredBuildItem(Capability capability) {
-        this.capability = capability;
+    String getAuthServerUrl() {
+        return authServerUrl;
     }
 
-    static boolean setOidcConfigProperties(List<KeycloakDevServicesRequiredBuildItem> items) {
-        return items.stream().anyMatch(i -> i.capability == Capability.OIDC);
+    public static KeycloakDevServicesRequiredBuildItem of(KeycloakDevServicesConfigurator devServicesConfigurator,
+            String authServerUrl, String... dontStartConfigProperties) {
+        if (shouldStartDevService(dontStartConfigProperties, authServerUrl)) {
+            return new KeycloakDevServicesRequiredBuildItem(devServicesConfigurator, authServerUrl);
+        }
+        return null;
     }
 
-    static boolean setOidcClientConfigProperties(List<KeycloakDevServicesRequiredBuildItem> items) {
-        boolean serverUrlOrTokenPathConfigured = ConfigUtils.isPropertyNonEmpty(OIDC_CLIENT_AUTH_SERVER_URL_CONFIG_KEY)
-                || ConfigUtils.isPropertyNonEmpty(OIDC_CLIENT_TOKEN_PATH_CONFIG_KEY);
-        return !serverUrlOrTokenPathConfigured
-                && items.stream().anyMatch(i -> i.capability == Capability.OIDC_CLIENT);
+    static KeycloakDevServicesConfigurator getDevServicesConfigurator(List<KeycloakDevServicesRequiredBuildItem> items) {
+        return new KeycloakDevServicesConfigurator() {
+            @Override
+            public Map<String, String> createProperties(ConfigPropertiesContext context) {
+                return items
+                        .stream()
+                        .map(i -> i.devServicesConfigurator)
+                        .map(producer -> producer.createProperties(context))
+                        .map(Map::entrySet)
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            }
+
+            @Override
+            public void customizeDefaultRealm(RealmRepresentation realmRepresentation) {
+                items
+                        .stream()
+                        .map(i -> i.devServicesConfigurator)
+                        .forEach(i -> i.customizeDefaultRealm(realmRepresentation));
+            }
+        };
     }
 
-    public static KeycloakDevServicesRequiredBuildItem requireDevServiceForOidc() {
-        return new KeycloakDevServicesRequiredBuildItem(Capability.OIDC);
+    private static boolean shouldStartDevService(String[] dontStartConfigProperties, String authServerUrl) {
+        return Stream
+                .concat(Stream.of(authServerUrl), Arrays.stream(dontStartConfigProperties))
+                .allMatch(KeycloakDevServicesRequiredBuildItem::shouldStartDevService);
     }
 
-    public static KeycloakDevServicesRequiredBuildItem requireDevServiceForOidcClient() {
-        return new KeycloakDevServicesRequiredBuildItem(Capability.OIDC_CLIENT);
+    private static boolean shouldStartDevService(String dontStartConfigProperty) {
+        if (ConfigUtils.isPropertyNonEmpty(dontStartConfigProperty)) {
+            // this build item does not require to start the Keycloak Dev Service as runtime property was set
+            LOG.debugf("Not starting Dev Services for Keycloak as '%s' has been provided", dontStartConfigProperty);
+            return false;
+        }
+        return true;
     }
 }

--- a/extensions/oidc-client-registration/deployment/pom.xml
+++ b/extensions/oidc-client-registration/deployment/pom.xml
@@ -31,6 +31,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-common-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-keycloak</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -83,10 +87,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.docker.image>${keycloak.docker.legacy.image}</keycloak.docker.image>
-                                <keycloak.use.https>false</keycloak.use.https>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/extensions/oidc-client-registration/deployment/src/main/java/io/quarkus/oidc/client/registration/deployment/devservices/keycloak/KeycloakDevServiceRequiredBuildStep.java
+++ b/extensions/oidc-client-registration/deployment/src/main/java/io/quarkus/oidc/client/registration/deployment/devservices/keycloak/KeycloakDevServiceRequiredBuildStep.java
@@ -1,0 +1,71 @@
+package io.quarkus.oidc.client.registration.deployment.devservices.keycloak;
+
+import static io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem.OIDC_AUTH_SERVER_URL_CONFIG_KEY;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.representations.idm.ComponentExportRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.devservices.keycloak.KeycloakAdminPageBuildItem;
+import io.quarkus.devservices.keycloak.KeycloakDevServicesConfigurator;
+import io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.oidc.client.registration.deployment.OidcClientRegistrationBuildStep;
+
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { OidcClientRegistrationBuildStep.IsEnabled.class,
+        GlobalDevServicesConfig.Enabled.class })
+public class KeycloakDevServiceRequiredBuildStep {
+
+    private static final String OIDC_CLIENT_REG_AUTH_SERVER_URL_CONFIG_KEY = "quarkus.oidc-client-registration.auth-server-url";
+
+    @BuildStep
+    KeycloakDevServicesRequiredBuildItem requireKeycloakDevService() {
+        var devServicesConfigurator = new KeycloakDevServicesConfigurator() {
+
+            @Override
+            public Map<String, String> createProperties(ConfigPropertiesContext ctx) {
+                return Map.of(OIDC_CLIENT_REG_AUTH_SERVER_URL_CONFIG_KEY, ctx.authServerInternalUrl());
+            }
+
+            @Override
+            public void customizeDefaultRealm(RealmRepresentation realmRepresentation) {
+                if (getInitialToken() == null) {
+                    realmRepresentation.setRegistrationAllowed(true);
+                    realmRepresentation.setRegistrationFlow("registration");
+                    if (realmRepresentation.getComponents() == null) {
+                        realmRepresentation.setComponents(new MultivaluedHashMap<>());
+                    }
+                    var componentExportRepresentation = new ComponentExportRepresentation();
+                    componentExportRepresentation.setName("Full Scope Disabled");
+                    componentExportRepresentation.setProviderId("scope");
+                    componentExportRepresentation.setSubType("anonymous");
+                    realmRepresentation.getComponents().put(
+                            "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy",
+                            List.of(componentExportRepresentation));
+                }
+            }
+        };
+
+        return KeycloakDevServicesRequiredBuildItem.of(devServicesConfigurator,
+                OIDC_CLIENT_REG_AUTH_SERVER_URL_CONFIG_KEY, OIDC_AUTH_SERVER_URL_CONFIG_KEY);
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    KeycloakAdminPageBuildItem addCardWithLinkToKeycloakAdmin() {
+        return new KeycloakAdminPageBuildItem(new CardPageBuildItem());
+    }
+
+    private static String getInitialToken() {
+        return ConfigProvider.getConfig().getOptionalValue("quarkus.oidc-client-registration.initial-token", String.class)
+                .orElse(null);
+    }
+}

--- a/extensions/oidc-client-registration/deployment/src/test/java/io/quarkus/oidc/client/registration/OidcClientRegistrationKeycloakDevServiceTest.java
+++ b/extensions/oidc-client-registration/deployment/src/test/java/io/quarkus/oidc/client/registration/OidcClientRegistrationKeycloakDevServiceTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.oidc.client.registration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OidcClientRegistrationKeycloakDevServiceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(
+                            new StringAsset(
+                                    """
+                                            quarkus.oidc-client-registration.metadata.client-name=Default Test Client
+                                            quarkus.oidc-client-registration.metadata.redirect-uri=http://localhost:8081/default/redirect
+                                            quarkus.oidc-client-registration.named.metadata.client-name=Named Test Client
+                                            quarkus.oidc-client-registration.named.metadata.redirect-uri=http://localhost:8081/named/redirect
+                                            quarkus.oidc-client-registration.named.auth-server-url=${quarkus.oidc-client-registration.auth-server-url}
+                                            """),
+                            "application.properties"));
+
+    @Inject
+    TestClientRegistrations testClientRegistrations;
+
+    @Test
+    public void testDefaultRegisteredClient() {
+        assertEquals("Default Test Client", testClientRegistrations.defaultClientMetadata.getClientName());
+        assertEquals("http://localhost:8081/default/redirect",
+                testClientRegistrations.defaultClientMetadata.getRedirectUris().get(0));
+    }
+
+    @Test
+    public void testNamedRegisteredClient() {
+        assertEquals("Named Test Client", testClientRegistrations.namedClientMetadata.getClientName());
+        assertEquals("http://localhost:8081/named/redirect",
+                testClientRegistrations.namedClientMetadata.getRedirectUris().get(0));
+    }
+
+    @Singleton
+    public static final class TestClientRegistrations {
+
+        private volatile ClientMetadata defaultClientMetadata;
+        private volatile ClientMetadata namedClientMetadata;
+
+        void prepareDefaultClientMetadata(@Observes StartupEvent event, OidcClientRegistrations clientRegistrations) {
+            var clientRegistration = clientRegistrations.getClientRegistration();
+            var registeredClient = clientRegistration.registeredClient().await().indefinitely();
+            defaultClientMetadata = registeredClient.metadata();
+
+            clientRegistration = clientRegistrations.getClientRegistration("named");
+            registeredClient = clientRegistration.registeredClient().await().indefinitely();
+            namedClientMetadata = registeredClient.metadata();
+        }
+    }
+}

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
@@ -105,8 +105,11 @@ public class OidcClientRegistrationRecorder {
                 if (isEmptyMetadata(oidcConfig.metadata)) {
                     return Uni.createFrom().nullItem();
                 }
+                var clientName = DEFAULT_ID.equals(oidcConfig.id.orElse(DEFAULT_ID)) ? "" : "." + oidcConfig.id.get();
                 throw new ConfigurationException(
-                        "Either 'quarkus.oidc-client-registration.auth-server-url' or absolute 'quarkus.oidc-client-registration.registration-path' URL must be set");
+                        "Either 'quarkus.oidc-client-registration" + clientName
+                                + ".auth-server-url' or absolute 'quarkus.oidc-client-registration" + clientName
+                                + ".registration-path' URL must be set");
             }
             OidcCommonUtils.verifyEndpointUrl(getEndpointUrl(oidcConfig));
         } catch (Throwable t) {
@@ -194,7 +197,7 @@ public class OidcClientRegistrationRecorder {
                                         public OidcClientRegistration apply(RegisteredClient r, Throwable t2) {
                                             RegisteredClient registeredClient;
                                             if (t2 != null) {
-                                                LOG.errorf("%s client registartion failed: %s, it can be retried later",
+                                                LOG.errorf("%s client registration failed: %s, it can be retried later",
                                                         oidcConfig.id.orElse(DEFAULT_ID), t2.getMessage());
                                                 registeredClient = null;
                                             } else {

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
@@ -25,8 +25,6 @@ import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.Feature;
-import io.quarkus.deployment.IsDevelopment;
-import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -37,11 +35,6 @@ import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
-import io.quarkus.devservices.keycloak.KeycloakDevServicesConfigBuildItem;
-import io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem;
-import io.quarkus.devui.spi.page.CardPageBuildItem;
-import io.quarkus.devui.spi.page.Page;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.MethodCreator;
@@ -189,27 +182,6 @@ public class OidcClientBuildStep {
             }
         }
         return index.getIndex().getAnnotations(ACCESS_TOKEN).stream().map(ItemBuilder::new).map(ItemBuilder::build).toList();
-    }
-
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
-    KeycloakDevServicesRequiredBuildItem requireKeycloakDevService() {
-        // this needs to be done as the shared Keycloak Dev Service doesn't know if the OIDC Client is enabled
-        return KeycloakDevServicesRequiredBuildItem.requireDevServiceForOidcClient();
-    }
-
-    @BuildStep(onlyIf = IsDevelopment.class)
-    void produceDevUiCardWithKeycloakUrl(Optional<KeycloakDevServicesConfigBuildItem> configProps,
-            BuildProducer<CardPageBuildItem> cardPageProducer) {
-        final String keycloakAdminUrl = configProps.map(item -> item.getConfig().get("keycloak.url")).orElse(null);
-        if (keycloakAdminUrl != null) {
-            // Add Admin page
-            final CardPageBuildItem cardPage = new CardPageBuildItem();
-            cardPage.addPage(Page.externalPageBuilder("Keycloak Admin")
-                    .icon("font-awesome-solid:key")
-                    .doNotEmbed(true)
-                    .url(keycloakAdminUrl));
-            cardPageProducer.produce(cardPage);
-        }
     }
 
     /**

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/devservices/keycloak/KeycloakDevServiceRequiredBuildStep.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/devservices/keycloak/KeycloakDevServiceRequiredBuildStep.java
@@ -1,0 +1,45 @@
+package io.quarkus.oidc.client.deployment.devservices.keycloak;
+
+import static io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem.OIDC_AUTH_SERVER_URL_CONFIG_KEY;
+
+import java.util.HashMap;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.devservices.keycloak.KeycloakAdminPageBuildItem;
+import io.quarkus.devservices.keycloak.KeycloakDevServicesConfig;
+import io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.oidc.client.deployment.OidcClientBuildStep;
+
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { OidcClientBuildStep.IsEnabled.class, GlobalDevServicesConfig.Enabled.class })
+public class KeycloakDevServiceRequiredBuildStep {
+
+    private static final String CONFIG_PREFIX = "quarkus.oidc-client.";
+    private static final String OIDC_CLIENT_AUTH_SERVER_URL_CONFIG_KEY = CONFIG_PREFIX + "auth-server-url";
+    private static final String OIDC_CLIENT_TOKEN_PATH_CONFIG_KEY = CONFIG_PREFIX + "token-path";
+    private static final String OIDC_CLIENT_SECRET_CONFIG_KEY = CONFIG_PREFIX + "credentials.secret";
+    private static final String OIDC_CLIENT_ID_CONFIG_KEY = CONFIG_PREFIX + "client-id";
+
+    @BuildStep
+    KeycloakDevServicesRequiredBuildItem requireKeycloakDevService(KeycloakDevServicesConfig config) {
+        return KeycloakDevServicesRequiredBuildItem.of(ctx -> {
+            var configProperties = new HashMap<String, String>();
+            configProperties.put(OIDC_CLIENT_AUTH_SERVER_URL_CONFIG_KEY, ctx.authServerInternalUrl());
+            configProperties.put(OIDC_CLIENT_TOKEN_PATH_CONFIG_KEY, "/protocol/openid-connect/tokens");
+            if (config.createClient()) {
+                configProperties.put(OIDC_CLIENT_ID_CONFIG_KEY, ctx.oidcClientId());
+                configProperties.put(OIDC_CLIENT_SECRET_CONFIG_KEY, ctx.oidcClientSecret());
+            }
+            return configProperties;
+        }, OIDC_CLIENT_AUTH_SERVER_URL_CONFIG_KEY, OIDC_CLIENT_TOKEN_PATH_CONFIG_KEY, OIDC_AUTH_SERVER_URL_CONFIG_KEY);
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    KeycloakAdminPageBuildItem addCardWithLinkToKeycloakAdmin() {
+        return new KeycloakAdminPageBuildItem(new CardPageBuildItem());
+    }
+}

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -46,7 +46,6 @@ import io.quarkus.arc.processor.QualifierRegistrar;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
-import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -58,8 +57,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
-import io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem;
 import io.quarkus.oidc.AuthorizationCodeFlow;
 import io.quarkus.oidc.BearerTokenAuthentication;
 import io.quarkus.oidc.IdToken;
@@ -396,12 +393,6 @@ public class OidcBuildStep {
         return List.of(
                 new HttpAuthMechanismAnnotationBuildItem(DotName.createSimple(AuthorizationCodeFlow.class), CODE_FLOW_CODE),
                 new HttpAuthMechanismAnnotationBuildItem(DotName.createSimple(BearerTokenAuthentication.class), BEARER_SCHEME));
-    }
-
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
-    KeycloakDevServicesRequiredBuildItem requireKeycloakDevService() {
-        // this needs to be done as the shared Keycloak Dev Service doesn't know if the OIDC is enabled
-        return KeycloakDevServicesRequiredBuildItem.requireDevServiceForOidc();
     }
 
     private static boolean isInjected(BeanRegistrationPhaseBuildItem beanRegistrationPhaseBuildItem, DotName requiredType,

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServiceRequiredBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServiceRequiredBuildStep.java
@@ -1,0 +1,55 @@
+package io.quarkus.oidc.deployment.devservices.keycloak;
+
+import static io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem.OIDC_AUTH_SERVER_URL_CONFIG_KEY;
+
+import java.util.HashMap;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.devservices.keycloak.KeycloakDevServicesConfig;
+import io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem;
+import io.quarkus.oidc.deployment.OidcBuildStep;
+
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { OidcBuildStep.IsEnabled.class, GlobalDevServicesConfig.Enabled.class })
+public class KeycloakDevServiceRequiredBuildStep {
+
+    private static final Logger LOG = Logger.getLogger(KeycloakDevServiceRequiredBuildStep.class);
+    private static final String CONFIG_PREFIX = "quarkus.oidc.";
+    private static final String TENANT_ENABLED_CONFIG_KEY = CONFIG_PREFIX + "tenant-enabled";
+    private static final String PROVIDER_CONFIG_KEY = CONFIG_PREFIX + "provider";
+    private static final String APPLICATION_TYPE_CONFIG_KEY = CONFIG_PREFIX + "application-type";
+    private static final String CLIENT_ID_CONFIG_KEY = CONFIG_PREFIX + "client-id";
+    private static final String CLIENT_SECRET_CONFIG_KEY = CONFIG_PREFIX + "credentials.secret";
+
+    @BuildStep
+    KeycloakDevServicesRequiredBuildItem requireKeycloakDevService(KeycloakDevServicesConfig config) {
+        if (!isOidcTenantEnabled() && !config.startWithDisabledTenant()) {
+            LOG.debug("Not starting Dev Services for Keycloak as 'quarkus.oidc.tenant.enabled' is false");
+            return null;
+        }
+
+        return KeycloakDevServicesRequiredBuildItem.of(ctx -> {
+            var configProperties = new HashMap<String, String>();
+            configProperties.put(OIDC_AUTH_SERVER_URL_CONFIG_KEY, ctx.authServerInternalUrl());
+            configProperties.put(APPLICATION_TYPE_CONFIG_KEY, getOidcApplicationType());
+            if (config.createClient()) {
+                configProperties.put(CLIENT_ID_CONFIG_KEY, ctx.oidcClientId());
+                configProperties.put(CLIENT_SECRET_CONFIG_KEY, ctx.oidcClientSecret());
+            }
+            return configProperties;
+        }, OIDC_AUTH_SERVER_URL_CONFIG_KEY, PROVIDER_CONFIG_KEY);
+    }
+
+    private static boolean isOidcTenantEnabled() {
+        return ConfigProvider.getConfig().getOptionalValue(TENANT_ENABLED_CONFIG_KEY, Boolean.class).orElse(true);
+    }
+
+    private static String getOidcApplicationType() {
+        return ConfigProvider.getConfig().getOptionalValue(APPLICATION_TYPE_CONFIG_KEY, String.class).orElse("service");
+    }
+}


### PR DESCRIPTION
This PR does 2 things:

- improves extendability of Keycloak Dev Service as we plan to support KC Dev Svc for Keycloak Admin Client
- starts Keycloak Dev Service when OIDC Client Registration is used without OIDC extension and OIDC Client extension (implements part of the #44143)
