### PR TITLE
Update Kotlin to version 2.1.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.5</smallrye-open-api.version>
-        <smallrye-graphql.version>2.11.0</smallrye-graphql.version>
+        <smallrye-graphql.version>2.12.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.7.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.1.2</smallrye-context-propagation.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -150,8 +150,8 @@
         <cloudevents-api.version>3.0.0</cloudevents-api.version>
         <azure-functions-java-library.version>3.1.0</azure-functions-java-library.version>
         <azure-functions-java-spi.version>1.0.0</azure-functions-java-spi.version>
-        <kotlin.version>2.0.21</kotlin.version>
-        <kotlin.coroutine.version>1.9.0</kotlin.coroutine.version>
+        <kotlin.version>2.1.0</kotlin.version>
+        <kotlin.coroutine.version>1.10.0</kotlin.coroutine.version>
         <azure.toolkit-lib.version>0.27.0</azure.toolkit-lib.version>
         <kotlin-serialization.version>1.7.3</kotlin-serialization.version>
         <dekorate.version>4.1.4</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,7 +20,7 @@
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <compiler-plugin.version>${version.compiler.plugin}</compiler-plugin.version>
-        <kotlin.version>2.0.21</kotlin.version>
+        <kotlin.version>2.1.0</kotlin.version>
         <dokka.version>2.0.0</dokka.version>
         <scala.version>2.13.12</scala.version>
         <scala-maven-plugin.version>4.9.2</scala-maven-plugin.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 plugin-publish = "1.3.0"
 
 # updating Kotlin here makes QuarkusPluginTest > shouldNotFailOnProjectDependenciesWithoutMain(Path) fail
-kotlin = "2.0.21"
+kotlin = "2.1.0"
 smallrye-config = "3.10.2"
 
 junit5 = "5.10.5"

--- a/extensions/schema-registry/confluent/pom.xml
+++ b/extensions/schema-registry/confluent/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
-                <version>2.0.21</version>
+                <version>2.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -52,8 +52,8 @@
         <!-- test versions -->
         <version.assertj>3.27.0</version.assertj>
         <version.junit5>5.10.5</version.junit5>
-        <version.kotlin>2.0.21</version.kotlin>
-        <version.kotlin-coroutines>1.9.0</version.kotlin-coroutines>
+        <version.kotlin>2.1.0</version.kotlin>
+        <version.kotlin-coroutines>1.10.0</version.kotlin-coroutines>
         <version.mockito>5.14.2</version.mockito>
         <!-- TCK versions -->
         <version.arquillian>1.7.0.Final</version.arquillian>

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-no-java/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-no-java/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "2.0.21"
-    kotlin("plugin.allopen") version "2.0.21"
+    kotlin("jvm") version "2.1.0"
+    kotlin("plugin.allopen") version "2.1.0"
 
     id("io.quarkus") apply false
 }

--- a/integration-tests/kafka-json-schema-apicurio2/pom.xml
+++ b/integration-tests/kafka-json-schema-apicurio2/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
-                <version>2.0.21</version>
+                <version>2.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/CountryNameMessageTransformer.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/CountryNameMessageTransformer.kt
@@ -13,6 +13,6 @@ class CountryNameMessageTransformer {
     @Outgoing("countries-t2-out")
     suspend fun transform(input: Message<Country>): Message<String> {
         delay(100)
-        return input.withPayload(input.payload.name.toLowerCase())
+        return input.withPayload(input.payload.name.lowercase())
     }
 }

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/CountryNamePayloadTransformer.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/CountryNamePayloadTransformer.kt
@@ -12,6 +12,6 @@ class CountryNamePayloadTransformer {
     @Outgoing("countries-t1-out")
     suspend fun transform(country: Country): Country {
         delay(100)
-        return Country(country.name.toUpperCase(), country.capital)
+        return Country(country.name.lowercase(), country.capital)
     }
 }


### PR DESCRIPTION
This PR updates Kotlin to the [newly released version 2.1.0](https://blog.jetbrains.com/kotlin/2024/11/kotlin-2-1-0-released/)