### PR TITLE
Extension info - Fixed the assign value to the latestCommitTime

### DIFF
--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
@@ -85,7 +85,7 @@ public class InfoProcessor {
             Map<String, Object> commit = new LinkedHashMap<>();
             String latestCommitId = latestCommit.getName();
             commit.put("id", latestCommitId);
-            String latestCommitTime = formatDate(Instant.ofEpochMilli(latestCommit.getCommitTime()), ZoneId.systemDefault());
+            String latestCommitTime = formatDate(Instant.ofEpochSecond(latestCommit.getCommitTime()), ZoneId.systemDefault());
             commit.put("time", latestCommitTime);
 
             if (addFullInfo) {


### PR DESCRIPTION
Replaced the method Instant.ofEpochMilli() with the method Instant.ofEpochSecond() because RevCommit.getCommitTime() return the number of the seconds from epoch.

Before the fix:
![image](https://github.com/user-attachments/assets/8a420b92-d7b7-492c-8261-2674a6f65379)

After fix:
![image](https://github.com/user-attachments/assets/ff62ee55-f818-49be-a656-ca55d1e559b9)
