### PR TITLE
ArC: improve how intercepted methods are searched for

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -194,11 +194,15 @@ final class Methods {
             Set<AnnotationInstance> bindings = mergeBindings(beanDeployment, originalClassInfo, classLevelBindings,
                     ignoreMethodLevelBindings, method, noClassInterceptorsMethods, bindingsDiscovery);
             boolean possiblyIntercepted = !bindings.isEmpty() || targetHasAroundInvokes;
+            if (!possiblyIntercepted) {
+                candidates.put(key, bindings);
+                continue;
+            }
             if (skipPredicate.test(method)) {
                 continue;
             }
             boolean addToCandidates = true;
-            if (Modifier.isFinal(method.flags()) && possiblyIntercepted) {
+            if (Modifier.isFinal(method.flags())) {
                 if (transformUnproxyableClasses && !isNoninterceptableKotlinMethod(method)) {
                     methodsFromWhichToRemoveFinal.add(new MethodKey(method));
                 } else {
@@ -207,7 +211,7 @@ final class Methods {
                 }
             }
             if (addToCandidates) {
-                candidates.putIfAbsent(key, bindings);
+                candidates.put(key, bindings);
             }
         }
         skipPredicate.methodsProcessed();


### PR DESCRIPTION
If there are no interceptor binding annotations on the method, we can interrupt the search process a bit earlier and don't have to call the "skip this method?" predicate. This slightly improves the user experience, because the predicate can pring warnings (which would be useless in this case).