### PR TITLE
Docs: Fix missing groupId in rest-virtual-threads.adoc

### DIFF
--- a/docs/src/main/asciidoc/rest-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/rest-virtual-threads.adoc
@@ -53,7 +53,7 @@ and in particular, adds the following dependencies:
 .build.gradle
 ----
 implementation("io.quarkus:quarkus-rest-jackson")
-implementation("quarkus-rest-client-jackson")
+implementation("io.quarkus:quarkus-rest-client-jackson")
 ----
 
 [NOTE]


### PR DESCRIPTION
The dependency coordinates in the `build.gradle` example was missing the groupId.