### PR TITLE
Send SentMail Instances When Sending Emails

### DIFF
--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/SentMail.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/SentMail.java
@@ -1,0 +1,44 @@
+package io.quarkus.mailer;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Flow;
+
+/**
+ * Represents a sent mail.
+ * Instances of this class are sent using CDI events.
+ *
+ * @param from the sender address
+ * @param to the list of recipients
+ * @param cc the list of CC recipients
+ * @param bcc the list of BCC recipients
+ * @param replyTo the list of reply-to addresses
+ * @param bounceAddress the bounce address
+ * @param subject the subject
+ * @param textBody the text body
+ * @param htmlBody the HTML body
+ * @param headers the headers
+ * @param attachments the attachments
+ */
+public record SentMail(String from,
+        List<String> to, List<String> cc, List<String> bcc,
+        String replyTo, String bounceAddress,
+        String subject, String textBody, String htmlBody,
+        Map<String, List<String>> headers, List<SentAttachment> attachments) {
+
+    /**
+     * An immutable representation of an attachment that has been sent.
+     *
+     * @param name the name
+     * @param file the file
+     * @param description the description
+     * @param disposition the disposition
+     * @param data the data
+     * @param contentType the content type
+     * @param contentId the content ID
+     */
+    public record SentAttachment(String name, File file, String description, String disposition,
+            Flow.Publisher<Byte> data, String contentType, String contentId) {
+    }
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.mailer.runtime;
 import static java.util.Arrays.stream;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -13,10 +14,13 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.event.Event;
+
 import org.jboss.logging.Logger;
 
 import io.quarkus.mailer.Attachment;
 import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.SentMail;
 import io.quarkus.mailer.reactive.ReactiveMailer;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -51,10 +55,11 @@ public class MutinyMailerImpl implements ReactiveMailer {
     private final boolean logRejectedRecipients;
 
     private final boolean logInvalidRecipients;
+    private final Event<SentMail> sentEmailEvent;
 
     MutinyMailerImpl(Vertx vertx, MailClient client, MockMailboxImpl mockMailbox,
             String from, String bounceAddress, boolean mock, List<Pattern> approvedRecipients,
-            boolean logRejectedRecipients, boolean logInvalidRecipients) {
+            boolean logRejectedRecipients, boolean logInvalidRecipients, Event<SentMail> sentEmailEvent) {
         this.vertx = vertx;
         this.client = client;
         this.mockMailbox = mockMailbox;
@@ -64,6 +69,7 @@ public class MutinyMailerImpl implements ReactiveMailer {
         this.approvedRecipients = approvedRecipients;
         this.logRejectedRecipients = logRejectedRecipients;
         this.logInvalidRecipients = logInvalidRecipients;
+        this.sentEmailEvent = sentEmailEvent;
     }
 
     @Override
@@ -128,10 +134,38 @@ public class MutinyMailerImpl implements ReactiveMailer {
                     message.getCc(), message.getBcc(),
                     message.getText() == null ? "<empty>" : message.getText(),
                     message.getHtml() == null ? "<empty>" : message.getHtml());
-            return mockMailbox.send(mail, message);
+            return mockMailbox.send(mail, message)
+                    .invoke(() -> fire(mail, message));
         } else {
             return client.sendMail(message)
+                    .invoke(() -> fire(mail, message))
                     .replaceWithVoid();
+        }
+    }
+
+    private Map<String, List<String>> copy(MultiMap headers) {
+        return headers.entries().stream()
+                .collect(
+                        Collectors.groupingBy(Map.Entry::getKey, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+    }
+
+    private List<SentMail.SentAttachment> copy(List<Attachment> attachments) {
+        return attachments.stream()
+                .map(attachment -> new SentMail.SentAttachment(attachment.getName(), attachment.getFile(),
+                        attachment.getDescription(), attachment.getDisposition(), attachment.getData(),
+                        attachment.getContentType(), attachment.getContentId()))
+                .collect(Collectors.toList());
+    }
+
+    private void fire(Mail mail, MailMessage message) {
+        if (sentEmailEvent != null) {
+            SentMail sentMail = new SentMail(message.getFrom(),
+                    Collections.unmodifiableList(message.getTo()), Collections.unmodifiableList(message.getCc()),
+                    Collections.unmodifiableList(message.getBcc()),
+                    mail.getReplyTo(), message.getBounceAddress(),
+                    message.getSubject(), message.getText(), message.getHtml(),
+                    copy(message.getHeaders()), copy(mail.getAttachments()));
+            sentEmailEvent.fire(sentMail);
         }
     }
 

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
@@ -79,7 +79,7 @@ public class FakeSmtpTestBase {
                     public void register(String name, TlsConfiguration configuration) {
                         throw new UnsupportedOperationException();
                     }
-                });
+                }, null);
         return mailers.reactiveMailerFromName(Mailers.DEFAULT_MAILER_NAME);
     }
 
@@ -108,7 +108,7 @@ public class FakeSmtpTestBase {
                     public void register(String name, TlsConfiguration configuration) {
                         throw new UnsupportedOperationException();
                     }
-                });
+                }, null);
         return mailers.reactiveMailerFromName(Mailers.DEFAULT_MAILER_NAME);
     }
 

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerImplTest.java
@@ -59,7 +59,7 @@ class MailerImplTest {
         mailer = new MutinyMailerImpl(vertx,
                 MailClient.createShared(vertx,
                         new MailConfig().setPort(wiser.getServer().getPort())),
-                null, FROM, null, false, List.of(), false, false);
+                null, FROM, null, false, List.of(), false, false, null);
 
         wiser.getMessages().clear();
     }
@@ -271,7 +271,7 @@ class MailerImplTest {
 
     private String read(BodyPart part) throws IOException, MessagingException {
         try (InputStream is = part.getInputStream()) {
-            Scanner s = new Scanner(is, "UTF-8").useDelimiter("\\A");
+            Scanner s = new Scanner(is, StandardCharsets.UTF_8).useDelimiter("\\A");
             return s.hasNext() ? s.next() : "";
         }
     }

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerWithMultipartImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerWithMultipartImplTest.java
@@ -62,7 +62,7 @@ class MailerWithMultipartImplTest {
     void init() {
         mailer = new MutinyMailerImpl(vertx, MailClient.createShared(vertx,
                 new MailConfig().setPort(wiser.getServer().getPort()).setMultiPartOnly(true)), null,
-                FROM, null, false, List.of(), false, false);
+                FROM, null, false, List.of(), false, false, null);
 
         wiser.getMessages().clear();
     }
@@ -261,7 +261,7 @@ class MailerWithMultipartImplTest {
 
     private String read(BodyPart part) throws IOException, MessagingException {
         try (InputStream is = part.getInputStream()) {
-            Scanner s = new Scanner(is, "UTF-8").useDelimiter("\\A");
+            Scanner s = new Scanner(is, StandardCharsets.UTF_8).useDelimiter("\\A");
             return s.hasNext() ? s.next() : "";
         }
     }

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MockMailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MockMailerImplTest.java
@@ -35,7 +35,7 @@ class MockMailerImplTest {
     @BeforeEach
     void init() {
         mockMailbox = new MockMailboxImpl();
-        mailer = new MutinyMailerImpl(vertx, null, mockMailbox, FROM, null, true, List.of(), false, false);
+        mailer = new MutinyMailerImpl(vertx, null, mockMailbox, FROM, null, true, List.of(), false, false, null);
     }
 
     @Test


### PR DESCRIPTION
This PR introduces the use of CDI events to emit instances of SentMail whenever an email is successfully sent.

The SentMail class is an immutable representation of the sent email, preventing unintended modifications. This approach avoids the need to introduce a new API by leveraging CDI events.

Fixes https://github.com/quarkusio/quarkus/issues/45135.
