### PR TITLE
Using BuildForkOptions in QuarkusBuildTask

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -272,7 +272,7 @@ public abstract class QuarkusBuildTask extends QuarkusTask {
                             .collect(Collectors.joining("\n    ", "\n    ", "")));
         }
 
-        WorkQueue workQueue = workQueue(quarkusProperties, getExtensionView().getCodeGenForkOptions().get());
+        WorkQueue workQueue = workQueue(quarkusProperties, getExtensionView().getBuildForkOptions().get());
 
         workQueue.submit(BuildWorker.class, params -> {
             params.getBuildSystemProperties()

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
@@ -64,6 +64,7 @@ public abstract class QuarkusPluginExtensionView {
         getCleanupBuildOutput().set(extension.getCleanupBuildOutput());
         getFinalName().set(extension.getFinalName());
         getCodeGenForkOptions().set(getProviderFactory().provider(() -> extension.codeGenForkOptions));
+        getBuildForkOptions().set(getProviderFactory().provider(() -> extension.buildForkOptions));
         getIgnoredEntries().set(extension.ignoredEntriesProperty());
         getMainResources().setFrom(project.getExtensions().getByType(SourceSetContainer.class).getByName(MAIN_SOURCE_SET_NAME)
                 .getResources().getSourceDirectories());
@@ -126,6 +127,9 @@ public abstract class QuarkusPluginExtensionView {
 
     @Nested
     public abstract ListProperty<Action<? super JavaForkOptions>> getCodeGenForkOptions();
+
+    @Nested
+    public abstract ListProperty<Action<? super JavaForkOptions>> getBuildForkOptions();
 
     @Input
     @Optional

--- a/integration-tests/gradle/src/main/resources/basic-java-application-with-fork-options/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/basic-java-application-with-fork-options/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    java
+    id("io.quarkus")
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+val quarkusPlatformGroupId: String by project
+val quarkusPlatformArtifactId: String by project
+val quarkusPlatformVersion: String by project
+
+dependencies {
+    implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
+}
+
+quarkus {
+    buildForkOptions {
+        println("message!")
+    }
+}

--- a/integration-tests/gradle/src/main/resources/basic-java-application-with-fork-options/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/basic-java-application-with-fork-options/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/basic-java-application-with-fork-options/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-application-with-fork-options/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/main/resources/basic-java-application-with-fork-options/src/main/java/org/acme/EntryPoint.java
+++ b/integration-tests/gradle/src/main/resources/basic-java-application-with-fork-options/src/main/java/org/acme/EntryPoint.java
@@ -1,0 +1,9 @@
+package org.acme;
+
+
+
+public class EntryPoint {
+    public static void main(String[] args) {
+
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/BuildForkOptionsAreIncludedInQuarkusBuildTaskTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/BuildForkOptionsAreIncludedInQuarkusBuildTaskTest.java
@@ -1,0 +1,16 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class BuildForkOptionsAreIncludedInQuarkusBuildTaskTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testBuildForkOptionsAreProcessed() throws Exception {
+        var projectDir = getProjectDir("basic-java-application-with-fork-options");
+        var buildResult = runGradleWrapper(projectDir, "clean", "quarkusBuild");
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":quarkusGenerateCode"))).isTrue();
+        assertThat(buildResult.getOutput().contains("message!")).isTrue();
+    }
+}


### PR DESCRIPTION
Issue related: https://github.com/quarkusio/quarkus/issues/44438 


`QuarkusBuildTask` must use `BuildForkOptions` instead of `CodeGenForkOptions`.
This PR creates the list actions in the `QuarkusPluginExtensionView.` used by `QuarkusBuildTask` and updates the workQueue parameters. 
Additionally, we are adding a new integration test. 

- Fixes: #44438