### PR TITLE
Improve the way OIDC tenants are grouped and their properties are generated

### DIFF
--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/DefaultPolicyEnforcerResolver.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/DefaultPolicyEnforcerResolver.java
@@ -49,7 +49,7 @@ public class DefaultPolicyEnforcerResolver implements PolicyEnforcerResolver {
             this.tlsSupport = OidcTlsSupport.empty();
         }
 
-        var defaultTenantConfig = new OidcTenantConfig(oidcConfig.defaultTenant(), OidcUtils.DEFAULT_TENANT_ID);
+        var defaultTenantConfig = new OidcTenantConfig(OidcConfig.getDefaultTenant(oidcConfig), OidcUtils.DEFAULT_TENANT_ID);
         var defaultTenantTlsSupport = tlsSupport.forConfig(defaultTenantConfig.tls);
         this.defaultPolicyEnforcer = createPolicyEnforcer(defaultTenantConfig, config.defaultTenant(),
                 defaultTenantTlsSupport);

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerUtil.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerUtil.java
@@ -226,7 +226,7 @@ public final class KeycloakPolicyEnforcerUtil {
 
     static OidcTenantConfig getOidcTenantConfig(OidcConfig oidcConfig, String tenant) {
         if (tenant == null || DEFAULT_TENANT_ID.equals(tenant)) {
-            return new OidcTenantConfig(oidcConfig.defaultTenant(), DEFAULT_TENANT_ID);
+            return new OidcTenantConfig(OidcConfig.getDefaultTenant(oidcConfig), DEFAULT_TENANT_ID);
         }
 
         var oidcTenantConfig = oidcConfig.namedTenants().get(tenant);

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -36,10 +37,14 @@ public interface OidcClientCommonConfig extends OidcCommonConfig {
     Optional<String> clientName();
 
     /**
-     * Credentials the OIDC adapter uses to authenticate to the OIDC server.
+     * Different authentication options for OIDC client to access OIDC token and other secured endpoints.
      */
+    @ConfigDocSection
     Credentials credentials();
 
+    /**
+     * Credentials used by OIDC client to authenticate to OIDC token and other secured endpoints.
+     */
     interface Credentials {
 
         /**

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcCommonConfig.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -77,13 +78,15 @@ public interface OidcCommonConfig {
     boolean followRedirects();
 
     /**
-     * Options to configure the proxy the OIDC adapter uses to talk with the OIDC server.
+     * HTTP proxy configuration.
      */
+    @ConfigDocSection
     Proxy proxy();
 
     /**
-     * TLS configurations
+     * TLS configuration.
      */
+    @ConfigDocSection
     Tls tls();
 
     interface Tls {

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.deployment;
 
 import io.quarkus.oidc.runtime.OidcConfig;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
@@ -18,8 +19,9 @@ public interface OidcBuildTimeConfig {
     boolean enabled();
 
     /**
-     * Dev UI configuration.
+     * OIDC Dev UI configuration which is effective in dev mode only.
      */
+    @ConfigDocSection
     DevUiConfig devui();
 
     /**

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResource.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResource.java
@@ -45,7 +45,7 @@ public class ProtectedResource {
     @Path("access-token-name")
     @GET
     public String accessTokenName() {
-        if (!config.defaultTenant().authentication().verifyAccessToken()) {
+        if (!OidcConfig.getDefaultTenant(config).authentication().verifyAccessToken()) {
             throw new IllegalStateException("Access token verification should be enabled");
         }
         return accessToken.getName();

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResourceWithJwtAccessToken.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResourceWithJwtAccessToken.java
@@ -26,6 +26,6 @@ public class ProtectedResourceWithJwtAccessToken {
 
     @GET
     public String getName() {
-        return idToken.getName() + ":" + config.defaultTenant().authentication().verifyAccessToken();
+        return idToken.getName() + ":" + OidcConfig.getDefaultTenant(config).authentication().verifyAccessToken();
     }
 }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResourceWithoutJwtAccessToken.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResourceWithoutJwtAccessToken.java
@@ -23,6 +23,6 @@ public class ProtectedResourceWithoutJwtAccessToken {
 
     @GET
     public String getName() {
-        return idToken.getName() + ":" + config.defaultTenant().authentication().verifyAccessToken();
+        return idToken.getName() + ":" + OidcConfig.getDefaultTenant(config).authentication().verifyAccessToken();
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -37,7 +37,7 @@ public class BackChannelLogoutHandler {
     }
 
     public void setup(@Observes Router router) {
-        addRoute(router, new OidcTenantConfig(oidcConfig.defaultTenant(), OidcUtils.DEFAULT_TENANT_ID));
+        addRoute(router, new OidcTenantConfig(OidcConfig.getDefaultTenant(oidcConfig), OidcUtils.DEFAULT_TENANT_ID));
 
         for (var nameToOidcTenantConfig : oidcConfig.namedTenants().entrySet()) {
             addRoute(router, new OidcTenantConfig(nameToOidcTenantConfig.getValue(), nameToOidcTenantConfig.getKey()));

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -111,7 +111,7 @@ public class OidcRecorder {
             boolean userInfoInjectionPointDetected) {
         OidcRecorder.userInfoInjectionPointDetected = userInfoInjectionPointDetected;
 
-        var defaultTenant = new OidcTenantConfig(config.defaultTenant(), DEFAULT_TENANT_ID);
+        var defaultTenant = new OidcTenantConfig(OidcConfig.getDefaultTenant(config), DEFAULT_TENANT_ID);
         String defaultTenantId = defaultTenant.getTenantId().get();
         var defaultTenantInitializer = createStaticTenantContextCreator(vertxValue, defaultTenant,
                 !config.namedTenants().isEmpty(), defaultTenantId, tlsSupport);
@@ -120,6 +120,9 @@ public class OidcRecorder {
 
         Map<String, TenantConfigContext> staticTenantsConfig = new HashMap<>();
         for (var tenant : config.namedTenants().entrySet()) {
+            if (OidcConfig.DEFAULT_TENANT_KEY.equals(tenant.getKey())) {
+                continue;
+            }
             var namedTenantConfig = new OidcTenantConfig(tenant.getValue(), tenant.getKey());
             OidcCommonUtils.verifyConfigurationId(defaultTenantId, tenant.getKey(), namedTenantConfig.getTenantId());
             var staticTenantInitializer = createStaticTenantContextCreator(vertxValue, namedTenantConfig, false,
@@ -709,7 +712,7 @@ public class OidcRecorder {
             this.blockingExecutor = Arc.container().instance(BlockingSecurityExecutor.class).get();
             if (tenantId.equals(DEFAULT_TENANT_ID)) {
                 OidcConfig config = Arc.container().instance(OidcConfig.class).get();
-                this.tenantId = config.defaultTenant().tenantId().orElse(OidcUtils.DEFAULT_TENANT_ID);
+                this.tenantId = OidcConfig.getDefaultTenant(config).tenantId().orElse(OidcUtils.DEFAULT_TENANT_ID);
             } else {
                 this.tenantId = tenantId;
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -16,6 +16,7 @@ import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig;
 import io.quarkus.oidc.common.runtime.config.OidcCommonConfig;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.smallrye.config.WithConverter;
@@ -103,14 +104,16 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
     Optional<String> publicKey();
 
     /**
-     * Introspection Basic Authentication which must be configured only if the introspection is required
-     * and OpenId Connect Provider does not support the OIDC client authentication configured with
+     * Optional introspection endpoint-specific basic authentication configuration.
+     * It must be configured only if the introspection is required
+     * but OpenId Connect Provider does not support the OIDC client authentication configured with
      * {@link OidcCommonConfig#credentials} for its introspection endpoint.
      */
+    @ConfigDocSection
     IntrospectionCredentials introspectionCredentials();
 
     /**
-     * Introspection Basic Authentication configuration
+     * Optional introspection endpoint-specific authentication configuration.
      */
     interface IntrospectionCredentials {
         /**
@@ -132,18 +135,21 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
     }
 
     /**
-     * Configuration to find and parse a custom claim containing the roles information.
+     * Configuration to find and parse custom claims which contain roles.
      */
+    @ConfigDocSection
     Roles roles();
 
     /**
-     * Configuration how to validate the token claims.
+     * Configuration to customize validation of token claims.
      */
+    @ConfigDocSection
     Token token();
 
     /**
-     * RP Initiated, BackChannel and FrontChannel Logout configuration
+     * RP-initiated, back-channel and front-channel logout configuration.
      */
+    @ConfigDocSection
     Logout logout();
 
     /**
@@ -161,8 +167,12 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
      * If the truststore does not have the leaf certificate imported, then the leaf certificate must be identified by its Common
      * Name.
      */
+    @ConfigDocSection
     CertificateChain certificateChain();
 
+    /**
+     * Configuration of the certificate chain which can be used to verify tokens.
+     */
     interface CertificateChain {
         /**
          * Common name of the leaf certificate. It must be set if the {@link #trustStoreFile} does not have
@@ -196,18 +206,21 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
     }
 
     /**
-     * Different options to configure authorization requests
+     * Configuration for managing an authorization code flow.
      */
+    @ConfigDocSection
     Authentication authentication();
 
     /**
-     * Authorization code grant configuration
+     * Configuration to complete an authorization code flow grant.
      */
+    @ConfigDocSection
     CodeGrant codeGrant();
 
     /**
      * Default token state manager configuration
      */
+    @ConfigDocSection
     TokenStateManager tokenStateManager();
 
     /**
@@ -317,8 +330,9 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
     }
 
     /**
-     * Configuration for controlling how JsonWebKeySet containing verification keys should be acquired and managed.
+     * How JsonWebKey verification key set should be acquired and managed.
      */
+    @ConfigDocSection
     Jwks jwks();
 
     interface Jwks {

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcEventResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcEventResource.java
@@ -16,7 +16,7 @@ public class OidcEventResource {
     private final String expectedAuthServerUrl;
 
     public OidcEventResource(OidcEventObserver oidcEventObserver, OidcConfig oidcConfig) {
-        this.expectedAuthServerUrl = dropTrailingSlash(oidcConfig.defaultTenant().authServerUrl().get());
+        this.expectedAuthServerUrl = dropTrailingSlash(OidcConfig.getDefaultTenant(oidcConfig).authServerUrl().get());
         this.oidcEventObserver = oidcEventObserver;
     }
 


### PR DESCRIPTION
At the moment, [OIDC configuration properties](https://quarkus.io/guides/security-oidc-configuration-properties-reference) list about 310 properties if we count them one by one, first about 160 properties for the default tenant, and then approximately 150 properties are listed for named tenants.

This PR groups it together (thanks @radcortez for the hint), with about 160 properties grouped together.
Additionally, `@ConfigDocSection` is introduced with a few exceptions.

Now it will look more organized, see the fragment of it:

![Screenshot From 2024-11-07 19-10-33](https://github.com/user-attachments/assets/0bcf3e0c-9ecf-48a1-9b9c-83fb09d40d5a)
 
This is only an initial, tactical PR to address a pretty bad situation with a massive number of properties generated. 

Expanded config doc reference with the detailed explanations, recommendations, as well as a question tree will be looked at later.

Unfortunately it might be a breaking change for some users who are working directly with the `OidcConfig` group, but the pros of this update are too important for the OIDC simplification story for this update be avoided...

My only concern is that `OidcConfig.getDefaultTenant(OidcConfig config)` static helper returns `null` if no default tenant config is found, but I've tested it with empty `application.properties` and when only non-default named tenants are present and it works, so hopefully it can never be null... (CC @radcortez )