### PR TITLE
Update SmallRye Config to 3.10.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -48,7 +48,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
         <smallrye-common.version>2.8.0</smallrye-common.version>
-        <smallrye-config.version>3.10.0</smallrye-config.version>
+        <smallrye-config.version>3.10.1</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.1</smallrye-open-api.version>


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.10.1</h2>
    <ul>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1251">#1251</a> Validate mapping annotation only in SmallRyeConfigBuilder</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1250">#1250</a> Reduce allocations when generating default names</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1248">#1248</a> fix 1246: honor ConfigProperties.UNCONFIGURED_PREFIX again</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1247">#1247</a> Remove ConfigValuePropertiesConfigSource from docs</li>
        <li><a href="https://redirect.github.com/smallrye/smallrye-config/issues/1245">#1245</a> Bump io.smallrye.common:smallrye-common-bom from 2.7.0 to 2.8.0</li>
    </ul>
</blockquote>