### PR TITLE
Move from vectorized/redpanda images to redpandadata/redpanda

### DIFF
--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -56,8 +56,8 @@ Dev Services for Kafka supports https://redpanda.com[Redpanda], https://github/o
 and https://strimzi.io[Strimzi] (in https://github.com/apache/kafka/blob/trunk/config/kraft/README.md[Kraft] mode)  images.
 
 **Redpanda** is a Kafka compatible event streaming platform.
-Because it provides a fast startup times, Dev Services defaults to Redpanda images from `vectorized/redpanda`.
-You can select any version from https://hub.docker.com/r/vectorized/redpanda.
+Because it provides a fast startup times, Dev Services defaults to Redpanda images from `redpandadata/redpanda`.
+You can select any version from https://hub.docker.com/r/redpandadata/redpanda.
 
 **kafka-native** provides images of standard Apache Kafka distribution compiled to native binary using Quarkus and GraalVM.
 While still being _experimental_, it provides very fast startup times with small footprint.

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -228,7 +228,7 @@ public class DevServicesKafkaProcessor {
             switch (config.provider) {
                 case REDPANDA:
                     RedpandaKafkaContainer redpanda = new RedpandaKafkaContainer(
-                            DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("vectorized/redpanda"),
+                            DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("redpandadata/redpanda"),
                             config.fixedExposedPort,
                             launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
                             useSharedNetwork, config.redpanda);

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -34,7 +34,7 @@ public class KafkaDevServicesBuildTimeConfig {
      * Redpanda, Strimzi and kafka-native container providers are supported. Default is redpanda.
      * <p>
      * For Redpanda:
-     * See https://docs.redpanda.com/current/get-started/quick-start/ and https://hub.docker.com/r/vectorized/redpanda
+     * See https://docs.redpanda.com/current/get-started/quick-start/ and https://hub.docker.com/r/redpandadata/redpanda
      * <p>
      * For Strimzi:
      * See https://github.com/strimzi/test-container and https://quay.io/repository/strimzi-test-container/test-container
@@ -48,7 +48,7 @@ public class KafkaDevServicesBuildTimeConfig {
     public Provider provider = Provider.REDPANDA;
 
     public enum Provider {
-        REDPANDA("docker.io/vectorized/redpanda:v24.1.2"),
+        REDPANDA("docker.io/redpandadata/redpanda:v24.1.2"),
         STRIMZI("quay.io/strimzi-test-container/test-container:latest-kafka-3.7.0"),
         KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest");
 


### PR DESCRIPTION
Move from vectorized/redpanda images to redpandadata/redpanda

vectorized/redpanda images are no longer available

Fixes https://github.com/quarkusio/quarkus/issues/45026

Details in https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/redpanda.20images.20not.20available/near/487201886

Workaround for released Quarkus versions:
```
docker pull docker.io/redpandadata/redpanda:v24.1.2
docker image tag docker.io/redpandadata/redpanda:v24.1.2 docker.io/vectorized/redpanda:v24.1.2
```
or

`quarkus.kafka.devservices.image-name=docker.io/redpandadata/redpanda:v24.1.2` in you application.properties