### PR TITLE
Remove a left-over TODO statement

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
@@ -195,7 +195,6 @@ class ForwardedParser {
         authority = HostAndPort.create(host, port >= 0 ? port : -1);
         host = host + (port >= 0 ? ":" + port : "");
         delegate.headers().set(HOST_HEADER, host);
-        // TODO Add a test
         if (forwardingProxyOptions.enableTrustedProxyHeader) {
             // Verify that the header was not already set.
             if (delegate.headers().contains(X_FORWARDED_TRUSTED_PROXY)) {


### PR DESCRIPTION
The test mentioned in the TODO has been implemented in a previous PR.
