### PR TITLE
Fix local proxy handling in REST Client module

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/devservices/DevServicesRestClientHttpProxyProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/devservices/DevServicesRestClientHttpProxyProcessor.java
@@ -211,10 +211,12 @@ public class DevServicesRestClientHttpProxyProcessor {
 
             var urlKeyName = String.format("quarkus.rest-client.\"%s\".override-uri", bi.getClassName());
             var urlKeyValue = String.format("http://%s:%d", createResult.host(), createResult.port());
-            if (baseUri.getPath() != null) {
-                if (!"/".equals(baseUri.getPath()) && !baseUri.getPath().isEmpty()) {
-                    urlKeyValue = urlKeyValue + "/" + baseUri.getPath();
+            String basePath = baseUri.getPath();
+            if ((basePath != null) && !basePath.isEmpty()) {
+                if (basePath.startsWith("/")) {
+                    basePath = basePath.substring(1);
                 }
+                urlKeyValue = urlKeyValue + "/" + basePath;
             }
 
             devServicePropertiesProducer.produce(


### PR DESCRIPTION
With the previous implementation, Cloudfare was
blocking requests coming from the local proxy