### PR TITLE
Bump netty from 4.1.111 to 4.1.115

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -132,7 +132,7 @@
         <infinispan.version>15.0.10.Final</infinispan.version>
         <infinispan.protostream.version>5.0.12.Final</infinispan.protostream.version>
         <caffeine.version>3.1.8</caffeine.version>
-        <netty.version>4.1.111.Final</netty.version>
+        <netty.version>4.1.115.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>


### PR DESCRIPTION
Upgrade netty to 4.1.115
fixes cve GHSA-xq3w-v528-46rv