### PR TITLE
Wrong index of ParameterizedType argument of Map when register type to be generated in JacksonCodeGenerator

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -193,7 +193,7 @@ public abstract class JacksonCodeGenerator {
                 }
             }
             if (pType.arguments().size() == 2 && typeName.equals("java.util.Map")) {
-                registerTypeToBeGenerated(pType.arguments().get(1));
+                registerTypeToBeGenerated(pType.arguments().get(0));
                 registerTypeToBeGenerated(pType.arguments().get(1));
                 return FieldKind.MAP;
             }


### PR DESCRIPTION
Wrong index of ParameterizedType argument of Map when register type to be generated in JacksonCodeGenerator