### PR TITLE
Remove com.google.code.findbugs:jsr305 from gRPC

### DIFF
--- a/extensions/grpc-common/runtime/pom.xml
+++ b/extensions/grpc-common/runtime/pom.xml
@@ -14,10 +14,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-grpc</artifactId>
             <exclusions>

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
@@ -4,8 +4,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.Nullable;
-
 import jakarta.inject.Inject;
 
 import org.bson.BsonDocument;
@@ -100,8 +98,8 @@ public class MongoTracingCommandListener implements CommandListener {
                 AttributesBuilder attributesBuilder,
                 Context context,
                 MongoCommand command,
-                @Nullable Void unused,
-                @Nullable Throwable throwable) {
+                Void unused,
+                Throwable throwable) {
         }
     }
 }

--- a/test-framework/grpc/pom.xml
+++ b/test-framework/grpc/pom.xml
@@ -15,10 +15,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-grpc-client</artifactId>
             <exclusions>


### PR DESCRIPTION
Closes #44325

We will see how CI will behave. 

~~Is there any problem with removing the dep from BOM? I don't think so, but not sure about your policy around this.~~ The dep needs to be part of the BOM - at least `mongodb-client` extension uses it. 

Unfortunately, [grpc/grpc-java](https://github.com/grpc/grpc-java) still provides the dependency, so we are not able to remove these exclusions. 