### PR TITLE
Enable more MongoDB Micrometer metrics

### DIFF
--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -63,7 +63,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
+            <artifactId>quarkus-micrometer-deployment</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -92,6 +92,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -125,6 +125,21 @@ public class MongoClientProcessor {
     }
 
     @BuildStep
+    AdditionalIndexedClassesBuildItem includeMongoCommandMetricListener(
+            MongoClientBuildTimeConfig buildTimeConfig,
+            Optional<MetricsCapabilityBuildItem> metricsCapability) {
+        if (!buildTimeConfig.metricsEnabled) {
+            return new AdditionalIndexedClassesBuildItem();
+        }
+        boolean withMicrometer = metricsCapability.map(cap -> cap.metricsSupported(MetricsFactory.MICROMETER))
+                .orElse(false);
+        if (withMicrometer) {
+            return new AdditionalIndexedClassesBuildItem(MongoClientRecorder.getMicrometerCommandListenerClassName());
+        }
+        return new AdditionalIndexedClassesBuildItem();
+    }
+
+    @BuildStep
     public void registerDnsProvider(BuildProducer<NativeImageResourceBuildItem> nativeProducer) {
         nativeProducer.produce(new NativeImageResourceBuildItem("META-INF/services/" + DnsClientProvider.class.getName()));
     }

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -126,18 +126,18 @@ public class MongoClientProcessor {
     }
 
     @BuildStep
-    AdditionalIndexedClassesBuildItem includeMongoCommandMetricListener(
+    void includeMongoCommandMetricListener(
+            BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClasses,
             MongoClientBuildTimeConfig buildTimeConfig,
             Optional<MetricsCapabilityBuildItem> metricsCapability) {
         if (!buildTimeConfig.metricsEnabled) {
-            return new AdditionalIndexedClassesBuildItem();
+            return;
         }
         boolean withMicrometer = metricsCapability.map(cap -> cap.metricsSupported(MetricsFactory.MICROMETER))
                 .orElse(false);
         if (withMicrometer) {
-            return new AdditionalIndexedClassesBuildItem(MicrometerCommandListener.class.getName());
+            additionalIndexedClasses.produce(new AdditionalIndexedClassesBuildItem(MicrometerCommandListener.class.getName()));
         }
-        return new AdditionalIndexedClassesBuildItem();
     }
 
     @BuildStep

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -64,6 +64,7 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildI
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.mongodb.MongoClientName;
+import io.quarkus.mongodb.metrics.MicrometerCommandListener;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.mongodb.runtime.MongoClientCustomizer;
@@ -134,7 +135,7 @@ public class MongoClientProcessor {
         boolean withMicrometer = metricsCapability.map(cap -> cap.metricsSupported(MetricsFactory.MICROMETER))
                 .orElse(false);
         if (withMicrometer) {
-            return new AdditionalIndexedClassesBuildItem(MongoClientRecorder.getMicrometerCommandListenerClassName());
+            return new AdditionalIndexedClassesBuildItem(MicrometerCommandListener.class.getName());
         }
         return new AdditionalIndexedClassesBuildItem();
     }

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoLazyTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoLazyTest.java
@@ -4,58 +4,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.inject.Inject;
 
-import org.eclipse.microprofile.metrics.Metric;
-import org.eclipse.microprofile.metrics.MetricID;
-import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.Tag;
-import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.mongodb.client.MongoClient;
 
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.arc.Arc;
-import io.quarkus.mongodb.metrics.ConnectionPoolGauge;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.test.QuarkusUnitTest;
 
 /** Variation of {@link io.quarkus.mongodb.MongoMetricsTest} to verify lazy client initialization. */
-public class MongoLazyTest extends MongoTestBase {
+class MongoLazyTest extends MongoTestBase {
 
     @Inject
-    @RegistryType(type = MetricRegistry.Type.VENDOR)
-    MetricRegistry registry;
+    MeterRegistry meterRegistry;
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar.addClasses(MongoTestBase.class))
+            .withApplicationRoot(jar -> jar.addClasses(MongoTestBase.class))
             .withConfigurationResource("application-metrics-mongo.properties");
 
     @Test
     void testLazyClientCreation() {
         // Clients are created lazily, this metric should not be present yet
-        assertThat(getGaugeValueOrNull("mongodb.connection-pool.size", getTags())).isNull();
-        assertThat(getGaugeValueOrNull("mongodb.connection-pool.checked-out-count", getTags())).isNull();
+        assertThat(getMetric("mongodb.driver.pool.size")).isNull();
+        assertThat(getMetric("mongodb.driver.pool.checkedout")).isNull();
+        assertThat(getMetric("mongodb.driver.commands")).isNull();
 
         // doing this here instead of in another method in order to avoid messing with the initialization stats
         assertThat(Arc.container().instance(MongoClient.class).get()).isNull();
         assertThat(Arc.container().instance(ReactiveMongoClient.class).get()).isNull();
     }
 
-    private Long getGaugeValueOrNull(String metricName, Tag[] tags) {
-        MetricID metricID = new MetricID(metricName, tags);
-        Metric metric = registry.getMetrics().get(metricID);
-
-        if (metric == null) {
-            return null;
-        }
-        return ((ConnectionPoolGauge) metric).getValue();
+    private Double getMetric(String name) {
+        Meter metric = meterRegistry.getMeters()
+                .stream()
+                .filter(mtr -> mtr.getId().getName().contains(name))
+                .findFirst()
+                .orElse(null);
+        return metric == null ? null : metric.measure().iterator().next().getValue();
     }
 
-    private Tag[] getTags() {
-        return new Tag[] {
-                new Tag("host", "127.0.0.1"),
-                new Tag("port", "27018"),
-        };
-    }
 }

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoMetricsTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoMetricsTest.java
@@ -1,38 +1,32 @@
 package io.quarkus.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.inject.Inject;
 
-import org.eclipse.microprofile.metrics.Metric;
-import org.eclipse.microprofile.metrics.MetricID;
-import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.Tag;
-import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.mongodb.client.MongoClient;
 
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.arc.Arc;
-import io.quarkus.mongodb.metrics.ConnectionPoolGauge;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class MongoMetricsTest extends MongoTestBase {
+class MongoMetricsTest extends MongoTestBase {
 
     @Inject
     MongoClient client;
 
     @Inject
-    @RegistryType(type = MetricRegistry.Type.VENDOR)
-    MetricRegistry registry;
+    MeterRegistry meterRegistry;
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar.addClasses(MongoTestBase.class))
+            .withApplicationRoot(jar -> jar.addClasses(MongoTestBase.class))
             .withConfigurationResource("application-metrics-mongo.properties");
 
     @AfterEach
@@ -45,38 +39,32 @@ public class MongoMetricsTest extends MongoTestBase {
     @Test
     void testMetricsInitialization() {
         // Clients are created lazily, this metric should not be present yet
-        assertThat(getGaugeValueOrNull("mongodb.connection-pool.size", getTags())).isNull();
-        assertThat(getGaugeValueOrNull("mongodb.connection-pool.checked-out-count", getTags())).isNull();
+        assertThat(getMetric("mongodb.driver.pool.size")).isNull();
+        assertThat(getMetric("mongodb.driver.pool.checkedout")).isNull();
 
         // Just need to execute something so that a connection is opened
         String name = client.listDatabaseNames().first();
 
-        assertEquals(1L, getGaugeValueOrNull("mongodb.connection-pool.size", getTags()));
-        assertEquals(0L, getGaugeValueOrNull("mongodb.connection-pool.checked-out-count", getTags()));
+        assertThat(getMetric("mongodb.driver.pool.size")).isOne();
+        assertThat(getMetric("mongodb.driver.commands")).isOne();
+        assertThat(getMetric("mongodb.driver.pool.checkedout")).isZero();
 
         client.close();
-        assertEquals(0L, getGaugeValueOrNull("mongodb.connection-pool.size", getTags()));
-        assertEquals(0L, getGaugeValueOrNull("mongodb.connection-pool.checked-out-count", getTags()));
+        assertThat(getMetric("mongodb.driver.pool.size")).isNull();
+        assertThat(getMetric("mongodb.driver.pool.checkedout")).isNull();
 
         // doing this here instead of in another method in order to avoid messing with the initialization stats
         assertThat(Arc.container().instance(MongoClient.class).get()).isNotNull();
         assertThat(Arc.container().instance(ReactiveMongoClient.class).get()).isNull();
     }
 
-    private Long getGaugeValueOrNull(String metricName, Tag[] tags) {
-        MetricID metricID = new MetricID(metricName, tags);
-        Metric metric = registry.getMetrics().get(metricID);
-
-        if (metric == null) {
-            return null;
-        }
-        return ((ConnectionPoolGauge) metric).getValue();
+    private Double getMetric(String metricName) {
+        Meter metric = meterRegistry.getMeters()
+                .stream()
+                .filter(mtr -> mtr.getId().getName().contains(metricName))
+                .findFirst()
+                .orElse(null);
+        return metric == null ? null : metric.measure().iterator().next().getValue();
     }
 
-    private Tag[] getTags() {
-        return new Tag[] {
-                new Tag("host", "127.0.0.1"),
-                new Tag("port", "27018"),
-        };
-    }
 }

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/deployment/MongoClientProcessorTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/deployment/MongoClientProcessorTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.mongodb.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
+import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
+import io.quarkus.runtime.metrics.MetricsFactory;
+
+class MongoClientProcessorTest {
+    private final MongoClientProcessor buildStep = new MongoClientProcessor();
+
+    @ParameterizedTest
+    @CsvSource({
+            "true, true, true", // Metrics enabled and Micrometer supported
+            "true, false, false", // Metrics enabled but Micrometer not supported
+            "false, true, false", // Metrics disabled and Micrometer supported
+            "false, false, false" // Metrics disabled and Micrometer not supported
+    })
+    void testIncludeMongoCommandMetricListener(boolean metricsEnabled, boolean micrometerSupported, boolean expectedResult) {
+        MongoClientBuildTimeConfig config = config(metricsEnabled);
+        Optional<MetricsCapabilityBuildItem> capability = capability(metricsEnabled, micrometerSupported);
+
+        AdditionalIndexedClassesBuildItem result = buildStep.includeMongoCommandMetricListener(config, capability);
+
+        if (expectedResult) {
+            assertThat(result.getClassesToIndex())
+                    .containsExactly("io.quarkus.mongodb.metrics.MicrometerCommandListener");
+        } else {
+            assertThat(result.getClassesToIndex()).isEmpty();
+        }
+    }
+
+    private static Optional<MetricsCapabilityBuildItem> capability(boolean metricsEnabled, boolean micrometerSupported) {
+        MetricsCapabilityBuildItem capability = metricsEnabled
+                ? new MetricsCapabilityBuildItem(factory -> MetricsFactory.MICROMETER.equals(factory) && micrometerSupported)
+                : null;
+        return Optional.ofNullable(capability);
+    }
+
+    private static MongoClientBuildTimeConfig config(boolean metricsEnabled) {
+        MongoClientBuildTimeConfig buildTimeConfig = new MongoClientBuildTimeConfig();
+        buildTimeConfig.metricsEnabled = metricsEnabled;
+        return buildTimeConfig;
+    }
+
+}

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/metrics/MicrometerCommandListener.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/metrics/MicrometerCommandListener.java
@@ -1,0 +1,14 @@
+package io.quarkus.mongodb.metrics;
+
+import jakarta.inject.Inject;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.mongodb.MongoMetricsCommandListener;
+
+public class MicrometerCommandListener extends MongoMetricsCommandListener {
+    @Inject
+    public MicrometerCommandListener(MeterRegistry registry) {
+        super(registry);
+    }
+
+}

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -14,6 +14,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.event.ConnectionPoolListener;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.mongodb.metrics.MicrometerCommandListener;
 import io.quarkus.mongodb.metrics.MicrometerConnectionPoolListener;
 import io.quarkus.mongodb.metrics.MongoMetricsConnectionPoolListener;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
@@ -97,6 +98,10 @@ public class MongoClientRecorder {
                 return MicrometerConnectionPoolListener.createMicrometerConnectionPool();
             }
         };
+    }
+
+    public static String getMicrometerCommandListenerClassName() {
+        return MicrometerCommandListener.class.getName();
     }
 
     public Supplier<ConnectionPoolListener> createMPMetricsConnectionPoolListener() {

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -14,7 +14,6 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.event.ConnectionPoolListener;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.mongodb.metrics.MicrometerCommandListener;
 import io.quarkus.mongodb.metrics.MicrometerConnectionPoolListener;
 import io.quarkus.mongodb.metrics.MongoMetricsConnectionPoolListener;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
@@ -98,10 +97,6 @@ public class MongoClientRecorder {
                 return MicrometerConnectionPoolListener.createMicrometerConnectionPool();
             }
         };
-    }
-
-    public static String getMicrometerCommandListenerClassName() {
-        return MicrometerCommandListener.class.getName();
     }
 
     public Supplier<ConnectionPoolListener> createMPMetricsConnectionPoolListener() {

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -357,6 +357,7 @@ class MongodbPanacheResourceTest {
                 .when().get("/q/metrics")
                 .then()
                 .statusCode(200)
+                .body(CoreMatchers.containsString("mongodb_driver_commands_seconds_max"))
                 .body(CoreMatchers.containsString("mongodb_driver_pool_checkedout"))
                 .body(CoreMatchers.containsString("mongodb_driver_pool_size"))
                 .body(CoreMatchers.containsString("mongodb_driver_pool_waitqueuesize"));


### PR DESCRIPTION
Currently only connection pool micrometer metrics are supported. This PR enables all available metrics based on `io.micrometer.core.instrument.binder.mongodb.MongoMetricsCommandListener`

All unit tests in mongodb-client extension are based on microprofile metrics, so it was not possible to add tests for micrometer, without modifying dependencies and existing tests. However I've added an assertion in MongodbPanacheResourceTest.java in integration-tests/mongodb-panache  module