### PR TITLE
Include allowed roles in security scheme scopes when OpenApi version is 3.1.0 or greater

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -560,7 +560,7 @@ public class SmallRyeOpenApiProcessor {
 
         if (!classNamesMethods.isEmpty() || !rolesAllowedMethods.isEmpty() || !authenticatedMethods.isEmpty()) {
             return new OperationFilter(classNamesMethods, rolesAllowedMethods, authenticatedMethods, config.securitySchemeName,
-                    config.autoAddTags, config.autoAddOperationSummary);
+                    config.autoAddTags, config.autoAddOperationSummary, isOpenApi_3_1_0_OrGreater(config));
         }
 
         return null;
@@ -1168,5 +1168,10 @@ public class SmallRyeOpenApiProcessor {
             }
         }
         return filenames;
+    }
+
+    private static boolean isOpenApi_3_1_0_OrGreater(SmallRyeOpenApiConfig config) {
+        final String openApiVersion = config.openApiVersion.orElse(null);
+        return openApiVersion == null || (!openApiVersion.startsWith("2") && !openApiVersion.startsWith("3.0"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/OperationFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/OperationFilter.java
@@ -42,12 +42,13 @@ public class OperationFilter implements OASFilter {
     private final String defaultSecuritySchemeName;
     private final boolean doAutoTag;
     private final boolean doAutoOperation;
+    private final boolean alwaysIncludeScopesValidForScheme;
 
     public OperationFilter(Map<String, ClassAndMethod> classNameMap,
             Map<String, List<String>> rolesAllowedMethodReferences,
             List<String> authenticatedMethodReferences,
             String defaultSecuritySchemeName,
-            boolean doAutoTag, boolean doAutoOperation) {
+            boolean doAutoTag, boolean doAutoOperation, boolean alwaysIncludeScopesValidForScheme) {
 
         this.classNameMap = Objects.requireNonNull(classNameMap);
         this.rolesAllowedMethodReferences = Objects.requireNonNull(rolesAllowedMethodReferences);
@@ -55,13 +56,14 @@ public class OperationFilter implements OASFilter {
         this.defaultSecuritySchemeName = Objects.requireNonNull(defaultSecuritySchemeName);
         this.doAutoTag = doAutoTag;
         this.doAutoOperation = doAutoOperation;
+        this.alwaysIncludeScopesValidForScheme = alwaysIncludeScopesValidForScheme;
     }
 
     @Override
     public void filterOpenAPI(OpenAPI openAPI) {
         var securityScheme = getSecurityScheme(openAPI);
         String schemeName = securityScheme.map(Map.Entry::getKey).orElse(defaultSecuritySchemeName);
-        boolean scopesValidForScheme = securityScheme.map(Map.Entry::getValue)
+        boolean scopesValidForScheme = alwaysIncludeScopesValidForScheme || securityScheme.map(Map.Entry::getValue)
                 .map(SecurityScheme::getType)
                 .map(Set.of(SecurityScheme.Type.OAUTH2, SecurityScheme.Type.OPENIDCONNECT)::contains)
                 .orElse(false);

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedUnsupportedScopesTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedUnsupportedScopesTestCase.java
@@ -2,7 +2,6 @@ package io.quarkus.smallrye.openapi.test.jaxrs;
 
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -21,7 +20,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-class AutoSecurityRolesAllowedTestCase {
+/**
+ * Run same tests as {@link AutoSecurityRolesAllowedTestCase}, but with OpenAPI version 3.0.2
+ * that only allowed security requirement scopes for Oauth2 and OpenID Connect schemes.
+ */
+public class AutoSecurityRolesAllowedUnsupportedScopesTestCase {
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
@@ -30,12 +33,14 @@ class AutoSecurityRolesAllowedTestCase {
                             OpenApiResourceSecuredAtClassLevel2.class, OpenApiResourceSecuredAtMethodLevel.class,
                             OpenApiResourceSecuredAtMethodLevel2.class)
                     .addAsResource(
-                            new StringAsset("quarkus.smallrye-openapi.security-scheme=jwt\n"
-                                    + "quarkus.smallrye-openapi.security-scheme-name=JWTCompanyAuthentication\n"
-                                    + "quarkus.smallrye-openapi.security-scheme-description=JWT Authentication\n"
-                                    + "quarkus.smallrye-openapi.security-scheme-extensions.x-my-extension1=extension-value\n"
-                                    + "quarkus.smallrye-openapi.security-scheme-extensions.my-extension2=extension-value"),
-
+                            new StringAsset("""
+                                    quarkus.smallrye-openapi.open-api-version=3.0.2
+                                    quarkus.smallrye-openapi.security-scheme=jwt
+                                    quarkus.smallrye-openapi.security-scheme-name=JWTCompanyAuthentication
+                                    quarkus.smallrye-openapi.security-scheme-description=JWT Authentication
+                                    quarkus.smallrye-openapi.security-scheme-extensions.x-my-extension1=extension-value
+                                    quarkus.smallrye-openapi.security-scheme-extensions.my-extension2=extension-value
+                                    """),
                             "application.properties"));
 
     static Matcher<Iterable<Object>> schemeArray(String schemeName) {
@@ -57,6 +62,7 @@ class AutoSecurityRolesAllowedTestCase {
                 .then()
                 .log().body()
                 .and()
+                .body("openapi", Matchers.is("3.0.2"))
                 .body("components.securitySchemes.JWTCompanyAuthentication", allOf(
                         hasEntry("type", "http"),
                         hasEntry("scheme", "bearer"),
@@ -66,20 +72,20 @@ class AutoSecurityRolesAllowedTestCase {
                         not(hasKey("my-extension2"))))
                 .and()
                 // OpenApiResourceSecuredAtMethodLevel
-                .body("paths.'/resource2/test-security/naked'.get.security", defaultSecurityScheme("admin"))
+                .body("paths.'/resource2/test-security/naked'.get.security", defaultSecurity)
                 .body("paths.'/resource2/test-security/annotated'.get.security", defaultSecurity)
-                .body("paths.'/resource2/test-security/methodLevel/1'.get.security", defaultSecurityScheme("user1"))
-                .body("paths.'/resource2/test-security/methodLevel/2'.get.security", defaultSecurityScheme("user2"))
+                .body("paths.'/resource2/test-security/methodLevel/1'.get.security", defaultSecurity)
+                .body("paths.'/resource2/test-security/methodLevel/2'.get.security", defaultSecurity)
                 .body("paths.'/resource2/test-security/methodLevel/public'.get.security", nullValue())
                 .body("paths.'/resource2/test-security/annotated/documented'.get.security", defaultSecurity)
-                .body("paths.'/resource2/test-security/methodLevel/3'.get.security", defaultSecurityScheme("admin"))
+                .body("paths.'/resource2/test-security/methodLevel/3'.get.security", defaultSecurity)
                 .body("paths.'/resource2/test-security/methodLevel/4'.get.security", defaultSecurity)
                 .and()
                 // OpenApiResourceSecuredAtClassLevel
-                .body("paths.'/resource2/test-security/classLevel/1'.get.security", defaultSecurityScheme("user1"))
-                .body("paths.'/resource2/test-security/classLevel/2'.get.security", defaultSecurityScheme("user2"))
+                .body("paths.'/resource2/test-security/classLevel/1'.get.security", defaultSecurity)
+                .body("paths.'/resource2/test-security/classLevel/2'.get.security", defaultSecurity)
                 .body("paths.'/resource2/test-security/classLevel/3'.get.security", schemeArray("MyOwnName"))
-                .body("paths.'/resource2/test-security/classLevel/4'.get.security", defaultSecurityScheme("admin"))
+                .body("paths.'/resource2/test-security/classLevel/4'.get.security", defaultSecurity)
                 .and()
                 // OpenApiResourceSecuredAtMethodLevel2
                 .body("paths.'/resource3/test-security/annotated'.get.security", schemeArray("AtClassLevel"))
@@ -174,11 +180,4 @@ class AutoSecurityRolesAllowedTestCase {
                         Matchers.equalTo("Not Allowed"));
     }
 
-    static Matcher<Iterable<Object>> defaultSecurityScheme(String... roles) {
-        return allOf(
-                iterableWithSize(1),
-                hasItem(allOf(
-                        aMapWithSize(1),
-                        hasEntry(equalTo("JWTCompanyAuthentication"), containsInAnyOrder(roles)))));
-    }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithInterfaceTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithInterfaceTestCase.java
@@ -2,7 +2,7 @@ package io.quarkus.smallrye.openapi.test.jaxrs;
 
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToObject;
 import static org.hamcrest.Matchers.hasEntry;
@@ -24,18 +24,18 @@ class AutoSecurityRolesAllowedWithInterfaceTestCase {
                     .addClasses(ApplicationContext.class,
                             FooAPI.class, FooResource.class));
 
-    static Matcher<Iterable<Object>> schemeArray(String schemeName) {
+    static Matcher<Iterable<Object>> schemeArray(String schemeName, String... roles) {
         return allOf(
                 iterableWithSize(1),
                 hasItem(allOf(
                         aMapWithSize(1),
-                        hasEntry(equalTo(schemeName), emptyIterable()))));
+                        hasEntry(equalTo(schemeName), containsInAnyOrder(roles)))));
     }
 
     @Test
     void testAutoSecurityRequirement() {
 
-        var oidcAuth = schemeArray("oidc_auth");
+        var oidcAuth = schemeArray("oidc_auth", "RoleXY");
 
         RestAssured.given()
                 .header("Accept", "application/json")


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/37199