### PR TITLE
Make sure the result from QCL.getElementsWithResource(name) does not include duplicates

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -356,9 +356,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             if (configuredClassLoading.isRemovedArtifact(dependency.getKey())) {
                 continue;
             }
-            if (dependency.isRuntimeCp() && dependency.isJar() &&
-                    (dependency.isReloadable() && appModel.getReloadableWorkspaceDependencies().contains(dependency.getKey()) ||
-                            configuredClassLoading.isReloadableArtifact(dependency.getKey()))) {
+            if (isReloadableRuntimeDependency(dependency)) {
                 processCpElement(dependency, element -> addCpElement(builder, dependency, element));
             }
         }
@@ -366,6 +364,12 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             builder.addNormalPriorityElement(ClassPathElement.fromPath(root, true));
         }
         return builder.build();
+    }
+
+    private boolean isReloadableRuntimeDependency(ResolvedDependency dependency) {
+        return dependency.isRuntimeCp() && dependency.isJar() &&
+                (dependency.isReloadable() && appModel.getReloadableWorkspaceDependencies().contains(dependency.getKey()) ||
+                        configuredClassLoading.isReloadableArtifact(dependency.getKey()));
     }
 
     public String getClassLoaderNameSuffix() {
@@ -405,9 +409,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             if (configuredClassLoading.isRemovedArtifact(dependency.getKey())) {
                 continue;
             }
-            if (dependency.isRuntimeCp() && dependency.isJar() &&
-                    (dependency.isReloadable() && appModel.getReloadableWorkspaceDependencies().contains(dependency.getKey()) ||
-                            configuredClassLoading.isReloadableArtifact(dependency.getKey()))) {
+            if (isReloadableRuntimeDependency(dependency)) {
                 processCpElement(dependency, element -> addCpElement(builder, dependency, element));
             }
         }


### PR DESCRIPTION
This fixes a case when `QuarkusClassLoader.visitRuntimeResources(resourceName, visitor)` visits the same classpath elements twice.