### PR TITLE
Bring back the dependencies menu item in Dev UI

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/DependenciesProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/DependenciesProcessor.java
@@ -84,7 +84,7 @@ public class DependenciesProcessor {
     private boolean isEnabled() {
         var value = ConfigProvider.getConfig().getConfigValue("quarkus.bootstrap.incubating-model-resolver");
         // if it's not false and if it's false it doesn't come from the default value
-        return value == null || !"false".equals(value.getValue()) || "default values".equals(value.getSourceName());
+        return value == null || !"false".equals(value.getValue()) || "DefaultValuesConfigSource".equals(value.getSourceName());
     }
 
     private void buildTree(ApplicationModel model, Root root, Optional<Set<String>> allGavs, Optional<String> toTarget) {


### PR DESCRIPTION
It looks like the name of the ConfigSource providing the default values has changed. This somehow should be done in a better way (until the incubating resolver has become the default one).

FYI @phillip-kruger 