### PR TITLE
Fix code indentation

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/devmode-test/java/deployment/src/test/java/{package-name.dir}/test/{class-name-base}DevModeTest.tpl.qute.java
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/devmode-test/java/deployment/src/test/java/{package-name.dir}/test/{class-name-base}DevModeTest.tpl.qute.java
@@ -13,7 +13,7 @@ public class {class-name-base}DevModeTest {
     // Start hot reload (DevMode) test with your extension loaded
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest()
-        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Test
     public void writeYourOwnDevModeTest() {

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/unit-test/java/deployment/src/test/java/{package-name.dir}/test/{class-name-base}Test.tpl.qute.java
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/unit-test/java/deployment/src/test/java/{package-name.dir}/test/{class-name-base}Test.tpl.qute.java
@@ -13,7 +13,7 @@ public class {class-name-base}Test {
     // Start unit test with your extension loaded
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
-        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Test
     public void writeYourOwnUnitTest() {


### PR DESCRIPTION
When creating a new Quarkiverse extension and pushing to GitHub, the build fails because these generated files are not indented properly

- eg. https://github.com/quarkiverse/quarkus-presidio/actions/runs/12235924912/job/34128251622