### PR TITLE
Fix invalid proxy setting when the port ends with a whitespace

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -15,9 +15,11 @@ import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.configuration.MemorySize;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithDefaults;
 import io.smallrye.config.WithKeys;
@@ -58,7 +60,7 @@ public interface RestClientsConfig {
      * <p>
      * Can be overwritten by client-specific settings.
      */
-    Optional<String> proxyAddress();
+    Optional<@WithConverter(TrimmedStringConverter.class) String> proxyAddress();
 
     /**
      * Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
@@ -449,7 +451,7 @@ public interface RestClientsConfig {
          * <p>
          * Use `none` to disable proxy
          */
-        Optional<String> proxyAddress();
+        Optional<@WithConverter(TrimmedStringConverter.class) String> proxyAddress();
 
         /**
          * Proxy username.

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/configuration-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/configuration-test-application.properties
@@ -27,7 +27,8 @@ quarkus.rest-client.client-prefix.providers=io.quarkus.rest.client.reactive.Hell
 quarkus.rest-client.client-prefix.connect-timeout=5000
 quarkus.rest-client.client-prefix.read-timeout=6000
 quarkus.rest-client.client-prefix.follow-redirects=true
-quarkus.rest-client.client-prefix.proxy-address=localhost:8080
+# intentionally add whitespace at the end to ensure we strip it
+quarkus.rest-client.client-prefix.proxy-address=localhost:8080 
 quarkus.rest-client.client-prefix.query-param-style=COMMA_SEPARATED
 quarkus.rest-client.client-prefix.connection-ttl=30000
 quarkus.rest-client.client-prefix.connection-pool-size=10


### PR DESCRIPTION
**Scenario:** 

A user configures the proxy address (for example in `application.properties`, `.env `file etc) and there is a whitespace at the end of the settings like here:

`'quarkus.rest-client.proxy-address=localhost:8080 '`

**Error:** 

After splitting the proxy address, part with the port is a string value like `"8080 "` and Integer.parseInt("8080 ") will throw a `NumberFormatException`:

`Invalid proxy setting. The port is not a number in 'localhost:8080 '`