### PR TITLE
Fix off-by-one error in exception decoration code

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -449,7 +449,7 @@ public final class LoggingResourceProcessor {
                                                 Object[] np = p != null ? Arrays.copyOf(p, p.length + 1) : new Object[1];
                                                 np[np.length - 1] = decoratedString;
                                                 elr.setParameters(np);
-                                                elr.setMessage(elr.getMessage() + "\n\n%" + (np.length - 1) + "$s",
+                                                elr.setMessage(elr.getMessage() + "\n\n%" + np.length + "$s",
                                                         ExtLogRecord.FormatStyle.PRINTF);
                                             }
                                             case NO_FORMAT -> {


### PR DESCRIPTION
This was failing only in dev mode when using printf-style logging (`%s` indexes are 1-based).

Fixes https://github.com/smallrye/smallrye-graphql/issues/2230