### PR TITLE
Allow `@PermissionChecker` methods to authorize secured methods when `@TestSecurity` annotation is applied and conditionally apply `SecurityIdentityAugmentors`

### DIFF
--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -156,6 +156,50 @@ public String getDetail() {
 }
 ----
 
+It is also possible to set custom permissions like in the example below:
+
+[source,java]
+----
+@PermissionsAllowed("see", permission = CustomPermission.class)
+public String getDetail() {
+    return "detail";
+}
+----
+
+The `CustomPermission` needs to be granted to the `SecurityIdentity` created
+by the `@TestSecurity` annotation with a `SecurityIdentityAugmentor` CDI bean:
+
+[source,java]
+----
+@ApplicationScoped
+public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmentor {
+    @Override
+    public Uni<SecurityIdentity> augment(SecurityIdentity securityIdentity,
+            AuthenticationRequestContext authenticationRequestContext) {
+        final SecurityIdentity augmentedIdentity;
+        if (shouldGrantCustomPermission(securityIdentity) {
+            augmentedIdentity = QuarkusSecurityIdentity.builder(securityIdentity)
+                                   .addPermission(new CustomPermission("see")).build();
+        } else {
+            augmentedIdentity = securityIdentity;
+        }
+        return Uni.createFrom().item(augmentedIdentity);
+    }
+}
+----
+
+Quarkus will only augment the `SecurityIdentity` created with the `@TestSecurity` annotation if you set
+the `@TestSecurity#augmentors` annotation attribute to the `CustomSecurityIdentityAugmentor.class` like this:
+
+[source,java]
+----
+@Test
+@TestSecurity(user = "testUser", permissions = "see:detail", augmentors = CustomSecurityIdentityAugmentor.class)
+void someTestMethod() {
+    ...
+}
+----
+
 === Mixing security tests
 
 If it becomes necessary to test security features using both `@TestSecurity` and Basic Auth (which is the fallback auth

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -107,6 +107,7 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.security.deployment.PermissionSecurityChecks.PermissionSecurityChecksBuilder;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.quarkus.security.runtime.IdentityProviderManagerCreator;
+import io.quarkus.security.runtime.QuarkusPermissionSecurityIdentityAugmentor;
 import io.quarkus.security.runtime.QuarkusSecurityRolesAllowedConfigBuilder;
 import io.quarkus.security.runtime.SecurityBuildTimeConfig;
 import io.quarkus.security.runtime.SecurityCheckRecorder;
@@ -691,7 +692,8 @@ public class SecurityProcessor {
             // - this processor relies on the bean archive index (cycle: idx -> additional bean -> idx)
             // - we have injection points (=> better validation from Arc) as checker beans are only requested from this augmentor
             var syntheticBeanConfigurator = SyntheticBeanBuildItem
-                    .configure(SecurityIdentityAugmentor.class)
+                    .configure(QuarkusPermissionSecurityIdentityAugmentor.class)
+                    .addType(SecurityIdentityAugmentor.class)
                     // ATM we do get augmentors from CDI once, no need to keep the instance in the CDI container
                     .scope(Dependent.class)
                     .unremovable()

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusPermissionSecurityIdentityAugmentor.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/QuarkusPermissionSecurityIdentityAugmentor.java
@@ -15,7 +15,7 @@ import io.smallrye.mutiny.Uni;
  * Adds a permission checker that grants access to the {@link QuarkusPermission}
  * when {@link QuarkusPermission#isGranted(SecurityIdentity)} is true.
  */
-final class QuarkusPermissionSecurityIdentityAugmentor implements SecurityIdentityAugmentor {
+public final class QuarkusPermissionSecurityIdentityAugmentor implements SecurityIdentityAugmentor {
 
     /**
      * Permission checker only authorizes authenticated users and checkers shouldn't throw a security exception.

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityCheckRecorder.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityCheckRecorder.java
@@ -29,7 +29,6 @@ import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.StringPermission;
-import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.quarkus.security.runtime.interceptor.SecurityCheckStorageBuilder;
 import io.quarkus.security.runtime.interceptor.SecurityConstrainer;
 import io.quarkus.security.runtime.interceptor.check.AuthenticatedCheck;
@@ -436,10 +435,11 @@ public class SecurityCheckRecorder {
         }
     }
 
-    public Function<SyntheticCreationalContext<SecurityIdentityAugmentor>, SecurityIdentityAugmentor> createPermissionAugmentor() {
-        return new Function<SyntheticCreationalContext<SecurityIdentityAugmentor>, SecurityIdentityAugmentor>() {
+    public Function<SyntheticCreationalContext<QuarkusPermissionSecurityIdentityAugmentor>, QuarkusPermissionSecurityIdentityAugmentor> createPermissionAugmentor() {
+        return new Function<SyntheticCreationalContext<QuarkusPermissionSecurityIdentityAugmentor>, QuarkusPermissionSecurityIdentityAugmentor>() {
             @Override
-            public SecurityIdentityAugmentor apply(SyntheticCreationalContext<SecurityIdentityAugmentor> ctx) {
+            public QuarkusPermissionSecurityIdentityAugmentor apply(
+                    SyntheticCreationalContext<QuarkusPermissionSecurityIdentityAugmentor> ctx) {
                 return new QuarkusPermissionSecurityIdentityAugmentor(ctx.getInjectedReference(BlockingSecurityExecutor.class));
             }
         };

--- a/integration-tests/elytron-resteasy/src/main/java/io/quarkus/it/resteasy/elytron/RootResource.java
+++ b/integration-tests/elytron-resteasy/src/main/java/io/quarkus/it/resteasy/elytron/RootResource.java
@@ -16,6 +16,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.SecurityContext;
 
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.PermissionChecker;
+import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.identity.SecurityIdentity;
 
 @Path("/")
@@ -72,5 +74,20 @@ public class RootResource {
         return attributes.entrySet().stream()
                 .map(e -> e.getKey() + "=" + e.getValue())
                 .collect(Collectors.joining(","));
+    }
+
+    @GET
+    @Path("/test-security-permission-checker")
+    @PermissionsAllowed("see-principal")
+    public String getPrincipal(@Context SecurityContext sec) {
+        return sec.getUserPrincipal().getName() + ":" + identity.getPrincipal().getName() + ":" + principal.getName();
+    }
+
+    @PermissionChecker("see-principal")
+    boolean canSeePrincipal(SecurityContext sec) {
+        if (sec.getUserPrincipal() == null || sec.getUserPrincipal().getName() == null) {
+            return false;
+        }
+        return "meat loaf".equals(sec.getUserPrincipal().getName());
     }
 }

--- a/integration-tests/smallrye-jwt-token-propagation/src/main/java/io/quarkus/it/keycloak/CustomPermission.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/main/java/io/quarkus/it/keycloak/CustomPermission.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.keycloak;
+
+import java.security.BasicPermission;
+
+public class CustomPermission extends BasicPermission {
+
+    public CustomPermission(String name) {
+        super(name);
+    }
+}

--- a/integration-tests/smallrye-jwt-token-propagation/src/main/java/io/quarkus/it/keycloak/ProtectedJwtResource.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/main/java/io/quarkus/it/keycloak/ProtectedJwtResource.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.identity.SecurityIdentity;
 
 @Path("/web-app")
@@ -36,6 +37,14 @@ public class ProtectedJwtResource {
     @Path("test-security")
     @RolesAllowed("viewer")
     public String testSecurity() {
+        return securityContext.getUserPrincipal().getName() + ":" + identity.getPrincipal().getName() + ":"
+                + principal.getName();
+    }
+
+    @GET
+    @Path("test-security-with-augmentors")
+    @PermissionsAllowed(permission = CustomPermission.class, value = "augmented")
+    public String testSecurityWithAugmentors() {
         return securityContext.getUserPrincipal().getName() + ":" + identity.getPrincipal().getName() + ":"
                 + principal.getName();
     }

--- a/integration-tests/smallrye-jwt-token-propagation/src/main/java/io/quarkus/it/keycloak/TestSecurityIdentityAugmentor.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/main/java/io/quarkus/it/keycloak/TestSecurityIdentityAugmentor.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class TestSecurityIdentityAugmentor implements SecurityIdentityAugmentor {
+
+    private static volatile boolean invoked = false;
+
+    @Override
+    public Uni<SecurityIdentity> augment(SecurityIdentity securityIdentity,
+            AuthenticationRequestContext authenticationRequestContext) {
+        invoked = true;
+        final SecurityIdentity identity;
+        if (securityIdentity.isAnonymous() || !"authorized-user".equals(securityIdentity.getPrincipal().getName())) {
+            identity = securityIdentity;
+        } else {
+            identity = QuarkusSecurityIdentity.builder(securityIdentity)
+                    .addPermission(new CustomPermission("augmented")).build();
+        }
+        return Uni.createFrom().item(identity);
+    }
+
+    public static boolean isInvoked() {
+        return invoked;
+    }
+
+    public static void resetInvoked() {
+        invoked = false;
+    }
+}

--- a/integration-tests/smallrye-jwt-token-propagation/src/main/resources/application.properties
+++ b/integration-tests/smallrye-jwt-token-propagation/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.keycloak.devservices.enabled=false
+
 mp.jwt.verify.publickey.location=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 mp.jwt.verify.issuer=${keycloak.url}/realms/quarkus
 smallrye.jwt.path.groups=realm_access/roles

--- a/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
@@ -20,6 +21,53 @@ import io.restassured.http.ContentType;
 @QuarkusTest
 @TestHTTPEndpoint(ProtectedJwtResource.class)
 public class TestSecurityLazyAuthTest {
+
+    @Test
+    public void testTestSecurityAnnotationWithAugmentors_anonymousUser() {
+        TestSecurityIdentityAugmentor.resetInvoked();
+        // user is not authenticated and doesn't have required role granted by the augmentor
+        RestAssured.get("test-security-with-augmentors").then().statusCode(401);
+        // identity manager applies augmentors on anonymous identity
+        // because @TestSecurity is not in action and that's what we do for the anonymous requests
+        Assertions.assertTrue(TestSecurityIdentityAugmentor.isInvoked());
+    }
+
+    @TestSecurity(user = "authenticated-user")
+    @Test
+    public void testTestSecurityAnnotationNoAugmentors_authenticatedUser() {
+        TestSecurityIdentityAugmentor.resetInvoked();
+        // user is authenticated, but doesn't have required role granted by the augmentor
+        // and no augmentors are applied
+        RestAssured.get("test-security-with-augmentors").then().statusCode(403);
+        Assertions.assertFalse(TestSecurityIdentityAugmentor.isInvoked());
+    }
+
+    @TestSecurity(user = "authenticated-user", augmentors = TestSecurityIdentityAugmentor.class)
+    @Test
+    public void testTestSecurityAnnotationWithAugmentors_authenticatedUser() {
+        TestSecurityIdentityAugmentor.resetInvoked();
+        // user is authenticated, but doesn't have required role granted by the augmentor
+        RestAssured.get("test-security-with-augmentors").then().statusCode(403);
+        Assertions.assertTrue(TestSecurityIdentityAugmentor.isInvoked());
+    }
+
+    @TestSecurity(user = "authorized-user")
+    @Test
+    public void testTestSecurityAnnotationNoAugmentors_authorizedUser() {
+        // should fail because no augmentors are applied
+        TestSecurityIdentityAugmentor.resetInvoked();
+        RestAssured.get("test-security-with-augmentors").then().statusCode(403);
+        Assertions.assertFalse(TestSecurityIdentityAugmentor.isInvoked());
+    }
+
+    @TestSecurity(user = "authorized-user", augmentors = TestSecurityIdentityAugmentor.class)
+    @Test
+    public void testTestSecurityAnnotationWithAugmentors_authorizedUser() {
+        TestSecurityIdentityAugmentor.resetInvoked();
+        RestAssured.get("test-security-with-augmentors").then().statusCode(200)
+                .body(is("authorized-user:authorized-user:authorized-user"));
+        Assertions.assertTrue(TestSecurityIdentityAugmentor.isInvoked());
+    }
 
     @Test
     @TestAsUser1Viewer

--- a/test-framework/security/src/main/java/io/quarkus/test/security/TestIdentityAssociation.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/TestIdentityAssociation.java
@@ -26,12 +26,12 @@ public class TestIdentityAssociation extends SecurityIdentityAssociation {
         }
     }
 
-    volatile SecurityIdentity testIdentity;
+    private volatile SecurityIdentity testIdentity;
 
     /**
      * Whether authentication is successful only if right mechanism was used to authenticate.
      */
-    volatile boolean isPathBasedIdentity = false;
+    private volatile boolean isPathBasedIdentity = false;
 
     /**
      * A request scoped delegate that allows the system to function as normal when

--- a/test-framework/security/src/main/java/io/quarkus/test/security/TestSecurity.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/TestSecurity.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Target;
 
 import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
@@ -35,10 +36,17 @@ public @interface TestSecurity {
      * That is, permission is separated from actions with {@link PermissionsAllowed#PERMISSION_TO_ACTION_SEPARATOR}.
      * For example, value {@code see:detail} gives permission to {@code see} action {@code detail}.
      * All permissions are added as {@link io.quarkus.security.StringPermission}.
-     * If you need to test custom permissions, you can add them with
-     * {@link io.quarkus.security.identity.SecurityIdentityAugmentor}.
+     * {@link io.quarkus.security.PermissionChecker} methods always authorize matched {@link PermissionsAllowed#value()}
+     * permissions. This annotation attribute cannot grant access to permissions granted by the checker methods.
      */
     String[] permissions() default {};
+
+    /**
+     * Specify {@link SecurityIdentityAugmentor} CDI beans that should augment {@link SecurityIdentity} created with
+     * this annotation. By default, no identity augmentors are applied. Use this option if you need to test
+     * custom {@link PermissionsAllowed#permission()} added with the identity augmentors.
+     */
+    Class<? extends SecurityIdentityAugmentor>[] augmentors() default {};
 
     /**
      * Adds attributes to a {@link SecurityIdentity} configured by this annotation.


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/44479
- till now, methods secured with `@PermissionAllowed("see")` where the `see` permission was granted by `@PermissionChecker("see")` checker method always returned 401/403, now the checker method is actually invoked when the `@TestSecurity` annotation is applied
- `SecurityIdentityAugmentors` did not augment the identity produced by the `@TestSecurity` annotation, now users can explicitly list augmentors that should be applied