### PR TITLE
Support RunOnVirtualThread annotations on beans implementing a JAX-RS interface

### DIFF
--- a/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/JaxrsMethodsProcessor.java
+++ b/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/JaxrsMethodsProcessor.java
@@ -2,15 +2,20 @@ package io.quarkus.resteasy.reactive.common.deployment;
 
 import java.util.function.Predicate;
 
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
 
+import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
 
 public class JaxrsMethodsProcessor {
     @BuildStep
-    ExecutionModelAnnotationsAllowedBuildItem jaxrsMethods() {
+    ExecutionModelAnnotationsAllowedBuildItem jaxrsMethods(BeanArchiveIndexBuildItem beanArchiveIndex) {
+        IndexView index = beanArchiveIndex.getIndex();
         return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
             @Override
             public boolean test(MethodInfo method) {
@@ -19,7 +24,29 @@ public class JaxrsMethodsProcessor {
                 if (method.declaringClass().hasDeclaredAnnotation(ResteasyReactiveDotNames.PATH)) {
                     return true;
                 }
+                if (isJaxrsResourceMethod(method)) {
+                    return true;
+                }
 
+                // also look at interfaces implemented by the method's declaringClass
+                for (Type interfaceType : method.declaringClass().interfaceTypes()) {
+                    ClassInfo interfaceInfo = index.getClassByName(interfaceType.name());
+                    if (interfaceInfo != null) {
+                        if (interfaceInfo.hasDeclaredAnnotation(ResteasyReactiveDotNames.PATH)) {
+                            return true;
+                        }
+                        MethodInfo overriddenMethodInfo = interfaceInfo.method(method.name(),
+                                method.parameterTypes().toArray(new Type[0]));
+                        if (overriddenMethodInfo != null && isJaxrsResourceMethod(overriddenMethodInfo)) {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            private boolean isJaxrsResourceMethod(MethodInfo method) {
                 // we currently don't handle custom @HttpMethod annotations, should be fine most of the time
                 return method.hasDeclaredAnnotation(ResteasyReactiveDotNames.PATH)
                         || method.hasDeclaredAnnotation(ResteasyReactiveDotNames.GET)

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/IResource.java
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/IResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.virtual.rr;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+@Path("/itf")
+public interface IResource {
+
+    @GET
+    String testGet();
+
+    @POST
+    String testPost(String body);
+
+}

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/IResourceOnClass.java
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/IResourceOnClass.java
@@ -1,0 +1,16 @@
+package io.quarkus.virtual.rr;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+@Path("/itfOnClass")
+public interface IResourceOnClass {
+
+    @GET
+    String testGet();
+
+    @POST
+    String testPost(String body);
+
+}

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/ResourceImpl.java
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/ResourceImpl.java
@@ -1,0 +1,29 @@
+package io.quarkus.virtual.rr;
+
+import jakarta.enterprise.context.RequestScoped;
+
+import io.quarkus.test.vertx.VirtualThreadsAssertions;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+
+@RequestScoped
+public class ResourceImpl implements IResource {
+
+    private final Counter counter;
+
+    ResourceImpl(Counter counter) {
+        this.counter = counter;
+    }
+
+    @RunOnVirtualThread
+    public String testGet() {
+        VirtualThreadsAssertions.assertEverything();
+        return "hello-" + counter.increment();
+    }
+
+    @RunOnVirtualThread
+    public String testPost(String body) {
+        VirtualThreadsAssertions.assertEverything();
+        return body + "-" + counter.increment();
+    }
+
+}

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/ResourceOnClassImpl.java
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/ResourceOnClassImpl.java
@@ -1,0 +1,28 @@
+package io.quarkus.virtual.rr;
+
+import jakarta.enterprise.context.RequestScoped;
+
+import io.quarkus.test.vertx.VirtualThreadsAssertions;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+
+@RequestScoped
+@RunOnVirtualThread
+public class ResourceOnClassImpl implements IResourceOnClass {
+
+    private final Counter counter;
+
+    ResourceOnClassImpl(Counter counter) {
+        this.counter = counter;
+    }
+
+    public String testGet() {
+        VirtualThreadsAssertions.assertEverything();
+        return "hello-" + counter.increment();
+    }
+
+    public String testPost(String body) {
+        VirtualThreadsAssertions.assertEverything();
+        return body + "-" + counter.increment();
+    }
+
+}

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/test/java/io/quarkus/virtual/rr/RunOnVirtualThreadTest.java
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/test/java/io/quarkus/virtual/rr/RunOnVirtualThreadTest.java
@@ -2,6 +2,7 @@ package io.quarkus.virtual.rr;
 
 import static org.hamcrest.Matchers.is;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -18,30 +19,42 @@ class RunOnVirtualThreadTest {
 
     @Test
     void testGet() {
-        RestAssured.get().then()
-                .assertThat().statusCode(200)
-                .body(is("hello-1"));
-        RestAssured.get().then()
-                .assertThat().statusCode(200)
-                // Same value - request scoped bean
-                .body(is("hello-1"));
+        // test all variations:
+        // - MyResource ("/"): simple JAX-RS bean
+        // - ResourceImpl ("/itf"): bean implementing a JAX-RS interface with VT annotation on the method
+        // - ResourceOnClassImpl ("/itfOnClass"): bean implementing a JAX-RS interface with VT annotation on the class
+        for (String url : Arrays.asList("/", "itf", "itfOnClass")) {
+            RestAssured.get(url).then()
+                    .assertThat().statusCode(200)
+                    .body(is("hello-1"));
+            RestAssured.get(url).then()
+                    .assertThat().statusCode(200)
+                    // Same value - request scoped bean
+                    .body(is("hello-1"));
+        }
     }
 
     @Test
     void testPost() {
-        var body1 = UUID.randomUUID().toString();
-        var body2 = UUID.randomUUID().toString();
-        RestAssured
-                .given().body(body1)
-                .post().then()
-                .assertThat().statusCode(200)
-                .body(is(body1 + "-1"));
-        RestAssured
-                .given().body(body2)
-                .post().then()
-                .assertThat().statusCode(200)
-                // Same value - request scoped bean
-                .body(is(body2 + "-1"));
+        // test all variations:
+        // - MyResource ("/"): simple JAX-RS bean
+        // - ResourceImpl ("/itf"): bean implementing a JAX-RS interface with VT annotation on the method
+        // - ResourceOnClassImpl ("/itfOnClass"): bean implementing a JAX-RS interface with VT annotation on the class
+        for (String url : Arrays.asList("/", "itf", "itfOnClass")) {
+            var body1 = UUID.randomUUID().toString();
+            var body2 = UUID.randomUUID().toString();
+            RestAssured
+                    .given().body(body1)
+                    .post(url).then()
+                    .assertThat().statusCode(200)
+                    .body(is(body1 + "-1"));
+            RestAssured
+                    .given().body(body2)
+                    .post(url).then()
+                    .assertThat().statusCode(200)
+                    // Same value - request scoped bean
+                    .body(is(body2 + "-1"));
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes: #45186

This PR is about support for beans that implement a JAX-RS interface.

It does four things:
- fix the resteasy `EndpointIndexer` such that explicit annotations on the bean overwrite the defaultBlocking
- Extend the `JaxRsMethodProcessor` such that the `ExecutionModelAnnotationsProcessor` will not complain about RunOnVirtualThread annotations on the bean
- Extend the `ResteasyReactiveScanner` to allow \@RunOnVirualThread annotations on the JAX-RS Application to set the defaultBlocking
- Add integration tests for beans implementing a JAX-RS interface with \@RunOnVirtualThread annotations either on the method or on the bean class