### PR TITLE
Add configuration for the "created" category in the lottery

### DIFF
--- a/.github/quarkus-github-lottery.yml
+++ b/.github/quarkus-github-lottery.yml
@@ -7,6 +7,10 @@ buckets:
     delay: PT0S
     timeout: P3D
   maintenance:
+    created:
+      delay: PT0S
+      timeout: P1D
+      expiry: P14D
     feedback:
       labels: ["triage/needs-reproducer", "triage/needs-feedback"]
       needed:
@@ -30,18 +34,22 @@ participants:
     maintenance:
       labels: ["area/hibernate-orm", "area/hibernate-search", "area/elasticsearch", "area/jdbc"]
       days: ["WEDNESDAY"]
+      created:
+        maxIssues: 3
       feedback:
         needed:
-          maxIssues: 10
+          maxIssues: 3
         provided:
-          maxIssues: 10
+          maxIssues: 3
       stale:
-        maxIssues: 5
+        maxIssues: 1
   - username: "marko-bekhta"
     timezone: "Europe/Warsaw"
     maintenance:
       labels: ["area/hibernate-search", "area/elasticsearch", "area/hibernate-validator"]
       days: ["WEDNESDAY"]
+      created:
+        maxIssues: 3
       feedback:
         needed:
           maxIssues: 10
@@ -57,6 +65,8 @@ participants:
     maintenance:
       labels: ["area/hibernate-validator", "area/jakarta"]
       days: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
+      created:
+        maxIssues: 2
       feedback:
         needed:
           maxIssues: 4
@@ -120,6 +130,8 @@ participants:
     maintenance:
       labels: ["area/core", "area/testing", "area/kotlin", "area/spring", "area/rest", "area/kubernetes"]
       days: ["WEDNESDAY", "FRIDAY"]
+      created:
+        maxIssues: 2
       feedback:
         needed:
           maxIssues: 4


### PR DESCRIPTION
This must be merged before https://github.com/quarkusio/quarkus-github-lottery/pull/198 , otherwise the lottery will stop working due to missing configuration.

https://github.com/quarkusio/quarkus-github-lottery/pull/198 will enable listing in the lottery new issues (and pull requests!) assigned to a maintenance area.

@geoand : yes, an equivalent for stewardship would be nice, but I didn't have time to work on it (yet). Maybe I should open a separate issue...

@geoand @gsmet @marko-bekhta I already changed your config so that you do get notifications for newly created issues/PRs. I hope that's alright? We need some early adopters to test this :)

Note that ultimately, we should be able to get rid of pinging by bots for people who participate in the lottery: they will get notified, just differently... and more importantly, for areas with multiple maintainers, the notifications will have a built-in rate limiter and load balancer... :]
