### PR TITLE
Add support for ping message callbacks to WebSockets Next

### DIFF
--- a/docs/src/main/asciidoc/websockets-next-reference.adoc
+++ b/docs/src/main/asciidoc/websockets-next-reference.adoc
@@ -79,7 +79,7 @@ implementation("io.quarkus:quarkus-websockets-next")
 
 Both the <<server-api>> and <<client-api>> define _endpoints_ that are used to consume and send messages.
 The endpoints are implemented as CDI beans and support injection.
-Endpoints declare <<callback-methods,_callback methods_>> annotated with `@OnTextMessage`, `@OnBinaryMessage`, `@OnPong`, `@OnOpen`, `@OnClose` and `@OnError`.
+Endpoints declare <<callback-methods,_callback methods_>> annotated with `@OnTextMessage`, `@OnBinaryMessage`, `@OnPingMessage`, `@OnPongMessage`, `@OnOpen`, `@OnClose` and `@OnError`.
 These methods are used to handle various WebSocket events.
 Typically, a method annotated with `@OnTextMessage` is called when the connected client sends a message to the server and vice versa.
 
@@ -210,6 +210,7 @@ A WebSocket endpoint may declare:
 
 * At most one `@OnTextMessage` method: Handles the text messages from the connected client/server.
 * At most one `@OnBinaryMessage` method: Handles the binary messages from the connected client/server.
+* At most one `@OnPingMessage` method: Handles the ping messages from the connected client/server.
 * At most one `@OnPongMessage` method: Handles the pong messages from the connected client/server.
 * At most one `@OnOpen` method: Invoked when a connection is opened.
 * At most one `@OnClose` method: Executed when the connection is closed.
@@ -551,38 +552,54 @@ Item find(Item item) {
 1. Specify the codec to use for the deserialization of the incoming message
 2. Specify the codec to use for the serialization of the outgoing message
 
-=== Ping/pong messages
+=== Ping/Pong messages
 
 A https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2[ping message] may serve as a keepalive or to verify the remote endpoint.
 A https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.3[pong message] is sent in response to a ping message and it must have an identical payload.
 
-Server/client endpoints automatically respond to a ping message sent from the client/server.
-In other words, there is no need for `@OnPingMessage` callback declared on an endpoint.
+==== Sending ping messages
 
-The server can send ping messages to a connected client.
-`WebSocketConnection`/`WebSocketClientConnection` declare methods to send ping messages; there is a non-blocking variant: `sendPing(Buffer)` and a blocking variant: `sendPingAndAwait(Buffer)`.
-By default, the ping messages are not sent automatically.
-However, the configuration properties `quarkus.websockets-next.server.auto-ping-interval` and `quarkus.websockets-next.client.auto-ping-interval` can be used to set the interval after which, the server/client sends a ping message to a connected client/server automatically.
+Ping messages are optional and not sent by default. However, server and client endpoints can be configured to automatically send ping messages on an interval.
 
 [source,properties]
 ----
 quarkus.websockets-next.server.auto-ping-interval=2 <1>
+quarkus.websockets-next.client.auto-ping-interval=10 <2>
 ----
-<1> Sends a ping message from the server to a connected client every 2 seconds.
+<1> Sends a ping message from the server to each connected client every 2 seconds.
+<2> Sends a ping message from all connected client instances to their remote servers every 10 seconds.
 
-The `@OnPongMessage` annotation is used to define a callback that consumes pong messages sent from the client/server.
-An endpoint must declare at most one method annotated with `@OnPongMessage`.
+Servers and clients can send ping messages programmatically at any time using `WebSocketConnection` or `WebSocketClientConnection`.
+There is a non-blocking variant: `Sender#sendPing(Buffer)` and a blocking variant: `Sender#sendPingAndAwait(Buffer)`.
+
+==== Sending pong messages
+
+Server and client endpoints will always respond to a ping message sent from the remote party with a corresponding pong message, using the application data from the ping message.
+This behavior is built-in and requires no additional code or configuration.
+
+Servers and clients can send unsolicited pong messages that may serve as a unidirectional heartbeat using `WebSocketConnection` or `WebSocketClientConnection`. There is a non-blocking variant: `Sender#sendPong(Buffer)` and a blocking variant: `Sender#sendPongAndAwait(Buffer)`.
+
+==== Handling ping/pong messages
+
+Because ping messages are handled automatically and pong messages require no response, it is not necessary to write handlers for these messages to comply with the WebSocket protocol.
+However, it is sometimes useful to know when ping or pong messages are received by an endpoint.
+
+The `@OnPingMessage` and `@OnPongMessage` annotations can be used to define callbacks that consume ping or pong messages sent from the remote party.
+An endpoint may declare at most one `@OnPingMessage` callback and at most  one `@OnPongMessage` callback.
 The callback method must return either `void` or `Uni<Void>` (or be a Kotlin `suspend` function returning `Unit`), and it must accept a single parameter of type `Buffer`.
 
 [source,java]
 ----
+@OnPingMessage
+void ping(Buffer data) {
+    // an incoming ping that will automatically receive a pong
+}
+
 @OnPongMessage
 void pong(Buffer data) {
-    // ....
+    // an incoming pong in response to the last ping sent
 }
 ----
-
-NOTE: The server/client can also send unsolicited pong messages that may serve as a unidirectional heartbeat. There is a non-blocking variant: `WebSocketConnection#sendPong(Buffer)` and also a blocking variant: `WebSocketConnection#sendPongAndAwait(Buffer)`.
 
 [[inbound-processing-mode]]
 === Inbound processing mode

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/Callback.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/Callback.java
@@ -56,6 +56,8 @@ public class Callback {
             this.messageType = MessageType.BINARY;
         } else if (WebSocketDotNames.ON_TEXT_MESSAGE.equals(annotation.name())) {
             this.messageType = MessageType.TEXT;
+        } else if (WebSocketDotNames.ON_PING_MESSAGE.equals(annotation.name())) {
+            this.messageType = MessageType.PING;
         } else if (WebSocketDotNames.ON_PONG_MESSAGE.equals(annotation.name())) {
             this.messageType = MessageType.PONG;
         } else {
@@ -123,7 +125,7 @@ public class Callback {
     }
 
     public boolean acceptsBinaryMessage() {
-        return messageType == MessageType.BINARY || messageType == MessageType.PONG;
+        return messageType == MessageType.BINARY || messageType == MessageType.PING || messageType == MessageType.PONG;
     }
 
     public boolean acceptsMulti() {
@@ -162,6 +164,7 @@ public class Callback {
 
     public enum MessageType {
         NONE,
+        PING,
         PONG,
         TEXT,
         BINARY

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgument.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/CallbackArgument.java
@@ -89,6 +89,7 @@ interface CallbackArgument {
         default boolean acceptsMessage() {
             return WebSocketDotNames.ON_BINARY_MESSAGE.equals(callbackAnnotation().name())
                     || WebSocketDotNames.ON_TEXT_MESSAGE.equals(callbackAnnotation().name())
+                    || WebSocketDotNames.ON_PING_MESSAGE.equals(callbackAnnotation().name())
                     || WebSocketDotNames.ON_PONG_MESSAGE.equals(callbackAnnotation().name());
         }
 

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketDotNames.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketDotNames.java
@@ -10,6 +10,7 @@ import io.quarkus.websockets.next.OnBinaryMessage;
 import io.quarkus.websockets.next.OnClose;
 import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnPingMessage;
 import io.quarkus.websockets.next.OnPongMessage;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.PathParam;
@@ -37,6 +38,7 @@ final class WebSocketDotNames {
     static final DotName ON_OPEN = DotName.createSimple(OnOpen.class);
     static final DotName ON_TEXT_MESSAGE = DotName.createSimple(OnTextMessage.class);
     static final DotName ON_BINARY_MESSAGE = DotName.createSimple(OnBinaryMessage.class);
+    static final DotName ON_PING_MESSAGE = DotName.createSimple(OnPingMessage.class);
     static final DotName ON_PONG_MESSAGE = DotName.createSimple(OnPongMessage.class);
     static final DotName ON_CLOSE = DotName.createSimple(OnClose.class);
     static final DotName ON_ERROR = DotName.createSimple(OnError.class);
@@ -57,5 +59,5 @@ final class WebSocketDotNames {
     static final DotName TRANSACTIONAL = DotName.createSimple("jakarta.transaction.Transactional");
 
     static final List<DotName> CALLBACK_ANNOTATIONS = List.of(ON_OPEN, ON_CLOSE, ON_BINARY_MESSAGE, ON_TEXT_MESSAGE,
-            ON_PONG_MESSAGE, ON_ERROR);
+            ON_PING_MESSAGE, ON_PONG_MESSAGE, ON_ERROR);
 }

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketEndpointBuildItem.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/WebSocketEndpointBuildItem.java
@@ -26,14 +26,15 @@ public final class WebSocketEndpointBuildItem extends MultiBuildItem {
     public final Callback onOpen;
     public final Callback onTextMessage;
     public final Callback onBinaryMessage;
+    public final Callback onPingMessage;
     public final Callback onPongMessage;
     public final Callback onClose;
     public final List<Callback> onErrors;
 
     WebSocketEndpointBuildItem(boolean isClient, BeanInfo bean, String path, String id,
             InboundProcessingMode inboundProcessingMode,
-            Callback onOpen, Callback onTextMessage, Callback onBinaryMessage, Callback onPongMessage, Callback onClose,
-            List<Callback> onErrors) {
+            Callback onOpen, Callback onTextMessage, Callback onBinaryMessage, Callback onPingMessage,
+            Callback onPongMessage, Callback onClose, List<Callback> onErrors) {
         this.isClient = isClient;
         this.bean = bean;
         this.path = path;
@@ -42,6 +43,7 @@ public final class WebSocketEndpointBuildItem extends MultiBuildItem {
         this.onOpen = onOpen;
         this.onTextMessage = onTextMessage;
         this.onBinaryMessage = onBinaryMessage;
+        this.onPingMessage = onPingMessage;
         this.onPongMessage = onPongMessage;
         this.onClose = onClose;
         this.onErrors = onErrors;

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/devui/WebSocketServerDevUIProcessor.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/devui/WebSocketServerDevUIProcessor.java
@@ -68,6 +68,7 @@ public class WebSocketServerDevUIProcessor {
             addCallback(endpoint.onOpen, callbacks);
             addCallback(endpoint.onBinaryMessage, callbacks);
             addCallback(endpoint.onTextMessage, callbacks);
+            addCallback(endpoint.onPingMessage, callbacks);
             addCallback(endpoint.onPongMessage, callbacks);
             addCallback(endpoint.onClose, callbacks);
             for (Callback c : endpoint.onErrors) {

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/BasicConnectorTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/client/BasicConnectorTest.java
@@ -59,6 +59,7 @@ public class BasicConnectorTest {
         assertThrows(NullPointerException.class, () -> connector.onTextMessage(null));
         assertThrows(NullPointerException.class, () -> connector.onOpen(null));
         assertThrows(NullPointerException.class, () -> connector.onClose(null));
+        assertThrows(NullPointerException.class, () -> connector.onPing(null));
         assertThrows(NullPointerException.class, () -> connector.onPong(null));
         assertThrows(NullPointerException.class, () -> connector.onError(null));
 

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/pingpong/ClientAutoPingIntervalTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/pingpong/ClientAutoPingIntervalTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.websockets.next.test.client;
+package io.quarkus.websockets.next.test.pingpong;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/pingpong/ServerAutoPingIntervalTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/pingpong/ServerAutoPingIntervalTest.java
@@ -21,7 +21,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.WebSocketClient;
 
-public class AutoPingIntervalTest {
+public class ServerAutoPingIntervalTest {
 
     @RegisterExtension
     public static final QuarkusUnitTest test = new QuarkusUnitTest()

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/BasicWebSocketConnector.java
@@ -157,6 +157,15 @@ public interface BasicWebSocketConnector {
     BasicWebSocketConnector onBinaryMessage(BiConsumer<WebSocketClientConnection, Buffer> consumer);
 
     /**
+     * Set a callback to be invoked when a ping message is received from the server.
+     *
+     * @param consumer
+     * @return self
+     * @see #executionModel(ExecutionModel)
+     */
+    BasicWebSocketConnector onPing(BiConsumer<WebSocketClientConnection, Buffer> consumer);
+
+    /**
      * Set a callback to be invoked when a pong message is received from the server.
      *
      * @param consumer

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/OnPingMessage.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/OnPingMessage.java
@@ -1,0 +1,48 @@
+package io.quarkus.websockets.next;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * {@link WebSocket} and {@link WebSocketClient} endpoint methods annotated with this annotation consume ping messages. An
+ * endpoint may declare at most one method annotated with this annotation.
+ *
+ * <h2>Execution model</h2>
+ *
+ * <ul>
+ * <li>Methods annotated with {@link io.smallrye.common.annotation.RunOnVirtualThread} are considered blocking and should be
+ * executed on a virtual thread.</li>
+ * <li>Methods annotated with {@link io.smallrye.common.annotation.Blocking} are considered blocking and should be executed on a
+ * worker thread.</li>
+ * <li>Methods annotated with {@link io.smallrye.common.annotation.NonBlocking} are considered non-blocking and should be
+ * executed on an event loop thread.</li>
+ * </ul>
+ *
+ * Execution model for methods which don't declare any of the annotation listed above is derived from the return type:
+ * <p>
+ * <ul>
+ * <li>Methods returning {@code void} are considered blocking and should be executed on a worker thread.</li>
+ * <li>Methods returning {@code io.smallrye.mutiny.Uni<Void>} are considered non-blocking and should be executed on an event
+ * loop thread.</li>
+ * </ul>
+ *
+ * <h2>Method parameters</h2>
+ *
+ * The method must accept exactly one ping message parameter represented as a {@link io.vertx.core.buffer.Buffer}. The method
+ * may also accept the following parameters:
+ * <ul>
+ * <li>{@link WebSocketConnection}/{@link WebSocketClientConnection}; depending on the endpoint type</li>
+ * <li>{@link HandshakeRequest}</li>
+ * <li>{@link String} parameters annotated with {@link PathParam}</li>
+ * </ul>
+ * <p>
+ *
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface OnPingMessage {
+
+}

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocket.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocket.java
@@ -12,8 +12,8 @@ import jakarta.inject.Singleton;
 /**
  * Denotes a WebSocket server endpoint.
  * <p>
- * An endpoint must declare a method annotated with {@link OnTextMessage}, {@link OnBinaryMessage}, {@link OnPongMessage} or
- * {@link OnOpen}. An endpoint may declare a method annotated with {@link OnClose}.
+ * An endpoint must declare a method annotated with {@link OnTextMessage}, {@link OnBinaryMessage}, {@link OnPingMessage},
+ * {@link OnPongMessage} or {@link OnOpen}. An endpoint may declare a method annotated with {@link OnClose}.
  *
  * <h2>Lifecycle and concurrency</h2>
  * Endpoint implementation class must be a CDI bean. If no scope annotation is defined then {@link Singleton} is used.

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClient.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/WebSocketClient.java
@@ -12,8 +12,8 @@ import jakarta.inject.Singleton;
 /**
  * Denotes a WebSocket client endpoint.
  * <p>
- * An endpoint must declare a method annotated with {@link OnTextMessage}, {@link OnBinaryMessage}, {@link OnPongMessage} or
- * {@link OnOpen}. An endpoint may declare a method annotated with {@link OnClose}.
+ * An endpoint must declare a method annotated with {@link OnTextMessage}, {@link OnBinaryMessage}, {@link OnPingMessage},
+ * {@link OnPongMessage} or {@link OnOpen}. An endpoint may declare a method annotated with {@link OnClose}.
  *
  * <h2>Lifecycle and concurrency</h2>
  * Client endpoint implementation class must be a CDI bean. If no scope annotation is defined then {@link Singleton} is used.

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpoint.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpoint.java
@@ -60,6 +60,14 @@ public interface WebSocketEndpoint {
         throw new UnsupportedOperationException();
     }
 
+    // @OnPingMessage
+
+    Future<Void> onPingMessage(Buffer message);
+
+    default ExecutionModel onPingMessageExecutionModel() {
+        return ExecutionModel.NONE;
+    }
+
     // @OnPongMessage
 
     Future<Void> onPongMessage(Buffer message);

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpointBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketEndpointBase.java
@@ -86,6 +86,11 @@ public abstract class WebSocketEndpointBase implements WebSocketEndpoint {
     }
 
     @Override
+    public Future<Void> onPingMessage(Buffer message) {
+        return execute(message, onPingMessageExecutionModel(), this::doOnPingMessage, false);
+    }
+
+    @Override
     public Future<Void> onPongMessage(Buffer message) {
         return execute(message, onPongMessageExecutionModel(), this::doOnPongMessage, false);
     }
@@ -279,6 +284,10 @@ public abstract class WebSocketEndpointBase implements WebSocketEndpoint {
     }
 
     protected Uni<Void> doOnBinaryMessage(Object message) {
+        return Uni.createFrom().voidItem();
+    }
+
+    protected Uni<Void> doOnPingMessage(Buffer message) {
         return Uni.createFrom().voidItem();
     }
 

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/telemetry/ForwardingWebSocketEndpoint.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/telemetry/ForwardingWebSocketEndpoint.java
@@ -76,6 +76,16 @@ abstract class ForwardingWebSocketEndpoint implements WebSocketEndpoint {
     }
 
     @Override
+    public Future<Void> onPingMessage(Buffer message) {
+        return delegate.onPingMessage(message);
+    }
+
+    @Override
+    public ExecutionModel onPingMessageExecutionModel() {
+        return delegate.onPingMessageExecutionModel();
+    }
+
+    @Override
     public Future<Void> onPongMessage(Buffer message) {
         return delegate.onPongMessage(message);
     }


### PR DESCRIPTION
This PR adds an `@OnPingMessage` companion to `@OnPongMessage` for WebSockets Next endpoints. This is useful for endpoints that want to observe ping frames arriving from remote parties. Under the covers it uses the Vert.x frameHandler.