### PR TITLE
Introduce property to disable default mapper per REST Client

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1437,6 +1437,34 @@ public interface EchoClient {
 }
 ----
 
+=== Disabling the default mapper
+
+As mandated by the REST Client specification, a default exception mapper is included, that throws an exception when HTTP status code is higher than 400.
+While this behavior is fine when the client returns a regular object, it is however very unintuitive when the client needs to return a `jakarta.ws.rs.core.Response`
+(with the intention of allowing the caller to decide how to handle the HTTP status code).
+
+For this reason, the REST Client includes a property named `disable-default-mapper` which can be used to disable the default mapper when using a REST client in a declarative manner.
+
+For example, with a client like so:
+
+[source, java]
+----
+    @Path("foo")
+    @RegisterRestClient(configKey = "bar")
+    public interface Client {
+        @GET
+        Response get();
+    }
+----
+
+The default exception mapper can be disabled by setting `quarkus.rest-client.bar.disable-default-mapper=true` to disable the exception mapper for the REST Client configured with the key `bar`.
+
+[NOTE]
+====
+When using the programmatic approach for creating a REST Client, `QuarkusRestClientBuilder` provides a method named `disableDefaultMapper`
+that provides the same feature.
+====
+
 [[multipart]]
 == Multipart Form support
 

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -594,8 +594,7 @@ public interface RestClientsConfig {
         Optional<Boolean> http2();
 
         /**
-         * The max HTTP ch
-         * unk size (8096 bytes by default).
+         * The max HTTP chunk size (8096 bytes by default).
          * <p>
          * This property is not applicable to the RESTEasy Client.
          */
@@ -615,6 +614,14 @@ public interface RestClientsConfig {
          * This stacktrace will be used if the invocation throws an exception
          */
         Optional<Boolean> captureStacktrace();
+
+        /**
+         * If set to {@code true}, then this REST Client will not the default exception mapper which
+         * always throws an exception if HTTP response code >= 400.
+         * This property is not applicable to the RESTEasy Client.
+         */
+        @WithDefault("${microprofile.rest.client.disable.default.mapper:false}")
+        Boolean disableDefaultMapper();
     }
 
     class RestClientKeysProvider implements Supplier<Iterable<String>> {

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/error/GlobalExceptionMapperDisabledTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/error/GlobalExceptionMapperDisabledTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.rest.client.reactive.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class GlobalExceptionMapperDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, Resource.class))
+            .overrideRuntimeConfigKey("quarkus.rest-client.test.url", "${test.url}")
+            .overrideRuntimeConfigKey("microprofile.rest.client.disable.default.mapper", "true");
+
+    @RestClient
+    Client client;
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void testDeclarativeClient() {
+        Response response = client.get();
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void testProgrammaticClient() {
+        OtherClient otherClient = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).build(OtherClient.class);
+        Response response = otherClient.get();
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Path("/error")
+    public static class Resource {
+        @GET
+        public Response returnError() {
+            return Response.status(404).build();
+        }
+    }
+
+    @Path("/error")
+    @RegisterRestClient(configKey = "test")
+    public interface Client {
+        @GET
+        Response get();
+    }
+
+    @Path("/error")
+    public interface OtherClient {
+        @GET
+        Response get();
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/error/PerClientExceptionMapperDisabledTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/error/PerClientExceptionMapperDisabledTest.java
@@ -1,0 +1,87 @@
+package io.quarkus.rest.client.reactive.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class PerClientExceptionMapperDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, Resource.class))
+            .overrideRuntimeConfigKey("quarkus.rest-client.test.url", "${test.url}")
+            .overrideRuntimeConfigKey("quarkus.rest-client.test.disable-default-mapper", "true")
+            .overrideRuntimeConfigKey("quarkus.rest-client.test2.url", "${test.url}");
+
+    @RestClient
+    Client client;
+
+    @RestClient
+    Client2 client2;
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void testDeclarativeClient() {
+        Response response = client.get();
+        assertThat(response.getStatus()).isEqualTo(404);
+
+        assertThatThrownBy(() -> client2.get()).isInstanceOf(WebApplicationException.class);
+    }
+
+    @Test
+    void testProgrammaticClient() {
+        OtherClient otherClient = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).disableDefaultMapper(true)
+                .build(OtherClient.class);
+        Response response = otherClient.get();
+        assertThat(response.getStatus()).isEqualTo(404);
+
+        OtherClient otherClient2 = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).build(OtherClient.class);
+        assertThatThrownBy(otherClient2::get).isInstanceOf(WebApplicationException.class);
+    }
+
+    @Path("/error")
+    public static class Resource {
+        @GET
+        public Response returnError() {
+            return Response.status(404).build();
+        }
+    }
+
+    @Path("/error")
+    @RegisterRestClient(configKey = "test")
+    public interface Client {
+        @GET
+        Response get();
+    }
+
+    @Path("/error")
+    @RegisterRestClient(configKey = "test2")
+    public interface Client2 {
+        @GET
+        Response get();
+    }
+
+    @Path("/error")
+    public interface OtherClient {
+        @GET
+        Response get();
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
@@ -299,6 +299,12 @@ public interface QuarkusRestClientBuilder extends Configurable<QuarkusRestClient
     QuarkusRestClientBuilder userAgent(String userAgent);
 
     /**
+     * If set to {@code true}, then this REST Client will not the default exception mapper which
+     * always throws an exception if HTTP response code >= 400
+     */
+    QuarkusRestClientBuilder disableDefaultMapper(Boolean disable);
+
+    /**
      * Based on the configured QuarkusRestClientBuilder, creates a new instance of the given REST interface to invoke API calls
      * against.
      *

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
@@ -263,6 +263,12 @@ public class QuarkusRestClientBuilderImpl implements QuarkusRestClientBuilder {
     }
 
     @Override
+    public QuarkusRestClientBuilder disableDefaultMapper(Boolean disable) {
+        proxy.disableDefaultMapper(disable);
+        return this;
+    }
+
+    @Override
     public <T> T build(Class<T> clazz) throws IllegalStateException, RestClientDefinitionException {
         return proxy.build(clazz);
     }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -142,6 +142,8 @@ public class RestClientCDIDelegateBuilder<T> {
 
         Boolean captureStacktrace = oneOf(restClientConfig.captureStacktrace()).orElse(configRoot.captureStacktrace());
         builder.property(QuarkusRestClientProperties.CAPTURE_STACKTRACE, captureStacktrace);
+
+        builder.disableDefaultMapper(restClientConfig.disableDefaultMapper());
     }
 
     private static Function<MemorySize, Integer> intChunkSize() {


### PR DESCRIPTION
The default mapper has a very confusing behavior where it throws an exception HTTP code >= 400 even if the method return type is Response.
This PR means to provide a way so users can disable this mapper per client instead of globally.

- Closes: #44813