### PR TITLE
[3.15] Realign Infinispan version to 15.0.8.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -134,8 +134,8 @@
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->
         <junit.jupiter.version>5.10.3</junit.jupiter.version>
-        <infinispan.version>15.0.10.Final</infinispan.version>
-        <infinispan.protostream.version>5.0.12.Final</infinispan.protostream.version>
+        <infinispan.version>15.0.8.Final</infinispan.version>
+        <infinispan.protostream.version>5.0.8.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
         <netty.version>4.1.111.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>


### PR DESCRIPTION
@ppalaga here is the last patch for 3.15.2: we just go back to the version we had in 3.15.1 so it shouldn't be an issue for you.