### PR TITLE
Change status of ADR 003 (web socket next client) and 006 (binary libraries in native executable)

### DIFF
--- a/adr/0003-websocket-next-client.adoc
+++ b/adr/0003-websocket-next-client.adoc
@@ -1,6 +1,6 @@
 = WebSocket Client API
 
-* Status: proposed
+* Status: _accepted__
 * Date: 2024-06-04 by @cescoffier, @geoand, @mkouba
 // * Revised:
 

--- a/adr/0006-native-compilation-with-binary-libraries.adoc
+++ b/adr/0006-native-compilation-with-binary-libraries.adoc
@@ -1,6 +1,6 @@
 = Including Native Libraries in the Native Image
 
-* Status: _Proposed_
+* Status: _accepted_
 * Date: 2024-10-21
 * Authors: @cescoffier, @zakkak
 


### PR DESCRIPTION
These ADRs were still in the proposed state while already enforced.
