### PR TITLE
Reduce log level of OTel side exporter classes

### DIFF
--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
@@ -4,6 +4,7 @@ import static io.quarkus.opentelemetry.runtime.config.build.ExporterType.Constan
 
 import java.util.List;
 import java.util.function.BooleanSupplier;
+import java.util.logging.Level;
 
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
@@ -21,6 +22,7 @@ import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.*;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.LogCategoryBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig;
 import io.quarkus.opentelemetry.runtime.config.build.exporter.OtlpExporterBuildConfig;
@@ -73,6 +75,13 @@ public class OtlpExporterProcessor {
                     otelBuildConfig.logs().exporter().contains(CDI_VALUE) &&
                     exportBuildConfig.enabled();
         }
+    }
+
+    @BuildStep
+    void logging(BuildProducer<LogCategoryBuildItem> log) {
+        // Reduce the log level of the exporters because it's too much, and we do log important things ourselves.
+        log.produce(new LogCategoryBuildItem("io.opentelemetry.exporter.internal.grpc.GrpcExporter", Level.OFF));
+        log.produce(new LogCategoryBuildItem("io.opentelemetry.exporter.internal.http.HttpExporter", Level.OFF));
     }
 
     @BuildStep


### PR DESCRIPTION
Removes annoying stack trace in the logs when no collector is available:

```
2024-12-05 09:29:29,279 SEVERE [io.ope.exp.int.grp.GrpcExporter] (vert.x-eventloop-thread-5) Failed to export spans. The request could not be executed. Error message: Connection refused: localhost/127.0.0.1:4317 [Error Occurred After Shutdown]: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:4317
        Suppressed: java.lang.IllegalStateException: Retries exhausted: 3/3
                at io.smallrye.mutiny.helpers.ExponentialBackoff$1.lambda$apply$0(ExponentialBackoff.java:46)
                at io.smallrye.context.impl.wrappers.SlowContextualFunction.apply(SlowContextualFunction.java:21)
                at io.smallrye.mutiny.groups.MultiOnItem.lambda$transformToUni$6(MultiOnItem.java:268)
                at io.smallrye.mutiny.operators.multi.MultiConcatMapOp$MainSubscriber.onItem(MultiConcatMapOp.java:117)
                at io.smallrye.mutiny.subscription.MultiSubscriber.onNext(MultiSubscriber.java:61)
                at io.smallrye.mutiny.operators.multi.processors.UnicastProcessor.drainWithDownstream(UnicastProcessor.java:108)
                at io.smallrye.mutiny.operators.multi.processors.UnicastProcessor.drain(UnicastProcessor.java:139)
                at io.smallrye.mutiny.operators.multi.processors.UnicastProcessor.onNext(UnicastProcessor.java:205)
                at io.smallrye.mutiny.operators.multi.processors.SerializedProcessor.onNext(SerializedProcessor.java:104)
                at io.smallrye.mutiny.subscription.SerializedSubscriber.onItem(SerializedSubscriber.java:74)
                at io.smallrye.mutiny.subscription.MultiSubscriber.onNext(MultiSubscriber.java:61)
                at io.smallrye.mutiny.operators.multi.MultiRetryWhenOp$RetryWhenOperator.onFailure(MultiRetryWhenOp.java:127)
                at io.smallrye.mutiny.subscription.MultiSubscriber.onError(MultiSubscriber.java:73)
                at io.smallrye.mutiny.converters.uni.UniToMultiPublisher$UniToMultiSubscription.onFailure(UniToMultiPublisher.java:104)
                at io.smallrye.mutiny.operators.uni.UniOnFailureFlatMap$UniOnFailureFlatMapProcessor.dispatch(UniOnFailureFlatMap.java:85)
                at io.smallrye.mutiny.operators.uni.UniOnFailureFlatMap$UniOnFailureFlatMapProcessor.onFailure(UniOnFailureFlatMap.java:60)
                at io.smallrye.mutiny.operators.uni.builders.UniCreateFromCompletionStage$CompletionStageUniSubscription.forwardResult(UniCreateFromCompletionStage.java:60)
                at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
                at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
                at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
                at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2194)
                at io.vertx.core.Future.lambda$toCompletionStage$3(Future.java:604)
                at io.vertx.core.impl.future.FutureImpl$4.onFailure(FutureImpl.java:188)
                at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:81)
                at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:278)
                at io.vertx.core.impl.future.Mapping.onFailure(Mapping.java:45)
                at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:81)
                at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:278)
                at io.vertx.core.http.impl.HttpClientImpl.lambda$doRequest$4(HttpClientImpl.java:398)
                at io.vertx.core.net.impl.pool.Endpoint.lambda$getConnection$0(Endpoint.java:52)
                at io.vertx.core.http.impl.SharedClientHttpStreamEndpoint$Request.handle(SharedClientHttpStreamEndpoint.java:162)
                at io.vertx.core.http.impl.SharedClientHttpStreamEndpoint$Request.handle(SharedClientHttpStreamEndpoint.java:123)
                at io.vertx.core.impl.ContextImpl.emit(ContextImpl.java:342)
                at io.vertx.core.impl.ContextImpl.emit(ContextImpl.java:335)
                at io.vertx.core.net.impl.pool.SimpleConnectionPool$ConnectFailed$1.run(SimpleConnectionPool.java:380)
                at io.vertx.core.net.impl.pool.Task.runNextTasks(Task.java:43)
                at io.vertx.core.net.impl.pool.CombinerExecutor.submit(CombinerExecutor.java:91)
                at io.vertx.core.net.impl.pool.SimpleConnectionPool.execute(SimpleConnectionPool.java:244)
                at io.vertx.core.net.impl.pool.SimpleConnectionPool.lambda$connect$2(SimpleConnectionPool.java:258)
                at io.vertx.core.http.impl.SharedClientHttpStreamEndpoint.lambda$connect$2(SharedClientHttpStreamEndpoint.java:104)
                at io.vertx.core.impl.future.FutureImpl$4.onFailure(FutureImpl.java:188)
                at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:81)
                at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:278)
                at io.vertx.core.impl.future.Composition$1.onFailure(Composition.java:66)
                at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:81)
                at io.vertx.core.impl.future.FailedFuture.addListener(FailedFuture.java:98)
                at io.vertx.core.impl.future.Composition.onFailure(Composition.java:55)
                at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:81)
                at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:278)
                at io.vertx.core.impl.ContextImpl.emit(ContextImpl.java:342)
                at io.vertx.core.impl.ContextImpl.emit(ContextImpl.java:335)
                at io.vertx.core.net.impl.NetClientImpl.failed(NetClientImpl.java:351)
                at io.vertx.core.net.impl.NetClientImpl.lambda$connectInternal2$6(NetClientImpl.java:323)
                at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590)
                at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:557)
                at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492)
                at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636)
                at io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:629)
                at io.netty.util.concurrent.DefaultPromise.setFailure(DefaultPromise.java:110)
                at io.vertx.core.net.impl.ChannelProvider.lambda$handleConnect$0(ChannelProvider.java:157)
                at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590)
                at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:583)
                at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:559)
                at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492)
                at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636)
                at io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:629)
                at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:118)
                at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.fulfillConnectPromise(AbstractNioChannel.java:326)
                at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:342)
                at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:776)
                at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
                at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
                at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
                at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
                at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
                at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
                at java.base/java.lang.Thread.run(Thread.java:1570)
        Caused by: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:4317
                Suppressed: [CIRCULAR REFERENCE: java.lang.IllegalStateException: Retries exhausted: 3/3]
        Caused by: java.net.ConnectException: Connection refused
                at java.base/sun.nio.ch.Net.pollConnect(Native Method)
                at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:682)
                at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:1060)
                at io.netty.channel.socket.nio.NioSocketChannel.doFinishConnect(NioSocketChannel.java:336)
                at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:339)
                at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:776)
                at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
                at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
                at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
                at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
                at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
                at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
                at java.base/java.lang.Thread.run(Thread.java:1570)
Caused by: [CIRCULAR REFERENCE: java.net.ConnectException: Connection refused]

```

We do log a sensible warning already:

```
2024-12-05 09:36:04,035 WARNING [io.qua.ope.run.exp.otl.sen.VertxGrpcSender] (vert.x-eventloop-thread-4) Failed to export TraceRequestMarshalers. The request could not be executed. Full error message: Connection refused: localhost/127.0.0.1:4317
```