### PR TITLE
Fix concurrency protocol in UniResponseHandler

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/UniResponseHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/UniResponseHandler.java
@@ -17,26 +17,28 @@ public class UniResponseHandler implements ServerRestHandler {
         if (requestContext.getResult() instanceof Uni<?> result) {
             requestContext.suspend();
 
-            AtomicBoolean done = new AtomicBoolean();
+            AtomicBoolean done = new AtomicBoolean(false);
             Cancellable cancellable = result.subscribe().with(new Consumer<Object>() {
                 @Override
                 public void accept(Object v) {
-                    done.set(true);
-                    requestContext.setResult(v);
-                    requestContext.resume();
+                    if (done.compareAndSet(false, true)) {
+                        requestContext.setResult(v);
+                        requestContext.resume();
+                    }
                 }
             }, new Consumer<>() {
                 @Override
                 public void accept(Throwable t) {
-                    done.set(true);
-                    requestContext.resume(t, true);
+                    if (done.compareAndSet(false, true)) {
+                        requestContext.resume(t, true);
+                    }
                 }
             });
 
             requestContext.serverResponse().addCloseHandler(new Runnable() {
                 @Override
                 public void run() {
-                    if (!done.get()) {
+                    if (done.compareAndSet(false, true)) {
                         cancellable.cancel();
                         try {
                             // get rid of everything related to the request since the connection has already gone away


### PR DESCRIPTION
If the HTTP connection is closed before the subscription callbacks are called, you may end up in a race between the subscription and the close handler. This was only happening if the subscription was switching threads (otherwise everything was called on the same thread and the race could not happen)
