### PR TITLE
Add support of @RunOnVirtualThread on class for websockets next

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -240,15 +240,19 @@ WebSocket Next supports _blocking_ and _non-blocking_ logic, akin to Quarkus RES
 Here are the rules governing execution:
 
 * Methods annotated with `@RunOnVirtualThread`, `@Blocking` or `@Transactional` are considered blocking.
+* Methods declared in a class annotated with `@RunOnVirtualThread` are considered blocking.
 * Methods annotated with `@NonBlocking` are considered non-blocking.
-* Methods declared on a class annotated with `@Transactional` are considered blocking unless annotated with `@NonBlocking`.
+* Methods declared in a class annotated with `@Transactional` are considered blocking unless annotated with `@NonBlocking`.
 * If the method does not declare any of the annotations listed above the execution model is derived from the return type:
 ** Methods returning `Uni` and `Multi` are considered non-blocking.
 ** Methods returning `void` or any other type are considered blocking.
-* Kotlin `suspend` functions are always considered non-blocking and may not be annotated with `@Blocking`, `@NonBlocking` or `@RunOnVirtualThread`.
+* Kotlin `suspend` functions are always considered non-blocking and may not be annotated with `@Blocking`, `@NonBlocking`
+ or `@RunOnVirtualThread` and may not be in a class annotated with `@RunOnVirtualThread`.
 * Non-blocking methods must execute on the connection's event loop thread.
-* Blocking methods must execute on a worker thread unless annotated with `@RunOnVirtualThread`.
-* Methods annotated with `@RunOnVirtualThread` must execute on a virtual thread, each invocation spawns a new virtual thread.
+* Blocking methods must execute on a worker thread unless annotated with `@RunOnVirtualThread` or in a class annotated
+ with `@RunOnVirtualThread`.
+* Methods annotated with `@RunOnVirtualThread` or declared in class annotated with `@RunOnVirtualThread` must execute on
+ a virtual thread, each invocation spawns a new virtual thread.
 
 ==== Method parameters
 

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketProcessor.java
@@ -1613,12 +1613,15 @@ public class WebSocketProcessor {
     private static ExecutionModel executionModel(MethodInfo method, TransformedAnnotationsBuildItem transformedAnnotations) {
         if (KotlinUtils.isKotlinSuspendMethod(method)
                 && (transformedAnnotations.hasAnnotation(method, WebSocketDotNames.RUN_ON_VIRTUAL_THREAD)
+                        || transformedAnnotations.hasAnnotation(method.declaringClass(),
+                                WebSocketDotNames.RUN_ON_VIRTUAL_THREAD)
                         || transformedAnnotations.hasAnnotation(method, WebSocketDotNames.BLOCKING)
                         || transformedAnnotations.hasAnnotation(method, WebSocketDotNames.NON_BLOCKING))) {
             throw new WebSocketException("Kotlin `suspend` functions in WebSockets Next endpoints may not be "
                     + "annotated @Blocking, @NonBlocking or @RunOnVirtualThread: " + method);
         }
-        if (transformedAnnotations.hasAnnotation(method, WebSocketDotNames.RUN_ON_VIRTUAL_THREAD)) {
+        if (transformedAnnotations.hasAnnotation(method, WebSocketDotNames.RUN_ON_VIRTUAL_THREAD)
+                || transformedAnnotations.hasAnnotation(method.declaringClass(), WebSocketDotNames.RUN_ON_VIRTUAL_THREAD)) {
             return ExecutionModel.VIRTUAL_THREAD;
         } else if (transformedAnnotations.hasAnnotation(method, WebSocketDotNames.BLOCKING)) {
             return ExecutionModel.WORKER_THREAD;


### PR DESCRIPTION
This PR allows to configure the virtual thread execution model of the websockets next endpoints on the class with `@RunOnVirtualThread` .


```java
    @RunOnVirtualThread
    @WebSocket(path = "/chat")
    public class ChatWebsocket {
        @OnTextMessage
        String text(String message) {
          ....
        }
    }
```