### PR TITLE
Ensure request body is consumed so that multipart requests with large payloads never hang when exception happens before body is consumed

### DIFF
--- a/extensions/resteasy-classic/resteasy-multipart/deployment/src/test/java/io/quarkus/resteasy/multipart/LargeMultipartPayloadTest.java
+++ b/extensions/resteasy-classic/resteasy-multipart/deployment/src/test/java/io/quarkus/resteasy/multipart/LargeMultipartPayloadTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.resteasy.multipart;
+
+import java.util.function.Supplier;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class LargeMultipartPayloadTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addAsResource(new StringAsset("""
+                                    quarkus.http.limits.max-body-size=30M
+                                    """),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testConnectionClosedOnException() {
+        RestAssured
+                .given()
+                .multiPart("content", twentyMegaBytes())
+                .post("/test/multipart")
+                .then()
+                .statusCode(500);
+    }
+
+    private static String twentyMegaBytes() {
+        return new String(new byte[20_000_000]);
+    }
+
+    @Path("/test")
+    public static class Resource {
+        @POST
+        @Path("/multipart")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public String postForm(@MultipartForm final FormBody ignored) {
+            return "ignored";
+        }
+    }
+
+    public static class FormBody {
+
+        @FormParam("content")
+        public String content;
+
+    }
+
+    @Priority(Priorities.USER)
+    @Provider
+    public static class Filter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(ContainerRequestContext containerRequestContext) {
+            throw new RuntimeException("Expected exception");
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/LargeMultipartPayloadTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/LargeMultipartPayloadTest.java
@@ -1,0 +1,105 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.hamcrest.Matchers;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.common.model.ResourceClass;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.model.ServerResourceMethod;
+import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class LargeMultipartPayloadTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addAsResource(new StringAsset("""
+                                    quarkus.http.limits.max-body-size=30M
+                                    """),
+                                    "application.properties");
+                }
+            }).addBuildChainCustomizer(buildChainBuilder -> buildChainBuilder.addBuildStep(context -> context.produce(
+                    new MethodScannerBuildItem(new MethodScanner() {
+                        @Override
+                        public List<HandlerChainCustomizer> scan(MethodInfo method, ClassInfo actualEndpointClass,
+                                Map<String, Object> methodContext) {
+                            return List.of(new AlwaysFailHandler());
+                        }
+                    }))).produces(MethodScannerBuildItem.class).build());
+
+    @Test
+    public void testConnectionClosedOnException() {
+        given()
+                .multiPart("file", twentyMegaBytes())
+                .post("/test")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("Expected failure!"));
+    }
+
+    private static String twentyMegaBytes() {
+        return new String(new byte[20_000_000]);
+    }
+
+    @Path("/test")
+    public static class Resource {
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public String uploadFile(@RestForm("file") FileUpload file) {
+            return "File " + file.fileName() + " uploaded!";
+        }
+    }
+
+    public static class Mappers {
+
+        @ServerExceptionMapper(RuntimeException.class)
+        Uni<Response> handle() {
+            return Uni.createFrom().item(Response.status(200).entity("Expected failure!").build());
+        }
+
+    }
+
+    public static class AlwaysFailHandler implements ServerRestHandler, HandlerChainCustomizer {
+
+        @Override
+        public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
+            requestContext.suspend();
+            requestContext.resume(new RuntimeException("Expected exception!"), true);
+        }
+
+        @Override
+        public List<ServerRestHandler> handlers(Phase phase, ResourceClass resourceClass, ServerResourceMethod resourceMethod) {
+            return List.of(new AlwaysFailHandler());
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -534,8 +534,9 @@ public class VertxHttpRecorder {
             };
         }
 
+        final boolean mustResumeRequest = httpConfiguration.limits.maxBodySize.isPresent();
         Handler<HttpServerRequest> delegate = root;
-        root = HttpServerCommonHandlers.enforceDuplicatedContext(delegate);
+        root = HttpServerCommonHandlers.enforceDuplicatedContext(delegate, mustResumeRequest);
         if (httpConfiguration.recordRequestStartTime) {
             httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_RECORD_START_TIME).handler(new Handler<RoutingContext>() {
                 @Override
@@ -576,7 +577,7 @@ public class VertxHttpRecorder {
             HttpServerCommonHandlers.applyHeaders(managementConfiguration.getValue().header, mr);
             applyCompression(managementBuildTimeConfig.enableCompression, mr);
 
-            Handler<HttpServerRequest> handler = HttpServerCommonHandlers.enforceDuplicatedContext(mr);
+            Handler<HttpServerRequest> handler = HttpServerCommonHandlers.enforceDuplicatedContext(mr, mustResumeRequest);
             handler = HttpServerCommonHandlers.applyProxy(managementConfiguration.getValue().proxy, handler, vertx);
 
             int routesBeforeMiEvent = mr.getRoutes().size();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
@@ -15,11 +15,11 @@ import io.vertx.core.http.StreamPriority;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.streams.ReadStream;
 
-class AbstractResponseWrapper implements HttpServerResponse {
+public class AbstractResponseWrapper implements HttpServerResponse {
 
     private final HttpServerResponse delegate;
 
-    AbstractResponseWrapper(HttpServerResponse delegate) {
+    protected AbstractResponseWrapper(HttpServerResponse delegate) {
         this.delegate = delegate;
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
@@ -65,7 +65,8 @@ public class HttpServerCommonHandlers {
         }
     }
 
-    public static Handler<HttpServerRequest> enforceDuplicatedContext(Handler<HttpServerRequest> delegate) {
+    public static Handler<HttpServerRequest> enforceDuplicatedContext(Handler<HttpServerRequest> delegate,
+            boolean mustResumeRequest) {
         return new Handler<HttpServerRequest>() {
             @Override
             public void handle(HttpServerRequest event) {
@@ -78,12 +79,12 @@ public class HttpServerCommonHandlers {
                         @Override
                         public void handle(Void x) {
                             setCurrentContextSafe(true);
-                            delegate.handle(new ResumingRequestWrapper(event));
+                            delegate.handle(new ResumingRequestWrapper(event, mustResumeRequest));
                         }
                     });
                 } else {
                     setCurrentContextSafe(true);
-                    delegate.handle(new ResumingRequestWrapper(event));
+                    delegate.handle(new ResumingRequestWrapper(event, mustResumeRequest));
                 }
             }
         };


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/44929