### PR TITLE
Fix retry count in remote dev mode error message

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java
@@ -259,7 +259,7 @@ public class HttpRemoteDevClient implements RemoteDevClient {
                     errorCount++;
                     log.error("Remote dev request failed", e);
                     if (errorCount == retryMaxAttempts) {
-                        log.error("Connection failed after 10 retries, exiting");
+                        log.errorf("Connection failed after %d retries, exiting", errorCount);
                         return;
                     }
                     try {


### PR DESCRIPTION
The [remote development mode](https://quarkus.io/guides/maven-tooling#remote-development-mode) does not honour `quarkus.live-reload.retry-max-attempts` in connect error messages.

To verify, issue this command that will provoke a connect error:

```shell
mvn quarkus:remote-dev -Dquarkus.live-reload.url=http://localhost:42/ -Dquarkus.live-reload.password=very-secret -Dquarkus.live-reload.retry-max-attempts=2
```
Expected error message:

    2024-11-26 22:46:34,496 ERROR [io.qua.ver.htt.dep.dev.HttpRemoteDevClient] (Remote dev client thread) Connection failed after 2 retries, exiting

Actual error message:

    2024-11-26 22:46:34,496 ERROR [io.qua.ver.htt.dep.dev.HttpRemoteDevClient] (Remote dev client thread) Connection failed after 10 retries, exiting

Reason: The default value of 10 retries is hardcoded into the error message.

Fix: Replace it with the actual retry count.