### PR TITLE
Document default connection-pool-size for REST Clients and raise default pool size to 50 for Quarkus REST

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -150,6 +150,7 @@ public interface RestClientsConfig {
      * <p>
      * Can be overwritten by client-specific settings.
      */
+    @ConfigDocDefault("50")
     Optional<Integer> connectionPoolSize();
 
     /**
@@ -542,6 +543,7 @@ public interface RestClientsConfig {
         /**
          * The size of the connection pool for this client.
          */
+        @ConfigDocDefault("50")
         Optional<Integer> connectionPoolSize();
 
         /**

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
@@ -89,7 +89,7 @@ public class ClientImpl implements Client {
     private static final Logger log = Logger.getLogger(ClientImpl.class);
 
     private static final int DEFAULT_CONNECT_TIMEOUT = 15000;
-    private static final int DEFAULT_CONNECTION_POOL_SIZE = 20;
+    private static final int DEFAULT_CONNECTION_POOL_SIZE = 50;
 
     final ClientContext clientContext;
     final boolean closeVertx;


### PR DESCRIPTION
Default value for [`quarkus.rest-client.connection-pool-size`](https://quarkus.io/guides/rest-client#quarkus-rest-client-config_quarkus-rest-client-connection-pool-size) is 50. This is the default value set by Resteasy itself that quarkus don't override by default: https://github.com/resteasy/resteasy/blob/0ccb17086c7dfffd0d6a7970db9b147fa7a0fb5c/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java#L62

