### PR TITLE
REST Server/Client allows configuring the removal of trailing slashs

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
@@ -53,9 +53,19 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
     private static final String REST_CLIENT_PREFIX = "quarkus.rest-client.";
 
+    private final boolean runtime;
+
+    public AbstractRestClientConfigBuilder() {
+        this.runtime = true;
+        RestClientsConfig.RestClientKeysProvider.KEYS.clear();
+    }
+
+    public AbstractRestClientConfigBuilder(boolean runtime) {
+        this.runtime = runtime;
+    }
+
     @Override
     public SmallRyeConfigBuilder configBuilder(final SmallRyeConfigBuilder builder) {
-        RestClientsConfig.RestClientKeysProvider.KEYS.clear();
         List<RegisteredRestClient> restClients = getRestClients();
 
         Map<String, String> quarkusFallbacks = new HashMap<>();
@@ -63,7 +73,9 @@ public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
         // relocates [All Combinations] -> quarkus.rest-client."FQN".*
         Map<String, String> relocates = new HashMap<>();
         for (RegisteredRestClient restClient : restClients) {
-            RestClientsConfig.RestClientKeysProvider.KEYS.add(restClient.getFullName());
+            if (runtime) {
+                RestClientsConfig.RestClientKeysProvider.KEYS.add(restClient.getFullName());
+            }
 
             // FQN -> Simple Name
             String quotedFullName = "\"" + restClient.getFullName() + "\"";

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsBuildTimeConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsBuildTimeConfig.java
@@ -143,7 +143,7 @@ public interface RestClientsBuildTimeConfig {
                 .withCustomizers(new SmallRyeConfigBuilderCustomizer() {
                     @Override
                     public void configBuilder(final SmallRyeConfigBuilder builder) {
-                        new AbstractRestClientConfigBuilder() {
+                        new AbstractRestClientConfigBuilder(false) {
                             @Override
                             public List<RegisteredRestClient> getRestClients() {
                                 return restClients;

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsBuildTimeConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsBuildTimeConfig.java
@@ -13,11 +13,13 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
 
 @ConfigMapping(prefix = "quarkus.rest-client")
@@ -29,6 +31,14 @@ public interface RestClientsBuildTimeConfig {
     @WithParentName
     @WithDefaults
     Map<String, RestClientBuildConfig> clients();
+
+    /**
+     * If true, the extension will automatically remove the trailing slash in the paths if any.
+     * This property is not applicable to the RESTEasy Client.
+     */
+    @WithName("removes-trailing-slash")
+    @WithDefault("true")
+    boolean removesTrailingSlash();
 
     interface RestClientBuildConfig {
 
@@ -69,6 +79,14 @@ public interface RestClientsBuildTimeConfig {
          * </ul>
          */
         Optional<String> localProxyProvider();
+
+        /**
+         * If true, the extension will automatically remove the trailing slash in the paths if any.
+         * This property is not applicable to the RESTEasy Client.
+         */
+        @WithName("removes-trailing-slash")
+        @WithDefault("true")
+        boolean removesTrailingSlash();
     }
 
     /**

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
@@ -2,6 +2,7 @@ package io.quarkus.restclient.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -230,6 +231,19 @@ class RestClientConfigTest {
         RestClientConfig restClientConfig = restClientsConfig.getClient(MPConfigKeyRestClient.class);
         assertTrue(restClientConfig.uri().isPresent());
         assertThat(restClientConfig.uri().get()).isEqualTo("http://localhost:8082");
+    }
+
+    @Test
+    void buildTimeConfig() {
+        SmallRyeConfig config = ConfigUtils.emptyConfigBuilder()
+                .withMapping(RestClientsBuildTimeConfig.class)
+                .build();
+        assertNotNull(config);
+
+        RestClientsBuildTimeConfig buildTimeConfig = config.getConfigMapping(RestClientsBuildTimeConfig.class)
+                .get(List.of(new RegisteredRestClient(ConfigKeyRestClient.class, "key")));
+
+        assertFalse(buildTimeConfig.clients().get(ConfigKeyRestClient.class.getName()).removesTrailingSlash());
     }
 
     private void verifyConfig(RestClientConfig config) {

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/resources/application.properties
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/resources/application.properties
@@ -15,6 +15,7 @@ quarkus.rest-client."io.quarkus.restclient.config.FullNameRestClient".connection
 quarkus.rest-client."io.quarkus.restclient.config.FullNameRestClient".connection-pool-size=10
 quarkus.rest-client."io.quarkus.restclient.config.FullNameRestClient".max-chunk-size=1024
 
+quarkus.rest-client.key.removes-trailing-slash=false
 quarkus.rest-client.key.url=http://localhost:8080
 quarkus.rest-client.key.uri=http://localhost:8081
 quarkus.rest-client.key.scope=Singleton

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -288,7 +288,9 @@ public class JaxrsClientReactiveProcessor {
             List<RestClientDefaultProducesBuildItem> defaultConsumes,
             List<RestClientDefaultConsumesBuildItem> defaultProduces,
             List<RestClientDisableSmartDefaultProduces> disableSmartDefaultProduces,
+            List<RestClientDisableRemovalTrailingSlashBuildItem> disableRemovalTrailingSlashProduces,
             List<ParameterContainersBuildItem> parameterContainersBuildItems) {
+
         String defaultConsumesType = defaultMediaType(defaultConsumes, MediaType.APPLICATION_OCTET_STREAM);
         String defaultProducesType = defaultMediaType(defaultProduces, MediaType.TEXT_PLAIN);
 
@@ -403,8 +405,9 @@ public class JaxrsClientReactiveProcessor {
             ClassInfo clazz = index.getClassByName(i.getKey());
             //these interfaces can also be clients
             //so we generate client proxies for them
-            MaybeRestClientInterface maybeClientProxy = clientEndpointIndexer.createClientProxy(clazz,
-                    i.getValue());
+            String path = sanitizePath(i.getValue(),
+                    isRemovalTrailingSlashEnabled(i.getKey(), disableRemovalTrailingSlashProduces));
+            MaybeRestClientInterface maybeClientProxy = clientEndpointIndexer.createClientProxy(clazz, path);
             if (maybeClientProxy.exists()) {
                 RestClientInterface clientProxy = maybeClientProxy.getRestClientInterface();
                 try {
@@ -3074,6 +3077,30 @@ public class JaxrsClientReactiveProcessor {
                         MethodDescriptor.ofMethod(Invocation.Builder.class, "cookie", Invocation.Builder.class, String.class,
                                 String.class),
                         invocationBuilder, notNullValue.load(paramName), cookieParamHandle));
+    }
+
+    private String sanitizePath(String path, boolean removesTrailingSlash) {
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+
+        // For the client side, by default, we're only removing the trailing slash for the
+        // `@Path` annotations at class level which is configurable.
+        if (removesTrailingSlash && path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
+    private boolean isRemovalTrailingSlashEnabled(DotName restClientName,
+            List<RestClientDisableRemovalTrailingSlashBuildItem> buildItems) {
+        for (RestClientDisableRemovalTrailingSlashBuildItem buildItem : buildItems) {
+            if (buildItem.getClients().contains(restClientName)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private enum ReturnCategory {

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/RestClientDisableRemovalTrailingSlashBuildItem.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/RestClientDisableRemovalTrailingSlashBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.jaxrs.client.reactive.deployment;
+
+import java.util.List;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * This build item disables the removal of trailing slashes from the paths.
+ */
+public final class RestClientDisableRemovalTrailingSlashBuildItem extends MultiBuildItem {
+    private final List<DotName> clients;
+
+    public RestClientDisableRemovalTrailingSlashBuildItem(List<DotName> clients) {
+        this.clients = clients;
+    }
+
+    public List<DotName> getClients() {
+        return clients;
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/SlashPathRestClientTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/SlashPathRestClientTest.java
@@ -1,0 +1,127 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SlashPathRestClientTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloClientRemovingSlashes.class,
+                            HelloClientUsingConfigKey.class,
+                            HelloClientUsingSimpleName.class,
+                            HelloClientUsingClassName.class,
+                            HelloResource.class))
+            // disable the removal of trailing slash at client side
+            .overrideConfigKey("quarkus.rest-client.test.removes-trailing-slash", "false")
+            .overrideConfigKey("quarkus.rest-client.HelloClientUsingSimpleName.removes-trailing-slash", "false")
+            .overrideConfigKey(
+                    "quarkus.rest-client.\"io.quarkus.rest.client.reactive.SlashPathRestClientTest$HelloClientUsingClassName\".removes-trailing-slash",
+                    "false")
+            // disable the removal of trailing slash at server side
+            .overrideConfigKey("quarkus.rest.removes-trailing-slash", "false")
+            .overrideRuntimeConfigKey("quarkus.rest-client.test.url",
+                    "http://localhost:${quarkus.http.test-port:8081}")
+            .overrideRuntimeConfigKey("quarkus.rest-client.default.url",
+                    "http://localhost:${quarkus.http.test-port:8081}")
+            .overrideRuntimeConfigKey("quarkus.rest-client.HelloClientUsingSimpleName.url",
+                    "http://localhost:${quarkus.http.test-port:8081}")
+            .overrideRuntimeConfigKey(
+                    "quarkus.rest-client.\"io.quarkus.rest.client.reactive.SlashPathRestClientTest$HelloClientUsingClassName\".url",
+                    "http://localhost:${quarkus.http.test-port:8081}");
+
+    @RestClient
+    HelloClientRemovingSlashes clientUsingDefaultBehaviour;
+
+    @RestClient
+    HelloClientUsingConfigKey clientUsingConfigKey;
+
+    @RestClient
+    HelloClientUsingSimpleName clientUsingSimpleName;
+
+    @RestClient
+    HelloClientUsingClassName clientUsingClassName;
+
+    @Test
+    void shouldRemoveTrailingSlashByDefault() {
+        assertThat(clientUsingDefaultBehaviour.echo()).isEqualTo("/slash/without");
+    }
+
+    @Test
+    void shouldRemoveTrailingSlashUsingConfigKey() {
+        assertThat(clientUsingConfigKey.echo()).isEqualTo("/slash/with/");
+    }
+
+    @Test
+    void shouldRemoveTrailingSlashUsingSimpleName() {
+        assertThat(clientUsingSimpleName.echo()).isEqualTo("/slash/with/");
+    }
+
+    @Test
+    void shouldRemoveTrailingSlashUsingClassName() {
+        assertThat(clientUsingClassName.echo()).isEqualTo("/slash/with/");
+    }
+
+    @RegisterRestClient(configKey = "default")
+    @Path("/slash/without/")
+    public interface HelloClientRemovingSlashes {
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        String echo();
+    }
+
+    @RegisterRestClient(configKey = "test")
+    @Path("/slash/with/")
+    public interface HelloClientUsingConfigKey {
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        String echo();
+    }
+
+    @RegisterRestClient
+    @Path("/slash/with/")
+    public interface HelloClientUsingSimpleName {
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        String echo();
+    }
+
+    @RegisterRestClient
+    @Path("/slash/with/")
+    public interface HelloClientUsingClassName {
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        String echo();
+    }
+
+    @Path("/slash")
+    @Produces(MediaType.TEXT_PLAIN)
+    public static class HelloResource {
+
+        @GET
+        @Path("/without")
+        public String withoutSlash(@Context UriInfo uriInfo) {
+            return uriInfo.getPath();
+        }
+
+        @GET
+        @Path("/with/")
+        public String usingSlash(@Context UriInfo uriInfo) {
+            return uriInfo.getPath();
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
+++ b/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
@@ -75,4 +75,10 @@ public interface ResteasyReactiveConfig {
      */
     @WithDefault("false")
     boolean resumeOn404();
+
+    /**
+     * If true, the extension will automatically remove the trailing slash in the paths if any.
+     */
+    @WithDefault("true")
+    boolean removesTrailingSlash();
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -538,6 +538,7 @@ public class ResteasyReactiveProcessor {
                     .setInjectableBeans(injectableBeans)
                     .setAdditionalWriters(additionalWriters)
                     .setDefaultBlocking(appResult.getBlockingDefault())
+                    .setRemovesTrailingSlash(config.removesTrailingSlash())
                     .setApplicationScanningResult(appResult)
                     .setMultipartReturnTypeIndexerExtension(
                             new GeneratedHandlerMultipartReturnTypeIndexerExtension(classOutput))

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
@@ -60,19 +60,12 @@ public class ClientEndpointIndexer
         this.smartDefaultProduces = smartDefaultProduces;
     }
 
-    public MaybeRestClientInterface createClientProxy(ClassInfo classInfo,
-            String path) {
+    public MaybeRestClientInterface createClientProxy(ClassInfo classInfo, String path) {
         try {
             RestClientInterface clazz = new RestClientInterface();
             clazz.setClassName(classInfo.name().toString());
             clazz.setEncoded(classInfo.hasDeclaredAnnotation(ENCODED));
             if (path != null) {
-                if (!path.startsWith("/")) {
-                    path = "/" + path;
-                }
-                if (path.endsWith("/")) {
-                    path = path.substring(0, path.length() - 1);
-                }
                 clazz.setPath(path);
             }
             List<ResourceMethod> methods = createEndpoints(classInfo, classInfo, new HashSet<>(), new HashSet<>(),

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -283,7 +283,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             clazz.setClassName(classInfo.name().toString());
             if (path != null) {
                 if (path.endsWith("/")) {
-                    path = path.substring(0, path.length() - 1);
+                    path = handleTrailingSlash(path);
                 }
                 if (!path.startsWith("/")) {
                     path = "/" + path;
@@ -502,6 +502,9 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         return ret;
     }
 
+    /**
+     * By default, we are not removing the trailing slash.
+     */
     protected String handleTrailingSlash(String path) {
         return path;
     }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ResteasyReactiveDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ResteasyReactiveDeploymentManager.java
@@ -101,6 +101,8 @@ public class ResteasyReactiveDeploymentManager {
          */
         private boolean defaultProduces;
 
+        private boolean removesTrailingSlash = true;
+
         private Map<DotName, ClassInfo> additionalResources = new HashMap<>();
         private Map<DotName, String> additionalResourcePaths = new HashMap<>();
         private Set<String> excludedClasses = new HashSet<>();
@@ -199,6 +201,11 @@ public class ResteasyReactiveDeploymentManager {
             return this;
         }
 
+        public ScanStep setRemovesTrailingSlash(boolean removesTrailingSlash) {
+            this.removesTrailingSlash = removesTrailingSlash;
+            return this;
+        }
+
         public ScanResult scan() {
 
             ApplicationScanningResult applicationScanningResult = ResteasyReactiveScanner.scanForApplicationClass(index,
@@ -231,7 +238,8 @@ public class ResteasyReactiveDeploymentManager {
                             new ResteasyReactiveConfig(inputBufferSize, minChunkSize, outputBufferSize, singleDefaultProduces,
                                     defaultProduces))
                     .setHttpAnnotationToMethod(resources.getHttpAnnotationToMethod())
-                    .setApplicationScanningResult(applicationScanningResult);
+                    .setApplicationScanningResult(applicationScanningResult)
+                    .setRemovesTrailingSlash(removesTrailingSlash);
             for (MethodScanner scanner : methodScanners) {
                 builder.addMethodScanner(scanner);
             }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -111,6 +111,7 @@ public class ServerEndpointIndexer
     protected final List<MethodScanner> methodScanners;
     protected final FieldInjectionIndexerExtension fieldInjectionHandler;
     protected final ConverterSupplierIndexerExtension converterSupplierIndexerExtension;
+    protected final boolean removesTrailingSlash;
 
     protected ServerEndpointIndexer(AbstractBuilder builder) {
         super(builder);
@@ -118,6 +119,7 @@ public class ServerEndpointIndexer
         this.methodScanners = new ArrayList<>(builder.methodScanners);
         this.fieldInjectionHandler = builder.fieldInjectionIndexerExtension;
         this.converterSupplierIndexerExtension = builder.converterSupplierIndexerExtension;
+        this.removesTrailingSlash = builder.removesTrailingSlash;
     }
 
     @Override
@@ -551,9 +553,16 @@ public class ServerEndpointIndexer
         builder.setConverter(new PathSegmentParamConverter.Supplier());
     }
 
+    /**
+     * For the server side, by default, we are removing the trailing slash unless is not configured otherwise.
+     */
     @Override
     protected String handleTrailingSlash(String path) {
-        return path.substring(0, path.length() - 1);
+        if (removesTrailingSlash) {
+            return path.substring(0, path.length() - 1);
+        }
+
+        return path;
     }
 
     @Override
@@ -705,6 +714,7 @@ public class ServerEndpointIndexer
         private List<MethodScanner> methodScanners = new ArrayList<>();
         private FieldInjectionIndexerExtension fieldInjectionIndexerExtension;
         private ConverterSupplierIndexerExtension converterSupplierIndexerExtension = new ReflectionConverterIndexerExtension();
+        private boolean removesTrailingSlash = true;
 
         public EndpointInvokerFactory getEndpointInvokerFactory() {
             return endpointInvokerFactory;
@@ -732,6 +742,11 @@ public class ServerEndpointIndexer
 
         public B setFieldInjectionIndexerExtension(FieldInjectionIndexerExtension fieldInjectionHandler) {
             this.fieldInjectionIndexerExtension = fieldInjectionHandler;
+            return (B) this;
+        }
+
+        public B setRemovesTrailingSlash(boolean removesTrailingSlash) {
+            this.removesTrailingSlash = removesTrailingSlash;
             return (B) this;
         }
 


### PR DESCRIPTION
Relates to https://github.com/quarkusio/quarkus/issues/41689#issuecomment-2422198717

Before these changes, the REST server and client extensions were removing the trailing slashes that were set by users in the `@Path` annotations.

For example, when creating a resource like:

```java
@Path("/a/")
@Produces(MediaType.TEXT_PLAIN)
public class HelloResource {

        @GET
        public String echo() {
            // ...
        }
}
```

The effective path was `/a` instead of `/a/`. Note that it does not matter whether we place the `@Path` annotation at method level because the behaviour will be the same.

At the client side, when having the following client:

```java
@RegisterRestClient(configKey = "test")
@Path("/a/") <1>
public interface HelloClient {
        @GET
        @Produces(MediaType.TEXT_PLAIN)
        @Path("/b/")  <2>
        String echo();
}
```

In this case, the trailing slash will be removed from <1> but not from <2>.

After these changes, we are adding the following properties:
- `quarkus.resteasy-reactive.removes-trailing-slash`

To configure the server extension to not remove any trailing slash from the `@Path` annotations.

- `quarkus.rest-client.removes-trailing-slash`

To configure the client extension to not remove any traling slash from the `@Path` annotations used at interface level. The annotations set at method level will behave the same.

Note that this does not introduce any change in behaviour, so everything should keep working as before unless users use the new properties.