### PR TITLE
Handle InjectionPointsTransformer deprecations in OIDC extension

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -230,28 +230,12 @@ public class OidcBuildStep {
 
             @Override
             public void transform(TransformationContext ctx) {
-                if (ctx.getTarget().kind() == METHOD) {
+                var tenantAnnotation = Annotations.find(ctx.getAllTargetAnnotations(), TENANT_NAME);
+                if (tenantAnnotation != null && tenantAnnotation.value() != null) {
                     ctx
-                            .getAllAnnotations()
-                            .stream()
-                            .filter(a -> TENANT_NAME.equals(a.name()))
-                            .forEach(a -> {
-                                var annotationValue = new AnnotationValue[] {
-                                        AnnotationValue.createStringValue("value", a.value().asString()) };
-                                ctx
-                                        .transform()
-                                        .add(AnnotationInstance.create(NAMED, a.target(), annotationValue))
-                                        .done();
-                            });
-                } else {
-                    // field
-                    var tenantAnnotation = Annotations.find(ctx.getAllAnnotations(), TENANT_NAME);
-                    if (tenantAnnotation != null && tenantAnnotation.value() != null) {
-                        ctx
-                                .transform()
-                                .add(NAMED, AnnotationValue.createStringValue("value", tenantAnnotation.value().asString()))
-                                .done();
-                    }
+                            .transform()
+                            .add(NAMED, AnnotationValue.createStringValue("value", tenantAnnotation.value().asString()))
+                            .done();
                 }
             }
         });


### PR DESCRIPTION
`io.quarkus.arc.processor.InjectionPointsTransformer.TransformationContext#getTarget` and `io.quarkus.arc.processor.InjectionPointsTransformer.TransformationContext#getAllAnnotations` are marked for removal; I have mentioned that now, target may also be method parameter injection point, so it was possible to simplify the injection point transformation in question.

Little context: this buildstep makes sure that every `TenantIdentityProvider` injection point that has `@Tenant("name-1")` has also `@Named("name-1")` qualifier. We use it this way because `@Tenant` cannot be a qualifier.