### PR TITLE
Make sure excluded dependencies do not appear among ResolvedDependency.getDependencies()

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependencyBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependencyBuilder.java
@@ -19,7 +19,7 @@ public class ResolvedDependencyBuilder extends AbstractDependencyBuilder<Resolve
     PathCollection resolvedPaths;
     WorkspaceModule workspaceModule;
     private volatile ArtifactCoords coords;
-    private Set<ArtifactCoords> deps = Set.of();
+    private Collection<ArtifactCoords> deps = Set.of();
 
     @Override
     public PathCollection getResolvedPaths() {
@@ -71,6 +71,11 @@ public class ResolvedDependencyBuilder extends AbstractDependencyBuilder<Resolve
                 this.deps.addAll(deps);
             }
         }
+        return this;
+    }
+
+    public ResolvedDependencyBuilder setDependencies(Collection<ArtifactCoords> deps) {
+        this.deps = deps;
         return this;
     }
 

--- a/independent-projects/bootstrap/core/pom.xml
+++ b/independent-projects/bootstrap/core/pom.xml
@@ -61,6 +61,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-depchain</artifactId>
             <type>pom</type>

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/CollectDependenciesBase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/CollectDependenciesBase.java
@@ -1,12 +1,11 @@
 package io.quarkus.bootstrap.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.maven.dependency.ArtifactDependency;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
 
 /**
  *
@@ -47,10 +47,20 @@ public abstract class CollectDependenciesBase extends ResolverSetupCleanup {
             expected.addAll(expectedResult);
             expected.addAll(deploymentDeps);
         }
-        // stripping the resolved paths
-        final List<Dependency> resolvedDeps = getTestResolver().resolveModel(root.toArtifact()).getDependencies()
-                .stream().map(ArtifactDependency::new).collect(Collectors.toList());
-        assertEquals(new HashSet<>(expected), new HashSet<>(resolvedDeps));
+        final Collection<ResolvedDependency> buildDeps = getTestResolver().resolveModel(root.toArtifact()).getDependencies();
+        assertThat(stripResolvedPaths(buildDeps)).containsExactlyInAnyOrderElementsOf(expected);
+        assertBuildDependencies(buildDeps);
+    }
+
+    protected void assertBuildDependencies(Collection<ResolvedDependency> buildDeps) {
+    }
+
+    private static List<Dependency> stripResolvedPaths(Collection<ResolvedDependency> deps) {
+        final List<Dependency> result = new ArrayList<>(deps.size());
+        for (var dep : deps) {
+            result.add(new ArtifactDependency(dep));
+        }
+        return result;
     }
 
     protected BootstrapAppModelResolver getTestResolver() throws Exception {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesDevModelTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesDevModelTestCase.java
@@ -1,12 +1,20 @@
 package io.quarkus.bootstrap.resolver.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
 
 public class ConditionalDependenciesDevModelTestCase extends CollectDependenciesBase {
 
@@ -25,7 +33,11 @@ public class ConditionalDependenciesDevModelTestCase extends CollectDependencies
     @Override
     protected void setupDependencies() {
 
+        final TsArtifact excludedLib = TsArtifact.jar("excluded-lib");
+        install(excludedLib, false);
+
         final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        extA.getRuntime().addDependency(excludedLib);
         install(extA, false);
         addCollectedDeploymentDep(extA.getDeployment());
 
@@ -35,6 +47,7 @@ public class ConditionalDependenciesDevModelTestCase extends CollectDependencies
                         | DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
 
         final TsQuarkusExt extB = new TsQuarkusExt("ext-b");
+        extB.setDescriptorProp(ApplicationModelBuilder.EXCLUDED_ARTIFACTS, TsArtifact.DEFAULT_GROUP_ID + ":excluded-lib");
         install(extB, false);
         addCollectedDep(extB.getRuntime(), DependencyFlags.RUNTIME_EXTENSION_ARTIFACT);
         addCollectedDeploymentDep(extB.getDeployment());
@@ -96,5 +109,71 @@ public class ConditionalDependenciesDevModelTestCase extends CollectDependencies
                         | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT
                         | DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
         addCollectedDeploymentDep(extG.getDeployment());
+    }
+
+    @Override
+    protected void assertBuildDependencies(Collection<ResolvedDependency> buildDeps) {
+        if (!IncubatingApplicationModelResolver.isIncubatingEnabled(null)) {
+            return;
+        }
+        for (var d : buildDeps) {
+            switch (d.getArtifactId()) {
+                case "ext-a":
+                case "ext-b":
+                case "ext-c":
+                case "ext-d":
+                case "ext-h":
+                case "lib-e":
+                case "lib-e-build-time":
+                    assertThat(d.getDependencies()).isEmpty();
+                    break;
+                case "ext-a-deployment":
+                case "ext-b-deployment":
+                case "ext-c-deployment":
+                case "ext-d-deployment":
+                case "ext-h-deployment":
+                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID,
+                                    d.getArtifactId().substring(0, d.getArtifactId().length() - "-deployment".length()),
+                                    TsArtifact.DEFAULT_VERSION));
+                    break;
+                case "ext-e":
+                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "lib-e", TsArtifact.DEFAULT_VERSION));
+                    break;
+                case "ext-e-deployment":
+                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-e", TsArtifact.DEFAULT_VERSION),
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "lib-e-build-time", TsArtifact.DEFAULT_VERSION));
+                    break;
+                case "ext-f":
+                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-c", TsArtifact.DEFAULT_VERSION),
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-e", TsArtifact.DEFAULT_VERSION));
+                    break;
+                case "ext-f-deployment":
+                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-f", TsArtifact.DEFAULT_VERSION),
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION),
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-e-deployment", TsArtifact.DEFAULT_VERSION));
+                    break;
+                case "ext-g":
+                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-b", TsArtifact.DEFAULT_VERSION),
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "dev-only-lib", TsArtifact.DEFAULT_VERSION));
+                    break;
+                case "ext-g-deployment":
+                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-g", TsArtifact.DEFAULT_VERSION),
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION));
+                    break;
+                case "dev-only-lib":
+                    assertThat(d.getDependencies()).containsExactlyInAnyOrder(
+                            ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-h", TsArtifact.DEFAULT_VERSION));
+                    break;
+                default:
+                    throw new RuntimeException("unexpected dependency " + d.toCompactCoords());
+            }
+        }
     }
 }


### PR DESCRIPTION
This change fixes a bug when dependencies excluded with the `excluded-artifacts` property in the `quarkus-extension.properties` , while not being added to the `ApplicationModel` as application dependencies, still mentioned as dependencies of the included dependencies.