### PR TITLE
Correct javadoc of ReflectiveHierarchyBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -24,6 +24,7 @@ import io.quarkus.builder.item.MultiBuildItem;
  * register the following:
  * <p>
  * - Superclasses
+ * - Subclasses
  * - Component types of collections
  * - Types used in bean properties (if method reflection is enabled)
  * - Field types (if field reflection is enabled)


### PR DESCRIPTION
Based on Zulip conversation - https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/.E2.9C.94.20ReflectiveHierarchyBuildItem.20for.20subclasses

The code looks for subclasses of the registered type as well - see [this bit](https://github.com/quarkusio/quarkus/blob/main/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java#L155-L168) - yet the javadoc does not mention that.
