### PR TITLE
Make sure OidcRequestContextProperties are always modifiable

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestContextProperties.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestContextProperties.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.common;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class OidcRequestContextProperties {
@@ -16,7 +17,7 @@ public class OidcRequestContextProperties {
     }
 
     public OidcRequestContextProperties(Map<String, Object> properties) {
-        this.properties = properties;
+        this.properties = new HashMap<>(properties);
     }
 
     /**

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcRequestContextPropertiesTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcRequestContextPropertiesTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.oidc.common.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+
+public class OidcRequestContextPropertiesTest {
+
+    @Test
+    public void testModifyPropertiesDefaultConstructor() throws Exception {
+        OidcRequestContextProperties props = new OidcRequestContextProperties();
+        assertNull(props.get("a"));
+        props.put("a", "value");
+        assertEquals("value", props.get("a"));
+    }
+
+    @Test
+    public void testModifyExistinProperties() throws Exception {
+        OidcRequestContextProperties props = new OidcRequestContextProperties(Map.of("a", "value"));
+        assertEquals("value", props.get("a"));
+        props.put("a", "avalue");
+        assertEquals("avalue", props.get("a"));
+        props.put("b", "bvalue");
+        assertEquals("bvalue", props.get("b"));
+    }
+}

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -58,7 +58,7 @@ public class OidcClientTest {
         long expectedExpiresAt = now + 5;
         long accessTokenExpiresAt = Long.valueOf(data[1]);
         assertTrue(accessTokenExpiresAt >= expectedExpiresAt
-                && accessTokenExpiresAt <= expectedExpiresAt + 2);
+                && accessTokenExpiresAt <= expectedExpiresAt + 4);
     }
 
     @Test


### PR DESCRIPTION
This is a follow up to #44203, which was not complete because `Map.of` can be passed to `OidcRequestContextProperties` from different locations, the test in #44203 works because it just happens that a modifiable map is passed to `OidcRequestContextProperties` during the token request, with test filters which modify properties being bound to the token request.

Thanks to @sschellh for noticing it.