### PR TITLE
Copy attributes from Elytron SecurityIdentity to Quarkus SecurityIdentity

### DIFF
--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/LdapSecurityRealmTest.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/LdapSecurityRealmTest.java
@@ -128,7 +128,7 @@ public abstract class LdapSecurityRealmTest {
         setupAuth("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/subject/secured").then()
                 .statusCode(200)
-                .body(equalTo("standardUser"));
+                .body(equalTo(expectedStandardUserName()));
     }
 
     @Test
@@ -136,7 +136,11 @@ public abstract class LdapSecurityRealmTest {
         setupAuth("standardUser", "standardUserPassword")
                 .when().get("/jaxrs-secured/subject/principal-secured").then()
                 .statusCode(200)
-                .body(equalTo("standardUser"));
+                .body(equalTo(expectedStandardUserName()));
+    }
+
+    protected String expectedStandardUserName() {
+        return "standardUser";
     }
 
     /**

--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/MinimalConfigurationTest.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/MinimalConfigurationTest.java
@@ -12,4 +12,7 @@ public class MinimalConfigurationTest extends LdapSecurityRealmTest {
                     .addClasses(testClasses)
                     .addAsResource("minimal-config/application.properties", "application.properties"));
 
+    protected String expectedStandardUserName() {
+        return "standardUser:Standard User";
+    }
 }

--- a/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/rest/SubjectExposingResource.java
+++ b/extensions/elytron-security-ldap/deployment/src/test/java/io/quarkus/elytron/security/ldap/rest/SubjectExposingResource.java
@@ -11,19 +11,27 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.SecurityContext;
 
+import org.wildfly.security.authz.Attributes;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
 @Path("subject")
 public class SubjectExposingResource {
 
     @Inject
     Principal principal;
 
+    @Inject
+    SecurityIdentity identity;
+
     @GET
     @RolesAllowed("standardRole")
     @Path("secured")
-    public String getSubjectSecured(@Context SecurityContext sec) {
-        Principal user = sec.getUserPrincipal();
+    public String getSubjectSecured() {
+        Principal user = identity.getPrincipal();
         String name = user != null ? user.getName() : "anonymous";
-        return name;
+        Attributes.Entry attributeEntry = (Attributes.Entry) identity.getAttributes().get("displayName");
+        return attributeEntry == null ? name : name + ":" + attributeEntry.get(0);
     }
 
     @GET
@@ -34,7 +42,8 @@ public class SubjectExposingResource {
             throw new IllegalStateException("No injected principal");
         }
         String name = principal.getName();
-        return name;
+        Attributes.Entry attributeEntry = (Attributes.Entry) identity.getAttributes().get("displayName");
+        return attributeEntry == null ? name : name + ":" + attributeEntry.get(0);
     }
 
     @GET

--- a/extensions/elytron-security-ldap/deployment/src/test/resources/minimal-config/application.properties
+++ b/extensions/elytron-security-ldap/deployment/src/test/resources/minimal-config/application.properties
@@ -9,3 +9,8 @@ quarkus.security.ldap.identity-mapping.search-base-dn=ou=Users,dc=quarkus,dc=io
 quarkus.security.ldap.identity-mapping.attribute-mappings."0".from=cn
 quarkus.security.ldap.identity-mapping.attribute-mappings."0".filter=(member=uid={0},ou=Users,dc=quarkus,dc=io)
 quarkus.security.ldap.identity-mapping.attribute-mappings."0".filter-base-dn=ou=Roles,dc=quarkus,dc=io
+
+quarkus.security.ldap.identity-mapping.attribute-mappings."1".from=displayName
+quarkus.security.ldap.identity-mapping.attribute-mappings."1".to=displayName
+quarkus.security.ldap.identity-mapping.attribute-mappings."1".filter=(uid={0})
+quarkus.security.ldap.identity-mapping.attribute-mappings."1".filter-base-dn=ou=Users,dc=quarkus,dc=io

--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPasswordIdentityProvider.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPasswordIdentityProvider.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.evidence.PasswordGuessEvidence;
 
 import io.quarkus.security.AuthenticationFailedException;
@@ -52,6 +53,10 @@ public class ElytronPasswordIdentityProvider implements IdentityProvider<Usernam
                         throw new AuthenticationFailedException();
                     }
                     QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+                    for (Attributes.Entry entry : result.getAttributes().entries()) {
+                        builder.addAttribute(entry.getKey(), entry);
+                    }
+
                     builder.setPrincipal(result.getPrincipal());
                     for (String i : result.getRoles()) {
                         builder.addRole(i);

--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronTokenIdentityProvider.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronTokenIdentityProvider.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.evidence.BearerTokenEvidence;
 
 import io.quarkus.security.AuthenticationFailedException;
@@ -51,6 +52,9 @@ public class ElytronTokenIdentityProvider implements IdentityProvider<TokenAuthe
                         throw new AuthenticationFailedException();
                     }
                     QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+                    for (Attributes.Entry entry : result.getAttributes().entries()) {
+                        builder.addAttribute(entry.getKey(), entry);
+                    }
                     builder.setPrincipal(result.getPrincipal());
                     for (String i : result.getRoles()) {
                         builder.addRole(i);

--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronTrustedIdentityProvider.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronTrustedIdentityProvider.java
@@ -10,6 +10,7 @@ import org.wildfly.security.auth.server.RealmIdentity;
 import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.ServerAuthenticationContext;
+import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.credential.PasswordCredential;
 
 import io.quarkus.security.AuthenticationFailedException;
@@ -62,6 +63,9 @@ public class ElytronTrustedIdentityProvider implements IdentityProvider<TrustedA
                             throw new AuthenticationFailedException();
                         }
                         QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+                        for (Attributes.Entry entry : result.getAttributes().entries()) {
+                            builder.addAttribute(entry.getKey(), entry);
+                        }
                         builder.setPrincipal(result.getPrincipal());
                         for (String i : result.getRoles()) {
                             builder.addRole(i);

--- a/test-framework/ldap/src/main/resources/quarkus-io.ldif
+++ b/test-framework/ldap/src/main/resources/quarkus-io.ldif
@@ -31,6 +31,8 @@ cn: StandardUser
 sn: standardUser
 uid: standardUser
 userPassword: standardUserPassword
+displayName: Standard User
+
 
 dn: uid=adminUser,ou=Users,dc=quarkus,dc=io
 objectClass: top


### PR DESCRIPTION
Fixes #44804 

This PR is completely based on contribution from @MelkorCC (see #44880), I've only tweaked a couple of tests to test Elytron attributes are copied