### PR TITLE
Start Keycloak Dev Services for standalone Keycloak Admin REST/RESTEasy clients

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfigurator.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfigurator.java
@@ -6,7 +6,8 @@ import org.keycloak.representations.idm.RealmRepresentation;
 
 public interface KeycloakDevServicesConfigurator {
 
-    record ConfigPropertiesContext(String authServerInternalUrl, String oidcClientId, String oidcClientSecret) {
+    record ConfigPropertiesContext(String authServerInternalUrl, String oidcClientId, String oidcClientSecret,
+            String authServerInternalBaseUrl) {
     }
 
     Map<String, String> createProperties(ConfigPropertiesContext context);

--- a/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfig.java
+++ b/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfig.java
@@ -16,9 +16,10 @@ public interface KeycloakAdminClientConfig {
 
     /**
      * Keycloak server URL, for example, `https://host:port`.
-     * If this property is not set then the Keycloak Admin Client injection will fail - use
-     * {@linkplain org.keycloak.admin.client.KeycloakBuilder}
-     * to create it instead.
+     * When the Keycloak Dev Services is started and this property is not configured,
+     * Quarkus points the 'quarkus.keycloak.admin-client.server-url' configuration property to started Keycloak container.
+     * In other cases, when this property is not set then the Keycloak Admin Client injection will fail - use
+     * {@linkplain org.keycloak.admin.client.KeycloakBuilder} to create the client instead.
      */
     Optional<String> serverUrl();
 

--- a/extensions/keycloak-admin-rest-client/deployment/pom.xml
+++ b/extensions/keycloak-admin-rest-client/deployment/pom.xml
@@ -29,6 +29,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-keycloak-admin-client-common-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-keycloak</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -43,11 +47,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-oidc-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/keycloak-admin-rest-client/deployment/src/main/java/io/quarkus/keycloak/admin/client/reactive/devservices/KeycloakDevServiceRequiredBuildStep.java
+++ b/extensions/keycloak-admin-rest-client/deployment/src/main/java/io/quarkus/keycloak/admin/client/reactive/devservices/KeycloakDevServiceRequiredBuildStep.java
@@ -1,0 +1,32 @@
+package io.quarkus.keycloak.admin.client.reactive.devservices;
+
+import java.util.Map;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.devservices.keycloak.KeycloakAdminPageBuildItem;
+import io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.keycloak.admin.client.common.KeycloakAdminClientInjectionEnabled;
+
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class,
+        KeycloakAdminClientInjectionEnabled.class })
+public class KeycloakDevServiceRequiredBuildStep {
+
+    private static final String SERVER_URL_CONFIG_KEY = "quarkus.keycloak.admin-client.server-url";
+
+    @BuildStep
+    KeycloakDevServicesRequiredBuildItem requireKeycloakDevService() {
+        return KeycloakDevServicesRequiredBuildItem.of(
+                ctx -> Map.of(SERVER_URL_CONFIG_KEY, ctx.authServerInternalBaseUrl()),
+                SERVER_URL_CONFIG_KEY);
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    KeycloakAdminPageBuildItem addCardWithLinkToKeycloakAdmin() {
+        return new KeycloakAdminPageBuildItem(new CardPageBuildItem());
+    }
+}

--- a/extensions/keycloak-admin-rest-client/deployment/src/test/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientMutualTlsDevServicesTest.java
+++ b/extensions/keycloak-admin-rest-client/deployment/src/test/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientMutualTlsDevServicesTest.java
@@ -18,7 +18,9 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 
-import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
@@ -29,14 +31,18 @@ import io.smallrye.certs.junit5.Certificates;
 public class KeycloakAdminClientMutualTlsDevServicesTest {
 
     @RegisterExtension
-    final static QuarkusDevModeTest app = new QuarkusDevModeTest()
+    final static QuarkusUnitTest app = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar
                     .addClasses(MtlsResource.class)
                     .addAsResource(new File("target/certs/mtls-test-keystore.p12"), "server-keystore.p12")
                     .addAsResource(new File("target/certs/mtls-test-server-ca.crt"), "server-ca.crt")
                     .addAsResource(new File("target/certs/mtls-test-client-keystore.p12"), "client-keystore.p12")
                     .addAsResource(new File("target/certs/mtls-test-client-truststore.p12"), "client-truststore.p12")
-                    .addAsResource("app-mtls-config.properties", "application.properties"));
+                    .addAsResource("app-mtls-config.properties", "application.properties"))
+            // intention of this forced dependency is to test backwards compatibility
+            // when users started Keycloak Dev Service by adding OIDC extension and configured 'server-url'
+            .setForcedDependencies(
+                    List.of(Dependency.of("io.quarkus", "quarkus-oidc-deployment", Version.getVersion())));
 
     @Test
     public void testCreateRealm() {

--- a/extensions/keycloak-admin-rest-client/deployment/src/test/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientZeroConfigDevServicesTest.java
+++ b/extensions/keycloak-admin-rest-client/deployment/src/test/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientZeroConfigDevServicesTest.java
@@ -15,23 +15,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.RoleRepresentation;
 
-import io.quarkus.builder.Version;
-import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 
-public class KeycloakAdminClientInjectionDevServicesTest {
+public class KeycloakAdminClientZeroConfigDevServicesTest {
 
     @RegisterExtension
-    final static QuarkusUnitTest app = new QuarkusUnitTest()
-            .withApplicationRoot(jar -> jar
-                    .addClasses(AdminResource.class)
-                    .addAsResource("app-dev-mode-config.properties", "application.properties"))
-            // intention of this forced dependency is to test backwards compatibility
-            // when users started Keycloak Dev Service by adding OIDC extension and configured 'server-url'
-            .setForcedDependencies(
-                    List.of(Dependency.of("io.quarkus", "quarkus-oidc-deployment", Version.getVersion())));
+    final static QuarkusDevModeTest app = new QuarkusDevModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(AdminResource.class));
 
     @Test
     public void testGetRoles() {

--- a/extensions/keycloak-admin-rest-client/deployment/src/test/resources/app-dev-mode-config.properties
+++ b/extensions/keycloak-admin-rest-client/deployment/src/test/resources/app-dev-mode-config.properties
@@ -2,5 +2,4 @@
 quarkus.keycloak.devservices.port=8082
 
 # Configure Keycloak Admin Client
-quarkus.keycloak.admin-client=true
 quarkus.keycloak.admin-client.server-url=http://localhost:${quarkus.keycloak.devservices.port}

--- a/extensions/keycloak-admin-resteasy-client/deployment/pom.xml
+++ b/extensions/keycloak-admin-resteasy-client/deployment/pom.xml
@@ -37,6 +37,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-keycloak-admin-client-common-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-keycloak</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -51,11 +55,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-oidc-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/keycloak-admin-resteasy-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/devservices/KeycloakDevServiceRequiredBuildStep.java
+++ b/extensions/keycloak-admin-resteasy-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/devservices/KeycloakDevServiceRequiredBuildStep.java
@@ -1,0 +1,32 @@
+package io.quarkus.keycloak.adminclient.deployment.devservices;
+
+import java.util.Map;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.devservices.keycloak.KeycloakAdminPageBuildItem;
+import io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.keycloak.admin.client.common.KeycloakAdminClientInjectionEnabled;
+
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class,
+        KeycloakAdminClientInjectionEnabled.class })
+public class KeycloakDevServiceRequiredBuildStep {
+
+    private static final String SERVER_URL_CONFIG_KEY = "quarkus.keycloak.admin-client.server-url";
+
+    @BuildStep
+    KeycloakDevServicesRequiredBuildItem requireKeycloakDevService() {
+        return KeycloakDevServicesRequiredBuildItem.of(
+                ctx -> Map.of(SERVER_URL_CONFIG_KEY, ctx.authServerInternalBaseUrl()),
+                SERVER_URL_CONFIG_KEY);
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    KeycloakAdminPageBuildItem addCardWithLinkToKeycloakAdmin() {
+        return new KeycloakAdminPageBuildItem(new CardPageBuildItem());
+    }
+}

--- a/extensions/keycloak-admin-resteasy-client/deployment/src/test/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientInjectionDevServicesTest.java
+++ b/extensions/keycloak-admin-resteasy-client/deployment/src/test/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientInjectionDevServicesTest.java
@@ -15,17 +15,23 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.RoleRepresentation;
 
-import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 
 public class KeycloakAdminClientInjectionDevServicesTest {
 
     @RegisterExtension
-    final static QuarkusDevModeTest app = new QuarkusDevModeTest()
+    final static QuarkusUnitTest app = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar
                     .addClasses(AdminResource.class)
-                    .addAsResource("app-dev-mode-config.properties", "application.properties"));
+                    .addAsResource("app-dev-mode-config.properties", "application.properties"))
+            // intention of this forced dependency is to test backwards compatibility
+            // when users started Keycloak Dev Service by adding OIDC extension and configured 'server-url'
+            .setForcedDependencies(
+                    List.of(Dependency.of("io.quarkus", "quarkus-oidc-deployment", Version.getVersion())));
 
     @Test
     public void testGetRoles() {

--- a/extensions/keycloak-admin-resteasy-client/deployment/src/test/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientMutualTlsDevServicesTest.java
+++ b/extensions/keycloak-admin-resteasy-client/deployment/src/test/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientMutualTlsDevServicesTest.java
@@ -18,7 +18,9 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 
-import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
@@ -29,14 +31,18 @@ import io.smallrye.certs.junit5.Certificates;
 public class KeycloakAdminClientMutualTlsDevServicesTest {
 
     @RegisterExtension
-    final static QuarkusDevModeTest app = new QuarkusDevModeTest()
+    final static QuarkusUnitTest app = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar
                     .addClasses(MtlsResource.class)
                     .addAsResource(new File("target/certs/mtls-test-keystore.p12"), "server-keystore.p12")
                     .addAsResource(new File("target/certs/mtls-test-server-ca.crt"), "server-ca.crt")
                     .addAsResource(new File("target/certs/mtls-test-client-keystore.p12"), "client-keystore.p12")
                     .addAsResource(new File("target/certs/mtls-test-client-truststore.p12"), "client-truststore.p12")
-                    .addAsResource("app-mtls-config.properties", "application.properties"));
+                    .addAsResource("app-mtls-config.properties", "application.properties"))
+            // intention of this forced dependency is to test backwards compatibility
+            // when users started Keycloak Dev Service by adding OIDC extension and configured 'server-url'
+            .setForcedDependencies(
+                    List.of(Dependency.of("io.quarkus", "quarkus-oidc-deployment", Version.getVersion())));
 
     @Test
     public void testCreateRealm() {

--- a/extensions/keycloak-admin-resteasy-client/deployment/src/test/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientZeroConfigDevServicesTest.java
+++ b/extensions/keycloak-admin-resteasy-client/deployment/src/test/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientZeroConfigDevServicesTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.keycloak.admin.client.reactive;
+package io.quarkus.keycloak.adminclient.deployment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -15,23 +15,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.RoleRepresentation;
 
-import io.quarkus.builder.Version;
-import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 
-public class KeycloakAdminClientInjectionDevServicesTest {
+public class KeycloakAdminClientZeroConfigDevServicesTest {
 
     @RegisterExtension
-    final static QuarkusUnitTest app = new QuarkusUnitTest()
-            .withApplicationRoot(jar -> jar
-                    .addClasses(AdminResource.class)
-                    .addAsResource("app-dev-mode-config.properties", "application.properties"))
-            // intention of this forced dependency is to test backwards compatibility
-            // when users started Keycloak Dev Service by adding OIDC extension and configured 'server-url'
-            .setForcedDependencies(
-                    List.of(Dependency.of("io.quarkus", "quarkus-oidc-deployment", Version.getVersion())));
+    final static QuarkusDevModeTest app = new QuarkusDevModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(AdminResource.class));
 
     @Test
     public void testGetRoles() {

--- a/extensions/keycloak-admin-resteasy-client/deployment/src/test/resources/app-dev-mode-config.properties
+++ b/extensions/keycloak-admin-resteasy-client/deployment/src/test/resources/app-dev-mode-config.properties
@@ -2,5 +2,4 @@
 quarkus.keycloak.devservices.port=8082
 
 # Configure Keycloak Admin Client
-quarkus.keycloak.admin-client=true
 quarkus.keycloak.admin-client.server-url=http://localhost:${quarkus.keycloak.devservices.port}


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/38556
- closes: https://github.com/quarkusio/quarkus/issues/44143

Regarding documentation improvements for https://quarkus.io/version/main/guides/security-openid-connect-dev-services#dev-services-for-keycloak so that we catch OIDC Client, OIDC Client Registrations and Keycloak Admin Client improvements:

- I have decided to open separate follow-up PR after this one. Knowing my documentation skills, I think it will take multiple iterations to agree on the text and I want to be gentle to GH CI (we can only run docs GH workflow checks for the docs PR).
