### PR TITLE
Remove split package by moving the GraalVM Substitutions for Confluent JSON Schema Serde

### DIFF
--- a/extensions/schema-registry/confluent/json-schema/runtime/src/main/java/io/quarkus/confluent/registry/json/runtime/graal/ConfluentJsonSubstitutions.java
+++ b/extensions/schema-registry/confluent/json-schema/runtime/src/main/java/io/quarkus/confluent/registry/json/runtime/graal/ConfluentJsonSubstitutions.java
@@ -1,4 +1,4 @@
-package io.quarkus.confluent.registry.json;
+package io.quarkus.confluent.registry.json.runtime.graal;
 
 import java.io.IOException;
 import java.util.Arrays;


### PR DESCRIPTION
This commit moves the GraalVM substitutions related to the Confluent JSON Schema Serde to a dedicated package. Previously, these substitutions caused a split-package issue between the deployment and runtime modules.

Fix https://github.com/quarkusio/quarkus/issues/44722
