### PR TITLE
Update websockets-next-tutorial.adoc

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-tutorial.adoc
+++ b/docs/src/main/asciidoc/websockets-next-tutorial.adoc
@@ -59,8 +59,8 @@ The solution is located in the `websockets-next-quickstart` link:{quickstarts-tr
 
 First, we need a new project. Create a new project with the following command:
 
-:create-app-artifact-id: websockets-quickstart
-:create-app-extensions: websockets
+:create-app-artifact-id: websockets-next-quickstart
+:create-app-extensions: websockets-next
 include::{includes}/devtools/create-app.adoc[]
 
 This command generates the project (without any classes) and imports the `websockets-next` extension.


### PR DESCRIPTION
For creating the project uses "websockets-next" instead of "websockets"