### PR TITLE
Fix glob to regex conversion to properly handle **/*.suffix

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/util/GlobUtil.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/util/GlobUtil.java
@@ -75,8 +75,13 @@ public class GlobUtil {
             switch (current) {
                 case '*':
                     if (i < length && glob.charAt(i) == '*') {
-                        result.append(".*");
                         i++;
+                        if (i < length && glob.charAt(i) == '/') {
+                            result.append("([^/]*/)*");
+                            i++;
+                        } else {
+                            result.append(".*");
+                        }
                     } else {
                         result.append("[^/]*");
                     }

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/util/GlobUtilTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/util/GlobUtilTest.java
@@ -34,6 +34,14 @@ public class GlobUtilTest {
         assertMatch("a**/b", Arrays.asList("a/b", "axy/b", "a/x/b"), Arrays.asList("a", "b", "a/bc", "bc/b"));
         assertMatch("a**b", Arrays.asList("ab", "axb", "axyb", "a/b", "a/x/b"), Arrays.asList("abc", "1ab"));
         assertMatch("a**b**/c", Arrays.asList("axbx/c", "axbx/c", "a/x/xbx/c", "axbx/xxx/c"), Arrays.asList("axbx/cc"));
+        assertMatch("**/*.txt", Arrays.asList("/test.txt", "test.txt", "/path/to/a.txt", "relative/path/to/a.txt"),
+                Arrays.asList("/test.py", "test.json", "/path/to/a.js", "relative/path/to/a.exe"));
+        assertMatch("foo/**/test.json",
+                Arrays.asList("foo/a/b/vd/test.json", "foo/test.json", "foo/42/test.json"),
+                Arrays.asList("/foo/path/to/test.json", "/test.py", "test.json", "/path/foo/test.json", "path/foo/test.json"));
+        assertMatch("foo/**/*.json",
+                Arrays.asList("foo/a/b/vd/a.json", "foo/dsa.json", "foo/32/test2.json"),
+                Arrays.asList("/foo/path/to/aasf.json", "/test.py", "test.json", "/path/foo/test.json", "path/foo/test.json"));
     }
 
     @Test


### PR DESCRIPTION
Fixes issue reported in https://github.com/quarkusio/quarkus/discussions/44664#discussioncomment-11369170

> In the reproducer **/*.json gets translated to the regex .*/[^/]*\\.json, which doesn't match test.json because it needs at least one /. 
> ...
> Now my understanding is that **/*.json is expected to match all json files (see [here](https://www.digitalocean.com/community/tools/glob?comments=true&glob=%2A%2A%2F%2A.js&matches=false&tests=test.js&tests=%2Ftest.js&tests=path%2Fto%2Ftest.js)), including test.json