### PR TITLE
Fix typo, use common ID syntax

### DIFF
--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -619,7 +619,7 @@ We suggest that you check out the quickstart solutions and explore the `security
 
 == Reference Guide
 
-[supported-injection-scopes]
+[[supported-injection-scopes]]
 === Supported Injection Scopes
 
 `@ApplicationScoped`, `@Singleton` and `@RequestScoped` outer bean injection scopes are all supported when an `org.eclipse.microprofile.jwt.JsonWebToken` is injected, with the `@RequestScoped` scoping for `JsonWebToken` enforced to ensure the current token is represented.


### PR DESCRIPTION
Updated the ID to use the common double-bracket syntax (`[[<value>]]`). This ensures that when the file is synchronized to the downstream product repository, the ID is correctly converted to `[id="<value>"]`, maintaining proper syntax and functionality.