### PR TITLE
Extension Info - Expose other information about Java and Git

### DIFF
--- a/extensions/info/deployment/src/main/resources/dev-ui/qwc-info.js
+++ b/extensions/info/deployment/src/main/resources/dev-ui/qwc-info.js
@@ -104,6 +104,8 @@ export class QwcInfo extends LitElement {
                         <vaadin-icon icon="font-awesome-brands:java"></vaadin-icon>
                         <table class="table">
                             <tr><td class="row-header">Version</td><td>${java.version}</td></tr>
+                            <tr><td class="row-header">Vendor</td><td>${java.vendor}</td></tr>
+                            <tr><td class="row-header">Vendor Version</td><td>${java.vendorVersion}</td></tr>
                         </table>
                     </div>    
                 </qui-card>`;
@@ -151,7 +153,8 @@ export class QwcInfo extends LitElement {
     _renderOptionalData(git){
         if(typeof git.commit.id !== "string"){
             return html`<tr><td class="row-header">Commit User</td><td>${git.commit.user.name} &lt;${git.commit.user.email}&gt;</td></tr>
-                        <tr><td class="row-header">Commit Message</td><td>${unsafeHTML(this._replaceNewLine(git.commit.id.message.full))}</td></tr>`
+                        <tr><td class="row-header">Commit Message</td><td>${unsafeHTML(this._replaceNewLine(git.commit.id.message.full))}</td></tr>
+                        <tr><td class="row-header">Remote URL</td><td>${unsafeHTML(git.remote)}</td></tr>`
         }
     }
 
@@ -165,6 +168,8 @@ export class QwcInfo extends LitElement {
             return html`<qui-card header="Build">
                     <div class="cardContent" slot="content">
                         <table class="table">
+                            <tr><td class="row-header">Quarkus</td><td>${build.quarkusVersion}</td></tr>
+                            <tr><td class="row-header">App Name</td><td>${unsafeHTML(build.name)}</td></tr>
                             <tr><td class="row-header">Group</td><td>${build.group}</td></tr>
                             <tr><td class="row-header">Artifact</td><td>${build.artifact}</td></tr>
                             <tr><td class="row-header">Version</td><td>${build.version}</td></tr>

--- a/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/EnabledInfoTest.java
+++ b/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/EnabledInfoTest.java
@@ -70,5 +70,7 @@ public class EnabledInfoTest {
 
         assertNotNull(javaInfo);
         assertNotNull(javaInfo.version());
+        assertNotNull(javaInfo.vendor());
+        assertNotNull(javaInfo.vendorVersion());
     }
 }

--- a/extensions/info/runtime/src/main/java/io/quarkus/info/JavaInfo.java
+++ b/extensions/info/runtime/src/main/java/io/quarkus/info/JavaInfo.java
@@ -9,21 +9,21 @@ package io.quarkus.info;
 public interface JavaInfo {
 
     /**
-     * Return the Java version with which application compiled.
+     * Return the Java runtime version.
      *
      * @return string that represent the Java version
      */
     String version();
 
     /**
-     * Return the Java vendor with which application compiled.
+     * Return the Java vendor.
      *
      * @return string that represent the Java vendor
      */
     String vendor();
 
     /**
-     * Return the Java vendor version with which application compiled.
+     * Return the Java vendor runtime version.
      *
      * @return string that represent the Java vendor version
      */

--- a/extensions/info/runtime/src/main/java/io/quarkus/info/JavaInfo.java
+++ b/extensions/info/runtime/src/main/java/io/quarkus/info/JavaInfo.java
@@ -3,4 +3,8 @@ package io.quarkus.info;
 public interface JavaInfo {
 
     String version();
+
+    String vendor();
+
+    String vendorVersion();
 }

--- a/extensions/info/runtime/src/main/java/io/quarkus/info/JavaInfo.java
+++ b/extensions/info/runtime/src/main/java/io/quarkus/info/JavaInfo.java
@@ -1,10 +1,31 @@
 package io.quarkus.info;
 
+/**
+ * This interface provides information about the Java runtime.
+ *
+ * @see io.quarkus.info.runtime.InfoRecorder
+ * @see io.quarkus.info.runtime.JavaInfoContributor
+ */
 public interface JavaInfo {
 
+    /**
+     * Return the Java version with which application compiled.
+     *
+     * @return string that represent the Java version
+     */
     String version();
 
+    /**
+     * Return the Java vendor with which application compiled.
+     *
+     * @return string that represent the Java vendor
+     */
     String vendor();
 
+    /**
+     * Return the Java vendor version with which application compiled.
+     *
+     * @return string that represent the Java vendor version
+     */
     String vendorVersion();
 }

--- a/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/InfoRecorder.java
+++ b/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/InfoRecorder.java
@@ -134,6 +134,16 @@ public class InfoRecorder {
                     public String version() {
                         return JavaInfoContributor.getVersion();
                     }
+
+                    @Override
+                    public String vendor() {
+                        return JavaInfoContributor.getVendor();
+                    }
+
+                    @Override
+                    public String vendorVersion() {
+                        return JavaInfoContributor.getVendorVersion();
+                    }
                 };
             }
         };


### PR DESCRIPTION
The following changes are present in this PR.

- Added the RemoteURL on the DevUI Info Git card
- Added the Application Name on the DevUI Info Build card.
- Added the Quarkus Version on the DevUI Info Build card.
- Added the JavaDoc on the JavaInfo interface.
- Extended the DevUI Info JavaInfo card with the new info.
- Extension of the JavaInfo interface
- Fixed the assign value to the latestCommitTime (see the PR #45123)

Below is an example of what DevUI Info looks like now.

![image](https://github.com/user-attachments/assets/72b85616-3f0b-4345-a06e-f2a631b9e0e0)

Below is an example of how to get the beans from the quarkus-info extension

```java
//...
import io.quarkus.info.BuildInfo;
import io.quarkus.info.GitInfo;
import io.quarkus.info.JavaInfo;
import io.quarkus.info.OsInfo;

@Path("/whoami")
public class WhoAmIResource {
    @Inject
    GitInfo gitInfo;

    @Inject
    BuildInfo buildInfo;

    @Inject
    JavaInfo javaInfo;

    @Inject
    OsInfo osInfo;
    
    // Use the inject bean
   //....
}    
```
Listing 1 - Example of how to get the beans of the quarkus-info extension