### PR TITLE
Fallback shared between Kubernetes-Openshift and Kubernetes-Knative

### DIFF
--- a/extensions/kubernetes/openshift/deployment/src/test/java/io/quarkus/openshift/deployment/config/OpenShiftConfigFallbackTest.java
+++ b/extensions/kubernetes/openshift/deployment/src/test/java/io/quarkus/openshift/deployment/config/OpenShiftConfigFallbackTest.java
@@ -25,7 +25,6 @@ public class OpenShiftConfigFallbackTest {
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
             .setApplicationName("config")
             .setApplicationVersion("0.1-SNAPSHOT")
-            .overrideConfigKey("quarkus.kubernetes.replicas", "10")
             .overrideConfigKey("quarkus.openshift.version", "999-SNAPSHOT")
             .overrideConfigKey("quarkus.openshift.labels.app", "openshift")
             .overrideConfigKey("quarkus.openshift.route.expose", "true")
@@ -50,10 +49,6 @@ public class OpenShiftConfigFallbackTest {
         Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
         YamlConfigSource kubernetes = new YamlConfigSource(kubernetesDir.resolve("kubernetes.yml").toUri().toURL());
         YamlConfigSource openshift = new YamlConfigSource(kubernetesDir.resolve("openshift.yml").toUri().toURL());
-
-        // spec.replicas is only for Kubernetes and Openshift, no fallback
-        assertEquals("10", kubernetes.getValue("spec.replicas"));
-        assertEquals("1", openshift.getValue("spec.replicas"));
 
         // In both, each should retain the value
         assertEquals("0.1-SNAPSHOT", kubernetes.getValue("spec.template.metadata.labels.\"app.kubernetes.io/version\""));

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigBuilderCustomizer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigBuilderCustomizer.java
@@ -2,12 +2,10 @@ package io.quarkus.kubernetes.deployment;
 
 import static io.smallrye.config.ConfigMappingInterface.getProperties;
 import static io.smallrye.config.ConfigMappingLoader.getConfigMapping;
-import static io.smallrye.config.ProfileConfigSourceInterceptor.convertProfile;
+import static io.smallrye.config.ConfigValue.CONFIG_SOURCE_COMPARATOR;
 
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Function;
@@ -17,7 +15,6 @@ import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigSourceInterceptorFactory;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
-import io.smallrye.config.NameIterator;
 import io.smallrye.config.Priorities;
 import io.smallrye.config.PropertyName;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
@@ -25,19 +22,21 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
 
 public class KubernetesConfigBuilderCustomizer implements SmallRyeConfigBuilderCustomizer {
+    private static final Set<PropertyName> IGNORE_OPENSHIFT_NAMES = ignoreOpenshiftNames();
+    private static final Set<PropertyName> IGNORE_KNATIVE_NAMES = ignoreKnativeNames();
+
     @Override
     public void configBuilder(final SmallRyeConfigBuilder builder) {
-        Set<PropertyName> ignoreNames = ignoreNames();
-
         builder.withInterceptorFactories(new ConfigSourceInterceptorFactory() {
             @Override
             public ConfigSourceInterceptor getInterceptor(final ConfigSourceInterceptorContext context) {
                 return new Fallbacks(new Function<String, String>() {
                     @Override
                     public String apply(final String name) {
-                        if (name.startsWith("quarkus.openshift.") && !ignoreNames.contains(new PropertyName(name))) {
+                        if (name.startsWith("quarkus.openshift.") && !IGNORE_OPENSHIFT_NAMES.contains(new PropertyName(name))) {
                             return "quarkus.kubernetes." + name.substring(18);
-                        } else if (name.startsWith("quarkus.knative.") && !ignoreNames.contains(new PropertyName(name))) {
+                        } else if (name.startsWith("quarkus.knative.")
+                                && !IGNORE_KNATIVE_NAMES.contains(new PropertyName(name))) {
                             return "quarkus.kubernetes." + name.substring(16);
                         }
                         return name;
@@ -64,7 +63,8 @@ public class KubernetesConfigBuilderCustomizer implements SmallRyeConfigBuilderC
                 return new RelocateConfigSourceInterceptor(new Function<String, String>() {
                     @Override
                     public String apply(final String name) {
-                        if (name.startsWith("quarkus.kubernetes.") && !ignoreNames.contains(new PropertyName(name))) {
+                        if (name.startsWith("quarkus.kubernetes.")
+                                && !IGNORE_OPENSHIFT_NAMES.contains(new PropertyName(name))) {
                             return "quarkus.openshift." + name.substring(19);
                         }
                         return name;
@@ -84,7 +84,7 @@ public class KubernetesConfigBuilderCustomizer implements SmallRyeConfigBuilderC
                 return new RelocateConfigSourceInterceptor(new Function<String, String>() {
                     @Override
                     public String apply(final String name) {
-                        if (name.startsWith("quarkus.kubernetes.") && !ignoreNames.contains(new PropertyName(name))) {
+                        if (name.startsWith("quarkus.kubernetes.") && !IGNORE_KNATIVE_NAMES.contains(new PropertyName(name))) {
                             return "quarkus.knative." + name.substring(19);
                         }
                         return name;
@@ -134,73 +134,71 @@ public class KubernetesConfigBuilderCustomizer implements SmallRyeConfigBuilderC
         }
     }
 
-    // TODO - This will become public in a new version of SmallRye Config - can be removed later
-    private static final Comparator<ConfigValue> CONFIG_SOURCE_COMPARATOR = new Comparator<ConfigValue>() {
-        @Override
-        public int compare(ConfigValue original, ConfigValue candidate) {
-            int result = Integer.compare(original.getConfigSourceOrdinal(), candidate.getConfigSourceOrdinal());
-            if (result != 0) {
-                return result;
-            }
-            result = Integer.compare(original.getConfigSourcePosition(), candidate.getConfigSourcePosition()) * -1;
-            if (result != 0) {
-                return result;
-            }
-            // If both properties are profiled, prioritize the one with the most specific profile.
-            if (original.getName().charAt(0) == '%' && candidate.getName().charAt(0) == '%') {
-                List<String> originalProfiles = convertProfile(
-                        new NameIterator(original.getName()).getNextSegment().substring(1));
-                List<String> candidateProfiles = convertProfile(
-                        new NameIterator(candidate.getName()).getNextSegment().substring(1));
-                return Integer.compare(originalProfiles.size(), candidateProfiles.size()) * -1;
-            }
-            return result;
-        }
-    };
-
     /**
-     * Collect the properties names that are not shared between <code>kubernetes</code>, <code>openshift</code> and
-     * <code>knative</code> to ignore when performing the fallback functions.
+     * Collect the properties names that are not shared between <code>kubernetes</code> and <code>openshift</code>
+     * to ignore when performing the fallback functions.
      *
      * @return a Set of properties names to ignore
      */
-    private static Set<PropertyName> ignoreNames() {
-        Set<String> kubernetes = getProperties(getConfigMapping(KubernetesConfig.class))
-                .get(KubernetesConfig.class).get("").keySet();
-        Set<String> openshift = getProperties(getConfigMapping(OpenShiftConfig.class))
-                .get(OpenShiftConfig.class).get("").keySet();
-        Set<String> knative = getProperties(getConfigMapping(KnativeConfig.class))
-                .get(KnativeConfig.class).get("").keySet();
+    private static Set<PropertyName> ignoreOpenshiftNames() {
+        Set<String> kubernetes = getProperties(getConfigMapping(KubernetesConfig.class)).get(KubernetesConfig.class).get("")
+                .keySet();
+        Set<String> openshift = getProperties(getConfigMapping(OpenShiftConfig.class)).get(OpenShiftConfig.class).get("")
+                .keySet();
 
         Set<PropertyName> ignored = new HashSet<>();
         for (String name : kubernetes) {
-            if (!openshift.contains(name) || !knative.contains(name)) {
+            if (!openshift.contains(name)) {
                 ignored.add(new PropertyName("quarkus.kubernetes." + name));
                 ignored.add(new PropertyName("quarkus.openshift." + name));
-                ignored.add(new PropertyName("quarkus.knative." + name));
             }
         }
+
         for (String name : openshift) {
-            if (!kubernetes.contains(name) || !knative.contains(name)) {
+            if (!kubernetes.contains(name)) {
                 ignored.add(new PropertyName("quarkus.kubernetes." + name));
                 ignored.add(new PropertyName("quarkus.openshift." + name));
-                ignored.add(new PropertyName("quarkus.knative." + name));
-            }
-        }
-        for (String name : knative) {
-            if (!kubernetes.contains(name) || !openshift.contains(name)) {
-                ignored.add(new PropertyName("quarkus.kubernetes." + name));
-                ignored.add(new PropertyName("quarkus.openshift." + name));
-                ignored.add(new PropertyName("quarkus.knative." + name));
             }
         }
 
         // These are shared, but must work independently
         ignored.add(new PropertyName("quarkus.kubernetes.deploy"));
         ignored.add(new PropertyName("quarkus.openshift.deploy"));
-        ignored.add(new PropertyName("quarkus.knative.deploy"));
         ignored.add(new PropertyName("quarkus.kubernetes.deploy-strategy"));
         ignored.add(new PropertyName("quarkus.openshift.deploy-strategy"));
+        return ignored;
+    }
+
+    /**
+     * Collect the properties names that are not shared between <code>kubernetes</code> and <code>knative</code> to
+     * ignore when performing the fallback functions.
+     *
+     * @return a Set of properties names to ignore
+     */
+    private static Set<PropertyName> ignoreKnativeNames() {
+        Set<String> kubernetes = getProperties(getConfigMapping(KubernetesConfig.class)).get(KubernetesConfig.class).get("")
+                .keySet();
+        Set<String> knative = getProperties(getConfigMapping(KnativeConfig.class)).get(KnativeConfig.class).get("").keySet();
+
+        Set<PropertyName> ignored = new HashSet<>();
+        for (String name : kubernetes) {
+            if (!knative.contains(name)) {
+                ignored.add(new PropertyName("quarkus.kubernetes." + name));
+                ignored.add(new PropertyName("quarkus.openshift." + name));
+            }
+        }
+
+        for (String name : knative) {
+            if (!kubernetes.contains(name)) {
+                ignored.add(new PropertyName("quarkus.kubernetes." + name));
+                ignored.add(new PropertyName("quarkus.openshift." + name));
+            }
+        }
+
+        // These are shared, but must work independently
+        ignored.add(new PropertyName("quarkus.kubernetes.deploy"));
+        ignored.add(new PropertyName("quarkus.knative.deploy"));
+        ignored.add(new PropertyName("quarkus.kubernetes.deploy-strategy"));
         ignored.add(new PropertyName("quarkus.knative.deploy-strategy"));
         return ignored;
     }


### PR DESCRIPTION
The property had to be present on all three configurations for a fallback from Kubernetes to Openshift or KNative to work. Now, it adds fallbacks from shared names between Kubernetes-Openshift and Kubernetes-Knative.

- Fixes #45021 