### PR TITLE
Remove ambiguity in wording of assertion

### DIFF
--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
@@ -155,7 +155,7 @@ public class QuarkusCodestartTest implements BeforeAllCallback, AfterAllCallback
      */
     public void buildProject(Language language) throws IOException {
         final int exitCode = WrapperRunner.run(getProjectWithRealDataDir(language));
-        Assertions.assertThat(exitCode).as("Run project return status is zero").isZero();
+        Assertions.assertThat(exitCode).as("Run project return status should be zero").isZero();
     }
 
     /**


### PR DESCRIPTION
"is" creates some confusion about whether the text is describing the current state or the desired state. "should" avoids that problem.