### PR TITLE
Check CL in ConfigRecorder

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
@@ -60,7 +60,11 @@ public class ConfigRecorder {
 
         if (!mismatches.isEmpty()) {
             String msg = "Build time property cannot be changed at runtime:\n" + String.join("\n", mismatches);
-            ConfigConfig configConfig = config.getConfigMapping(ConfigConfig.class);
+            SmallRyeConfig quarkusConfig = new QuarkusConfigFactory().getConfigFor(null, null);
+            if (!config.equals(quarkusConfig)) {
+                throw new IllegalStateException("SmallRyeConfig Classloaders mismatch!");
+            }
+            ConfigConfig configConfig = quarkusConfig.getConfigMapping(ConfigConfig.class);
             if (fail.equals(configConfig.buildTimeMismatchAtRuntime())) {
                 throw new IllegalStateException(msg);
             } else if (warn.equals(configConfig.buildTimeMismatchAtRuntime())) {


### PR DESCRIPTION
To detect possible issues with failures in `OverrideBuildTimeConfigTest`, observed in:
- https://github.com/quarkusio/quarkus/pull/44515
- https://github.com/quarkusio/quarkus/pull/44513