### PR TITLE
Avoid reifing Agroal configuration too early

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalConnectionConfigurer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalConnectionConfigurer.java
@@ -1,5 +1,7 @@
 package io.quarkus.agroal.runtime;
 
+import java.util.Map;
+
 import org.jboss.logging.Logger;
 
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
@@ -8,8 +10,17 @@ public interface AgroalConnectionConfigurer {
 
     Logger log = Logger.getLogger(AgroalConnectionConfigurer.class.getName());
 
+    /**
+     * @deprecated use {@link #disableSslSupport(String, AgroalDataSourceConfigurationSupplier, Map)} instead
+     */
+    @Deprecated(since = "3.18", forRemoval = true)
     default void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
         log.warnv("Agroal does not support disabling SSL for database kind: {0}", databaseKind);
+    }
+
+    default void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalJdbcProperties) {
+        disableSslSupport(databaseKind, dataSourceConfiguration);
     }
 
     default void setExceptionSorter(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -195,7 +195,8 @@ public class DataSources {
                 mpMetricsPresent);
 
         if (agroalDataSourceSupport.disableSslSupport) {
-            agroalConnectionConfigurer.disableSslSupport(resolvedDbKind, dataSourceConfiguration);
+            agroalConnectionConfigurer.disableSslSupport(resolvedDbKind, dataSourceConfiguration,
+                    dataSourceJdbcRuntimeConfig.additionalJdbcProperties());
         }
         //we use a custom cache for two reasons:
         //fast thread local cache should be faster

--- a/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/H2AgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/H2AgroalConnectionConfigurer.java
@@ -1,5 +1,7 @@
 package io.quarkus.jdbc.h2.runtime;
 
+import java.util.Map;
+
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.quarkus.agroal.runtime.AgroalConnectionConfigurer;
 import io.quarkus.agroal.runtime.JdbcDriver;
@@ -9,7 +11,8 @@ import io.quarkus.datasource.common.runtime.DatabaseKind;
 public class H2AgroalConnectionConfigurer implements AgroalConnectionConfigurer {
 
     @Override
-    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
+    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalProperties) {
         // do not log anything for H2
     }
 

--- a/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/MariaDBAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/MariaDBAgroalConnectionConfigurer.java
@@ -1,5 +1,7 @@
 package io.quarkus.jdbc.mariadb.runtime;
 
+import java.util.Map;
+
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.api.exceptionsorter.MySQLExceptionSorter;
 import io.quarkus.agroal.runtime.AgroalConnectionConfigurer;
@@ -10,7 +12,8 @@ import io.quarkus.datasource.common.runtime.DatabaseKind;
 public class MariaDBAgroalConnectionConfigurer implements AgroalConnectionConfigurer {
 
     @Override
-    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
+    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalProperties) {
         dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcProperty("useSSL", "false");
     }
 

--- a/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/MsSQLAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/MsSQLAgroalConnectionConfigurer.java
@@ -1,5 +1,7 @@
 package io.quarkus.jdbc.mssql.runtime;
 
+import java.util.Map;
+
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.api.exceptionsorter.MSSQLExceptionSorter;
 import io.quarkus.agroal.runtime.AgroalConnectionConfigurer;
@@ -10,7 +12,8 @@ import io.quarkus.datasource.common.runtime.DatabaseKind;
 public class MsSQLAgroalConnectionConfigurer implements AgroalConnectionConfigurer {
 
     @Override
-    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
+    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalProperties) {
         dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcProperty("encrypt", "false");
     }
 

--- a/extensions/jdbc/jdbc-mysql/runtime/src/main/java/io/quarkus/jdbc/mysql/runtime/MySQLAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-mysql/runtime/src/main/java/io/quarkus/jdbc/mysql/runtime/MySQLAgroalConnectionConfigurer.java
@@ -1,5 +1,7 @@
 package io.quarkus.jdbc.mysql.runtime;
 
+import java.util.Map;
+
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.api.exceptionsorter.MySQLExceptionSorter;
 import io.quarkus.agroal.runtime.AgroalConnectionConfigurer;
@@ -10,7 +12,8 @@ import io.quarkus.datasource.common.runtime.DatabaseKind;
 public class MySQLAgroalConnectionConfigurer implements AgroalConnectionConfigurer {
 
     @Override
-    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
+    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalProperties) {
         dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcProperty("useSSL", "false");
     }
 

--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/OracleAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/OracleAgroalConnectionConfigurer.java
@@ -1,6 +1,6 @@
 package io.quarkus.jdbc.oracle.runtime;
 
-import java.util.Properties;
+import java.util.Map;
 
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.api.exceptionsorter.OracleExceptionSorter;
@@ -19,13 +19,10 @@ public class OracleAgroalConnectionConfigurer implements AgroalConnectionConfigu
      * enable it.
      */
     @Override
-    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
-        final Properties jdbcProperties = dataSourceConfiguration.connectionPoolConfiguration()
-                .connectionFactoryConfiguration()
-                .get()
-                .jdbcProperties();
-        final Object setting = jdbcProperties.get("oracle.net.authentication_services");
-        if (setting != null && "SSL".equalsIgnoreCase(setting.toString())) {
+    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalProperties) {
+        final String property = additionalProperties.get("oracle.net.authentication_services");
+        if (property != null && "SSL".equalsIgnoreCase(property)) {
             log.warnv(
                     "SSL support has been disabled, but one of the Oracle JDBC connections has been configured to use SSL. This will likely fail");
         }

--- a/extensions/jdbc/jdbc-postgresql/runtime/src/main/java/io/quarkus/jdbc/postgresql/runtime/PostgreSQLAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-postgresql/runtime/src/main/java/io/quarkus/jdbc/postgresql/runtime/PostgreSQLAgroalConnectionConfigurer.java
@@ -1,5 +1,7 @@
 package io.quarkus.jdbc.postgresql.runtime;
 
+import java.util.Map;
+
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.api.exceptionsorter.PostgreSQLExceptionSorter;
 import io.quarkus.agroal.runtime.AgroalConnectionConfigurer;
@@ -10,7 +12,8 @@ import io.quarkus.datasource.common.runtime.DatabaseKind;
 public class PostgreSQLAgroalConnectionConfigurer implements AgroalConnectionConfigurer {
 
     @Override
-    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
+    public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration,
+            Map<String, String> additionalProperties) {
         dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcProperty("sslmode",
                 "disable");
     }


### PR DESCRIPTION
In OracleAgroalConnectionConfigurer, we are reifing the Agroal config and we shouldn't do it at this stage.
We need to check the properties directly and thus we add them to AgroalConnectionConfigurer. I kept the old method for now but it will be removed at some point in the future.

Fixes #44687