### PR TITLE
Fix wrong web endpoint path for resource on Windows

### DIFF
--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
@@ -85,6 +85,7 @@ public class WebDependencyLocatorProcessor {
                     webstream.forEach(path -> {
                         if (Files.isRegularFile(path)) {
                             String endpoint = SLASH + web.relativize(path);
+                            endpoint = endpoint.replace('\\', '/');
                             try {
                                 if (path.toString().endsWith(DOT_HTML)) {
                                     generatedStaticProducer.produce(new GeneratedStaticResourceBuildItem(endpoint,


### PR DESCRIPTION
Fixes #44576 

Tested it on Windows and it worked for me. This was caused by https://github.com/quarkusio/quarkus/pull/44128 which is marked for backport for 3.15 and was backported to 3.16.1. So for 3.15 it should be backported together.