### PR TITLE
Defining a Property to Resolve Conditional Dependencies in Gradle builds

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -48,6 +48,7 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
 
     private final Property<Boolean> cacheLargeArtifacts;
     private final Property<Boolean> cleanupBuildOutput;
+    private final Property<Boolean> conditionalExtensions;
 
     public QuarkusPluginExtension(Project project) {
         super(project);
@@ -56,6 +57,8 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
                 .convention(true);
         this.cacheLargeArtifacts = project.getObjects().property(Boolean.class)
                 .convention(!System.getenv().containsKey("CI"));
+        this.conditionalExtensions = project.getObjects().property(Boolean.class)
+                .convention(false);
 
         this.sourceSetExtension = new SourceSetExtension();
     }
@@ -128,6 +131,10 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
      */
     public Property<Boolean> getCleanupBuildOutput() {
         return cleanupBuildOutput;
+    }
+
+    public Property<Boolean> getConditionalExtensions() {
+        return conditionalExtensions;
     }
 
     public void setCleanupBuildOutput(boolean cleanupBuildOutput) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -52,6 +52,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
@@ -109,6 +110,7 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     public abstract ConfigurableFileCollection getOriginalClasspath();
 
     @InputFiles
+    @Optional
     public abstract ConfigurableFileCollection getDeploymentResolvedWorkaround();
 
     @Nested

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner/build.gradle
@@ -26,3 +26,7 @@ dependencies {
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
 }
+
+quarkus {
+    conditionalExtensions = true
+}

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/build.gradle
@@ -26,3 +26,7 @@ dependencies {
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
 }
+
+quarkus {
+  conditionalExtensions = true
+}


### PR DESCRIPTION
The configuration cache compatibility proposal aimed to avoid resolving dependencies during execution while ensuring no incompatible types were introduced. However, the initial PRs revealed failing tests related to ConditionalDependencies. To address this issue, we implemented eager resolution of the deployment configuration to support the required logic for this feature.

While this approach worked, as noted in issue #44940, it introduced an overhead in configuration time for medium-to-large projects.

I evaluated alternative approaches, but resolving the deployment configuration is necessary to handle the conditional dependencies logic. Since the reproducer for the original issue did not implement conditional dependencies, I propose this PR. It introduces logic in the Quarkus Extension to check whether a project uses conditional dependencies. If no conditional dependencies are present, we skip the eager resolution, reducing unnecessary overhead.

My assumption is that most projects do not use conditional dependencies, making this the optimal approach. However, if you believe the logic should be inverted or prefer that a Quarkus build property be used to control this behavior, please let me know.

**Tests**
#44940 Reproducer, configuration time first build(`build`):  14s https://ge.solutions-team.gradle.com/s/golwhimdl5sby/performance/configuration
#44940 Reproducer, configuration time second build(`build`): 3s https://ge.solutions-team.gradle.com/s/owqbjbbdvhz6u/performance/configuration 
#44940 Reproducer, configuration time first build, `quarkusBuild` with configuration cache: 42s https://ge.solutions-team.gradle.com/s/hmzeglndpvh7u/performance/configuration
#44940 Reproducer, configuration time second build, `quarkusBuild` with configuration cache: 1.9s https://ge.solutions-team.gradle.com/s/l72l75e575eea/performance/configuration