### PR TITLE
Bump Keycloak version to 26.0.7

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -95,7 +95,7 @@
         <junit4.version>4.13.2</junit4.version>
 
         <!-- The image to use for tests that run Keycloak -->
-        <keycloak.server.version>25.0.6</keycloak.server.version>
+        <keycloak.server.version>26.0.7</keycloak.server.version>
         <keycloak.wildfly.version>19.0.3</keycloak.wildfly.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.server.version}</keycloak.docker.image>
         <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.wildfly.version}-legacy</keycloak.docker.legacy.image>

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -306,7 +306,7 @@ docker run --name keycloak \
   start --hostname-strict=false --https-key-store-file=/etc/keycloak-keystore.jks <2>
 ----
 
-<1> For `keycloak.version`, ensure the version is `25.0.6` or later.
+<1> For `keycloak.version`, ensure the version is `26.0.7` or later.
 <2> For Keycloak keystore, use the `keycloak-keystore.jks` file located at https://github.com/quarkusio/quarkus-quickstarts/blob/main/security-keycloak-authorization-quickstart/config/keycloak-keystore.jks[quarkus-quickstarts/security-keycloak-authorization-quickstart/config].
 
 

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -217,7 +217,7 @@ For more information, see the <<bearer-token-tutorial-keycloak-dev-mode>> sectio
 docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 ====
-* Where the `keycloak.version` is set to version `25.0.6` or later.
+* Where the `keycloak.version` is set to version `26.0.7` or later.
 . You can access your Keycloak server at http://localhost:8180[localhost:8180].
 . To access the Keycloak Administration console, log in as the `admin` user by using the following login credentials:
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -201,7 +201,7 @@ To start a Keycloak server, use Docker and run the following command:
 docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
-where `keycloak.version` is set to `25.0.6` or later.
+where `keycloak.version` is set to `26.0.7` or later.
 
 You can access your Keycloak Server at http://localhost:8180[localhost:8180].
 

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -505,7 +505,7 @@ To start a Keycloak Server, you can use Docker and just run the following comman
 docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
-Set `{keycloak.version}` to `25.0.6` or later.
+Set `{keycloak.version}` to `26.0.7` or later.
 
 You can access your Keycloak Server at http://localhost:8180[localhost:8180].
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -258,7 +258,7 @@ For more information, see xref:security-oidc-bearer-token-authentication.adoc#be
 [[keycloak-initialization]]
 === Keycloak initialization
 
-The `quay.io/keycloak/keycloak:25.0.6` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
+The `quay.io/keycloak/keycloak:26.0.7` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
 `quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name.
 For example, set it to `quay.io/keycloak/keycloak:19.0.3-legacy` to use a Keycloak distribution powered by WildFly.
 Be aware that a Quarkus-based Keycloak distribution is only available starting from Keycloak `20.0.0`.

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -346,7 +346,7 @@ To start a Keycloak server, you can use Docker and run the following command:
 docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
-where `keycloak.version` is set to `25.0.6` or higher.
+where `keycloak.version` is set to `26.0.7` or higher.
 
 Access your Keycloak server at http://localhost:8180[localhost:8180].
 

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
@@ -39,7 +39,7 @@ public interface KeycloakDevServicesConfig {
      * ends with `-legacy`.
      * Override with `quarkus.keycloak.devservices.keycloak-x-image`.
      */
-    @WithDefault("quay.io/keycloak/keycloak:25.0.6")
+    @WithDefault("quay.io/keycloak/keycloak:26.0.7")
     String imageName();
 
     /**

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractDbTokenStateManagerTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            textPage = loginForm.getInputByName("login").click();
+            textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", textPage.getContent());
 

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/HibernateOrmPgDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/HibernateOrmPgDbTokenStateManagerTest.java
@@ -50,7 +50,7 @@ public class HibernateOrmPgDbTokenStateManagerTest extends AbstractDbTokenStateM
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals(200, page.getWebResponse().getStatusCode());
 
             WebResponse webResponse = webClient.loadWebResponse(

--- a/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/AbstractRedisTokenStateManagerTest.java
+++ b/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/AbstractRedisTokenStateManagerTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractRedisTokenStateManagerTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            textPage = loginForm.getInputByName("login").click();
+            textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", textPage.getContent());
 

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/AbstractPolicyEnforcerTest.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/AbstractPolicyEnforcerTest.java
@@ -78,7 +78,7 @@ public abstract class AbstractPolicyEnforcerTest {
 
             loginForm.getInputByName("username").setValueAttribute(user);
             loginForm.getInputByName("password").setValueAttribute(user);
-            WebResponse response = loginForm.getInputByName("login").click().getWebResponse();
+            WebResponse response = loginForm.getButtonByName("login").click().getWebResponse();
             assertEquals(200, response.getStatusCode());
             assertTrue(response.getContentAsString().contains("Permission Resource WebApp"));
 
@@ -102,7 +102,7 @@ public abstract class AbstractPolicyEnforcerTest {
             loginForm.getInputByName("username").setValueAttribute(user);
             loginForm.getInputByName("password").setValueAttribute(user);
             try {
-                loginForm.getInputByName("login").click();
+                loginForm.getButtonByName("login").click();
                 fail("403 status error is expected");
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(403, ex.getStatusCode());

--- a/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcClientRegistrationTest.java
+++ b/integration-tests/oidc-client-registration/src/test/java/io/quarkus/it/keycloak/OidcClientRegistrationTest.java
@@ -40,7 +40,7 @@ public class OidcClientRegistrationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("registered-client:Default Client Updated:alice", textPage.getContent());
         }
@@ -59,7 +59,7 @@ public class OidcClientRegistrationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("registered-client-tenant:Tenant Client:alice", textPage.getContent());
         }
@@ -77,7 +77,7 @@ public class OidcClientRegistrationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("registered-client-dynamically:Dynamic Client:alice", textPage.getContent());
         }
@@ -95,7 +95,7 @@ public class OidcClientRegistrationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("registered-client-dynamic-tenant:Dynamic Tenant Client:alice", textPage.getContent());
         }
@@ -113,7 +113,7 @@ public class OidcClientRegistrationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("registered-client-multi1:Multi1 Client:alice", textPage.getContent());
         }
@@ -131,7 +131,7 @@ public class OidcClientRegistrationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("registered-client-multi2:Multi2 Client:alice", textPage.getContent());
         }
@@ -149,7 +149,7 @@ public class OidcClientRegistrationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("registered-client-jwt-bearer-token-file:signed-jwt-test:alice", textPage.getContent());
         }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -78,7 +78,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("Welcome to Test App", page.getTitleText());
 
@@ -191,7 +191,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            webResponse = loginForm.getInputByName("login").click().getWebResponse();
+            webResponse = loginForm.getButtonByName("login").click().getWebResponse();
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
 
             // This is a redirect from the OIDC server to the endpoint
@@ -260,7 +260,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            webResponse = loginForm.getInputByName("login").click().getWebResponse();
+            webResponse = loginForm.getButtonByName("login").click().getWebResponse();
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
 
             // This is a redirect from the OIDC server to the endpoint containing the state and code
@@ -321,7 +321,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            webResponse = loginForm.getInputByName("login").click().getWebResponse();
+            webResponse = loginForm.getButtonByName("login").click().getWebResponse();
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
 
             // This is a redirect from the OIDC server to the endpoint
@@ -398,7 +398,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            webResponse = loginForm.getInputByName("login").click().getWebResponse();
+            webResponse = loginForm.getButtonByName("login").click().getWebResponse();
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
 
             // This is a redirect from the OIDC server to the endpoint
@@ -466,7 +466,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            webResponse = loginForm.getInputByName("login").click().getWebResponse();
+            webResponse = loginForm.getButtonByName("login").click().getWebResponse();
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
 
             // This is a redirect from the OIDC server to the endpoint
@@ -515,7 +515,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            webResponse = loginForm.getInputByName("login").click().getWebResponse();
+            webResponse = loginForm.getButtonByName("login").click().getWebResponse();
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
 
             // This is a redirect from the OIDC server to the endpoint
@@ -602,7 +602,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("Welcome to Test App", page.getTitleText());
             assertNull(getStateCookie(webClient, null));
@@ -646,7 +646,7 @@ public class CodeFlowTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("Tenant Logout, refreshed: false", page.asNormalizedText());
             assertNotNull(getSessionCookie(webClient, "tenant-logout"));
 
@@ -661,7 +661,7 @@ public class CodeFlowTest {
             loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("Tenant Logout, refreshed: false", page.asNormalizedText());
 
             assertNotNull(getSessionCookie(webClient, "tenant-logout"));
@@ -684,7 +684,7 @@ public class CodeFlowTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("Tenant Refresh, refreshed: false", page.asNormalizedText());
 
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-refresh");
@@ -770,7 +770,7 @@ public class CodeFlowTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("Tenant AutoRefresh, refreshed: false", page.asNormalizedText());
 
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-autorefresh");
@@ -803,7 +803,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("Welcome to Test App", page.getTitleText());
 
@@ -861,7 +861,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("callback:alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
@@ -887,7 +887,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            webResponse = loginForm.getInputByName("login").click().getWebResponse();
+            webResponse = loginForm.getButtonByName("login").click().getWebResponse();
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
 
             // This is a redirect from the OIDC server to the endpoint
@@ -925,7 +925,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            webResponse = loginForm.getInputByName("login").click().getWebResponse();
+            webResponse = loginForm.getButtonByName("login").click().getWebResponse();
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
 
             // This is a redirect from the OIDC server to the endpoint
@@ -955,7 +955,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             try {
-                loginForm.getInputByName("login").click();
+                loginForm.getButtonByName("login").click();
                 fail("401 status error is expected");
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(401, ex.getStatusCode());
@@ -979,7 +979,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("web-app2:alice", page.getBody().asNormalizedText());
 
@@ -1024,7 +1024,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             try {
-                loginForm.getInputByName("login").click();
+                loginForm.getButtonByName("login").click();
                 fail("401 status error is expected");
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(401, ex.getStatusCode());
@@ -1048,7 +1048,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             try {
-                page = loginForm.getInputByName("login").click();
+                page = loginForm.getButtonByName("login").click();
                 fail("401 status error is expected: " + page.getBody().asNormalizedText());
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(401, ex.getStatusCode());
@@ -1072,7 +1072,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("Welcome to Test App", page.getTitleText());
 
@@ -1097,7 +1097,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             try {
-                page = loginForm.getInputByName("login").click();
+                page = loginForm.getButtonByName("login").click();
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(404, ex.getStatusCode());
             }
@@ -1119,7 +1119,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("Welcome to Test App", page.getTitleText());
 
@@ -1143,7 +1143,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("RT injected", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
@@ -1163,7 +1163,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("tenant-idtoken-only:alice", page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/web-app/access/tenant-idtoken-only");
@@ -1194,7 +1194,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("tenant-id-refresh-token:alice", page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/web-app/access/tenant-id-refresh-token");
@@ -1236,7 +1236,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("tenant-split-tokens:alice, id token has 5 parts, access token has 5 parts, refresh token has 5 parts",
                     page.getBody().asNormalizedText());
 
@@ -1296,7 +1296,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("tenant-split-id-refresh-token:alice", page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/web-app/access/tenant-split-id-refresh-token");
@@ -1378,7 +1378,7 @@ public class CodeFlowTest {
         loginForm.getInputByName("username").setValueAttribute("alice");
         loginForm.getInputByName("password").setValueAttribute("alice");
 
-        page = loginForm.getInputByName("login").click();
+        page = loginForm.getButtonByName("login").click();
 
         assertEquals("RT injected(event:OIDC_LOGIN,tenantId:tenant-listener,blockingApi:true)",
                 page.getBody().asNormalizedText());
@@ -1399,7 +1399,7 @@ public class CodeFlowTest {
             doTestAccessAndRefreshTokenInjectionWithoutIndexHtmlAndListener(webClient);
 
             try {
-                page = loginForm.getInputByName("login").click();
+                page = loginForm.getButtonByName("login").click();
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(400, ex.getStatusCode());
                 assertTrue(ex.getResponse().getContentAsString().contains("You are already logged in"));
@@ -1421,7 +1421,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             // Query parameters are decoded by the time they reach the JAX-RS endpoint
             assertEquals("RT injected:aValue%", page.getBody().asNormalizedText());
@@ -1505,7 +1505,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
         }
@@ -1527,7 +1527,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             webClient.getOptions().setRedirectEnabled(false);
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("alice", page.getBody().asNormalizedText());
         } catch (FailingHttpStatusCodeException e) {
@@ -1549,7 +1549,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("codeFlowAuthMech", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();

--- a/integration-tests/oidc-mtls/src/main/resources/quarkus-realm.json
+++ b/integration-tests/oidc-mtls/src/main/resources/quarkus-realm.json
@@ -2518,7 +2518,7 @@
       "notBefore": 0,
       "groups": []
     } ],
-  "keycloakVersion": "25.0.6",
+  "keycloakVersion": "26.0.7",
   "userManagedAccessAllowed": false,
   "organizationsEnabled": false,
   "clientProfiles": {

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -58,7 +58,7 @@ public class BearerTokenAuthorizationTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             // First call after a redirect, tenant-id is initially calculated from the state `q_auth` cookie.
             // 'reauthenticated' flag is set is because, in fact, it is actually a 2nd call due to
             // quarkus-oidc doing a final redirect after completing a code flow to drop the redirect OIDC parameters
@@ -129,7 +129,7 @@ public class BearerTokenAuthorizationTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals(expectedResult, page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
@@ -143,7 +143,7 @@ public class BearerTokenAuthorizationTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertEquals("userName: alice, idToken: true, accessToken: true, refreshToken: true",
                     page.getBody().asNormalizedText());
@@ -213,7 +213,7 @@ public class BearerTokenAuthorizationTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("alice:web-app", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
@@ -238,7 +238,7 @@ public class BearerTokenAuthorizationTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("alice:web-app", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
@@ -274,7 +274,7 @@ public class BearerTokenAuthorizationTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("tenant-web-app-no-discovery:alice", page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app-no-discovery/api/user/webapp-no-discovery");
@@ -293,7 +293,7 @@ public class BearerTokenAuthorizationTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("tenant-web-app:alice:reauthenticated", page.getBody().asNormalizedText());
             assertNotNull(getSessionCookie(webClient, "tenant-web-app"));
             // tenant-web-app2
@@ -303,7 +303,7 @@ public class BearerTokenAuthorizationTest {
             loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("tenant-web-app2:alice", page.getBody().asNormalizedText());
             assertNull(getSessionCookie(webClient, "tenant-web-app"));
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-web-app2");
@@ -651,7 +651,7 @@ public class BearerTokenAuthorizationTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("tenant-web-app-dynamic:alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
@@ -842,7 +842,7 @@ public class BearerTokenAuthorizationTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
@@ -865,7 +865,7 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             webClient.getOptions().setRedirectEnabled(false);
-            loginForm.getInputByName("login").click();
+            loginForm.getButtonByName("login").click();
         } catch (FailingHttpStatusCodeException e) {
             codeFlowAuthFailed = true;
         }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/TestSecurityCombiningAuthMechTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/TestSecurityCombiningAuthMechTest.java
@@ -156,7 +156,7 @@ public class TestSecurityCombiningAuthMechTest {
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
             assertEquals("alice", page.getBody().asNormalizedText());
             assertNull(getSessionCookie(webClient, "tenant-web-app"));
         }

--- a/integration-tests/oidc-token-propagation-reactive/src/test/java/io/quarkus/it/keycloak/OidcTokenReactivePropagationTest.java
+++ b/integration-tests/oidc-token-propagation-reactive/src/test/java/io/quarkus/it/keycloak/OidcTokenReactivePropagationTest.java
@@ -27,7 +27,7 @@ public class OidcTokenReactivePropagationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
             assertEquals("Bearer:alice", textPage.getContent());
 
             textPage = webClient.getPage("http://localhost:8081/frontend/id-token-propagation");

--- a/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
+++ b/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
@@ -50,10 +50,8 @@ public class OidcTokenPropagationTest {
         RestAssured.given().auth().oauth2(getAccessToken("alice"))
                 .when().get("/frontend/access-token-propagation")
                 .then()
-                //.statusCode(200)
-                //.body(equalTo("alice"));
                 .statusCode(500)
-                .body(containsString("Client not allowed to exchange"));
+                .body(containsString("Unsupported grant_type"));
     }
 
     @Test


### PR DESCRIPTION
Bumping Keycloak to 26.0.5 and Keycloak client libs to 26.0.2. The introduction of `keycloak.client.version` is needed as Keycloak now have different release cycle for it's client libraries. You can read it [here](https://www.keycloak.org/docs/latest/release_notes/index.html#dedicated-release-cycle-for-the-client-libraries) 

Maybe this can be backported to 3.15 branch as this version of Keycloak is based on Quarkus 3.15. Don't know what are the preferences here.

Looking at [Keycloak release notes](https://www.keycloak.org/docs/latest/release_notes/index.html#keycloak-26-0-0) I don't see anything which should  be problematic. Only one think which can be problematic in future is [New generalized event types for credentials](https://www.keycloak.org/docs/latest/release_notes/index.html#new-generalized-event-types-for-credentials) (I found the `UPDATE_PASSWORD` in realm config file)