### PR TITLE
Strengthen tests for @QuarkusMain

### DIFF
--- a/docs/src/main/asciidoc/command-mode-reference.adoc
+++ b/docs/src/main/asciidoc/command-mode-reference.adoc
@@ -255,7 +255,7 @@ Consequently, mocking CDI beans with `QuarkusMock` or `@InjectMock` is not suppo
 
 It is possible to mock CDI beans by leveraging xref:getting-started-testing.adoc#testing_different_profiles[test profiles] though.
 
-For instance, in the following test, the singleton `CdiBean1` will be mocked by `MockedCdiBean1`:
+For instance, in the following test, the launched application would receive a mocked singleton `CdiBean1`. The implementation `MockedCdiBean1` is provided by the test:
 
 [source,java]
 ----

--- a/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/testsupport/commandmode/CdiBean.java
+++ b/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/testsupport/commandmode/CdiBean.java
@@ -1,0 +1,5 @@
+package io.quarkus.it.testsupport.commandmode;
+
+public interface CdiBean {
+    String myMethod();
+}

--- a/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/testsupport/commandmode/DefaultBean.java
+++ b/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/testsupport/commandmode/DefaultBean.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.testsupport.commandmode;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DefaultBean implements CdiBean {
+    @Override
+    public String myMethod() {
+        return "default bean";
+    }
+}

--- a/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/testsupport/commandmode/MainApp.java
+++ b/integration-tests/test-extension/tests/src/main/java/io/quarkus/it/testsupport/commandmode/MainApp.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.testsupport.commandmode;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+/*
+ * Because this app co-exists in a module with a QuarkusIntegrationTest, it needs to not be on the default path.
+ * Otherwise, this application is executed by the QuarkusIntegrationTest and exits early, causing test failures elsewhere.
+ */
+@QuarkusMain(name = "test")
+public class MainApp implements QuarkusApplication {
+
+    @Inject
+    CdiBean myBean;
+
+    @Override
+    public int run(String... args) throws Exception {
+        System.out.println("The bean is " + myBean.myMethod());
+        return 0;
+    }
+}

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/testsupport/commandmode/QuarkusMainTestWithTestProfileTestCase.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/testsupport/commandmode/QuarkusMainTestWithTestProfileTestCase.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.testsupport.commandmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+@QuarkusMainTest
+@TestProfile(QuarkusMainTestWithTestProfileTestCase.MyTestProfile.class)
+public class QuarkusMainTestWithTestProfileTestCase {
+
+    @Test
+    @Launch(value = {})
+    public void testLaunchCommand(LaunchResult result) {
+        assertThat(result.getOutput())
+                .contains("The bean is mocked value");
+    }
+
+    public static class MyTestProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.package.main-class", "test");
+        }
+
+        @Override
+        public Set<Class<?>> getEnabledAlternatives() {
+            return Set.of(MockedCdiBean.class);
+        }
+    }
+
+    @Alternative
+    @Singleton
+    public static class MockedCdiBean implements CdiBean {
+
+        @Override
+        public String myMethod() {
+            return "mocked value";
+        }
+    }
+}


### PR DESCRIPTION
Our test coverage for `@QuarkusMain` is all in the `picocli-native` project. Although it covers more complex scenarios relating to picocli commands, it doesn't cover the specific scenario in https://quarkus.io/guides/command-mode-reference#mocking. Since it's documented, we want it to keep working. #28997 

I've slightly updated the wording in the docs, since I needed a bit of help to understand the intent of the example test, and I've added an integration test which exercises the scenario of using a test profile to adjust injected beans. 