### PR TITLE
Add OIDC Client config builder

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -355,8 +355,8 @@ import java.util.Map;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.quarkus.oidc.client.OidcClient;
-import io.quarkus.oidc.client.OidcClientConfig;
-import io.quarkus.oidc.client.OidcClientConfig.Grant.Type;
+import io.quarkus.oidc.client.runtime.OidcClientConfig;
+import io.quarkus.oidc.client.runtime.OidcClientConfig.Grant.Type;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.mutiny.Uni;
@@ -383,14 +383,14 @@ public class OidcClientCreator {
     }
 
     private Uni<OidcClient> createOidcClient() {
-        OidcClientConfig cfg = new OidcClientConfig();
-        cfg.setId("myclient");
-        cfg.setAuthServerUrl(oidcProviderAddress);
-        cfg.setClientId("backend-service");
-        cfg.getCredentials().setSecret("secret");
-        cfg.getGrant().setType(Type.PASSWORD);
-        cfg.setGrantOptions(Map.of("password",
-        		Map.of("username", "alice", "password", "alice")));
+        OidcClientConfig cfg = OidcClientConfig
+            .authServerUrl(oidcProviderAddress)
+            .id("myclient")
+            .clientId("backend-service")
+            .credentials("secret")
+            .grant(Type.PASSWORD)
+            .grantOptions("password", Map.of("username", "alice", "password", "alice"))
+            .build();
         return oidcClients.newClient(cfg);
     }
 }

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -303,14 +303,14 @@ public class OidcClientCreator {
     }
 
     private Uni<OidcClient> createOidcClient() {
-        OidcClientConfig cfg = new OidcClientConfig();
-        cfg.setId("myclient");
-        cfg.setAuthServerUrl(oidcProviderAddress);
-        cfg.setClientId("backend-service");
-        cfg.getCredentials().setSecret("secret");
-        cfg.getGrant().setType(Type.PASSWORD);
-        cfg.setGrantOptions(Map.of("password",
-        		Map.of("username", "alice", "password", "alice")));
+        OidcClientConfig cfg = OidcClientConfig
+            .authServerUrl(oidcProviderAddress)
+            .id("myclient")
+            .clientId("backend-service")
+            .credentials("secret")
+            .grant(Type.PASSWORD)
+            .grantOptions("password", Map.of("username", "alice", "password", "alice"))
+            .build();
         return oidcClients.newClient(cfg);
     }
 }

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/DefaultPolicyEnforcerResolver.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/DefaultPolicyEnforcerResolver.java
@@ -50,7 +50,7 @@ public class DefaultPolicyEnforcerResolver implements PolicyEnforcerResolver {
         }
 
         var defaultTenantConfig = new OidcTenantConfig(OidcConfig.getDefaultTenant(oidcConfig), OidcUtils.DEFAULT_TENANT_ID);
-        var defaultTenantTlsSupport = tlsSupport.forConfig(defaultTenantConfig.tls);
+        var defaultTenantTlsSupport = tlsSupport.forConfig(defaultTenantConfig.tls());
         this.defaultPolicyEnforcer = createPolicyEnforcer(defaultTenantConfig, config.defaultTenant(),
                 defaultTenantTlsSupport);
         this.namedPolicyEnforcers = createNamedPolicyEnforcers(oidcConfig, config, tlsSupport);
@@ -101,7 +101,7 @@ public class DefaultPolicyEnforcerResolver implements PolicyEnforcerResolver {
                 .onItem().ifNotNull().transform(new Function<KeycloakPolicyEnforcerTenantConfig, PolicyEnforcer>() {
                     @Override
                     public PolicyEnforcer apply(KeycloakPolicyEnforcerTenantConfig tenant) {
-                        return createPolicyEnforcer(config, tenant, tlsSupport.forConfig(config.tls));
+                        return createPolicyEnforcer(config, tenant, tlsSupport.forConfig(config.tls()));
                     }
                 });
     }
@@ -116,7 +116,7 @@ public class DefaultPolicyEnforcerResolver implements PolicyEnforcerResolver {
         for (Map.Entry<String, KeycloakPolicyEnforcerTenantConfig> tenant : config.namedTenants().entrySet()) {
             OidcTenantConfig oidcTenantConfig = getOidcTenantConfig(oidcConfig, tenant.getKey());
             policyEnforcerTenants.put(tenant.getKey(),
-                    createPolicyEnforcer(oidcTenantConfig, tenant.getValue(), tlsSupport.forConfig(oidcTenantConfig.tls)));
+                    createPolicyEnforcer(oidcTenantConfig, tenant.getValue(), tlsSupport.forConfig(oidcTenantConfig.tls())));
         }
         return Map.copyOf(policyEnforcerTenants);
     }

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerUtil.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerUtil.java
@@ -18,8 +18,8 @@ import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
 
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
-import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcTlsSupport.TlsConfigSupport;
+import io.quarkus.oidc.common.runtime.config.OidcCommonConfig;
 import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
@@ -53,16 +53,16 @@ public final class KeycloakPolicyEnforcerUtil {
         adapterConfig.setCredentials(getCredentials(oidcConfig));
 
         if (!tlsConfigSupport.useTlsRegistry()) {
-            boolean trustAll = oidcConfig.tls.getVerification().isPresent()
-                    ? oidcConfig.tls.getVerification().get() == OidcCommonConfig.Tls.Verification.NONE
+            boolean trustAll = oidcConfig.tls().verification().isPresent()
+                    ? oidcConfig.tls().verification().get() == OidcCommonConfig.Tls.Verification.NONE
                     : tlsConfigSupport.isGlobalTrustAll();
             if (trustAll) {
                 adapterConfig.setDisableTrustManager(true);
                 adapterConfig.setAllowAnyHostname(true);
-            } else if (oidcConfig.tls.trustStoreFile.isPresent()) {
-                adapterConfig.setTruststore(oidcConfig.tls.trustStoreFile.get().toString());
-                adapterConfig.setTruststorePassword(oidcConfig.tls.trustStorePassword.orElse("password"));
-                if (OidcCommonConfig.Tls.Verification.CERTIFICATE_VALIDATION == oidcConfig.tls.verification
+            } else if (oidcConfig.tls().trustStoreFile().isPresent()) {
+                adapterConfig.setTruststore(oidcConfig.tls().trustStoreFile().get().toString());
+                adapterConfig.setTruststorePassword(oidcConfig.tls().trustStorePassword().orElse("password"));
+                if (OidcCommonConfig.Tls.Verification.CERTIFICATE_VALIDATION == oidcConfig.tls().verification()
                         .orElse(OidcCommonConfig.Tls.Verification.REQUIRED)) {
                     adapterConfig.setAllowAnyHostname(true);
                 }

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
@@ -34,6 +34,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
@@ -46,6 +47,7 @@ import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.Tokens;
 import io.quarkus.oidc.client.runtime.AbstractTokensProducer;
 import io.quarkus.oidc.client.runtime.OidcClientBuildTimeConfig;
+import io.quarkus.oidc.client.runtime.OidcClientDefaultIdConfigBuilder;
 import io.quarkus.oidc.client.runtime.OidcClientRecorder;
 import io.quarkus.oidc.client.runtime.OidcClientsConfig;
 import io.quarkus.oidc.client.runtime.TokenProviderProducer;
@@ -182,6 +184,11 @@ public class OidcClientBuildStep {
             }
         }
         return index.getIndex().getAnnotations(ACCESS_TOKEN).stream().map(ItemBuilder::new).map(ItemBuilder::build).toList();
+    }
+
+    @BuildStep
+    RunTimeConfigBuilderBuildItem useOidcClientDefaultIdConfigBuilder() {
+        return new RunTimeConfigBuilderBuildItem(OidcClientDefaultIdConfigBuilder.class);
     }
 
     /**

--- a/extensions/oidc-client/deployment/src/test/resources/oidc-client-dev-service-test.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/oidc-client-dev-service-test.properties
@@ -13,3 +13,11 @@ quarkus.oidc-client.client2.credentials.secret=${quarkus.oidc-client.credentials
 quarkus.oidc-client.client2.grant.type=password
 quarkus.oidc-client.client2.grant-options.password.username=bob
 quarkus.oidc-client.client2.grant-options.password.password=bob
+quarkus.oidc-client.client2.id=client2
+
+quarkus.oidc-client."client3".auth-server-url=${quarkus.oidc-client.auth-server-url}
+quarkus.oidc-client."client3".client-id=${quarkus.oidc-client.client-id}
+quarkus.oidc-client."client3".credentials.secret=${quarkus.oidc-client.credentials.secret}
+quarkus.oidc-client."client3".grant.type=password
+quarkus.oidc-client."client3".grant-options.password.username=bob
+quarkus.oidc-client."client3".grant-options.password.password=bob

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -8,7 +8,12 @@ import java.util.Optional;
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 
-public class OidcClientConfig extends OidcClientCommonConfig {
+/**
+ * @deprecated create {@link io.quarkus.oidc.client.runtime.OidcClientConfig} with the {@link OidcClientConfigBuilder}
+ *             for example, you can use the {@link io.quarkus.oidc.client.runtime.OidcClientConfig#builder()} method.
+ */
+@Deprecated(since = "3.18")
+public class OidcClientConfig extends OidcClientCommonConfig implements io.quarkus.oidc.client.runtime.OidcClientConfig {
 
     public OidcClientConfig() {
 
@@ -67,7 +72,82 @@ public class OidcClientConfig extends OidcClientCommonConfig {
 
     public Grant grant = new Grant();
 
-    public static class Grant {
+    @Override
+    public Optional<String> id() {
+        return id;
+    }
+
+    @Override
+    public boolean clientEnabled() {
+        return clientEnabled;
+    }
+
+    @Override
+    public Optional<List<String>> scopes() {
+        return scopes;
+    }
+
+    @Override
+    public Optional<Duration> refreshTokenTimeSkew() {
+        return refreshTokenTimeSkew;
+    }
+
+    @Override
+    public Optional<Duration> accessTokenExpiresIn() {
+        return accessTokenExpiresIn;
+    }
+
+    @Override
+    public boolean absoluteExpiresIn() {
+        return absoluteExpiresIn;
+    }
+
+    @Override
+    public io.quarkus.oidc.client.runtime.OidcClientConfig.Grant grant() {
+        return grant;
+    }
+
+    @Override
+    public Map<String, Map<String, String>> grantOptions() {
+        return grantOptions;
+    }
+
+    @Override
+    public boolean earlyTokensAcquisition() {
+        return earlyTokensAcquisition;
+    }
+
+    @Override
+    public Map<String, String> headers() {
+        return headers;
+    }
+
+    public static class Grant implements io.quarkus.oidc.client.runtime.OidcClientConfig.Grant {
+
+        @Override
+        public io.quarkus.oidc.client.runtime.OidcClientConfig.Grant.Type type() {
+            return type == null ? null : io.quarkus.oidc.client.runtime.OidcClientConfig.Grant.Type.valueOf(type.toString());
+        }
+
+        @Override
+        public String accessTokenProperty() {
+            return accessTokenProperty;
+        }
+
+        @Override
+        public String refreshTokenProperty() {
+            return refreshTokenProperty;
+        }
+
+        @Override
+        public String expiresInProperty() {
+            return expiresInProperty;
+        }
+
+        @Override
+        public String refreshExpiresInProperty() {
+            return refreshExpiresInProperty;
+        }
 
         public static enum Type {
             /**

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfigBuilder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfigBuilder.java
@@ -1,0 +1,390 @@
+package io.quarkus.oidc.client;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.quarkus.oidc.client.runtime.OidcClientConfig;
+import io.quarkus.oidc.client.runtime.OidcClientConfig.Grant;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder;
+
+/**
+ * Builder for the {@link io.quarkus.oidc.client.runtime.OidcClientConfig}. This builder is not thread-safe.
+ */
+public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder<OidcClientConfigBuilder> {
+
+    private static class OidcClientConfigImpl extends OidcClientCommonConfigImpl implements OidcClientConfig {
+
+        private final Map<String, String> headers;
+        private final boolean earlyTokensAcquisition;
+        private final Map<String, Map<String, String>> grantOptions;
+        private final Grant grant;
+        private final boolean absoluteExpiresIn;
+        private final Optional<Duration> accessTokenExpiresIn;
+        private final Optional<Duration> refreshTokenTimeSkew;
+        private final Optional<List<String>> scopes;
+        private final boolean clientEnabled;
+        private final Optional<String> id;
+
+        private OidcClientConfigImpl(OidcClientConfigBuilder builder) {
+            super(builder);
+            this.headers = Map.copyOf(builder.headers);
+            this.earlyTokensAcquisition = builder.earlyTokensAcquisition;
+            this.grantOptions = Map.copyOf(builder.grantOptions);
+            this.grant = builder.grant;
+            this.absoluteExpiresIn = builder.absoluteExpiresIn;
+            this.accessTokenExpiresIn = builder.accessTokenExpiresIn;
+            this.refreshTokenTimeSkew = builder.refreshTokenTimeSkew;
+            this.scopes = builder.scopes.isEmpty() ? Optional.empty() : Optional.of(List.copyOf(builder.scopes));
+            this.clientEnabled = builder.clientEnabled;
+            this.id = builder.id;
+        }
+
+        @Override
+        public Optional<String> id() {
+            return id;
+        }
+
+        @Override
+        public boolean clientEnabled() {
+            return clientEnabled;
+        }
+
+        @Override
+        public Optional<List<String>> scopes() {
+            return scopes;
+        }
+
+        @Override
+        public Optional<Duration> refreshTokenTimeSkew() {
+            return refreshTokenTimeSkew;
+        }
+
+        @Override
+        public Optional<Duration> accessTokenExpiresIn() {
+            return accessTokenExpiresIn;
+        }
+
+        @Override
+        public boolean absoluteExpiresIn() {
+            return absoluteExpiresIn;
+        }
+
+        @Override
+        public Grant grant() {
+            return grant;
+        }
+
+        @Override
+        public Map<String, Map<String, String>> grantOptions() {
+            return grantOptions;
+        }
+
+        @Override
+        public boolean earlyTokensAcquisition() {
+            return earlyTokensAcquisition;
+        }
+
+        @Override
+        public Map<String, String> headers() {
+            return headers;
+        }
+    }
+
+    private final Map<String, String> headers = new HashMap<>();
+    private boolean earlyTokensAcquisition;
+    private final Map<String, Map<String, String>> grantOptions = new HashMap<>();
+    private final List<String> scopes = new ArrayList<>();
+    private Grant grant;
+    private boolean absoluteExpiresIn;
+    private Optional<Duration> accessTokenExpiresIn;
+    private Optional<Duration> refreshTokenTimeSkew;
+    private boolean clientEnabled;
+    private Optional<String> id;
+
+    /**
+     * @param config created either by this builder or SmallRye Config; config methods must never return null
+     */
+    public OidcClientConfigBuilder(OidcClientConfig config) {
+        super(Objects.requireNonNull(config));
+        this.headers.putAll(config.headers());
+        this.earlyTokensAcquisition = config.earlyTokensAcquisition();
+        this.grantOptions.putAll(config.grantOptions());
+        this.grant = config.grant();
+        this.absoluteExpiresIn = config.absoluteExpiresIn();
+        this.accessTokenExpiresIn = config.accessTokenExpiresIn();
+        this.refreshTokenTimeSkew = config.refreshTokenTimeSkew();
+        this.clientEnabled = config.clientEnabled();
+        this.id = config.id();
+        if (config.scopes().isPresent()) {
+            this.scopes.addAll(config.scopes().get());
+        }
+    }
+
+    @Override
+    protected OidcClientConfigBuilder getBuilder() {
+        return this;
+    }
+
+    /**
+     * Adds new headers to the {@link OidcClientConfig#headers()} already set.
+     *
+     * @param headerName header name
+     * @param headerValue header value
+     * @return this builder
+     */
+    public OidcClientConfigBuilder headers(String headerName, String headerValue) {
+        Objects.requireNonNull(headerName);
+        Objects.requireNonNull(headerValue);
+        this.headers.put(headerName, headerValue);
+        return this;
+    }
+
+    /**
+     * Adds new headers to the headers already set.
+     *
+     * @param headers {@link OidcClientConfig#headers()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder headers(Map<String, String> headers) {
+        Objects.requireNonNull(headers);
+        this.headers.putAll(headers);
+        return this;
+    }
+
+    /**
+     * @param earlyTokensAcquisition {@link OidcClientConfig#earlyTokensAcquisition()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder earlyTokensAcquisition(boolean earlyTokensAcquisition) {
+        this.earlyTokensAcquisition = earlyTokensAcquisition;
+        return this;
+    }
+
+    /**
+     * Adds {@link OidcClientConfig#grantOptions()}.
+     *
+     * @return this builder
+     */
+    public OidcClientConfigBuilder grantOptions(String grantName, Map<String, String> options) {
+        Objects.requireNonNull(grantName);
+        Objects.requireNonNull(options);
+        this.grantOptions.computeIfAbsent(grantName, k -> new HashMap<>()).putAll(options);
+        return this;
+    }
+
+    /**
+     * Adds {@link OidcClientConfig#grantOptions()}.
+     *
+     * @return this builder
+     */
+    public OidcClientConfigBuilder grantOptions(String grantName, String key, String value) {
+        Objects.requireNonNull(grantName);
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        this.grantOptions.computeIfAbsent(grantName, k -> new HashMap<>()).put(key, value);
+        return this;
+    }
+
+    /**
+     * @param grantOptions {@link OidcClientConfig#grantOptions()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder grantOptions(Map<String, Map<String, String>> grantOptions) {
+        Objects.requireNonNull(grantOptions);
+        this.grantOptions.putAll(grantOptions);
+        return this;
+    }
+
+    /**
+     * @param absoluteExpiresIn {@link OidcClientConfig#absoluteExpiresIn()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder absoluteExpiresIn(boolean absoluteExpiresIn) {
+        this.absoluteExpiresIn = absoluteExpiresIn;
+        return this;
+    }
+
+    /**
+     * @param accessTokenExpiresIn {@link OidcClientConfig#accessTokenExpiresIn()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder accessTokenExpiresIn(Duration accessTokenExpiresIn) {
+        this.accessTokenExpiresIn = Optional.ofNullable(accessTokenExpiresIn);
+        return this;
+    }
+
+    /**
+     * @param refreshTokenTimeSkew {@link OidcClientConfig#refreshTokenTimeSkew()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder refreshTokenTimeSkew(Duration refreshTokenTimeSkew) {
+        this.refreshTokenTimeSkew = Optional.ofNullable(refreshTokenTimeSkew);
+        return this;
+    }
+
+    /**
+     * Adds scopes to the {@link OidcClientConfig#scopes()}.
+     *
+     * @param scopes {@link OidcClientConfig#scopes()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder scopes(List<String> scopes) {
+        Objects.requireNonNull(scopes);
+        this.scopes.addAll(scopes);
+        return this;
+    }
+
+    /**
+     * Adds scopes to the {@link OidcClientConfig#scopes()}.
+     *
+     * @param scopes {@link OidcClientConfig#scopes()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder scopes(String... scopes) {
+        Objects.requireNonNull(scopes);
+        this.scopes.addAll(Arrays.asList(scopes));
+        return this;
+    }
+
+    /**
+     * @param clientEnabled {@link OidcClientConfig#clientEnabled()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder clientEnabled(boolean clientEnabled) {
+        this.clientEnabled = clientEnabled;
+        return this;
+    }
+
+    /**
+     * @param id {@link OidcClientConfig#id()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder id(String id) {
+        this.id = Optional.ofNullable(id);
+        return this;
+    }
+
+    /**
+     * @param grant {@link OidcClientConfig#grant()} created either with {@link GrantBuilder} or SmallRye Config
+     * @return this builder
+     */
+    public OidcClientConfigBuilder grant(Grant grant) {
+        this.grant = Objects.requireNonNull(grant);
+        return this;
+    }
+
+    /**
+     * @param type {@link Grant#type()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder grant(Grant.Type type) {
+        return grant().type(type).end();
+    }
+
+    /**
+     * Creates {@link OidcClientConfig#grant()} builder.
+     *
+     * @return GrantBuilder
+     */
+    public GrantBuilder grant() {
+        return new GrantBuilder(this);
+    }
+
+    /**
+     * @return OidcClientConfig
+     */
+    public OidcClientConfig build() {
+        if (id.isEmpty()) {
+            throw new IllegalArgumentException("Client ID cannot be empty");
+        }
+        return new OidcClientConfigImpl(this);
+    }
+
+    public static final class GrantBuilder {
+
+        private record GrantImpl(Type type, String accessTokenProperty, String refreshTokenProperty, String expiresInProperty,
+                String refreshExpiresInProperty) implements Grant {
+
+        }
+
+        private final OidcClientConfigBuilder builder;
+        private Grant.Type type;
+        private String accessTokenProperty;
+        private String refreshTokenProperty;
+        private String expiresInProperty;
+        private String refreshExpiresInProperty;
+
+        public GrantBuilder() {
+            this(OidcClientConfig.builder());
+        }
+
+        public GrantBuilder(OidcClientConfigBuilder builder) {
+            this.builder = builder;
+            this.type = builder.grant.type();
+            this.accessTokenProperty = builder.grant.accessTokenProperty();
+            this.refreshTokenProperty = builder.grant.refreshTokenProperty();
+            this.expiresInProperty = builder.grant.expiresInProperty();
+            this.refreshExpiresInProperty = builder.grant.refreshExpiresInProperty();
+        }
+
+        /**
+         * @param type {@link Grant#type()}
+         * @return this builder
+         */
+        public GrantBuilder type(Grant.Type type) {
+            this.type = Objects.requireNonNull(type);
+            return this;
+        }
+
+        /**
+         * @param refreshTokenProperty {@link Grant#refreshTokenProperty()}
+         * @return this builder
+         */
+        public GrantBuilder refreshTokenProperty(String refreshTokenProperty) {
+            this.refreshTokenProperty = Objects.requireNonNull(refreshTokenProperty);
+            return this;
+        }
+
+        /**
+         * @param expiresInProperty {@link Grant#expiresInProperty()}
+         * @return this builder
+         */
+        public GrantBuilder expiresInProperty(String expiresInProperty) {
+            this.expiresInProperty = Objects.requireNonNull(expiresInProperty);
+            return this;
+        }
+
+        /**
+         * @param refreshExpiresInProperty {@link Grant#refreshExpiresInProperty()}
+         * @return this builder
+         */
+        public GrantBuilder refreshExpiresInProperty(String refreshExpiresInProperty) {
+            this.refreshExpiresInProperty = Objects.requireNonNull(refreshExpiresInProperty);
+            return this;
+        }
+
+        /**
+         * @param accessTokenProperty {@link Grant#accessTokenProperty()}
+         * @return this builder
+         */
+        public GrantBuilder accessTokenProperty(String accessTokenProperty) {
+            this.accessTokenProperty = Objects.requireNonNull(accessTokenProperty);
+            return this;
+        }
+
+        public OidcClientConfigBuilder end() {
+            Objects.requireNonNull(builder);
+            return builder.grant(build());
+        }
+
+        public Grant build() {
+            return new GrantImpl(type, accessTokenProperty, refreshTokenProperty, expiresInProperty, refreshExpiresInProperty);
+        }
+    }
+}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClients.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClients.java
@@ -2,6 +2,7 @@ package io.quarkus.oidc.client;
 
 import java.io.Closeable;
 
+import io.quarkus.oidc.client.runtime.OidcClientConfig;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -27,7 +28,7 @@ public interface OidcClients extends Closeable {
     /**
      * Returns a new {@link OidcClient}.
      *
-     * @param id {@link OidcClientConfig} new client configuration
+     * @param clientConfig {@link OidcClientConfig} new client configuration
      * @return Uni<OidcClient>
      */
     Uni<OidcClient> newClient(OidcClientConfig clientConfig);

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/AbstractTokensProducer.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/AbstractTokensProducer.java
@@ -46,7 +46,7 @@ public abstract class AbstractTokensProducer {
                 earlyTokenAcquisition = oidcClientsConfig.namedClients().get(clientId.get()).earlyTokensAcquisition();
             } else {
                 // default OidcClient
-                earlyTokenAcquisition = oidcClientsConfig.defaultClient().earlyTokensAcquisition();
+                earlyTokenAcquisition = OidcClientsConfig.getDefaultClient(oidcClientsConfig).earlyTokensAcquisition();
                 oidcClient = oidcClients.getClient();
             }
         } else {

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
@@ -5,9 +5,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.oidc.client.OidcClientConfigBuilder;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig;
+import io.quarkus.oidc.common.runtime.config.OidcCommonConfig;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.WithDefault;
 
 public interface OidcClientConfig extends OidcClientCommonConfig {
@@ -164,5 +167,59 @@ public interface OidcClientConfig extends OidcClientCommonConfig {
      * Custom HTTP headers which have to be sent to the token endpoint
      */
     Map<String, String> headers();
+
+    /**
+     * Creates {@link OidcClientConfigBuilder} builder populated with documented default values.
+     *
+     * @return OidcClientConfigBuilder builder
+     */
+    static OidcClientConfigBuilder builder() {
+        var clientsConfig = new SmallRyeConfigBuilder()
+                .addDiscoveredConverters()
+                .withMapping(OidcClientsConfig.class)
+                .build()
+                .getConfigMapping(OidcClientsConfig.class);
+        return builder(OidcClientsConfig.getDefaultClient(clientsConfig));
+    }
+
+    /**
+     * Creates {@link OidcClientConfigBuilder} builder populated with {@code config} values.
+     *
+     * @param config client config; must not be null
+     * @return OidcClientConfigBuilder
+     */
+    static OidcClientConfigBuilder builder(OidcClientConfig config) {
+        return new OidcClientConfigBuilder(config);
+    }
+
+    /**
+     * Creates {@link OidcClientConfigBuilder} builder populated with documented default values.
+     *
+     * @param authServerUrl {@link OidcCommonConfig#authServerUrl()}
+     * @return OidcClientConfigBuilder builder
+     */
+    static OidcClientConfigBuilder authServerUrl(String authServerUrl) {
+        return builder().authServerUrl(authServerUrl);
+    }
+
+    /**
+     * Creates {@link OidcClientConfigBuilder} builder populated with documented default values.
+     *
+     * @param registrationPath {@link OidcCommonConfig#registrationPath()}
+     * @return OidcClientConfigBuilder builder
+     */
+    static OidcClientConfigBuilder registrationPath(String registrationPath) {
+        return builder().registrationPath(registrationPath);
+    }
+
+    /**
+     * Creates {@link OidcClientConfigBuilder} builder populated with documented default values.
+     *
+     * @param tokenPath {@link OidcClientCommonConfig#tokenPath()}
+     * @return OidcClientConfigBuilder builder
+     */
+    static OidcClientConfigBuilder tokenPath(String tokenPath) {
+        return builder().tokenPath(tokenPath);
+    }
 
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientDefaultIdConfigBuilder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientDefaultIdConfigBuilder.java
@@ -1,0 +1,95 @@
+package io.quarkus.oidc.client.runtime;
+
+import static io.quarkus.oidc.client.runtime.OidcClientRecorder.DEFAULT_OIDC_CLIENT_ID;
+
+import java.util.Iterator;
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigSourceInterceptorFactory;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.Priorities;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+/**
+ * Sets default {@link OidcClientConfig#id()} to the client's named key.
+ * For example, the configuration property 'quarkus.oidc-client.<<named-key>>.id' is set to the '<<named-key>>' if
+ * user did not configure any value.
+ */
+public class OidcClientDefaultIdConfigBuilder implements ConfigBuilder {
+
+    private static final String OIDC_CLIENT_PREFIX = "quarkus.oidc-client.";
+    private static final String ID_POSTFIX = ".id";
+    private static final String DEFAULT_CLIENT_ID_PROPERTY_KEY = OIDC_CLIENT_PREFIX + "id";
+    private static final String DOUBLE_QUOTE = "\"";
+    private static final String WITH_DEFAULTS_ID_KEY = "quarkus.oidc-client.*.id";
+
+    @Override
+    public SmallRyeConfigBuilder configBuilder(SmallRyeConfigBuilder builder) {
+        final ConfigSourceInterceptor configSourceInterceptor = createConfigSourceInterceptor();
+        builder.withInterceptorFactories(new ConfigSourceInterceptorFactory() {
+
+            @Override
+            public ConfigSourceInterceptor getInterceptor(ConfigSourceInterceptorContext configSourceInterceptorContext) {
+                return configSourceInterceptor;
+            }
+
+            @Override
+            public OptionalInt getPriority() {
+                return OptionalInt.of(Priorities.LIBRARY + 200);
+            }
+        });
+        return builder;
+    }
+
+    @Override
+    public int priority() {
+        return Integer.MIN_VALUE;
+    }
+
+    private static boolean isNotSet(ConfigValue configValue) {
+        return configValue == null || configValue.getValue() == null || configValue.getValue().isEmpty();
+    }
+
+    private static ConfigValue createConfigValue(String name, String value) {
+        return ConfigValue.builder().withName(name).withValue(value).build();
+    }
+
+    private static ConfigSourceInterceptor createConfigSourceInterceptor() {
+        return new ConfigSourceInterceptor() {
+            @Override
+            public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
+                var configValue = context.proceed(name);
+                if (isNotSet(configValue) && name.startsWith(OIDC_CLIENT_PREFIX) && name.endsWith(ID_POSTFIX)
+                        && !WITH_DEFAULTS_ID_KEY.equals(name)) {
+                    if (name.equals(DEFAULT_CLIENT_ID_PROPERTY_KEY)) {
+                        return createConfigValue(name, DEFAULT_OIDC_CLIENT_ID);
+                    } else {
+                        var maybeClientName = name.substring(OIDC_CLIENT_PREFIX.length(), name.length() - ID_POSTFIX.length());
+                        // this will cause an issue if the client name contained dot
+                        // but the alternative is much more complex because we would have to presume that
+                        // there never will never be other property that starts with the 'quarkus.oidc-client.'
+                        // and ends with '.id' but is not the client id
+                        if (!maybeClientName.contains(".")) {
+                            // this is additional named client, now we know that OIDC client extension validates
+                            // the 'id' always equals named key, so we can preset this for users
+                            if (maybeClientName.startsWith(DOUBLE_QUOTE) && maybeClientName.endsWith(DOUBLE_QUOTE)) {
+                                var clientNameWithoutQuotes = maybeClientName.substring(1, maybeClientName.length() - 1);
+                                return createConfigValue(name, clientNameWithoutQuotes);
+                            }
+                            return createConfigValue(name, maybeClientName);
+                        }
+                    }
+                }
+                return configValue;
+            }
+
+            @Override
+            public Iterator<String> iterateNames(ConfigSourceInterceptorContext context) {
+                return context.iterateNames();
+            }
+        };
+    }
+}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientsConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientsConfig.java
@@ -3,27 +3,29 @@ package io.quarkus.oidc.client.runtime;
 import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigMapping(prefix = "quarkus.oidc-client")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface OidcClientsConfig {
 
-    /**
-     * The default client.
-     */
-    @WithParentName
-    OidcClientConfig defaultClient();
+    String DEFAULT_CLIENT_KEY = "<default>";
 
     /**
      * Additional named clients.
      */
-    @ConfigDocSection
     @ConfigDocMapKey("id")
     @WithParentName
+    @WithUnnamedKey(DEFAULT_CLIENT_KEY)
+    @WithDefaults
     Map<String, OidcClientConfig> namedClients();
+
+    static OidcClientConfig getDefaultClient(OidcClientsConfig config) {
+        return config.namedClients().get(DEFAULT_CLIENT_KEY);
+    }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientsImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientsImpl.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import io.quarkus.oidc.client.OidcClient;
-import io.quarkus.oidc.client.OidcClientConfig;
 import io.quarkus.oidc.client.OidcClientException;
 import io.quarkus.oidc.client.OidcClients;
 import io.smallrye.mutiny.Uni;
@@ -46,7 +45,7 @@ public class OidcClientsImpl implements OidcClients, Closeable {
 
     @Override
     public Uni<OidcClient> newClient(OidcClientConfig clientConfig) {
-        if (!clientConfig.getId().isPresent()) {
+        if (clientConfig.id().isEmpty()) {
             throw new OidcClientException("'id' property must be set");
         }
         return dynamicOidcClients.apply(clientConfig);

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigBuilderTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigBuilderTest.java
@@ -1,0 +1,730 @@
+package io.quarkus.oidc.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.client.runtime.OidcClientConfig;
+import io.quarkus.oidc.client.runtime.OidcClientConfig.Grant.Type;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt.Source;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret.Method;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder.CredentialsBuilder;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder.JwtBuilder;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder.SecretBuilder;
+
+public class OidcClientConfigBuilderTest {
+
+    @Test
+    public void testDefaultValues() {
+        var config = OidcClientConfig.builder().id("default-test").build();
+
+        // OidcClientConfig methods
+        assertEquals("default-test", config.id().orElse(null));
+        assertTrue(config.clientEnabled());
+        assertTrue(config.scopes().isEmpty());
+        assertTrue(config.refreshTokenTimeSkew().isEmpty());
+        assertTrue(config.accessTokenExpiresIn().isEmpty());
+        assertFalse(config.absoluteExpiresIn());
+        assertTrue(config.grantOptions().isEmpty());
+        assertTrue(config.earlyTokensAcquisition());
+        assertTrue(config.headers().isEmpty());
+        var grant = config.grant();
+        assertNotNull(grant);
+        assertEquals(Type.CLIENT, grant.type());
+        assertEquals(OidcConstants.ACCESS_TOKEN_VALUE, grant.accessTokenProperty());
+        assertEquals(OidcConstants.REFRESH_TOKEN_VALUE, grant.refreshTokenProperty());
+        assertEquals(OidcConstants.EXPIRES_IN, grant.expiresInProperty());
+        assertEquals(OidcConstants.REFRESH_EXPIRES_IN, grant.refreshExpiresInProperty());
+
+        // OidcClientCommonConfig methods
+        assertTrue(config.tokenPath().isEmpty());
+        assertTrue(config.revokePath().isEmpty());
+        assertTrue(config.clientId().isEmpty());
+        assertTrue(config.clientName().isEmpty());
+        var credentials = config.credentials();
+        assertNotNull(credentials);
+        assertTrue(credentials.secret().isEmpty());
+        var clientSecret = credentials.clientSecret();
+        assertNotNull(clientSecret);
+        assertTrue(clientSecret.value().isEmpty());
+        assertTrue(clientSecret.method().isEmpty());
+        var provider = clientSecret.provider();
+        assertNotNull(provider);
+        assertTrue(provider.key().isEmpty());
+        assertTrue(provider.keyringName().isEmpty());
+        assertTrue(provider.name().isEmpty());
+        var jwt = credentials.jwt();
+        assertNotNull(jwt);
+        assertEquals(Source.CLIENT, jwt.source());
+        assertTrue(jwt.secret().isEmpty());
+        provider = jwt.secretProvider();
+        assertNotNull(provider);
+        assertTrue(provider.key().isEmpty());
+        assertTrue(provider.keyringName().isEmpty());
+        assertTrue(provider.name().isEmpty());
+        assertTrue(jwt.key().isEmpty());
+        assertTrue(jwt.keyFile().isEmpty());
+        assertTrue(jwt.keyStoreFile().isEmpty());
+        assertTrue(jwt.keyStorePassword().isEmpty());
+        assertTrue(jwt.keyId().isEmpty());
+        assertTrue(jwt.keyPassword().isEmpty());
+        assertTrue(jwt.audience().isEmpty());
+        assertTrue(jwt.tokenKeyId().isEmpty());
+        assertTrue(jwt.issuer().isEmpty());
+        assertTrue(jwt.subject().isEmpty());
+        assertTrue(jwt.claims().isEmpty());
+        assertTrue(jwt.signatureAlgorithm().isEmpty());
+        assertEquals(10, jwt.lifespan());
+        assertFalse(jwt.assertion());
+
+        // OidcCommonConfig methods
+        assertTrue(config.authServerUrl().isEmpty());
+        assertTrue(config.discoveryEnabled().isEmpty());
+        assertTrue(config.registrationPath().isEmpty());
+        assertTrue(config.connectionDelay().isEmpty());
+        assertEquals(3, config.connectionRetryCount());
+        assertEquals(10, config.connectionTimeout().getSeconds());
+        assertFalse(config.useBlockingDnsLookup());
+        assertTrue(config.maxPoolSize().isEmpty());
+        assertTrue(config.followRedirects());
+        assertNotNull(config.proxy());
+        assertTrue(config.proxy().host().isEmpty());
+        assertEquals(80, config.proxy().port());
+        assertTrue(config.proxy().username().isEmpty());
+        assertTrue(config.proxy().password().isEmpty());
+        assertNotNull(config.tls());
+        assertTrue(config.tls().tlsConfigurationName().isEmpty());
+        assertTrue(config.tls().verification().isEmpty());
+        assertTrue(config.tls().keyStoreFile().isEmpty());
+        assertTrue(config.tls().keyStoreFileType().isEmpty());
+        assertTrue(config.tls().keyStoreProvider().isEmpty());
+        assertTrue(config.tls().keyStorePassword().isEmpty());
+        assertTrue(config.tls().keyStoreKeyAlias().isEmpty());
+        assertTrue(config.tls().keyStoreKeyPassword().isEmpty());
+        assertTrue(config.tls().trustStoreFile().isEmpty());
+        assertTrue(config.tls().trustStorePassword().isEmpty());
+        assertTrue(config.tls().trustStoreCertAlias().isEmpty());
+        assertTrue(config.tls().trustStoreFileType().isEmpty());
+        assertTrue(config.tls().trustStoreProvider().isEmpty());
+    }
+
+    @Test
+    public void testSetEveryProperty() {
+        var config = OidcClientConfig.builder()
+                // OidcClientConfig methods
+                .id("set-every-property-test")
+                .clientEnabled(false)
+                .scopes("one", "two")
+                .scopes(List.of("three", "four"))
+                .refreshTokenTimeSkew(Duration.ofSeconds(987))
+                .accessTokenExpiresIn(Duration.ofSeconds(789))
+                .absoluteExpiresIn(true)
+                .grant()
+                .type(Type.CODE)
+                .accessTokenProperty("access_token_test")
+                .refreshTokenProperty("refresh_token_test")
+                .expiresInProperty("expires_in_test")
+                .refreshExpiresInProperty("refresh_expires_in_test")
+                .end()
+                .grantOptions("one", "two", "three")
+                .grantOptions("four", Map.of("five", "six"))
+                .grantOptions(Map.of("seven", Map.of("eight", "nine")))
+                .earlyTokensAcquisition(false)
+                .headers("one", "two")
+                .headers(Map.of("three", "four"))
+                // OidcClientCommonConfig methods
+                .tokenPath("token-path-yep")
+                .revokePath("revoke-path-yep")
+                .clientId("client-id-yep")
+                .clientName("client-name-yep")
+                .credentials()
+                .secret("secret-yep")
+                .clientSecret()
+                .method(Method.QUERY)
+                .value("value-yep")
+                .provider("key-yep", "name-yep", "keyring-name-yep")
+                .end()
+                .jwt()
+                .source(Source.BEARER)
+                .secretProvider()
+                .keyringName("jwt-keyring-name-yep")
+                .key("jwt-key-yep")
+                .name("jwt-name-yep")
+                .end()
+                .secret("jwt-secret-yep")
+                .key("jwt-key-yep")
+                .keyFile("jwt-key-file-yep")
+                .keyStoreFile("jwt-key-store-file-yep")
+                .keyStorePassword("jwt-key-store-password-yep")
+                .keyId("jwt-key-id-yep")
+                .keyPassword("jwt-key-pwd-yep")
+                .audience("jwt-audience-yep")
+                .tokenKeyId("jwt-token-key-id-yep")
+                .issuer("jwt-issuer")
+                .subject("jwt-subject")
+                .claim("claim-one-name", "claim-one-value")
+                .claims(Map.of("claim-two-name", "claim-two-value"))
+                .signatureAlgorithm("ES512")
+                .lifespan(852)
+                .assertion(true)
+                .endCredentials()
+                // OidcCommonConfig methods
+                .authServerUrl("we")
+                .discoveryEnabled(false)
+                .registrationPath("don't")
+                .connectionDelay(Duration.ofSeconds(656))
+                .connectionRetryCount(565)
+                .connectionTimeout(Duration.ofSeconds(673))
+                .useBlockingDnsLookup(true)
+                .maxPoolSize(376)
+                .followRedirects(false)
+                .proxy("need", 55, "no", "education")
+                .tlsConfigurationName("Teacher!")
+                .build();
+
+        // OidcClientConfig methods
+        assertEquals("set-every-property-test", config.id().orElse(null));
+        assertFalse(config.clientEnabled());
+        assertTrue(config.scopes().isPresent());
+        List<String> scopes = config.scopes().get();
+        assertEquals(4, scopes.size());
+        assertTrue(scopes.contains("one"));
+        assertTrue(scopes.contains("two"));
+        assertTrue(scopes.contains("three"));
+        assertTrue(scopes.contains("four"));
+        assertEquals(987, config.refreshTokenTimeSkew().map(Duration::getSeconds).orElse(-1L));
+        assertEquals(789, config.accessTokenExpiresIn().map(Duration::getSeconds).orElse(-1L));
+        assertTrue(config.absoluteExpiresIn());
+        var grant = config.grant();
+        assertNotNull(grant);
+        assertEquals(Type.CODE, grant.type());
+        assertEquals("access_token_test", grant.accessTokenProperty());
+        assertEquals("refresh_token_test", grant.refreshTokenProperty());
+        assertEquals("expires_in_test", grant.expiresInProperty());
+        assertEquals("refresh_expires_in_test", grant.refreshExpiresInProperty());
+        var grantOptions = config.grantOptions();
+        assertNotNull(grantOptions);
+        assertEquals(3, grantOptions.size());
+        assertTrue(grantOptions.containsKey("one"));
+        assertEquals("three", grantOptions.get("one").get("two"));
+        assertTrue(grantOptions.containsKey("four"));
+        assertEquals("six", grantOptions.get("four").get("five"));
+        assertTrue(grantOptions.containsKey("seven"));
+        assertEquals("nine", grantOptions.get("seven").get("eight"));
+        assertFalse(config.earlyTokensAcquisition());
+        var headers = config.headers();
+        assertNotNull(headers);
+        assertEquals(2, headers.size());
+        assertTrue(headers.containsKey("one"));
+        assertEquals("two", headers.get("one"));
+        assertTrue(headers.containsKey("three"));
+        assertEquals("four", headers.get("three"));
+
+        // OidcClientCommonConfig methods
+        assertEquals("token-path-yep", config.tokenPath().orElse(null));
+        assertEquals("revoke-path-yep", config.revokePath().orElse(null));
+        assertEquals("client-id-yep", config.clientId().orElse(null));
+        assertEquals("client-name-yep", config.clientName().orElse(null));
+        var credentials = config.credentials();
+        assertNotNull(credentials);
+        assertEquals("secret-yep", credentials.secret().orElse(null));
+        var clientSecret = credentials.clientSecret();
+        assertNotNull(clientSecret);
+        assertEquals(Method.QUERY, clientSecret.method().orElse(null));
+        assertEquals("value-yep", clientSecret.value().orElse(null));
+        var provider = clientSecret.provider();
+        assertNotNull(provider);
+        assertEquals("key-yep", provider.key().orElse(null));
+        assertEquals("name-yep", provider.name().orElse(null));
+        assertEquals("keyring-name-yep", provider.keyringName().orElse(null));
+        var jwt = credentials.jwt();
+        assertNotNull(jwt);
+        assertEquals(Source.BEARER, jwt.source());
+        assertEquals("jwt-secret-yep", jwt.secret().orElse(null));
+        provider = jwt.secretProvider();
+        assertNotNull(provider);
+        assertEquals("jwt-keyring-name-yep", provider.keyringName().orElse(null));
+        assertEquals("jwt-name-yep", provider.name().orElse(null));
+        assertEquals("jwt-key-yep", provider.key().orElse(null));
+        assertEquals("jwt-key-yep", jwt.key().orElse(null));
+        assertEquals("jwt-key-file-yep", jwt.keyFile().orElse(null));
+        assertEquals("jwt-key-store-file-yep", jwt.keyStoreFile().orElse(null));
+        assertEquals("jwt-key-store-password-yep", jwt.keyStorePassword().orElse(null));
+        assertEquals("jwt-key-id-yep", jwt.keyId().orElse(null));
+        assertEquals("jwt-key-pwd-yep", jwt.keyPassword().orElse(null));
+        assertEquals("jwt-audience-yep", jwt.audience().orElse(null));
+        assertEquals("jwt-token-key-id-yep", jwt.tokenKeyId().orElse(null));
+        assertEquals("jwt-issuer", jwt.issuer().orElse(null));
+        assertEquals("jwt-subject", jwt.subject().orElse(null));
+        var claims = jwt.claims();
+        assertNotNull(claims);
+        assertEquals(2, claims.size());
+        assertTrue(claims.containsKey("claim-one-name"));
+        assertEquals("claim-one-value", claims.get("claim-one-name"));
+        assertTrue(claims.containsKey("claim-two-name"));
+        assertEquals("claim-two-value", claims.get("claim-two-name"));
+        assertEquals("ES512", jwt.signatureAlgorithm().orElse(null));
+        assertEquals(852, jwt.lifespan());
+        assertTrue(jwt.assertion());
+
+        // OidcCommonConfig methods
+        assertEquals("we", config.authServerUrl().orElse(null));
+        assertFalse(config.discoveryEnabled().orElse(false));
+        assertEquals("don't", config.registrationPath().orElse(null));
+        assertEquals(656, config.connectionDelay().map(Duration::getSeconds).orElse(null));
+        assertEquals(565, config.connectionRetryCount());
+        assertEquals(673, config.connectionTimeout().getSeconds());
+        assertTrue(config.useBlockingDnsLookup());
+        assertEquals(376, config.maxPoolSize().orElse(0));
+        assertFalse(config.followRedirects());
+        assertNotNull(config.proxy());
+        assertEquals("need", config.proxy().host().orElse(null));
+        assertEquals(55, config.proxy().port());
+        assertEquals("no", config.proxy().username().orElse(null));
+        assertEquals("education", config.proxy().password().orElse(null));
+        assertNotNull(config.tls());
+        assertEquals("Teacher!", config.tls().tlsConfigurationName().orElse(null));
+        assertTrue(config.tls().verification().isEmpty());
+        assertTrue(config.tls().keyStoreFile().isEmpty());
+        assertTrue(config.tls().keyStoreFileType().isEmpty());
+        assertTrue(config.tls().keyStoreProvider().isEmpty());
+        assertTrue(config.tls().keyStorePassword().isEmpty());
+        assertTrue(config.tls().keyStoreKeyAlias().isEmpty());
+        assertTrue(config.tls().keyStoreKeyPassword().isEmpty());
+        assertTrue(config.tls().trustStoreFile().isEmpty());
+        assertTrue(config.tls().trustStorePassword().isEmpty());
+        assertTrue(config.tls().trustStoreCertAlias().isEmpty());
+        assertTrue(config.tls().trustStoreFileType().isEmpty());
+        assertTrue(config.tls().trustStoreProvider().isEmpty());
+    }
+
+    @Test
+    public void testCopyProxyProperties() {
+        var previousConfig = OidcClientConfig.builder()
+                .id("copy-proxy-properties-test")
+                .proxy("need", 55, "no", "education")
+                .build();
+        var newConfig = OidcClientConfig.builder(previousConfig)
+                .proxy("fast-car", 22)
+                .build();
+
+        assertNotNull(previousConfig.proxy());
+        assertEquals("copy-proxy-properties-test", newConfig.id().orElse(null));
+        assertEquals("fast-car", newConfig.proxy().host().orElse(null));
+        assertEquals(22, newConfig.proxy().port());
+        assertEquals("no", newConfig.proxy().username().orElse(null));
+        assertEquals("education", newConfig.proxy().password().orElse(null));
+    }
+
+    @Test
+    public void testCopyOidcClientConfigProperties() {
+        var existingConfig = OidcClientConfig.builder()
+                // OidcClientConfig methods
+                .id("test-copy-client-props")
+                .clientEnabled(false)
+                .scopes("one", "two")
+                .scopes(List.of("three", "four"))
+                .refreshTokenTimeSkew(Duration.ofSeconds(987))
+                .accessTokenExpiresIn(Duration.ofSeconds(789))
+                .absoluteExpiresIn(true)
+                .grant()
+                .type(Type.CODE)
+                .accessTokenProperty("access_token_test")
+                .refreshTokenProperty("refresh_token_test")
+                .expiresInProperty("expires_in_test")
+                .refreshExpiresInProperty("refresh_expires_in_test")
+                .end()
+                .grantOptions("one", "two", "three")
+                .grantOptions("four", Map.of("five", "six"))
+                .grantOptions(Map.of("seven", Map.of("eight", "nine")))
+                .earlyTokensAcquisition(false)
+                .headers("one", "two")
+                .headers(Map.of("three", "four"))
+                .build();
+
+        // OidcClientConfig methods
+        assertEquals("test-copy-client-props", existingConfig.id().orElse(null));
+        assertFalse(existingConfig.clientEnabled());
+        assertTrue(existingConfig.scopes().isPresent());
+        List<String> scopes = existingConfig.scopes().get();
+        assertEquals(4, scopes.size());
+        assertTrue(scopes.contains("one"));
+        assertTrue(scopes.contains("two"));
+        assertTrue(scopes.contains("three"));
+        assertTrue(scopes.contains("four"));
+        assertEquals(987, existingConfig.refreshTokenTimeSkew().map(Duration::getSeconds).orElse(-1L));
+        assertEquals(789, existingConfig.accessTokenExpiresIn().map(Duration::getSeconds).orElse(-1L));
+        assertTrue(existingConfig.absoluteExpiresIn());
+        var grant = existingConfig.grant();
+        assertNotNull(grant);
+        assertEquals(Type.CODE, grant.type());
+        assertEquals("access_token_test", grant.accessTokenProperty());
+        assertEquals("refresh_token_test", grant.refreshTokenProperty());
+        assertEquals("expires_in_test", grant.expiresInProperty());
+        assertEquals("refresh_expires_in_test", grant.refreshExpiresInProperty());
+        var grantOptions = existingConfig.grantOptions();
+        assertNotNull(grantOptions);
+        assertEquals(3, grantOptions.size());
+        assertTrue(grantOptions.containsKey("one"));
+        assertEquals("three", grantOptions.get("one").get("two"));
+        assertTrue(grantOptions.containsKey("four"));
+        assertEquals("six", grantOptions.get("four").get("five"));
+        assertTrue(grantOptions.containsKey("seven"));
+        assertEquals("nine", grantOptions.get("seven").get("eight"));
+        assertFalse(existingConfig.earlyTokensAcquisition());
+        var headers = existingConfig.headers();
+        assertNotNull(headers);
+        assertEquals(2, headers.size());
+        assertTrue(headers.containsKey("one"));
+        assertEquals("two", headers.get("one"));
+        assertTrue(headers.containsKey("three"));
+        assertEquals("four", headers.get("three"));
+
+        var newConfig = OidcClientConfig.builder(existingConfig)
+                // OidcClientConfig methods
+                .clientEnabled(true)
+                .scopes("five", "six")
+                .accessTokenExpiresIn(Duration.ofSeconds(444))
+                .grant()
+                .accessTokenProperty("access_token_test-CHANGED")
+                .expiresInProperty("expires_in_test-CHANGED")
+                .end()
+                .earlyTokensAcquisition(true)
+                .build();
+
+        // OidcClientConfig methods
+        assertEquals("test-copy-client-props", newConfig.id().orElse(null));
+        assertTrue(newConfig.clientEnabled());
+        assertTrue(newConfig.scopes().isPresent());
+        scopes = newConfig.scopes().get();
+        assertEquals(6, scopes.size());
+        assertTrue(scopes.contains("one"));
+        assertTrue(scopes.contains("two"));
+        assertTrue(scopes.contains("three"));
+        assertTrue(scopes.contains("four"));
+        assertTrue(scopes.contains("five"));
+        assertTrue(scopes.contains("six"));
+        assertEquals(987, newConfig.refreshTokenTimeSkew().map(Duration::getSeconds).orElse(-1L));
+        assertEquals(444, newConfig.accessTokenExpiresIn().map(Duration::getSeconds).orElse(-1L));
+        assertTrue(newConfig.absoluteExpiresIn());
+        grant = newConfig.grant();
+        assertNotNull(grant);
+        assertEquals(Type.CODE, grant.type());
+        assertEquals("access_token_test-CHANGED", grant.accessTokenProperty());
+        assertEquals("refresh_token_test", grant.refreshTokenProperty());
+        assertEquals("expires_in_test-CHANGED", grant.expiresInProperty());
+        assertEquals("refresh_expires_in_test", grant.refreshExpiresInProperty());
+        grantOptions = newConfig.grantOptions();
+        assertNotNull(grantOptions);
+        assertEquals(3, grantOptions.size());
+        assertTrue(grantOptions.containsKey("one"));
+        assertEquals("three", grantOptions.get("one").get("two"));
+        assertTrue(grantOptions.containsKey("four"));
+        assertEquals("six", grantOptions.get("four").get("five"));
+        assertTrue(grantOptions.containsKey("seven"));
+        assertEquals("nine", grantOptions.get("seven").get("eight"));
+        assertTrue(newConfig.earlyTokensAcquisition());
+        headers = newConfig.headers();
+        assertNotNull(headers);
+        assertEquals(2, headers.size());
+        assertTrue(headers.containsKey("one"));
+        assertEquals("two", headers.get("one"));
+        assertTrue(headers.containsKey("three"));
+        assertEquals("four", headers.get("three"));
+    }
+
+    @Test
+    public void testCopyOidcClientCommonConfigProperties() {
+        var existingConfig = OidcClientConfig.builder()
+                // OidcClientConfig methods
+                .id("copy-oidc-client-common-props")
+                // OidcClientCommonConfig methods
+                .tokenPath("token-path-yep")
+                .revokePath("revoke-path-yep")
+                .clientId("client-id-yep")
+                .clientName("client-name-yep")
+                .credentials()
+                .secret("secret-yep")
+                .clientSecret()
+                .method(Method.QUERY)
+                .value("value-yep")
+                .provider("key-yep", "name-yep", "keyring-name-yep")
+                .end()
+                .jwt()
+                .source(Source.BEARER)
+                .secretProvider()
+                .keyringName("jwt-keyring-name-yep")
+                .key("jwt-key-yep")
+                .name("jwt-name-yep")
+                .end()
+                .secret("jwt-secret-yep")
+                .key("jwt-key-yep")
+                .keyFile("jwt-key-file-yep")
+                .keyStoreFile("jwt-key-store-file-yep")
+                .keyStorePassword("jwt-key-store-password-yep")
+                .keyId("jwt-key-id-yep")
+                .keyPassword("jwt-key-pwd-yep")
+                .audience("jwt-audience-yep")
+                .tokenKeyId("jwt-token-key-id-yep")
+                .issuer("jwt-issuer")
+                .subject("jwt-subject")
+                .claim("claim-one-name", "claim-one-value")
+                .claims(Map.of("claim-two-name", "claim-two-value"))
+                .signatureAlgorithm("ES512")
+                .lifespan(852)
+                .assertion(true)
+                .endCredentials()
+                .build();
+
+        assertEquals("copy-oidc-client-common-props", existingConfig.id().orElse(null));
+
+        // OidcClientCommonConfig methods
+        assertEquals("token-path-yep", existingConfig.tokenPath().orElse(null));
+        assertEquals("revoke-path-yep", existingConfig.revokePath().orElse(null));
+        assertEquals("client-id-yep", existingConfig.clientId().orElse(null));
+        assertEquals("client-name-yep", existingConfig.clientName().orElse(null));
+        var credentials = existingConfig.credentials();
+        assertNotNull(credentials);
+        assertEquals("secret-yep", credentials.secret().orElse(null));
+        var clientSecret = credentials.clientSecret();
+        assertNotNull(clientSecret);
+        assertEquals(Method.QUERY, clientSecret.method().orElse(null));
+        assertEquals("value-yep", clientSecret.value().orElse(null));
+        var provider = clientSecret.provider();
+        assertNotNull(provider);
+        assertEquals("key-yep", provider.key().orElse(null));
+        assertEquals("name-yep", provider.name().orElse(null));
+        assertEquals("keyring-name-yep", provider.keyringName().orElse(null));
+        var jwt = credentials.jwt();
+        assertNotNull(jwt);
+        assertEquals(Source.BEARER, jwt.source());
+        assertEquals("jwt-secret-yep", jwt.secret().orElse(null));
+        provider = jwt.secretProvider();
+        assertNotNull(provider);
+        assertEquals("jwt-keyring-name-yep", provider.keyringName().orElse(null));
+        assertEquals("jwt-name-yep", provider.name().orElse(null));
+        assertEquals("jwt-key-yep", provider.key().orElse(null));
+        assertEquals("jwt-key-yep", jwt.key().orElse(null));
+        assertEquals("jwt-key-file-yep", jwt.keyFile().orElse(null));
+        assertEquals("jwt-key-store-file-yep", jwt.keyStoreFile().orElse(null));
+        assertEquals("jwt-key-store-password-yep", jwt.keyStorePassword().orElse(null));
+        assertEquals("jwt-key-id-yep", jwt.keyId().orElse(null));
+        assertEquals("jwt-key-pwd-yep", jwt.keyPassword().orElse(null));
+        assertEquals("jwt-audience-yep", jwt.audience().orElse(null));
+        assertEquals("jwt-token-key-id-yep", jwt.tokenKeyId().orElse(null));
+        assertEquals("jwt-issuer", jwt.issuer().orElse(null));
+        assertEquals("jwt-subject", jwt.subject().orElse(null));
+        var claims = jwt.claims();
+        assertNotNull(claims);
+        assertEquals(2, claims.size());
+        assertTrue(claims.containsKey("claim-one-name"));
+        assertEquals("claim-one-value", claims.get("claim-one-name"));
+        assertTrue(claims.containsKey("claim-two-name"));
+        assertEquals("claim-two-value", claims.get("claim-two-name"));
+        assertEquals("ES512", jwt.signatureAlgorithm().orElse(null));
+        assertEquals(852, jwt.lifespan());
+        assertTrue(jwt.assertion());
+
+        var newConfig = OidcClientConfig.builder(existingConfig)
+                // OidcClientCommonConfig methods
+                .tokenPath("token-path-yep-CHANGED")
+                .clientId("client-id-yep-CHANGED")
+                .credentials()
+                .secret("secret-yep-CHANGED")
+                .clientSecret("val-1", Method.POST_JWT)
+                .jwt()
+                .secret("different-secret")
+                .secretProvider()
+                .key("jwt-key-yep-CHANGED")
+                .end()
+                .key("jwt-key-yep-CHANGED-2")
+                .keyStoreFile("jwt-key-store-file-yep-CHANGED")
+                .keyPassword("jwt-key-pwd-yep-CHANGED")
+                .issuer("jwt-issuer-CHANGED")
+                .claim("aaa", "bbb")
+                .lifespan(333)
+                .end()
+                .clientSecret("val-1", Method.POST_JWT)
+                .end()
+                .build();
+
+        assertEquals("copy-oidc-client-common-props", newConfig.id().orElse(null));
+
+        // OidcClientCommonConfig methods
+        assertEquals("token-path-yep-CHANGED", newConfig.tokenPath().orElse(null));
+        assertEquals("revoke-path-yep", newConfig.revokePath().orElse(null));
+        assertEquals("client-id-yep-CHANGED", newConfig.clientId().orElse(null));
+        assertEquals("client-name-yep", newConfig.clientName().orElse(null));
+        credentials = newConfig.credentials();
+        assertNotNull(credentials);
+        assertEquals("secret-yep-CHANGED", credentials.secret().orElse(null));
+        clientSecret = credentials.clientSecret();
+        assertNotNull(clientSecret);
+        assertEquals(Method.POST_JWT, clientSecret.method().orElse(null));
+        assertEquals("val-1", clientSecret.value().orElse(null));
+        provider = clientSecret.provider();
+        assertNotNull(provider);
+        assertEquals("key-yep", provider.key().orElse(null));
+        assertEquals("name-yep", provider.name().orElse(null));
+        assertEquals("keyring-name-yep", provider.keyringName().orElse(null));
+        jwt = credentials.jwt();
+        assertNotNull(jwt);
+        assertEquals(Source.BEARER, jwt.source());
+        assertEquals("different-secret", jwt.secret().orElse(null));
+        provider = jwt.secretProvider();
+        assertNotNull(provider);
+        assertEquals("jwt-keyring-name-yep", provider.keyringName().orElse(null));
+        assertEquals("jwt-name-yep", provider.name().orElse(null));
+        assertEquals("jwt-key-yep-CHANGED", provider.key().orElse(null));
+        assertEquals("jwt-key-yep-CHANGED-2", jwt.key().orElse(null));
+        assertEquals("jwt-key-file-yep", jwt.keyFile().orElse(null));
+        assertEquals("jwt-key-store-file-yep-CHANGED", jwt.keyStoreFile().orElse(null));
+        assertEquals("jwt-key-store-password-yep", jwt.keyStorePassword().orElse(null));
+        assertEquals("jwt-key-id-yep", jwt.keyId().orElse(null));
+        assertEquals("jwt-key-pwd-yep-CHANGED", jwt.keyPassword().orElse(null));
+        assertEquals("jwt-audience-yep", jwt.audience().orElse(null));
+        assertEquals("jwt-token-key-id-yep", jwt.tokenKeyId().orElse(null));
+        assertEquals("jwt-issuer-CHANGED", jwt.issuer().orElse(null));
+        assertEquals("jwt-subject", jwt.subject().orElse(null));
+        claims = jwt.claims();
+        assertNotNull(claims);
+        assertEquals(3, claims.size());
+        assertTrue(claims.containsKey("claim-one-name"));
+        assertEquals("claim-one-value", claims.get("claim-one-name"));
+        assertTrue(claims.containsKey("claim-two-name"));
+        assertEquals("claim-two-value", claims.get("claim-two-name"));
+        assertTrue(claims.containsKey("aaa"));
+        assertEquals("bbb", claims.get("aaa"));
+        assertEquals("ES512", jwt.signatureAlgorithm().orElse(null));
+        assertEquals(333, jwt.lifespan());
+        assertTrue(jwt.assertion());
+    }
+
+    @Test
+    public void testCopyOidcCommonConfigProperties() {
+        var previousConfig = OidcClientConfig.builder()
+                .id("common-props-test")
+                .authServerUrl("we")
+                .discoveryEnabled(false)
+                .registrationPath("don't")
+                .connectionDelay(Duration.ofSeconds(656))
+                .connectionRetryCount(565)
+                .connectionTimeout(Duration.ofSeconds(673))
+                .useBlockingDnsLookup(true)
+                .maxPoolSize(376)
+                .followRedirects(false)
+                .proxy("need", 55, "no", "education")
+                .tlsConfigurationName("Teacher!")
+                .build();
+        var newConfig = OidcClientConfig.builder(previousConfig)
+                .discoveryEnabled(true)
+                .connectionDelay(Duration.ofSeconds(753))
+                .connectionTimeout(Duration.ofSeconds(357))
+                .maxPoolSize(1988)
+                .proxy("cross", 44, "the", "boarder")
+                .build();
+
+        assertEquals("common-props-test", newConfig.id().orElse(null));
+        assertEquals("we", newConfig.authServerUrl().orElse(null));
+        assertTrue(newConfig.discoveryEnabled().orElse(false));
+        assertEquals("don't", newConfig.registrationPath().orElse(null));
+        assertEquals(753, newConfig.connectionDelay().map(Duration::getSeconds).orElse(null));
+        assertEquals(565, newConfig.connectionRetryCount());
+        assertEquals(357, newConfig.connectionTimeout().getSeconds());
+        assertTrue(newConfig.useBlockingDnsLookup());
+        assertEquals(1988, newConfig.maxPoolSize().orElse(0));
+        assertFalse(newConfig.followRedirects());
+        assertNotNull(newConfig.proxy());
+        assertEquals("cross", newConfig.proxy().host().orElse(null));
+        assertEquals(44, newConfig.proxy().port());
+        assertEquals("the", newConfig.proxy().username().orElse(null));
+        assertEquals("boarder", newConfig.proxy().password().orElse(null));
+        assertNotNull(newConfig.tls());
+        assertEquals("Teacher!", newConfig.tls().tlsConfigurationName().orElse(null));
+        assertTrue(newConfig.tls().verification().isEmpty());
+        assertTrue(newConfig.tls().keyStoreFile().isEmpty());
+        assertTrue(newConfig.tls().keyStoreFileType().isEmpty());
+        assertTrue(newConfig.tls().keyStoreProvider().isEmpty());
+        assertTrue(newConfig.tls().keyStorePassword().isEmpty());
+        assertTrue(newConfig.tls().keyStoreKeyAlias().isEmpty());
+        assertTrue(newConfig.tls().keyStoreKeyPassword().isEmpty());
+        assertTrue(newConfig.tls().trustStoreFile().isEmpty());
+        assertTrue(newConfig.tls().trustStorePassword().isEmpty());
+        assertTrue(newConfig.tls().trustStoreCertAlias().isEmpty());
+        assertTrue(newConfig.tls().trustStoreFileType().isEmpty());
+        assertTrue(newConfig.tls().trustStoreProvider().isEmpty());
+    }
+
+    @Test
+    public void testCreateBuilderShortcuts() {
+        OidcClientConfig config = OidcClientConfig.authServerUrl("auth-server-url").id("shortcuts-1").build();
+        assertEquals("auth-server-url", config.authServerUrl().orElse(null));
+        assertEquals("shortcuts-1", config.id().orElse(null));
+
+        config = OidcClientConfig.registrationPath("registration-path").id("shortcuts-2").build();
+        assertEquals("registration-path", config.registrationPath().orElse(null));
+        assertEquals("shortcuts-2", config.id().orElse(null));
+
+        config = OidcClientConfig.tokenPath("token-path").id("shortcuts-3").build();
+        assertEquals("token-path", config.tokenPath().orElse(null));
+        assertEquals("shortcuts-3", config.id().orElse(null));
+    }
+
+    @Test
+    public void testCredentialsBuilder() {
+        var jwt = new JwtBuilder<>()
+                .secret("hush-hush")
+                .build();
+        var clientSecret = new SecretBuilder<>()
+                .value("harry")
+                .build();
+        var credentials = new CredentialsBuilder<>()
+                .secret("1234")
+                .jwt(jwt)
+                .clientSecret(clientSecret)
+                .build();
+        var config = OidcClientConfig.builder().id("1").credentials(credentials).build();
+        var buildCredentials = config.credentials();
+        assertEquals("1", config.id().orElse(null));
+        assertNotNull(buildCredentials);
+        assertEquals("1234", buildCredentials.secret().orElse(null));
+        assertEquals("hush-hush", buildCredentials.jwt().secret().orElse(null));
+        assertEquals("harry", buildCredentials.clientSecret().value().orElse(null));
+    }
+
+    @Test
+    public void testGrantBuilder() {
+        var grant = new OidcClientConfigBuilder.GrantBuilder().build();
+        // tests defaults
+        assertEquals(Type.CLIENT, grant.type());
+        assertEquals(OidcConstants.ACCESS_TOKEN_VALUE, grant.accessTokenProperty());
+        assertEquals(OidcConstants.REFRESH_EXPIRES_IN, grant.refreshExpiresInProperty());
+        assertEquals(OidcConstants.REFRESH_TOKEN_VALUE, grant.refreshTokenProperty());
+        assertEquals(OidcConstants.EXPIRES_IN, grant.expiresInProperty());
+
+        grant = new OidcClientConfigBuilder.GrantBuilder()
+                .type(Type.CIBA)
+                .expiresInProperty("exp1")
+                .accessTokenProperty("acc1")
+                .refreshExpiresInProperty("exp2")
+                .refreshTokenProperty("ref1")
+                .build();
+        var config = OidcClientConfig.builder().id("2").grant(grant).build();
+        var buildGrant = config.grant();
+        assertEquals("2", config.id().orElse(null));
+        assertNotNull(buildGrant);
+        assertEquals(Type.CIBA, buildGrant.type());
+        assertEquals("exp1", buildGrant.expiresInProperty());
+        assertEquals("acc1", buildGrant.accessTokenProperty());
+        assertEquals("exp2", buildGrant.refreshExpiresInProperty());
+        assertEquals("ref1", buildGrant.refreshTokenProperty());
+    }
+}

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
@@ -4,9 +4,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-public class OidcClientCommonConfig extends OidcCommonConfig {
+public abstract class OidcClientCommonConfig extends OidcCommonConfig
+        implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig {
 
-    public OidcClientCommonConfig() {
+    protected OidcClientCommonConfig() {
 
     }
 
@@ -50,7 +51,32 @@ public class OidcClientCommonConfig extends OidcCommonConfig {
      */
     public Credentials credentials = new Credentials();
 
-    public static class Credentials {
+    @Override
+    public Optional<String> tokenPath() {
+        return tokenPath;
+    }
+
+    @Override
+    public Optional<String> revokePath() {
+        return revokePath;
+    }
+
+    @Override
+    public Optional<String> clientId() {
+        return clientId;
+    }
+
+    @Override
+    public Optional<String> clientName() {
+        return clientName;
+    }
+
+    @Override
+    public io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials credentials() {
+        return credentials;
+    }
+
+    public static class Credentials implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials {
 
         /**
          * The client secret used by the `client_secret_basic` authentication method.
@@ -102,13 +128,44 @@ public class OidcClientCommonConfig extends OidcCommonConfig {
             jwt.addConfigMappingValues(mapping.jwt());
         }
 
+        @Override
+        public Optional<String> secret() {
+            return secret;
+        }
+
+        @Override
+        public io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret clientSecret() {
+            return clientSecret;
+        }
+
+        @Override
+        public io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt jwt() {
+            return jwt;
+        }
+
         /**
          * Supports the client authentication methods that involve sending a client secret.
          *
          * @see <a href=
          *      "https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication</a>
          */
-        public static class Secret {
+        public static class Secret implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret {
+
+            @Override
+            public Optional<String> value() {
+                return value;
+            }
+
+            @Override
+            public io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Provider provider() {
+                return provider;
+            }
+
+            @Override
+            public Optional<io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret.Method> method() {
+                return method.map(Enum::toString)
+                        .map(io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret.Method::valueOf);
+            }
 
             public static enum Method {
                 /**
@@ -194,7 +251,94 @@ public class OidcClientCommonConfig extends OidcCommonConfig {
          * @see <a href=
          *      "https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication</a>
          */
-        public static class Jwt {
+        public static class Jwt implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt {
+
+            @Override
+            public io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt.Source source() {
+                return source == null ? null
+                        : io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt.Source
+                                .valueOf(source.toString());
+            }
+
+            @Override
+            public Optional<String> secret() {
+                return secret;
+            }
+
+            @Override
+            public io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Provider secretProvider() {
+                return secretProvider;
+            }
+
+            @Override
+            public Optional<String> key() {
+                return key;
+            }
+
+            @Override
+            public Optional<String> keyFile() {
+                return keyFile;
+            }
+
+            @Override
+            public Optional<String> keyStoreFile() {
+                return keyStoreFile;
+            }
+
+            @Override
+            public Optional<String> keyStorePassword() {
+                return keyStorePassword;
+            }
+
+            @Override
+            public Optional<String> keyId() {
+                return keyId;
+            }
+
+            @Override
+            public Optional<String> keyPassword() {
+                return keyPassword;
+            }
+
+            @Override
+            public Optional<String> audience() {
+                return audience;
+            }
+
+            @Override
+            public Optional<String> tokenKeyId() {
+                return tokenKeyId;
+            }
+
+            @Override
+            public Optional<String> issuer() {
+                return issuer;
+            }
+
+            @Override
+            public Optional<String> subject() {
+                return subject;
+            }
+
+            @Override
+            public Map<String, String> claims() {
+                return claims;
+            }
+
+            @Override
+            public Optional<String> signatureAlgorithm() {
+                return signatureAlgorithm;
+            }
+
+            @Override
+            public int lifespan() {
+                return lifespan;
+            }
+
+            @Override
+            public boolean assertion() {
+                return assertion;
+            }
 
             public static enum Source {
                 // JWT token is generated by the OIDC provider client to support
@@ -417,7 +561,8 @@ public class OidcClientCommonConfig extends OidcCommonConfig {
         /**
          * CredentialsProvider, which provides a client secret.
          */
-        public static class Provider {
+        public static class Provider
+                implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Provider {
 
             /**
              * The CredentialsProvider bean name, which should only be set if more than one CredentialsProvider is
@@ -468,6 +613,21 @@ public class OidcClientCommonConfig extends OidcCommonConfig {
                 name = mapping.name();
                 keyringName = mapping.keyringName();
                 key = mapping.key();
+            }
+
+            @Override
+            public Optional<String> name() {
+                return name;
+            }
+
+            @Override
+            public Optional<String> keyringName() {
+                return keyringName;
+            }
+
+            @Override
+            public Optional<String> key() {
+                return key;
             }
         }
     }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcTlsSupport.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcTlsSupport.java
@@ -6,13 +6,14 @@ import java.util.function.Supplier;
 
 import javax.net.ssl.SSLContext;
 
+import io.quarkus.oidc.common.runtime.config.OidcCommonConfig;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.TlsConfigurationRegistry;
 
 public interface OidcTlsSupport {
 
     default TlsConfigSupport forConfig(OidcCommonConfig.Tls config) {
-        return config == null ? forConfig(Optional.empty()) : forConfig(config.tlsConfigurationName);
+        return config == null ? forConfig(Optional.empty()) : forConfig(config.tlsConfigurationName());
     }
 
     TlsConfigSupport forConfig(Optional<String> tlsConfigurationName);

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfigBuilder.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfigBuilder.java
@@ -1,0 +1,747 @@
+package io.quarkus.oidc.common.runtime.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt.Source;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Provider;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret.Method;
+
+public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigBuilder<T> {
+
+    protected static class OidcClientCommonConfigImpl extends OidcCommonConfigImpl implements OidcClientCommonConfig {
+
+        private final Optional<String> tokenPath;
+        private final Optional<String> revokePath;
+        private final Optional<String> clientId;
+        private final Optional<String> clientName;
+        private final Credentials credentials;
+
+        protected OidcClientCommonConfigImpl(OidcClientCommonConfigBuilder<?> builder) {
+            super(builder);
+            this.tokenPath = builder.tokenPath;
+            this.revokePath = builder.revokePath;
+            this.clientId = builder.clientId;
+            this.clientName = builder.clientName;
+            this.credentials = builder.credentials;
+        }
+
+        @Override
+        public Optional<String> tokenPath() {
+            return tokenPath;
+        }
+
+        @Override
+        public Optional<String> revokePath() {
+            return revokePath;
+        }
+
+        @Override
+        public Optional<String> clientId() {
+            return clientId;
+        }
+
+        @Override
+        public Optional<String> clientName() {
+            return clientName;
+        }
+
+        @Override
+        public Credentials credentials() {
+            return credentials;
+        }
+    }
+
+    private Optional<String> tokenPath;
+    private Optional<String> revokePath;
+    private Optional<String> clientId;
+    private Optional<String> clientName;
+    private Credentials credentials;
+
+    protected OidcClientCommonConfigBuilder(OidcClientCommonConfig oidcClientCommonConfig) {
+        super(oidcClientCommonConfig);
+        this.tokenPath = oidcClientCommonConfig.tokenPath();
+        this.revokePath = oidcClientCommonConfig.revokePath();
+        this.clientId = oidcClientCommonConfig.clientId();
+        this.clientName = oidcClientCommonConfig.clientName();
+        this.credentials = oidcClientCommonConfig.credentials();
+    }
+
+    /**
+     * @param tokenPath {@link OidcClientCommonConfig#tokenPath()}
+     * @return T builder
+     */
+    public T tokenPath(String tokenPath) {
+        this.tokenPath = Optional.ofNullable(tokenPath);
+        return getBuilder();
+    }
+
+    /**
+     * @param revokePath {@link OidcClientCommonConfig#revokePath()}
+     * @return T builder
+     */
+    public T revokePath(String revokePath) {
+        this.revokePath = Optional.ofNullable(revokePath);
+        return getBuilder();
+    }
+
+    /**
+     * @param clientId {@link OidcClientCommonConfig#clientId()}
+     * @return T builder
+     */
+    public T clientId(String clientId) {
+        this.clientId = Optional.ofNullable(clientId);
+        return getBuilder();
+    }
+
+    /**
+     * @param clientName {@link OidcClientCommonConfig#clientName()}
+     * @return T builder
+     */
+    public T clientName(String clientName) {
+        this.clientName = Optional.ofNullable(clientName);
+        return getBuilder();
+    }
+
+    /**
+     * @param credentials {@link OidcClientCommonConfig#credentials()} created with {@link CredentialsBuilder} or SmallRye
+     *        Config
+     * @return T builder
+     */
+    public T credentials(Credentials credentials) {
+        this.credentials = Objects.requireNonNull(credentials);
+        return getBuilder();
+    }
+
+    /**
+     * Creates {@link OidcClientCommonConfig#credentials()} builder.
+     *
+     * @return CredentialsBuilder
+     */
+    public CredentialsBuilder<T> credentials() {
+        return new CredentialsBuilder<>(this);
+    }
+
+    /**
+     * @param secret {@link Credentials#secret()}
+     * @return T builder
+     */
+    public T credentials(String secret) {
+        return credentials().secret(secret).end();
+    }
+
+    /**
+     * @param clientSecret {@link Credentials#clientSecret()} created with {@link SecretBuilder} or SmallRye Config
+     * @return T builder
+     */
+    public T credentials(Secret clientSecret) {
+        Objects.requireNonNull(clientSecret);
+        return credentials().clientSecret(clientSecret).end();
+    }
+
+    /**
+     * @param jwt {@link Credentials#jwt()} created with {@link JwtBuilder} or SmallRye Config
+     * @return T builder
+     */
+    public T credentials(Jwt jwt) {
+        Objects.requireNonNull(jwt);
+        return credentials().jwt(jwt).end();
+    }
+
+    /**
+     * Builder for the {@link Credentials} config.
+     */
+    public static final class CredentialsBuilder<T> {
+
+        private record CredentialsImpl(Optional<String> secret, Secret clientSecret, Jwt jwt) implements Credentials {
+        }
+
+        private final OidcClientCommonConfigBuilder<T> builder;
+        private Optional<String> secret;
+        private Secret clientSecret;
+        private Jwt jwt;
+
+        public CredentialsBuilder() {
+            this.builder = null;
+            this.secret = Optional.empty();
+            this.clientSecret = new SecretBuilder<>().build();
+            this.jwt = new JwtBuilder<>().build();
+        }
+
+        public CredentialsBuilder(OidcClientCommonConfigBuilder<T> builder) {
+            this.builder = builder;
+            this.secret = builder.credentials.secret();
+            this.clientSecret = builder.credentials.clientSecret();
+            this.jwt = builder.credentials.jwt();
+        }
+
+        /**
+         * @param secret {@link Credentials#secret()}
+         * @return this builder
+         */
+        public CredentialsBuilder<T> secret(String secret) {
+            this.secret = Optional.ofNullable(secret);
+            return this;
+        }
+
+        /**
+         * @param clientSecret {@link Credentials#clientSecret()} created with the {@link SecretBuilder} or SmallRye Config
+         * @return this builder
+         */
+        public CredentialsBuilder<T> clientSecret(Secret clientSecret) {
+            this.clientSecret = Objects.requireNonNull(clientSecret);
+            return this;
+        }
+
+        /**
+         * Creates builder for the {@link Credentials#clientSecret()}.
+         *
+         * @return SecretBuilder
+         */
+        public SecretBuilder<T> clientSecret() {
+            return new SecretBuilder<>(this);
+        }
+
+        /**
+         * @param value {@link Secret#value()}
+         * @return this builder
+         */
+        public CredentialsBuilder<T> clientSecret(String value) {
+            return clientSecret().value(value).end();
+        }
+
+        /**
+         * @param provider {@link Secret#provider()}
+         * @return this builder
+         */
+        public CredentialsBuilder<T> clientSecret(Provider provider) {
+            return clientSecret().provider(provider).end();
+        }
+
+        /**
+         * @param value {@link Secret#value()}
+         * @param method {@link Secret#method()}
+         * @return this builder
+         */
+        public CredentialsBuilder<T> clientSecret(String value, Method method) {
+            return clientSecret().value(value).method(method).end();
+        }
+
+        /**
+         * @param jwt {@link Credentials#jwt()} created with the {@link JwtBuilder} or SmallRye Config
+         * @return this builder
+         */
+        public CredentialsBuilder<T> jwt(Jwt jwt) {
+            this.jwt = Objects.requireNonNull(jwt);
+            return this;
+        }
+
+        /**
+         * Creates builder for the {@link Credentials#jwt()}.
+         *
+         * @return JwtBuilder
+         */
+        public JwtBuilder<T> jwt() {
+            return new JwtBuilder<>(this);
+        }
+
+        /**
+         * Builds {@link Credentials} and returns the builder.
+         *
+         * @return T builder
+         */
+        public T end() {
+            Objects.requireNonNull(builder);
+            return builder.credentials(build());
+        }
+
+        /**
+         * @return Credentials
+         */
+        public Credentials build() {
+            return new CredentialsImpl(secret, clientSecret, jwt);
+        }
+    }
+
+    /**
+     * The {@link Secret} builder.
+     */
+    public static final class SecretBuilder<T> {
+
+        private record SecretImpl(Optional<String> value, Optional<Method> method, Provider provider) implements Secret {
+        }
+
+        private final CredentialsBuilder<T> builder;
+
+        private Optional<String> value;
+        private Optional<Method> method;
+        private Provider provider;
+
+        public SecretBuilder() {
+            this.builder = null;
+            this.value = Optional.empty();
+            this.method = Optional.empty();
+            this.provider = new ProviderBuilder<>().build();
+        }
+
+        public SecretBuilder(CredentialsBuilder<T> builder) {
+            this.builder = Objects.requireNonNull(builder);
+            this.value = builder.clientSecret.value();
+            this.method = builder.clientSecret.method();
+            this.provider = builder.clientSecret.provider();
+        }
+
+        /**
+         * @param method {@link Secret#method()}
+         * @return this builder
+         */
+        public SecretBuilder<T> method(Method method) {
+            this.method = Optional.ofNullable(method);
+            return this;
+        }
+
+        /**
+         * @param value {@link Secret#value()}
+         * @return this builder
+         */
+        public SecretBuilder<T> value(String value) {
+            this.value = Optional.ofNullable(value);
+            return this;
+        }
+
+        /**
+         * @param provider {@link Secret#provider()} created with the {@link ProviderBuilder} or SmallRye Config
+         * @return this builder
+         */
+        public SecretBuilder<T> provider(Provider provider) {
+            this.provider = Objects.requireNonNull(provider);
+            return this;
+        }
+
+        /**
+         * Adds {@link Secret#provider()}.
+         *
+         * @param key {@link Provider#key()}
+         * @return this builder
+         */
+        public SecretBuilder<T> provider(String key) {
+            return provider().key(key).end();
+        }
+
+        /**
+         * Adds {@link Secret#provider()}.
+         *
+         * @param key {@link Provider#key()}
+         * @param name {@link Provider#name()}
+         * @return this builder
+         */
+        public SecretBuilder<T> provider(String key, String name) {
+            return provider().key(key).name(name).end();
+        }
+
+        /**
+         * Adds {@link Secret#provider()}.
+         *
+         * @param key {@link Provider#key()}
+         * @param name {@link Provider#name()}
+         * @param keyringName {@link Provider#keyringName()}
+         * @return this builder
+         */
+        public SecretBuilder<T> provider(String key, String name, String keyringName) {
+            return provider().key(key).name(name).keyringName(keyringName).end();
+        }
+
+        /**
+         * Creates {@link Secret#provider()} builder.
+         *
+         * @return ProviderBuilder
+         */
+        public ProviderBuilder<SecretBuilder<T>> provider() {
+            return new ProviderBuilder<>(this::provider, provider);
+        }
+
+        /**
+         * Builds {@link Secret} client secret.
+         *
+         * @return CredentialsBuilder
+         */
+        public CredentialsBuilder<T> end() {
+            Objects.requireNonNull(builder);
+            return builder.clientSecret(build());
+        }
+
+        /**
+         * Builds {@link Credentials#clientSecret()} and {@link OidcClientCommonConfig#credentials()}.
+         *
+         * @return T builder
+         */
+        public T endCredentials() {
+            return end().end();
+        }
+
+        public Secret build() {
+            return new SecretImpl(value, method, provider);
+        }
+    }
+
+    /**
+     * The {@link Provider} builder.
+     */
+    public static final class ProviderBuilder<T> {
+
+        private record ProviderImpl(Optional<String> name, Optional<String> keyringName,
+                Optional<String> key) implements Provider {
+        }
+
+        private final Function<Provider, T> providerSetter;
+        private Optional<String> name;
+        private Optional<String> keyringName;
+        private Optional<String> key;
+
+        private ProviderBuilder(Function<Provider, T> providerSetter, Provider provider) {
+            this.providerSetter = providerSetter;
+            this.name = provider.name();
+            this.keyringName = provider.keyringName();
+            this.key = provider.key();
+        }
+
+        public ProviderBuilder() {
+            this.providerSetter = null;
+            this.name = Optional.empty();
+            this.keyringName = Optional.empty();
+            this.key = Optional.empty();
+        }
+
+        /**
+         * @param name {@link Provider#name()}
+         * @return this builder
+         */
+        public ProviderBuilder<T> name(String name) {
+            this.name = Optional.ofNullable(name);
+            return this;
+        }
+
+        /**
+         * @param keyringName {@link Provider#keyringName()}
+         * @return this builder
+         */
+        public ProviderBuilder<T> keyringName(String keyringName) {
+            this.keyringName = Optional.ofNullable(keyringName);
+            return this;
+        }
+
+        /**
+         * @param key {@link Provider#key()}
+         * @return this builder
+         */
+        public ProviderBuilder<T> key(String key) {
+            this.key = Optional.ofNullable(key);
+            return this;
+        }
+
+        /**
+         * Builds {@link Provider}.
+         *
+         * @return T builder
+         */
+        public T end() {
+            Objects.requireNonNull(providerSetter);
+            return providerSetter.apply(build());
+        }
+
+        /**
+         * Builds {@link Provider}.
+         *
+         * @return Provider
+         */
+        public Provider build() {
+            return new ProviderImpl(name, keyringName, key);
+        }
+
+    }
+
+    public static final class JwtBuilder<T> {
+
+        private record JwtImpl(Source source, Optional<String> secret, Provider secretProvider, Optional<String> key,
+                Optional<String> keyFile, Optional<String> keyStoreFile, Optional<String> keyStorePassword,
+                Optional<String> keyId, Optional<String> keyPassword, Optional<String> audience, Optional<String> tokenKeyId,
+                Optional<String> issuer, Optional<String> subject, Map<String, String> claims,
+                Optional<String> signatureAlgorithm, int lifespan, boolean assertion) implements Jwt {
+
+        }
+
+        private final CredentialsBuilder<T> builder;
+        private final Map<String, String> claims = new HashMap<>();
+        private Source source;
+        private Optional<String> secret;
+        private Provider secretProvider;
+        private Optional<String> key;
+        private Optional<String> keyFile;
+        private Optional<String> keyStoreFile;
+        private Optional<String> keyStorePassword;
+        private Optional<String> keyId;
+        private Optional<String> keyPassword;
+        private Optional<String> audience;
+        private Optional<String> tokenKeyId;
+        private Optional<String> issuer;
+        private Optional<String> subject;
+        private Optional<String> signatureAlgorithm;
+        private int lifespan;
+        private boolean assertion;
+
+        public JwtBuilder() {
+            this.builder = null;
+            this.source = Source.CLIENT;
+            this.secret = Optional.empty();
+            this.secretProvider = new ProviderBuilder<>().build();
+            this.key = Optional.empty();
+            this.keyFile = Optional.empty();
+            this.keyStoreFile = Optional.empty();
+            this.keyStorePassword = Optional.empty();
+            this.keyId = Optional.empty();
+            this.keyPassword = Optional.empty();
+            this.audience = Optional.empty();
+            this.tokenKeyId = Optional.empty();
+            this.issuer = Optional.empty();
+            this.subject = Optional.empty();
+            this.signatureAlgorithm = Optional.empty();
+            this.lifespan = 10;
+            this.assertion = false;
+        }
+
+        public JwtBuilder(CredentialsBuilder<T> builder) {
+            this(Objects.requireNonNull(builder), builder.jwt);
+        }
+
+        private JwtBuilder(CredentialsBuilder<T> builder, Jwt jwt) {
+            this.builder = builder;
+            this.source = jwt.source();
+            this.secret = jwt.secret();
+            this.secretProvider = jwt.secretProvider();
+            this.key = jwt.key();
+            this.keyFile = jwt.keyFile();
+            this.keyStoreFile = jwt.keyStoreFile();
+            this.keyStorePassword = jwt.keyStorePassword();
+            this.keyId = jwt.keyId();
+            this.keyPassword = jwt.keyPassword();
+            this.audience = jwt.audience();
+            this.tokenKeyId = jwt.tokenKeyId();
+            this.issuer = jwt.issuer();
+            this.subject = jwt.subject();
+            this.claims.putAll(jwt.claims());
+            this.signatureAlgorithm = jwt.signatureAlgorithm();
+            this.lifespan = jwt.lifespan();
+            this.assertion = jwt.assertion();
+        }
+
+        /**
+         * @return {@link Jwt#secretProvider()} builder
+         */
+        public ProviderBuilder<JwtBuilder<T>> secretProvider() {
+            return new ProviderBuilder<>(this::secretProvider, secretProvider);
+        }
+
+        /**
+         * @param secretProvider {@link Jwt#secretProvider()} created by {@link ProviderBuilder} or SmallRye Config
+         * @return this builder
+         */
+        public JwtBuilder<T> secretProvider(Provider secretProvider) {
+            Objects.requireNonNull(secretProvider);
+            this.secretProvider = secretProvider;
+            return this;
+        }
+
+        /**
+         * @param source {@link Jwt#source()}
+         * @return this builder
+         */
+        public JwtBuilder<T> source(Source source) {
+            Objects.requireNonNull(source);
+            this.source = source;
+            return this;
+        }
+
+        /**
+         * @param secret {@link Jwt#secret()}
+         * @return this builder
+         */
+        public JwtBuilder<T> secret(String secret) {
+            this.secret = Optional.ofNullable(secret);
+            return this;
+        }
+
+        /**
+         * @param key {@link Jwt#key()}
+         * @return this builder
+         */
+        public JwtBuilder<T> key(String key) {
+            this.key = Optional.ofNullable(key);
+            return this;
+        }
+
+        /**
+         * @param keyFile {@link Jwt#keyFile()}
+         * @return this builder
+         */
+        public JwtBuilder<T> keyFile(String keyFile) {
+            this.keyFile = Optional.ofNullable(keyFile);
+            return this;
+        }
+
+        /**
+         * @param keyStoreFile {@link Jwt#keyStoreFile()}
+         * @return this builder
+         */
+        public JwtBuilder<T> keyStoreFile(String keyStoreFile) {
+            this.keyStoreFile = Optional.ofNullable(keyStoreFile);
+            return this;
+        }
+
+        /**
+         * @param keyStorePassword {@link Jwt#keyStorePassword()}
+         * @return this builder
+         */
+        public JwtBuilder<T> keyStorePassword(String keyStorePassword) {
+            this.keyStorePassword = Optional.ofNullable(keyStorePassword);
+            return this;
+        }
+
+        /**
+         * @param keyId {@link Jwt#keyId()}
+         * @return this builder
+         */
+        public JwtBuilder<T> keyId(String keyId) {
+            this.keyId = Optional.ofNullable(keyId);
+            return this;
+        }
+
+        /**
+         * @param keyPassword {@link Jwt#keyPassword()}
+         * @return this builder
+         */
+        public JwtBuilder<T> keyPassword(String keyPassword) {
+            this.keyPassword = Optional.ofNullable(keyPassword);
+            return this;
+        }
+
+        /**
+         * @param audience {@link Jwt#audience()}
+         * @return this builder
+         */
+        public JwtBuilder<T> audience(String audience) {
+            this.audience = Optional.ofNullable(audience);
+            return this;
+        }
+
+        /**
+         * @param tokenKeyId {@link Jwt#tokenKeyId()}
+         * @return this builder
+         */
+        public JwtBuilder<T> tokenKeyId(String tokenKeyId) {
+            this.tokenKeyId = Optional.ofNullable(tokenKeyId);
+            return this;
+        }
+
+        /**
+         * @param issuer {@link Jwt#issuer()}
+         * @return this builder
+         */
+        public JwtBuilder<T> issuer(String issuer) {
+            this.issuer = Optional.ofNullable(issuer);
+            return this;
+        }
+
+        /**
+         * @param subject {@link Jwt#subject()}
+         * @return this builder
+         */
+        public JwtBuilder<T> subject(String subject) {
+            this.subject = Optional.ofNullable(subject);
+            return this;
+        }
+
+        /**
+         * @param claimName {@link Jwt#claims()} map entry key
+         * @param claimValue {@link Jwt#claims()} map entry value
+         * @return this builder
+         */
+        public JwtBuilder<T> claim(String claimName, String claimValue) {
+            Objects.requireNonNull(claimName);
+            Objects.requireNonNull(claimValue);
+            this.claims.put(claimName, claimValue);
+            return this;
+        }
+
+        /**
+         * @param claims {@link Jwt#claims()}
+         * @return this builder
+         */
+        public JwtBuilder<T> claims(Map<String, String> claims) {
+            Objects.requireNonNull(claims);
+            this.claims.putAll(claims);
+            return this;
+        }
+
+        /**
+         * @param signatureAlgorithm {@link Jwt#signatureAlgorithm()}
+         * @return this builder
+         */
+        public JwtBuilder<T> signatureAlgorithm(String signatureAlgorithm) {
+            this.signatureAlgorithm = Optional.ofNullable(signatureAlgorithm);
+            return this;
+        }
+
+        /**
+         * @param lifespan {@link Jwt#lifespan()}
+         * @return this builder
+         */
+        public JwtBuilder<T> lifespan(int lifespan) {
+            this.lifespan = lifespan;
+            return this;
+        }
+
+        /**
+         * @param assertion {@link Jwt#assertion()}
+         * @return this builder
+         */
+        public JwtBuilder<T> assertion(boolean assertion) {
+            this.assertion = assertion;
+            return this;
+        }
+
+        /**
+         * Builds {@link Credentials#jwt()}.
+         *
+         * @return CredentialsBuilder
+         */
+        public CredentialsBuilder<T> end() {
+            Objects.requireNonNull(builder);
+            return builder.jwt(build());
+        }
+
+        /**
+         * Builds {@link Credentials#jwt()} and {@link OidcClientCommonConfig#credentials()}.
+         *
+         * @return T builder
+         */
+        public T endCredentials() {
+            return end().end();
+        }
+
+        /**
+         * Builds {@link Jwt}.
+         *
+         * @return Jwt
+         */
+        public Jwt build() {
+            return new JwtImpl(source, secret, secretProvider, key, keyFile, keyStoreFile, keyStorePassword, keyId, keyPassword,
+                    audience, tokenKeyId, issuer, subject, Map.copyOf(claims), signatureAlgorithm, lifespan, assertion);
+        }
+    }
+}

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcCommonConfigBuilder.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcCommonConfigBuilder.java
@@ -37,7 +37,7 @@ public abstract class OidcCommonConfigBuilder<T> {
         private final Proxy proxy;
         private final Tls tls;
 
-        protected OidcCommonConfigImpl(OidcCommonConfigBuilder builder) {
+        protected OidcCommonConfigImpl(OidcCommonConfigBuilder<?> builder) {
             this.authServerUrl = builder.authServerUrl;
             this.discoveryEnabled = builder.discoveryEnabled;
             this.registrationPath = builder.registrationPath;

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
@@ -51,7 +51,8 @@ public class OidcCommonUtilsTest {
 
     @Test
     public void testJwtTokenWithScope() throws Exception {
-        OidcClientCommonConfig cfg = new OidcClientCommonConfig();
+        OidcClientCommonConfig cfg = new OidcClientCommonConfig() {
+        };
         cfg.setClientId("client");
         cfg.credentials.jwt.claims.put("scope", "read,write");
         PrivateKey key = KeyPairGenerator.getInstance("RSA").generateKeyPair().getPrivate();

--- a/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenRequestReactiveFilter.java
+++ b/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenRequestReactiveFilter.java
@@ -21,9 +21,9 @@ import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestFilte
 
 import io.quarkus.arc.Arc;
 import io.quarkus.oidc.client.OidcClient;
-import io.quarkus.oidc.client.OidcClientConfig.Grant;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.runtime.DisabledOidcClientException;
+import io.quarkus.oidc.client.runtime.OidcClientConfig.Grant;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.security.credential.TokenCredential;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;

--- a/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
+++ b/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
@@ -15,8 +15,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.oidc.client.OidcClient;
-import io.quarkus.oidc.client.OidcClientConfig.Grant;
 import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.client.runtime.OidcClientConfig.Grant;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.token.propagation.runtime.AbstractTokenRequestFilter;
 import io.quarkus.runtime.configuration.ConfigurationException;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -10,8 +10,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig;
-import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.common.runtime.config.OidcCommonConfig;
 import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -20,10 +20,10 @@ import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
 import io.quarkus.oidc.common.OidcRequestFilter.OidcRequestContext;
 import io.quarkus.oidc.common.OidcResponseFilter;
-import io.quarkus.oidc.common.runtime.OidcClientCommonConfig.Credentials.Secret.Method;
 import io.quarkus.oidc.common.runtime.OidcClientRedirectException;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret.Method;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniOnItem;
 import io.vertx.core.Vertx;
@@ -71,7 +71,7 @@ public class OidcProviderClient implements Closeable {
         this.introspectionBasicAuthScheme = initIntrospectionBasicAuthScheme(oidcConfig);
         this.requestFilters = requestFilters;
         this.responseFilters = responseFilters;
-        this.clientSecretQueryAuthentication = oidcConfig.credentials.clientSecret.method.orElse(null) == Method.QUERY;
+        this.clientSecretQueryAuthentication = oidcConfig.credentials().clientSecret().method().orElse(null) == Method.QUERY;
     }
 
     private static String initIntrospectionBasicAuthScheme(OidcTenantConfig oidcConfig) {
@@ -208,23 +208,23 @@ public class OidcProviderClient implements Closeable {
                 request.putHeader(AUTHORIZATION_HEADER, clientSecretBasicAuthScheme);
             } else if (clientJwtKey != null) {
                 String jwt = OidcCommonUtils.signJwtWithKey(oidcConfig, metadata.getTokenUri(), clientJwtKey);
-                if (OidcCommonUtils.isClientSecretPostJwtAuthRequired(oidcConfig.credentials)) {
+                if (OidcCommonUtils.isClientSecretPostJwtAuthRequired(oidcConfig.credentials())) {
                     formBody.add(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
                     formBody.add(OidcConstants.CLIENT_SECRET, jwt);
                 } else {
                     formBody.add(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
                     formBody.add(OidcConstants.CLIENT_ASSERTION, jwt);
                 }
-            } else if (OidcCommonUtils.isClientSecretPostAuthRequired(oidcConfig.credentials)) {
+            } else if (OidcCommonUtils.isClientSecretPostAuthRequired(oidcConfig.credentials())) {
                 formBody.add(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
-                formBody.add(OidcConstants.CLIENT_SECRET, OidcCommonUtils.clientSecret(oidcConfig.credentials));
+                formBody.add(OidcConstants.CLIENT_SECRET, OidcCommonUtils.clientSecret(oidcConfig.credentials()));
             } else {
                 formBody.add(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
             }
             buffer = OidcCommonUtils.encodeForm(formBody);
         } else {
             formBody.add(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
-            formBody.add(OidcConstants.CLIENT_SECRET, OidcCommonUtils.clientSecret(oidcConfig.credentials));
+            formBody.add(OidcConstants.CLIENT_SECRET, OidcCommonUtils.clientSecret(oidcConfig.credentials()));
             for (Map.Entry<String, String> entry : formBody) {
                 request.addQueryParam(entry.getKey(), OidcCommonUtils.urlEncode(entry.getValue()));
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -41,9 +41,9 @@ import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
 import io.quarkus.oidc.common.OidcResponseFilter;
-import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcTlsSupport;
+import io.quarkus.oidc.common.runtime.config.OidcCommonConfig;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -539,7 +539,7 @@ public class OidcRecorder {
 
         WebClientOptions options = new WebClientOptions();
         options.setFollowRedirects(oidcConfig.followRedirects);
-        OidcCommonUtils.setHttpClientOptions(oidcConfig, options, tlsSupport.forConfig(oidcConfig.tls));
+        OidcCommonUtils.setHttpClientOptions(oidcConfig, options, tlsSupport.forConfig(oidcConfig.tls()));
         var mutinyVertx = new io.vertx.mutiny.core.Vertx(vertx);
         WebClient client = WebClient.create(mutinyVertx, options);
 

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcRecorderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcRecorderTest.java
@@ -6,20 +6,20 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.common.runtime.OidcCommonConfig.Proxy;
 
 public class OidcRecorderTest {
 
     @Test
     public void testtoProxyOptionsWithHostCheckPresent() {
-        OidcTenantConfig.Proxy proxy = new OidcTenantConfig.Proxy();
+        Proxy proxy = new Proxy();
         proxy.host = Optional.of("server.example.com");
         assertTrue(OidcRecorder.toProxyOptions(proxy).isPresent());
     }
 
     @Test
     public void testtoProxyOptionsWithoutHostCheckNonPresent() {
-        OidcTenantConfig.Proxy proxy = new OidcTenantConfig.Proxy();
+        Proxy proxy = new Proxy();
         assertFalse(OidcRecorder.toProxyOptions(proxy).isPresent());
     }
 

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/OidcClientCreator.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/OidcClientCreator.java
@@ -9,9 +9,9 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.quarkus.oidc.client.OidcClient;
-import io.quarkus.oidc.client.OidcClientConfig;
-import io.quarkus.oidc.client.OidcClientConfig.Grant.Type;
 import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.client.runtime.OidcClientConfig;
+import io.quarkus.oidc.client.runtime.OidcClientConfig.Grant.Type;
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.mutiny.Uni;
 
@@ -40,14 +40,14 @@ public class OidcClientCreator {
     }
 
     private Uni<OidcClient> createOidcClient() {
-        OidcClientConfig cfg = new OidcClientConfig();
-        cfg.setId("myclient");
-        cfg.setAuthServerUrl(oidcProviderAddress);
-        cfg.setClientId(oidcClientId);
-        cfg.getCredentials().setSecret(oidcClientSecret);
-        cfg.getGrant().setType(Type.PASSWORD);
-        cfg.setGrantOptions(Map.of("password",
-                Map.of("username", "jdoe", "password", "jdoe")));
+        OidcClientConfig cfg = OidcClientConfig
+                .authServerUrl(oidcProviderAddress)
+                .id("myclient")
+                .clientId(oidcClientId)
+                .credentials(oidcClientSecret)
+                .grant(Type.PASSWORD)
+                .grantOptions("password", Map.of("username", "jdoe", "password", "jdoe"))
+                .build();
         return oidcClients.newClient(cfg);
     }
 }


### PR DESCRIPTION
- part of the https://github.com/quarkusio/quarkus/issues/39185
- introduce new OIDC Client config builder and deprecate former config class
- is backwards compatible - users can keep using old OidcClientConfig as now the class implements the configmapping group interface, so users can still do `oidcClients.newClient(formerConfigClass)` while we migrated to the config mapping; that should reduce copying between config mapping interfaces and config classes
- improves generated docs as number of config properties is reduced (we show both named and unnamed client in one row, which is what was already done for the OIDC extension here https://github.com/quarkusio/quarkus/pull/44374)
- because we cannot modify interfaces impl. returned by SmallRye Config, I added config builder that makes sure that `id` is set if user didn't specify it explicitly. In past, we set this config class property inside of the recorder, but now it needs to be set bit sooner; situation shouldn't change for users though