### PR TITLE
Minor change to add Dependency.isAnyFlagSet(int flags) and make FlagDependencyIterator use that

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
@@ -41,12 +41,29 @@ public interface ApplicationModel {
     Iterable<ResolvedDependency> getDependencies(int flags);
 
     /**
+     * Returns application dependencies that have any of the flags combined in the value of the {@code flags} arguments set.
+     *
+     * @param flags dependency flags to match
+     * @return application dependencies that matched the flags
+     */
+    Iterable<ResolvedDependency> getDependenciesWithAnyFlag(int flags);
+
+    /**
      * Returns application dependencies that have any of the flags passed in as arguments set.
      *
      * @param flags dependency flags to match
      * @return application dependencies that matched the flags
      */
-    Iterable<ResolvedDependency> getDependenciesWithAnyFlag(int... flags);
+    default Iterable<ResolvedDependency> getDependenciesWithAnyFlag(int... flags) {
+        if (flags.length == 0) {
+            throw new IllegalArgumentException("Flags are empty");
+        }
+        int combined = flags[0];
+        for (int i = 1; i < flags.length; ++i) {
+            combined |= flags[i];
+        }
+        return getDependenciesWithAnyFlag(combined);
+    }
 
     /**
      * Runtime dependencies of an application

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
@@ -62,12 +62,25 @@ public interface Dependency extends ArtifactCoords {
 
     /**
      * Checks whether a dependency has a given flag set.
+     * If the value of the {@code flag} argument combines multiple flags,
+     * the implementation will return {@code true} only if the dependency
+     * has all the flags set.
      *
-     * @param flag flag to check
+     * @param flag flag (or flags) to check
      * @return true if the flag is set, otherwise false
      */
     default boolean isFlagSet(int flag) {
         return (getFlags() & flag) == flag;
+    }
+
+    /**
+     * Checks whether a dependency has any of the flags combined in the value of {@code flags} set.
+     *
+     * @param flags flags to check
+     * @return true, if any of the flags is set, otherwise - false
+     */
+    default boolean isAnyFlagSet(int flags) {
+        return (getFlags() & flags) > 0;
     }
 
     /**

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/DevModeTestApplicationModel.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/DevModeTestApplicationModel.java
@@ -41,7 +41,7 @@ class DevModeTestApplicationModel implements ApplicationModel {
     }
 
     @Override
-    public Iterable<ResolvedDependency> getDependenciesWithAnyFlag(int... flags) {
+    public Iterable<ResolvedDependency> getDependenciesWithAnyFlag(int flags) {
         return delegate.getDependenciesWithAnyFlag(flags);
     }
 


### PR DESCRIPTION
This is a very minor change that allows passing dependency flags using bitwise OR instead of arrays for flag matching when iterating over application model dependencies.