### PR TITLE
Add OpenPGP's Bouncycastle library to application's BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3482,6 +3482,11 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpg-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
                 <artifactId>bc-fips</artifactId>
                 <version>${bouncycastle.fips.version}</version>
             </dependency>


### PR DESCRIPTION
Other Bouncycastle libraries are already managed in the application's BOM
