### PR TITLE
Generate RSA-256 keys on dev and test mode

### DIFF
--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -853,6 +853,37 @@ Please see the xref:security-openid-connect-client-reference.adoc#token-propagat
 [[integration-testing]]
 === Testing
 
+[[auto-generated-keys]]
+==== Automatic key generation
+
+This extension generates an asymmetric RSA 2024 bit signing key pair in the dev and test modes if the verification key has not been configured.
+Once the key pair is generated, the public RSA key is used to configure the `mp.jwt.verify.publickey` property, and the RSA private key is available to tests to sign tokens using `smallrye-jwt-build`, for example:
+
+[source,java]
+----
+import io.smallrye.jwt.build.Jwt;
+import jakarta.ws.rs.GET;
+
+@GET
+public String token() {
+   return Jwt.upn("Alice").sign();
+}
+----
+
+See xref:security-jwt-build.adoc#sign-claims[signing claims guide] for mode details.
+
+You can disable automatic key generation by setting at least one of the following properties:
+
+* `mp.jwt.verify.publickey.location`
+* `mp.jwt.verify.publickey`
+* `smallrye.jwt.sign.key.location`
+* `smallrye.jwt.sign.key`
+
+[NOTE]
+====
+Additionally, if you do not specify the issuer information (using the `mp.jwt.verify.issuer` property), the {extension-name} extension will set a default issuer as `https://quarkus.io/issuer`.
+====
+
 [[integration-testing-wiremock]]
 ==== Wiremock
 

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -64,7 +64,7 @@ class SmallRyeJwtProcessor {
 
     private static final Logger log = Logger.getLogger(SmallRyeJwtProcessor.class.getName());
 
-    private static final String MP_JWT_VERIFY_KEY_LOCATION = "mp.jwt.verify.publickey.location";
+    static final String MP_JWT_VERIFY_KEY_LOCATION = "mp.jwt.verify.publickey.location";
     private static final String MP_JWT_DECRYPT_KEY_LOCATION = "mp.jwt.decrypt.key.location";
 
     private static final DotName CLAIM_NAME = DotName.createSimple(Claim.class.getName());

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
@@ -1,0 +1,146 @@
+package io.quarkus.smallrye.jwt.deployment;
+
+import static io.quarkus.smallrye.jwt.deployment.SmallRyeJwtProcessor.MP_JWT_VERIFY_KEY_LOCATION;
+
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
+import io.smallrye.jwt.util.KeyUtils;
+
+public class SmallryeJwtDevModeProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(SmallryeJwtDevModeProcessor.class);
+
+    private static final String MP_JWT_VERIFY_PUBLIC_KEY = "mp.jwt.verify.publickey";
+    private static final String MP_JWT_VERIFY_ISSUER = "mp.jwt.verify.issuer";
+
+    private static final String SMALLRYE_JWT_NEW_TOKEN_ISSUER = "smallrye.jwt.new-token.issuer";
+    private static final String SMALLRYE_JWT_SIGN_KEY_LOCATION = "smallrye.jwt.sign.key.location";
+    private static final String SMALLRYE_JWT_SIGN_KEY = "smallrye.jwt.sign.key";
+
+    private static final String NONE = "NONE";
+    private static final String DEFAULT_ISSUER = "https://quarkus.io/issuer";
+
+    private static final int KEY_SIZE = 2048;
+
+    private static final Set<String> JWT_SIGN_KEY_PROPERTIES = Set.of(
+            MP_JWT_VERIFY_KEY_LOCATION,
+            MP_JWT_VERIFY_PUBLIC_KEY,
+            SMALLRYE_JWT_SIGN_KEY_LOCATION,
+            SMALLRYE_JWT_SIGN_KEY);
+
+    /**
+     * This build step generates an RSA-256 key pair for development and test modes.
+     * <p>
+     * The key pair is generated only if the user has not set any of the {@code *.key} or {@code *.location} properties.
+     * <p>
+     * Additionally, if the user has not provided the {@code mp.jwt.verify.issuer} and {@code smallrye.jwt.new-token.issuer}
+     * properties,
+     * this build step will add a default issuer, regardless of the above condition.
+     *
+     * @throws NoSuchAlgorithmException if RSA-256 key generation fails.
+     */
+    @BuildStep(onlyIfNot = { IsNormal.class })
+    void generateSignKeys(BuildProducer<DevServicesResultBuildItem> devServices,
+            LiveReloadBuildItem liveReloadBuildItem) throws NoSuchAlgorithmException {
+
+        Set<String> userProps = JWT_SIGN_KEY_PROPERTIES
+                .stream()
+                .filter(this::isConfigPresent)
+                .collect(Collectors.toSet());
+
+        if (!userProps.isEmpty()) {
+            // If the user has set the property, we need to avoid adding or overriding it with the
+            // smallrye default configuration
+            Map<String, String> devServiceProps = addDefaultSmallryePropertiesIfMissing(userProps);
+
+            if (!isConfigPresent(MP_JWT_VERIFY_ISSUER) && !isConfigPresent(SMALLRYE_JWT_NEW_TOKEN_ISSUER)) {
+                devServiceProps.put(MP_JWT_VERIFY_ISSUER, DEFAULT_ISSUER);
+                devServiceProps.put(SMALLRYE_JWT_NEW_TOKEN_ISSUER, DEFAULT_ISSUER);
+            }
+
+            devServices.produce(smallryeJwtDevServiceWith(devServiceProps));
+            return;
+        }
+
+        KeyPairContext ctx = liveReloadBuildItem.getContextObject(KeyPairContext.class);
+
+        LOGGER.info("The smallrye-jwt extension has configured an in-memory key pair, which is not enabled in production. " +
+                "Please ensure the correct keys/locations are set in production to avoid potential issues.");
+        if (ctx == null && !liveReloadBuildItem.isLiveReload()) {
+            // first execution
+            KeyPair keyPair = KeyUtils.generateKeyPair(KEY_SIZE);
+            String publicKey = getStringKey(keyPair.getPublic());
+            String privateKey = getStringKey(keyPair.getPrivate());
+
+            Map<String, String> devServiceProps = generateDevServiceProperties(publicKey, privateKey);
+
+            if (!isConfigPresent(MP_JWT_VERIFY_ISSUER) && !isConfigPresent(SMALLRYE_JWT_NEW_TOKEN_ISSUER)) {
+                devServiceProps.put(MP_JWT_VERIFY_ISSUER, DEFAULT_ISSUER);
+                devServiceProps.put(SMALLRYE_JWT_NEW_TOKEN_ISSUER, DEFAULT_ISSUER);
+            }
+
+            liveReloadBuildItem.setContextObject(KeyPairContext.class, new KeyPairContext(
+                    devServiceProps));
+
+            devServices.produce(smallryeJwtDevServiceWith(devServiceProps));
+        }
+
+        if (ctx != null && liveReloadBuildItem.isLiveReload()) {
+            devServices.produce(smallryeJwtDevServiceWith(ctx.properties()));
+        }
+    }
+
+    private Map<String, String> addDefaultSmallryePropertiesIfMissing(Set<String> userConfigs) {
+        HashMap<String, String> devServiceConfigs = new HashMap<>();
+        if (!userConfigs.contains(SMALLRYE_JWT_SIGN_KEY)) {
+            devServiceConfigs.put(SMALLRYE_JWT_SIGN_KEY, NONE);
+        }
+
+        if (!devServiceConfigs.containsKey(MP_JWT_VERIFY_PUBLIC_KEY)) {
+            devServiceConfigs.put(MP_JWT_VERIFY_PUBLIC_KEY, NONE);
+        }
+
+        return devServiceConfigs;
+    }
+
+    private boolean isConfigPresent(String property) {
+        return ConfigProvider.getConfig().getOptionalValue(property, String.class)
+                .isPresent();
+    }
+
+    private DevServicesResultBuildItem smallryeJwtDevServiceWith(Map<String, String> properties) {
+        return new DevServicesResultBuildItem(
+                Feature.SMALLRYE_JWT.name(), null, properties);
+    }
+
+    private static Map<String, String> generateDevServiceProperties(String publicKey, String privateKey) {
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put(MP_JWT_VERIFY_PUBLIC_KEY, publicKey);
+        properties.put(SMALLRYE_JWT_SIGN_KEY, privateKey);
+        return properties;
+    }
+
+    private static String getStringKey(Key key) {
+        return Base64.getEncoder()
+                .encodeToString(key.getEncoded());
+    }
+
+    record KeyPairContext(Map<String, String> properties) {
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/GreetingResource.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/GreetingResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.jwt.test;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/only-user")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @RolesAllowed({ "User" })
+    public String hello() {
+        return "Hello from Quarkus REST";
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtProcessorDevModeTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtProcessorDevModeTest.java
@@ -1,0 +1,183 @@
+package io.quarkus.jwt.test.dev;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.jwt.test.GreetingResource;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.smallrye.jwt.build.Jwt;
+import io.smallrye.jwt.util.KeyUtils;
+
+public class SmallryeJwtProcessorDevModeTest {
+
+    @RegisterExtension
+    static QuarkusDevModeTest devMode = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(
+                    GreetingResource.class, TokenResource.class).addAsResource(
+                            new StringAsset(""),
+                            "application.properties"));
+
+    @Test
+    public void shouldNotBeNecessaryToAddSignKeysOnApplicationProperties() {
+        String token = RestAssured.given()
+                .header(new Header("Accept", "text/plain"))
+                .get("/token")
+                .andReturn()
+                .body()
+                .asString();
+
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200);
+    }
+
+    @Test
+    public void shouldUseTheSameTokenEvenWhenTheUserChangesTheConfiguration() {
+        String token = RestAssured.given()
+                .header(new Header("Accept", "text/plain"))
+                .get("/token")
+                .andReturn()
+                .body()
+                .asString();
+
+        // there is no need to get another token
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200)
+                .body(Matchers.containsString("Hello from Quarkus REST"));
+
+        devMode.modifyResourceFile("application.properties", s -> """
+                smallrye.jwt.sign.key.location=invalidLocation.pem
+                mp.jwt.verify.publickey.location=invalidLocation.pem
+                """);
+
+        // should throw error because the private/public are invalid
+        String newToken = RestAssured.given()
+                .header(new Header("Accept", "text/plain"))
+                .get("/token")
+                .andReturn()
+                .body()
+                .asString();
+
+        // should return 500 because the location is invalid
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + newToken))
+                .get("/only-user")
+                .then().assertThat().statusCode(500);
+
+        devMode.modifyResourceFile("application.properties", s -> "");
+
+        // there is no need to get another token
+        // should work with old token
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200)
+                .body(Matchers.containsString("Hello from Quarkus REST"));
+    }
+
+    @Test
+    public void shouldUseTheSameKeyPairOnLiveReload() {
+        String token = RestAssured.given()
+                .header(new Header("Accept", "text/plain"))
+                .get("/token")
+                .andReturn()
+                .body()
+                .asString();
+
+        devMode.modifySourceFile("GreetingResource.java", s -> s.replace("Hello from Quarkus", "Hello from JWT"));
+
+        // there is no need to get another token
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200)
+                .body(Matchers.containsString("Hello from JWT"));
+    }
+
+    @Test
+    public void shouldUseTheSameTokenEvenWhenTheUserChangesTheConfigWithKeyProps() {
+
+        devMode.modifyResourceFile("application.properties", s -> "");
+
+        String token = RestAssured.given()
+                .header(new Header("Accept", "text/plain"))
+                .get("/token")
+                .andReturn()
+                .body()
+                .asString();
+
+        // there is no need to get another token
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200)
+                .body(Matchers.containsString("Hello from Quarkus REST"));
+
+        try {
+            String privateKey = KeyUtils.readKeyContent("/privateKey.pem");
+            String publicKey = KeyUtils.readKeyContent("/publicKey.pem");
+            devMode.modifyResourceFile("application.properties", s -> """
+                    smallrye.jwt.sign.key=%s
+                    mp.jwt.verify.publickey=%s
+                    """.formatted(privateKey, publicKey));
+        } catch (IOException e) {
+            fail("Was not possible for reading keys from resource");
+        }
+
+        // should throw error because the private/public are invalid
+        String newToken = RestAssured.given()
+                .header(new Header("Accept", "text/plain"))
+                .get("/token")
+                .andReturn()
+                .body()
+                .asString();
+
+        // should return 200 because the keys are valid
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + newToken))
+                .get("/only-user")
+                .then().assertThat().statusCode(200);
+
+        devMode.modifyResourceFile("application.properties", s -> "");
+
+        // there is no need to get another token
+        // should work with old token
+        RestAssured.given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .get("/only-user")
+                .then().assertThat().statusCode(200)
+                .body(Matchers.containsString("Hello from Quarkus REST"));
+    }
+
+    @Path("/token")
+    static class TokenResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        @PermitAll
+        public String hello() {
+            return Jwt.upn("jdoe@quarkus.io")
+                    .groups("User")
+                    .claim(Claims.birthdate.name(), "2001-07-13")
+                    .sign();
+        }
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -266,6 +266,7 @@
                 <module>oidc-token-propagation</module>
                 <module>oidc-token-propagation-reactive</module>
                 <module>openapi</module>
+                <module>smallrye-jwt</module>
                 <module>smallrye-jwt-oidc-webapp</module>
                 <module>smallrye-jwt-token-propagation</module>
                 <module>oidc-code-flow</module>

--- a/integration-tests/smallrye-jwt/pom.xml
+++ b/integration-tests/smallrye-jwt/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-smallrye-jwt</artifactId>
+    <name>Quarkus - Integration Tests - Smallrye JWT</name>
+    <description>Module that contains Smallrye JWT</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/smallrye-jwt/src/main/java/io/quarkus/it/keycloak/ManagementResource.java
+++ b/integration-tests/smallrye-jwt/src/main/java/io/quarkus/it/keycloak/ManagementResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/management")
+public class ManagementResource {
+
+    @GET
+    @Path("/only-user")
+    @Produces(MediaType.TEXT_PLAIN)
+    @RolesAllowed({ "USER" })
+    public String hello() {
+        return "User Panel ::: Management";
+    }
+}

--- a/integration-tests/smallrye-jwt/src/main/resources/application.properties
+++ b/integration-tests/smallrye-jwt/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+smallrye.jwt.new-token.issuer=https://quarkus.io/issuer

--- a/integration-tests/smallrye-jwt/src/test/java/io/quarkus/it/keycloak/ManagementResourceIT.java
+++ b/integration-tests/smallrye-jwt/src/test/java/io/quarkus/it/keycloak/ManagementResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.keycloak;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ManagementResourceIT extends ManagementResourceTest {
+}

--- a/integration-tests/smallrye-jwt/src/test/java/io/quarkus/it/keycloak/ManagementResourceTest.java
+++ b/integration-tests/smallrye-jwt/src/test/java/io/quarkus/it/keycloak/ManagementResourceTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.keycloak;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.Header;
+import io.smallrye.jwt.build.Jwt;
+
+@QuarkusTest
+public class ManagementResourceTest {
+
+    @Test
+    void testTokenWithUserGroup() {
+
+        var token = Jwt.upn("jdoe@quarkus.io")
+                .groups("USER")
+                .claim(Claims.birthdate.name(), "2001-07-13")
+                .sign();
+
+        given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .when().get("/management/only-user")
+                .then()
+                .statusCode(200)
+                .body(is("User Panel ::: Management"));
+    }
+
+    @Test
+    void testTokenWithWrongGroup() {
+        var token = Jwt.upn("jdoe@quarkus.io")
+                .groups("INVALID_GROUP")
+                .claim(Claims.birthdate.name(), "2001-07-13")
+                .sign();
+
+        given()
+                .header(new Header("Authorization", "Bearer " + token))
+                .when().get("/management/only-user")
+                .then()
+                .statusCode(403);
+    }
+
+}


### PR DESCRIPTION
### Description

Fixes https://github.com/quarkusio/quarkus/issues/44179

This PR aims to add on DEV mode, to generate a RSA-256 pair key. 

It is great for development and test environments, the user just need to set two 3 config properties:

```properties
smallrye.jwt.sign.key.location=privateKey.pem
mp.jwt.verify.publickey.location=publicKey.pem
quarkus.smallrye-jwt.generate-sign-keys=true
```
### Status: In progress

- [x] Add tests
- [x] Add documentation
- [ ] Improve javadoc
- [ ] Self review