### PR TITLE
Fixed Timestamp not being set for otel log signals

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogHandler.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogHandler.java
@@ -10,6 +10,7 @@ import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INST
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Handler;
@@ -43,6 +44,7 @@ public class OpenTelemetryLogHandler extends Handler {
         final LogRecordBuilder logRecordBuilder = openTelemetry.getLogsBridge()
                 .loggerBuilder(INSTRUMENTATION_NAME)
                 .build().logRecordBuilder()
+                .setTimestamp(Instant.now())
                 .setObservedTimestamp(record.getInstant());
 
         if (record.getLevel() != null) {


### PR DESCRIPTION
When using the otel logging, the log messages where displayed wrong in the Elastic Stack because the Timestamp was not set to the Log Signal. The Reason for this is that APM-Server is using the Timestamp and not the ObservedTimestamp for displaying the Message. For this reason they where display in the year 1970 in Elastic Stack.