### PR TITLE
Do not add host:port to Health path in Health UI

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -391,7 +391,7 @@ class SmallRyeHealthProcessor {
             }
 
             String healthPath = nonApplicationRootPathBuildItem.resolveManagementPath(healthConfig.rootPath,
-                    managementInterfaceBuildTimeConfig, launchModeBuildItem);
+                    managementInterfaceBuildTimeConfig, launchModeBuildItem, false);
 
             webJarBuildProducer.produce(
                     WebJarBuildItem.builder().artifactKey(HEALTH_UI_WEBJAR_ARTIFACT_KEY) //


### PR DESCRIPTION
The Health UI will be served from the exact same interface so we don't need to include the host:port.
It actually causes issues when you access the Health UI through a proxy as it might point to 0.0.0.0:9000 which will resolve to localhost.

Fixes #35980