### PR TITLE
Filter out OTel Java Agent version constraints

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6535,7 +6535,6 @@
                 <version>${project.version}</version>
             </dependency>
             <!-- End of Relocations, please put new extensions above this list -->
-
         </dependencies>
     </dependencyManagement>
 
@@ -6581,6 +6580,10 @@
                                 <!-- The exclusion can be removed once all imported BOMs depend on jboss-parent:41+ -->
                                 <!-- See also https://github.com/jboss/jboss-parent-pom/issues/236 -->
                                 <key>org.jboss:jdk-misc</key>
+
+                                <!-- OpenTelemetry Instrumentation Java Agent -->
+                                <key>io.opentelemetry.javaagent:*</key>
+                                <key>io.opentelemetry.javaagent.instrumentation:*</key>
                             </excludeArtifactKeys>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
         <gitflow-incremental-builder.version>4.5.4</gitflow-incremental-builder.version>
-        <quarkus-platform-bom-plugin.version>0.0.116</quarkus-platform-bom-plugin.version>
+        <quarkus-platform-bom-plugin.version>0.0.117</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>
         <skip.gradle.tests>false</skip.gradle.tests>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/44771

This change upgrades the `quarkus-platform-bom-maven-plugin` to 0.0.117 that allows configuring artifact coordinates patterns for the `flatten-platform-bom` goal and filters out `io.opentelemetry.javaagent:*` and `io.opentelemetry.javaagent.instrumentation:*` artifacts from the flattened BOM.