### PR TITLE
Update smallrye-jwt to 4.6.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-open-api.version>4.0.3</smallrye-open-api.version>
         <smallrye-graphql.version>2.11.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.6.2</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>4.6.0</smallrye-jwt.version>
+        <smallrye-jwt.version>4.6.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.1.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>


### PR DESCRIPTION
Updates smallrye-jwt to 4.6.1, which removes json provider re-instantiation [(complete changelog)](https://github.com/smallrye/smallrye-jwt/releases/tag/4.6.1)
