### PR TITLE
Avoiding calculate conditional dependencies again for the same configuration, model and project

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -228,32 +229,39 @@ public class ApplicationDeploymentClasspathBuilder {
                 configuration.setCanBeConsumed(false);
                 Configuration enforcedPlatforms = this.getPlatformConfiguration();
                 configuration.extendsFrom(enforcedPlatforms);
+                Map<String, Set<Dependency>> calculatedDependenciesByModeAndConfiguration = new HashMap<>();
                 ListProperty<Dependency> dependencyListProperty = project.getObjects().listProperty(Dependency.class);
                 configuration.getDependencies().addAllLater(dependencyListProperty.value(project.provider(() -> {
-                    ConditionalDependenciesEnabler cdEnabler = new ConditionalDependenciesEnabler(project, mode,
-                            enforcedPlatforms);
-                    final Collection<ExtensionDependency<?>> allExtensions = cdEnabler.getAllExtensions();
-                    Set<ExtensionDependency<?>> extensions = collectFirstMetQuarkusExtensions(getRawRuntimeConfiguration(),
-                            allExtensions);
-                    // Add conditional extensions
-                    for (ExtensionDependency<?> knownExtension : allExtensions) {
-                        if (knownExtension.isConditional()) {
-                            extensions.add(knownExtension);
-                        }
-                    }
-
-                    final Set<ModuleVersionIdentifier> alreadyProcessed = new HashSet<>(extensions.size());
-                    final DependencyHandler dependencies = project.getDependencies();
-                    final Set<Dependency> deploymentDependencies = new HashSet<>();
-                    for (ExtensionDependency<?> extension : extensions) {
-                        if (!alreadyProcessed.add(extension.getExtensionId())) {
-                            continue;
+                    String key = String.format("%s%s%s", mode, configuration.getName(), project.getName());
+                    if (!calculatedDependenciesByModeAndConfiguration.containsKey(key)) {
+                        ConditionalDependenciesEnabler cdEnabler = new ConditionalDependenciesEnabler(project, mode,
+                                enforcedPlatforms);
+                        final Collection<ExtensionDependency<?>> allExtensions = cdEnabler.getAllExtensions();
+                        Set<ExtensionDependency<?>> extensions = collectFirstMetQuarkusExtensions(getRawRuntimeConfiguration(),
+                                allExtensions);
+                        // Add conditional extensions
+                        for (ExtensionDependency<?> knownExtension : allExtensions) {
+                            if (knownExtension.isConditional()) {
+                                extensions.add(knownExtension);
+                            }
                         }
 
-                        deploymentDependencies.add(
-                                DependencyUtils.createDeploymentDependency(dependencies, extension));
+                        final Set<ModuleVersionIdentifier> alreadyProcessed = new HashSet<>(extensions.size());
+                        final DependencyHandler dependencies = project.getDependencies();
+                        final Set<Dependency> deploymentDependencies = new HashSet<>();
+                        for (ExtensionDependency<?> extension : extensions) {
+                            if (!alreadyProcessed.add(extension.getExtensionId())) {
+                                continue;
+                            }
+
+                            deploymentDependencies.add(
+                                    DependencyUtils.createDeploymentDependency(dependencies, extension));
+                        }
+                        calculatedDependenciesByModeAndConfiguration.put(key, deploymentDependencies);
+                        return deploymentDependencies;
+                    } else {
+                        return calculatedDependenciesByModeAndConfiguration.get(key);
                     }
-                    return deploymentDependencies;
                 })));
             });
         }


### PR DESCRIPTION
Second Attempt to Mitigate Issue #44940 

It is still unclear why the resolved configuration is triggered multiple times when resolving the conditional dependencies during configuration time with the compatible type. During the investigation, I observed that the first resolution is triggered in:

https://github.com/quarkusio/quarkus/blob/fc237a6007d7e02a50000d0cd110c2df5ced39c4/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java#L50

Subsequently, there are additional resolution in:

https://github.com/quarkusio/quarkus/blob/fc237a6007d7e02a50000d0cd110c2df5ced39c4/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java#L122

This behavior triggers the same resolution an arbitrary number of times.

This PR avoids triggering a new resolution of the conditional dependencies when the mode, project, and configuration have already been resolved. While this workaround reduces configuration time, the underlying cause of the multiple resolutions in the tests remains to be understood. The investigation continues but with this PR we reduce the current configuration time for large projects:

**3.16.4**
* Configuration time first build in fresh daemon (dependencies downloaded): 16s https://ge.solutions-team.gradle.com/s/ejpasnot2emzg/performance/configuration#summary-total
* Configuration time second build dependencies downloaded): 13s https://ge.solutions-team.gradle.com/s/ehp2d6lq2gxrs/performance/configuration#summary-total

**This PR**
* Configuration time first build in fresh daemon (dependencies downloaded): 9s https://ge.solutions-team.gradle.com/s/l425qx4xebsfs/performance/configuration#summary-total
* Configuration time second build dependencies downloaded): 6s https://ge.solutions-team.gradle.com/s/l6uqgfq26pe4y/performance/configuration#summary-total