### PR TITLE
Improve debugging of `GeneratedClassBuildItem`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedClassBuildItem.java
@@ -6,6 +6,8 @@ public final class GeneratedClassBuildItem extends MultiBuildItem {
 
     final boolean applicationClass;
     final String name;
+    String binaryName;
+    String internalName;
     final byte[] classData;
     final String source;
 
@@ -27,8 +29,37 @@ public final class GeneratedClassBuildItem extends MultiBuildItem {
         return applicationClass;
     }
 
+    /**
+     * {@return a name for this class}
+     *
+     * @deprecated This method may return the binary name, the internal name, or a hybrid thereof and should not be
+     *             used. Use {@link #binaryName()} or {@link #internalName()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public String getName() {
         return name;
+    }
+
+    /**
+     * {@return the <em>binary name</em> of the class, which is delimited by <code>.</code> characters}
+     */
+    public String binaryName() {
+        String binaryName = this.binaryName;
+        if (binaryName == null) {
+            binaryName = this.binaryName = name.replace('/', '.');
+        }
+        return binaryName;
+    }
+
+    /**
+     * {@return the <em>internal name</em> of the class, which is delimited by <code>/</code> characters}
+     */
+    public String internalName() {
+        String internalName = this.internalName;
+        if (internalName == null) {
+            internalName = this.internalName = name.replace('.', '/');
+        }
+        return internalName;
     }
 
     public byte[] getClassData() {
@@ -39,4 +70,7 @@ public final class GeneratedClassBuildItem extends MultiBuildItem {
         return source;
     }
 
+    public String toString() {
+        return "GeneratedClassBuildItem[" + binaryName() + "]";
+    }
 }

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
@@ -131,11 +131,12 @@ public class DefaultSerdeConfigTest {
                     });
 
             assertThat(generated)
-                    .extracting(GeneratedClassBuildItem::getName)
+                    .extracting(GeneratedClassBuildItem::internalName)
                     .allSatisfy(s -> assertThat(generatedNames).satisfiesOnlyOnce(c -> c.apply(s)));
 
             assertThat(reflective)
                     .flatExtracting(ReflectiveClassBuildItem::getClassNames)
+                    .extracting(n -> n.replace('/', '.'))
                     .allSatisfy(s -> assertThat(reflectiveNames).satisfiesOnlyOnce(c -> c.apply(s)));
         } finally {
             // must not leak the lazily-initialized Config instance associated to the system classloader


### PR DESCRIPTION
Add a `toString` so we can easily see the list in a debugger, and normalize the class name to "binary form" (i.e. separated by `.` instead of a mix of `.` and `/`).