### PR TITLE
Make abstract OIDC config classes undeprecated

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
@@ -4,10 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-/**
- * @deprecated use the {@link io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig} interface instead
- */
-@Deprecated(since = "3.18")
 public abstract class OidcClientCommonConfig extends OidcCommonConfig
         implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig {
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -5,10 +5,6 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-/**
- * @deprecated use the {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfig} interface instead
- */
-@Deprecated(since = "3.18")
 public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime.config.OidcCommonConfig {
 
     public OidcCommonConfig() {


### PR DESCRIPTION
This PR removes `@Deprecated` from abstract OIDC config classes as a lot of OIDC code gets deprecated warnings, even though it uses `OidcTenantConfig` interface methods on the legacy `OidcTenantConfig`. The old config methods on those abstract classes are deprecated, so there is no chance users would not notice if they miss using `@ConfigMapping`. 
I propose to deprecate the whole OidcTenantConfig tree once we are ready
 