### PR TITLE
Default to old console if user has not set it

### DIFF
--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
@@ -104,7 +104,17 @@ public abstract class QuarkusConsole {
         redirectsInstalled = false;
     }
 
+    private static void checkAndSetJdkConsole() {
+        // the JLine console in JDK 23+ causes significant startup slowdown,
+        // so we avoid it unless the user opted into it
+        String res = System.getProperty("jdk.console");
+        if (res == null) {
+            System.setProperty("jdk.console", "java.base");
+        }
+    }
+
     public static boolean hasColorSupport() {
+        checkAndSetJdkConsole();
         if (Boolean.getBoolean(FORCE_COLOR_SUPPORT)) {
             return true; //assume the IDE run window has color support
         }


### PR DESCRIPTION
This is done because the new JLine console
which is the default from JDK 23 (maybe even 22?)
causes a large regression in startup time due to
it loading a very large number of classes.

If users really want to use the new console,
they have to start the application with

`-Djdk.console=jdk.internal.le`

- Fixes: #44471
- Fixes: #44653

_Note on testing_

I tried to create a proper test for this but it's not easy because we don't have an attached console to check against (if we did, we could open up Java IO using: `--add-opens=java.base/java.io=ALL-UNNAMED` and do something like:

```java
private String determineConsoleName() {
        Console console = System.console();
        if (console == null) {
            return "null";
        }
        // in JDK 21+, the actual console is hidden behind in a delegate
        if ("java.io.ProxyingConsole".equals(console.getClass().getName())) {
            try {
                Class<?> proxyingClass = Thread.currentThread().getContextClassLoader().loadClass("java.io.ProxyingConsole");
                Field delegateField = proxyingClass.getDeclaredField("delegate");
                delegateField.setAccessible(true);
                Object jdkConsole = delegateField.get(console);
                return jdkConsole.getClass().getName();
            } catch (Exception e) {
                throw new RuntimeException(e);
            }
        }
        return console.getClass().getName();
    }
```