### PR TITLE
Fix the `io.quarkus.virtual.threads` split package

### DIFF
--- a/extensions/virtual-threads/deployment/src/main/java/io/quarkus/virtual/threads/deployment/VirtualThreadsProcessor.java
+++ b/extensions/virtual-threads/deployment/src/main/java/io/quarkus/virtual/threads/deployment/VirtualThreadsProcessor.java
@@ -1,4 +1,4 @@
-package io.quarkus.virtual.threads;
+package io.quarkus.virtual.threads.deployment;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -14,6 +14,9 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.virtual.threads.VirtualThreads;
+import io.quarkus.virtual.threads.VirtualThreadsConfig;
+import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 
 public class VirtualThreadsProcessor {
 


### PR DESCRIPTION
The deployment package was only containing the processor. Thus, this PR just moves it to `io.quarkus.virtual.threads.deployment.`

Fix #44717 
