### PR TITLE
Get rid of unnecessary reflective calls at RESTEasy Reactive startup

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -17,11 +17,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
@@ -177,19 +175,8 @@ public class RuntimeResourceDeployment {
             }
         }
 
-        Annotation[] resourceClassAnnotations = resourceClass.getAnnotations();
-        Set<String> classAnnotationNames;
-        if (resourceClassAnnotations.length == 0) {
-            classAnnotationNames = Collections.emptySet();
-        } else {
-            classAnnotationNames = new HashSet<>(resourceClassAnnotations.length);
-            for (Annotation annotation : resourceClassAnnotations) {
-                classAnnotationNames.add(annotation.annotationType().getName());
-            }
-        }
-
         ResteasyReactiveResourceInfo lazyMethod = new ResteasyReactiveResourceInfo(method.getName(), resourceClass,
-                parameterDeclaredUnresolvedTypes, classAnnotationNames, method.getMethodAnnotationNames(),
+                parameterDeclaredUnresolvedTypes,
                 !defaultBlocking && !method.isBlocking(), method.getActualDeclaringClassName());
 
         RuntimeInterceptorDeployment.MethodInterceptorContext interceptorDeployment = runtimeInterceptorDeployment

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveResourceInfo.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveResourceInfo.java
@@ -3,7 +3,6 @@ package org.jboss.resteasy.reactive.server.spi;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.Set;
 
 import jakarta.ws.rs.container.ResourceInfo;
 
@@ -20,8 +19,6 @@ public class ResteasyReactiveResourceInfo implements ResourceInfo {
     private final String name;
     private final Class<?> declaringClass;
     private final Class[] parameterTypes;
-    private final Set<String> classAnnotationNames;
-    private final Set<String> methodAnnotationNames;
     /**
      * If it's non-blocking method within the runtime that won't always default to blocking
      */
@@ -30,27 +27,17 @@ public class ResteasyReactiveResourceInfo implements ResourceInfo {
      * This class name will only differ from {@link this#declaringClass} name when the {@link this#method} was inherited.
      */
     private final String actualDeclaringClassName;
-    private volatile Annotation[] classAnnotations;
     private volatile Method method;
     private volatile Annotation[] annotations;
     private volatile Type returnType;
     private volatile String methodId;
 
-    @Deprecated
     public ResteasyReactiveResourceInfo(String name, Class<?> declaringClass, Class[] parameterTypes,
-            Set<String> classAnnotationNames, Set<String> methodAnnotationNames, boolean isNonBlocking) {
-        this(name, declaringClass, parameterTypes, classAnnotationNames, methodAnnotationNames, isNonBlocking,
-                declaringClass.getName());
-    }
-
-    public ResteasyReactiveResourceInfo(String name, Class<?> declaringClass, Class[] parameterTypes,
-            Set<String> classAnnotationNames, Set<String> methodAnnotationNames, boolean isNonBlocking,
+            boolean isNonBlocking,
             String actualDeclaringClassName) {
         this.name = name;
         this.declaringClass = declaringClass;
         this.parameterTypes = parameterTypes;
-        this.classAnnotationNames = classAnnotationNames;
-        this.methodAnnotationNames = methodAnnotationNames;
         this.isNonBlocking = isNonBlocking;
         this.actualDeclaringClassName = actualDeclaringClassName;
     }
@@ -61,14 +48,6 @@ public class ResteasyReactiveResourceInfo implements ResourceInfo {
 
     public Class[] getParameterTypes() {
         return parameterTypes;
-    }
-
-    public Set<String> getClassAnnotationNames() {
-        return classAnnotationNames;
-    }
-
-    public Set<String> getMethodAnnotationNames() {
-        return methodAnnotationNames;
     }
 
     public Method getMethod() {
@@ -87,13 +66,6 @@ public class ResteasyReactiveResourceInfo implements ResourceInfo {
             }
         }
         return method;
-    }
-
-    public Annotation[] getClassAnnotations() {
-        if (classAnnotations == null) {
-            classAnnotations = declaringClass.getAnnotations();
-        }
-        return classAnnotations;
     }
 
     public Annotation[] getAnnotations() {


### PR DESCRIPTION
These calls were originally done to support
REST Links, but the information they obtained
has long been available at build time, meaning
the reflective calls are totally unnecessary
(and wasteful)