### PR TITLE
Support title and type fields when generating HAL links

### DIFF
--- a/extensions/hal/runtime/src/main/java/io/quarkus/hal/HalLink.java
+++ b/extensions/hal/runtime/src/main/java/io/quarkus/hal/HalLink.java
@@ -3,12 +3,24 @@ package io.quarkus.hal;
 public class HalLink {
 
     private final String href;
+    private final String title;
+    private final String type;
 
-    public HalLink(String href) {
+    public HalLink(String href, String title, String type) {
         this.href = href;
+        this.title = title;
+        this.type = type;
     }
 
     public String getHref() {
         return href;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getType() {
+        return type;
     }
 }

--- a/extensions/hal/runtime/src/main/java/io/quarkus/hal/HalLinkJacksonSerializer.java
+++ b/extensions/hal/runtime/src/main/java/io/quarkus/hal/HalLinkJacksonSerializer.java
@@ -12,6 +12,14 @@ public class HalLinkJacksonSerializer extends JsonSerializer<HalLink> {
     public void serialize(HalLink value, JsonGenerator generator, SerializerProvider serializers) throws IOException {
         generator.writeStartObject();
         generator.writeObjectField("href", value.getHref());
+        if (value.getTitle() != null) {
+            generator.writeObjectField("title", value.getTitle());
+        }
+
+        if (value.getType() != null) {
+            generator.writeObjectField("type", value.getType());
+        }
+
         generator.writeEndObject();
     }
 }

--- a/extensions/hal/runtime/src/main/java/io/quarkus/hal/HalLinkJsonbSerializer.java
+++ b/extensions/hal/runtime/src/main/java/io/quarkus/hal/HalLinkJsonbSerializer.java
@@ -10,6 +10,14 @@ public class HalLinkJsonbSerializer implements JsonbSerializer<HalLink> {
     public void serialize(HalLink value, JsonGenerator generator, SerializationContext context) {
         generator.writeStartObject();
         generator.write("href", value.getHref());
+        if (value.getTitle() != null) {
+            generator.write("title", value.getTitle());
+        }
+
+        if (value.getType() != null) {
+            generator.write("type", value.getType());
+        }
+
         generator.writeEnd();
     }
 }

--- a/extensions/hal/runtime/src/main/java/io/quarkus/hal/HalWrapper.java
+++ b/extensions/hal/runtime/src/main/java/io/quarkus/hal/HalWrapper.java
@@ -24,7 +24,9 @@ public abstract class HalWrapper {
     @SuppressWarnings("unused")
     public void addLinks(Link... links) {
         for (Link link : links) {
-            this.links.put(link.getRel(), new HalLink(link.getUri().toString()));
+            this.links.put(link.getRel(), new HalLink(link.getUri().toString(),
+                    link.getTitle(),
+                    link.getType()));
         }
     }
 }

--- a/extensions/resteasy-classic/resteasy-links/runtime/src/main/java/io/quarkus/resteasy/links/runtime/hal/ResteasyHalService.java
+++ b/extensions/resteasy-classic/resteasy-links/runtime/src/main/java/io/quarkus/resteasy/links/runtime/hal/ResteasyHalService.java
@@ -29,7 +29,7 @@ public class ResteasyHalService extends HalService {
     private Map<String, HalLink> linksToMap(RESTServiceDiscovery serviceDiscovery) {
         Map<String, HalLink> links = new HashMap<>(serviceDiscovery.size());
         for (RESTServiceDiscovery.AtomLink atomLink : serviceDiscovery) {
-            links.put(atomLink.getRel(), new HalLink(atomLink.getHref()));
+            links.put(atomLink.getRel(), new HalLink(atomLink.getHref(), atomLink.getTitle(), atomLink.getType()));
         }
         return links;
     }

--- a/extensions/resteasy-reactive/rest-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksContainerFactory.java
+++ b/extensions/resteasy-reactive/rest-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksContainerFactory.java
@@ -62,6 +62,8 @@ final class LinksContainerFactory {
             AnnotationInstance restLinkAnnotation, String resourceClassPath, IndexView index) {
         Type returnType = getNonAsyncReturnType(resourceMethodInfo.returnType());
         String rel = getAnnotationValue(restLinkAnnotation, "rel", deductRel(resourceMethod, returnType, index));
+        String title = getAnnotationValue(restLinkAnnotation, "title", null);
+        String type = getAnnotationValue(restLinkAnnotation, "type", null);
         String entityType = getAnnotationValue(restLinkAnnotation, "entityType", deductEntityType(returnType));
         String path = UriBuilder.fromPath(resourceClassPath).path(resourceMethod.getPath()).toTemplate();
         while (path.endsWith("/")) {
@@ -69,7 +71,7 @@ final class LinksContainerFactory {
         }
         Set<String> pathParameters = getPathParameters(path);
 
-        return new LinkInfo(rel, entityType, path, pathParameters);
+        return new LinkInfo(rel, title, type, entityType, path, pathParameters);
     }
 
     /**

--- a/extensions/resteasy-reactive/rest-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/AbstractHalLinksTest.java
+++ b/extensions/resteasy-reactive/rest-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/AbstractHalLinksTest.java
@@ -3,6 +3,9 @@ package io.quarkus.resteasy.reactive.links.deployment;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
 import org.jboss.resteasy.reactive.common.util.RestMediaType;
 import org.junit.jupiter.api.Test;
 
@@ -89,5 +92,19 @@ public abstract class AbstractHalLinksTest {
                 .thenReturn();
 
         assertThat(response.body().jsonPath().getString("_links.self.href")).endsWith("/records/with-rest-link-id/100");
+        assertThat(response.body().jsonPath().getString("_links.self.title")).isEqualTo("The with rest link title");
+        assertThat(response.body().jsonPath().getString("_links.self.type")).isEqualTo(MediaType.APPLICATION_JSON);
+    }
+
+    @Test
+    void shouldIncludeAllFieldsFromLink() {
+        Response response = given()
+                .header(HttpHeaders.ACCEPT, RestMediaType.APPLICATION_HAL_JSON)
+                .get("/records/with-rest-link-with-all-fields")
+                .thenReturn();
+
+        assertThat(response.body().jsonPath().getString("_links.all.href")).endsWith("/records/with-rest-link-id/100");
+        assertThat(response.body().jsonPath().getString("_links.all.title")).isEqualTo("The title link");
+        assertThat(response.body().jsonPath().getString("_links.all.type")).isEqualTo(MediaType.APPLICATION_JSON);
     }
 }

--- a/extensions/resteasy-reactive/rest-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResource.java
+++ b/extensions/resteasy-reactive/rest-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.reactive.links.deployment;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -11,10 +12,12 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Link;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.reactive.common.util.RestMediaType;
 
+import io.quarkus.hal.HalEntityWrapper;
 import io.quarkus.resteasy.reactive.links.InjectRestLinks;
 import io.quarkus.resteasy.reactive.links.RestLink;
 import io.quarkus.resteasy.reactive.links.RestLinkType;
@@ -172,13 +175,27 @@ public class TestResource {
     @GET
     @Path("/with-rest-link-id/{id}")
     @Produces({ MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_HAL_JSON })
-    @RestLink(entityType = TestRecordWithRestLinkId.class)
+    @RestLink(entityType = TestRecordWithRestLinkId.class, title = "The with rest link title", type = MediaType.APPLICATION_JSON)
     @InjectRestLinks
     public TestRecordWithRestLinkId getWithRestLinkId(@PathParam("id") int id) {
         return REST_LINK_ID_RECORDS.stream()
                 .filter(record -> record.getRestLinkId() == id)
                 .findFirst()
                 .orElseThrow(NotFoundException::new);
+    }
+
+    @GET
+    @Path("/with-rest-link-with-all-fields")
+    @Produces({ MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_HAL_JSON })
+    public HalEntityWrapper<TestRecordWithIdAndPersistenceIdAndRestLinkId> getAllFieldsFromLink() {
+
+        var entity = new TestRecordWithIdAndPersistenceIdAndRestLinkId(1, 10, 100, "one");
+        return new HalEntityWrapper<>(entity,
+                Link.fromUri(URI.create("/records/with-rest-link-id/100"))
+                        .rel("all")
+                        .title("The title link")
+                        .type(MediaType.APPLICATION_JSON)
+                        .build());
     }
 
 }

--- a/extensions/resteasy-reactive/rest-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/RestLink.java
+++ b/extensions/resteasy-reactive/rest-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/RestLink.java
@@ -26,6 +26,20 @@ public @interface RestLink {
     String rel() default "";
 
     /**
+     * Intended for labelling the link with a human-readable identifier.
+     *
+     * @return the link title.
+     */
+    String title() default "";
+
+    /**
+     * Hint to indicate the media type expected when dereferencing the target resource.
+     *
+     * @return the link expected media type.
+     */
+    String type() default "";
+
+    /**
      * Declares a link for the given type of resources.
      * If not set, it will default to the returning type of the annotated method.
      *

--- a/extensions/resteasy-reactive/rest-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/LinkInfo.java
+++ b/extensions/resteasy-reactive/rest-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/LinkInfo.java
@@ -6,14 +6,20 @@ public final class LinkInfo {
 
     private final String rel;
 
+    private final String title;
+
+    private final String type;
+
     private final String entityType;
 
     private final String path;
 
     private final Set<String> pathParameters;
 
-    public LinkInfo(String rel, String entityType, String path, Set<String> pathParameters) {
+    public LinkInfo(String rel, String title, String type, String entityType, String path, Set<String> pathParameters) {
         this.rel = rel;
+        this.title = title;
+        this.type = type;
         this.entityType = entityType;
         this.path = path;
         this.pathParameters = pathParameters;
@@ -21,6 +27,14 @@ public final class LinkInfo {
 
     public String getRel() {
         return rel;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getType() {
+        return type;
     }
 
     public String getEntityType() {

--- a/extensions/resteasy-reactive/rest-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/RestLinksProviderImpl.java
+++ b/extensions/resteasy-reactive/rest-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/RestLinksProviderImpl.java
@@ -37,9 +37,7 @@ final class RestLinksProviderImpl implements RestLinksProvider {
         List<Link> links = new ArrayList<>(linkInfoList.size());
         for (LinkInfo linkInfo : linkInfoList) {
             if (linkInfo.getPathParameters().size() == 0) {
-                links.add(Link.fromUriBuilder(uriInfo.getBaseUriBuilder().path(linkInfo.getPath()))
-                        .rel(linkInfo.getRel())
-                        .build());
+                links.add(linkBuilderFor(linkInfo).build());
             }
         }
         return links;
@@ -52,11 +50,23 @@ final class RestLinksProviderImpl implements RestLinksProvider {
         List<LinkInfo> linkInfoList = linksContainer.getForClass(instance.getClass());
         List<Link> links = new ArrayList<>(linkInfoList.size());
         for (LinkInfo linkInfo : linkInfoList) {
-            links.add(Link.fromUriBuilder(uriInfo.getBaseUriBuilder().path(linkInfo.getPath()))
-                    .rel(linkInfo.getRel())
-                    .build(getPathParameterValues(linkInfo, instance)));
+            links.add(linkBuilderFor(linkInfo).build(getPathParameterValues(linkInfo, instance)));
         }
         return links;
+    }
+
+    private Link.Builder linkBuilderFor(LinkInfo linkInfo) {
+        Link.Builder builder = Link.fromUriBuilder(uriInfo.getBaseUriBuilder().path(linkInfo.getPath()))
+                .rel(linkInfo.getRel());
+        if (linkInfo.getTitle() != null) {
+            builder.title(linkInfo.getTitle());
+        }
+
+        if (linkInfo.getType() != null) {
+            builder.type(linkInfo.getType());
+        }
+
+        return builder;
     }
 
     private Object[] getPathParameterValues(LinkInfo linkInfo, Object instance) {

--- a/extensions/resteasy-reactive/rest-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/hal/ResteasyReactiveHalService.java
+++ b/extensions/resteasy-reactive/rest-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/hal/ResteasyReactiveHalService.java
@@ -34,7 +34,7 @@ public class ResteasyReactiveHalService extends HalService {
     private Map<String, HalLink> linksToMap(Collection<Link> refLinks) {
         Map<String, HalLink> links = new HashMap<>();
         for (Link link : refLinks) {
-            links.put(link.getRel(), new HalLink(link.getUri().toString()));
+            links.put(link.getRel(), new HalLink(link.getUri().toString(), link.getTitle(), link.getType()));
         }
 
         return links;


### PR DESCRIPTION
Before these changes, we were only considering the "href" field for the HAL links. Example:

```json
{
  "_links": {
    "subject": {
      "href": "/subject"
    }
  }
}
```

After these changes, users that populate also the title and/or the type like:

```java
@GET
    @Path("/with-rest-link-with-all-fields")
    @Produces({ MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_HAL_JSON })
    public HalEntityWrapper<TestRecordWithIdAndPersistenceIdAndRestLinkId> get() {

        var entity = // ...
        return new HalEntityWrapper<>(entity,
                Link.fromUri(URI.create("/path/to/100"))
                        .rel("all")
                        .title("The title link") // the link title
                        .type(MediaType.APPLICATION_JSON) // the link type
                        .build());
    }
```

Or using the annotation like:

```java
@GET
    @Produces({ MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_HAL_JSON })
    @RestLink(entityType = TestRecordWithRestLinkId.class, title = "The with rest link title", type = MediaType.APPLICATION_JSON)
    @InjectRestLinks
    public TestRecordWithRestLinkId get() {
        return // ...
    }
```

Then, the links will have the title and/or type fields populated:
```json
{
  "_links": {
    "subject": {
      "href": "/subject",
      "title": "The with rest link title",
      "type": "application/json"
    }
  }
}
```