### PR TITLE
Pass secured method arguments into security checks for `@PreAuthorize` security annotation on SpringWeb endpoints

### DIFF
--- a/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/BeanMethodInvocationGenerator.java
+++ b/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/BeanMethodInvocationGenerator.java
@@ -130,6 +130,7 @@ class BeanMethodInvocationGenerator {
                 instanceNullTrue.returnValue(newInstance);
             }
 
+            boolean checkRequiresMethodArguments = false;
             try (MethodCreator check = cc.getMethodCreator("check", boolean.class, SecurityIdentity.class, Object[].class)
                     .setModifiers(Modifier.PROTECTED)) {
                 ResultHandle arcContainer = check
@@ -155,6 +156,7 @@ class BeanMethodInvocationGenerator {
 
                         argHandles[i] = check.load(argumentExpression.replace("'", ""));
                     } else if (trimmedArgumentExpression.matches(METHOD_PARAMETER_REGEX)) { // secured method's parameter case
+                        checkRequiresMethodArguments = true;
                         Matcher parameterMatcher = METHOD_PARAMETER_PATTERN.matcher(trimmedArgumentExpression);
                         if (!parameterMatcher.find()) { // should never happen
                             throw createGenericMalformedException(securedMethodInfo, expression);
@@ -205,6 +207,13 @@ class BeanMethodInvocationGenerator {
                 }
 
                 check.returnValue(result);
+            }
+
+            if (checkRequiresMethodArguments) {
+                try (MethodCreator check = cc.getMethodCreator("requiresMethodArguments", boolean.class)
+                        .setModifiers(Modifier.PUBLIC)) {
+                    check.returnBoolean(true);
+                }
             }
         }
 

--- a/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/security/PersonChecker.java
+++ b/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/security/PersonChecker.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.spring.security;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PersonChecker {
+    public boolean check(String name) {
+        return name.equals("correct-name");
+    }
+}

--- a/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/security/TheController.java
+++ b/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/security/TheController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -63,4 +64,9 @@ public class TheController {
         return "preAuthorizeOnController";
     }
 
+    @GetMapping("/preAuthorizeOnControllerWithArgs/{user}")
+    @PreAuthorize("@personChecker.check(#user)")
+    public String preAuthorizeOnControllerWithArgs(@PathVariable String user) {
+        return "Hello " + user + "!";
+    }
 }

--- a/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SecurityTest.java
+++ b/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SecurityTest.java
@@ -51,6 +51,16 @@ public class SecurityTest {
     }
 
     @Test
+    public void preAuthorizeOnControllerWithArgs() {
+        String path = "/api/preAuthorizeOnControllerWithArgs/";
+        assertForAnonymous(path + "correct-name", 401, Optional.empty());
+        assertStatusAndContent(RestAssured.given().auth().preemptive().basic("stuart", "test"), path + "wrong-name", 403,
+                Optional.empty());
+        assertStatusAndContent(RestAssured.given().auth().preemptive().basic("aurea", "auri"), path + "correct-name", 200,
+                Optional.of("Hello correct-name!"));
+    }
+
+    @Test
     public void shouldAccessAllowed() {
         assertForAnonymous("/api/accessibleForAllMethod", 200, Optional.of("accessibleForAll"));
         assertForUsers("/api/accessibleForAllMethod", 200, Optional.of("accessibleForAll"));


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/44511

When `@PreAuthorize` placed on endpoints requires secured method arguments, we need to divide security check into 2, one is done eagerly ("is authenticated") and one is done by CDI interceptors when secured method arguments are already available. This is valid for both RESTEasy and Quarkus REST used together with Spring Web, but we only need to test that https://github.com/quarkusio/quarkus/blob/9007580a2c4614fe13d88090fe0b67ef8b4d49e9/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/SecurityCheck.java#L46 returns true (as the mechanism itself is heavily tested for other reasons). I don't know if in Spring you can pass secured method arguments for anonymous users as well, but that we won't support.