### PR TITLE
Fix buildpack docker host handling for macos

### DIFF
--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
@@ -73,6 +73,19 @@ public class BuildpackConfig {
     public Optional<String> dockerHost;
 
     /**
+     * use Daemon mode?
+     * Defaults to 'true'
+     */
+    @ConfigItem(defaultValue = "true")
+    public Boolean useDaemon;
+
+    /**
+     * Use specified docker network during build
+     */
+    @ConfigItem
+    public Optional<String> dockerNetwork;
+
+    /**
      * Log level to use..
      * Defaults to 'info'
      */


### PR DESCRIPTION
Macos has the podman rootless socket at a different location to linux, and the underlying snowdrop library has no smarts to recognise that. This would not be a problem as we offer a way to configure a custom Docker Host, but sadly that route is non-functional.

Overriding  Docker Host should be possible via the configuration, but fails because the 'editDockerConfig' call does not retrigger the constructor in the snowdrop library. 

This change removes the editDockerConfig call, configuring the library DockerConfig object just once. 

Additionally, logic is added to default the docker host value to the env var DOCKER_HOST to work around an unrelated snowdrop library issue. 

Finally useDaemon & dockerNetwork are exposed as configuration options in an attempt to provide more options to avoid dockerSocket issues in the future. 