### PR TITLE
Convert Lambda REST and HTTP to @ConfigMapping

### DIFF
--- a/extensions/amazon-lambda-http/deployment/pom.xml
+++ b/extensions/amazon-lambda-http/deployment/pom.xml
@@ -68,9 +68,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -49,7 +49,7 @@ public class AmazonLambdaHttpProcessor {
     @BuildStep
     public void setupSecurity(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             LambdaHttpBuildTimeConfig config) {
-        if (!config.enableSecurity)
+        if (!config.enableSecurity())
             return;
 
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder().setUnremovable();

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/LambdaHttpBuildTimeConfig.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/LambdaHttpBuildTimeConfig.java
@@ -1,14 +1,16 @@
 package io.quarkus.amazon.lambda.http.deployment;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigRoot
-public class LambdaHttpBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.lambda-http")
+public interface LambdaHttpBuildTimeConfig {
     /**
      * Enable security mechanisms to process lambda and AWS based security (i.e. Cognito, IAM) from
      * the http event sent from API Gateway
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableSecurity;
+    @WithDefault("false")
+    boolean enableSecurity();
 }

--- a/extensions/amazon-lambda-http/pom.xml
+++ b/extensions/amazon-lambda-http/pom.xml
@@ -19,7 +19,6 @@
         <module>runtime</module>
         <module>http-event-server</module>
         <module>deployment</module>
-
         <module>maven-archetype</module>
     </modules>
 

--- a/extensions/amazon-lambda-http/runtime/pom.xml
+++ b/extensions/amazon-lambda-http/runtime/pom.xml
@@ -76,9 +76,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
@@ -76,8 +76,8 @@ public class CognitoPrincipal implements JsonWebToken {
     @Override
     public Set<String> getGroups() {
         if (groups == null) {
-            if (jwt.getClaims().containsKey(LambdaHttpRecorder.config.cognitoRoleClaim)) {
-                String claim = jwt.getClaims().get(LambdaHttpRecorder.config.cognitoRoleClaim);
+            if (jwt.getClaims().containsKey(LambdaHttpRecorder.config.cognitoRoleClaim())) {
+                String claim = jwt.getClaims().get(LambdaHttpRecorder.config.cognitoRoleClaim());
                 Matcher matcher = LambdaHttpRecorder.groupPattern.matcher(claim);
                 groups = new HashSet<>();
                 while (matcher.find()) {

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaIdentityProvider.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaIdentityProvider.java
@@ -27,7 +27,7 @@ final public class DefaultLambdaIdentityProvider implements IdentityProvider<Def
     public Uni<SecurityIdentity> authenticate(DefaultLambdaAuthenticationRequest request,
             AuthenticationRequestContext context) {
         APIGatewayV2HTTPEvent event = request.getEvent();
-        SecurityIdentity identity = authenticate(event, LambdaHttpRecorder.config.mapCognitoToRoles);
+        SecurityIdentity identity = authenticate(event, LambdaHttpRecorder.config.mapCognitoToRoles());
         if (identity == null) {
             return Uni.createFrom().optional(Optional.empty());
         }

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpConfig.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpConfig.java
@@ -1,34 +1,36 @@
 package io.quarkus.amazon.lambda.http;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
-public class LambdaHttpConfig {
+@ConfigMapping(prefix = "quarkus.lambda-http")
+public interface LambdaHttpConfig {
 
     /**
      * If true, Quarkus will map claims from Cognito to Quarkus security roles.
      * The "cognito:groups" claim will be used by default. Change cognitoRoleClaim
      * config value to change the claim source.
-     *
+     * <p>
      * True by default
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean mapCognitoToRoles;
+    @WithDefault("true")
+    boolean mapCognitoToRoles();
 
     /**
      * Cognito claim that contains roles you want to map. Defaults to "cognito:groups"
      */
-    @ConfigItem(defaultValue = "cognito:groups")
-    public String cognitoRoleClaim;
+    @WithDefault("cognito:groups")
+    String cognitoRoleClaim();
 
     /**
      * Regular expression to locate role values within a Cognito claim string.
-     * By default it looks for space delimited strings enclosed in brackets
+     * By default, it looks for space delimited strings enclosed in brackets
      * "[^\[\] \t]+"
      */
-    @ConfigItem(defaultValue = "[^\\[\\] \\t]+")
-    public String cognitoClaimMatcher;
+    @WithDefault(value = "[^\\[\\] \\t]+")
+    String cognitoClaimMatcher();
 
 }

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpRecorder.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpRecorder.java
@@ -11,7 +11,7 @@ public class LambdaHttpRecorder {
 
     public void setConfig(LambdaHttpConfig c) {
         config = c;
-        String pattern = c.cognitoClaimMatcher;
+        String pattern = c.cognitoClaimMatcher();
         groupPattern = Pattern.compile(pattern);
     }
 }

--- a/extensions/amazon-lambda-rest/deployment/pom.xml
+++ b/extensions/amazon-lambda-rest/deployment/pom.xml
@@ -68,9 +68,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -49,7 +49,7 @@ public class AmazonLambdaHttpProcessor {
     @BuildStep
     public void setupSecurity(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             LambdaHttpBuildTimeConfig config) {
-        if (!config.enableSecurity)
+        if (!config.enableSecurity())
             return;
 
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder().setUnremovable();

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/LambdaHttpBuildTimeConfig.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/LambdaHttpBuildTimeConfig.java
@@ -1,14 +1,16 @@
 package io.quarkus.amazon.lambda.http.deployment;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigRoot
-public class LambdaHttpBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.lambda-http")
+public interface LambdaHttpBuildTimeConfig {
     /**
      * Enable security mechanisms to process lambda and AWS based security (i.e. Cognito, IAM) from
      * the http event sent from API Gateway
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableSecurity;
+    @WithDefault("false")
+    boolean enableSecurity();
 }

--- a/extensions/amazon-lambda-rest/runtime/pom.xml
+++ b/extensions/amazon-lambda-rest/runtime/pom.xml
@@ -57,9 +57,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/CognitoPrincipal.java
@@ -81,7 +81,7 @@ public class CognitoPrincipal implements JsonWebToken {
     @Override
     public Set<String> getGroups() {
         if (groups == null) {
-            String grpClaim = claims.getClaim(LambdaHttpRecorder.config.cognitoRoleClaim);
+            String grpClaim = claims.getClaim(LambdaHttpRecorder.config.cognitoRoleClaim());
             if (grpClaim != null) {
                 Matcher matcher = LambdaHttpRecorder.groupPattern.matcher(grpClaim);
                 groups = new HashSet<>();

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaIdentityProvider.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/DefaultLambdaIdentityProvider.java
@@ -27,7 +27,7 @@ final public class DefaultLambdaIdentityProvider implements IdentityProvider<Def
     public Uni<SecurityIdentity> authenticate(DefaultLambdaAuthenticationRequest request,
             AuthenticationRequestContext context) {
         AwsProxyRequest event = request.getEvent();
-        SecurityIdentity identity = authenticate(event, LambdaHttpRecorder.config.mapCognitoToRoles);
+        SecurityIdentity identity = authenticate(event, LambdaHttpRecorder.config.mapCognitoToRoles());
         if (identity == null) {
             return Uni.createFrom().optional(Optional.empty());
         }

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpConfig.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpConfig.java
@@ -1,11 +1,13 @@
 package io.quarkus.amazon.lambda.http;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
-public class LambdaHttpConfig {
+@ConfigMapping(prefix = "quarkus.lambda-http")
+public interface LambdaHttpConfig {
 
     /**
      * If true, runtime will search Cognito JWT claims for "cognito:groups"
@@ -13,20 +15,20 @@ public class LambdaHttpConfig {
      *
      * True by default
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean mapCognitoToRoles;
+    @WithDefault("true")
+    boolean mapCognitoToRoles();
 
     /**
      * Cognito claim that contains roles you want to map. Defaults to "cognito:groups"
      */
-    @ConfigItem(defaultValue = "cognito:groups")
-    public String cognitoRoleClaim;
+    @WithDefault("cognito:groups")
+    String cognitoRoleClaim();
 
     /**
      * Regular expression to locate role values within a Cognito claim string.
-     * By default it looks for space delimited strings enclosed in brackets
+     * By default, it looks for space delimited strings enclosed in brackets
      * "[^\[\] \t]+"
      */
-    @ConfigItem(defaultValue = "[^\\[\\] \\t]+")
-    public String cognitoClaimMatcher;
+    @WithDefault("[^\\[\\] \\t]+")
+    String cognitoClaimMatcher();
 }

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpRecorder.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpRecorder.java
@@ -11,7 +11,7 @@ public class LambdaHttpRecorder {
 
     public void setConfig(LambdaHttpConfig c) {
         config = c;
-        String pattern = c.cognitoClaimMatcher;
+        String pattern = c.cognitoClaimMatcher();
         groupPattern = Pattern.compile(pattern);
     }
 }

--- a/extensions/amazon-lambda/deployment/pom.xml
+++ b/extensions/amazon-lambda/deployment/pom.xml
@@ -62,9 +62,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This pull request aims to apply important Quarkus changes, you can see in more details [here](https://github.com/orgs/quarkiverse/discussions/228#discussioncomment-10451967) and [here](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.14#getting-your-application-to-compile).

Changes:

- Remove the need to use annotation processor compile args  `-AlegacyConfigRoot=true`
- Use `@ConfigMapping` and `@WithDefault` annotations.
