### PR TITLE
Disable Sonarcloud analysis on forks

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,6 +7,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: github.repository == 'quarkusio/quarkus'
+
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Because it won't work without a token anyway.

I went with the same condition as the CodeQL analysis: https://github.com/quarkusio/quarkus/blob/a7d39b0341e3fda56fd594836a303eac864f8920/.github/workflows/codeql-analysis.yml#L17