### PR TITLE
Add permission checker shortcuts to QuarkusSecurityIdentity.Builder

### DIFF
--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -1008,7 +1008,6 @@ In the following example, xref:security-customization.adoc#security-identity-cus
 [source,java]
 ----
 import java.security.Permission;
-import java.util.function.Function;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -1034,24 +1033,15 @@ public class PermissionsIdentityAugmentor implements SecurityIdentityAugmentor {
     }
 
     SecurityIdentity build(SecurityIdentity identity) {
-        Permission possessedPermission = new MediaLibraryPermission("media-library",
-                new String[] { "read", "write", "list"}); <1>
         return QuarkusSecurityIdentity.builder(identity)
-                .addPermissionChecker(new Function<Permission, Uni<Boolean>>() { <2>
-                    @Override
-                    public Uni<Boolean> apply(Permission requiredPermission) {
-                        boolean accessGranted = possessedPermission.implies(requiredPermission);
-                        return Uni.createFrom().item(accessGranted);
-                    }
-                })
+                .addPermission(new MediaLibraryPermission("media-library", new String[] { "read", "write", "list"}); <1>
                 .build();
     }
 
 }
 ----
-<1> The permission `media-library` that was created can perform `read`, `write`, and `list` actions.
+<1> Add a `media-library` permission that was created can perform `read`, `write`, and `list` actions.
 Because `MediaLibrary` is the `TvLibrary` class parent, a user with the `admin` role is also permitted to modify `TvLibrary`.
-<2> You can add a permission checker through `io.quarkus.security.runtime.QuarkusSecurityIdentity.Builder#addPermissionChecker`.
 
 CAUTION: Annotation-based permissions do not work with custom xref:security-customization.adoc#jaxrs-security-context[Jakarta REST SecurityContexts] because there are no permissions in `jakarta.ws.rs.core.SecurityContext`.
 
@@ -1076,7 +1066,7 @@ import jakarta.ws.rs.Path;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.RestPath;
 
-@Path("/project")
+@Path("/project/{projectName}")
 public class ProjectResource {
 
     @PermissionsAllowed("rename-project") <1>
@@ -1129,7 +1119,7 @@ public class ProjectPermissionChecker {
 <1> A CDI bean with the permission checker must be either a normal scoped bean or a `@Singleton` bean.
 <2> The permission checker method must return either `boolean` or `Uni<Boolean>`. Private checker methods are not supported.
 
-TIP: Permission checks run by default on event loops whenever possible.
+TIP: Permission checks run by default on event loops.
 Annotate a permission checker method with the `io.smallrye.common.annotation.Blocking` annotation if you want to run the check on a worker thread.
 
 [[permission-meta-annotation]]

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.security.Permission;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -262,22 +261,6 @@ public class OidcUtilsTest {
         assertTrue(json.containsKey("iat"));
         assertTrue(json.containsKey("exp"));
         assertTrue(json.containsKey("jti"));
-    }
-
-    @Test
-    public void testTransformScopeToPermission() throws Exception {
-        Permission[] perms = OidcUtils.transformScopesToPermissions(
-                List.of("read", "read:d", "read:", ":read"));
-        assertEquals(4, perms.length);
-
-        assertEquals("read", perms[0].getName());
-        assertNull(perms[0].getActions());
-        assertEquals("read", perms[1].getName());
-        assertEquals("d", perms[1].getActions());
-        assertEquals("read:", perms[2].getName());
-        assertNull(perms[2].getActions());
-        assertEquals(":read", perms[3].getName());
-        assertNull(perms[3].getActions());
     }
 
     @Test

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusSecurityIdentity.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusSecurityIdentity.java
@@ -10,7 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import io.quarkus.security.StringPermission;
 import io.quarkus.security.credential.Credential;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.mutiny.Uni;
@@ -144,6 +146,7 @@ public class QuarkusSecurityIdentity implements SecurityIdentity {
         Principal principal;
         Set<String> roles = new HashSet<>();
         Set<Credential> credentials = new HashSet<>();
+        Set<Permission> permissions = new HashSet<>();
         Map<String, Object> attributes = new HashMap<>();
         List<Function<Permission, Uni<Boolean>>> permissionCheckers = new ArrayList<>();
         private boolean anonymous;
@@ -206,6 +209,48 @@ public class QuarkusSecurityIdentity implements SecurityIdentity {
         }
 
         /**
+         * Adds a permission as String.
+         *
+         * @param permission The permission in a String format.
+         * @return This builder
+         */
+        public Builder addPermissionAsString(String permission) {
+            return addPermissionsAsString(Set.of(permission));
+        }
+
+        /**
+         * Adds permissions as String
+         *
+         * @param permissions The permissions in a String format.
+         * @return This builder
+         */
+        public Builder addPermissionsAsString(Set<String> permissions) {
+            return addPermissions(permissions.stream().map(p -> toPermission(p))
+                    .collect(Collectors.toSet()));
+        }
+
+        /**
+         * Adds a permission.
+         *
+         * @param permission The permission
+         * @return This builder
+         */
+        public Builder addPermission(Permission permission) {
+            return addPermissions(Set.of(permission));
+        }
+
+        /**
+         * Adds permissions.
+         *
+         * @param permissions The permissions
+         * @return This builder
+         */
+        public Builder addPermissions(Set<Permission> permissions) {
+            this.permissions.addAll(permissions);
+            return this;
+        }
+
+        /**
          * Adds a permission checker function. This permission checker has the following semantics:
          *
          * If it returns null, or the CompletionStage evaluates to null then this check is ignored
@@ -258,9 +303,43 @@ public class QuarkusSecurityIdentity implements SecurityIdentity {
             if (principal == null && !anonymous) {
                 throw new IllegalStateException("Principal is null but anonymous status is false");
             }
+            addPossesedPermissionsChecker();
 
             built = true;
             return new QuarkusSecurityIdentity(this);
         }
+
+        private void addPossesedPermissionsChecker() {
+            if (!permissions.isEmpty()) {
+                addPermissionChecker(
+                        new Function<Permission, Uni<Boolean>>() {
+
+                            @Override
+                            public Uni<Boolean> apply(Permission requiredPermission) {
+
+                                for (Permission possessedPermission : permissions) {
+                                    if (possessedPermission.implies(requiredPermission)) {
+                                        return Uni.createFrom().item(true);
+                                    }
+                                }
+                                return Uni.createFrom().item(false);
+
+                            }
+                        });
+            }
+
+        }
+
+        static Permission toPermission(String permissionAsString) {
+            int semicolonIndex = permissionAsString.indexOf(':');
+            if (semicolonIndex > 0 && semicolonIndex < permissionAsString.length() - 1) {
+                return new StringPermission(permissionAsString.substring(0, semicolonIndex),
+                        permissionAsString.substring(semicolonIndex + 1));
+            } else {
+                return new StringPermission(permissionAsString);
+            }
+
+        }
     }
+
 }


### PR DESCRIPTION
Fixes #43717.

This PR adds a few `QuarkusSecurityIdentity.Builder` permission checker shortcuts for users be able to avoid having to write permission checker functions.

You can see the impact on the changed OIDC code which converts scopes to permissions. This code is tested in the oidc-tenancy tests (see #36361).

IMHO we should not be talking about permission checkers in the Permission docs to avoid the confusion, and to try to give a message it is all very simple. We can add some notes later if some users find that simply adding permissions to the identity builder is not enough for them 