### PR TITLE
More appropriate test application module initialization in QuarkusDevModeTest

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeMain.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.PrintStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
@@ -24,6 +25,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.util.ProcessUtil;
 import io.quarkus.dev.appstate.ApplicationStateNotification;
 import io.quarkus.dev.spi.DevModeType;
@@ -39,12 +41,18 @@ public class DevModeMain implements Closeable {
     private static final Logger log = Logger.getLogger(DevModeMain.class);
 
     private final DevModeContext context;
+    private final ApplicationModel appModel;
 
     private volatile CuratedApplication curatedApplication;
     private Closeable realCloseable;
 
     public DevModeMain(DevModeContext context) {
+        this(context, null);
+    }
+
+    public DevModeMain(DevModeContext context, ApplicationModel appModel) {
         this.context = context;
+        this.appModel = appModel;
     }
 
     public static void main(String... args) throws Exception {
@@ -65,47 +73,15 @@ public class DevModeMain implements Closeable {
 
     public void start() throws Exception {
         //propagate system props
-        for (Map.Entry<String, String> i : context.getSystemProperties().entrySet()) {
-            if (!System.getProperties().containsKey(i.getKey())) {
-                System.setProperty(i.getKey(), i.getValue());
-            }
-        }
+        propagateSystemProperties();
 
         try {
-            URL thisArchive = getClass().getResource(DevModeMain.class.getSimpleName() + ".class");
-            int endIndex = thisArchive.getPath().indexOf("!");
-            Path path;
-            if (endIndex != -1) {
-                path = Paths.get(new URI(thisArchive.getPath().substring(0, endIndex)));
-            } else {
-                path = Paths.get(thisArchive.toURI());
-                path = path.getParent();
-                for (char i : DevModeMain.class.getName().toCharArray()) {
-                    if (i == '.') {
-                        path = path.getParent();
-                    }
-                }
-            }
-            final PathList.Builder appRootsBuilder = PathList.builder();
-            final Path classesPath = Path.of(context.getApplicationRoot().getMain().getClassesPath());
-            if (Files.exists(classesPath)) {
-                appRootsBuilder.add(classesPath);
-            }
-            if (context.getApplicationRoot().getMain().getResourcesOutputPath() != null
-                    && !context.getApplicationRoot().getMain().getResourcesOutputPath()
-                            .equals(context.getApplicationRoot().getMain().getClassesPath())) {
-                final Path resourcesOutputPath = Paths.get(context.getApplicationRoot().getMain().getResourcesOutputPath());
-                if (Files.exists(resourcesOutputPath)) {
-                    appRootsBuilder.add(resourcesOutputPath);
-                }
-            }
-
-            final PathList appRoots = appRootsBuilder.build();
             QuarkusBootstrap.Builder bootstrapBuilder = QuarkusBootstrap.builder()
-                    .setApplicationRoot(appRoots)
+                    .setApplicationRoot(getApplicationBuildDirs())
+                    .setExistingModel(appModel)
                     .setIsolateDeployment(true)
                     .setLocalProjectDiscovery(context.isLocalProjectDiscovery())
-                    .addAdditionalDeploymentArchive(path)
+                    .addAdditionalDeploymentArchive(getThisClassOrigin())
                     .setBaseName(context.getBaseName())
                     .setMode(context.getMode());
             if (context.getDevModeRunnerJarFile() != null) {
@@ -136,6 +112,59 @@ public class DevModeMain implements Closeable {
             log.error("Quarkus dev mode failed to start", t);
             throw (t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t));
             //System.exit(1);
+        }
+    }
+
+    private PathList getApplicationBuildDirs() {
+        final String classesDir = context.getApplicationRoot().getMain().getClassesPath();
+        final String resourcesOutputDir = context.getApplicationRoot().getMain().getResourcesOutputPath();
+        if (resourcesOutputDir == null || resourcesOutputDir.equals(classesDir)) {
+            return toListOfExistingOrEmpty(Path.of(classesDir));
+        }
+        return toListOfExistingOrEmpty(Path.of(classesDir), Path.of(resourcesOutputDir));
+    }
+
+    private static PathList toListOfExistingOrEmpty(Path p1, Path p2) {
+        return !Files.exists(p1) ? toListOfExistingOrEmpty(p2)
+                : (!Files.exists(p2) ? toListOfExistingOrEmpty(p1) : PathList.of(p1, p2));
+    }
+
+    /**
+     * Returns a {@link PathList} containing the path if it exists, otherwise returns an empty {@link PathList}.
+     *
+     * @param path path
+     * @return {@link PathList} containing the path if it exists, otherwise returns an empty {@link PathList}
+     */
+    private static PathList toListOfExistingOrEmpty(Path path) {
+        return Files.exists(path) ? PathList.of(path) : PathList.empty();
+    }
+
+    /**
+     * Returns the classpath element containing this class
+     *
+     * @return classpath element containing this class
+     * @throws URISyntaxException in case of a failure
+     */
+    private Path getThisClassOrigin() throws URISyntaxException {
+        URL thisArchive = getClass().getResource(DevModeMain.class.getSimpleName() + ".class");
+        int endIndex = thisArchive.getPath().indexOf("!");
+        if (endIndex != -1) {
+            return Path.of(new URI(thisArchive.getPath().substring(0, endIndex)));
+        }
+        Path path = Path.of(thisArchive.toURI());
+        path = path.getParent();
+        for (char i : DevModeMain.class.getName().toCharArray()) {
+            if (i == '.') {
+                path = path.getParent();
+            }
+        }
+
+        return path;
+    }
+
+    private void propagateSystemProperties() {
+        for (Map.Entry<String, String> i : context.getSystemProperties().entrySet()) {
+            System.getProperties().putIfAbsent(i.getKey(), i.getValue());
         }
     }
 

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/DevModeTestApplicationModel.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/DevModeTestApplicationModel.java
@@ -1,0 +1,92 @@
+package io.quarkus.test;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.ExtensionCapabilities;
+import io.quarkus.bootstrap.model.ExtensionDevModeConfig;
+import io.quarkus.bootstrap.model.PlatformImports;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+/**
+ * {@link ApplicationModel} implementation that allows overriding the application artifact
+ * of another {@link ApplicationModel} instance.
+ */
+class DevModeTestApplicationModel implements ApplicationModel {
+
+    private final ResolvedDependency appArtifact;
+    private final ApplicationModel delegate;
+
+    DevModeTestApplicationModel(ResolvedDependency testAppArtifact, ApplicationModel delegate) {
+        this.appArtifact = testAppArtifact;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ResolvedDependency getAppArtifact() {
+        return appArtifact;
+    }
+
+    @Override
+    public Collection<ResolvedDependency> getDependencies() {
+        return delegate.getDependencies();
+    }
+
+    @Override
+    public Iterable<ResolvedDependency> getDependencies(int flags) {
+        return delegate.getDependencies(flags);
+    }
+
+    @Override
+    public Iterable<ResolvedDependency> getDependenciesWithAnyFlag(int... flags) {
+        return delegate.getDependenciesWithAnyFlag(flags);
+    }
+
+    @Override
+    public Collection<ResolvedDependency> getRuntimeDependencies() {
+        return delegate.getRuntimeDependencies();
+    }
+
+    @Override
+    public PlatformImports getPlatforms() {
+        return delegate.getPlatforms();
+    }
+
+    @Override
+    public Collection<ExtensionCapabilities> getExtensionCapabilities() {
+        return delegate.getExtensionCapabilities();
+    }
+
+    @Override
+    public Set<ArtifactKey> getParentFirst() {
+        return delegate.getParentFirst();
+    }
+
+    @Override
+    public Set<ArtifactKey> getRunnerParentFirst() {
+        return delegate.getRunnerParentFirst();
+    }
+
+    @Override
+    public Set<ArtifactKey> getLowerPriorityArtifacts() {
+        return delegate.getLowerPriorityArtifacts();
+    }
+
+    @Override
+    public Set<ArtifactKey> getReloadableWorkspaceDependencies() {
+        return delegate.getReloadableWorkspaceDependencies();
+    }
+
+    @Override
+    public Map<ArtifactKey, Set<String>> getRemovedResources() {
+        return delegate.getRemovedResources();
+    }
+
+    @Override
+    public Collection<ExtensionDevModeConfig> getExtensionDevModeConfig() {
+        return delegate.getExtensionDevModeConfig();
+    }
+}

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -41,13 +41,20 @@ import org.junit.jupiter.api.extension.TestInstanceFactory;
 import org.junit.jupiter.api.extension.TestInstanceFactoryContext;
 import org.junit.jupiter.api.extension.TestInstantiationException;
 
+import io.quarkus.bootstrap.BootstrapAppModelFactory;
+import io.quarkus.bootstrap.BootstrapException;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.workspace.ArtifactSources;
+import io.quarkus.bootstrap.workspace.SourceDir;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
 import io.quarkus.deployment.dev.CompilationProvider;
 import io.quarkus.deployment.dev.DevModeContext;
 import io.quarkus.deployment.dev.DevModeMain;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.dev.appstate.ApplicationStateNotification;
 import io.quarkus.dev.testing.TestScanningLock;
-import io.quarkus.maven.dependency.GACT;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.common.GroovyClassValue;
@@ -175,7 +182,7 @@ public class QuarkusDevModeTest
     /**
      * Customize the application root.
      *
-     * @param applicationRootConsumer
+     * @param testArchiveConsumer
      * @return self
      */
     public QuarkusDevModeTest withTestArchive(Consumer<JavaArchive> testArchiveConsumer) {
@@ -256,12 +263,7 @@ public class QuarkusDevModeTest
             TestResourceManager tm = testResourceManager;
 
             store.put(TestResourceManager.class.getName(), testResourceManager);
-            store.put(TestResourceManager.CLOSEABLE_NAME, new ExtensionContext.Store.CloseableResource() {
-                @Override
-                public void close() throws Throwable {
-                    tm.close();
-                }
-            });
+            store.put(TestResourceManager.CLOSEABLE_NAME, (ExtensionContext.Store.CloseableResource) tm::close);
         }
         TestResourceManager tm = (TestResourceManager) store.get(TestResourceManager.class.getName());
         //dev mode tests just use system properties
@@ -289,18 +291,8 @@ public class QuarkusDevModeTest
             } else {
                 projectSourceRoot = Paths.get(sourcePath);
             }
-            // TODO: again a hack, assumes the sources dir is one dir above java sources path
-            Path projectSourceParent = projectSourceRoot.getParent();
 
-            DevModeContext context = exportArchive(deploymentDir, projectSourceRoot, projectSourceParent);
-            context.setBaseName(extensionContext.getDisplayName() + " (QuarkusDevModeTest)");
-            context.setArgs(commandLineArgs);
-            context.setTest(true);
-            context.setAbortOnFailedStart(!allowFailedStart);
-            context.getBuildSystemProperties().put("quarkus.banner.enabled", "false");
-            context.getBuildSystemProperties().put("quarkus.console.disable-input", "true"); //surefire communicates via stdin, we don't want the test to be reading input
-            context.getBuildSystemProperties().putAll(buildSystemProperties);
-            devModeMain = new DevModeMain(context);
+            devModeMain = newDevModeMain(extensionContext, deploymentDir, projectSourceRoot);
             devModeMain.start();
             ApplicationStateNotification.waitForApplicationStart();
         } catch (Exception e) {
@@ -343,7 +335,8 @@ public class QuarkusDevModeTest
         inMemoryLogHandler.clearRecords();
     }
 
-    private DevModeContext exportArchive(Path deploymentDir, Path testSourceDir, Path testSourcesParentDir) {
+    private DevModeMain newDevModeMain(ExtensionContext extensionContext, Path deploymentDir, Path testSourceDir) {
+
         try {
 
             deploymentSourcePath = deploymentDir.resolve("src/main/java");
@@ -357,45 +350,27 @@ public class QuarkusDevModeTest
             Files.createDirectories(classes);
             Files.createDirectories(cache);
 
-            //first we export the archive
-            //then we attempt to generate a source tree
             JavaArchive archive = archiveProducer.get();
-            archive.as(ExplodedExporter.class).exportExplodedInto(classes.toFile());
-            copyFromSource(testSourceDir, deploymentSourcePath, classes);
-            copyCodeGenSources(testSourcesParentDir, deploymentSourceParentPath, codeGenSources);
+            exportAndGenerateSourceTree(archive, classes, testSourceDir, deploymentSourcePath, deploymentResourcePath);
 
-            //now copy resources
-            //we assume everything that is not a .class file is a resource
-            //resources are handled differently to sources as they are often not in the same location
-            //in the FS, or are dynamically created
-            try (Stream<Path> stream = Files.walk(classes)) {
-                stream.forEach(s -> {
-                    if (s.toString().endsWith(".class") ||
-                            Files.isDirectory(s)) {
-                        return;
-                    }
-                    String relative = classes.relativize(s).toString();
-                    try {
-                        try (InputStream in = Files.newInputStream(s)) {
-                            byte[] data = FileUtil.readFileContents(in);
-                            Path resolved = deploymentResourcePath.resolve(relative);
-                            Files.createDirectories(resolved.getParent());
-                            Files.write(resolved, data, OPEN_OPTIONS);
-                        }
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
-            }
+            // TODO: again a hack, assumes the sources dir is one dir above java sources path
+            final Path testSourcesParentDir = projectSourceRoot.getParent();
+            copyCodeGenSources(testSourcesParentDir, deploymentSourceParentPath, codeGenSources);
 
             //debugging code
             ExportUtil.exportToQuarkusDeploymentPath(archive);
 
             DevModeContext context = new DevModeContext();
+            context.setBaseName(extensionContext.getDisplayName() + " (QuarkusDevModeTest)");
+            context.setArgs(commandLineArgs);
+            context.setTest(true);
+            context.setAbortOnFailedStart(!allowFailedStart);
+            context.getBuildSystemProperties().put("quarkus.banner.enabled", "false");
+            context.getBuildSystemProperties().put("quarkus.console.disable-input", "true"); //surefire communicates via stdin, we don't want the test to be reading input
+            context.getBuildSystemProperties().putAll(buildSystemProperties);
             context.setCacheDir(cache.toFile());
 
-            DevModeContext.ModuleInfo.Builder moduleBuilder = new DevModeContext.ModuleInfo.Builder()
-                    .setArtifactKey(GACT.fromString("io.quarkus.test:app-under-test"))
+            final DevModeContext.ModuleInfo.Builder moduleBuilder = new DevModeContext.ModuleInfo.Builder()
                     .setProjectDirectory(deploymentDir.toAbsolutePath().toString())
                     .setSourcePaths(PathList.of(deploymentSourcePath.toAbsolutePath()))
                     .setClassesPath(classes.toAbsolutePath().toString())
@@ -404,6 +379,13 @@ public class QuarkusDevModeTest
                     .setSourceParents(PathList.of(deploymentSourceParentPath.toAbsolutePath()))
                     .setPreBuildOutputDir(targetDir.resolve("generated-sources").toAbsolutePath().toString())
                     .setTargetDir(targetDir.toAbsolutePath().toString());
+
+            final WorkspaceModule.Mutable testModuleBuilder = WorkspaceModule.builder()
+                    .addArtifactSources(ArtifactSources.main(
+                            SourceDir.of(deploymentSourcePath, classes),
+                            SourceDir.of(deploymentResourcePath, classes)))
+                    .setBuildDir(targetDir)
+                    .setModuleDir(deploymentDir);
 
             //now tests, if required
             if (testArchiveProducer != null) {
@@ -416,35 +398,12 @@ public class QuarkusDevModeTest
                 Files.createDirectories(deploymentTestResourcePath);
                 Files.createDirectories(testClasses);
 
-                //first we export the archive
-                //then we attempt to generate a source tree
-                JavaArchive testArchive = testArchiveProducer.get();
-                testArchive.as(ExplodedExporter.class).exportExplodedInto(testClasses.toFile());
-                copyFromSource(testSourceDir, deploymentTestSourcePath, testClasses);
+                testModuleBuilder.addArtifactSources(ArtifactSources.test(
+                        SourceDir.of(deploymentTestSourcePath, testClasses),
+                        SourceDir.of(deploymentTestResourcePath, testClasses)));
 
-                //now copy resources
-                //we assume everything that is not a .class file is a resource
-                //resources are handled differently to sources as they are often not in the same location
-                //in the FS, or are dynamically created
-                try (Stream<Path> stream = Files.walk(testClasses)) {
-                    stream.forEach(s -> {
-                        if (s.toString().endsWith(".class") ||
-                                Files.isDirectory(s)) {
-                            return;
-                        }
-                        String relative = testClasses.relativize(s).toString();
-                        try {
-                            try (InputStream in = Files.newInputStream(s)) {
-                                byte[] data = FileUtil.readFileContents(in);
-                                Path resolved = deploymentTestResourcePath.resolve(relative);
-                                Files.createDirectories(resolved.getParent());
-                                Files.write(resolved, data, OPEN_OPTIONS);
-                            }
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
-                    });
-                }
+                exportAndGenerateSourceTree(testArchiveProducer.get(), testClasses, testSourceDir, deploymentTestSourcePath,
+                        deploymentTestResourcePath);
                 moduleBuilder
                         .setTestSourcePaths(PathList.of(deploymentTestSourcePath.toAbsolutePath()))
                         .setTestClassesPath(testClasses.toAbsolutePath().toString())
@@ -452,13 +411,82 @@ public class QuarkusDevModeTest
                         .setTestResourcesOutputPath(testClasses.toAbsolutePath().toString());
             }
 
-            context.setApplicationRoot(
-                    moduleBuilder
-                            .build());
+            final ApplicationModel originalAppModel = resolveOriginalAppModel();
+            var testArtifact = originalAppModel.getAppArtifact();
 
-            return context;
+            context.setApplicationRoot(moduleBuilder.setArtifactKey(testArtifact.getKey()).build());
+
+            return new DevModeMain(context, new DevModeTestApplicationModel(
+                    ResolvedDependencyBuilder.newInstance()
+                            .setCoords(testArtifact)
+                            .setResolvedPath(classes)
+                            .setWorkspaceModule(testModuleBuilder.setModuleId(
+                                    WorkspaceModuleId.of(testArtifact.getGroupId(),
+                                            testArtifact.getArtifactId(), testArtifact.getVersion()))
+                                    .build())
+                            .build(),
+                    originalAppModel));
         } catch (Exception e) {
             throw new RuntimeException("Unable to create the archive", e);
+        }
+    }
+
+    /**
+     * Resolves an {@link ApplicationModel} for the current module running the test.
+     *
+     * @return application model for the module runnign the test
+     */
+    private static ApplicationModel resolveOriginalAppModel() {
+        try {
+            return BootstrapAppModelFactory.newInstance()
+                    .setTest(true)
+                    .setProjectRoot(Path.of("").normalize().toAbsolutePath())
+                    .resolveAppModel()
+                    .getApplicationModel();
+        } catch (BootstrapException e) {
+            throw new RuntimeException("Failed to resolve the ApplicationModel", e);
+        }
+    }
+
+    /**
+     * Exports the archive to the classes directory and creates a source tree.
+     *
+     * @param archive application archive
+     * @param classes target classes directory
+     * @param testSourceDir test sources directory
+     * @param deploymentSourcePath test application sources directory
+     * @param deploymentResourcePath test application resources directory
+     * @throws IOException in case of an IO failure
+     */
+    private void exportAndGenerateSourceTree(JavaArchive archive, Path classes, Path testSourceDir,
+            Path deploymentSourcePath, Path deploymentResourcePath) throws IOException {
+        //first we export the archive
+        //then we attempt to generate a source tree
+        archive.as(ExplodedExporter.class).exportExplodedInto(classes.toFile());
+        copyFromSource(testSourceDir, deploymentSourcePath, classes);
+
+        //now copy resources
+        //we assume everything that is not a .class file is a resource
+        //resources are handled differently to sources as they are often not in the same location
+        //in the FS, or are dynamically created
+        try (Stream<Path> stream = Files.walk(classes)) {
+            stream.forEach(s -> {
+                if (s.toString().endsWith(".class") ||
+                        Files.isDirectory(s)) {
+                    return;
+                }
+                String relative = classes.relativize(s).toString();
+                try {
+                    try (InputStream in = Files.newInputStream(s)) {
+                        byte[] data = FileUtil.readFileContents(in);
+                        Path resolved = deploymentResourcePath.resolve(relative);
+                        Files.createDirectories(resolved.getParent());
+                        Files.write(resolved, data, OPEN_OPTIONS);
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
This fixes warnings running `QuarkusDevModeTest`s, such as
```
[INFO] Running io.quarkus.devui.BuildMetricsTest
2024-11-28 23:51:03,005 WARN  [io.qua.boo.BootstrapAppModelFactory] (main) Expected project directory /home/aloubyansky/git/quarkus/extensions/vertx-http/deployment/target/quarkus-dev-mode-test18265132251066872043 does not match current project directory /home/aloubyansky/git/quarkus/extensions/vertx-http/deployment
```
by making sure the correct test application module is returned from `ApplicationModel.getAppArtifact()`.

This should also fix issues reported in the comments of https://github.com/quarkusio/quarkus/pull/44104