### PR TITLE
Option to serialize ApplicationModel in quarkus:generate-code-tests for QuarkusTest runs

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -1,5 +1,6 @@
 package io.quarkus.maven;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.List;
@@ -16,6 +17,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.util.BootstrapUtils;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathList;
@@ -31,8 +33,11 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
      * Skip the execution of this mojo
      */
     @Parameter(defaultValue = "false", property = "quarkus.generate-code.skip", alias = "quarkus.prepare.skip")
-    private boolean skipSourceGeneration = false;
+    boolean skipSourceGeneration = false;
 
+    /**
+     * Application launch mode for which to generate the source code.
+     */
     @Parameter(defaultValue = "NORMAL", property = "launchMode")
     String mode;
 
@@ -55,9 +60,8 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
                 path -> mavenProject().addCompileSourceRoot(path.toString()), false);
     }
 
-    void generateCode(PathCollection sourceParents,
-            Consumer<Path> sourceRegistrar,
-            boolean test) throws MojoFailureException, MojoExecutionException {
+    void generateCode(PathCollection sourceParents, Consumer<Path> sourceRegistrar, boolean test)
+            throws MojoExecutionException {
 
         final LaunchMode launchMode;
         if (test) {
@@ -97,11 +101,29 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
             if (deploymentClassLoader != null) {
                 deploymentClassLoader.close();
             }
-            // in case of test mode, we can't share the bootstrapped app with the testing plugins, so we are closing it right away
+            // In case of the test mode, we can't share the application model with the test plugins, so we are closing it right away,
+            // but we are serializing the application model so the test plugins can deserialize it from disk instead of re-initializing
+            // the resolver and re-resolving it as part of the test bootstrap
             if (test && curatedApplication != null) {
-                curatedApplication.close();
+                var appModel = curatedApplication.getApplicationModel();
+                closeApplication(LaunchMode.TEST);
+                if (isSerializeTestModel()) {
+                    final int workspaceId = getWorkspaceId();
+                    if (workspaceId != 0) {
+                        try {
+                            BootstrapUtils.writeAppModelWithWorkspaceId(appModel, workspaceId, BootstrapUtils
+                                    .getSerializedTestAppModelPath(Path.of(mavenProject().getBuild().getDirectory())));
+                        } catch (IOException e) {
+                            getLog().warn("Failed to serialize application model", e);
+                        }
+                    }
+                }
             }
         }
+    }
+
+    protected boolean isSerializeTestModel() {
+        return false;
     }
 
     protected PathCollection getParentDirs(List<String> sourceDirs) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
@@ -13,15 +13,29 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.builder.Json;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.runtime.LaunchMode;
 
 @Mojo(name = "generate-code-tests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class GenerateCodeTestsMojo extends GenerateCodeMojo {
+
+    /**
+     * A switch that enables or disables serialization of an {@link ApplicationModel} to a file for tests.
+     * Deserializing an application model when bootstrapping Quarkus tests has a performance advantage in that
+     * the tests will not have to initialize a Maven resolver and re-resolve the application model, which may save,
+     * depending on a project, ~80-95% of time on {@link ApplicationModel} resolution.
+     * <p>
+     * Serialization of the test model is enabled by default.
+     */
+    @Parameter(property = "quarkus.generate-code.serialize-test-model", defaultValue = "true")
+    boolean serializeTestModel;
+
     @Override
     protected void doExecute() throws MojoExecutionException, MojoFailureException {
         generateCode(getParentDirs(mavenProject().getTestCompileSourceRoots()),
@@ -30,6 +44,11 @@ public class GenerateCodeTestsMojo extends GenerateCodeMojo {
         if (isTestWithNativeAgent()) {
             generateNativeAgentFilters();
         }
+    }
+
+    @Override
+    protected boolean isSerializeTestModel() {
+        return serializeTestModel;
     }
 
     private boolean isTestWithNativeAgent() {

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -296,6 +296,20 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
         return bootstrapProvider.bootstrapApplication(this, mode);
     }
 
+    protected void closeApplication(LaunchMode mode) {
+        bootstrapProvider.closeApplication(this, mode);
+    }
+
+    /**
+     * Workspace ID associated with a given bootstrap mojo.
+     * If the returned value is {@code 0}, a workspace was not associated with the bootstrap mojo.
+     *
+     * @return workspace ID associated with a given bootstrap mojo
+     */
+    protected int getWorkspaceId() {
+        return bootstrapProvider.getWorkspaceId(this);
+    }
+
     protected CuratedApplication bootstrapApplication(LaunchMode mode, Consumer<QuarkusBootstrap.Builder> builderCustomizer)
             throws MojoExecutionException {
         return bootstrapProvider.bootstrapApplication(this, mode, builderCustomizer);

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
@@ -9,13 +9,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.GACT;
+import io.quarkus.maven.dependency.ResolvedDependency;
 
 public class BootstrapUtils {
+
+    private static final Logger log = Logger.getLogger(BootstrapUtils.class);
+
+    private static final int CP_CACHE_FORMAT_ID = 2;
 
     private static Pattern splitByWs;
 
@@ -81,7 +89,90 @@ public class BootstrapUtils {
         throw new AppModelResolverException("Unable to locate quarkus model");
     }
 
+    /**
+     * Returns a location where a serialized {@link ApplicationModel} would be found for dev mode.
+     *
+     * @param projectBuildDir project build directory
+     * @return file of a serialized application model for dev mode
+     */
     public static Path resolveSerializedAppModelPath(Path projectBuildDir) {
-        return projectBuildDir.resolve("quarkus").resolve("bootstrap").resolve("dev-app-model.dat");
+        return getBootstrapBuildDir(projectBuildDir).resolve("dev-app-model.dat");
+    }
+
+    /**
+     * Returns a location where a serialized {@link ApplicationModel} would be found for test mode.
+     *
+     * @param projectBuildDir project build directory
+     * @return file of a serialized application model for test mode
+     */
+    public static Path getSerializedTestAppModelPath(Path projectBuildDir) {
+        return getBootstrapBuildDir(projectBuildDir).resolve("test-app-model.dat");
+    }
+
+    private static Path getBootstrapBuildDir(Path projectBuildDir) {
+        return projectBuildDir.resolve("quarkus").resolve("bootstrap");
+    }
+
+    /**
+     * Serializes an {@link ApplicationModel} along with the workspace ID for which it was resolved.
+     * The serialization format will be different from the one used by {@link #resolveSerializedAppModelPath(Path)}
+     * and {@link #getSerializedTestAppModelPath(Path)}.
+     *
+     * @param appModel application model to serialize
+     * @param workspaceId workspace ID
+     * @param file target file
+     * @throws IOException in case of an IO failure
+     */
+    public static void writeAppModelWithWorkspaceId(ApplicationModel appModel, int workspaceId, Path file) throws IOException {
+        Files.createDirectories(file.getParent());
+        try (ObjectOutputStream out = new ObjectOutputStream(Files.newOutputStream(file))) {
+            out.writeInt(CP_CACHE_FORMAT_ID);
+            out.writeInt(workspaceId);
+            out.writeObject(appModel);
+        }
+        log.debugf("Serialized application model to %s", file);
+    }
+
+    /**
+     * Deserializes an {@link ApplicationModel} from a file.
+     * <p>
+     * The implementation will check whether the serialization format of the file matches the expected one.
+     * If it does not, the method will return null even if the file exists.
+     * <p>
+     * The implementation will compare the deserialized workspace ID to the argument {@code workspaceId}
+     * and if they don't match the method will return null.
+     * <p>
+     * Once the {@link ApplicationModel} was deserialized, the dependency paths will be checked for existence.
+     * If a dependency path does not exist, the method will throw an exception.
+     *
+     * @param file serialized application model file
+     * @param workspaceId expected workspace ID
+     * @return deserialized application model
+     * @throws ClassNotFoundException in case a required class could not be loaded
+     * @throws IOException in case of an IO failure
+     */
+    public static ApplicationModel readAppModelWithWorkspaceId(Path file, int workspaceId)
+            throws ClassNotFoundException, IOException {
+        try (ObjectInputStream reader = new ObjectInputStream(Files.newInputStream(file))) {
+            if (reader.readInt() == CP_CACHE_FORMAT_ID) {
+                if (reader.readInt() == workspaceId) {
+                    final ApplicationModel appModel = (ApplicationModel) reader.readObject();
+                    log.debugf("Loaded application model %s from %s", appModel, file);
+                    for (ResolvedDependency d : appModel.getDependencies(DependencyFlags.DEPLOYMENT_CP)) {
+                        for (Path p : d.getResolvedPaths()) {
+                            if (!Files.exists(p)) {
+                                throw new IOException("Cached artifact does not exist: " + p);
+                            }
+                        }
+                    }
+                    return appModel;
+                } else {
+                    log.debugf("Application model saved in %s has a different workspace ID", file);
+                }
+            } else {
+                log.debugf("Unsupported application model serialization format in %s", file);
+            }
+        }
+        return null;
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
@@ -1,11 +1,11 @@
 package io.quarkus.bootstrap;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
+import static io.quarkus.bootstrap.util.BootstrapUtils.readAppModelWithWorkspaceId;
+import static io.quarkus.bootstrap.util.BootstrapUtils.writeAppModelWithWorkspaceId;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -30,6 +30,7 @@ import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
 import io.quarkus.bootstrap.resolver.maven.workspace.ModelUtils;
+import io.quarkus.bootstrap.util.BootstrapUtils;
 import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
@@ -51,8 +52,6 @@ public class BootstrapAppModelFactory {
     public static final String CREATOR_APP_CLASSIFIER = "creator.app.classifier";
     public static final String CREATOR_APP_TYPE = "creator.app.type";
     public static final String CREATOR_APP_VERSION = "creator.app.version";
-
-    private static final int CP_CACHE_FORMAT_ID = 2;
 
     private static final Logger log = Logger.getLogger(BootstrapAppModelFactory.class);
 
@@ -207,35 +206,26 @@ public class BootstrapAppModelFactory {
     }
 
     public CurationResult resolveAppModel() throws BootstrapException {
-        // gradle tests and dev encode the result on the class path
-        final String serializedModel;
-        if (test) {
-            serializedModel = System.getProperty(BootstrapConstants.SERIALIZED_TEST_APP_MODEL);
-        } else {
-            serializedModel = System.getProperty(BootstrapConstants.SERIALIZED_APP_MODEL);
+        CurationResult result = loadFromSystemProperty();
+        if (result != null) {
+            return result;
         }
 
-        if (serializedModel != null) {
-            final Path p = Paths.get(serializedModel);
-            if (Files.exists(p)) {
-                try (InputStream existing = Files.newInputStream(p)) {
-                    final ApplicationModel appModel = (ApplicationModel) new ObjectInputStream(existing).readObject();
-                    return new CurationResult(appModel);
-                } catch (IOException | ClassNotFoundException e) {
-                    log.error("Failed to load serialized app mode", e);
-                }
-                IoUtils.recursiveDelete(p);
-            } else {
-                log.error("Failed to locate serialized application model at " + serializedModel);
-            }
+        result = createAppModelForJarOrNull(projectRoot);
+        if (result != null) {
+            return result;
         }
 
-        // Massive hack to dected zipped/jar
-        if (projectRoot != null
-                && (!Files.isDirectory(projectRoot) || projectRoot.getFileSystem().getClass().getName().contains("Zip"))) {
-            return createAppModelForJar(projectRoot);
-        }
+        return resolveAppModelForWorkspace();
+    }
 
+    /**
+     * Resolves an application for a project in a workspace.
+     *
+     * @return application model
+     * @throws BootstrapException in case of a failure
+     */
+    private CurationResult resolveAppModelForWorkspace() throws BootstrapException {
         ResolvedDependency appArtifact = this.appArtifact;
         try {
             LocalProject localProject = null;
@@ -264,27 +254,10 @@ public class BootstrapAppModelFactory {
                 cachedCpPath = resolveCachedCpPath(localProject);
                 if (Files.exists(cachedCpPath)
                         && workspace.getLastModified() < Files.getLastModifiedTime(cachedCpPath).toMillis()) {
-                    try (DataInputStream reader = new DataInputStream(Files.newInputStream(cachedCpPath))) {
-                        if (reader.readInt() == CP_CACHE_FORMAT_ID) {
-                            if (reader.readInt() == workspace.getId()) {
-                                ObjectInputStream in = new ObjectInputStream(reader);
-                                ApplicationModel appModel = (ApplicationModel) in.readObject();
-
-                                log.debugf("Loaded cached AppModel %s from %s", appModel, cachedCpPath);
-                                for (ResolvedDependency d : appModel.getDependencies()) {
-                                    for (Path p : d.getResolvedPaths()) {
-                                        if (!Files.exists(p)) {
-                                            throw new IOException("Cached artifact does not exist: " + p);
-                                        }
-                                    }
-                                }
-                                return new CurationResult(appModel);
-                            } else {
-                                debug("Cached deployment classpath has expired for %s", appArtifact);
-                            }
-                        } else {
-                            debug("Unsupported classpath cache format in %s for %s", cachedCpPath,
-                                    appArtifact);
+                    try {
+                        final ApplicationModel appModel = readAppModelWithWorkspaceId(cachedCpPath, workspace.getId());
+                        if (appModel != null) {
+                            return new CurationResult(appModel);
                         }
                     } catch (IOException e) {
                         log.warn("Failed to read deployment classpath cache from " + cachedCpPath + " for "
@@ -296,12 +269,9 @@ public class BootstrapAppModelFactory {
                     .resolveManagedModel(appArtifact, forcedDependencies, managingProject, reloadableModules));
             if (cachedCpPath != null) {
                 Files.createDirectories(cachedCpPath.getParent());
-                try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(cachedCpPath))) {
-                    out.writeInt(CP_CACHE_FORMAT_ID);
-                    out.writeInt(workspace.getId());
-                    ObjectOutputStream obj = new ObjectOutputStream(out);
-                    obj.writeObject(curationResult.getApplicationModel());
-                } catch (Exception e) {
+                try {
+                    writeAppModelWithWorkspaceId(curationResult.getApplicationModel(), workspace.getId(), cachedCpPath);
+                } catch (IOException e) {
                     log.warn("Failed to write classpath cache", e);
                 }
             }
@@ -309,6 +279,37 @@ public class BootstrapAppModelFactory {
         } catch (Exception e) {
             throw new BootstrapException("Failed to create the application model for " + appArtifact, e);
         }
+    }
+
+    /**
+     * Attempts to load an application model from a file system path set as a value of a system property.
+     * In test mode the system property will be {@link BootstrapConstants#SERIALIZED_TEST_APP_MODEL}, otherwise
+     * it will be {@link BootstrapConstants#SERIALIZED_APP_MODEL}.
+     * <p>
+     * If the property was not set, the method will return null.
+     * <p>
+     * If the model could not deserialized, an error will be logged and null returned.
+     *
+     * @return deserialized application model or null
+     */
+    private CurationResult loadFromSystemProperty() {
+        // gradle tests and dev encode the result on the class path
+        final String serializedModel = test ? System.getProperty(BootstrapConstants.SERIALIZED_TEST_APP_MODEL)
+                : System.getProperty(BootstrapConstants.SERIALIZED_APP_MODEL);
+        if (serializedModel != null) {
+            final Path p = Paths.get(serializedModel);
+            if (Files.exists(p)) {
+                try (InputStream existing = Files.newInputStream(p)) {
+                    return new CurationResult((ApplicationModel) new ObjectInputStream(existing).readObject());
+                } catch (IOException | ClassNotFoundException e) {
+                    log.error("Failed to load serialized app mode", e);
+                }
+                IoUtils.recursiveDelete(p);
+            } else {
+                log.error("Failed to locate serialized application model at " + serializedModel);
+            }
+        }
+        return null;
     }
 
     private boolean isWorkspaceDiscoveryEnabled() {
@@ -336,34 +337,43 @@ public class BootstrapAppModelFactory {
         return project;
     }
 
-    private CurationResult createAppModelForJar(Path appArtifactPath) {
-        AppModelResolver modelResolver = getAppModelResolver();
-        final ApplicationModel appModel;
-        ResolvedDependency appArtifact = this.appArtifact;
-        try {
-            if (appArtifact == null) {
-                appArtifact = ModelUtils.resolveAppArtifact(appArtifactPath);
+    /**
+     * Checks whether the project path is a JAR and if it is, creates an application model for it.
+     * If the project path is not a JAR, the method will return null.
+     *
+     * @param appArtifactPath application artifact path
+     * @return resolved application model or null
+     */
+    private CurationResult createAppModelForJarOrNull(Path appArtifactPath) {
+        if (projectRoot != null
+                && (!Files.isDirectory(projectRoot) || projectRoot.getFileSystem().getClass().getName().contains("Zip"))) {
+            AppModelResolver modelResolver = getAppModelResolver();
+            final ApplicationModel appModel;
+            ResolvedDependency appArtifact = this.appArtifact;
+            try {
+                if (appArtifact == null) {
+                    appArtifact = ModelUtils.resolveAppArtifact(appArtifactPath);
+                }
+                modelResolver.relink(appArtifact, appArtifactPath);
+                //we need some way to figure out dependencies here
+                appModel = modelResolver.resolveManagedModel(appArtifact, List.of(), managingProject,
+                        reloadableModules);
+            } catch (AppModelResolverException | IOException e) {
+                throw new RuntimeException("Failed to resolve initial application dependencies", e);
             }
-            modelResolver.relink(appArtifact, appArtifactPath);
-            //we need some way to figure out dependencies here
-            appModel = modelResolver.resolveManagedModel(appArtifact, List.of(), managingProject,
-                    reloadableModules);
-        } catch (AppModelResolverException | IOException e) {
-            throw new RuntimeException("Failed to resolve initial application dependencies", e);
+            return new CurationResult(appModel);
         }
-        return new CurationResult(appModel);
+        return null;
     }
 
     private Path resolveCachedCpPath(LocalProject project) {
-        final String filePrefix = devMode ? "dev-" : (test ? "test-" : null);
-        return project.getOutputDir().resolve(QUARKUS).resolve(BOOTSTRAP)
-                .resolve(filePrefix == null ? APP_MODEL_DAT : filePrefix + APP_MODEL_DAT);
-    }
-
-    private static void debug(String msg, Object... args) {
-        if (log.isDebugEnabled()) {
-            log.debug(String.format(msg, args));
+        if (devMode) {
+            return BootstrapUtils.resolveSerializedAppModelPath(project.getOutputDir());
         }
+        if (test) {
+            return BootstrapUtils.getSerializedTestAppModelPath(project.getOutputDir());
+        }
+        return project.getOutputDir().resolve(QUARKUS).resolve(BOOTSTRAP).resolve(APP_MODEL_DAT);
     }
 
     public BootstrapAppModelFactory setMavenArtifactResolver(MavenArtifactResolver mavenArtifactResolver) {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -162,7 +162,7 @@ public class LocalProject {
         this.modelBuildingResult = modelBuildingResult;
         this.workspace = workspace;
         if (workspace != null) {
-            workspace.addProject(this, rawModel.getPomFile().lastModified());
+            workspace.addProject(this);
         }
     }
 
@@ -178,13 +178,17 @@ public class LocalProject {
         version = rawVersionIsUnresolved ? ModelUtils.resolveVersion(rawVersion, rawModel) : rawVersion;
 
         if (workspace != null) {
-            workspace.addProject(this, rawModel.getPomFile().lastModified());
+            workspace.addProject(this);
             if (rawVersionIsUnresolved && version != null) {
                 workspace.setResolvedVersion(version);
             }
         } else if (version == null && rawVersionIsUnresolved) {
             throw UnresolvedVersionException.forGa(key.getGroupId(), key.getArtifactId(), rawVersion);
         }
+    }
+
+    protected long getPomLastModified() {
+        return rawModel.getPomFile().lastModified();
     }
 
     public LocalProject getLocalParent() {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,8 +35,8 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader, 
     private final WorkspaceRepository wsRepo = new WorkspaceRepository();
     private ArtifactKey lastFindVersionsKey;
     private List<String> lastFindVersions;
-    private long lastModified;
-    private int id = 1;
+    private volatile long lastModified = -1;
+    private volatile int id = -1;
 
     // value of the resolved version in case the raw version contains a property like ${revision} (see "Maven CI Friendly Versions")
     private String resolvedVersion;
@@ -45,12 +46,8 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader, 
     private BootstrapMavenContext mvnCtx;
     private LocalProject currentProject;
 
-    protected void addProject(LocalProject project, long lastModified) {
+    protected void addProject(LocalProject project) {
         projects.put(project.getKey(), project);
-        if (lastModified > this.lastModified) {
-            this.lastModified = lastModified;
-        }
-        id = 31 * id + (int) (lastModified ^ (lastModified >>> 32));
     }
 
     public LocalProject getProject(String groupId, String artifactId) {
@@ -61,12 +58,41 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader, 
         return projects.get(key);
     }
 
+    /**
+     * The latest last modified time of all the POMs in the workspace.
+     *
+     * @return the latest last modified time of all the POMs in the workspace
+     */
     public long getLastModified() {
+        if (lastModified < 0) {
+            initLastModifiedAndHash();
+        }
         return lastModified;
     }
 
+    /**
+     * This is essentially a hash code derived from each module's key.
+     *
+     * @return a hash code derived from each module's key
+     */
     public int getId() {
+        if (id < 0) {
+            initLastModifiedAndHash();
+        }
         return id;
+    }
+
+    private void initLastModifiedAndHash() {
+        long lastModified = 0;
+        final int[] hashes = new int[projects.size()];
+        int i = 0;
+        for (var project : projects.values()) {
+            lastModified = Math.max(project.getPomLastModified(), lastModified);
+            hashes[i++] = project.getKey().hashCode();
+        }
+        Arrays.sort(hashes);
+        this.id = Arrays.hashCode(hashes);
+        this.lastModified = lastModified;
     }
 
     @Override


### PR DESCRIPTION
This is an optimization. With this change projects that have `generate-code-tests` goal configured will benefit from the application model resolved during this phase being serialized to a file and deserialized when bootstrapping tests. This has a couple of advantages:

1. it saves time on the application model resolution (depending on the project ~80-95%), e.g. for super heroes rest-fights, it deserializes the model in ~110 ms compared to ~2066ms going through the resolver (after that the model would be serialized and the subsequent tests would load in ~35ms, so this whole change would be optimizing the first test run).
2. It may happen that the resolver initialized in tests behaves somewhat differently from the original resolver used in mojos (due to issues in resolver initialization), so this change will help make sure the original Maven resolver was used to resolve the model.

A parameter called `serializeTestModel` was added to the `quarkus:generate-code-test` goal that can be used to disable test application model serialization to keep the previous behavior.