### PR TITLE
Use `QUARKUS_FLYWAY_ACTIVE` instead of `QUARKUS_FLYWAY_ENABLED` env in Kubernetes resources

### DIFF
--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/FlywayProcessor.java
@@ -298,8 +298,8 @@ class FlywayProcessor {
     public InitTaskBuildItem configureInitTask(ApplicationInfoBuildItem app) {
         return InitTaskBuildItem.create()
                 .withName(app.getName() + "-flyway-init")
-                .withTaskEnvVars(Map.of("QUARKUS_INIT_AND_EXIT", "true", "QUARKUS_FLYWAY_ENABLED", "true"))
-                .withAppEnvVars(Map.of("QUARKUS_FLYWAY_ENABLED", "false"))
+                .withTaskEnvVars(Map.of("QUARKUS_INIT_AND_EXIT", "true", "QUARKUS_FLYWAY_ACTIVE", "true"))
+                .withAppEnvVars(Map.of("QUARKUS_FLYWAY_ACTIVE", "false"))
                 .withSharedEnvironment(true)
                 .withSharedFilesystem(true);
     }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitBase.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitBase.java
@@ -29,9 +29,7 @@ public class KubernetesWithFlywayInitBase {
                         && name.equals(d.getMetadata().getName()))
                 .map(d -> (Deployment) d).findAny();
 
-        assertTrue(deployment.isPresent());
-        assertThat(deployment).satisfies(j -> j.isPresent());
-        assertThat(deployment.get()).satisfies(d -> {
+        assertThat(deployment).isPresent().get().satisfies(d -> {
             assertThat(d.getMetadata()).satisfies(m -> {
                 assertThat(m.getName()).isEqualTo(name);
             });
@@ -56,9 +54,7 @@ public class KubernetesWithFlywayInitBase {
                 .filter(j -> "Job".equals(j.getKind()) && jobName.equals(j.getMetadata().getName()))
                 .map(j -> (Job) j)
                 .findAny();
-        assertTrue(job.isPresent());
-
-        assertThat(job.get()).satisfies(j -> {
+        assertThat(job).isPresent().get().satisfies(j -> {
             assertThat(j.getSpec()).satisfies(jobSpec -> {
                 assertThat(jobSpec.getCompletionMode()).isEqualTo("NonIndexed");
                 assertThat(jobSpec.getTemplate()).satisfies(t -> {
@@ -69,7 +65,7 @@ public class KubernetesWithFlywayInitBase {
                         assertThat(podSpec.getRestartPolicy()).isEqualTo("OnFailure");
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getName()).isEqualTo(jobName);
-                            assertThat(container.getEnv()).filteredOn(env -> "QUARKUS_FLYWAY_ENABLED".equals(env.getName()))
+                            assertThat(container.getEnv()).filteredOn(env -> "QUARKUS_FLYWAY_ACTIVE".equals(env.getName()))
                                     .singleElement().satisfies(env -> {
                                         assertThat(env.getValue()).isEqualTo("true");
                                     });


### PR DESCRIPTION
Because this is a build-time configuration property, it doesn't make sense to have it added here
As suggested in https://github.com/quarkusio/quarkus/issues/37040#issuecomment-1864181029
- Fixes #37040
