### PR TITLE
Quarkus REST Jackson: Improve detection of generic fields annotated with the `@SecureField` and allow to explicitly enable secure serialization

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -1535,6 +1535,9 @@ WARNING: Currently you cannot use the `@SecureField` annotation to secure your d
 ====
 All resource methods returning data secured with the `@SecureField` annotation should be tested.
 Please make sure data are secured as you intended.
+Quarkus always attempts to detect fields annotated with the `@SecureField` annotation,
+however it may fail to infer returned type and miss the `@SecureField` annotation instance.
+If that happens, please explicitly enable secure serialization on the resource endpoint with the `@EnableSecureSerialization` annotation.
 ====
 
 Assuming security has been set up for the application (see our xref:security-overview.adoc[guide] for more details), when a user with the `admin` role

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/DisableSecureSerializationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/DisableSecureSerializationTest.java
@@ -1,0 +1,94 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.jackson.DisableSecureSerialization;
+import io.quarkus.resteasy.reactive.jackson.EnableSecureSerialization;
+import io.quarkus.resteasy.reactive.jackson.SecureField;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+
+public class DisableSecureSerializationTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class));
+
+    @Test
+    public void testDisablingOfSecureSerialization() {
+        request("disabled", "user").body("secretField", Matchers.is("secret"));
+        request("disabled", "admin").body("secretField", Matchers.is("secret"));
+        request("enabled", "user").body("secretField", Matchers.nullValue());
+        request("enabled", "admin").body("secretField", Matchers.is("secret"));
+    }
+
+    private static ValidatableResponse request(String subPath, String user) {
+        TestIdentityController.resetRoles().add(user, user, user);
+        return RestAssured
+                .with()
+                .auth().preemptive().basic(user, user)
+                .get("/test/" + subPath)
+                .then()
+                .statusCode(200)
+                .body("publicField", Matchers.is("public"));
+    }
+
+    @DisableSecureSerialization
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("test")
+    public static class GreetingsResource {
+
+        @Path("disabled")
+        @GET
+        public Dto disabled() {
+            return Dto.createDto();
+        }
+
+        @EnableSecureSerialization
+        @Path("enabled")
+        @GET
+        public Dto enabled() {
+            return Dto.createDto();
+        }
+    }
+
+    public static class Dto {
+
+        public Dto(String secretField, String publicField) {
+            this.secretField = secretField;
+            this.publicField = publicField;
+        }
+
+        @SecureField(rolesAllowed = "admin")
+        private final String secretField;
+
+        private final String publicField;
+
+        public String getSecretField() {
+            return secretField;
+        }
+
+        public String getPublicField() {
+            return publicField;
+        }
+
+        private static Dto createDto() {
+            return new Dto("secret", "public");
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/Fruit.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/Fruit.java
@@ -1,0 +1,16 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.List;
+
+public class Fruit {
+
+    public String name;
+
+    public List<Price> prices;
+
+    public Fruit(String name, Float price) {
+        this.name = name;
+        this.prices = List.of(new Price("USD", price));
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/GenericWrapper.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/GenericWrapper.java
@@ -1,0 +1,14 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+public class GenericWrapper<T> {
+
+    public String name;
+
+    public T entity;
+
+    public GenericWrapper(String name, T entity) {
+        this.name = name;
+        this.entity = entity;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/Price.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/Price.java
@@ -1,0 +1,17 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import io.quarkus.resteasy.reactive.jackson.SecureField;
+
+public class Price {
+
+    @SecureField(rolesAllowed = "admin")
+    public Float price;
+
+    public String currency;
+
+    public Price(String currency, Float price) {
+        this.currency = currency;
+        this.price = price;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import io.quarkus.resteasy.reactive.jackson.CustomDeserialization;
 import io.quarkus.resteasy.reactive.jackson.CustomSerialization;
 import io.quarkus.resteasy.reactive.jackson.DisableSecureSerialization;
-import io.quarkus.resteasy.reactive.jackson.EnableSecureSerialization;
 import io.quarkus.runtime.BlockingOperationControl;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
@@ -41,7 +40,6 @@ import io.smallrye.mutiny.Uni;
 
 @Path("/simple")
 @NonBlocking
-@DisableSecureSerialization
 public class SimpleJsonResource extends SuperClass<Person> {
 
     @ServerExceptionMapper
@@ -50,6 +48,7 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return Response.status(Response.Status.BAD_REQUEST).entity(cause.getMessage()).build();
     }
 
+    @DisableSecureSerialization
     @GET
     @Path("/person")
     public Person getPerson() {
@@ -61,7 +60,6 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return person;
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/frog")
     public Frog getFrog() {
@@ -74,35 +72,30 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return frog;
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/frog-body-parts")
     public FrogBodyParts getFrogBodyParts() {
         return new FrogBodyParts("protruding eyes");
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/interface-dog")
     public SecuredPersonInterface getInterfaceDog() {
         return createDog();
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/abstract-dog")
     public AbstractPet getAbstractDog() {
         return createDog();
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/abstract-named-dog")
     public AbstractNamedPet getAbstractNamedDog() {
         return createDog();
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/dog")
     public Dog getDog() {
@@ -130,46 +123,46 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return mapWrapper;
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/abstract-cat")
     public AbstractPet getAbstractCat() {
         return createCat();
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/interface-cat")
     public SecuredPersonInterface getInterfaceCat() {
         return createCat();
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/abstract-named-cat")
     public AbstractNamedPet getAbstractNamedCat() {
         return createCat();
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/cat")
     public Cat getCat() {
         return createCat();
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/unsecured-pet")
     public UnsecuredPet getUnsecuredPet() {
         return createUnsecuredPet();
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("/abstract-unsecured-pet")
     public AbstractUnsecuredPet getAbstractUnsecuredPet() {
         return createUnsecuredPet();
+    }
+
+    @GET
+    @Path("/secure-field-on-type-variable")
+    public GenericWrapper<Fruit> getWithSecureFieldOnTypeVariable() {
+        return new GenericWrapper<>("wrapper", new Fruit("Apple", 1.0f));
     }
 
     private static UnsecuredPet createUnsecuredPet() {
@@ -212,6 +205,7 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return getPerson();
     }
 
+    @DisableSecureSerialization
     @CustomDeserialization(UnquotedFieldsPersonDeserialization.class)
     @POST
     @Path("custom-deserialized-person")
@@ -219,7 +213,6 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return request;
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("secure-person")
     public Person getSecurePerson() {
@@ -227,7 +220,6 @@ public class SimpleJsonResource extends SuperClass<Person> {
     }
 
     @JsonView(Views.Public.class)
-    @EnableSecureSerialization
     @GET
     @Path("secure-person-with-public-view")
     public Person getSecurePersonWithPublicView() {
@@ -235,7 +227,6 @@ public class SimpleJsonResource extends SuperClass<Person> {
     }
 
     @JsonView(Views.Public.class)
-    @EnableSecureSerialization
     @GET
     @Path("uni-secure-person-with-public-view")
     public Uni<Person> getUniSecurePersonWithPublicView() {
@@ -243,41 +234,37 @@ public class SimpleJsonResource extends SuperClass<Person> {
     }
 
     @JsonView(Views.Private.class)
-    @EnableSecureSerialization
     @GET
     @Path("secure-person-with-private-view")
     public Person getSecurePersonWithPrivateView() {
         return getPerson();
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("secure-uni-person")
     public Uni<Person> getSecureUniPerson() {
         return Uni.createFrom().item(getPerson());
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("secure-rest-response-person")
     public RestResponse<Person> getSecureRestResponsePerson() {
         return RestResponse.ok(getPerson());
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("secure-people")
     public List<Person> getSecurePeople() {
         return Collections.singletonList(getPerson());
     }
 
-    @EnableSecureSerialization
     @GET
     @Path("secure-uni-people")
     public Uni<List<Person>> getSecureUniPeople() {
         return Uni.createFrom().item(Collections.singletonList(getPerson()));
     }
 
+    @DisableSecureSerialization
     @POST
     @Path("/person")
     @Produces(MediaType.APPLICATION_JSON)
@@ -322,6 +309,7 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return Response.ok(person).status(201).header("Content-Type", "application/vnd.quarkus.other-v1+json").build();
     }
 
+    @DisableSecureSerialization
     @POST
     @Path("/people")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -354,6 +342,7 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return strings;
     }
 
+    @DisableSecureSerialization
     @POST
     @Path("/person-large")
     @Produces(MediaType.APPLICATION_JSON)
@@ -365,6 +354,7 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return person;
     }
 
+    @DisableSecureSerialization
     @POST
     @Path("/person-validated")
     @Produces(MediaType.APPLICATION_JSON)

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -36,7 +36,8 @@ public class SimpleJsonTest {
                                     AbstractPet.class, Dog.class, Cat.class, Veterinarian.class, AbstractNamedPet.class,
                                     AbstractUnsecuredPet.class, UnsecuredPet.class, SecuredPersonInterface.class, Frog.class,
                                     Pond.class, FrogBodyParts.class, FrogBodyParts.BodyPart.class, ContainerDTO.class,
-                                    NestedInterface.class, StateRecord.class, MapWrapper.class)
+                                    NestedInterface.class, StateRecord.class, MapWrapper.class, GenericWrapper.class,
+                                    Fruit.class, Price.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n"), "application.properties");
@@ -582,6 +583,26 @@ public class SimpleJsonTest {
                 .then()
                 .statusCode(200)
                 .body("parts[0].name", Matchers.is("protruding eyes"));
+    }
+
+    @Test
+    public void testSecureFieldOnTypeVariable() {
+        TestIdentityController.resetRoles().add("max", "max", "user");
+        RestAssured
+                .with()
+                .auth().preemptive().basic("max", "max")
+                .get("/simple/secure-field-on-type-variable")
+                .then()
+                .statusCode(200)
+                .body("entity.prices[0].price", Matchers.nullValue());
+        TestIdentityController.resetRoles().add("rolfe", "rolfe", "admin");
+        RestAssured
+                .with()
+                .auth().preemptive().basic("rolfe", "rolfe")
+                .get("/simple/secure-field-on-type-variable")
+                .then()
+                .statusCode(200)
+                .body("entity.prices[0].price", Matchers.notNullValue());
     }
 
     private static void testSecuredFieldOnReturnTypeField(String subPath) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -5,6 +5,8 @@ import java.util.function.Supplier;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.security.test.utils.TestIdentityController;
@@ -25,7 +27,8 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends SimpleJsonTest 
                                     AbstractPet.class, Dog.class, Cat.class, Veterinarian.class, AbstractNamedPet.class,
                                     AbstractUnsecuredPet.class, UnsecuredPet.class, SecuredPersonInterface.class, Frog.class,
                                     Pond.class, FrogBodyParts.class, FrogBodyParts.BodyPart.class, ContainerDTO.class,
-                                    NestedInterface.class, StateRecord.class, MapWrapper.class)
+                                    NestedInterface.class, StateRecord.class, MapWrapper.class, GenericWrapper.class,
+                                    Fruit.class, Price.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +
@@ -33,4 +36,11 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends SimpleJsonTest 
                                     "application.properties");
                 }
             });
+
+    @Disabled("Doesn't work with the reflection free serializers")
+    @Test
+    @Override
+    public void testSecureFieldOnTypeVariable() {
+        super.testSecureFieldOnTypeVariable();
+    }
 }


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/44646
- fixes reproducer that requires to resolve type params to actual types
  - this is done only for the endpoint return type (AKA once, it shouldn't have impact on time required to detect secure field)
- however this won't work for more complex scenarios and personally I think it was never aim; for that reason, this PR propose to always include `SecurityCustomSerialization` when secure serialization is explicitly enabled with the `EnableSecureSerialization` annotation, which gives users means to use `@SecureField` for non-trivial scenarios
- docs is improved to so that users understand secure serialization is enabled implicitly on the best-effort bases and they may need to enable it explicitly