### PR TITLE
Run classpath test on non-native paths

### DIFF
--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ClasspathTestCase.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ClasspathTestCase.java
@@ -3,7 +3,6 @@ package io.quarkus.it.extension;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.DisabledOnIntegrationTest;
@@ -53,9 +52,10 @@ public class ClasspathTestCase {
                 .body(is("OK"));
     }
 
+    // For some reason, class files are not accessible as resources through the runtime init classloader;"
+    // that's beside the point of this PR though, so we'll ignore that."
     @Test
-    @Disabled("For some reason, class files are not accessible as resources through the runtime init classloader;"
-            + " that's beside the point of this PR though, so we'll ignore that.")
+    @DisabledOnIntegrationTest()
     public void testRuntimeInitMainClassNoDuplicate() {
         given().param("resourceName", CLASS_FILE)
                 .param("phase", "runtime_init")
@@ -65,6 +65,8 @@ public class ClasspathTestCase {
 
     @Test
     public void testRuntimeInitMainResourceNoDuplicate() {
+        // Runtime classloader classes are stored in memory, as "quarkus:" resources, and we do not have a quarkus filesystem provider
+        // at the moment, the path helper works around that by hacking/reverse engineering a file-based location
         given().param("resourceName", RESOURCE_FILE)
                 .param("phase", "runtime_init")
                 .when().get("/core/classpath").then()


### PR DESCRIPTION
This test was blanket `@Disabled`, but I think it only needs to be disabled for integration tests. 