### PR TITLE
Remove `jdk.internal.io.JdkConsoleProvider` service providers from `ServiceCatalog` in a similar way to GraalVM's `ServiceLoaderFeature` which Quarkus disables by default

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -784,6 +784,11 @@ public class NativeImageBuildStep {
                 for (NativeImageFeatureBuildItem nativeImageFeature : nativeImageFeatures) {
                     featuresList.add(nativeImageFeature.getQualifiedName());
                 }
+                if (!nativeConfig.autoServiceLoaderRegistration()) {
+                    featuresList.add("io.quarkus.runtime.graal.SkipConsoleServiceProvidersFeature");
+                    // required by the feature
+                    nativeImageArgs.add("-J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED");
+                }
                 nativeImageArgs.add("--features=" + String.join(",", featuresList));
 
                 if (nativeConfig.debug().enabled()) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/SkipConsoleServiceProvidersFeature.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/SkipConsoleServiceProvidersFeature.java
@@ -1,0 +1,54 @@
+package io.quarkus.runtime.graal;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.graalvm.nativeimage.hosted.Feature;
+
+/**
+ * Removes {@code jdk.internal.io.JdkConsoleProvider} service providers from the {@code ServiceCatalog} in a similar way to
+ * GraalVM's {@code ServiceLoaderFeature} which Quarkus disables by default.
+ */
+public class SkipConsoleServiceProvidersFeature implements Feature {
+    static final HashMap<String, Set<String>> omittedServiceProviders;
+
+    @Override
+    public String getDescription() {
+        return "Skip unsupported console service providers when quarkus.native.auto-service-loader-registration is false";
+    }
+
+    static {
+        omittedServiceProviders = new HashMap<>(1);
+        omittedServiceProviders.put("jdk.internal.io.JdkConsoleProvider",
+                new HashSet<>(Arrays.asList("jdk.jshell.execution.impl.ConsoleImpl$ConsoleProviderImpl",
+                        "jdk.internal.org.jline.JdkConsoleProviderImpl")));
+    }
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        Class<?> serviceCatalogSupport;
+        Method singleton;
+        Method removeServices;
+        try {
+            serviceCatalogSupport = Class.forName("com.oracle.svm.core.jdk.ServiceCatalogSupport");
+            singleton = serviceCatalogSupport.getDeclaredMethod("singleton");
+            removeServices = serviceCatalogSupport.getDeclaredMethod("removeServicesFromServicesCatalog", String.class,
+                    Set.class);
+            var result = singleton.invoke(null);
+            omittedServiceProviders.forEach((key, value) -> {
+                try {
+                    removeServices.invoke(result, key, value);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
GraalVM removes/skips [`jdk.internal.org.jline.JdkConsoleProviderImpl` and `jdk.jshell.execution.impl.ConsoleImpl$ConsoleProviderImpl` providers in the `ServiceLoaderFeature`](https://github.com/oracle/graal/blob/f51c7c3049d705c3e53e81f2bc3a29a63f9119a8/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ServiceLoaderFeature.java#L116-L117).

Since Quarkus disabled this feature by default, this PR handles the removal/skip of these providers to work-around warnings related to these providers when using `-H:ThrowMissingRegistrationErrors=`.

Relates to https://github.com/quarkusio/quarkus/issues/41995