### PR TITLE
Update OidcTenantConfigBuilder shortcuts

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfigBuilder.java
@@ -466,20 +466,11 @@ public final class OidcTenantConfigBuilder extends OidcClientCommonConfigBuilder
     }
 
     /**
-     * @param verifyAccessTokenWithUserInfo {@link Token#verifyAccessTokenWithUserInfo()}
      * @param principalClaim {@link Token#principalClaim()}
      * @return this builder
      */
-    public OidcTenantConfigBuilder token(boolean verifyAccessTokenWithUserInfo, String principalClaim) {
-        return token().verifyAccessTokenWithUserInfo(verifyAccessTokenWithUserInfo).principalClaim(principalClaim).end();
-    }
-
-    /**
-     * @param verifyAccessTokenWithUserInfo {@link Token#verifyAccessTokenWithUserInfo()}
-     * @return this builder
-     */
-    public OidcTenantConfigBuilder token(boolean verifyAccessTokenWithUserInfo) {
-        return token().verifyAccessTokenWithUserInfo(verifyAccessTokenWithUserInfo).end();
+    public OidcTenantConfigBuilder token(String principalClaim) {
+        return token().principalClaim(principalClaim).end();
     }
 
     /**

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -34,7 +34,7 @@ public class KnownOidcProviders {
         return OidcTenantConfig
                 .authServerUrl("https://slack.com")
                 .applicationType(WEB_APP)
-                .token().principalClaim("name").end()
+                .token("name")
                 .authentication()
                 .forceRedirectHttpsScheme()
                 .scopes("profile", "email")
@@ -64,7 +64,7 @@ public class KnownOidcProviders {
                 .authorizationPath("authorize")
                 .tokenPath("access_token")
                 .userInfoPath("https://api.github.com/user")
-                .token(true, "name")
+                .token().verifyAccessTokenWithUserInfo(true).principalClaim("name").end()
                 .authentication(authBuilder.build())
                 .build();
     }
@@ -93,7 +93,7 @@ public class KnownOidcProviders {
                 .authServerUrl("https://accounts.google.com")
                 .applicationType(WEB_APP)
                 .authentication().scopes("openid", "email", "profile").end()
-                .token(true, "name")
+                .token().verifyAccessTokenWithUserInfo(true).principalClaim("name").end()
                 .build();
     }
 
@@ -171,7 +171,7 @@ public class KnownOidcProviders {
                 .authorizationPath("authorize")
                 .tokenPath("api/token")
                 .userInfoPath("https://api.spotify.com/v1/me")
-                .token(true, "display_name")
+                .token().verifyAccessTokenWithUserInfo(true).principalClaim("display_name").end()
                 .authentication(authentication)
                 .build();
     }
@@ -183,7 +183,7 @@ public class KnownOidcProviders {
                 .discoveryEnabled(false)
                 .authorizationPath("authorize")
                 .tokenPath("token")
-                .token(true)
+                .token().verifyAccessTokenWithUserInfo(true).end()
                 .userInfoPath("https://www.strava.com/api/v3/athlete");
 
         builder.authentication()
@@ -218,7 +218,7 @@ public class KnownOidcProviders {
                 .authorizationPath("authorize")
                 .tokenPath("token")
                 .jwksPath("keys")
-                .token(true)
+                .token().verifyAccessTokenWithUserInfo(true).end()
                 .authentication().scopes("identify", "email").idTokenRequired(false).end()
                 .userInfoPath("https://discord.com/api/users/@me")
                 .build();

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
@@ -1089,7 +1089,7 @@ public class OidcTenantConfigBuilderTest {
                 .requiredClaims(Map.of("III", "IV"))
                 .audience("extra");
         var config2 = second.end()
-                .token(false, "prince")
+                .token().verifyAccessTokenWithUserInfo(false).principalClaim("prince").end()
                 .build();
         var builtSecond = config2.token();
         assertFalse(builtSecond.verifyAccessTokenWithUserInfo().orElseThrow());
@@ -1107,7 +1107,7 @@ public class OidcTenantConfigBuilderTest {
         assertTrue(builtSecond.audience().orElseThrow().contains("extra"));
         assertEquals("prince", builtSecond.principalClaim().orElse(null));
 
-        var config3 = OidcTenantConfig.builder(config2).token(true).build();
+        var config3 = OidcTenantConfig.builder(config2).token().verifyAccessTokenWithUserInfo().end().build();
         assertTrue(config3.token().verifyAccessTokenWithUserInfo().orElseThrow());
 
         assertEquals("haha", config3.tenantId().orElse(null));


### PR DESCRIPTION
Hi @michalvavrik, I was experimenting with the Snyk provider yesterday and found `oidcTenantConfigBuilder.token(true)` shortcut a bit non-intuitive - and it can be a bit confusing when both ID and access tokens are available. I know you've been dealing with hundreds of these properties, and that was one variation of `Token` producing shortcuts.

IMHO, `verifyAccessTokenWithUserInfo` is a very specific property which should be set with a dedicated setter, you are right we set it everywhere in `KnownOidcProviders` - but it is mainly for OAuth2 providers which can only give binary access tokens and we wrap setting it with `quarkus.oidc.provider=slack`, etc.

Without this shortcut it looks more verbose, but IMHO it is easier to understand. I've kept one shortcut for the principal name - that should be more typical token property to customize in general.

What I'd like to propose going forward, is to keep adding some shortcuts which do not return a parent builder, for example:
```
TokenConfigBuilder builder = oidcTenantConfigBuilder.verifyAccessTokenWithUserInfo();
```
or
```
OidcTenantConfig cfg = oidcTenantConfigBuilder.verifyAccessTokenWithUserInfo().principalClaimName("prince").end().build();
```

etc... I can keep adding them gradually, one by one, for typical cases