### PR TITLE
Fix issues in RegisterForReflection#registerFullHierarchy() handling

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -187,7 +187,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
     /**
      * @deprecated As of GraalVM 21.2 finalFieldsWritable is no longer needed when registering fields for reflection. This will
-     *             be removed in a future verion of Quarkus.
+     *             be removed in a future version of Quarkus.
      */
     @Deprecated
     public boolean areFinalFieldsWritable() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -240,7 +240,8 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         private boolean fields = true;
         private boolean serialization;
         private boolean unsafeAllocated;
-        private boolean ignoreNested;
+        // when registering a hierarchy, we want to inspect what's actually needed and blindly include nested classes is not a good idea
+        private boolean ignoreNested = true;
 
         /**
          * @deprecated use {@link ReflectiveHierarchyBuildItem#builder(Type)},

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -42,7 +42,12 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
     private final Predicate<FieldInfo> ignoreFieldPredicate;
     private final Predicate<MethodInfo> ignoreMethodPredicate;
     private final String source;
+    private final boolean constructors;
+    private final boolean methods;
+    private final boolean fields;
     private final boolean serialization;
+    private final boolean unsafeAllocated;
+    private final boolean ignoreNested;
 
     /**
      * @deprecated Use the Builder instead.
@@ -106,19 +111,25 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
     @Deprecated
     public ReflectiveHierarchyBuildItem(Type type, IndexView index, Predicate<DotName> ignoreTypePredicate, String source) {
         this(type, index, ignoreTypePredicate, DefaultIgnoreFieldPredicate.INSTANCE, DefaultIgnoreMethodPredicate.INSTANCE,
-                source, false);
+                source, true, true, true, false, false, true);
     }
 
     private ReflectiveHierarchyBuildItem(Type type, IndexView index, Predicate<DotName> ignoreTypePredicate,
-            Predicate<FieldInfo> ignoreFieldPredicate, Predicate<MethodInfo> ignoreMethodPredicate, String source,
-            boolean serialization) {
+            Predicate<FieldInfo> ignoreFieldPredicate, Predicate<MethodInfo> ignoreMethodPredicate,
+            String source, boolean constructors, boolean methods, boolean fields, boolean serialization,
+            boolean unsafeAllocated, boolean ignoreNested) {
         this.type = type;
         this.index = index;
         this.ignoreTypePredicate = ignoreTypePredicate;
         this.ignoreFieldPredicate = ignoreFieldPredicate;
         this.ignoreMethodPredicate = ignoreMethodPredicate;
         this.source = source;
+        this.constructors = constructors;
+        this.methods = methods;
+        this.fields = fields;
         this.serialization = serialization;
+        this.unsafeAllocated = unsafeAllocated;
+        this.ignoreNested = ignoreNested;
     }
 
     public Type getType() {
@@ -145,8 +156,28 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         return source != null;
     }
 
+    public boolean isConstructors() {
+        return constructors;
+    }
+
+    public boolean isMethods() {
+        return methods;
+    }
+
+    public boolean isFields() {
+        return fields;
+    }
+
     public boolean isSerialization() {
         return serialization;
+    }
+
+    public boolean isUnsafeAllocated() {
+        return unsafeAllocated;
+    }
+
+    public boolean isIgnoreNested() {
+        return ignoreNested;
     }
 
     public String getSource() {
@@ -204,7 +235,12 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         private Predicate<FieldInfo> ignoreFieldPredicate = DefaultIgnoreFieldPredicate.INSTANCE;
         private Predicate<MethodInfo> ignoreMethodPredicate = DefaultIgnoreMethodPredicate.INSTANCE;
         private String source = UNKNOWN_SOURCE;
+        private boolean constructors = true;
+        private boolean methods = true;
+        private boolean fields = true;
         private boolean serialization;
+        private boolean unsafeAllocated;
+        private boolean ignoreNested;
 
         /**
          * @deprecated use {@link ReflectiveHierarchyBuildItem#builder(Type)},
@@ -277,14 +313,41 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
             return this;
         }
 
+        public Builder constructors(boolean constructors) {
+            this.constructors = constructors;
+            return this;
+        }
+
+        public Builder methods(boolean methods) {
+            this.methods = methods;
+            return this;
+        }
+
+        public Builder fields(boolean fields) {
+            this.fields = fields;
+            return this;
+        }
+
         public Builder serialization(boolean serialization) {
             this.serialization = serialization;
             return this;
         }
 
+        public Builder unsafeAllocated(boolean unsafeAllocated) {
+            this.unsafeAllocated = unsafeAllocated;
+            return this;
+        }
+
+        public Builder ignoreNested(boolean ignoreNested) {
+            this.ignoreNested = ignoreNested;
+            return this;
+        }
+
         public ReflectiveHierarchyBuildItem build() {
             return new ReflectiveHierarchyBuildItem(type, index, ignoreTypePredicate, ignoreFieldPredicate,
-                    ignoreMethodPredicate, source, serialization);
+                    ignoreMethodPredicate, source,
+                    constructors, methods, fields, serialization, unsafeAllocated,
+                    ignoreNested);
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
@@ -1,21 +1,14 @@
 package io.quarkus.deployment.steps;
 
-import static io.quarkus.deployment.steps.KotlinUtil.isKotlinClass;
-
-import java.lang.reflect.Modifier;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
-import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
-import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
-import org.jboss.jandex.Type.Kind;
 
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -25,7 +18,6 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.LambdaCapturingTypeBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
-import io.quarkus.deployment.util.JandexUtil;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 public class RegisterForReflectionBuildStep {
@@ -52,7 +44,7 @@ public class RegisterForReflectionBuildStep {
             boolean ignoreNested = i.valueWithDefault(computingIndex, "ignoreNested").asBoolean();
             boolean serialization = i.valueWithDefault(computingIndex, "serialization").asBoolean();
             boolean unsafeAllocated = i.valueWithDefault(computingIndex, "unsafeAllocated").asBoolean();
-            boolean registerFullHierarchyValue = i.valueWithDefault(computingIndex, "registerFullHierarchy").asBoolean();
+            boolean registerFullHierarchy = i.valueWithDefault(computingIndex, "registerFullHierarchy").asBoolean();
 
             AnnotationValue targetsValue = i.value("targets");
             AnnotationValue classNamesValue = i.value("classNames");
@@ -65,153 +57,95 @@ public class RegisterForReflectionBuildStep {
             }
 
             if (targetsValue == null && classNamesValue == null) {
-                if (capabilities.isPresent(Capability.KOTLIN) && ignoreNested) {
-                    // for Kotlin classes, we need to register the nested classes as well because companion classes are very often necessary at runtime
-                    if (isKotlinClass(classInfo)) {
-                        ignoreNested = false;
-                    }
-                }
-                registerClass(computingIndex, reason, classInfo.name().toString(), methods, fields, ignoreNested,
-                        serialization, unsafeAllocated, reflectiveClass, reflectiveClassHierarchy,
-                        processedReflectiveHierarchies, registerFullHierarchyValue);
+                registerClass(reflectiveClass, reflectiveClassHierarchy, processedReflectiveHierarchies, computingIndex,
+                        capabilities, reason, classInfo.name().toString(), methods, fields, ignoreNested, serialization,
+                        unsafeAllocated, registerFullHierarchy);
                 continue;
             }
 
             if (targetsValue != null) {
                 Type[] targets = targetsValue.asClassArray();
                 for (Type type : targets) {
-                    registerClass(computingIndex, reason, type.name().toString(), methods, fields, ignoreNested,
-                            serialization, unsafeAllocated, reflectiveClass, reflectiveClassHierarchy,
-                            processedReflectiveHierarchies, registerFullHierarchyValue);
+                    registerClass(reflectiveClass, reflectiveClassHierarchy, processedReflectiveHierarchies, computingIndex,
+                            capabilities, reason, type.name().toString(), methods, fields, ignoreNested, serialization,
+                            unsafeAllocated, registerFullHierarchy);
                 }
             }
 
             if (classNamesValue != null) {
                 String[] classNames = classNamesValue.asStringArray();
                 for (String className : classNames) {
-                    registerClass(computingIndex, reason, className, methods, fields, ignoreNested, serialization,
-                            unsafeAllocated, reflectiveClass, reflectiveClassHierarchy, processedReflectiveHierarchies,
-                            registerFullHierarchyValue);
+                    registerClass(reflectiveClass, reflectiveClassHierarchy, processedReflectiveHierarchies, computingIndex,
+                            capabilities, reason, className, methods, fields, ignoreNested, serialization, unsafeAllocated,
+                            registerFullHierarchy);
                 }
             }
         }
     }
 
-    /**
-     * BFS Recursive Method to register a class and its inner classes for Reflection.
-     *
-     * @param unsafeAllocated
-     * @param reflectiveClassHierarchy
-     * @param processedReflectiveHierarchies
-     * @param registerFullHierarchyValue
-     * @param builder
-     */
-    private void registerClass(IndexView computingIndex, String reason, String className,
-            boolean methods, boolean fields, boolean ignoreNested, boolean serialization, boolean unsafeAllocated,
-            final BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+    private void registerClass(final BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchy, Set<DotName> processedReflectiveHierarchies,
+            IndexView computingIndex,
+            Capabilities capabilities, String reason, String className, boolean methods, boolean fields,
+            boolean ignoreNested,
+            boolean serialization, boolean unsafeAllocated,
             boolean registerFullHierarchyValue) {
+        if (registerFullHierarchyValue) {
+            registerFullHierarchy(reflectiveClassHierarchy, reason, computingIndex, processedReflectiveHierarchies,
+                    methods, fields, ignoreNested, serialization, unsafeAllocated, className);
+            return;
+        }
+
         reflectiveClass.produce(serialization
                 ? ReflectiveClassBuildItem.builder(className).reason(reason).serialization().unsafeAllocated(unsafeAllocated)
                         .build()
                 : ReflectiveClassBuildItem.builder(className).reason(reason).constructors().methods(methods).fields(fields)
                         .unsafeAllocated(unsafeAllocated).build());
 
-        //Search all class hierarchy, fields and methods in order to register its classes for reflection
-        if (registerFullHierarchyValue) {
-            registerClassDependencies(reflectiveClassHierarchy, computingIndex, processedReflectiveHierarchies,
-                    methods, className);
-        }
+        ClassInfo classInfo = computingIndex.getClassByName(className);
 
-        if (ignoreNested) {
+        if (ignoreNested && !isKotlinClass(capabilities, classInfo)) {
             return;
         }
 
-        ClassInfo classInfo = computingIndex.getClassByName(className);
         if (classInfo != null) {
             for (DotName memberClass : classInfo.memberClasses()) {
-                registerClass(computingIndex, reason, memberClass.toString(), methods, fields, false, serialization,
-                        unsafeAllocated, reflectiveClass, reflectiveClassHierarchy, processedReflectiveHierarchies,
+                registerClass(reflectiveClass, reflectiveClassHierarchy, processedReflectiveHierarchies, computingIndex,
+                        capabilities, reason, memberClass.toString(), methods, fields, false, serialization, unsafeAllocated,
                         registerFullHierarchyValue);
             }
         }
     }
 
-    private void registerClassDependencies(BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchy,
-            IndexView computingIndex, Set<DotName> processedReflectiveHierarchies, boolean methods,
-            String className) {
+    private void registerFullHierarchy(BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchy,
+            String reason, IndexView computingIndex, Set<DotName> processedReflectiveHierarchies, boolean methods,
+            boolean fields, boolean ignoreNested, boolean serialization, boolean unsafeAllocated, String className) {
         DotName dotName = DotName.createSimple(className);
-        if (!processedReflectiveHierarchies.contains(dotName)
-                && !ReflectiveHierarchyBuildItem.DefaultIgnoreTypePredicate.INSTANCE.test(dotName)) {
 
-            processedReflectiveHierarchies.add(dotName);
-            reflectiveClassHierarchy.produce(ReflectiveHierarchyBuildItem.builder(dotName)
-                    .index(computingIndex)
-                    .source(RegisterForReflectionBuildStep.class.getSimpleName())
-                    .build());
-
-            ClassInfo classInfo = computingIndex.getClassByName(dotName);
-            if (methods) {
-                addMethodsForReflection(reflectiveClassHierarchy, computingIndex, processedReflectiveHierarchies,
-                        computingIndex, dotName, classInfo, methods);
-            }
-            registerClassFields(reflectiveClassHierarchy, computingIndex, processedReflectiveHierarchies,
-                    computingIndex, dotName, classInfo, methods);
+        if (processedReflectiveHierarchies.contains(dotName)
+                || ReflectiveHierarchyBuildItem.DefaultIgnoreTypePredicate.INSTANCE.test(dotName)) {
+            return;
         }
+
+        processedReflectiveHierarchies.add(dotName);
+        reflectiveClassHierarchy.produce(ReflectiveHierarchyBuildItem.builder(dotName)
+                .index(computingIndex)
+                .source(RegisterForReflectionBuildStep.class.getSimpleName())
+                .ignoreMethodPredicate(methods ? ReflectiveHierarchyBuildItem.DefaultIgnoreMethodPredicate.INSTANCE : m -> true)
+                .ignoreFieldPredicate(fields ? ReflectiveHierarchyBuildItem.DefaultIgnoreFieldPredicate.INSTANCE : m -> true)
+                .methods(methods)
+                .fields(fields)
+                .ignoreNested(ignoreNested)
+                .serialization(serialization)
+                .unsafeAllocated(unsafeAllocated)
+                .build());
     }
 
-    private void addMethodsForReflection(BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchy,
-            IndexView computingIndex, Set<DotName> processedReflectiveHierarchies, IndexView indexView,
-            DotName initialName,
-            ClassInfo classInfo, boolean methods) {
-        List<MethodInfo> methodList = classInfo.methods();
-        for (MethodInfo methodInfo : methodList) {
-            // we will only consider potential getters
-            if (methodInfo.parameters().size() > 0 ||
-                    Modifier.isStatic(methodInfo.flags()) ||
-                    methodInfo.returnType().kind() == Kind.VOID || methodInfo.returnType().kind() == Kind.PRIMITIVE) {
-                continue;
-            }
-            registerType(reflectiveClassHierarchy, computingIndex, processedReflectiveHierarchies,
-                    methods,
-                    getMethodReturnType(indexView, initialName, classInfo, methodInfo));
+    private static boolean isKotlinClass(Capabilities capabilities, ClassInfo classInfo) {
+        if (capabilities.isPresent(Capability.KOTLIN) && KotlinUtil.isKotlinClass(classInfo)) {
+            return true;
         }
-    }
 
-    private void registerClassFields(BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchy,
-            IndexView computingIndex, Set<DotName> processedReflectiveHierarchies, IndexView indexView,
-            DotName initialName, ClassInfo classInfo, boolean methods) {
-        List<FieldInfo> fieldList = classInfo.fields();
-        for (FieldInfo fieldInfo : fieldList) {
-            if (Modifier.isStatic(fieldInfo.flags()) ||
-                    fieldInfo.name().startsWith("this$") || fieldInfo.name().startsWith("val$")) {
-                continue;
-            }
-            registerType(reflectiveClassHierarchy, computingIndex, processedReflectiveHierarchies,
-                    methods, fieldInfo.type());
-        }
+        return false;
     }
-
-    private void registerType(BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchy,
-            IndexView computingIndex, Set<DotName> processedReflectiveHierarchies, boolean methods,
-            Type type) {
-        if (type.kind().equals(Kind.ARRAY)) {
-            type = type.asArrayType().constituent();
-        }
-        if (type.kind() != Kind.PRIMITIVE && !processedReflectiveHierarchies.contains(type.name())) {
-            registerClassDependencies(reflectiveClassHierarchy, computingIndex, processedReflectiveHierarchies,
-                    methods, type.name().toString());
-        }
-    }
-
-    private static Type getMethodReturnType(IndexView indexView, DotName initialName, ClassInfo info, MethodInfo method) {
-        Type methodReturnType = method.returnType();
-        if ((methodReturnType.kind() == Kind.TYPE_VARIABLE) && (info.typeParameters().size() == 1) &&
-                methodReturnType.asTypeVariable().identifier().equals(info.typeParameters().get(0).identifier())) {
-            List<Type> types = JandexUtil.resolveTypeParameters(initialName, info.name(), indexView);
-            methodReturnType = types.get(0);
-        }
-        return methodReturnType;
-    }
-
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
@@ -59,10 +59,8 @@ public @interface RegisterForReflection {
     String[] lambdaCapturingTypes() default {};
 
     /**
-     * If the full class hierarchy and dependencies should be registered.
+     * Whether the full class hierarchy and dependencies should be registered.
      * This is useful in order to use a class to be transfered through a restful service API
-     *
-     * @return
      */
     boolean registerFullHierarchy() default false;
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
@@ -60,7 +60,10 @@ public @interface RegisterForReflection {
 
     /**
      * Whether the full class hierarchy and dependencies should be registered.
-     * This is useful in order to use a class to be transfered through a restful service API
+     * This is useful in order to use a class to be transfered through a RESTful service API.
+     * <p>
+     * In some cases, including nested classes might register classes you don't want to register. You can ignore nested classes
+     * by setting {@link #ignoreNested()} to true.
      */
     boolean registerFullHierarchy() default false;
 }


### PR DESCRIPTION
We were passing to ReflectiveHierarchyBuildItem and index that solely contained the annotated class so it was doomed to fail and output a lot of warnings.

Fixes a few other minor infelicities in passing.

Fixes #38486