### PR TITLE
Remove use of Json in JWT and OIDC test security

### DIFF
--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentor.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentor.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.security.jwt;
 
+import static io.quarkus.jsonp.JsonProviderHolder.jsonProvider;
+
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collections;
@@ -7,7 +9,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.json.Json;
 import jakarta.json.JsonValue;
 
 import org.eclipse.microprofile.jwt.Claims;
@@ -79,9 +80,9 @@ public class JwtTestSecurityIdentityAugmentor implements TestSecurityIdentityAug
         Claims claimType = getClaimType(claim.key());
         if (Claims.UNKNOWN == claimType) {
             if (convertedClaimValue instanceof Long) {
-                return Json.createValue((Long) convertedClaimValue);
+                return jsonProvider().createValue((Long) convertedClaimValue);
             } else if (convertedClaimValue instanceof Integer) {
-                return Json.createValue((Integer) convertedClaimValue);
+                return jsonProvider().createValue((Integer) convertedClaimValue);
             } else if (convertedClaimValue instanceof Boolean) {
                 return (Boolean) convertedClaimValue ? JsonValue.TRUE : JsonValue.FALSE;
             }

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentor.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentor.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.security.oidc;
 
+import static io.quarkus.jsonp.JsonProviderHolder.jsonProvider;
+
 import java.lang.annotation.Annotation;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -8,7 +10,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObjectBuilder;
 
@@ -63,10 +64,10 @@ public class OidcTestSecurityIdentityAugmentor implements TestSecurityIdentityAu
 
         if (!introspectionRequired) {
             // JsonWebToken
-            JsonObjectBuilder claims = Json.createObjectBuilder();
+            JsonObjectBuilder claims = jsonProvider().createObjectBuilder();
             claims.add(Claims.preferred_username.name(), identity.getPrincipal().getName());
             claims.add(Claims.groups.name(),
-                    Json.createArrayBuilder(identity.getRoles().stream().collect(Collectors.toList())).build());
+                    jsonProvider().createArrayBuilder(identity.getRoles().stream().collect(Collectors.toList())).build());
             if (oidcSecurity != null && oidcSecurity.claims() != null) {
                 for (Claim claim : oidcSecurity.claims()) {
                     Object claimValue = convertClaimValue(claim);
@@ -99,7 +100,7 @@ public class OidcTestSecurityIdentityAugmentor implements TestSecurityIdentityAu
             builder.addCredential(idToken);
             builder.addCredential(accessToken);
         } else {
-            JsonObjectBuilder introspectionBuilder = Json.createObjectBuilder();
+            JsonObjectBuilder introspectionBuilder = jsonProvider().createObjectBuilder();
             introspectionBuilder.add(OidcConstants.INTROSPECTION_TOKEN_ACTIVE, true);
             introspectionBuilder.add(OidcConstants.INTROSPECTION_TOKEN_USERNAME, identity.getPrincipal().getName());
             introspectionBuilder.add(OidcConstants.TOKEN_SCOPE,
@@ -118,7 +119,7 @@ public class OidcTestSecurityIdentityAugmentor implements TestSecurityIdentityAu
 
         // UserInfo
         if (oidcSecurity != null && oidcSecurity.userinfo() != null) {
-            JsonObjectBuilder userInfoBuilder = Json.createObjectBuilder();
+            JsonObjectBuilder userInfoBuilder = jsonProvider().createObjectBuilder();
             for (UserInfo userinfo : oidcSecurity.userinfo()) {
                 userInfoBuilder.add(userinfo.key(), userinfo.value());
             }


### PR DESCRIPTION
JWT and OIDC test security support uses `jakarta.json.Json` directly, so this PR fixes it