### PR TITLE
Use `TestConfig` to load test config instead of property names

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -185,7 +185,7 @@ public interface TestConfig {
      * When the artifact is a {@code container}, this string is passed right after the {@code docker run} command.
      * When the artifact is a {@code native binary}, this string is passed right after the native binary name.
      */
-    Optional<List<String>> argLine();
+    Optional<@WithConverter(TrimmedStringConverter.class) List<String>> argLine();
 
     /**
      * Additional environment variables to be set in the process that {@code @QuarkusIntegrationTest} launches.

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -34,6 +34,7 @@ public final class LauncherUtil {
     private LauncherUtil() {
     }
 
+    @Deprecated(forRemoval = true, since = "3.17")
     public static Config installAndGetSomeConfig() {
         return ConfigProvider.getConfig();
     }
@@ -227,7 +228,6 @@ public final class LauncherUtil {
         if (effectivePort != null) {
             System.setProperty("quarkus.http.port", effectivePort.toString()); //set the port as a system property in order to have it applied to Config
             System.setProperty("quarkus.http.test-port", effectivePort.toString()); // needed for RestAssuredManager
-            installAndGetSomeConfig(); // reinitialize the configuration to make sure the actual port is used
             System.clearProperty("test.url"); // make sure the old value does not interfere with setting the new one
             System.setProperty("test.url", TestHTTPResourceManager.getUri());
         }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestConfigUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestConfigUtil.java
@@ -18,6 +18,7 @@ public final class TestConfigUtil {
     private TestConfigUtil() {
     }
 
+    @Deprecated(forRemoval = true, since = "3.17")
     public static List<String> argLineValue(Config config) {
         String strValue = config.getOptionalValue("quarkus.test.arg-line", String.class)
                 .orElse(config.getOptionalValue("quarkus.test.argLine", String.class) // legacy value
@@ -37,17 +38,20 @@ public final class TestConfigUtil {
         return result;
     }
 
+    @Deprecated(forRemoval = true, since = "3.17")
     public static Map<String, String> env(Config config) {
         return ((SmallRyeConfig) config).getOptionalValues("quarkus.test.env", String.class, String.class)
                 .orElse(Collections.emptyMap());
     }
 
+    @Deprecated(forRemoval = true, since = "3.17")
     public static Duration waitTimeValue(Config config) {
         return config.getOptionalValue("quarkus.test.wait-time", Duration.class)
                 .orElseGet(() -> config.getOptionalValue("quarkus.test.jar-wait-time", Duration.class) // legacy value
                         .orElseGet(() -> Duration.ofSeconds(DEFAULT_WAIT_TIME_SECONDS)));
     }
 
+    @Deprecated(forRemoval = true, since = "3.17")
     public static String integrationTestProfile(Config config) {
         return config.getOptionalValue("quarkus.test.integration-test-profile", String.class)
                 .orElseGet(() -> config.getOptionalValue("quarkus.test.native-image-profile", String.class)

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -29,7 +29,7 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.jandex.Index;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -49,7 +49,6 @@ import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.logging.LoggingSetupRecorder;
 import io.quarkus.test.common.ArtifactLauncher;
-import io.quarkus.test.common.LauncherUtil;
 import io.quarkus.test.common.PathTestHelper;
 import io.quarkus.test.common.TestClassIndexer;
 import io.quarkus.test.common.TestResourceManager;
@@ -276,9 +275,8 @@ public final class IntegrationTestUtil {
             } catch (Exception e) {
                 // use the network the use has specified or else just generate one if none is configured
 
-                Config config = LauncherUtil.installAndGetSomeConfig();
-                Optional<String> networkIdOpt = config
-                        .getOptionalValue("quarkus.test.container.network", String.class);
+                Optional<String> networkIdOpt = ConfigProvider.getConfig().getOptionalValue("quarkus.test.container.network",
+                        String.class);
                 if (networkIdOpt.isPresent()) {
                     networkId = networkIdOpt.get();
                 } else {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
 
-import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -26,16 +26,16 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
+import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.runtime.logging.JBossVersion;
 import io.quarkus.test.common.ArtifactLauncher;
-import io.quarkus.test.common.LauncherUtil;
-import io.quarkus.test.common.TestConfigUtil;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.junit.launcher.ArtifactLauncherProvider;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import io.quarkus.test.junit.main.QuarkusMainLauncher;
 import io.quarkus.test.junit.util.CloseAdaptor;
+import io.smallrye.config.SmallRyeConfig;
 
 public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWithContextExtension
         implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
@@ -157,13 +157,13 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
 
                 testResourceManager.inject(context.getRequiredTestInstance());
 
-                Config config = LauncherUtil.installAndGetSomeConfig();
-                String testProfile = TestConfigUtil.integrationTestProfile(config);
+                SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+                TestConfig testConfig = config.getConfigMapping(TestConfig.class);
 
                 ArtifactLauncher<?> launcher = null;
                 ServiceLoader<ArtifactLauncherProvider> loader = ServiceLoader.load(ArtifactLauncherProvider.class);
                 for (ArtifactLauncherProvider launcherProvider : loader) {
-                    if (launcherProvider.supportsArtifactType(artifactType, testProfile)) {
+                    if (launcherProvider.supportsArtifactType(artifactType, testConfig.integrationTestProfile())) {
                         launcher = launcherProvider.create(
                                 new DefaultArtifactLauncherCreateContext(quarkusArtifactProperties, context, requiredTestClass,
                                         devServicesLaunchResult));

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
@@ -17,13 +17,14 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.ServiceLoader;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.deployment.images.ContainerImages;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.DefaultDockerContainerLauncher;
 import io.quarkus.test.common.DockerContainerArtifactLauncher;
-import io.quarkus.test.common.LauncherUtil;
-import io.quarkus.test.common.TestConfigUtil;
 import io.smallrye.config.SmallRyeConfig;
 
 public class DockerContainerLauncherProvider implements ArtifactLauncherProvider {
@@ -38,6 +39,7 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
         String containerImage = context.quarkusArtifactProperties().getProperty("metadata.container-image");
         boolean pullRequired = Boolean
                 .parseBoolean(context.quarkusArtifactProperties().getProperty("metadata.pull-required", "false"));
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
         if ((containerImage != null) && !containerImage.isEmpty()) {
             DockerContainerArtifactLauncher launcher;
             ServiceLoader<DockerContainerArtifactLauncher> loader = ServiceLoader.load(DockerContainerArtifactLauncher.class);
@@ -47,7 +49,6 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
             } else {
                 launcher = new DefaultDockerContainerLauncher();
             }
-            SmallRyeConfig config = (SmallRyeConfig) LauncherUtil.installAndGetSomeConfig();
             launcherInit(context, launcher, config, containerImage, pullRequired, Optional.empty(), volumeMounts(config),
                     Collections.emptyList());
             return launcher;
@@ -59,10 +60,8 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
             // adding a volume mapping pointing to the build output directory,
             // and then instructing the java process to run the run jar,
             // along with the native image agent arguments and any other additional parameters.
-            SmallRyeConfig config = (SmallRyeConfig) LauncherUtil.installAndGetSomeConfig();
-            String testProfile = TestConfigUtil.integrationTestProfile(config);
-
-            if ("test-with-native-agent".equals(testProfile)) {
+            TestConfig testConfig = config.getConfigMapping(TestConfig.class);
+            if ("test-with-native-agent".equals(testConfig.integrationTestProfile())) {
                 DockerContainerArtifactLauncher launcher = new DefaultDockerContainerLauncher();
                 Optional<String> entryPoint = Optional.of("java");
                 Map<String, String> volumeMounts = new HashMap<>(volumeMounts(config));
@@ -83,13 +82,14 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
     private void launcherInit(CreateContext context, DockerContainerArtifactLauncher launcher, SmallRyeConfig config,
             String containerImage, boolean pullRequired, Optional<String> entryPoint, Map<String, String> volumeMounts,
             List<String> programArgs) {
+        TestConfig testConfig = config.getConfigMapping(TestConfig.class);
         launcher.init(new DefaultDockerInitContext(
                 config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                 config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
-                TestConfigUtil.waitTimeValue(config),
-                TestConfigUtil.integrationTestProfile(config),
-                TestConfigUtil.argLineValue(config),
-                TestConfigUtil.env(config),
+                testConfig.waitTime(),
+                testConfig.integrationTestProfile(),
+                testConfig.argLine().orElse(List.of()),
+                testConfig.env(),
                 context.devServicesLaunchResult(),
                 containerImage,
                 pullRequired,

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
@@ -12,13 +12,13 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.ServiceLoader;
 
-import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 
+import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.DefaultJarLauncher;
 import io.quarkus.test.common.JarArtifactLauncher;
-import io.quarkus.test.common.LauncherUtil;
-import io.quarkus.test.common.TestConfigUtil;
+import io.smallrye.config.SmallRyeConfig;
 
 public class JarLauncherProvider implements ArtifactLauncherProvider {
 
@@ -40,14 +40,15 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
                 launcher = new DefaultJarLauncher();
             }
 
-            Config config = LauncherUtil.installAndGetSomeConfig();
+            SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+            TestConfig testConfig = config.getConfigMapping(TestConfig.class);
             launcher.init(new DefaultJarInitContext(
                     config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
-                    TestConfigUtil.waitTimeValue(config),
-                    TestConfigUtil.integrationTestProfile(config),
-                    TestConfigUtil.argLineValue(config),
-                    TestConfigUtil.env(config),
+                    testConfig.waitTime(),
+                    testConfig.integrationTestProfile(),
+                    testConfig.argLine().orElse(List.of()),
+                    testConfig.env(),
                     context.devServicesLaunchResult(),
                     context.buildOutputDirectory().resolve(pathStr)));
             return launcher;

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
@@ -11,13 +11,13 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.ServiceLoader;
 
-import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 
+import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.DefaultNativeImageLauncher;
-import io.quarkus.test.common.LauncherUtil;
 import io.quarkus.test.common.NativeImageLauncher;
-import io.quarkus.test.common.TestConfigUtil;
+import io.smallrye.config.SmallRyeConfig;
 
 public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
     @Override
@@ -38,14 +38,15 @@ public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
                 launcher = new DefaultNativeImageLauncher();
             }
 
-            Config config = LauncherUtil.installAndGetSomeConfig();
+            SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+            TestConfig testConfig = config.getConfigMapping(TestConfig.class);
             launcher.init(new NativeImageLauncherProvider.DefaultNativeImageInitContext(
                     config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(DEFAULT_PORT),
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
-                    TestConfigUtil.waitTimeValue(config),
-                    TestConfigUtil.integrationTestProfile(config),
-                    TestConfigUtil.argLineValue(config),
-                    TestConfigUtil.env(config),
+                    testConfig.waitTime(),
+                    testConfig.nativeImageProfile(),
+                    testConfig.argLine().orElse(List.of()),
+                    testConfig.env(),
                     context.devServicesLaunchResult(),
                     System.getProperty("native.image.path"),
                     config.getOptionalValue("quarkus.package.output-directory", String.class).orElse(null),


### PR DESCRIPTION
With #42715,  the `TestConfig` mapping became part of the test `Config` instance., including the defaults provided by the mapping. This caused the method https://github.com/quarkusio/quarkus/pull/45100/files#diff-86eda0ddf834021bf33a10113850cc3ce523cefe3d5a7cf1c97f4029e04271e6R55-R57 always to return the value of `quarkus.test.integration-test-profile` and ignore `quarkus.test.native-image-profile`.

To avoid overburdening #42717 too much, I didn't make this change there, but I was planning to do it at some point. Now we need it because of #45083, so I made some minimal changes. There are probably other places where we can use the `TestConfig` instead of the property name lookup, which I intended to look for.

- Fixes #45083