### PR TITLE
Support custom thread pool in quartz

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
@@ -43,6 +43,15 @@ public class QuartzBuildTimeConfig {
     public StoreType storeType;
 
     /**
+     * The class name of the thread pool implementation to use.
+     * <p>
+     * It's important to bear in mind that Quartz threads are not used to execute scheduled methods, instead the regular Quarkus
+     * thread pool is used by default. See also {@code quarkus.quartz.run-blocking-scheduled-method-on-quartz-thread}.
+     */
+    @ConfigItem(defaultValue = "org.quartz.simpl.SimpleThreadPool")
+    public String threadPoolClass;
+
+    /**
      * The name of the datasource to use.
      * <p>
      * Ignored if using a `ram` store i.e {@link StoreType#RAM}.

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -579,7 +579,7 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
         props.put(StdSchedulerFactory.PROP_SCHED_MAX_BATCH_SIZE, "" + runtimeConfig.batchTriggerAcquisitionMaxCount);
         props.put(StdSchedulerFactory.PROP_SCHED_WRAP_JOB_IN_USER_TX, "false");
         props.put(StdSchedulerFactory.PROP_SCHED_SCHEDULER_THREADS_INHERIT_CONTEXT_CLASS_LOADER_OF_INITIALIZING_THREAD, "true");
-        props.put(StdSchedulerFactory.PROP_THREAD_POOL_CLASS, "org.quartz.simpl.SimpleThreadPool");
+        props.put(StdSchedulerFactory.PROP_THREAD_POOL_CLASS, buildTimeConfig.threadPoolClass);
         props.put(StdSchedulerFactory.PROP_SCHED_CLASS_LOAD_HELPER_CLASS, InitThreadContextClassLoadHelper.class.getName());
         props.put(StdSchedulerFactory.PROP_THREAD_POOL_PREFIX + ".threadCount", "" + runtimeConfig.threadCount);
         props.put(StdSchedulerFactory.PROP_THREAD_POOL_PREFIX + ".threadPriority", "" + runtimeConfig.threadPriority);


### PR DESCRIPTION
Tested both jvm and native ~~(needs to be registered for reflection)~~

Using property: quarkus.quartz.thread-pool-class=org.acme.SimpleVirtualThreadPool

Sample class
```java
package org.acme;

import java.util.concurrent.ExecutorService;
import java.util.concurrent.Executors;

import org.quartz.SchedulerConfigException;
import org.quartz.spi.ThreadPool;

import io.quarkus.runtime.annotations.RegisterForReflection;
import lombok.Getter;
import lombok.Setter;

@Getter
@Setter
public class SimpleVirtualThreadPool implements ThreadPool {

    private int threadCount = -1;

    private int threadPriority = Thread.NORM_PRIORITY;

    private static ExecutorService getVirtualExecutor() {
        return Executors.newVirtualThreadPerTaskExecutor();
    }

    private ExecutorService executorService = null;

    public SimpleVirtualThreadPool() {}

    @Override
    public boolean runInThread(Runnable runnable) {
        if (executorService != null) {
            executorService.submit(runnable);
            return true;
        }
        return false;
    }

    @Override
    public int blockForAvailableThreads() {
        return Integer.MAX_VALUE; // does not block, there is potentially no limit
    }

    @Override
    public void initialize() throws SchedulerConfigException {
        executorService = getVirtualExecutor();
        if (executorService == null) {
            throw new SchedulerConfigException("Virtual Threads are not supported!");
        }
    }

    @Override
    public void shutdown(boolean waitForJobsToComplete) {
        if (waitForJobsToComplete) {
            executorService.shutdown();
        } else {
            executorService.shutdownNow();
        }
    }

    @Override
    public int getPoolSize() {
        return Integer.MAX_VALUE; // because it is unlimited
    }

    @Override
    public void setInstanceId(String schedInstId) {}

    @Override
    public void setInstanceName(String schedName) {}
```

- Fixes: https://github.com/quarkusio/quarkus/issues/45182
