### PR TITLE
Adjust descriptions of Agroal and Narayana extensions and remove mention of Hibernate

### DIFF
--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-agroal</artifactId>
     <name>Quarkus - Agroal - Runtime</name>
-    <description>Pool JDBC database connections (included in Hibernate ORM)</description>
+    <description>JDBC Datasources and connection pooling</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-narayana-jta</artifactId>
     <name>Quarkus - Narayana JTA - Runtime</name>
-    <description>Offer JTA transaction support (included in Hibernate ORM)</description>
+    <description>JTA transaction support</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
There's no reason to mention the dependents of an extension in that extensions' description. Especially since both Agroal and Narayana can be used without Hibernate.

Also, I came across people online assuming that Agroal is maintained by the Hibernate team. Let's not bring more confusion to what's evidently already quite confusing.