### PR TITLE
More efficient dependency tree conflict resolver

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/OptionalDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/OptionalDepsTest.java
@@ -5,14 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.aether.util.artifact.JavaScopes;
+
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsDependency;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactDependency;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.DependencyFlags;
-import io.quarkus.maven.dependency.GACTV;
 
 public class OptionalDepsTest extends BootstrapFromOriginalJarTestBase {
 
@@ -70,17 +72,73 @@ public class OptionalDepsTest extends BootstrapFromOriginalJarTestBase {
     @Override
     protected void assertAppModel(ApplicationModel model) throws Exception {
         final Set<Dependency> expected = new HashSet<>();
-        expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile",
+
+        expected.add(new ArtifactDependency(
+                ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-a", TsArtifact.DEFAULT_VERSION),
+                JavaScopes.COMPILE,
+                DependencyFlags.DIRECT,
+                DependencyFlags.OPTIONAL,
+                DependencyFlags.RUNTIME_EXTENSION_ARTIFACT,
+                DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT,
+                DependencyFlags.RUNTIME_CP,
+                DependencyFlags.DEPLOYMENT_CP));
+
+        expected.add(new ArtifactDependency(
+                ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-a-dep", TsArtifact.DEFAULT_VERSION),
+                JavaScopes.COMPILE,
+                DependencyFlags.OPTIONAL,
+                DependencyFlags.RUNTIME_CP,
+                DependencyFlags.DEPLOYMENT_CP));
+
+        expected.add(new ArtifactDependency(
+                ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION),
+                JavaScopes.COMPILE,
                 DependencyFlags.OPTIONAL,
                 DependencyFlags.DEPLOYMENT_CP));
-        expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-b-deployment-dep", "1"), "compile",
+
+        expected.add(new ArtifactDependency(
+                ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "app-optional-dep", TsArtifact.DEFAULT_VERSION),
+                JavaScopes.COMPILE,
+                DependencyFlags.OPTIONAL,
+                DependencyFlags.DIRECT,
+                DependencyFlags.RUNTIME_CP,
+                DependencyFlags.DEPLOYMENT_CP));
+
+        expected.add(new ArtifactDependency(
+                ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-b", TsArtifact.DEFAULT_VERSION),
+                JavaScopes.COMPILE,
+                DependencyFlags.OPTIONAL,
+                DependencyFlags.RUNTIME_EXTENSION_ARTIFACT,
+                DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT,
+                DependencyFlags.RUNTIME_CP,
+                DependencyFlags.DEPLOYMENT_CP));
+
+        expected.add(new ArtifactDependency(ArtifactCoords.jar(
+                TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment", TsArtifact.DEFAULT_VERSION),
+                JavaScopes.COMPILE,
                 DependencyFlags.OPTIONAL,
                 DependencyFlags.DEPLOYMENT_CP));
-        expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-b-deployment", "1"), "compile",
+
+        expected.add(new ArtifactDependency(
+                ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-b-deployment-dep", TsArtifact.DEFAULT_VERSION),
+                JavaScopes.COMPILE,
                 DependencyFlags.OPTIONAL,
                 DependencyFlags.DEPLOYMENT_CP));
-        expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-d-deployment", "1"), "compile",
+
+        expected.add(new ArtifactDependency(
+                ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-d", TsArtifact.DEFAULT_VERSION),
+                JavaScopes.COMPILE,
+                DependencyFlags.DIRECT,
+                DependencyFlags.RUNTIME_EXTENSION_ARTIFACT,
+                DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT,
+                DependencyFlags.RUNTIME_CP,
                 DependencyFlags.DEPLOYMENT_CP));
-        assertEquals(expected, getDeploymentOnlyDeps(model));
+
+        expected.add(new ArtifactDependency(
+                ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "ext-d-deployment", TsArtifact.DEFAULT_VERSION),
+                JavaScopes.COMPILE,
+                DependencyFlags.DEPLOYMENT_CP));
+
+        assertEquals(expected, getDependenciesWithFlag(model, DependencyFlags.DEPLOYMENT_CP));
     }
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DependencyTreeConflictResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DependencyTreeConflictResolver.java
@@ -1,0 +1,101 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+import static io.quarkus.bootstrap.util.DependencyUtils.getKey;
+import static io.quarkus.bootstrap.util.DependencyUtils.hasWinner;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.aether.collection.DependencyGraphTransformationContext;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.graph.transformer.ConflictResolver;
+
+import io.quarkus.maven.dependency.ArtifactKey;
+
+/**
+ * Dependency tree conflict resolver.
+ * <p>
+ * The idea is to have a more efficient implementation than the
+ * {@link org.eclipse.aether.util.graph.transformer.ConflictIdSorter#transformGraph(DependencyNode, DependencyGraphTransformationContext)}
+ * for the use-cases the Quarkus deployment dependency resolver is designed for.
+ * <p>
+ * Specifically, this conflict resolver does not properly handle version ranges, that are not expected to be present in the
+ * phase it used.
+ */
+class DependencyTreeConflictResolver {
+
+    /**
+     * Resolves dependency version conflicts in the given dependency tree.
+     *
+     * @param root the root of the dependency tree
+     */
+    static void resolveConflicts(DependencyNode root) {
+        new DependencyTreeConflictResolver(root).run();
+    }
+
+    final OrderedDependencyVisitor visitor;
+
+    private DependencyTreeConflictResolver(DependencyNode root) {
+        visitor = new OrderedDependencyVisitor(root);
+    }
+
+    private void run() {
+        visitor.next();// skip the root
+        final Map<ArtifactKey, VisitedDependency> visited = new HashMap<>();
+        while (visitor.hasNext()) {
+            var node = visitor.next();
+            if (!hasWinner(node)) {
+                visited.compute(getKey(node.getArtifact()), this::resolveConflict);
+            }
+        }
+    }
+
+    private VisitedDependency resolveConflict(ArtifactKey key, VisitedDependency prev) {
+        if (prev == null) {
+            return new VisitedDependency(visitor);
+        }
+        prev.resolveConflict(visitor);
+        return prev;
+    }
+
+    private static class VisitedDependency {
+        final DependencyNode node;
+        final int subtreeIndex;
+
+        private VisitedDependency(OrderedDependencyVisitor visitor) {
+            this.node = visitor.getCurrent();
+            this.subtreeIndex = visitor.getSubtreeIndex();
+        }
+
+        private void resolveConflict(OrderedDependencyVisitor visitor) {
+            var otherNode = visitor.getCurrent();
+            if (subtreeIndex != visitor.getSubtreeIndex()) {
+                final Dependency currentDep = node.getDependency();
+                final Dependency otherDep = otherNode.getDependency();
+                if (!currentDep.getScope().equals(otherDep.getScope())
+                        && getScopePriority(currentDep.getScope()) > getScopePriority(otherDep.getScope())) {
+                    node.setScope(otherDep.getScope());
+                }
+                if (currentDep.isOptional() && !otherDep.isOptional()) {
+                    node.setOptional(false);
+                }
+            }
+            otherNode.setChildren(List.of());
+            otherNode.setData(ConflictResolver.NODE_DATA_WINNER, new DefaultDependencyNode(node.getDependency()));
+        }
+    }
+
+    private static int getScopePriority(String scope) {
+        return switch (scope) {
+            case JavaScopes.COMPILE -> 0;
+            case JavaScopes.RUNTIME -> 1;
+            case JavaScopes.PROVIDED -> 2;
+            case JavaScopes.TEST -> 3;
+            default -> 4;
+        };
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/OrderedDependencyVisitorTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/OrderedDependencyVisitorTest.java
@@ -59,77 +59,90 @@ public class OrderedDependencyVisitorTest {
         assertThat(visitor.next()).isSameAs(root);
         assertThat(visitor.getCurrent()).isSameAs(root);
         assertThat(visitor.getCurrentDistance()).isEqualTo(0);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(0);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 1, colors
         assertThat(visitor.next()).isSameAs(colors);
         assertThat(visitor.getCurrent()).isSameAs(colors);
         assertThat(visitor.getCurrentDistance()).isEqualTo(1);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(1);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 1, pets
         assertThat(visitor.next()).isSameAs(pets);
         assertThat(visitor.getCurrent()).isSameAs(pets);
         assertThat(visitor.getCurrentDistance()).isEqualTo(1);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(2);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 1, trees
         assertThat(visitor.next()).isSameAs(trees);
         assertThat(visitor.getCurrent()).isSameAs(trees);
         assertThat(visitor.getCurrentDistance()).isEqualTo(1);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(3);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 2, colors, red
         assertThat(visitor.next()).isSameAs(red);
         assertThat(visitor.getCurrent()).isSameAs(red);
         assertThat(visitor.getCurrentDistance()).isEqualTo(2);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(1);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 2, colors, green
         assertThat(visitor.next()).isSameAs(green);
         assertThat(visitor.getCurrent()).isSameAs(green);
         assertThat(visitor.getCurrentDistance()).isEqualTo(2);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(1);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 2, colors, blue
         assertThat(visitor.next()).isSameAs(blue);
         assertThat(visitor.getCurrent()).isSameAs(blue);
         assertThat(visitor.getCurrentDistance()).isEqualTo(2);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(1);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 2, pets, dog
         assertThat(visitor.next()).isSameAs(dog);
         assertThat(visitor.getCurrent()).isSameAs(dog);
         assertThat(visitor.getCurrentDistance()).isEqualTo(2);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(2);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 2, pets, cat
         assertThat(visitor.next()).isSameAs(cat);
         assertThat(visitor.getCurrent()).isSameAs(cat);
         assertThat(visitor.getCurrentDistance()).isEqualTo(2);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(2);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 2, trees, pine
         assertThat(visitor.next()).isSameAs(pine);
         assertThat(visitor.getCurrent()).isSameAs(pine);
         assertThat(visitor.getCurrentDistance()).isEqualTo(2);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(3);
         assertThat(visitor.hasNext()).isTrue();
         // replace the current node
         visitor.replaceCurrent(oak);
         assertThat(visitor.getCurrent()).isSameAs(oak);
         assertThat(visitor.getCurrentDistance()).isEqualTo(2);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(3);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 3, pets, dog, puppy
         assertThat(visitor.next()).isSameAs(puppy);
         assertThat(visitor.getCurrent()).isSameAs(puppy);
         assertThat(visitor.getCurrentDistance()).isEqualTo(3);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(2);
         assertThat(visitor.hasNext()).isTrue();
 
         // distance 3, trees, oak, acorn
         assertThat(visitor.next()).isSameAs(acorn);
         assertThat(visitor.getCurrent()).isSameAs(acorn);
         assertThat(visitor.getCurrentDistance()).isEqualTo(3);
+        assertThat(visitor.getSubtreeIndex()).isEqualTo(3);
         assertThat(visitor.hasNext()).isFalse();
     }
 


### PR DESCRIPTION
An enhancement for the Quarkus Maven resolver., for now applied only to the incubating one.
This change introduces a more efficient implementation of the dependency conflict resolution.

In the super heroes rest-fights it saves ~140ms on the Quarkus ApplicationModel dependency resolution.
In the QE beefy-scenarios it's up to ~200ms on the all-extensions project.