### PR TITLE
Change the JsonRPC Service for OIDC to use recorder

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -24,6 +24,7 @@ import io.quarkus.oidc.deployment.devservices.AbstractDevUIProcessor;
 import io.quarkus.oidc.runtime.devui.OidcDevJsonRpcService;
 import io.quarkus.oidc.runtime.devui.OidcDevUiRecorder;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.runtime.HttpConfiguration;
 
 public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
 
@@ -34,9 +35,10 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     void produceProviderComponent(Optional<KeycloakDevServicesConfigBuildItem> configProps,
             BuildProducer<KeycloakAdminPageBuildItem> keycloakAdminPageProducer,
+            HttpConfiguration httpConfiguration,
             OidcDevUiRecorder recorder,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
+            BeanContainerBuildItem beanContainer,
             ConfigurationBuildItem configurationBuildItem,
             Capabilities capabilities) {
         final String keycloakAdminUrl = KeycloakDevServicesConfigBuildItem.getKeycloakUrl(configProps);
@@ -58,7 +60,7 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
                     realmUrl + "/protocol/openid-connect/token",
                     realmUrl + "/protocol/openid-connect/logout",
                     true,
-                    syntheticBeanBuildItemBuildProducer,
+                    beanContainer,
                     oidcConfig.devui().webClientTimeout(),
                     oidcConfig.devui().grantOptions(),
                     nonApplicationRootPathBuildItem,
@@ -66,7 +68,8 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
                     keycloakAdminUrl,
                     users,
                     keycloakRealms,
-                    configProps.get().isContainerRestarted());
+                    configProps.get().isContainerRestarted(),
+                    httpConfiguration);
             // use same card page so that both pages appear on the same card
             var keycloakAdminPageItem = new KeycloakAdminPageBuildItem(cardPageBuildItem);
             keycloakAdminPageProducer.produce(keycloakAdminPageItem);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
@@ -2,114 +2,69 @@ package io.quarkus.oidc.runtime.devui;
 
 import static io.quarkus.oidc.runtime.devui.OidcDevServicesUtils.getTokens;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 
-import io.quarkus.arc.Arc;
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.smallrye.common.annotation.NonBlocking;
-import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 
 public class OidcDevJsonRpcService {
+    private OidcDevUiRpcSvcPropertiesBean props;
+    private HttpConfiguration httpConfiguration;
 
-    private final String authorizationUrl;
-    private final String tokenUrl;
-    private final String logoutUrl;
-    private final Duration timeout;
-    private final Map<String, String> codeGrantOptions;
-    private final Map<String, String> passwordGrantOptions;
-    private final Map<String, String> clientCredGrantOptions;
-    private final Map<String, String> oidcUserToPassword;
-    private final int httpPort;
-    private final SmallRyeConfig config;
-    private final Vertx vertx;
-    private final String oidcProviderName;
-    private final String oidcApplicationType;
-    private final String oidcGrantType;
-    private final boolean introspectionIsAvailable;
-    private final String keycloakAdminUrl;
-    private final List<String> keycloakRealms;
-    private final boolean swaggerIsAvailable;
-    private final boolean graphqlIsAvailable;
-    private final String swaggerUiPath;
-    private final String graphqlUiPath;
-    private final boolean alwaysLogoutUserInDevUiOnReload;
-    private final String propertiesStateId;
+    private Vertx vertx;
 
-    public OidcDevJsonRpcService(HttpConfiguration httpConfiguration, SmallRyeConfig config, Vertx vertx) {
+    @PostConstruct
+    public void startup() {
+        vertx = Vertx.vertx();
+    }
 
-        // we need to inject properties bean lazily as 'OidcDevJsonRpcService' is also produced when OIDC DEV UI is not
-        // we must always produce it when in DEV mode because we can't check for 'KeycloakDevServicesConfigBuildItem'
-        // due to circular reference: JSON RPC provider is additional bean and 'LoggingSetupBuildItem' used by
-        // 'KeycloakDevServicesProcessor' is created with combined index
-        final var propsInstanceHandle = Arc.container().instance(OidcDevUiRpcSvcPropertiesBean.class);
-        final OidcDevUiRpcSvcPropertiesBean props;
-        if (propsInstanceHandle.isAvailable()) {
-            props = propsInstanceHandle.get();
-        } else {
-            // OIDC Dev UI is disabled, but this RPC service still gets initialized by Quarkus DEV UI
-            props = new OidcDevUiRpcSvcPropertiesBean(null, null, null, null, Map.of(), Map.of(), null, null, null, false, null,
-                    List.of(), false, false, null, null, false);
-        }
-
-        this.httpPort = httpConfiguration.port;
-        this.config = config;
-        this.vertx = vertx;
-        this.authorizationUrl = props.getAuthorizationUrl();
-        this.tokenUrl = props.getTokenUrl();
-        this.logoutUrl = props.getLogoutUrl();
-        this.timeout = props.getWebClientTimeout();
-        this.codeGrantOptions = props.getCodeGrantOptions();
-        this.passwordGrantOptions = props.getPasswordGrantOptions();
-        this.clientCredGrantOptions = props.getClientCredGrantOptions();
-        this.oidcUserToPassword = props.getOidcUsers();
-        this.oidcProviderName = props.getOidcProviderName();
-        this.oidcApplicationType = props.getOidcApplicationType();
-        this.oidcGrantType = props.getOidcGrantType();
-        this.introspectionIsAvailable = props.isIntrospectionIsAvailable();
-        this.keycloakAdminUrl = props.getKeycloakAdminUrl();
-        this.keycloakRealms = props.getKeycloakRealms();
-        this.swaggerIsAvailable = props.isSwaggerIsAvailable();
-        this.graphqlIsAvailable = props.isGraphqlIsAvailable();
-        this.swaggerUiPath = props.getSwaggerUiPath();
-        this.graphqlUiPath = props.getGraphqlUiPath();
-        this.alwaysLogoutUserInDevUiOnReload = props.isAlwaysLogoutUserInDevUiOnReload();
-        this.propertiesStateId = props.getPropertiesStateId();
+    @PreDestroy
+    public void shutdown() {
+        vertx.close();
     }
 
     @NonBlocking
     public OidcDevUiRuntimePropertiesDTO getProperties() {
-        return new OidcDevUiRuntimePropertiesDTO(authorizationUrl, tokenUrl, logoutUrl, config, httpPort,
-                oidcProviderName, oidcApplicationType, oidcGrantType, introspectionIsAvailable, keycloakAdminUrl,
-                keycloakRealms, swaggerIsAvailable, graphqlIsAvailable, swaggerUiPath, graphqlUiPath,
-                alwaysLogoutUserInDevUiOnReload, propertiesStateId);
+        return new OidcDevUiRuntimePropertiesDTO(props.getAuthorizationUrl(), props.getTokenUrl(), props.getLogoutUrl(),
+                ConfigProvider.getConfig(), httpConfiguration.port,
+                props.getOidcProviderName(), props.getOidcApplicationType(), props.getOidcGrantType(),
+                props.isIntrospectionIsAvailable(), props.getKeycloakAdminUrl(),
+                props.getKeycloakRealms(), props.isSwaggerIsAvailable(), props.isGraphqlIsAvailable(), props.getSwaggerUiPath(),
+                props.getGraphqlUiPath(),
+                props.isAlwaysLogoutUserInDevUiOnReload(), props.getPropertiesStateId());
     }
 
     public Uni<String> exchangeCodeForTokens(String tokenUrl, String clientId, String clientSecret,
             String authorizationCode, String redirectUri) {
-        return getTokens(tokenUrl, clientId, clientSecret, authorizationCode, redirectUri, vertx, codeGrantOptions)
-                .ifNoItem().after(timeout).fail();
+        return getTokens(tokenUrl, clientId, clientSecret, authorizationCode, redirectUri, vertx, props.getCodeGrantOptions())
+                .ifNoItem().after(props.getWebClientTimeout()).fail();
     }
 
     public Uni<Integer> testServiceWithToken(String token, String serviceUrl) {
         return OidcDevServicesUtils
                 .testServiceWithToken(serviceUrl, token, vertx)
-                .ifNoItem().after(timeout).fail();
+                .ifNoItem().after(props.getWebClientTimeout()).fail();
     }
 
     public Uni<String> testServiceWithPassword(String tokenUrl, String serviceUrl, String clientId,
             String clientSecret, String username, String password) {
         return OidcDevServicesUtils.testServiceWithPassword(tokenUrl, serviceUrl, clientId, clientSecret, username,
-                password, vertx, timeout, passwordGrantOptions, oidcUserToPassword);
+                password, vertx, props.getWebClientTimeout(), props.getPasswordGrantOptions(), props.getOidcUsers());
     }
 
     public Uni<String> testServiceWithClientCred(String tokenUrl, String serviceUrl, String clientId,
             String clientSecret) {
         return OidcDevServicesUtils.testServiceWithClientCred(tokenUrl, serviceUrl, clientId, clientSecret, vertx,
-                timeout, clientCredGrantOptions);
+                props.getWebClientTimeout(), props.getClientCredGrantOptions());
     }
 
+    public void hydrate(OidcDevUiRpcSvcPropertiesBean properties, HttpConfiguration httpConfiguration) {
+        this.props = properties;
+        this.httpConfiguration = httpConfiguration;
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevUiRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevUiRecorder.java
@@ -3,25 +3,31 @@ package io.quarkus.oidc.runtime.devui;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.vertx.http.runtime.HttpConfiguration;
 
 @Recorder
 public class OidcDevUiRecorder {
-    public Supplier<OidcDevUiRpcSvcPropertiesBean> prepareRpcServiceProperties(String authorizationUrl, String tokenUrl,
+
+    public void createJsonRPCService(BeanContainer beanContainer,
+            RuntimeValue<OidcDevUiRpcSvcPropertiesBean> oidcDevUiRpcSvcPropertiesBean, HttpConfiguration httpConfiguration) {
+        OidcDevJsonRpcService jsonRpcService = beanContainer.beanInstance(OidcDevJsonRpcService.class);
+        jsonRpcService.hydrate(oidcDevUiRpcSvcPropertiesBean.getValue(), httpConfiguration);
+    }
+
+    public RuntimeValue<OidcDevUiRpcSvcPropertiesBean> getRpcServiceProperties(String authorizationUrl, String tokenUrl,
             String logoutUrl, Duration webClientTimeout, Map<String, Map<String, String>> grantOptions,
             Map<String, String> oidcUsers, String oidcProviderName, String oidcApplicationType, String oidcGrantType,
             boolean introspectionIsAvailable, String keycloakAdminUrl, List<String> keycloakRealms, boolean swaggerIsAvailable,
             boolean graphqlIsAvailable, String swaggerUiPath, String graphqlUiPath, boolean alwaysLogoutUserInDevUiOnReload) {
-        return new Supplier<OidcDevUiRpcSvcPropertiesBean>() {
-            @Override
-            public OidcDevUiRpcSvcPropertiesBean get() {
-                return new OidcDevUiRpcSvcPropertiesBean(authorizationUrl, tokenUrl, logoutUrl,
+
+        return new RuntimeValue<OidcDevUiRpcSvcPropertiesBean>(
+                new OidcDevUiRpcSvcPropertiesBean(authorizationUrl, tokenUrl, logoutUrl,
                         webClientTimeout, grantOptions, oidcUsers, oidcProviderName, oidcApplicationType, oidcGrantType,
                         introspectionIsAvailable, keycloakAdminUrl, keycloakRealms, swaggerIsAvailable,
-                        graphqlIsAvailable, swaggerUiPath, graphqlUiPath, alwaysLogoutUserInDevUiOnReload);
-            }
-        };
+                        graphqlIsAvailable, swaggerUiPath, graphqlUiPath, alwaysLogoutUserInDevUiOnReload));
     }
 }


### PR DESCRIPTION
This is for #44181. It does not fix it, but takes Dev UI out of the picture. 

This PR change the way we make data available to the JSON RPC service.  It now use a recorder to record it directly on the JsonRPC Service.

On another note, we can probably use build time data (that can also accept a runtime value) for some of the json-rpc methods. However this is a bigger and riskier change (with the same result) so I kept it simple. If the maintainers (@sberyozkin) wants to pursue this I can show what I suggest.