### PR TITLE
Fix runtime/deployment detection and propagate it

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -21,7 +21,7 @@ import javax.tools.Diagnostic.Kind;
 import org.jboss.jdeparser.JDeparser;
 
 import io.quarkus.annotation.processor.documentation.config.ConfigDocExtensionProcessor;
-import io.quarkus.annotation.processor.documentation.config.model.Extension;
+import io.quarkus.annotation.processor.documentation.config.model.ExtensionModule;
 import io.quarkus.annotation.processor.documentation.config.util.Types;
 import io.quarkus.annotation.processor.extension.ExtensionBuildProcessor;
 import io.quarkus.annotation.processor.util.Config;
@@ -45,11 +45,12 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                 .parseBoolean(utils.processingEnv().getOptions().getOrDefault(Options.LEGACY_CONFIG_ROOT, "false"));
         boolean debug = Boolean.getBoolean(DEBUG);
 
-        Extension extension = utils.extension().getExtension();
-        Config config = new Config(extension, useConfigMapping, debug);
+        ExtensionModule extensionModule = utils.extension().getExtensionModule();
+
+        Config config = new Config(extensionModule, useConfigMapping, debug);
 
         if (!useConfigMapping) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, "Extension " + extension.artifactId()
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, "Extension module " + extensionModule.artifactId()
                     + " config implementation is deprecated. Please migrate to use @ConfigMapping: https://quarkus.io/guides/writing-extensions#configuration");
         }
 
@@ -61,7 +62,7 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
         // for now, we generate the old config doc by default but we will change this behavior soon
         if (generateDoc) {
-            if (extension.detected()) {
+            if (extensionModule.detected()) {
                 extensionProcessors.add(new ConfigDocExtensionProcessor());
             } else {
                 processingEnv.getMessager().printMessage(Kind.WARNING,

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ExtensionModule.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/ExtensionModule.java
@@ -1,0 +1,20 @@
+package io.quarkus.annotation.processor.documentation.config.model;
+
+public record ExtensionModule(String groupId, String artifactId, ExtensionModuleType type, Extension extension,
+        boolean detected) {
+
+    public static ExtensionModule createNotDetected() {
+        return new ExtensionModule("not.detected", "not.detected", ExtensionModuleType.UNKNOWN, Extension.createNotDetected(),
+                false);
+    }
+
+    public static ExtensionModule of(String groupId, String artifactId, ExtensionModuleType type, Extension extension) {
+        return new ExtensionModule(groupId, artifactId, type, extension, true);
+    }
+
+    public enum ExtensionModuleType {
+        RUNTIME,
+        DEPLOYMENT,
+        UNKNOWN;
+    }
+}

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/util/Config.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/util/Config.java
@@ -1,21 +1,26 @@
 package io.quarkus.annotation.processor.util;
 
 import io.quarkus.annotation.processor.documentation.config.model.Extension;
+import io.quarkus.annotation.processor.documentation.config.model.ExtensionModule;
 
 public class Config {
 
-    private final Extension extension;
+    private final ExtensionModule extensionModule;
     private final boolean useConfigMapping;
     private final boolean debug;
 
-    public Config(Extension extension, boolean useConfigMapping, boolean debug) {
-        this.extension = extension;
+    public Config(ExtensionModule extensionModule, boolean useConfigMapping, boolean debug) {
+        this.extensionModule = extensionModule;
         this.useConfigMapping = useConfigMapping;
         this.debug = debug;
     }
 
+    public ExtensionModule getExtensionModule() {
+        return extensionModule;
+    }
+
     public Extension getExtension() {
-        return extension;
+        return extensionModule.extension();
     }
 
     public boolean useConfigMapping() {


### PR DESCRIPTION
That way, we can assert if the module is a deployment module later in the process.

Related to https://github.com/quarkusio/quarkus/pull/43513

/cc @mcruzdev the idea would be to check things in `ConfigMappingListener#onConfigRoot()`. You have the `ExtensionModule` in the passed `Config config` after this patch.