### PR TITLE
Introduce IsLocalDevelopment boolean supplier

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsLocalDevelopment.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsLocalDevelopment.java
@@ -1,0 +1,27 @@
+package io.quarkus.deployment;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.dev.spi.DevModeType;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * Similar to {@link IsDevelopment} except checks whether the application is being launched in dev mode but not from a
+ * {@code mutable-jar} package,
+ * in other words, not a remote server in a remote dev session.
+ */
+public class IsLocalDevelopment implements BooleanSupplier {
+
+    private final LaunchMode launchMode;
+    private final DevModeType devModeType;
+
+    public IsLocalDevelopment(LaunchMode launchMode, DevModeType devModeType) {
+        this.launchMode = launchMode;
+        this.devModeType = devModeType;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return launchMode == LaunchMode.DEVELOPMENT && devModeType != DevModeType.REMOTE_SERVER_SIDE;
+    }
+}

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
@@ -2,7 +2,7 @@ package io.quarkus.agroal.deployment.devui;
 
 import io.quarkus.agroal.runtime.DataSourcesJdbcBuildTimeConfig;
 import io.quarkus.agroal.runtime.dev.ui.DatabaseInspector;
-import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -12,7 +12,7 @@ import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 
-@BuildSteps(onlyIf = IsDevelopment.class)
+@BuildSteps(onlyIf = IsLocalDevelopment.class)
 class AgroalDevUIProcessor {
 
     @BuildStep


### PR DESCRIPTION
`IsLocalDevelopment` should probably used now for all the Dev UI-related build steps instead of `IsDevelopment`.

It should also apply to any build step not relevant for a `mutable-jar` application launched in dev mode (`remote-dev` server)