### PR TITLE
Update version of MongoDB used for testing to 7.0

### DIFF
--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultAndNamedMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultAndNamedMongoClientConfigTest.java
@@ -11,6 +11,8 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.mongodb.client.MongoClient;
@@ -21,6 +23,7 @@ import io.quarkus.arc.ClientProxy;
 import io.quarkus.mongodb.health.MongoHealthCheck;
 import io.quarkus.test.QuarkusUnitTest;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Flapdoodle doesn't work very well on Windows with replicas")
 public class DefaultAndNamedMongoClientConfigTest extends MongoWithReplicasTestBase {
 
     @RegisterExtension

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/DefaultMongoClientConfigTest.java
@@ -11,6 +11,8 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.mongodb.client.MongoClient;
@@ -19,6 +21,7 @@ import io.quarkus.mongodb.health.MongoHealthCheck;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.test.QuarkusUnitTest;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Flapdoodle doesn't work very well on Windows with replicas")
 public class DefaultMongoClientConfigTest extends MongoWithReplicasTestBase {
 
     @RegisterExtension

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoClientConfigTest.java
@@ -8,6 +8,8 @@ import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.mongodb.ReadConcern;
@@ -21,6 +23,7 @@ import io.quarkus.mongodb.impl.ReactiveMongoClientImpl;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.test.QuarkusUnitTest;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Flapdoodle doesn't work very well on Windows with replicas")
 public class MongoClientConfigTest extends MongoWithReplicasTestBase {
 
     @RegisterExtension

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
@@ -42,7 +42,7 @@ public class MongoTestBase {
         String uri = getConfiguredConnectionString();
         // This switch allow testing against a running mongo database.
         if (uri == null) {
-            Version.Main version = Version.Main.V4_4;
+            Version.Main version = Version.Main.V7_0;
             int port = 27018;
             LOGGER.infof("Starting Mongo %s on port %s", version, port);
 

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
@@ -11,6 +11,7 @@ import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.mongo.transitions.Mongod;
 import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess;
+import de.flapdoodle.embed.process.types.ProcessConfig;
 import de.flapdoodle.reverse.TransitionWalker;
 import de.flapdoodle.reverse.transitions.Start;
 
@@ -53,6 +54,9 @@ public class MongoTestBase {
                             .build()))
                     .withMongodArguments(Start.to(MongodArguments.class)
                             .initializedWith(MongodArguments.defaults().withUseNoJournal(false)))
+                    .withProcessConfig(
+                            Start.to(ProcessConfig.class)
+                                    .initializedWith(ProcessConfig.defaults().withStopTimeoutInMillis(15_000)))
                     .start(version);
 
         } else {

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
@@ -1,7 +1,6 @@
 package io.quarkus.mongodb;
 
 import static io.quarkus.mongodb.MongoTestBase.getConfiguredConnectionString;
-import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_MINUTE;
 import static org.awaitility.Durations.ONE_SECOND;
 
@@ -47,7 +46,7 @@ public class MongoWithReplicasTestBase {
 
         // This switch allow testing against a running mongo database.
         if (uri == null) {
-            startedServers = startReplicaSet(Version.Main.V4_4, 27018, "test001");
+            startedServers = startReplicaSet(Version.Main.V7_0, 27018, "test001");
         } else {
             LOGGER.infof("Using existing Mongo %s", uri);
         }

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
@@ -31,6 +31,7 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.mongo.transitions.Mongod;
 import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess;
 import de.flapdoodle.embed.process.io.ProcessOutput;
+import de.flapdoodle.embed.process.types.ProcessConfig;
 import de.flapdoodle.reverse.TransitionWalker;
 import de.flapdoodle.reverse.transitions.Start;
 
@@ -92,7 +93,10 @@ public class MongoWithReplicasTestBase {
                 .withProcessOutput(Start.to(ProcessOutput.class).initializedWith(ProcessOutput.silent()))
                 .withMongodArguments(Start.to(MongodArguments.class).initializedWith(
                         MongodArguments.defaults().withArgs(Map.of("--replSet", replicaSet)).withSyncDelay(10)
-                                .withUseSmallFiles(true).withUseNoJournal(false)));
+                                .withUseSmallFiles(true).withUseNoJournal(false)))
+                .withProcessConfig(
+                        Start.to(ProcessConfig.class)
+                                .initializedWith(ProcessConfig.defaults().withStopTimeoutInMillis(15_000)));
     }
 
     @AfterAll

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NamedMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NamedMongoClientConfigTest.java
@@ -13,6 +13,8 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.mongodb.client.MongoClient;
@@ -23,6 +25,7 @@ import io.quarkus.arc.InstanceHandle;
 import io.quarkus.mongodb.health.MongoHealthCheck;
 import io.quarkus.test.QuarkusUnitTest;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Flapdoodle doesn't work very well on Windows with replicas")
 public class NamedMongoClientConfigTest extends MongoWithReplicasTestBase {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NamedReactiveMongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NamedReactiveMongoClientConfigTest.java
@@ -14,6 +14,8 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.mongodb.reactivestreams.client.MongoClient;
@@ -28,6 +30,7 @@ import io.quarkus.mongodb.impl.ReactiveMongoClientImpl;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.test.QuarkusUnitTest;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Flapdoodle doesn't work very well on Windows with replicas")
 public class NamedReactiveMongoClientConfigTest extends MongoWithReplicasTestBase {
 
     @RegisterExtension

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/ConnectionToReplicaSetTest.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/ConnectionToReplicaSetTest.java
@@ -10,6 +10,8 @@ import java.util.concurrent.TimeUnit;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.reactivestreams.client.MongoClients;
@@ -17,6 +19,7 @@ import com.mongodb.reactivestreams.client.MongoClients;
 import io.quarkus.mongodb.ChangeStreamOptions;
 import io.quarkus.mongodb.impl.ReactiveMongoClientImpl;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Flapdoodle doesn't work very well on Windows with replicas")
 class ConnectionToReplicaSetTest extends MongoWithReplicasTestBase {
 
     private ReactiveMongoClient client;

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/ListDatabaseTest.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/ListDatabaseTest.java
@@ -8,6 +8,8 @@ import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.reactivestreams.client.ClientSession;
@@ -15,6 +17,7 @@ import com.mongodb.reactivestreams.client.MongoClients;
 
 import io.quarkus.mongodb.impl.ReactiveMongoClientImpl;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Flapdoodle doesn't work very well on Windows with replicas")
 class ListDatabaseTest extends MongoWithReplicasTestBase {
 
     private ReactiveMongoClient client;

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
@@ -21,6 +21,7 @@ import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.mongo.transitions.Mongod;
 import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess;
+import de.flapdoodle.embed.process.types.ProcessConfig;
 import de.flapdoodle.reverse.TransitionWalker;
 import de.flapdoodle.reverse.transitions.Start;
 import io.smallrye.mutiny.Uni;
@@ -66,6 +67,9 @@ public class MongoTestBase {
                             .build()))
                     .withMongodArguments(Start.to(MongodArguments.class)
                             .initializedWith(MongodArguments.defaults().withUseNoJournal(false)))
+                    .withProcessConfig(
+                            Start.to(ProcessConfig.class)
+                                    .initializedWith(ProcessConfig.defaults().withStopTimeoutInMillis(15_000)))
                     .start(version);
 
         } else {

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
@@ -55,7 +55,7 @@ public class MongoTestBase {
         String uri = getConfiguredConnectionString();
         // This switch allow testing against a running mongo database.
         if (uri == null) {
-            Version.Main version = Version.Main.V4_4;
+            Version.Main version = Version.Main.V7_0;
             int port = 27018;
             LOGGER.infof("Starting Mongo %s on port %s", version, port);
 

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
@@ -46,7 +46,7 @@ public class MongoWithReplicasTestBase {
 
         // This switch allow testing against a running mongo database.
         if (uri == null) {
-            startedServers = startReplicaSet(Version.Main.V4_4, 27018, "test001");
+            startedServers = startReplicaSet(Version.Main.V7_0, 27018, "test001");
         } else {
             LOGGER.infof("Using existing Mongo %s", uri);
         }

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
@@ -31,6 +31,7 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.mongo.transitions.Mongod;
 import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess;
 import de.flapdoodle.embed.process.io.ProcessOutput;
+import de.flapdoodle.embed.process.types.ProcessConfig;
 import de.flapdoodle.reverse.TransitionWalker;
 import de.flapdoodle.reverse.transitions.Start;
 
@@ -92,7 +93,10 @@ public class MongoWithReplicasTestBase {
                 .withProcessOutput(Start.to(ProcessOutput.class).initializedWith(ProcessOutput.silent()))
                 .withMongodArguments(Start.to(MongodArguments.class).initializedWith(
                         MongodArguments.defaults().withArgs(Map.of("--replSet", replicaSet)).withSyncDelay(10)
-                                .withUseSmallFiles(true).withUseNoJournal(false)));
+                                .withUseSmallFiles(true).withUseNoJournal(false)))
+                .withProcessConfig(
+                        Start.to(ProcessConfig.class)
+                                .initializedWith(ProcessConfig.defaults().withStopTimeoutInMillis(15_000)));
     }
 
     @AfterAll

--- a/test-framework/mongodb/src/main/java/io/quarkus/test/mongodb/MongoTestResource.java
+++ b/test-framework/mongodb/src/main/java/io/quarkus/test/mongodb/MongoTestResource.java
@@ -13,6 +13,7 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.mongo.distribution.Versions;
 import de.flapdoodle.embed.mongo.transitions.Mongod;
 import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess;
+import de.flapdoodle.embed.process.types.ProcessConfig;
 import de.flapdoodle.reverse.TransitionWalker;
 import de.flapdoodle.reverse.transitions.Start;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -68,6 +69,8 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
                 .initializedWith(Net.builder().from(Net.defaults()).port(port).build()))
                 .withMongodArguments(Start.to(MongodArguments.class)
                         .initializedWith(MongodArguments.defaults().withUseNoJournal(false)))
+                .withProcessConfig(
+                        Start.to(ProcessConfig.class).initializedWith(ProcessConfig.defaults().withStopTimeoutInMillis(15_000)))
                 .start(version);
 
         return Collections.singletonMap("quarkus.mongodb.hosts", String.format("127.0.0.1:%d", port));

--- a/test-framework/mongodb/src/main/java/io/quarkus/test/mongodb/MongoTestResource.java
+++ b/test-framework/mongodb/src/main/java/io/quarkus/test/mongodb/MongoTestResource.java
@@ -39,7 +39,7 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
         return versionArg.<IFeatureAwareVersion> map(Version.Main::valueOf)
                 .orElseGet(() -> versionArg.map(
                         versionStr -> Versions.withFeatures(de.flapdoodle.embed.process.distribution.Version.of(versionStr)))
-                        .orElse(Version.Main.V4_4));
+                        .orElse(Version.Main.V7_0));
     }
 
     public static void forceExtendedSocketOptionsClassInit() {


### PR DESCRIPTION
It is not the latest (8.0 was released in November) but it's probably the most common used and also it's consistent with the version used as a container.

Hopefully, this will be compatible with Ubuntu 22 and 24.