### PR TITLE
Qute: fix rendered=false if a fragment includes nested fragment

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
@@ -391,7 +391,9 @@ class TemplateImpl implements Template {
         @Override
         public TemplateInstance instance() {
             TemplateInstance instance = super.instance();
-            instance.setAttribute(Fragment.ATTRIBUTE, true);
+            // when a fragment is executed separately we need a way to instruct FragmentSectionHelper to ignore the "renreded" parameter
+            // Fragment.ATTRIBUTE contains the generated id of the template that declares the fragment section and the fragment identifier
+            instance.setAttribute(Fragment.ATTRIBUTE, TemplateImpl.this.getGeneratedId() + FragmentImpl.this.getId());
             return instance;
         }
 

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/FragmentTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/FragmentTest.java
@@ -77,4 +77,41 @@ public class FragmentTest {
                 expected.getMessage());
     }
 
+    @Test
+    public void testNestedFragmentRendered() {
+        Engine engine = Engine.builder().addDefaults().build();
+        Template alpha = engine.parse("""
+                    OK
+                    {#fragment id=\"nested\" rendered=false}
+                    NOK
+                    {/}
+                    {#fragment id=\"visible\"}
+                    01
+                    {/fragment}
+                """);
+        engine.putTemplate("alpha", alpha);
+        assertEquals("OK01", alpha.render().replaceAll("\\s", ""));
+        assertEquals("NOK", alpha.getFragment("nested").render().trim());
+
+        Template bravo = engine.parse("""
+                {#include $nested}
+                {#fragment id=\"nested\" rendered=false}
+                OK
+                {/}
+                """);
+        assertEquals("OK", bravo.render().trim());
+        assertEquals("OK", bravo.getFragment("nested").render().trim());
+
+        assertEquals("NOK", engine.parse("{#include alpha$nested /}").render().trim());
+        Template charlie = engine.parse("{#include alpha /}");
+        assertEquals("OK01", charlie.render().replaceAll("\\s", ""));
+
+        Template delta = engine.parse("""
+                {#fragment id=\"nested\" rendered=false}
+                    {#include alpha /}
+                {/}
+                """);
+        assertEquals("OK01", delta.getFragment("nested").render().replaceAll("\\s", ""));
+    }
+
 }


### PR DESCRIPTION
- problem occurs if a fragment is rendered separately and that fragment includes a template that declares another fragment like `{#fragment rendered=false}` - the `rendered=false` is ignored
- fixes #44281