### PR TITLE
Optional `quarkus.config.build-time-mismatch-at-runtime` with default

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
@@ -62,7 +62,8 @@ public class ConfigRecorder {
             String msg = "Build time property cannot be changed at runtime:\n" + String.join("\n", mismatches);
             // TODO - This should use ConfigConfig, but for some reason, the test fails sometimes with mapping not found when looking ConfigConfig
             BuildTimeMismatchAtRuntime buildTimeMismatchAtRuntime = config
-                    .getValue("quarkus.config.build-time-mismatch-at-runtime", BuildTimeMismatchAtRuntime.class);
+                    .getOptionalValue("quarkus.config.build-time-mismatch-at-runtime", BuildTimeMismatchAtRuntime.class)
+                    .orElse(warn);
             if (fail.equals(buildTimeMismatchAtRuntime)) {
                 throw new IllegalStateException(msg);
             } else if (warn.equals(buildTimeMismatchAtRuntime)) {


### PR DESCRIPTION
To fix failure found in:
https://github.com/quarkusio/quarkus/pull/44588#issuecomment-2488674112

The previous code in https://github.com/quarkusio/quarkus/pull/44559 wouldn't fix it because the mapping itself provides the default. If the mapping is not available, the default wouldn't be either.