### PR TITLE
Support for short and uncommon field names like set, get, and is

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -161,7 +161,7 @@ public abstract class JacksonCodeGenerator {
         MAP(true),
         TYPE_VARIABLE(true);
 
-        private boolean generic;
+        private final boolean generic;
 
         FieldKind(boolean generic) {
             this.generic = generic;
@@ -281,7 +281,7 @@ public abstract class JacksonCodeGenerator {
             if (isPublicField()) {
                 return fieldInfo.type();
             }
-            if (methodInfo.name().startsWith("set")) {
+            if (methodInfo.parametersCount() == 1 && methodInfo.name().startsWith("set")) {
                 return methodInfo.parameterType(0);
             }
             return methodInfo.returnType();
@@ -304,6 +304,9 @@ public abstract class JacksonCodeGenerator {
 
         private String fieldNameFromMethod(MethodInfo methodInfo) {
             String methodName = methodInfo.name();
+            if (methodName.equals("get") || methodName.equals("set") || methodName.equals("is")) {
+                return methodName;
+            }
             if (methodName.startsWith("is")) {
                 return methodName.substring(2, 3).toLowerCase() + methodName.substring(3);
             }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FieldNameSetGetPrefixResourceTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FieldNameSetGetPrefixResourceTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.NonBlocking;
+
+// Ensures uncommon field names like "set", "get", and "is" are generated correctly.
+class FieldNameSetGetPrefixResourceTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Resource.class, Resource.UncommonBody.class).addAsResource(
+                            new StringAsset(
+                                    "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                            "application.properties"));
+
+    @Test
+    void testFieldNameSetGetIsPrefix() {
+        RestAssured.get("/field-name-prefixes")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("id", Matchers.equalTo("id"))
+                .body("set", Matchers.is(true))
+                .body("get", Matchers.is(true))
+                .body("is", Matchers.is(false))
+                .body("setText", Matchers.equalTo("setText"));
+    }
+
+    @NonBlocking
+    @Path("/field-name-prefixes")
+    private static class Resource {
+        @GET
+        public UncommonBody get() {
+            return new UncommonBody("id", true, true, false, "setText");
+        }
+
+        private record UncommonBody(String id, boolean set, boolean get, boolean is, String setText) {
+        }
+    }
+
+}


### PR DESCRIPTION
fix: #44433 
Enhance handling of short field names specifically for records, ensuring correct support for fields like set, get, and is.