### PR TITLE
Upgrade to Hibernate ORM 6.6.2.Final

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ClassNamesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ClassNamesTest.java
@@ -107,6 +107,8 @@ public class ClassNamesTest {
     }
 
     private static void ignoreInternalAnnotations(Set<DotName> annotationSet) {
+        annotationSet.removeIf(name -> name.toString().equals("org.hibernate.cfg.Compatibility"));
+        annotationSet.removeIf(name -> name.toString().equals("org.hibernate.cfg.Unsafe"));
         annotationSet.removeIf(name -> name.toString().equals("org.hibernate.Incubating"));
         annotationSet.removeIf(name -> name.toString().equals("org.hibernate.Internal"));
         annotationSet.removeIf(name -> name.toString().equals("org.hibernate.Remove"));

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <jacoco.version>0.8.12</jacoco.version>
         <kubernetes-client.version>6.13.4</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.0</rest-assured.version>
-        <hibernate-orm.version>6.6.1.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>6.6.2.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.14.18</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->


### PR DESCRIPTION
Supersedes #44378

Fixes #7462
Fixes #43056
Fixes #43296

Opening as draft as the fix for [HHH-16572](https://hibernate.atlassian.net/browse/HHH-16572) is causing problems, failing one test and more importantly probably breaking some user applications that were not working very well, but will now not even build. See https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/HHH-16572 for details, but whatever happens I suspect we'll need a 6.6.3 before we can upgrade in Quarkus.