### PR TITLE
Log in smallrye-jwt and oauth2 extensions when no bearer access token is available

### DIFF
--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/auth/OAuth2AuthMechanism.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/auth/OAuth2AuthMechanism.java
@@ -5,6 +5,8 @@ import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.jboss.logging.Logger;
+
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.security.credential.TokenCredential;
@@ -23,7 +25,7 @@ import io.vertx.ext.web.RoutingContext;
  */
 @ApplicationScoped
 public class OAuth2AuthMechanism implements HttpAuthenticationMechanism {
-
+    private static final Logger LOG = Logger.getLogger(OAuth2AuthMechanism.class);
     private static final String BEARER_PREFIX = "Bearer ";
 
     protected static final ChallengeData CHALLENGE_DATA = new ChallengeData(
@@ -46,7 +48,9 @@ public class OAuth2AuthMechanism implements HttpAuthenticationMechanism {
         String authHeader = context.request().headers().get("Authorization");
 
         if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
-            // No suitable bearer token has been found in this request,
+            // No suitable bearer token has been found in this request
+            LOG.debug("Bearer access token is not available");
+
             return Uni.createFrom().nullItem();
         }
 

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.jboss.logging.Logger;
+
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
@@ -34,6 +36,7 @@ import io.vertx.ext.web.RoutingContext;
  */
 @ApplicationScoped
 public class JWTAuthMechanism implements HttpAuthenticationMechanism {
+    private static final Logger LOG = Logger.getLogger(JWTAuthMechanism.class);
     private static final String ERROR_MSG = "SmallRye JWT requires a safe (isolated) Vert.x sub-context for propagation "
             + "of the '" + TokenCredential.class.getName() + "', but the current context hasn't been flagged as such.";
     protected static final String COOKIE_HEADER = "Cookie";
@@ -86,6 +89,8 @@ public class JWTAuthMechanism implements HttpAuthenticationMechanism {
             return identityProviderManager
                     .authenticate(HttpSecurityUtils.setRoutingContextAttribute(
                             new TokenAuthenticationRequest(new JsonWebTokenCredential(jwtToken)), context));
+        } else {
+            LOG.debug("Bearer access token is not available");
         }
         return Uni.createFrom().optional(Optional.empty());
     }


### PR DESCRIPTION
If the endpoint is secured by a bearer access token verification mechanism then, when no token is provided, a debug log message should inform users about it.
It is already done in `quarkus-oidc` [here](https://github.com/quarkusio/quarkus/blob/main/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java#L30).
But `quarkus-smallrye-jwt` does not log the same message, so this PR adds it there as well. 