### PR TITLE
Remove `cleanOnValidationError` config in Flyway

### DIFF
--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayCreator.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayCreator.java
@@ -117,7 +117,6 @@ class FlywayCreator {
         }
 
         configure.ignoreMigrationPatterns(ignoreMigrationPatterns);
-        configure.cleanOnValidationError(flywayRuntimeConfig.cleanOnValidationError);
         configure.outOfOrder(flywayRuntimeConfig.outOfOrder);
         if (flywayRuntimeConfig.baselineVersion.isPresent()) {
             configure.baselineVersion(flywayRuntimeConfig.baselineVersion.get());

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
@@ -132,12 +132,6 @@ public final class FlywayDataSourceRuntimeConfig {
     public boolean cleanDisabled;
 
     /**
-     * true to automatically call clean when a validation error occurs, false otherwise.
-     */
-    @ConfigItem
-    public boolean cleanOnValidationError;
-
-    /**
      * true to execute Flyway automatically when the application starts, false otherwise.
      *
      */

--- a/extensions/flyway/runtime/src/test/java/io/quarkus/flyway/runtime/FlywayCreatorTest.java
+++ b/extensions/flyway/runtime/src/test/java/io/quarkus/flyway/runtime/FlywayCreatorTest.java
@@ -222,22 +222,6 @@ class FlywayCreatorTest {
         assertTrue(ValidatePatternUtils.isFutureIgnored(createdFlywayConfig().getIgnoreMigrationPatterns()));
     }
 
-    @Test
-    @DisplayName("cleanOnValidationError defaults to false and is correctly set")
-    void testCleanOnValidationError() {
-        creator = new FlywayCreator(runtimeConfig, buildConfig);
-        assertEquals(runtimeConfig.cleanOnValidationError, createdFlywayConfig().isCleanOnValidationError());
-        assertFalse(runtimeConfig.cleanOnValidationError);
-
-        runtimeConfig.cleanOnValidationError = false;
-        creator = new FlywayCreator(runtimeConfig, buildConfig);
-        assertFalse(createdFlywayConfig().isCleanOnValidationError());
-
-        runtimeConfig.cleanOnValidationError = true;
-        creator = new FlywayCreator(runtimeConfig, buildConfig);
-        assertTrue(createdFlywayConfig().isCleanOnValidationError());
-    }
-
     @ParameterizedTest
     @MethodSource("validateOnMigrateOverwritten")
     @DisplayName("validate on migrate overwritten in configuration")


### PR DESCRIPTION
Starting in Flyway 11.0.0 (see https://documentation.red-gate.com/flyway/release-notes-and-older-versions/release-notes-for-flyway-engine), the `cleanOnValidationError` function and configuration has been removed.
An error will be thrown if this feature is configured.

Therefore it is better to remove this configuration from Quarkus so applications using it would fail as well (instead of deprecating it).

- Added to migration guide as well: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.18#cleanonvalidationerror-configuration-removed
- Added to update script: https://github.com/quarkusio/quarkus-updates/pull/231