### PR TITLE
Bump smallrye-open-api from 4.0.2 to 4.0.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <smallrye-config.version>3.10.1</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>4.0.2</smallrye-open-api.version>
+        <smallrye-open-api.version>4.0.3</smallrye-open-api.version>
         <smallrye-graphql.version>2.11.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.6.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.0</smallrye-jwt.version>


### PR DESCRIPTION
Update smallrye-open-api to [4.0.3 release](https://github.com/smallrye/smallrye-open-api/releases/tag/4.0.3)