### PR TITLE
Add configuration property to container-based datasource devservices for capturing logs with JBossLoggingConsumer

### DIFF
--- a/docs/src/main/asciidoc/appcds.adoc
+++ b/docs/src/main/asciidoc/appcds.adoc
@@ -102,6 +102,6 @@ When building container images using the `quarkus-container-image-jib` extension
 This way, by simply setting `quarkus.package.jar.appcds.enabled` to `true`, containers using the generated image can benefit from a slight reduction in startup time and memory usage.
 
 You may see that Quarkus starts a container to generate the AppCDS archive.
-It does this to ensure that the Java version of the build align with that of the generated container image.
+It does this to ensure that the Java version of the build aligns with that of the generated container image.
 It is possible to opt out of this by setting `quarkus.package.jar.appcds.use-container` to `false`.
 In that case, it is your responsibility to ensure that the Java version that will run the Quarkus application matches that of the machine building it.

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -61,6 +61,16 @@ ibmcom/db2:11.5.0.0a
 mcr.microsoft.com/mssql/server:2022-latest
 ----
 
+=== Capturing Logs
+
+By default, logs of the underlying database are not exposed.
+By capturing the logs, they become visible amongst other log statements:
+
+[source,properties]
+----
+quarkus.datasource.devservices.show-logs=true
+----
+
 [[reuse]]
 == Reusing Dev Services
 

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
@@ -18,6 +18,7 @@ public class DevServicesDatasourceContainerConfig {
     private final Optional<String> initScriptPath;
     private final Map<String, String> volumes;
     private final boolean reuse;
+    private final boolean showLogs;
 
     public DevServicesDatasourceContainerConfig(Optional<String> imageName,
             Map<String, String> containerEnv,
@@ -30,7 +31,8 @@ public class DevServicesDatasourceContainerConfig {
             Optional<String> password,
             Optional<String> initScriptPath,
             Map<String, String> volumes,
-            boolean reuse) {
+            boolean reuse,
+            boolean showLogs) {
         this.imageName = imageName;
         this.containerEnv = containerEnv;
         this.containerProperties = containerProperties;
@@ -43,6 +45,7 @@ public class DevServicesDatasourceContainerConfig {
         this.initScriptPath = initScriptPath;
         this.volumes = volumes;
         this.reuse = reuse;
+        this.showLogs = showLogs;
     }
 
     public Optional<String> getImageName() {
@@ -83,6 +86,10 @@ public class DevServicesDatasourceContainerConfig {
 
     public Optional<String> getInitScriptPath() {
         return initScriptPath;
+    }
+
+    public boolean isShowLogs() {
+        return showLogs;
     }
 
     public Map<String, String> getVolumes() {

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -287,7 +287,8 @@ public class DevServicesDatasourceProcessor {
                     dataSourceBuildTimeConfig.devservices().password(),
                     dataSourceBuildTimeConfig.devservices().initScriptPath(),
                     dataSourceBuildTimeConfig.devservices().volumes(),
-                    dataSourceBuildTimeConfig.devservices().reuse());
+                    dataSourceBuildTimeConfig.devservices().reuse(),
+                    dataSourceBuildTimeConfig.devservices().showLogs());
 
             DevServicesDatasourceProvider.RunningDevServicesDatasource datasource = devDbProvider
                     .startDatabase(

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -129,4 +129,12 @@ public interface DevServicesBuildTimeConfig {
     @WithDefault("true")
     boolean reuse();
 
+    /**
+     * Whether the logs should be consumed by the JBoss logger.
+     * <p>
+     * This has no effect if the provider is not a container-based database, such as H2 or Derby.
+     */
+    @WithDefault("false")
+    boolean showLogs();
+
 }

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
+import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
@@ -65,6 +66,9 @@ public class DB2DevServicesProcessor {
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
+                if (containerConfig.isShowLogs()) {
+                    container.withLogConsumer(new JBossLoggingConsumer(LOG));
+                }
                 container.start();
 
                 LOG.info("Dev Services for IBM Db2 started.");

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
+import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
@@ -74,6 +75,9 @@ public class MariaDBDevServicesProcessor {
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
+                if (containerConfig.isShowLogs()) {
+                    container.withLogConsumer(new JBossLoggingConsumer(LOG));
+                }
                 container.start();
 
                 LOG.info("Dev Services for MariaDB started.");

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -20,6 +20,7 @@ import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
+import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
@@ -65,6 +66,9 @@ public class MSSQLDevServicesProcessor {
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
+                if (containerConfig.isShowLogs()) {
+                    container.withLogConsumer(new JBossLoggingConsumer(LOG));
+                }
 
                 container.start();
 

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
+import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
@@ -73,6 +74,9 @@ public class MySQLDevServicesProcessor {
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
+                if (containerConfig.isShowLogs()) {
+                    container.withLogConsumer(new JBossLoggingConsumer(LOG));
+                }
 
                 container.start();
 

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
+import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
@@ -79,6 +80,9 @@ public class OracleDevServicesProcessor {
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
+                if (containerConfig.isShowLogs()) {
+                    container.withLogConsumer(new JBossLoggingConsumer(LOG));
+                }
 
                 container.start();
 

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
+import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
@@ -76,6 +77,9 @@ public class PostgresqlDevServicesProcessor {
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
                 containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
+                if (containerConfig.isShowLogs()) {
+                    container.withLogConsumer(new JBossLoggingConsumer(LOG));
+                }
 
                 container.start();
 


### PR DESCRIPTION
Brings support for JBossLoggingConsumer (following https://github.com/quarkusio/quarkus/pull/43809) to container-based datasource dev services, and adds a little section to the documentation about the new "showLogs" option.

Also contains a minor correction to the AppCDS documentation.

I ran `MAVEN_OPTS="-Xmx4g" ./mvnw -Dquickly` followed by `./mvnw install -f extensions/devservices/` but have honestly no idea if this will work. Is there an easy way to test this locally? Should I "mvn install" the entire quarkus repo locally, make a tiny quarkus app, and update the bom version to 999-SNAPSHOT to verify this?