### PR TITLE
Remote development mode can be used on deployments with context path

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -296,7 +296,7 @@ public class VertxHttpRecorder {
             if (liveReloadConfig.password().isPresent()
                     && hotReplacementContext.getDevModeType() == DevModeType.REMOTE_SERVER_SIDE) {
                 root = remoteSyncHandler = new RemoteSyncHandler(liveReloadConfig.password().get(), root,
-                        hotReplacementContext);
+                        hotReplacementContext, "/");
             }
             rootHandler = root;
 
@@ -547,7 +547,8 @@ public class VertxHttpRecorder {
         }
         if (launchMode == LaunchMode.DEVELOPMENT && liveReloadConfig.password().isPresent()
                 && hotReplacementContext.getDevModeType() == DevModeType.REMOTE_SERVER_SIDE) {
-            root = remoteSyncHandler = new RemoteSyncHandler(liveReloadConfig.password().get(), root, hotReplacementContext);
+            root = remoteSyncHandler = new RemoteSyncHandler(liveReloadConfig.password().get(), root, hotReplacementContext,
+                    rootPath);
         }
         rootHandler = root;
 


### PR DESCRIPTION
[Remote development mode](https://quarkus.io/guides/maven-tooling#remote-development-mode) currently cannot be used on deployments that have a [context path](https://quarkus.io/guides/http-reference#context-path) (aka root url) other than `/`.

Reasons:
1. The paths used by remote dev mode are [hard coded](https://github.com/quarkusio/quarkus/blob/e3ab6bd81c7b1d02b059b5454157bae69ac3279f/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java#L101-L106) and rooted on `/ `.
2. If you add a (context) path to `quarkus.live-reload.url`, it will be honoured by the `./mvnw quarkus remote-dev` command. But when changed files are uploaded, the path of the corresponding PUT request will be used to determine the file location in the container. The files will be placed in sub-folders of their expected location.

This PR fixes both issues. The dev mode endpoints may be prefixed by a context path, and the context path is stripped from file upload urls.

### How to verify
You can verify the PR locally with [Minikube](https://quarkus.io/guides/deploying-to-kubernetes#deploying-to-minikube).
Note that the application has the context path "/api".

**build and install Quarkus locally.**

**create app**
```shell
quarkus create app --extensions rest,minikube,docker minikube-remote-dev
cd minikube-remote-dev
```

edit `pom.xml` to use local quarkus snapshot build
```xml
        <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
```

**add to `application.properties`**
```properties
quarkus.http.root-path=/api
quarkus.package.jar.type=mutable-jar
quarkus.live-reload.password=changeit
quarkus.kubernetes.env.vars.QUARKUS_LAUNCH_DEVMODE=true
```

**build and deploy**
```shell
eval $(minikube docker-env)
mvn clean package -DskipTests -Dquarkus.kubernetes.deploy
```

**start remote dev session**
```shell
SERVICE_URL=$(minikube service minikube-remote-dev --url)
mvn quarkus:remote-dev -Dquarkus.live-reload.url=$SERVICE_URL/api
```

**call the hello endpoint**
in another terminal:
```shell
SERVICE_URL=$(minikube service minikube-remote-dev --url)
curl $SERVICE_URL/api/hello
```

Finally, modify the `GreetingResource`'s message and call the service again.
The resource should return the updated message.

Without this PR, the remote dev connect will fail with

    Remote dev request failed: java.io.IOException: Server did not start a remote dev session: Unknown path /api/connect make sure your remote dev URL is pointing to the context root for your Quarkus instance, and not to a sub path.