### PR TITLE
[3.15] Fixing the badly ended Datasource guide conditional

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -212,7 +212,7 @@ Read <<in-memory-databases,Testing with in-memory databases>> for suggestions re
 * PostgreSQL - `quarkus-jdbc-postgresql`
 ifndef::no-quarkiverse[]
 * Other JDBC extensions, such as link:https://github.com/quarkiverse/quarkus-jdbc-sqlite[SQLite] and its link:https://docs.quarkiverse.io/quarkus-jdbc-sqlite/dev/index.html[documentation], can be found in the https://github.com/quarkiverse[Quarkiverse].
-ifndef::no-quarkiverse[]
+endif::no-quarkiverse[]
 +
 For example, to add the PostgreSQL driver dependency:
 +


### PR DESCRIPTION
Tiny cosmetic fix that can solve the issues with the downstreaming pipeline.
https://github.com/quarkusio/quarkus/pull/44294

If this will provide a solution to our problem, we can backport the above-mention issue or merge this directly.

Also, if this PR fixes the downstreaming issues, I will close:
* https://github.com/quarkusio/quarkus/pull/44252
https://github.com/quarkusio/quarkus/pull/44223

Downstreaming pipeline for this PR:
https://gitlab.cee.redhat.com/quarkus-documentation/quarkus/-/jobs/28552502