### PR TITLE
Bump smallrye-open-api.version from 4.0.4 to 4.0.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-config.version>3.10.2</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>4.0.4</smallrye-open-api.version>
+        <smallrye-open-api.version>4.0.5</smallrye-open-api.version>
         <smallrye-graphql.version>2.11.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.7.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.1</smallrye-jwt.version>


### PR DESCRIPTION
Closes #40328
Closes #44035
Closes #44627
