### PR TITLE
Do not try to list synthetic injection points in "inactive bean" errors

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1100,7 +1100,7 @@ public class BeanGenerator extends AbstractGenerator {
 
             List<InjectionPointInfo> matchingIPs = new ArrayList<>();
             for (InjectionPointInfo injectionPoint : bean.getDeployment().getInjectionPoints()) {
-                if (bean.equals(injectionPoint.getResolvedBean())) {
+                if (!injectionPoint.isSynthetic() && bean.equals(injectionPoint.getResolvedBean())) {
                     matchingIPs.add(injectionPoint);
                 }
             }


### PR DESCRIPTION
Attempting to list them results in an error message such as:

```
04:07:27,906 INFO  [app] Caused by: io.quarkus.runtime.configuration.ConfigurationException: Unable to find datasource '<default>' for persistence unit 'default-reactive': Bean is not active: SYNTHETIC bean [class=io.vertx.pgclient.PgPool, id=WVL9cdM2vfa8AHSEpmajClhheoQ]
04:07:27,906 INFO  [app] Reason: Datasource '<default>' was deactivated automatically because its URL is not set. To activate the datasource, set configuration property 'quarkus.datasource.reactive.url'. Refer to https://quarkus.io/guides/datasource for guidance.
04:07:27,906 INFO  [app] To avoid this exception while keeping the bean inactive:
04:07:27,906 INFO  [app] 	- Configure all extensions consuming this bean as inactive as well, if they allow it, e.g. 'quarkus.someextension.active=false'
04:07:27,906 INFO  [app] 	- Make sure that custom code only accesses this bean if it is active
04:07:27,907 INFO  [app] 	- Inject the bean with 'Instance<io.vertx.pgclient.PgPool>' instead of 'io.vertx.pgclient.PgPool'
04:07:27,907 INFO  [app] This bean is injected into:
04:07:27,907 INFO  [app] 	-
04:07:27,907 INFO  [app] 	at io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.unableToFindDataSource(PersistenceUnitUtil.java:115)
```

See the empty list item after "This bean is injected into"?

Spotted in https://github.com/quarkusio/quarkus/issues/44297

Follows up on #41810