### PR TITLE
ThrowMissingRegistrationErrors: AWT Desktop i18N, SPI for ImageIO

### DIFF
--- a/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/JDKSubstitutions.java
+++ b/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/JDKSubstitutions.java
@@ -61,5 +61,43 @@ final class Target_sun_awt_FontConfiguration {
     }
 }
 
+/**
+ * We get rid of ResourceBundle.getBundle(...) for
+ * sun.awt.resources.awt
+ * sun/awt/resources/awt.properties
+ * sun.awt.resources.awt_en
+ * sun/awt/resources/awt_en.properties
+ * sun.awt.resources.awt_en_US
+ * sun/awt/resources/awt_en_US.properties
+ * we don't include those bundles anyway, so the search is in vain,
+ * and we don't need those as they contain strings for GUI elements,
+ * useless in our exclusively headless setup.
+ * See https://github.com/quarkusio/quarkus/issues/44622
+ */
+@TargetClass(className = "java.awt.Toolkit$4")
+final class Target_java_awt_Toolkit$4 {
+    @Substitute
+    public Void run() {
+        return null;
+    }
+}
+
+/**
+ * TODO: This is perhaps too harsh, is it needed?
+ * See See https://github.com/quarkusio/quarkus/issues/44622
+ */
+@TargetClass(className = "javax.imageio.spi.IIORegistry")
+final class Target_javax_imageio_spi_IIORegistry {
+    @Substitute
+    private void registerInstalledProviders() {
+        // Do nothing. We don't support ImageIO plugins via META-INF/services anyway.
+    }
+
+    @Substitute
+    private void registerApplicationClasspathSpis() {
+        // Do nothing. We don't support ImageIO plugins found on classpath.
+    }
+}
+
 public class JDKSubstitutions {
 }


### PR DESCRIPTION
Fixes #44622
...although "fixes" is a rather too nice a statement. It feels like @zakkak reported a crack in a fine pottery and I provided a fix fit a hammer.

## Resource bundles in java.awt.Toolkit

This is fine. All those resource bundles are for Desktop UI we don't support. Quarkus support int he core repo is strictly about server side image processing.

## ImageIO SPI

I find this potentially problematic. If you write your own plugin and you would like to register it to be known at build time, this substitution cripples the ability to load it. The core test suite passes though.

## Summary

The warnings, triggered as:

```
$ ./mvnw clean package -Dnative -Dnative.surefire.skip 
   -Dquarkus.native.enable-reports -pl integration-tests/awt 
   -Dquarkus.native.additional-build-args=-H:ThrowMissingRegistrationErrors= 

$  ./integration-tests/awt/target/quarkus-integration-test-awt-999-SNAPSHOT-runner -XX:MissingRegistrationReportingMode=Warn
```

Are all gone expect for those AWT unrelated:

```
com.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: The program tried to access the resource at path

   application.properties

without it being registered as reachable. Add it to the resource metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#resources-and-resource-bundles for help
  java.base@23.0.1/java.lang.ClassLoader.getResources(ClassLoader.java:101)
  io.smallrye.common.classloader.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:84)
  io.smallrye.config.AbstractLocationConfigSourceLoader.tryClassPath(AbstractLocationConfigSourceLoader.java:144)
  io.smallrye.config.AbstractLocationConfigSourceLoader.loadConfigSources(AbstractLocationConfigSourceLoader.java:107)


com.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: The program tried to access the resource at path

   application.properties

without it being registered as reachable. Add it to the resource metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#resources-and-resource-bundles for help
  java.base@23.0.1/java.lang.ClassLoader.getResources(ClassLoader.java:102)
  io.smallrye.common.classloader.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:84)
  io.smallrye.config.AbstractLocationConfigSourceLoader.tryClassPath(AbstractLocationConfigSourceLoader.java:144)
  io.smallrye.config.AbstractLocationConfigSourceLoader.loadConfigSources(AbstractLocationConfigSourceLoader.java:107)


com.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: The program tried to access the resource at path

   META-INF/microprofile-config.properties

without it being registered as reachable. Add it to the resource metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#resources-and-resource-bundles for help
  java.base@23.0.1/java.lang.ClassLoader.getResources(ClassLoader.java:101)
  io.smallrye.common.classloader.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:84)
  io.smallrye.config.AbstractLocationConfigSourceLoader.tryClassPath(AbstractLocationConfigSourceLoader.java:144)
  io.smallrye.config.AbstractLocationConfigSourceLoader.loadConfigSources(AbstractLocationConfigSourceLoader.java:107)


com.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: The program tried to access the resource at path

   META-INF/microprofile-config.properties

without it being registered as reachable. Add it to the resource metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#resources-and-resource-bundles for help
  java.base@23.0.1/java.lang.ClassLoader.getResources(ClassLoader.java:102)
  io.smallrye.common.classloader.ClassPathUtils.consumeAsPaths(ClassPathUtils.java:84)
  io.smallrye.config.AbstractLocationConfigSourceLoader.tryClassPath(AbstractLocationConfigSourceLoader.java:144)
  io.smallrye.config.AbstractLocationConfigSourceLoader.loadConfigSources(AbstractLocationConfigSourceLoader.java:107)
```

As you can see, the main config file for Quarkus is being looked up until it's found. I'd like to have some better tool on the GraalVM side to address this. Something like `-H:ExcludeResources=...` but let's say `-H:IgnoreResources=...` or something like that. To tell the app that it's O.K. these resources weren't found and that we don't care...?

WDYT?

