### PR TITLE
Improve documentation on the usage of io.quarkus.logging.Log in extensions

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -118,6 +118,19 @@ In this example, the logger name would be `com.example.MyService`.
 WARNING: Only use the `Log` API in application classes, not in external dependencies.
 `Log` method calls that are not processed by Quarkus at build time will throw an exception.
 
+[[log-api-extension-warning]]
+==== Important Note on Using `io.quarkus.logging.Log` in Extensions
+
+While the `Log` API simplifies logging in application classes, it should not be used in extension modules or external dependencies. The following considerations apply:
+
+* `io.quarkus.logging.Log` depends on Quarkus bytecode transformations that occur at build time.
+* In extension modules, the use of `Log` may work if the module has a Jandex index. However, this behavior is not officially supported and might lead to unreliable logging.
+
+For extension development:
+
+* Use standard loggers like `org.jboss.logging.Logger.getLogger(String)` instead of `io.quarkus.logging.Log`.
+* This avoids potential performance issues caused by the stack walk fallback when Quarkus build-time processing is unavailable.
+
 
 [[injection-of-a-configured-logger]]
 === Injecting a configured logger


### PR DESCRIPTION
Description:

The current Quarkus documentation suggests using Log only in application classes, not in external dependencies. However, Log can work in extension modules if they have a Jandex index, although this behavior might not be reliable.

The documentation doesn’t mention that:

The stack walk fallback in logging can cause performance issues.
Extensions should use standard loggers like Logger.getLogger() instead of Log.