### PR TITLE
Remove customizer mappings from runtime recording Config

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -84,6 +84,7 @@ import io.smallrye.config.PropertyName;
 import io.smallrye.config.SecretKeys;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
 import io.smallrye.config.SysPropConfigSource;
 import io.smallrye.config.common.AbstractConfigSource;
 
@@ -1112,6 +1113,17 @@ public final class BuildTimeConfigurationReader {
             builder.getProfiles().add("");
             builder.getSources().clear();
             builder.getSourceProviders().clear();
+            builder.withCustomizers(new SmallRyeConfigBuilderCustomizer() {
+                @Override
+                public void configBuilder(final SmallRyeConfigBuilder builder) {
+                    builder.getMappingsBuilder().getMappings().clear();
+                }
+
+                @Override
+                public int priority() {
+                    return Integer.MAX_VALUE;
+                }
+            });
             builder.setAddDefaultSources(false)
                     // Customizers may duplicate sources, but not much we can do about it, we need to run them
                     .addDiscoveredCustomizers()


### PR DESCRIPTION
- Fixes #44246

Caused by #42157.

In #42157, we added https://github.com/radcortez/quarkus/blob/9eff425f2b6ad59e6e205b736ce2611417971d60/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigBuilderCustomizer.java to register the log config which is required in both build time and runtime.

The customizer now applies to the stripped-down version of a config instance we use to record configuration (where we have to remove the system sources):
https://github.com/quarkusio/quarkus/blob/ada7e07ff98abf80371b5f58ebf4bd8e482816a6/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java#L1101-L1110

This instance does not require any mappings at all, and it is only used to query configuration names to proceed with the recording.