### PR TITLE
Hibernate: Silence DB connection info logging

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/DisableLoggingFeature.java
@@ -16,7 +16,8 @@ public class DisableLoggingFeature implements Feature {
             "org.hibernate.Version",
             "org.hibernate.annotations.common.Version",
             "SQL dialect",
-            "org.hibernate.cfg.Environment"
+            "org.hibernate.cfg.Environment",
+            "org.hibernate.orm.connections.pooling"
     };
 
     private final Map<String, Level> categoryMap = new HashMap<>(CATEGORIES.length);


### PR DESCRIPTION
- Follow up from https://github.com/quarkusio/quarkus/commit/235f0a7535f8f1c50703804a1a59cdf27560994d


This gets rid of the message during the native build:

```
[22:50:37,387 INFO  [org.hib.orm.con.pooling] HHH10001005: Database info:
	Database JDBC URL [undefined/unknown]
	Database driver: undefined/unknown
	Database version: 2.3.230
	Autocommit mode: undefined/unknown
	Isolation level: <unknown>
	Minimum pool size: undefined/unknown
	Maximum pool size: undefined/unknown
```