### PR TITLE
Configure the resolver for dev mode in QuarkusDevModeTest

### DIFF
--- a/integration-tests/logging-panache/pom.xml
+++ b/integration-tests/logging-panache/pom.xml
@@ -32,11 +32,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-agroal-dev</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
             <scope>test</scope>
         </dependency>

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -442,6 +442,7 @@ public class QuarkusDevModeTest
         try {
             return BootstrapAppModelFactory.newInstance()
                     .setTest(true)
+                    .setDevMode(true)
                     .setProjectRoot(Path.of("").normalize().toAbsolutePath())
                     .resolveAppModel()
                     .getApplicationModel();


### PR DESCRIPTION
This change makes the resolver in the `QuarkusDevModeTest` pick up dependencies relevant for dev mode, not only test, which is now even more critical with conditional dev mode dependencies.