### PR TITLE
Fix nullpointer on null code websockets-next

### DIFF
--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/BasicWebSocketConnectorImpl.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/BasicWebSocketConnectorImpl.java
@@ -239,7 +239,11 @@ public class BasicWebSocketConnectorImpl extends WebSocketConnectorBase<BasicWeb
                         trafficLogger.connectionClosed(connection);
                     }
                     if (closeHandler != null) {
-                        doExecute(connection, new CloseReason(ws.closeStatusCode(), ws.closeReason()), closeHandler);
+                        CloseReason reason = CloseReason.INTERNAL_SERVER_ERROR;
+                        if (ws.closeStatusCode() != null) {
+                            reason = new CloseReason(ws.closeStatusCode(), ws.closeReason());
+                        }
+                        doExecute(connection, reason, closeHandler);
                     }
                     connectionManager.remove(BasicWebSocketConnectorImpl.class.getName(), connection);
                     client.get().close();


### PR DESCRIPTION
Fix nullpointer in ws-next basic connector when the websocket `closeStatusCode` is null.