### PR TITLE
[3.15] 3.15.3 backports 3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -162,7 +162,7 @@
         <dekorate.version>4.1.4</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <jboss-logmanager.version>3.0.6.Final</jboss-logmanager.version>
+        <jboss-logmanager.version>3.1.0.Final</jboss-logmanager.version>
         <flyway.version>10.17.3</flyway.version>
         <yasson.version>3.0.4</yasson.version>
         <!-- liquibase-mongodb is not released everytime with liquibase anymore, but the two versions need to be compatible -->

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -162,7 +162,7 @@
         <dekorate.version>4.1.4</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <jboss-logmanager.version>3.1.0.Final</jboss-logmanager.version>
+        <jboss-logmanager.version>3.1.1.Final</jboss-logmanager.version>
         <flyway.version>10.17.3</flyway.version>
         <yasson.version>3.0.4</yasson.version>
         <!-- liquibase-mongodb is not released everytime with liquibase anymore, but the two versions need to be compatible -->

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -220,7 +220,7 @@
         <mime4j.version>0.8.11</mime4j.version>
         <mutiny-zero.version>1.1.0</mutiny-zero.version>
         <pulsar-client.version>3.3.0</pulsar-client.version>
-        <async-http-client.version>2.12.3</async-http-client.version>
+        <async-http-client.version>2.12.4</async-http-client.version>
         <!-- keep in-sync, if possible, with Micrometer registry Prometheus -->
         <prometheus.version>0.16.0</prometheus.version>
         <!-- Dev UI -->

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
@@ -104,7 +104,17 @@ public abstract class QuarkusConsole {
         redirectsInstalled = false;
     }
 
+    private static void checkAndSetJdkConsole() {
+        // the JLine console in JDK 23+ causes significant startup slowdown,
+        // so we avoid it unless the user opted into it
+        String res = System.getProperty("jdk.console");
+        if (res == null) {
+            System.setProperty("jdk.console", "java.base");
+        }
+    }
+
     public static boolean hasColorSupport() {
+        checkAndSetJdkConsole();
         if (Boolean.getBoolean(FORCE_COLOR_SUPPORT)) {
             return true; //assume the IDE run window has color support
         }

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
@@ -103,6 +103,7 @@ public class SpringDataJPAProcessor {
                 "org.springframework.data.domain.Page",
                 "org.springframework.data.domain.Slice",
                 "org.springframework.data.domain.PageImpl",
+                "org.springframework.data.domain.Pageable",
                 "org.springframework.data.domain.SliceImpl",
                 "org.springframework.data.domain.Sort",
                 "org.springframework.data.domain.Chunk",

--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
@@ -85,6 +85,7 @@ public class WebDependencyLocatorProcessor {
                     webstream.forEach(path -> {
                         if (Files.isRegularFile(path)) {
                             String endpoint = SLASH + web.relativize(path);
+                            endpoint = endpoint.replace('\\', '/');
                             try {
                                 if (path.toString().endsWith(DOT_HTML)) {
                                     generatedStaticProducer.produce(new GeneratedStaticResourceBuildItem(endpoint,

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/util/GlobUtil.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/util/GlobUtil.java
@@ -75,8 +75,13 @@ public class GlobUtil {
             switch (current) {
                 case '*':
                     if (i < length && glob.charAt(i) == '*') {
-                        result.append(".*");
                         i++;
+                        if (i < length && glob.charAt(i) == '/') {
+                            result.append("([^/]*/)*");
+                            i++;
+                        } else {
+                            result.append(".*");
+                        }
                     } else {
                         result.append("[^/]*");
                     }

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/util/GlobUtilTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/util/GlobUtilTest.java
@@ -34,6 +34,14 @@ public class GlobUtilTest {
         assertMatch("a**/b", Arrays.asList("a/b", "axy/b", "a/x/b"), Arrays.asList("a", "b", "a/bc", "bc/b"));
         assertMatch("a**b", Arrays.asList("ab", "axb", "axyb", "a/b", "a/x/b"), Arrays.asList("abc", "1ab"));
         assertMatch("a**b**/c", Arrays.asList("axbx/c", "axbx/c", "a/x/xbx/c", "axbx/xxx/c"), Arrays.asList("axbx/cc"));
+        assertMatch("**/*.txt", Arrays.asList("/test.txt", "test.txt", "/path/to/a.txt", "relative/path/to/a.txt"),
+                Arrays.asList("/test.py", "test.json", "/path/to/a.js", "relative/path/to/a.exe"));
+        assertMatch("foo/**/test.json",
+                Arrays.asList("foo/a/b/vd/test.json", "foo/test.json", "foo/42/test.json"),
+                Arrays.asList("/foo/path/to/test.json", "/test.py", "test.json", "/path/foo/test.json", "path/foo/test.json"));
+        assertMatch("foo/**/*.json",
+                Arrays.asList("foo/a/b/vd/a.json", "foo/dsa.json", "foo/32/test2.json"),
+                Arrays.asList("/foo/path/to/aasf.json", "/test.py", "test.json", "/path/foo/test.json", "path/foo/test.json"));
     }
 
     @Test

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -62,7 +62,7 @@
         <guava.failureaccess.version>1.0.1</guava.failureaccess.version><!-- keep in sync with guava.version -->
         <j2objc.annotations.version>2.8</j2objc.annotations.version><!-- keep in sync with guava.version -->
         <shrinkwrap-depchain.version>1.2.6</shrinkwrap-depchain.version>
-        <jboss-logmanager.version>3.1.0.Final</jboss-logmanager.version>
+        <jboss-logmanager.version>3.1.1.Final</jboss-logmanager.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <slf4j-api.version>2.0.6</slf4j-api.version>
         <graal-sdk.version>23.1.0</graal-sdk.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -62,7 +62,7 @@
         <guava.failureaccess.version>1.0.1</guava.failureaccess.version><!-- keep in sync with guava.version -->
         <j2objc.annotations.version>2.8</j2objc.annotations.version><!-- keep in sync with guava.version -->
         <shrinkwrap-depchain.version>1.2.6</shrinkwrap-depchain.version>
-        <jboss-logmanager.version>3.0.6.Final</jboss-logmanager.version>
+        <jboss-logmanager.version>3.1.0.Final</jboss-logmanager.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <slf4j-api.version>2.0.6</slf4j-api.version>
         <graal-sdk.version>23.1.0</graal-sdk.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -51,7 +51,7 @@
         <maven.version>3.9.8</maven.version>
         <assertj.version>3.26.3</assertj.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>
-        <jboss-logmanager.version>3.0.6.Final</jboss-logmanager.version>
+        <jboss-logmanager.version>3.1.0.Final</jboss-logmanager.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <gizmo.version>1.8.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -51,7 +51,7 @@
         <maven.version>3.9.8</maven.version>
         <assertj.version>3.26.3</assertj.version>
         <jboss-logging.version>3.6.0.Final</jboss-logging.version>
-        <jboss-logmanager.version>3.1.0.Final</jboss-logmanager.version>
+        <jboss-logmanager.version>3.1.1.Final</jboss-logmanager.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <gizmo.version>1.8.0</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/devmode-test/java/deployment/src/test/java/{package-name.dir}/test/{class-name-base}DevModeTest.tpl.qute.java
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/devmode-test/java/deployment/src/test/java/{package-name.dir}/test/{class-name-base}DevModeTest.tpl.qute.java
@@ -13,7 +13,7 @@ public class {class-name-base}DevModeTest {
     // Start hot reload (DevMode) test with your extension loaded
     @RegisterExtension
     static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest()
-        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Test
     public void writeYourOwnDevModeTest() {

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/unit-test/java/deployment/src/test/java/{package-name.dir}/test/{class-name-base}Test.tpl.qute.java
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/unit-test/java/deployment/src/test/java/{package-name.dir}/test/{class-name-base}Test.tpl.qute.java
@@ -13,7 +13,7 @@ public class {class-name-base}Test {
     // Start unit test with your extension loaded
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
-        .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Test
     public void writeYourOwnUnitTest() {

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/github-action/base/.github/workflows/ci.tpl.qute.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/github-action/base/.github/workflows/ci.tpl.qute.yml
@@ -12,22 +12,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Set up JDK {java.version}
         uses: actions/setup-java@v4
         with:
           java-version: {java.version}
           distribution: temurin
-          {#if buildtool.cli == 'gradle'}
+          {#if buildtool.cli.contains('gradle')}
           cache: gradle
           {#else}
           cache: maven
           {/if}
+
+     {#if buildtool.cli.contains('gradle')}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+     {/if}
       - name: Build
-        {#if buildtool.cli == 'gradle'}
-          uses: eskatos/gradle-command-action@v1
-          with:
-            arguments: {buildtool.cmd.build-ci}
-        {#else}
         run: {buildtool.cli} {buildtool.cmd.build-ci}
-        {/if}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -262,7 +262,23 @@ class QuarkusCodestartGenerationTest {
         checkGradle(projectDir);
 
         assertThatMatchSnapshot(testInfo, projectDir, ".github/workflows/ci.yml")
-                .satisfies(checkContains("run: ./gradlew build"));
+                .satisfies(
+                        checkContains("cache: gradle"),
+                        checkContains("run: ./gradlew build"));
+    }
+
+    @Test
+    public void generateMavenGithubAction(TestInfo testInfo) throws Throwable {
+        final QuarkusCodestartProjectInput input = newInputBuilder()
+                .buildTool(BuildTool.MAVEN)
+                .addData(getGenerationTestInputData())
+                .addCodestarts(Collections.singletonList("tooling-github-action"))
+                .build();
+        Path projectDir = testDirPath.resolve("maven-github");
+        getCatalog().createProject(input).generate(projectDir);
+
+        assertThatMatchSnapshot(testInfo, projectDir, ".github/workflows/ci.yml")
+                .satisfies(checkContains("cache: maven"));
     }
 
     @Test
@@ -279,8 +295,9 @@ class QuarkusCodestartGenerationTest {
         checkGradle(projectDir);
 
         assertThatMatchSnapshot(testInfo, projectDir, ".github/workflows/ci.yml")
-                .satisfies(checkContains("uses: eskatos/gradle-command-action@v1"))
-                .satisfies(checkContains("arguments: build"));
+                .satisfies(
+                        checkContains("uses: gradle/actions/setup-gradle"),
+                        checkContains("cache: gradle"));
     }
 
     private void checkDockerfiles(Path projectDir, BuildTool buildTool) {

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateGradleWrapperGithubAction/.github_workflows_ci.yml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateGradleWrapperGithubAction/.github_workflows_ci.yml
@@ -12,12 +12,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
-          cache: maven
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Build
         run: ./gradlew build

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenGithubAction/.github_workflows_ci.yml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenGithubAction/.github_workflows_ci.yml
@@ -19,10 +19,7 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
-          cache: gradle
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+          cache: maven
 
       - name: Build
-        run: gradle build
+        run: ./mvnw verify -B

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/BookRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/BookRepository.java
@@ -3,6 +3,9 @@ package io.quarkus.it.spring.data.jpa;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -44,6 +47,12 @@ public interface BookRepository extends Repository<Book, Integer> {
     // issue 9192
     @Query(value = "SELECT b.publicationYear FROM Book b where b.bid = :bid")
     Integer customFindPublicationYearObject(@Param("bid") Integer bid);
+
+    // Related to issue 41292
+    public default Page<Book> findPaged(Pageable pageable) {
+        List<Book> list = findAll();
+        return new PageImpl<>(list, pageable, list.size());
+    }
 
     interface BookCountByYear {
         int getPublicationYear();

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/BookResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/BookResource.java
@@ -8,7 +8,11 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 @Path("/book")
 public class BookResource {
@@ -113,6 +117,12 @@ public class BookResource {
     @Produces("text/plain")
     public Integer customFindPublicationYearObject(@PathParam("bid") Integer bid) {
         return bookRepository.customFindPublicationYearObject(bid);
+    }
+
+    @GET
+    @Path("/paged")
+    public Page<Book> getPaged(@QueryParam("size") int size, @QueryParam("page") int page) {
+        return bookRepository.findPaged(PageRequest.of(page, size));
     }
 
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/BookResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/BookResourceTest.java
@@ -1,13 +1,17 @@
 package io.quarkus.it.spring.data.jpa;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
 
 @QuarkusTest
 public class BookResourceTest {
@@ -131,5 +135,17 @@ public class BookResourceTest {
         when().get("/book/customPublicationYearObject/1").then()
                 .statusCode(200)
                 .body(is("2011"));
+    }
+
+    @Test
+    void testEnsureFieldPageableIsSerialized() {
+        Response response = given()
+                .accept("application/json")
+                .queryParam("size", "2")
+                .queryParam("page", "1")
+                .when().get("/book/paged");
+        Assertions.assertEquals(200, response.statusCode());
+        assertThat(response.body().jsonPath().getString("pageable")).contains("paged:true");
+        assertThat(response.body().jsonPath().getString("pageable")).contains("unpaged:false");
     }
 }


### PR DESCRIPTION
Here is a proposal of additional backports. I mentioned most of them but a few additional ones popped up:

- [Fix wrong generated web endpoint path on Windows](https://github.com/quarkusio/quarkus/commit/e4dc3791e8c2e2e7c40f5fd71420a09be30b5246) - this one is a regression due to a patch we already backported, reported and fixed by QE
- [Fix glob to regex conversation to properly handle **/*.suffix](https://github.com/quarkusio/quarkus/commit/15f3104b0b9a2dfd9edd36301bcf576eb0c3318d) - this one can be very annoying and has proper tests
- JBoss LogManager update
- Default to old console patch
- [Bump org.asynchttpclient:async-http-client from 2.12.3 to 2.12.4](https://github.com/quarkusio/quarkus/commit/86f8679d1f4565b86fb6033f3df156fc50f61e5d) - this one fixes a CVE and is only used by Pulsar so I think it's an easy win - see https://access.redhat.com/security/cve/CVE-2024-53990, severity important with score 8.1
- [Register for reflection Pageable class for not missing paged/unpaged](https://github.com/quarkusio/quarkus/commit/1e52cec031054595a7d83ae887426f3a06047b27) - this one fixes an old regression reported by QE in June

I will let you comment and I can reduce the payload if need be.