### PR TITLE
Respect max message size property fo Quarkus GRPC client (44853)

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
@@ -79,6 +79,7 @@ import io.vertx.core.net.PemKeyCertOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClientChannel;
+import io.vertx.grpc.client.GrpcClientOptions;
 
 @SuppressWarnings({ "OptionalIsPresent" })
 public class Channels {
@@ -335,7 +336,9 @@ public class Channels {
             options.setMetricsName("grpc|" + name);
 
             Vertx vertx = container.instance(Vertx.class).get();
-            io.vertx.grpc.client.GrpcClient client = io.vertx.grpc.client.GrpcClient.client(vertx, options);
+            io.vertx.grpc.client.GrpcClient client = io.vertx.grpc.client.GrpcClient.client(vertx,
+                    new GrpcClientOptions().setTransportOptions(options)
+                            .setMaxMessageSize(config.maxInboundMessageSize.orElse(DEFAULT_MAX_MESSAGE_SIZE)));
             Channel channel;
             if (stork) {
                 ManagedExecutor executor = container.instance(ManagedExecutor.class).get();


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/44853 and gives a workaround for https://github.com/quarkusio/quarkus/issues/44852