### PR TITLE
Allow CORS wildcard headers

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSAccessControlWildcardTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSAccessControlWildcardTestCase.java
@@ -19,16 +19,26 @@ class CORSAccessControlWildcardTestCase
 
 	@Test
 	@DisplayName("Checks that setting the config of the Access-Control-* header to wildcard will end up in at the client.")
-	void corsAccessControlHeaderCanBeWildcards()
+	void corsControlExposeHeaderCanBeWildcards()
 	{
 
 		given().header("Origin", "http://custom.origin.quarkus")
 			.when()
 			.get("/test").then()
 			.statusCode(200)
+			.header("Access-Control-Expose-Headers", "*");
+	}
+	@Test
+	@DisplayName("Checks that setting the config of the Access-Control-* header to wildcard will end up in at the client.")
+	void corsAccessControlHeaderCanBeWildcards()
+	{
+
+		given().header("Origin", "http://custom.origin.quarkus")
+			.when()
+			.options("/test").then()
+			.statusCode(200)
 			.header("Access-Control-Allow-Origin", "http://custom.origin.quarkus")
 			.header("Access-Control-Allow-Methods", "*")
-			.header("Access-Control-Expose-Headers", "*")
 			.header("Access-Control-Allow-Headers", "*");
 	}
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSAccessControlWildcardTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSAccessControlWildcardTestCase.java
@@ -1,0 +1,35 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class CORSAccessControlWildcardTestCase
+{
+
+	@RegisterExtension
+	static QuarkusUnitTest runner = new QuarkusUnitTest()
+		.withApplicationRoot((jar) -> jar
+			.addClasses(BeanRegisteringRoute.class)
+			.addAsResource("conf/cors-access-control-wildcard.properties", "application.properties"));
+
+	@Test
+	@DisplayName("Checks that setting the config of the Access-Control-* header to wildcard will end up in at the client.")
+	void corsAccessControlHeaderCanBeWildcards()
+	{
+
+		given().header("Origin", "http://custom.origin.quarkus")
+			.when()
+			.get("/test").then()
+			.statusCode(200)
+			.header("Access-Control-Allow-Origin", "http://custom.origin.quarkus")
+			.header("Access-Control-Allow-Methods", "*")
+			.header("Access-Control-Expose-Headers", "*")
+			.header("Access-Control-Allow-Headers", "*");
+	}
+
+}

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-access-control-wildcard.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-access-control-wildcard.properties
@@ -1,0 +1,5 @@
+quarkus.http.cors=true
+quarkus.http.cors.origins=http://custom.origin.quarkus, http://www.quarkus.io
+quarkus.http.cors.methods=*
+quarkus.http.cors.headers=*
+quarkus.http.cors.exposed-headers=*

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -55,9 +55,6 @@ public class CORSFilter implements Handler<RoutingContext> {
         if (headers.get().isEmpty()) {
             return null;
         }
-        if (headers.get().size() == 1 && headers.get().get(0).equals("*")) {
-            return null;
-        }
         return String.join(",", headers.get());
     }
 


### PR DESCRIPTION
Currently it is not possible to set wildcard header values for some CORS Headers.

This bug concerns:
- [Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers)
- [Access-Control-Allow-Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods)
- [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers)

All of which can, according to the specs set to "\*". 
Setting this value in the quarkus properies, results in quarkus not setting the header field. This is not correct, since the default values are not "\*". 

This PR fixes this behavior.