### PR TITLE
Support protoc Kotlin code generation

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6251,6 +6251,12 @@
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-kotlin</artifactId>
+                <version>${protobuf-kotlin.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
                 <artifactId>protoc</artifactId>
                 <classifier>linux-aarch_64</classifier>
                 <type>exe</type>

--- a/docs/src/main/asciidoc/grpc-generation-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-generation-reference.adoc
@@ -165,6 +165,17 @@ quarkus.generate-code.grpc.scan-for-proto-exclude."<groupId>:<artifactId>"=foo/p
 
 Note that `:` characters in the property keys must be escaped.
 
+== Kotlin code generation
+
+`protoc` also supports https://protobuf.dev/reference/kotlin/kotlin-generated/[generating Kotlin code] in addition to the generated Java code.
+
+By default, the Kotlin code generation is enabled if the dependency `io.quarkus:quarkus-kotlin` is present.
+
+To explicitly en-/disable this feature, set the `quarkus.generate-code.grpc.kotlin.generate` property in your `application.properties` file to `true` or `false`.
+
+
+IMPORTANT: When using Gradle, you also have to include `com.google.protobuf:protobuf-kotlin` as a `compileOnly` dependency in your project.
+
 == Skipping code generation
 
 You can skip gRPC code generation using:

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-no-java/application/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-no-java/application/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.quarkus:quarkus-arc")
     implementation("io.quarkus:quarkus-grpc")
+    compileOnly("com.google.protobuf:protobuf-kotlin")
 
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.rest-assured:rest-assured")

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
@@ -15,6 +15,7 @@ repositories {
 }
 
 dependencies {
+    compileOnly 'com.google.protobuf:protobuf-kotlin'
     implementation 'io.quarkus:quarkus-kotlin'
     implementation 'io.quarkus:quarkus-grpc'
     implementation 'io.quarkus:quarkus-smallrye-graphql'

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/main/kotlin/org/acme/ExampleResource.kt
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/main/kotlin/org/acme/ExampleResource.kt
@@ -6,11 +6,12 @@ import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
 
 import io.quarkus.example.HelloMsg
+import io.quarkus.example.helloMsg
 
 @Path("/hello")
 class ExampleResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    fun hello() = "hello" + HelloMsg.Status.TEST_ONE.getNumber()
+    fun hello() = "hello" + helloMsg { status = HelloMsg.Status.TEST_ONE }.statusValue
 }

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <grpc-jprotoc.version>1.2.2</grpc-jprotoc.version>
         <protoc.version>3.25.5</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
+        <protobuf-kotlin.version>4.29.3</protobuf-kotlin.version>
         <proto-google-common-protos.version>2.53.0</proto-google-common-protos.version>
 
         <!-- Used in the build parent and test BOM (for the junit 5 plugin) and in the BOM (for the API) -->


### PR DESCRIPTION
Closes #39127

This PR adds support to generate [Kotlin DSLs/Extensions for protoc](https://protobuf.dev/reference/kotlin/kotlin-generated/) via adding the `kotlin_out` parameter to the `protoc` command:

* By default, the Kotlin code generation is enabled if the dependency `io.quarkus:quarkus-kotlin` is present
* It can be explicetely en-/disabled via the `quarkus.generate-code.grpc.kotlin.generate` property

To test it I reused the `kotlin-grpc-project` integration-test to use the generated DSL for `HelloMsg`.
Now currently when running the `KotlinGRPCProjectBuildTest`, `compileKotlin` fails with:

```shell
e: file://.../quarkus/integration-tests/gradle/target/classes/kotlin-grpc-project/build/classes/java/quarkus-generated-sources/grpc/io/quarkus/example/HelloMsgKt.kt:15:17 Annotation argument must be a compile-time constant.
e: file://.../quarkus/integration-tests/gradle/target/classes/kotlin-grpc-project/build/classes/java/quarkus-generated-sources/grpc/io/quarkus/example/HelloMsgKt.kt:15:37 Unresolved reference 'kotlin'.
e: file://.../quarkus/integration-tests/gradle/target/classes/kotlin-grpc-project/build/classes/java/quarkus-generated-sources/grpc/io/quarkus/example/HelloMsgKt.kt:16:24 Unresolved reference 'kotlin'.
```
<details>
  <summary>HelloMsgKt.kt</summary>
  
  ```kotlin
// Generated by the protocol buffer compiler. DO NOT EDIT!
// source: hello.proto

// Generated files should ignore deprecation warnings
@file:Suppress("DEPRECATION")
package io.quarkus.example;

@kotlin.jvm.JvmName("-initializehelloMsg")
public inline fun helloMsg(block: io.quarkus.example.HelloMsgKt.Dsl.() -> kotlin.Unit): io.quarkus.example.HelloMsg =
  io.quarkus.example.HelloMsgKt.Dsl._create(io.quarkus.example.HelloMsg.newBuilder()).apply { block() }._build()
/**
 * Protobuf type `io.quarkus.example.HelloMsg`
 */
public object HelloMsgKt {
  @kotlin.OptIn(com.google.protobuf.kotlin.OnlyForUseByGeneratedProtoCode::class)
  @com.google.protobuf.kotlin.ProtoDslMarker
  public class Dsl private constructor(
    private val _builder: io.quarkus.example.HelloMsg.Builder
  ) {
    public companion object {
      @kotlin.jvm.JvmSynthetic
      @kotlin.PublishedApi
      internal fun _create(builder: io.quarkus.example.HelloMsg.Builder): Dsl = Dsl(builder)
    }

    @kotlin.jvm.JvmSynthetic
    @kotlin.PublishedApi
    internal fun _build(): io.quarkus.example.HelloMsg = _builder.build()

    /**
     * `string message = 1;`
     */
    public var message: kotlin.String
      @JvmName("getMessage")
      get() = _builder.getMessage()
      @JvmName("setMessage")
      set(value) {
        _builder.setMessage(value)
      }
    /**
     * `string message = 1;`
     */
    public fun clearMessage() {
      _builder.clearMessage()
    }

    /**
     * `.google.protobuf.Timestamp date_time = 2;`
     */
    public var dateTime: com.google.protobuf.Timestamp
      @JvmName("getDateTime")
      get() = _builder.getDateTime()
      @JvmName("setDateTime")
      set(value) {
        _builder.setDateTime(value)
      }
    /**
     * `.google.protobuf.Timestamp date_time = 2;`
     */
    public fun clearDateTime() {
      _builder.clearDateTime()
    }
    /**
     * `.google.protobuf.Timestamp date_time = 2;`
     * @return Whether the dateTime field is set.
     */
    public fun hasDateTime(): kotlin.Boolean {
      return _builder.hasDateTime()
    }

    /**
     * `.io.quarkus.example.HelloMsg.Status status = 3;`
     */
    public var status: io.quarkus.example.HelloMsg.Status
      @JvmName("getStatus")
      get() = _builder.getStatus()
      @JvmName("setStatus")
      set(value) {
        _builder.setStatus(value)
      }
    public var statusValue: kotlin.Int
      @JvmName("getStatusValue")
      get() = _builder.getStatusValue()
      @JvmName("setStatusValue")
      set(value) {
        _builder.setStatusValue(value)
      }
    /**
     * `.io.quarkus.example.HelloMsg.Status status = 3;`
     */
    public fun clearStatus() {
      _builder.clearStatus()
    }
  }
}
@kotlin.jvm.JvmSynthetic
public inline fun io.quarkus.example.HelloMsg.copy(block: `io.quarkus.example`.HelloMsgKt.Dsl.() -> kotlin.Unit): io.quarkus.example.HelloMsg =
  `io.quarkus.example`.HelloMsgKt.Dsl._create(this.toBuilder()).apply { block() }._build()

public val io.quarkus.example.HelloMsgOrBuilder.dateTimeOrNull: com.google.protobuf.Timestamp?
  get() = if (hasDateTime()) getDateTime() else null


  ```
  
</details>

I am guessing this is because the generated kotlin code should not be in `build/classes/java` but rather `build/classes/kotlin`?
But if we provide a different output path for the `kotlin_out` than for `java_out` we would need a way to add this extra path also to the compile sources, which is done in `CodeGenerator.init()`, right?

