### PR TITLE
Register for reflection Pageable class 

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
@@ -103,6 +103,7 @@ public class SpringDataJPAProcessor {
                 "org.springframework.data.domain.Page",
                 "org.springframework.data.domain.Slice",
                 "org.springframework.data.domain.PageImpl",
+                "org.springframework.data.domain.Pageable",
                 "org.springframework.data.domain.SliceImpl",
                 "org.springframework.data.domain.Sort",
                 "org.springframework.data.domain.Chunk",

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/BookRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/BookRepository.java
@@ -3,6 +3,9 @@ package io.quarkus.it.spring.data.jpa;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -44,6 +47,12 @@ public interface BookRepository extends Repository<Book, Integer> {
     // issue 9192
     @Query(value = "SELECT b.publicationYear FROM Book b where b.bid = :bid")
     Integer customFindPublicationYearObject(@Param("bid") Integer bid);
+
+    // Related to issue 41292
+    public default Page<Book> findPaged(Pageable pageable) {
+        List<Book> list = findAll();
+        return new PageImpl<>(list, pageable, list.size());
+    }
 
     interface BookCountByYear {
         int getPublicationYear();

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/BookResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/BookResource.java
@@ -8,7 +8,11 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 @Path("/book")
 public class BookResource {
@@ -113,6 +117,12 @@ public class BookResource {
     @Produces("text/plain")
     public Integer customFindPublicationYearObject(@PathParam("bid") Integer bid) {
         return bookRepository.customFindPublicationYearObject(bid);
+    }
+
+    @GET
+    @Path("/paged")
+    public Page<Book> getPaged(@QueryParam("size") int size, @QueryParam("page") int page) {
+        return bookRepository.findPaged(PageRequest.of(page, size));
     }
 
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/BookResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/BookResourceTest.java
@@ -1,13 +1,17 @@
 package io.quarkus.it.spring.data.jpa;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
 
 @QuarkusTest
 public class BookResourceTest {
@@ -131,5 +135,17 @@ public class BookResourceTest {
         when().get("/book/customPublicationYearObject/1").then()
                 .statusCode(200)
                 .body(is("2011"));
+    }
+
+    @Test
+    void testEnsureFieldPageableIsSerialized() {
+        Response response = given()
+                .accept("application/json")
+                .queryParam("size", "2")
+                .queryParam("page", "1")
+                .when().get("/book/paged");
+        Assertions.assertEquals(200, response.statusCode());
+        assertThat(response.body().jsonPath().getString("pageable")).contains("paged:true");
+        assertThat(response.body().jsonPath().getString("pageable")).contains("unpaged:false");
     }
 }


### PR DESCRIPTION
We were missing paged/unpaged attributes in serialization. (See https://github.com/quarkusio/quarkus/issues/41292#issuecomment-2539271921). 

I've verified it works with the issue reproducer. However I'm not sure how to add a test for checking it automatically during the build.

- Fixes: #41292

cc @geoand 