### PR TITLE
Support @AuthorizationPolicy on suspended Kotlin endpoint methods

### DIFF
--- a/integration-tests/resteasy-reactive-kotlin/standard/pom.xml
+++ b/integration-tests/resteasy-reactive-kotlin/standard/pom.xml
@@ -41,6 +41,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-integration-test-shared-library</artifactId>
         </dependency>
         <!-- Added only to make sure that the default exporter compiles in native -->
@@ -176,6 +180,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SecuredClassResource.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SecuredClassResource.kt
@@ -1,0 +1,17 @@
+package io.quarkus.it.resteasy.reactive.kotlin
+
+import io.quarkus.vertx.http.security.AuthorizationPolicy
+import jakarta.annotation.security.PermitAll
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+
+@AuthorizationPolicy(name = "suspended")
+@Path("/secured-class")
+class SecuredClassResource {
+
+    @Path("/authorization-policy-suspend")
+    @GET
+    suspend fun authorizationPolicySuspend() = "Hello from Quarkus REST"
+
+    @PermitAll @Path("/public") @GET suspend fun publicEndpoint() = "Hello to everyone!"
+}

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SecuredMethodResource.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SecuredMethodResource.kt
@@ -1,0 +1,14 @@
+package io.quarkus.it.resteasy.reactive.kotlin
+
+import io.quarkus.vertx.http.security.AuthorizationPolicy
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+
+@Path("/secured-method")
+class SecuredMethodResource {
+
+    @Path("/authorization-policy-suspend")
+    @GET
+    @AuthorizationPolicy(name = "suspended")
+    suspend fun authorizationPolicySuspend() = "Hello from Quarkus REST"
+}

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SuspendAuthorizationPolicy.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SuspendAuthorizationPolicy.kt
@@ -1,0 +1,26 @@
+package io.quarkus.it.resteasy.reactive.kotlin
+
+import io.quarkus.security.identity.SecurityIdentity
+import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy
+import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.CheckResult
+import io.smallrye.mutiny.Uni
+import io.vertx.core.http.HttpHeaders
+import io.vertx.ext.web.RoutingContext
+import jakarta.enterprise.context.ApplicationScoped
+
+@ApplicationScoped
+class SuspendAuthorizationPolicy : HttpSecurityPolicy {
+    override fun checkPermission(
+        request: RoutingContext?,
+        identity: Uni<SecurityIdentity>?,
+        requestContext: HttpSecurityPolicy.AuthorizationRequestContext?
+    ): Uni<CheckResult> {
+        val authZHeader = request?.request()?.getHeader(HttpHeaders.AUTHORIZATION)
+        if (authZHeader == "you-can-trust-me") {
+            return CheckResult.permit()
+        }
+        return CheckResult.deny()
+    }
+
+    override fun name() = "suspended"
+}

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SecurityTest.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SecurityTest.kt
@@ -1,0 +1,47 @@
+package io.quarkus.it.resteasy.reactive.kotlin
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.vertx.core.http.HttpHeaders
+import org.hamcrest.CoreMatchers
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class SecurityTest {
+
+    @Test
+    fun testAuthorizationPolicyOnSuspendedMethod_MethodLevel() {
+        When { get("/secured-method/authorization-policy-suspend") } Then { statusCode(403) }
+        Given { header(HttpHeaders.AUTHORIZATION.toString(), "you-can-trust-me") } When
+            {
+                get("/secured-method/authorization-policy-suspend")
+            } Then
+            {
+                statusCode(200)
+                body(CoreMatchers.`is`("Hello from Quarkus REST"))
+            }
+    }
+
+    @Test
+    fun testAuthorizationPolicyOnSuspendedMethod_ClassLevel() {
+        // test class-level annotation is applied on a secured method
+        When { get("/secured-class/authorization-policy-suspend") } Then { statusCode(403) }
+        Given { header(HttpHeaders.AUTHORIZATION.toString(), "you-can-trust-me") } When
+            {
+                get("/secured-class/authorization-policy-suspend")
+            } Then
+            {
+                statusCode(200)
+                body(CoreMatchers.`is`("Hello from Quarkus REST"))
+            }
+
+        // test method-level @PermitAll has priority over @AuthorizationPolicy on the class
+        When { get("/secured-class/public") } Then
+            {
+                statusCode(200)
+                body(CoreMatchers.`is`("Hello to everyone!"))
+            }
+    }
+}


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/44568

When there is suspended Kotlin endpoints secured with `@AuthorizePolicy`, build fails because I have added extra validation that when annotated method doesn't match some minimal parameters (is public, not a constructor, not static, not synthetic), validation fails. The idea was to inform user early they probably made mistake. I didn't know that for suspended Kotlin functions, there are 2 methods:

- originalMethodName
- originalMethodName$suspendImpl