### PR TITLE
Minor OIDC updates

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
@@ -107,6 +107,10 @@ public class OidcConfigurationMetadata {
         return endSessionUri;
     }
 
+    public String getRegistrationUri() {
+        return registrationUri;
+    }
+
     public List<String> getSupportedScopes() {
         return getStringList(SCOPES_SUPPORTED);
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -251,7 +251,7 @@ public class OidcProviderClient implements Closeable {
 
     private AuthorizationCodeTokens getAuthorizationCodeTokens(OidcRequestContextProperties requestProps,
             HttpResponse<Buffer> resp) {
-        JsonObject json = getJsonObject(requestProps, metadata.getAuthorizationUri(), resp, OidcEndpoint.Type.TOKEN);
+        JsonObject json = getJsonObject(requestProps, metadata.getTokenUri(), resp, OidcEndpoint.Type.TOKEN);
         final String idToken = json.getString(OidcConstants.ID_TOKEN_VALUE);
         final String accessToken = json.getString(OidcConstants.ACCESS_TOKEN_VALUE);
         final String refreshToken = json.getString(OidcConstants.REFRESH_TOKEN_VALUE);


### PR DESCRIPTION
I've noticed Guillaume started preparing for 3.17.4, so here is a PR with 2 minor OIDC updates, following some recent demo experiments:

* When `quarkus-oidc` fails to exchange the code for tokens, it will pass the `authorization endpoint URI`, as opposed to the correct `token endpoint URI` to the method which logs this URI in case of the error, I've been confused by it for a while, since it is only a user who is facing the authorization endpoint challenge, `quarkus-oidc` never calls it directly, it only calls the token endpoint
* OIDC Client registration URI, even though it may have been discovered by `quarkus-oidc`, is not visible to the code which has `OidcConfigurationMetadata` injected. It is not a big problem, https://quarkus.io/guides/security-openid-connect-client-registration does not require it, and it is expected that `quarkus-oidc-client-registration` can function completely independently, without even expecting `quarkus-oidc` loaded. But `quarkus-oidc-client-registration` needs the `registration URI` to initialize itself, so if `quarkus-oidc` is loaded, it may as well pick up the already discovered `registration URI`  