### PR TITLE
Fix GraphQL when using CompletionStage and Blocking batch source

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLThreadTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLThreadTest.java
@@ -2,12 +2,16 @@ package io.quarkus.smallrye.graphql.deployment;
 
 import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.MEDIATYPE_JSON;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -326,6 +330,41 @@ public class GraphQLThreadTest extends AbstractGraphQLTest {
 
     }
 
+    @Test
+    public void testCompletionStageWithBlockingBatchSource() {
+
+        String fooRequest = getPayload("{\n" +
+                "  completionStageWithBlockingBatch {\n" +
+                "    name\n" +
+                "    batchSource{\n" +
+                "       name\n" +
+                "       vertxContextClassName\n" +
+                "    }\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body("data.completionStageWithBlockingBatch.name", Matchers.not(Matchers.startsWith("executor-thread")))
+                .and()
+                .log().body().and()
+                .body("data.completionStageWithBlockingBatch.batchSource.name",
+                        Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.completionStageWithBlockingBatch.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
     @GraphQLApi
     public static class TestThreadResource {
 
@@ -398,6 +437,19 @@ public class GraphQLThreadTest extends AbstractGraphQLTest {
         @NonBlocking
         public CompletionStage<TestThread> annotatedNonBlockingCompletionStage() {
             return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        @Query
+        public CompletionStage<TestThread> completionStageWithBlockingBatch() {
+            return CompletableFuture.supplyAsync(() -> getTestThread());
+        }
+
+        public List<TestThread> batchSource(@Source List<TestThread> mainThreads) {
+            List<TestThread> batchedSourceChildren = new ArrayList<>();
+            for (TestThread mainThread : mainThreads) {
+                batchedSourceChildren.add(getTestThread());
+            }
+            return batchedSourceChildren;
         }
 
         private TestThread getTestThread() {

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
@@ -4,27 +4,37 @@ import java.util.concurrent.Callable;
 
 import io.smallrye.graphql.schema.model.Execute;
 import io.smallrye.graphql.schema.model.Operation;
-import io.vertx.core.Context;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 
 public final class BlockingHelper {
 
     private BlockingHelper() {
     }
 
-    public static boolean blockingShouldExecuteNonBlocking(Operation operation, Context vc) {
+    public static boolean blockingShouldExecuteNonBlocking(Operation operation) {
         // Rule is that by default this should execute blocking except if marked as non-blocking)
         return operation.getExecute().equals(Execute.NON_BLOCKING);
     }
 
-    public static boolean nonBlockingShouldExecuteBlocking(Operation operation, Context vc) {
+    public static boolean nonBlockingShouldExecuteBlocking(Operation operation) {
         // Rule is that by default this should execute non-blocking except if marked as blocking
-        return operation.getExecute().equals(Execute.BLOCKING) && vc.isEventLoopContext();
+        return operation.getExecute().equals(Execute.BLOCKING) && Vertx.currentContext().isEventLoopContext();
     }
 
     @SuppressWarnings("unchecked")
-    public static void runBlocking(Context vc, Callable<Object> contextualCallable, Promise result) {
+    public static void runBlocking(Callable<Object> contextualCallable, Promise result) {
         // Here call blocking with context
-        vc.executeBlocking(contextualCallable).onComplete(result);
+        Uni.createFrom().item(contextualCallable)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .subscribe().with(r -> {
+                    try {
+                        result.complete(r.call());
+                    } catch (Exception ex) {
+                        result.fail(ex);
+                    }
+                });
     }
 }

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusCompletionStageDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusCompletionStageDataFetcher.java
@@ -22,18 +22,17 @@ public class QuarkusCompletionStageDataFetcher<K, T> extends AbstractAsyncDataFe
 
     @Override
     protected Uni<?> handleUserMethodCall(DataFetchingEnvironment dfe, Object[] transformedArguments) throws Exception {
-        Context vc = Vertx.currentContext();
-        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation)) {
             return handleUserMethodCallNonBlocking(transformedArguments);
         } else {
-            return handleUserMethodCallBlocking(transformedArguments, vc);
+            return handleUserMethodCallBlocking(transformedArguments);
         }
     }
 
     @Override
     protected Uni<List<T>> handleUserBatchLoad(DataFetchingEnvironment dfe, Object[] arguments) throws Exception {
         Context vc = Vertx.currentContext();
-        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation)) {
             return handleUserBatchLoadNonBlocking(arguments);
         } else {
             return handleUserBatchLoadBlocking(arguments, vc);
@@ -47,7 +46,7 @@ public class QuarkusCompletionStageDataFetcher<K, T> extends AbstractAsyncDataFe
     }
 
     @SuppressWarnings("unchecked")
-    private Uni<?> handleUserMethodCallBlocking(Object[] transformedArguments, Context vc)
+    private Uni<?> handleUserMethodCallBlocking(Object[] transformedArguments)
             throws Exception {
 
         SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
@@ -61,7 +60,7 @@ public class QuarkusCompletionStageDataFetcher<K, T> extends AbstractAsyncDataFe
         });
 
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(contextualCallable, result);
         return Uni.createFrom().completionStage(result.future().toCompletionStage());
     }
 
@@ -86,7 +85,7 @@ public class QuarkusCompletionStageDataFetcher<K, T> extends AbstractAsyncDataFe
         });
 
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(contextualCallable, result);
         return Uni.createFrom().completionStage(result.future().toCompletionStage());
     }
 

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusUniDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusUniDataFetcher.java
@@ -9,9 +9,7 @@ import io.smallrye.context.SmallRyeThreadContext;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Type;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.Context;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 
 public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> {
 
@@ -21,21 +19,19 @@ public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> 
 
     @Override
     protected Uni<?> handleUserMethodCall(DataFetchingEnvironment dfe, Object[] transformedArguments) throws Exception {
-        Context vc = Vertx.currentContext();
-        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation)) {
             return handleUserMethodCallNonBlocking(transformedArguments);
         } else {
-            return handleUserMethodCallBlocking(transformedArguments, vc);
+            return handleUserMethodCallBlocking(transformedArguments);
         }
     }
 
     @Override
     protected Uni<List<T>> handleUserBatchLoad(DataFetchingEnvironment dfe, Object[] arguments) throws Exception {
-        Context vc = Vertx.currentContext();
-        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation)) {
             return handleUserBatchLoadNonBlocking(arguments);
         } else {
-            return handleUserBatchLoadBlocking(arguments, vc);
+            return handleUserBatchLoadBlocking(arguments);
         }
     }
 
@@ -44,7 +40,7 @@ public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> 
         return (Uni<?>) operationInvoker.invoke(transformedArguments);
     }
 
-    private Uni<?> handleUserMethodCallBlocking(Object[] transformedArguments, Context vc)
+    private Uni<?> handleUserMethodCallBlocking(Object[] transformedArguments)
             throws Exception {
 
         SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
@@ -58,7 +54,7 @@ public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> 
         });
 
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(contextualCallable, result);
         return Uni.createFrom().completionStage(result.future().toCompletionStage());
     }
 
@@ -68,7 +64,7 @@ public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> 
         return ((Uni<List<T>>) operationInvoker.invoke(arguments));
     }
 
-    private Uni<List<T>> handleUserBatchLoadBlocking(Object[] arguments, Context vc)
+    private Uni<List<T>> handleUserBatchLoadBlocking(Object[] arguments)
             throws Exception {
 
         SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
@@ -83,7 +79,7 @@ public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> 
         });
 
         // Here call blocking with context
-        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        BlockingHelper.runBlocking(contextualCallable, result);
         return Uni.createFrom().completionStage(result.future().toCompletionStage());
     }
 


### PR DESCRIPTION
Second attempt to fix #44762

@cescoffier - I removed the verx part, and replaced with Uni, but we can also only do this when Vertx context is null (like the exception in the issue). Let me know. For now I made the change for all. @jmartisk I added tests.