### PR TITLE
Messaging RunOnVirtualThreads fix on class annotation

### DIFF
--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
@@ -204,7 +204,8 @@ public final class QuarkusMediatorConfigurationUtil {
         AnnotationInstance transactionalAnnotation = methodInfo.annotation(TRANSACTIONAL);
         AnnotationInstance runOnVirtualThreadAnnotation = methodInfo.annotation(RUN_ON_VIRTUAL_THREAD);
         // IF @RunOnVirtualThread is used on the declaring class, it forces all @Blocking method to be run on virtual threads.
-        AnnotationInstance runOnVirtualThreadClassAnnotation = methodInfo.declaringClass().annotation(RUN_ON_VIRTUAL_THREAD);
+        AnnotationInstance runOnVirtualThreadClassAnnotation = methodInfo.declaringClass()
+                .declaredAnnotation(RUN_ON_VIRTUAL_THREAD);
         if (blockingAnnotation != null || smallryeBlockingAnnotation != null || transactionalAnnotation != null
                 || runOnVirtualThreadAnnotation != null) {
             mediatorConfigurationSupport.validateBlocking(validationOutput);


### PR DESCRIPTION
For future reference, classinfo.annotation gives the first annotation among all indexed annotations used inside the class. 