### PR TITLE
Add copy button for configuration properties in config tables

### DIFF
--- a/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/GenerateConfigDocMojo.java
+++ b/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/GenerateConfigDocMojo.java
@@ -40,6 +40,7 @@ import io.quarkus.maven.config.doc.generator.Formatter;
 import io.quarkus.maven.config.doc.generator.GenerationReport;
 import io.quarkus.maven.config.doc.generator.GenerationReport.GenerationViolation;
 import io.quarkus.qute.Engine;
+import io.quarkus.qute.EngineBuilder;
 import io.quarkus.qute.ReflectionValueResolver;
 import io.quarkus.qute.UserTagSectionHelper;
 import io.quarkus.qute.ValueResolver;
@@ -296,7 +297,7 @@ public class GenerateConfigDocMojo extends AbstractMojo {
     }
 
     private static Engine initializeQuteEngine(Formatter formatter, Format format, String theme) {
-        Engine engine = Engine.builder()
+        EngineBuilder engineBuilder = Engine.builder()
                 .addDefaults()
                 .addSectionHelper(new UserTagSectionHelper.Factory("configProperty", "configProperty"))
                 .addSectionHelper(new UserTagSectionHelper.Factory("configSection", "configSection"))
@@ -402,9 +403,13 @@ public class GenerateConfigDocMojo extends AbstractMojo {
                         .applyToName("formatName")
                         .applyToNoParameters()
                         .resolveSync(ctx -> formatter.formatName((Extension) ctx.getBase()))
-                        .build())
-                .build();
+                        .build());
 
+        if (format == Format.asciidoc) {
+            engineBuilder.addSectionHelper(new UserTagSectionHelper.Factory("propertyCopyButton", "propertyCopyButton"));
+        }
+
+        Engine engine = engineBuilder.build();
         engine.putTemplate("configReference",
                 engine.parse(getTemplate("templates", format, theme, "configReference", false)));
         engine.putTemplate("allConfig",
@@ -419,6 +424,11 @@ public class GenerateConfigDocMojo extends AbstractMojo {
                 engine.parse(getTemplate("templates", format, theme, "durationNote", true)));
         engine.putTemplate("memorySizeNote",
                 engine.parse(getTemplate("templates", format, theme, "memorySizeNote", true)));
+
+        if (format == Format.asciidoc) {
+            engine.putTemplate("propertyCopyButton",
+                    engine.parse(getTemplate("templates", format, theme, "propertyCopyButton", true)));
+        }
 
         return engine;
     }

--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/tags/configProperty.qute.adoc
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/tags/configProperty.qute.adoc
@@ -1,7 +1,10 @@
 a|{#if configProperty.phase.fixedAtBuildTime}icon:lock[title=Fixed at build time]{/if} [[{configProperty.toAnchor(extension, additionalAnchorPrefix)}]] [.property-path]##link:#{configProperty.toAnchor(extension, additionalAnchorPrefix)}[`{configProperty.path.property}`]##
+{#propertyCopyButton configProperty.path.property /}
+
 {#for additionalPath in configProperty.additionalPaths}
 
 `{additionalPath.property}`
+{#propertyCopyButton additionalPath.property /}
 {/for}
 
 [.description]

--- a/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/tags/propertyCopyButton.qute.adoc
+++ b/devtools/config-doc-maven-plugin/src/main/resources/templates/asciidoc/default/tags/propertyCopyButton.qute.adoc
@@ -1,0 +1,3 @@
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++{it}+++[]
+endif::add-copy-button-to-config-props[]


### PR DESCRIPTION
Addresses: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Doc.20-.20Copy.20property.20name/near/452271216

![two-buttons](https://github.com/user-attachments/assets/8aec4c96-792a-45d4-9126-63c04e100596)
![single-button](https://github.com/user-attachments/assets/c229bb97-4587-4c22-b641-caedefe78df5)

This won't work until https://github.com/quarkusio/quarkusio.github.io/pull/2157 is merged and CI is rerun with that change.