### PR TITLE
SmallRye Fault Tolerance: upgrade to 6.7.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -53,7 +53,7 @@
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.3</smallrye-open-api.version>
         <smallrye-graphql.version>2.11.0</smallrye-graphql.version>
-        <smallrye-fault-tolerance.version>6.6.3</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>6.7.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.1.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>

--- a/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
@@ -535,11 +535,14 @@ public class CoffeeResource {
 We can override the `maxRetries` parameter with 6 retries instead of 4 by the following configuration item:
 [source,properties]
 ----
+quarkus.fault-tolerance."org.acme.CoffeeResource/coffees".retry.max-retries=6
+
+# alternatively, a specification-defined property can be used
 org.acme.CoffeeResource/coffees/Retry/maxRetries=6
 ----
 
-NOTE: The format is `fully-qualified-class-name/method-name/annotation-name/property-name=value`.
-You can also configure a property for all the annotation via `annotation-name/property-name=value`.
+The full set of Quarkus-native configuration properties is detailed in the <<configuration-reference>>.
+The specification-defined configuration properties are still supported, but the Quarkus-native configuration takes priority.
 
 == Conclusion
 
@@ -573,7 +576,7 @@ implementation("io.quarkus:quarkus-smallrye-fault-tolerance")
 == Additional resources
 
 SmallRye Fault Tolerance has more features than shown here.
-Please check the link:https://smallrye.io/docs/smallrye-fault-tolerance/6.3.0/index.html[SmallRye Fault Tolerance documentation] to learn about them.
+Please check the link:https://smallrye.io/docs/smallrye-fault-tolerance/6.7.0/index.html[SmallRye Fault Tolerance documentation] to learn about them.
 
 In Quarkus, you can use the SmallRye Fault Tolerance optional features out of the box.
 
@@ -591,7 +594,7 @@ The entire point of context propagation is to make sure the new thread has the s
 ====
 
 Non-compatible mode is enabled by default.
-This means that methods that return `CompletionStage` (or `Uni`) have asynchronous fault tolerance applied without any `@Asynchronous`, `@AsynchronousNonBlocking`, `@Blocking` or `@NonBlocking` annotation.
+This means that methods that return `CompletionStage` (or `Uni`) have asynchronous fault tolerance applied without the `@Asynchronous` or `@AsynchronousNonBlocking` annotation.
 It also means that circuit breaker, fallback and retry automatically inspect the exception cause chain if the exception itself is insufficient to decide what should happen.
 
 [NOTE]
@@ -601,12 +604,12 @@ To restore full compatibility, add this configuration property:
 
 [source,properties]
 ----
-smallrye.faulttolerance.mp-compatibility=true
+quarkus.fault-tolerance.mp-compatibility=true
 ----
 ====
 
-The link:https://smallrye.io/docs/smallrye-fault-tolerance/6.3.0/reference/programmatic-api.html[programmatic API] is present, including Mutiny support, and integrated with the declarative, annotation-based API.
-You can use the `FaultTolerance` and `MutinyFaultTolerance` APIs out of the box.
+The link:https://smallrye.io/docs/smallrye-fault-tolerance/6.7.0/reference/programmatic-api.html[programmatic API] is present and integrated with the declarative, annotation-based API.
+You can use the `Guard`, `TypedGuard` and `@ApplyGuard` APIs out of the box.
 
 Support for Kotlin is present (assuming you use the Quarkus extension for Kotlin), so you can guard your `suspend` functions with fault tolerance annotations.
 
@@ -614,3 +617,43 @@ Metrics are automatically discovered and integrated.
 If your application uses the Quarkus extension for Micrometer, SmallRye Fault Tolerance will emit metrics to Micrometer.
 If your application uses the Quarkus extension for SmallRye Metrics, SmallRye Fault Tolerance will emit metrics to MicroProfile Metrics.
 Otherwise, SmallRye Fault Tolerance metrics will be disabled.
+
+[[configuration-reference]]
+== Configuration reference
+
+The `"<identifier>"` below is:
+
+* `"<classname>/<methodname>"` for per method configuration
+* `"<classname>"` for per class configuration
+* `global` for global configuration
+
+include::{generated-dir}/config/quarkus-smallrye-fault-tolerance.adoc[opts=optional, leveloffset=+1]
+
+This is how the specification-defined properties are mapped to the Quarkus-native configuration:
+
+[%header,cols="1,1"]
+|===
+|Specification-defined config property
+|Quarkus-native config property
+
+|`<classname>/<methodname>/<annotation>/<member>`
+|`quarkus.fault-tolerance."<classname>/<methodname>".<annotation>.<member>`
+
+|`<classname>/<annotation>/<member>`
+|`quarkus.fault-tolerance."<classname>".<annotation>.<member>`
+
+|`<annotation>/<member>`
+|`quarkus.fault-tolerance.global.<annotation>.<member>`
+
+|`MP_Fault_Tolerance_NonFallback_Enabled`
+|`quarkus.fault-tolerance.enabled`
+
+|`MP_Fault_Tolerance_Metrics_Enabled`
+|`quarkus.fault-tolerance.metrics.enabled`
+|===
+
+All the `<annotation>` and `<member>` parts are changed from camel case (`BeforeRetry`, `methodName`) to kebab case (`before-retry`, `method-name`).
+Two annotation members are special cased to improve consistency:
+
+- `Retry/durationUnit` moves to `retry.max-duration-unit`
+- `Retry/jitterDelayUnit` moves to `retry.jitter-unit`

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/ConfigUtilJandex.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/ConfigUtilJandex.java
@@ -1,0 +1,43 @@
+package io.quarkus.smallrye.faulttolerance.deployment;
+
+import java.lang.annotation.Annotation;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
+
+import io.smallrye.faulttolerance.config.ConfigPrefix;
+import io.smallrye.faulttolerance.config.NewConfig;
+
+// copy of `io.smallrye.faulttolerance.config.ConfigUtil` and translation from reflection to Jandex
+final class ConfigUtilJandex {
+    static final String GLOBAL = "global";
+
+    static String newKey(Class<? extends Annotation> annotation, String member, MethodInfo declaringMethod) {
+        return ConfigPrefix.VALUE + "\"" + declaringMethod.declaringClass().name() + "/" + declaringMethod.name()
+                + "\"." + NewConfig.get(annotation, member);
+    }
+
+    static String oldKey(Class<? extends Annotation> annotation, String member, MethodInfo declaringMethod) {
+        return declaringMethod.declaringClass().name() + "/" + declaringMethod.name()
+                + "/" + annotation.getSimpleName() + "/" + member;
+    }
+
+    static String newKey(Class<? extends Annotation> annotation, String member, ClassInfo declaringClass) {
+        return ConfigPrefix.VALUE + "\"" + declaringClass.name() + "\"."
+                + NewConfig.get(annotation, member);
+    }
+
+    static String oldKey(Class<? extends Annotation> annotation, String member, ClassInfo declaringClass) {
+        return declaringClass.name() + "/" + annotation.getSimpleName() + "/" + member;
+    }
+
+    static String newKey(Class<? extends Annotation> annotation, String member) {
+        return ConfigPrefix.VALUE + GLOBAL + "." + NewConfig.get(annotation, member);
+    }
+
+    static String oldKey(Class<? extends Annotation> annotation, String member) {
+        return annotation.getSimpleName() + "/" + member;
+    }
+
+    // no need to have the `isEnabled()` method, that is only needed at runtime
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/DotNames.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/DotNames.java
@@ -12,9 +12,11 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.jboss.jandex.DotName;
 
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.faulttolerance.FaultToleranceInterceptor;
 import io.smallrye.faulttolerance.api.ApplyFaultTolerance;
+import io.smallrye.faulttolerance.api.ApplyGuard;
 import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
 import io.smallrye.faulttolerance.api.BeforeRetry;
 import io.smallrye.faulttolerance.api.BeforeRetryHandler;
@@ -23,21 +25,28 @@ import io.smallrye.faulttolerance.api.CustomBackoff;
 import io.smallrye.faulttolerance.api.CustomBackoffStrategy;
 import io.smallrye.faulttolerance.api.ExponentialBackoff;
 import io.smallrye.faulttolerance.api.FibonacciBackoff;
+import io.smallrye.faulttolerance.api.Guard;
 import io.smallrye.faulttolerance.api.RateLimit;
 import io.smallrye.faulttolerance.api.RetryWhen;
+import io.smallrye.faulttolerance.api.TypedGuard;
 
 public final class DotNames {
     public static final DotName OBJECT = DotName.createSimple(Object.class);
+    public static final DotName IDENTIFIER = DotName.createSimple(Identifier.class);
 
     public static final DotName FALLBACK_HANDLER = DotName.createSimple(FallbackHandler.class);
     public static final DotName BEFORE_RETRY_HANDLER = DotName.createSimple(BeforeRetryHandler.class);
 
     public static final DotName FAULT_TOLERANCE_INTERCEPTOR = DotName.createSimple(FaultToleranceInterceptor.class);
 
+    public static final DotName GUARD = DotName.createSimple(Guard.class);
+    public static final DotName TYPED_GUARD = DotName.createSimple(TypedGuard.class);
+
     // ---
     // fault tolerance annotations
 
     public static final DotName APPLY_FAULT_TOLERANCE = DotName.createSimple(ApplyFaultTolerance.class);
+    public static final DotName APPLY_GUARD = DotName.createSimple(ApplyGuard.class);
 
     public static final DotName ASYNCHRONOUS = DotName.createSimple(Asynchronous.class);
     public static final DotName ASYNCHRONOUS_NON_BLOCKING = DotName.createSimple(AsynchronousNonBlocking.class);
@@ -62,7 +71,7 @@ public final class DotNames {
     // certain SmallRye annotations (@CircuitBreakerName, @[Non]Blocking, @*Backoff, @RetryWhen, @BeforeRetry)
     // do _not_ trigger the fault tolerance interceptor alone, only in combination
     // with other fault tolerance annotations
-    public static final Set<DotName> FT_ANNOTATIONS = Set.of(APPLY_FAULT_TOLERANCE, ASYNCHRONOUS,
+    public static final Set<DotName> FT_ANNOTATIONS = Set.of(APPLY_FAULT_TOLERANCE, APPLY_GUARD, ASYNCHRONOUS,
             ASYNCHRONOUS_NON_BLOCKING, BULKHEAD, CIRCUIT_BREAKER, FALLBACK, RATE_LIMIT, RETRY, TIMEOUT);
 
     public static final Set<DotName> BACKOFF_ANNOTATIONS = Set.of(EXPONENTIAL_BACKOFF, FIBONACCI_BACKOFF, CUSTOM_BACKOFF);

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/resources/dev-ui/qwc-fault-tolerance-methods.js
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/resources/dev-ui/qwc-fault-tolerance-methods.js
@@ -72,6 +72,7 @@ export class QwcFaultToleranceMethods extends LitElement {
         return html`
             <vaadin-vertical-layout>
                 ${guardedMethod.ApplyFaultTolerance ? this._renderApplyFaultTolerance(guardedMethod.ApplyFaultTolerance) : html``}
+                ${guardedMethod.ApplyGuard ? this._renderApplyGuard(guardedMethod.ApplyGuard) : html``}
                 ${guardedMethod.Asynchronous ? html`<span>@Asynchronous</span>` : html``}
                 ${guardedMethod.AsynchronousNonBlocking ? html`<span>@AsynchronousNonBlocking</span>` : html``}
                 ${guardedMethod.Blocking ? html`<span>@Blocking</span>` : html``}
@@ -95,6 +96,12 @@ export class QwcFaultToleranceMethods extends LitElement {
     _renderApplyFaultTolerance(applyFaultTolerance) {
         return html`
             <span>@ApplyFaultTolerance("${applyFaultTolerance.value}")</span>
+        `;
+    }
+
+    _renderApplyGuard(applyGuard) {
+        return html`
+            <span>@ApplyGuard("${applyGuard.value}")</span>
         `;
     }
 

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/BulkheadConfigBean.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/BulkheadConfigBean.java
@@ -1,0 +1,26 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+
+@ApplicationScoped
+public class BulkheadConfigBean {
+    @Bulkhead(value = 5)
+    public void value(CompletableFuture<?> barrier) {
+        barrier.join();
+    }
+
+    @Bulkhead(value = 1, waitingTaskQueue = 5)
+    @Asynchronous
+    public Future<Void> waitingTaskQueue(CompletableFuture<?> barrier) {
+        barrier.join();
+        return completedFuture(null);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/BulkheadConfigTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/BulkheadConfigTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BulkheadConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(BulkheadConfigBean.class))
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.BulkheadConfigBean/value\".bulkhead.value",
+                    "1")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.BulkheadConfigBean/waitingTaskQueue\".bulkhead.waiting-task-queue",
+                    "1");
+
+    @Inject
+    private BulkheadConfigBean bean;
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    public void setUp() {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @AfterEach
+    public void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void value() throws Exception {
+        CompletableFuture<?> barrier = new CompletableFuture<>();
+
+        executor.submit(() -> bean.value(barrier));
+        Thread.sleep(500);
+        assertThatThrownBy(() -> bean.value(null)).isExactlyInstanceOf(BulkheadException.class);
+
+        barrier.complete(null);
+    }
+
+    @Test
+    public void waitingTaskQueue() throws Exception {
+        CompletableFuture<?> barrier1 = new CompletableFuture<>();
+        CompletableFuture<?> barrier2 = new CompletableFuture<>();
+
+        executor.submit(() -> bean.waitingTaskQueue(barrier1));
+        executor.submit(() -> bean.waitingTaskQueue(barrier2));
+        Thread.sleep(500);
+        assertThatThrownBy(() -> bean.waitingTaskQueue(null).get())
+                .isExactlyInstanceOf(ExecutionException.class)
+                .hasCauseExactlyInstanceOf(BulkheadException.class);
+
+        barrier1.complete(null);
+        barrier2.complete(null);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/CircuitBreakerConfigBean.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/CircuitBreakerConfigBean.java
@@ -1,0 +1,46 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import java.time.temporal.ChronoUnit;
+
+import jakarta.enterprise.context.Dependent;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+@Dependent
+public class CircuitBreakerConfigBean {
+    @CircuitBreaker(requestVolumeThreshold = 2, failOn = TestConfigExceptionB.class)
+    public void failOn() {
+        throw new TestConfigExceptionA();
+    }
+
+    @CircuitBreaker(requestVolumeThreshold = 2)
+    public void skipOn() {
+        throw new TestConfigExceptionA();
+    }
+
+    @CircuitBreaker(requestVolumeThreshold = 2, delay = 20, delayUnit = ChronoUnit.MICROS)
+    public void delay(boolean fail) {
+        if (fail) {
+            throw new TestConfigExceptionA();
+        }
+    }
+
+    @CircuitBreaker(requestVolumeThreshold = 2)
+    public void requestVolumeThreshold() {
+        throw new TestConfigExceptionA();
+    }
+
+    @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 1.0)
+    public void failureRatio(boolean fail) {
+        if (fail) {
+            throw new TestConfigExceptionA();
+        }
+    }
+
+    @CircuitBreaker(requestVolumeThreshold = 10, successThreshold = 4, delay = 1000)
+    public void successThreshold(boolean fail) {
+        if (fail) {
+            throw new TestConfigExceptionA();
+        }
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/CircuitBreakerConfigTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/CircuitBreakerConfigTest.java
@@ -1,0 +1,136 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CircuitBreakerConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(CircuitBreakerConfigBean.class, TestConfigExceptionA.class,
+                    TestConfigExceptionB.class))
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.CircuitBreakerConfigBean/skipOn\".circuit-breaker.skip-on",
+                    "io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionA")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.CircuitBreakerConfigBean/failOn\".circuit-breaker.fail-on",
+                    "io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionA")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.CircuitBreakerConfigBean/delay\".circuit-breaker.delay",
+                    "1000")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.CircuitBreakerConfigBean/delay\".circuit-breaker.delay-unit",
+                    "millis")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.CircuitBreakerConfigBean/requestVolumeThreshold\".circuit-breaker.request-volume-threshold",
+                    "4")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.CircuitBreakerConfigBean/failureRatio\".circuit-breaker.failure-ratio",
+                    "0.8")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.CircuitBreakerConfigBean/successThreshold\".circuit-breaker.success-threshold",
+                    "2");
+
+    @Inject
+    private CircuitBreakerConfigBean bean;
+
+    @Test
+    public void failOn() {
+        assertThatThrownBy(() -> bean.failOn()).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.failOn()).isExactlyInstanceOf(TestConfigExceptionA.class);
+
+        assertThatThrownBy(() -> bean.failOn()).isExactlyInstanceOf(CircuitBreakerOpenException.class);
+    }
+
+    @Test
+    public void testConfigureSkipOn() {
+        assertThatThrownBy(() -> bean.skipOn()).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.skipOn()).isExactlyInstanceOf(TestConfigExceptionA.class);
+
+        assertThatThrownBy(() -> bean.skipOn()).isExactlyInstanceOf(TestConfigExceptionA.class);
+    }
+
+    @Test
+    public void delay() {
+        assertThatThrownBy(() -> bean.delay(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.delay(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+
+        assertThatThrownBy(() -> bean.delay(false)).isExactlyInstanceOf(CircuitBreakerOpenException.class);
+
+        long start = System.nanoTime();
+        await().atMost(1, TimeUnit.MINUTES).untilAsserted(() -> {
+            assertThatCode(() -> bean.delay(false)).doesNotThrowAnyException();
+        });
+        long end = System.nanoTime();
+
+        long durationInMillis = Duration.ofNanos(end - start).toMillis();
+        assertThat(durationInMillis).isGreaterThan(800);
+        assertThat(durationInMillis).isLessThan(2000);
+    }
+
+    @Test
+    public void requestVolumeThreshold() {
+        assertThatThrownBy(() -> bean.requestVolumeThreshold()).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.requestVolumeThreshold()).isExactlyInstanceOf(TestConfigExceptionA.class);
+
+        assertThatThrownBy(() -> bean.requestVolumeThreshold()).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.requestVolumeThreshold()).isExactlyInstanceOf(TestConfigExceptionA.class);
+
+        assertThatThrownBy(() -> bean.requestVolumeThreshold()).isExactlyInstanceOf(CircuitBreakerOpenException.class);
+    }
+
+    @Test
+    public void failureRatio() {
+        assertThatThrownBy(() -> bean.failureRatio(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.failureRatio(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatCode(() -> bean.failureRatio(false)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> bean.failureRatio(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.failureRatio(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.failureRatio(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatCode(() -> bean.failureRatio(false)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> bean.failureRatio(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.failureRatio(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThatThrownBy(() -> bean.failureRatio(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+
+        assertThatThrownBy(() -> bean.failureRatio(false)).isExactlyInstanceOf(CircuitBreakerOpenException.class);
+    }
+
+    @Test
+    public void successThreshold() {
+        for (int i = 0; i < 10; i++) {
+            assertThatThrownBy(() -> bean.successThreshold(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        }
+
+        assertThatThrownBy(() -> bean.successThreshold(false)).isExactlyInstanceOf(CircuitBreakerOpenException.class);
+        await().atMost(1, TimeUnit.MINUTES).untilAsserted(() -> {
+            assertThatCode(() -> bean.successThreshold(false)).doesNotThrowAnyException();
+        });
+
+        assertThatCode(() -> bean.successThreshold(false)).doesNotThrowAnyException();
+
+        for (int i = 0; i < 10; i++) {
+            assertThatThrownBy(() -> bean.successThreshold(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+        }
+
+        assertThatThrownBy(() -> bean.successThreshold(false)).isExactlyInstanceOf(CircuitBreakerOpenException.class);
+        await().atMost(1, TimeUnit.MINUTES).untilAsserted(() -> {
+            assertThatCode(() -> bean.successThreshold(false)).doesNotThrowAnyException();
+        });
+
+        assertThatThrownBy(() -> bean.successThreshold(true)).isExactlyInstanceOf(TestConfigExceptionA.class);
+
+        assertThatThrownBy(() -> bean.successThreshold(false)).isExactlyInstanceOf(CircuitBreakerOpenException.class);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/ConfigPropertyBean.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/ConfigPropertyBean.java
@@ -1,0 +1,21 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import jakarta.enterprise.context.Dependent;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Dependent
+@Retry
+public class ConfigPropertyBean {
+    private int retry = 0;
+
+    @Retry
+    public void triggerException() {
+        retry++;
+        throw new IllegalStateException("Exception");
+    }
+
+    public int getRetry() {
+        return retry;
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/ConfigPropertyGlobalVsClassTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/ConfigPropertyGlobalVsClassTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigPropertyGlobalVsClassTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(ConfigPropertyBean.class))
+            .overrideConfigKey("quarkus.fault-tolerance.global.retry.max-retries",
+                    "7")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.ConfigPropertyBean\".retry.max-retries",
+                    "5");
+
+    @Inject
+    private ConfigPropertyBean bean;
+
+    @Test
+    void test() {
+        assertThatThrownBy(() -> bean.triggerException()).isExactlyInstanceOf(IllegalStateException.class);
+        assertThat(bean.getRetry()).isEqualTo(8);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/ConfigPropertyGlobalVsClassVsMethodTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/ConfigPropertyGlobalVsClassVsMethodTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigPropertyGlobalVsClassVsMethodTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(ConfigPropertyBean.class))
+            .overrideConfigKey("quarkus.fault-tolerance.global.retry.max-retries", "7")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.ConfigPropertyBean\".retry.max-retries",
+                    "5")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.ConfigPropertyBean/triggerException\".retry.max-retries",
+                    "6");
+
+    @Inject
+    private ConfigPropertyBean bean;
+
+    @Test
+    void test() {
+        assertThatThrownBy(() -> bean.triggerException()).isExactlyInstanceOf(IllegalStateException.class);
+        assertThat(bean.getRetry()).isEqualTo(7);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/ConfigPropertyOnClassAndMethodTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/ConfigPropertyOnClassAndMethodTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigPropertyOnClassAndMethodTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(ConfigPropertyBean.class))
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.ConfigPropertyBean\".retry.max-retries",
+                    "5")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.ConfigPropertyBean/triggerException\".retry.max-retries",
+                    "6");
+
+    @Inject
+    private ConfigPropertyBean bean;
+
+    @Test
+    void test() {
+        assertThatThrownBy(() -> bean.triggerException()).isExactlyInstanceOf(IllegalStateException.class);
+        assertThat(bean.getRetry()).isEqualTo(7);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackApplyOnConfigTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackApplyOnConfigTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FallbackApplyOnConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(FallbackConfigBean.class, TestConfigExceptionA.class,
+                    TestConfigExceptionB.class, FallbackHandlerA.class))
+            .overrideConfigKey("quarkus.fault-tolerance.global.fallback.apply-on",
+                    "io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionA");
+
+    @Inject
+    private FallbackConfigBean bean;
+
+    @Test
+    public void applyOn() {
+        assertThat(bean.applyOn()).isEqualTo("FALLBACK");
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackConfigBean.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackConfigBean.java
@@ -1,0 +1,36 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import jakarta.enterprise.context.Dependent;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@Dependent
+public class FallbackConfigBean {
+    @Fallback(fallbackMethod = "theFallback", applyOn = TestConfigExceptionB.class)
+    public String applyOn() {
+        throw new TestConfigExceptionA();
+    }
+
+    @Fallback(fallbackMethod = "theFallback")
+    public String skipOn() {
+        throw new TestConfigExceptionA();
+    }
+
+    @Fallback(fallbackMethod = "theFallback")
+    public String fallbackMethod() {
+        throw new IllegalArgumentException();
+    }
+
+    @Fallback(FallbackHandlerA.class)
+    public String fallbackHandler() {
+        throw new IllegalArgumentException();
+    }
+
+    public String theFallback() {
+        return "FALLBACK";
+    }
+
+    public String anotherFallback() {
+        return "ANOTHER FALLBACK";
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackConfigTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackConfigTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FallbackConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(FallbackConfigBean.class, TestConfigExceptionA.class,
+                    TestConfigExceptionB.class, FallbackHandlerA.class, FallbackHandlerB.class))
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.FallbackConfigBean/applyOn\".fallback.apply-on",
+                    "io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionA")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.FallbackConfigBean/skipOn\".fallback.skip-on",
+                    "io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionA")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.FallbackConfigBean/fallbackMethod\".fallback.fallback-method",
+                    "anotherFallback")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.FallbackConfigBean/fallbackHandler\".fallback.value",
+                    "io.quarkus.smallrye.faulttolerance.test.config.FallbackHandlerB");
+
+    @Inject
+    private FallbackConfigBean bean;
+
+    @Test
+    public void applyOn() {
+        assertThat(bean.applyOn()).isEqualTo("FALLBACK");
+    }
+
+    @Test
+    public void skipOn() {
+        assertThatThrownBy(() -> bean.skipOn()).isExactlyInstanceOf(TestConfigExceptionA.class);
+    }
+
+    @Test
+    public void fallbackMethod() {
+        assertThat(bean.fallbackMethod()).isEqualTo("ANOTHER FALLBACK");
+    }
+
+    @Test
+    public void fallbackHandler() {
+        assertThat(bean.fallbackHandler()).isEqualTo("FallbackHandlerB");
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackHandlerA.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackHandlerA.java
@@ -1,0 +1,11 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+
+public class FallbackHandlerA implements FallbackHandler<String> {
+    @Override
+    public String handle(ExecutionContext context) {
+        return "FallbackHandlerA";
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackHandlerB.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackHandlerB.java
@@ -1,0 +1,11 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+
+public class FallbackHandlerB implements FallbackHandler<String> {
+    @Override
+    public String handle(ExecutionContext context) {
+        return "FallbackHandlerB";
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackSkipOnConfigTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/FallbackSkipOnConfigTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FallbackSkipOnConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(FallbackConfigBean.class, TestConfigExceptionA.class,
+                    TestConfigExceptionB.class, FallbackHandlerA.class))
+            .overrideConfigKey("quarkus.fault-tolerance.global.fallback.skip-on",
+                    "io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionA");
+
+    @Inject
+    private FallbackConfigBean bean;
+
+    @Test
+    public void skipOn() {
+        assertThatThrownBy(() -> bean.skipOn()).isExactlyInstanceOf(TestConfigExceptionA.class);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RateLimitConfigBean.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RateLimitConfigBean.java
@@ -1,0 +1,25 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import java.time.temporal.ChronoUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.faulttolerance.api.RateLimit;
+
+@ApplicationScoped
+public class RateLimitConfigBean {
+    @RateLimit(value = 10)
+    public String value() {
+        return "value";
+    }
+
+    @RateLimit(value = 3, window = 10, windowUnit = ChronoUnit.MINUTES)
+    public String window() {
+        return "window";
+    }
+
+    @RateLimit(value = 3, minSpacing = 10, minSpacingUnit = ChronoUnit.MINUTES)
+    public String minSpacing() {
+        return "minSpacing";
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RateLimitConfigTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RateLimitConfigTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.faulttolerance.api.RateLimitException;
+
+public class RateLimitConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(RateLimitConfigBean.class))
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RateLimitConfigBean/value\".rate-limit.value",
+                    "3")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RateLimitConfigBean/window\".rate-limit.window",
+                    "100")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RateLimitConfigBean/window\".rate-limit.window-unit",
+                    "millis")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RateLimitConfigBean/minSpacing\".rate-limit.min-spacing",
+                    "100")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RateLimitConfigBean/minSpacing\".rate-limit.min-spacing-unit",
+                    "millis");
+
+    @Inject
+    private RateLimitConfigBean bean;
+
+    @Test
+    public void value() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            assertThat(bean.value()).isEqualTo("value");
+        }
+        assertThatThrownBy(() -> bean.value()).isExactlyInstanceOf(RateLimitException.class);
+    }
+
+    @Test
+    public void window() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            assertThat(bean.window()).isEqualTo("window");
+        }
+        assertThatThrownBy(() -> bean.window()).isExactlyInstanceOf(RateLimitException.class);
+
+        Thread.sleep(500);
+
+        assertThat(bean.window()).isEqualTo("window");
+    }
+
+    @Test
+    public void minSpacing() throws Exception {
+        assertThat(bean.minSpacing()).isEqualTo("minSpacing");
+        assertThatThrownBy(() -> bean.minSpacing()).isExactlyInstanceOf(RateLimitException.class);
+
+        Thread.sleep(500);
+
+        assertThat(bean.minSpacing()).isEqualTo("minSpacing");
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RetryConfigBean.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RetryConfigBean.java
@@ -1,0 +1,56 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@ApplicationScoped
+public class RetryConfigBean {
+    @Retry(delay = 0, jitter = 0)
+    public void maxRetries(AtomicInteger counter) {
+        counter.getAndIncrement();
+        throw new TestException();
+    }
+
+    @Retry(maxDuration = 10000, durationUnit = ChronoUnit.MILLIS, maxRetries = 10000, delay = 200, jitter = 0)
+    public void maxDuration() {
+        throw new TestException();
+    }
+
+    @Retry(maxRetries = 5, delay = 2, delayUnit = ChronoUnit.SECONDS, jitter = 0)
+    public void delay() {
+        throw new TestException();
+    }
+
+    @Retry(maxRetries = 1, delay = 0, jitter = 0)
+    public void retryOn(RuntimeException e, AtomicInteger counter) {
+        counter.getAndIncrement();
+        throw e;
+    }
+
+    @Retry(retryOn = { TestConfigExceptionA.class,
+            TestConfigExceptionB.class }, abortOn = RuntimeException.class, maxRetries = 1, delay = 0, jitter = 0)
+    public void abortOn(RuntimeException e, AtomicInteger counter) {
+        counter.getAndIncrement();
+        throw e;
+    }
+
+    private long lastStartTime = 0;
+
+    @Retry(abortOn = TestConfigExceptionA.class, delay = 0, jitter = 0, maxRetries = 1000, maxDuration = 10, durationUnit = ChronoUnit.SECONDS)
+    public void jitter() {
+        long startTime = System.nanoTime();
+        if (lastStartTime != 0) {
+            Duration delay = Duration.ofNanos(startTime - lastStartTime);
+            if (delay.compareTo(Duration.ofMillis(100)) > 0) {
+                throw new TestConfigExceptionA();
+            }
+        }
+        lastStartTime = startTime;
+        throw new TestException();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RetryConfigTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/RetryConfigTest.java
@@ -1,0 +1,131 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RetryConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(RetryConfigBean.class, TestException.class,
+                    TestConfigExceptionA.class, TestConfigExceptionB.class, TestConfigExceptionB1.class))
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RetryConfigBean/maxRetries\".retry.max-retries",
+                    "10")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RetryConfigBean/maxDuration\".retry.max-duration",
+                    "1")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RetryConfigBean/maxDuration\".retry.max-duration-unit",
+                    "seconds")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RetryConfigBean/delay\".retry.delay",
+                    "2000")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RetryConfigBean/delay\".retry.delay-unit",
+                    "micros")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RetryConfigBean/retryOn\".retry.retry-on",
+                    "io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionA,io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionB")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RetryConfigBean/abortOn\".retry.abort-on",
+                    "io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionA,io.quarkus.smallrye.faulttolerance.test.config.TestConfigExceptionB1")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RetryConfigBean/jitter\".retry.jitter",
+                    "1")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.RetryConfigBean/jitter\".retry.jitter-unit",
+                    "seconds");
+
+    @Inject
+    private RetryConfigBean bean;
+
+    @Test
+    public void maxRetries() {
+        AtomicInteger counter = new AtomicInteger();
+        assertThatThrownBy(() -> bean.maxRetries(counter)).isExactlyInstanceOf(TestException.class);
+        assertThat(counter).hasValue(11);
+    }
+
+    @Test
+    public void maxDuration() {
+        long startTime = System.nanoTime();
+        assertThatThrownBy(() -> bean.maxDuration()).isExactlyInstanceOf(TestException.class);
+        long endTime = System.nanoTime();
+
+        Duration duration = Duration.ofNanos(endTime - startTime);
+        assertThat(duration).isLessThan(Duration.ofSeconds(8));
+    }
+
+    @Test
+    public void delay() {
+        long startTime = System.nanoTime();
+        assertThatThrownBy(() -> bean.delay()).isExactlyInstanceOf(TestException.class);
+        long endTime = System.nanoTime();
+
+        Duration duration = Duration.ofNanos(endTime - startTime);
+        assertThat(duration).isLessThan(Duration.ofSeconds(8));
+    }
+
+    @Test
+    public void retryOn() {
+        AtomicInteger counter = new AtomicInteger();
+
+        counter.set(0);
+        assertThatThrownBy(() -> bean.retryOn(new TestException(), counter)).isExactlyInstanceOf(TestException.class);
+        assertThat(counter).hasValue(1);
+
+        counter.set(0);
+        assertThatThrownBy(() -> bean.retryOn(new TestConfigExceptionA(), counter))
+                .isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThat(counter).hasValue(2);
+
+        counter.set(0);
+        assertThatThrownBy(() -> bean.retryOn(new TestConfigExceptionB(), counter))
+                .isExactlyInstanceOf(TestConfigExceptionB.class);
+        assertThat(counter).hasValue(2);
+
+        counter.set(0);
+        assertThatThrownBy(() -> bean.retryOn(new TestConfigExceptionB1(), counter))
+                .isExactlyInstanceOf(TestConfigExceptionB1.class);
+        assertThat(counter).hasValue(2);
+    }
+
+    @Test
+    public void abortOn() {
+        AtomicInteger counter = new AtomicInteger();
+
+        counter.set(0);
+        assertThatThrownBy(() -> bean.abortOn(new TestException(), counter)).isExactlyInstanceOf(TestException.class);
+        assertThat(counter).hasValue(1);
+
+        counter.set(0);
+        assertThatThrownBy(() -> bean.abortOn(new TestConfigExceptionA(), counter))
+                .isExactlyInstanceOf(TestConfigExceptionA.class);
+        assertThat(counter).hasValue(1);
+
+        counter.set(0);
+        assertThatThrownBy(() -> bean.abortOn(new TestConfigExceptionB(), counter))
+                .isExactlyInstanceOf(TestConfigExceptionB.class);
+        assertThat(counter).hasValue(2);
+
+        counter.set(0);
+        assertThatThrownBy(() -> bean.abortOn(new TestConfigExceptionB1(), counter))
+                .isExactlyInstanceOf(TestConfigExceptionB1.class);
+        assertThat(counter).hasValue(1);
+    }
+
+    @Test
+    public void jitter() {
+        assertThatThrownBy(() -> bean.jitter()).isExactlyInstanceOf(TestConfigExceptionA.class);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TestConfigExceptionA.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TestConfigExceptionA.java
@@ -1,0 +1,4 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+public class TestConfigExceptionA extends RuntimeException {
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TestConfigExceptionB.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TestConfigExceptionB.java
@@ -1,0 +1,4 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+public class TestConfigExceptionB extends RuntimeException {
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TestConfigExceptionB1.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TestConfigExceptionB1.java
@@ -1,0 +1,4 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+public class TestConfigExceptionB1 extends TestConfigExceptionB {
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TestException.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TestException.java
@@ -1,0 +1,4 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+public class TestException extends RuntimeException {
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TimeoutConfigBean.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TimeoutConfigBean.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+@ApplicationScoped
+public class TimeoutConfigBean {
+    @Timeout(value = 1, unit = ChronoUnit.MILLIS)
+    public void value() throws InterruptedException {
+        Thread.sleep(TimeUnit.MINUTES.toMillis(1));
+    }
+
+    @Timeout(value = 1000, unit = ChronoUnit.MICROS)
+    public void unit() throws InterruptedException {
+        Thread.sleep(TimeUnit.MINUTES.toMillis(1));
+    }
+
+    @Timeout(value = 10, unit = ChronoUnit.MICROS)
+    @Asynchronous
+    public CompletionStage<Void> both() throws InterruptedException {
+        Thread.sleep(TimeUnit.MINUTES.toMillis(1));
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TimeoutConfigTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/config/TimeoutConfigTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.smallrye.faulttolerance.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TimeoutConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(TimeoutConfigBean.class))
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.TimeoutConfigBean/value\".timeout.value",
+                    "1000")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.TimeoutConfigBean/unit\".timeout.unit",
+                    "millis")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.TimeoutConfigBean/both\".timeout.value",
+                    "1000")
+            .overrideConfigKey(
+                    "quarkus.fault-tolerance.\"io.quarkus.smallrye.faulttolerance.test.config.TimeoutConfigBean/both\".timeout.unit",
+                    "millis");
+
+    @Inject
+    private TimeoutConfigBean bean;
+
+    @Test
+    public void value() {
+        doTest(() -> bean.value());
+    }
+
+    @Test
+    public void unit() {
+        doTest(() -> bean.unit());
+    }
+
+    @Test
+    public void both() {
+        doTest(() -> {
+            try {
+                bean.both().toCompletableFuture().get(1, TimeUnit.MINUTES);
+            } catch (ExecutionException e) {
+                throw e.getCause();
+            }
+        });
+    }
+
+    private void doTest(ThrowingCallable action) {
+        long start = System.nanoTime();
+        assertThatThrownBy(action).isExactlyInstanceOf(TimeoutException.class);
+        long end = System.nanoTime();
+
+        long durationInMillis = Duration.ofNanos(end - start).toMillis();
+        assertThat(durationInMillis).isGreaterThan(800);
+        assertThat(durationInMillis).isLessThan(2000);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/ExpectedOutcomeException.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/ExpectedOutcomeException.java
@@ -1,0 +1,10 @@
+package io.quarkus.smallrye.faulttolerance.test.fallback.causechain;
+
+public class ExpectedOutcomeException extends Exception {
+    public ExpectedOutcomeException() {
+    }
+
+    public ExpectedOutcomeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/FallbackWithApplyOn.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/FallbackWithApplyOn.java
@@ -1,0 +1,18 @@
+package io.quarkus.smallrye.faulttolerance.test.fallback.causechain;
+
+import java.io.IOException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@ApplicationScoped
+public class FallbackWithApplyOn {
+    @Fallback(fallbackMethod = "fallback", applyOn = IOException.class)
+    public void hello(Exception e) throws Exception {
+        throw e;
+    }
+
+    public void fallback(Exception ignored) {
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/FallbackWithBothSkipOnAndApplyOn.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/FallbackWithBothSkipOnAndApplyOn.java
@@ -1,0 +1,18 @@
+package io.quarkus.smallrye.faulttolerance.test.fallback.causechain;
+
+import java.io.IOException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@ApplicationScoped
+public class FallbackWithBothSkipOnAndApplyOn {
+    @Fallback(fallbackMethod = "fallback", skipOn = ExpectedOutcomeException.class, applyOn = IOException.class)
+    public void hello(Exception e) throws Exception {
+        throw e;
+    }
+
+    public void fallback(Exception ignored) {
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/FallbackWithExceptionCauseChainTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/FallbackWithExceptionCauseChainTest.java
@@ -1,0 +1,121 @@
+package io.quarkus.smallrye.faulttolerance.test.fallback.causechain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.IOException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FallbackWithExceptionCauseChainTest {
+    @RegisterExtension
+    final static QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(ExpectedOutcomeException.class, FallbackWithApplyOn.class,
+                    FallbackWithBothSkipOnAndApplyOn.class, FallbackWithSkipOn.class));
+
+    @Inject
+    FallbackWithBothSkipOnAndApplyOn fallbackWithBothSkipOnAndApplyOn;
+
+    @Inject
+    FallbackWithSkipOn fallbackWithSkipOn;
+
+    @Inject
+    FallbackWithApplyOn fallbackWithApplyOn;
+
+    @Test
+    public void bothSkipOnAndApplyOn() {
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new RuntimeException()))
+                .isExactlyInstanceOf(RuntimeException.class);
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new RuntimeException(new IOException())))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new RuntimeException(new ExpectedOutcomeException())))
+                .isExactlyInstanceOf(RuntimeException.class);
+
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new Exception()))
+                .isExactlyInstanceOf(Exception.class);
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new Exception(new IOException())))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new Exception(new ExpectedOutcomeException())))
+                .isExactlyInstanceOf(Exception.class);
+
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new IOException()))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new IOException(new Exception())))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new IOException(new ExpectedOutcomeException())))
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new ExpectedOutcomeException()))
+                .isExactlyInstanceOf(ExpectedOutcomeException.class);
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new ExpectedOutcomeException(new Exception())))
+                .isExactlyInstanceOf(ExpectedOutcomeException.class);
+        assertThatCode(() -> fallbackWithBothSkipOnAndApplyOn.hello(new ExpectedOutcomeException(new IOException())))
+                .isExactlyInstanceOf(ExpectedOutcomeException.class);
+    }
+
+    @Test
+    public void skipOn() {
+        assertThatCode(() -> fallbackWithSkipOn.hello(new RuntimeException()))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithSkipOn.hello(new RuntimeException(new IOException())))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithSkipOn.hello(new RuntimeException(new ExpectedOutcomeException())))
+                .isExactlyInstanceOf(RuntimeException.class);
+
+        assertThatCode(() -> fallbackWithSkipOn.hello(new Exception()))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithSkipOn.hello(new Exception(new IOException())))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithSkipOn.hello(new Exception(new ExpectedOutcomeException())))
+                .isExactlyInstanceOf(Exception.class);
+
+        assertThatCode(() -> fallbackWithSkipOn.hello(new IOException()))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithSkipOn.hello(new IOException(new Exception())))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithSkipOn.hello(new IOException(new ExpectedOutcomeException())))
+                .isExactlyInstanceOf(IOException.class);
+
+        assertThatCode(() -> fallbackWithSkipOn.hello(new ExpectedOutcomeException()))
+                .isExactlyInstanceOf(ExpectedOutcomeException.class);
+        assertThatCode(() -> fallbackWithSkipOn.hello(new ExpectedOutcomeException(new Exception())))
+                .isExactlyInstanceOf(ExpectedOutcomeException.class);
+        assertThatCode(() -> fallbackWithSkipOn.hello(new ExpectedOutcomeException(new IOException())))
+                .isExactlyInstanceOf(ExpectedOutcomeException.class);
+    }
+
+    @Test
+    public void applyOn() {
+        assertThatCode(() -> fallbackWithApplyOn.hello(new RuntimeException()))
+                .isExactlyInstanceOf(RuntimeException.class);
+        assertThatCode(() -> fallbackWithApplyOn.hello(new RuntimeException(new IOException())))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithApplyOn.hello(new RuntimeException(new ExpectedOutcomeException())))
+                .isExactlyInstanceOf(RuntimeException.class);
+
+        assertThatCode(() -> fallbackWithApplyOn.hello(new Exception()))
+                .isExactlyInstanceOf(Exception.class);
+        assertThatCode(() -> fallbackWithApplyOn.hello(new Exception(new IOException())))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithApplyOn.hello(new Exception(new ExpectedOutcomeException())))
+                .isExactlyInstanceOf(Exception.class);
+
+        assertThatCode(() -> fallbackWithApplyOn.hello(new IOException()))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithApplyOn.hello(new IOException(new Exception())))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> fallbackWithApplyOn.hello(new IOException(new ExpectedOutcomeException())))
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> fallbackWithApplyOn.hello(new ExpectedOutcomeException()))
+                .isExactlyInstanceOf(ExpectedOutcomeException.class);
+        assertThatCode(() -> fallbackWithApplyOn.hello(new ExpectedOutcomeException(new Exception())))
+                .isExactlyInstanceOf(ExpectedOutcomeException.class);
+        assertThatCode(() -> fallbackWithApplyOn.hello(new ExpectedOutcomeException(new IOException())))
+                .doesNotThrowAnyException();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/FallbackWithSkipOn.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/fallback/causechain/FallbackWithSkipOn.java
@@ -1,0 +1,16 @@
+package io.quarkus.smallrye.faulttolerance.test.fallback.causechain;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@ApplicationScoped
+public class FallbackWithSkipOn {
+    @Fallback(fallbackMethod = "fallback", skipOn = ExpectedOutcomeException.class)
+    public void hello(Exception e) throws Exception {
+        throw e;
+    }
+
+    public void fallback(Exception ignored) {
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/programmatic/HelloService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/programmatic/HelloService.java
@@ -8,7 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
 import io.smallrye.faulttolerance.api.CircuitBreakerName;
-import io.smallrye.faulttolerance.api.FaultTolerance;
+import io.smallrye.faulttolerance.api.TypedGuard;
 
 @ApplicationScoped
 public class HelloService {
@@ -16,9 +16,10 @@ public class HelloService {
     static final int THRESHOLD = 5;
     static final int DELAY = 500;
 
-    private final Supplier<String> anotherHello = FaultTolerance.createSupplier(this::anotherHelloImpl)
+    private final Supplier<String> anotherHello = TypedGuard.create(String.class)
             .withCircuitBreaker().requestVolumeThreshold(THRESHOLD).delay(DELAY, ChronoUnit.MILLIS).name("another-hello").done()
-            .build();
+            .build()
+            .adaptSupplier(this::anotherHelloImpl);
 
     @CircuitBreaker(requestVolumeThreshold = THRESHOLD, delay = DELAY)
     @CircuitBreakerName("hello")

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/reuse/HelloService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/reuse/HelloService.java
@@ -1,0 +1,19 @@
+package io.quarkus.smallrye.faulttolerance.test.reuse;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.faulttolerance.api.ApplyGuard;
+
+@ApplicationScoped
+public class HelloService {
+    static final String OK = "Hello";
+
+    @ApplyGuard("my-guard")
+    public String hello(Exception exception) throws Exception {
+        if (exception != null) {
+            throw exception;
+        }
+
+        return OK;
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/reuse/MyGuard.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/reuse/MyGuard.java
@@ -1,0 +1,21 @@
+package io.quarkus.smallrye.faulttolerance.test.reuse;
+
+import java.time.temporal.ChronoUnit;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.faulttolerance.api.Guard;
+
+@Singleton
+public class MyGuard {
+    static final int THRESHOLD = 5;
+    static final int DELAY = 500;
+
+    @Produces
+    @Identifier("my-guard")
+    public static final Guard GUARD = Guard.create()
+            .withCircuitBreaker().requestVolumeThreshold(THRESHOLD).delay(DELAY, ChronoUnit.MILLIS).name("hello").done()
+            .build();
+}

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/config/SmallRyeFaultToleranceBuildTimeConfig.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/config/SmallRyeFaultToleranceBuildTimeConfig.java
@@ -1,0 +1,72 @@
+package io.quarkus.smallrye.faulttolerance.runtime.config;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
+import io.smallrye.faulttolerance.api.BeforeRetry;
+
+// this interface, as well as the nested interfaces, are never used;
+// they only exist to signal to Quarkus that these config properties exist
+@ConfigMapping(prefix = "quarkus.fault-tolerance")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface SmallRyeFaultToleranceBuildTimeConfig {
+    /**
+     * Configuration of fault tolerance strategies; either global, per class, or per method.
+     * Keys are:
+     *
+     * <ul>
+     * <li>{@code global}: for global configuration</li>
+     * <li>{@code "<classname>"}: for per class configuration</li>
+     * <li>{@code "<classname>/<methodname>"}: for per method configuration</li>
+     * </ul>
+     *
+     * Note that configuration follows the MicroProfile Fault Tolerance specification.
+     * That is, if an annotation is present on a method, the configuration must be per method;
+     * if an annotation is present on a class, the configuration must be per class.
+     * Global configuration is a fallback for both per method and per class configuration,
+     * but per class configuration is <em>not</em> a fallback for per method configuration.
+     */
+    @WithParentName
+    @ConfigDocMapKey("<identifier>")
+    Map<String, StrategiesConfig> strategies();
+
+    interface StrategiesConfig {
+        /**
+         * Configuration of the {@code @BeforeRetry} fault tolerance strategy.
+         */
+        Optional<BeforeRetryConfig> beforeRetry();
+
+        /**
+         * Configuration of the {@code @Fallback} fault tolerance strategy.
+         */
+        Optional<FallbackConfig> fallback();
+
+        interface BeforeRetryConfig {
+            /**
+             * The name of the method to call before retrying. The method belongs to the same class
+             * as the guarded method. The method must have no parameters and return {@code void}.
+             *
+             * @see BeforeRetry#methodName()
+             */
+            Optional<String> methodName();
+        }
+
+        interface FallbackConfig {
+            /**
+             * The name of the method to call on fallback. The method belongs to the same class
+             * as the guarded method. The method must have a signature matching the signature
+             * of the guarded method.
+             *
+             * @see Fallback#fallbackMethod()
+             */
+            Optional<String> fallbackMethod();
+        }
+    }
+}

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/config/SmallRyeFaultToleranceConfig.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/config/SmallRyeFaultToleranceConfig.java
@@ -1,0 +1,577 @@
+package io.quarkus.smallrye.faulttolerance.runtime.config;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.function.Predicate;
+
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
+import io.smallrye.config.WithParentName;
+import io.smallrye.faulttolerance.api.ApplyGuard;
+import io.smallrye.faulttolerance.api.BeforeRetry;
+import io.smallrye.faulttolerance.api.BeforeRetryHandler;
+import io.smallrye.faulttolerance.api.CustomBackoff;
+import io.smallrye.faulttolerance.api.CustomBackoffStrategy;
+import io.smallrye.faulttolerance.api.ExponentialBackoff;
+import io.smallrye.faulttolerance.api.FibonacciBackoff;
+import io.smallrye.faulttolerance.api.RateLimit;
+import io.smallrye.faulttolerance.api.RateLimitType;
+import io.smallrye.faulttolerance.api.RetryWhen;
+
+// this interface, as well as the nested interfaces, are never used;
+// they only exist to signal to Quarkus that these config properties exist
+@ConfigMapping(prefix = "quarkus.fault-tolerance")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface SmallRyeFaultToleranceConfig {
+    /**
+     * Whether fault tolerance strategies are enabled. Note that {@code @Fallback}
+     * is always enabled, this applies to all other strategies.
+     */
+    @ConfigDocDefault("true")
+    Optional<Boolean> enabled();
+
+    /**
+     * Whether fault tolerance metrics are enabled.
+     */
+    @WithName("metrics.enabled")
+    @ConfigDocDefault("true")
+    Optional<Boolean> metricsEnabled();
+
+    /**
+     * Whether SmallRye Fault Tolerance should be compatible with the MicroProfile
+     * Fault Tolerance specification.
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> mpCompatibility();
+
+    /**
+     * Configuration of fault tolerance strategies; either global, per class, or per method.
+     * Keys are:
+     *
+     * <ul>
+     * <li>{@code global}: for global configuration</li>
+     * <li>{@code "<classname>"}: for per class configuration</li>
+     * <li>{@code "<classname>/<methodname>"}: for per method configuration</li>
+     * </ul>
+     *
+     * Note that configuration follows the MicroProfile Fault Tolerance specification.
+     * That is, if an annotation is present on a method, the configuration must be per method;
+     * if an annotation is present on a class, the configuration must be per class.
+     * Global configuration is a fallback for both per method and per class configuration,
+     * but per class configuration is <em>not</em> a fallback for per method configuration.
+     */
+    @WithParentName
+    @ConfigDocMapKey("<identifier>")
+    Map<String, StrategiesConfig> strategies();
+
+    interface StrategiesConfig {
+        /**
+         * Configuration of the {@code @ApplyGuard} fault tolerance strategy.
+         */
+        Optional<ApplyGuardConfig> applyGuard();
+
+        /**
+         * Configuration of the {@code @Asynchronous} fault tolerance strategy.
+         */
+        Optional<AsynchronousConfig> asynchronous();
+
+        /**
+         * Configuration of the {@code @AsynchronousNonBlocking} fault tolerance strategy.
+         */
+        Optional<AsynchronousNonBlockingConfig> asynchronousNonBlocking();
+
+        /**
+         * Configuration of the {@code @BeforeRetry} fault tolerance strategy.
+         */
+        Optional<BeforeRetryConfig> beforeRetry();
+
+        /**
+         * Configuration of the {@code @Bulkhead} fault tolerance strategy.
+         */
+        Optional<BulkheadConfig> bulkhead();
+
+        /**
+         * Configuration of the {@code @CircuitBreaker} fault tolerance strategy.
+         */
+        Optional<CircuitBreakerConfig> circuitBreaker();
+
+        /**
+         * Configuration of the {@code @CustomBackoff} fault tolerance strategy.
+         */
+        Optional<CustomBackoffConfig> customBackoff();
+
+        /**
+         * Configuration of the {@code @ExponentialBackoff} fault tolerance strategy.
+         */
+        Optional<ExponentialBackoffConfig> exponentialBackoff();
+
+        /**
+         * Configuration of the {@code @Fallback} fault tolerance strategy.
+         */
+        Optional<FallbackConfig> fallback();
+
+        /**
+         * Configuration of the {@code @FibonacciBackoff} fault tolerance strategy.
+         */
+        Optional<FibonacciBackoffConfig> fibonacciBackoff();
+
+        /**
+         * Configuration of the {@code @RateLimit} fault tolerance strategy.
+         */
+        Optional<RateLimitConfig> rateLimit();
+
+        /**
+         * Configuration of the {@code @Retry} fault tolerance strategy.
+         */
+        Optional<RetryConfig> retry();
+
+        /**
+         * Configuration of the {@code @RetryWhen} fault tolerance strategy.
+         */
+        Optional<RetryWhenConfig> retryWhen();
+
+        /**
+         * Configuration of the {@code @Timeout} fault tolerance strategy.
+         */
+        Optional<TimeoutConfig> timeout();
+
+        interface ApplyGuardConfig {
+            /**
+             * Whether the {@code @ApplyGuard} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The {@link io.smallrye.common.annotation.Identifier @Identifier}
+             * of the {@link io.smallrye.faulttolerance.api.Guard Guard}
+             * or {@link io.smallrye.faulttolerance.api.TypedGuard TypedGuard}
+             * to use on the annotated method.
+             *
+             * @see ApplyGuard#value()
+             */
+            Optional<String> value();
+        }
+
+        interface AsynchronousConfig {
+            /**
+             * Whether the {@code @Asynchronous} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+        }
+
+        interface AsynchronousNonBlockingConfig {
+            /**
+             * Whether the {@code @AsynchronousNonBlocking} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+        }
+
+        interface BeforeRetryConfig {
+            /**
+             * Whether the {@code @BeforeRetry} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The class of the {@link BeforeRetryHandler} to call before retrying.
+             *
+             * @see BeforeRetry#value()
+             */
+            Optional<Class<? extends BeforeRetryHandler>> value();
+        }
+
+        interface BulkheadConfig {
+            /**
+             * Whether the {@code @Bulkhead} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The maximum number of concurrent invocations.
+             *
+             * @see Bulkhead#value()
+             */
+            @ConfigDocDefault("10")
+            OptionalInt value();
+
+            /**
+             * The maximum number of queued asynchronous invocations. Asynchronous invocations are queued
+             * when the number of concurrent invocations in progress has already reached the maximum.
+             * Synchronous invocations are not queued at all and are rejected immediately.
+             *
+             * @see Bulkhead#waitingTaskQueue()
+             */
+            @ConfigDocDefault("10")
+            OptionalInt waitingTaskQueue();
+        }
+
+        interface CircuitBreakerConfig {
+            /**
+             * Whether the {@code @CircuitBreaker} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The delay after which an open circuit breaker will move to half-open.
+             *
+             * @see CircuitBreaker#delay()
+             */
+            @ConfigDocDefault("5 seconds")
+            OptionalLong delay();
+
+            /**
+             * The unit for {@link #delay()}.
+             *
+             * @see CircuitBreaker#delayUnit()
+             */
+            Optional<ChronoUnit> delayUnit();
+
+            /**
+             * The exception types that are considered failures.
+             *
+             * @see CircuitBreaker#failOn()
+             */
+            @ConfigDocDefault("Throwable (all exceptions)")
+            Optional<Class<? extends Throwable>[]> failOn();
+
+            /**
+             * The ratio of failures within the rolling window that will move a closed circuit breaker to open.
+             *
+             * @see CircuitBreaker#failureRatio()
+             */
+            @ConfigDocDefault("0.5")
+            OptionalDouble failureRatio();
+
+            /**
+             * The size of the circuit breaker rolling window.
+             *
+             * @see CircuitBreaker#requestVolumeThreshold()
+             */
+            @ConfigDocDefault("20")
+            OptionalInt requestVolumeThreshold();
+
+            /**
+             * The exception types that are not considered failures. Takes priority over {@link #failOn()}.
+             *
+             * @see CircuitBreaker#skipOn()
+             */
+            @ConfigDocDefault("<empty set>")
+            Optional<Class<? extends Throwable>[]> skipOn();
+
+            /**
+             * The number of successful executions that move a half-open circuit breaker to closed.
+             *
+             * @see CircuitBreaker#successThreshold()
+             */
+            @ConfigDocDefault("1")
+            OptionalInt successThreshold();
+        }
+
+        interface CustomBackoffConfig {
+            /**
+             * Whether the {@code @CustomBackoff} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The class of the {@link CustomBackoffStrategy} that will be used to compute retry delays.
+             *
+             * @see CustomBackoff#value()
+             */
+            Optional<Class<? extends CustomBackoffStrategy>> value();
+        }
+
+        interface ExponentialBackoffConfig {
+            /**
+             * Whether the {@code @ExponentialBackoff} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The multiplicative factor used when determining a delay between two retries. A delay is computed
+             * as {@code factor * previousDelay}, resulting in an exponential growth.
+             *
+             * @see ExponentialBackoff#factor()
+             */
+            @ConfigDocDefault("2")
+            OptionalInt factor();
+
+            /**
+             * The maximum delay between retries.
+             *
+             * @see ExponentialBackoff#maxDelay()
+             */
+            @ConfigDocDefault("1 minute")
+            OptionalLong maxDelay();
+
+            /**
+             * The unit for {@link #maxDelay()}.
+             *
+             * @see ExponentialBackoff#maxDelayUnit()
+             */
+            Optional<ChronoUnit> maxDelayUnit();
+        }
+
+        interface FallbackConfig {
+            /**
+             * Whether the {@code @Fallback} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The exception types that are considered failures and hence should trigger fallback.
+             *
+             * @see Fallback#applyOn()
+             */
+            @ConfigDocDefault("Throwable (all exceptions)")
+            Optional<Class<? extends Throwable>[]> applyOn();
+
+            /**
+             * The exception types that are not considered failures and hence should not trigger fallback.
+             * Takes priority over {@link #applyOn()}}.
+             *
+             * @see Fallback#skipOn()
+             */
+            @ConfigDocDefault("<empty set>")
+            Optional<Class<? extends Throwable>[]> skipOn();
+
+            /**
+             * The class of the {@link FallbackHandler} to call on fallback.
+             *
+             * @see Fallback#value()
+             */
+            Optional<Class<? extends FallbackHandler<?>>> value();
+        }
+
+        interface FibonacciBackoffConfig {
+            /**
+             * Whether the {@code @FibonacciBackoff} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The maximum delay between retries.
+             *
+             * @see FibonacciBackoff#maxDelay()
+             */
+            @ConfigDocDefault("1 minute")
+            OptionalLong maxDelay();
+
+            /**
+             * The unit for {@link #maxDelay()}.
+             *
+             * @see FibonacciBackoff#maxDelayUnit()
+             */
+            Optional<ChronoUnit> maxDelayUnit();
+        }
+
+        interface RateLimitConfig {
+            /**
+             * Whether the {@code @RateLimit} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * Minimum time between two consecutive invocations. If the time between two consecutive
+             * invocations is shorter, the second invocation is rejected.
+             *
+             * @see RateLimit#minSpacing()
+             */
+            @ConfigDocDefault("0")
+            OptionalLong minSpacing();
+
+            /**
+             * The unit for {@link #minSpacing()}.
+             *
+             * @see RateLimit#minSpacingUnit()
+             */
+            Optional<ChronoUnit> minSpacingUnit();
+
+            /**
+             * The type of type windows used for rate limiting.
+             *
+             * @see RateLimit#type()
+             */
+            @ConfigDocDefault("fixed")
+            Optional<RateLimitType> type();
+
+            /**
+             * The maximum number of invocations in a time window.
+             *
+             * @see RateLimit#value()
+             */
+            @ConfigDocDefault("100")
+            OptionalInt value();
+
+            /**
+             * The time window length.
+             *
+             * @see RateLimit#window()
+             */
+            @ConfigDocDefault("1 second")
+            OptionalLong window();
+
+            /**
+             * The unit for {@link #window()}.
+             *
+             * @see RateLimit#windowUnit()
+             */
+            Optional<ChronoUnit> windowUnit();
+        }
+
+        interface RetryConfig {
+            /**
+             * Whether the {@code @Retry} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The exception types that are not considered failures and hence should not be retried.
+             * Takes priority over {@link #retryOn()}.
+             *
+             * @see Retry#abortOn()
+             */
+            @ConfigDocDefault("<empty set>")
+            Optional<Class<? extends Throwable>[]> abortOn();
+
+            /**
+             * The delay between retry attempts.
+             *
+             * @see Retry#delay()
+             */
+            @ConfigDocDefault("0")
+            OptionalLong delay();
+
+            /**
+             * The unit for {@link #delay()}.
+             *
+             * @see Retry#delayUnit()
+             */
+            Optional<ChronoUnit> delayUnit();
+
+            /**
+             * The maximum jitter to apply for the delay between retry attempts.
+             * The actual delay will be in the interval {@code [delay - jitter, delay + jitter]},
+             * but will not be negative.
+             *
+             * @see Retry#jitter()
+             */
+            @ConfigDocDefault("200 millis")
+            OptionalLong jitter();
+
+            /**
+             * The unit for {@link #jitter()}.
+             *
+             * @see Retry#jitterDelayUnit()
+             */
+            Optional<ChronoUnit> jitterUnit(); // `Retry.jitterDelayUnit()`
+
+            /**
+             * The maximum duration for which to retry.
+             *
+             * @see Retry#maxDuration()
+             */
+            @ConfigDocDefault("3 minutes")
+            OptionalLong maxDuration();
+
+            /**
+             * The unit for {@link #maxDuration()}.
+             *
+             * @see Retry#durationUnit()
+             */
+            Optional<ChronoUnit> maxDurationUnit(); // `Retry.durationUnit()`
+
+            /**
+             * The maximum number of retry attempts.
+             *
+             * @see Retry#maxRetries()
+             */
+            @ConfigDocDefault("3")
+            OptionalInt maxRetries();
+
+            /**
+             * The exception types that are considered failures and hence should be retried.
+             *
+             * @see Retry#retryOn()
+             */
+            @ConfigDocDefault("Exception (all exceptions)")
+            Optional<Class<? extends Throwable>[]> retryOn();
+        }
+
+        interface RetryWhenConfig {
+            /**
+             * Whether the {@code @RetryWhen} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * Class of the predicate that will be used to determine whether the invocation should be retried
+             * if the guarded method has thrown an exception.
+             *
+             * @see RetryWhen#exception()
+             */
+            @ConfigDocDefault("AlwaysOnException")
+            Optional<Class<? extends Predicate<Throwable>>> exception();
+
+            /**
+             * Class of the predicate that will be used to determine whether the invocation should be retried
+             * if the guarded method has returned a result.
+             *
+             * @see RetryWhen#result()
+             */
+            @ConfigDocDefault("NeverOnResult")
+            Optional<Class<? extends Predicate<Object>>> result();
+        }
+
+        interface TimeoutConfig {
+            /**
+             * Whether the {@code @Timeout} strategy is enabled.
+             */
+            @ConfigDocDefault("true")
+            Optional<Boolean> enabled();
+
+            /**
+             * The unit for {@link #value()}.
+             *
+             * @see Timeout#unit()
+             */
+            Optional<ChronoUnit> unit();
+
+            /**
+             * The timeout to enforce.
+             *
+             * @see Timeout#value()
+             */
+            @ConfigDocDefault("1 second")
+            OptionalLong value();
+        }
+    }
+}

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/config/SmallRyeFaultToleranceConfigRelocate.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/config/SmallRyeFaultToleranceConfigRelocate.java
@@ -1,0 +1,18 @@
+package io.quarkus.smallrye.faulttolerance.runtime.config;
+
+import java.util.function.Function;
+
+import io.smallrye.config.RelocateConfigSourceInterceptor;
+
+public class SmallRyeFaultToleranceConfigRelocate extends RelocateConfigSourceInterceptor {
+    private static final Function<String, String> RELOCATION = name -> {
+        if (name.startsWith("smallrye.faulttolerance.")) {
+            return name.replaceFirst("smallrye\\.faulttolerance\\.", "quarkus.fault-tolerance.");
+        }
+        return name;
+    };
+
+    public SmallRyeFaultToleranceConfigRelocate() {
+        super(RELOCATION);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/devui/FaultToleranceJsonRpcService.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/devui/FaultToleranceJsonRpcService.java
@@ -16,6 +16,7 @@ import io.quarkus.smallrye.faulttolerance.runtime.QuarkusFaultToleranceOperation
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.faulttolerance.api.ApplyFaultTolerance;
+import io.smallrye.faulttolerance.api.ApplyGuard;
 import io.smallrye.faulttolerance.api.AsynchronousNonBlocking;
 import io.smallrye.faulttolerance.api.BeforeRetry;
 import io.smallrye.faulttolerance.api.CircuitBreakerName;
@@ -52,6 +53,10 @@ public class FaultToleranceJsonRpcService {
         if (operation.hasApplyFaultTolerance()) {
             result.put(ApplyFaultTolerance.class.getSimpleName(), new JsonObject()
                     .put("value", operation.getApplyFaultTolerance().value()));
+        }
+        if (operation.hasApplyGuard()) {
+            result.put(ApplyGuard.class.getSimpleName(), new JsonObject()
+                    .put("value", operation.getApplyGuard().value()));
         }
 
         if (operation.hasAsynchronous()) {

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,0 +1,1 @@
+io.quarkus.smallrye.faulttolerance.runtime.config.SmallRyeFaultToleranceConfigRelocate

--- a/integration-tests/main/src/main/java/io/quarkus/it/faulttolerance/PreconfiguredFaultTolerance.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/faulttolerance/PreconfiguredFaultTolerance.java
@@ -4,13 +4,13 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 
 import io.smallrye.common.annotation.Identifier;
-import io.smallrye.faulttolerance.api.FaultTolerance;
+import io.smallrye.faulttolerance.api.Guard;
 
 @ApplicationScoped
 public class PreconfiguredFaultTolerance {
     @Produces
     @Identifier("my-fault-tolerance")
-    public static final FaultTolerance<String> FT = FaultTolerance.<String> create()
+    public static final Guard GUARD = Guard.create()
             .withRetry().maxRetries(10).done()
             .build();
 }

--- a/integration-tests/main/src/main/java/io/quarkus/it/faulttolerance/Service.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/faulttolerance/Service.java
@@ -8,7 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
-import io.smallrye.faulttolerance.api.ApplyFaultTolerance;
+import io.smallrye.faulttolerance.api.ApplyGuard;
 
 @ApplicationScoped
 public class Service {
@@ -22,7 +22,7 @@ public class Service {
         name = "Lucie";
     }
 
-    @ApplyFaultTolerance("my-fault-tolerance")
+    @ApplyGuard("my-fault-tolerance")
     public String getName(AtomicInteger counter) {
         if (counter.incrementAndGet() >= THRESHOLD) {
             return name;


### PR DESCRIPTION
- https://smallrye.io/blog/fault-tolerance-6-7-0/

This commit not only bumps the SmallRye Fault Tolerance version, but also adapts the extension to the extensive changes made in this version.

This especially includes:

- deprecation of `FaultTolerance` and `@ApplyFaultTolerance`; replacements are `Guard`, `TypedGuard` and `@ApplyGuard`
- new `smallrye.faulttolerance.*` configuration properties, together with adaptation to `quarkus.fault-tolerance.*`

Most changes in this commit are added tests, which all adapt already existing tests in SmallRye Fault Tolerance.

Fixes #24533