### PR TITLE
Config Doc - Improve HTML Javadoc -> Asciidoc conversion

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
@@ -193,6 +193,7 @@ public final class JavadocToAsciidocTransformer {
                     newLine(sb);
                     htmlToAsciidoc(sb, childNode, inlineMacroMode, context);
                     newLine(sb);
+                    newLine(sb);
                     break;
                 case LIST_ITEM_NODE:
                     final String marker = childNode.parentNode().nodeName().equals(ORDERED_LIST_NODE)


### PR DESCRIPTION
Note that these two issues were preexisting to the rewrite. I noticed them this week-end when I had a look at the config doc of `quarkus.native.resources.includes` to help a user.

I'm pretty sure it was a problem in other areas as well as things were quite wrong as soon as you had inline tags.

Also HTML tables were completely ignored and rendering raw text.

**Before:**

![Screenshot from 2024-11-25 11-52-19](https://github.com/user-attachments/assets/ff4d4940-d5e4-4088-8108-c5e1ba6e5b68)

**After (AsciiDoc local build):**

![Screenshot from 2024-11-25 12-37-02](https://github.com/user-attachments/assets/4917cdce-b080-45ae-8c20-5b30d276c8ce)

