### PR TITLE
Incubating Maven resolver: do not load the workspace when the original resolver isn't aware of it

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BlockingModelResolutionTaskRunner.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BlockingModelResolutionTaskRunner.java
@@ -1,0 +1,22 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+/**
+ * Blocking implementation of the {@link ModelResolutionTaskRunner}.
+ * Each call to {@link #run(ModelResolutionTask)} will block until the task has finished running.
+ * {@link #waitForCompletion()} is a no-op in this implementation.
+ */
+class BlockingModelResolutionTaskRunner implements ModelResolutionTaskRunner {
+
+    static BlockingModelResolutionTaskRunner getInstance() {
+        return new BlockingModelResolutionTaskRunner();
+    }
+
+    @Override
+    public void run(ModelResolutionTask task) {
+        task.run();
+    }
+
+    @Override
+    public void waitForCompletion() {
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ModelResolutionTask.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ModelResolutionTask.java
@@ -4,5 +4,5 @@ package io.quarkus.bootstrap.resolver.maven;
  * Task related to resolution of an {@link io.quarkus.bootstrap.model.ApplicationModel}
  */
 public interface ModelResolutionTask {
-    void run() throws Exception;
+    void run();
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/NonBlockingModelResolutionTaskRunner.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/NonBlockingModelResolutionTaskRunner.java
@@ -1,0 +1,84 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Phaser;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Non-blocking task runner implementation
+ */
+class NonBlockingModelResolutionTaskRunner implements ModelResolutionTaskRunner {
+
+    private static final Logger log = Logger.getLogger(NonBlockingModelResolutionTaskRunner.class);
+
+    private final Phaser phaser = new Phaser(1);
+
+    /**
+     * Errors caught while running tasks
+     */
+    private final Collection<Exception> errors = new ConcurrentLinkedDeque<>();
+
+    /**
+     * Runs a model resolution task asynchronously. This method may return before the task has completed.
+     *
+     * @param task task to run
+     */
+    @Override
+    public void run(ModelResolutionTask task) {
+        phaser.register();
+        CompletableFuture.runAsync(() -> {
+            try {
+                task.run();
+            } catch (Exception e) {
+                errors.add(e);
+            } finally {
+                phaser.arriveAndDeregister();
+            }
+        });
+    }
+
+    /**
+     * Blocks until all the tasks have completed.
+     * <p>
+     * In case some tasks failed with errors, this method will log each error and throw a {@link RuntimeException}
+     * with a corresponding message.
+     */
+    @Override
+    public void waitForCompletion() {
+        phaser.arriveAndAwaitAdvance();
+        assertNoErrors();
+    }
+
+    private void assertNoErrors() {
+        if (!errors.isEmpty()) {
+            var sb = new StringBuilder(
+                    "The following errors were encountered while processing Quarkus application dependencies:");
+            log.error(sb);
+            var i = 1;
+            for (var error : errors) {
+                var prefix = i++ + ")";
+                log.error(prefix, error);
+                sb.append(System.lineSeparator()).append(prefix).append(" ").append(error.getLocalizedMessage());
+                for (var e : error.getStackTrace()) {
+                    sb.append(System.lineSeparator());
+                    for (int j = 0; j < prefix.length(); ++j) {
+                        sb.append(" ");
+                    }
+                    sb.append("at ").append(e);
+                    if (e.getClassName().contains("io.quarkus")) {
+                        sb.append(System.lineSeparator());
+                        for (int j = 0; j < prefix.length(); ++j) {
+                            sb.append(" ");
+                        }
+                        sb.append("...");
+                        break;
+                    }
+                }
+            }
+            throw new RuntimeException(sb.toString());
+        }
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/OrderedDependencyVisitorTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/OrderedDependencyVisitorTest.java
@@ -2,6 +2,7 @@ package io.quarkus.bootstrap.resolver.maven;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -42,7 +43,11 @@ public class OrderedDependencyVisitorTest {
 
         // trees
         var pine = newNode("pine");
-        trees.setChildren(List.of(pine));
+        trees.setChildren(Arrays.asList(pine)); // List.of() can't be used for replace
+        var oak = newNode("oak");
+        // oak, acorn
+        var acorn = newNode("acorn");
+        oak.setChildren(List.of(acorn));
 
         // create a visitor
         var visitor = new OrderedDependencyVisitor(root);
@@ -109,10 +114,21 @@ public class OrderedDependencyVisitorTest {
         assertThat(visitor.getCurrent()).isSameAs(pine);
         assertThat(visitor.getCurrentDistance()).isEqualTo(2);
         assertThat(visitor.hasNext()).isTrue();
+        // replace the current node
+        visitor.replaceCurrent(oak);
+        assertThat(visitor.getCurrent()).isSameAs(oak);
+        assertThat(visitor.getCurrentDistance()).isEqualTo(2);
+        assertThat(visitor.hasNext()).isTrue();
 
-        // distance 3, pets, dog, puppe
+        // distance 3, pets, dog, puppy
         assertThat(visitor.next()).isSameAs(puppy);
         assertThat(visitor.getCurrent()).isSameAs(puppy);
+        assertThat(visitor.getCurrentDistance()).isEqualTo(3);
+        assertThat(visitor.hasNext()).isTrue();
+
+        // distance 3, trees, oak, acorn
+        assertThat(visitor.next()).isSameAs(acorn);
+        assertThat(visitor.getCurrent()).isSameAs(acorn);
         assertThat(visitor.getCurrentDistance()).isEqualTo(3);
         assertThat(visitor.hasNext()).isFalse();
     }


### PR DESCRIPTION
This change includes an important enhancement in the incubating application model resolver impl to skip workspace loading when it's not necessary.
It also introduces an option to switch to a blocking task runner in the incubating resolver (for now not documented, for my own testing, I'll make it a proper option later) and some other clean up.