### PR TITLE
Adjust how we limit CPU count for Oracle Dev Services

### DIFF
--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -5,7 +5,9 @@ import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DE
 import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -68,14 +70,14 @@ public class OracleDevServicesProcessor {
                 Labels.addDataSourceLabel(container, datasourceName);
                 Volumes.addVolumes(container, containerConfig.getVolumes());
 
-                container.withEnv(containerConfig.getContainerEnv());
-
                 // We need to limit the maximum amount of CPUs being used by the container;
                 // otherwise the hardcoded memory configuration of the DB might not be enough to successfully boot it.
                 // See https://github.com/gvenzl/oci-oracle-xe/issues/64
                 // I choose to limit it to "2 cpus": should be more than enough for any local testing needs,
                 // and keeps things simple.
-                container.withCreateContainerCmdModifier(cmd -> cmd.getHostConfig().withNanoCPUs(2_000_000_000l));
+                Map<String, String> containerEnv = new HashMap<>(containerConfig.getContainerEnv());
+                containerEnv.put("CPU_COUNT", "2");
+                container.withEnv(containerEnv);
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);


### PR DESCRIPTION
Fixes #38003

/cc @fedinskiy I put you as coauthor. Can you check it's in line with what you wanted to do? I just adjusted things to avoid updating the Map coming from the config as we might make it immutable at some point.