### PR TITLE
Lazily access `ObjectMapper` in Quarkus REST Jackson module

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MessageBodyReaderTests.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MessageBodyReaderTests.java
@@ -7,12 +7,16 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.annotation.Annotation;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.CompletionCallback;
 import jakarta.ws.rs.container.ConnectionCallback;
@@ -119,7 +123,8 @@ class MessageBodyReaderTests {
     @Nested
     @DisplayName("ServerJacksonMessageBodyReader")
     class ServerJacksonMessageBodyReaderTests {
-        private final CommonReaderTests tests = new CommonReaderTests(new ServerJacksonMessageBodyReader(new ObjectMapper()));
+        private final CommonReaderTests tests = new CommonReaderTests(
+                new ServerJacksonMessageBodyReader(new NewObjectMapperInstance()));
 
         @Test
         void shouldThrowWebExceptionWithStreamReadExceptionCause() {
@@ -146,7 +151,7 @@ class MessageBodyReaderTests {
 
         @Test
         void shouldThrowWebExceptionWithValueInstantiationExceptionCauseUsingServerRequestContext() throws IOException {
-            var reader = new ServerJacksonMessageBodyReader(new ObjectMapper());
+            var reader = new ServerJacksonMessageBodyReader(new NewObjectMapperInstance());
             // missing non-nullable property
             var stream = new ByteArrayInputStream("{\"cost\": 2}".getBytes(StandardCharsets.UTF_8));
             var context = new MockServerRequestContext(stream);
@@ -277,6 +282,58 @@ class MessageBodyReaderTests {
         @Override
         public void abortWith(Response response) {
 
+        }
+    }
+
+    private static class NewObjectMapperInstance implements Instance<ObjectMapper> {
+        @Override
+        public Instance<ObjectMapper> select(Annotation... qualifiers) {
+            throw new IllegalStateException("Should never be called");
+        }
+
+        @Override
+        public <U extends ObjectMapper> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+            throw new IllegalStateException("Should never be called");
+        }
+
+        @Override
+        public <U extends ObjectMapper> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            throw new IllegalStateException("Should never be called");
+        }
+
+        @Override
+        public boolean isUnsatisfied() {
+            throw new IllegalStateException("Should never be called");
+        }
+
+        @Override
+        public boolean isAmbiguous() {
+            throw new IllegalStateException("Should never be called");
+        }
+
+        @Override
+        public void destroy(ObjectMapper instance) {
+            throw new IllegalStateException("Should never be called");
+        }
+
+        @Override
+        public Handle<ObjectMapper> getHandle() {
+            throw new IllegalStateException("Should never be called");
+        }
+
+        @Override
+        public Iterable<? extends Handle<ObjectMapper>> handles() {
+            throw new IllegalStateException("Should never be called");
+        }
+
+        @Override
+        public ObjectMapper get() {
+            return new ObjectMapper();
+        }
+
+        @Override
+        public Iterator<ObjectMapper> iterator() {
+            throw new IllegalStateException("Should never be called");
         }
     }
 }

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/AbstractServerJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/AbstractServerJacksonMessageBodyReader.java
@@ -1,0 +1,54 @@
+package io.quarkus.resteasy.reactive.jackson.runtime.serialisers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.reactive.common.providers.serialisers.AbstractJsonMessageBodyReader;
+import org.jboss.resteasy.reactive.common.util.EmptyInputStream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import io.quarkus.arc.impl.LazyValue;
+
+public abstract class AbstractServerJacksonMessageBodyReader extends AbstractJsonMessageBodyReader {
+
+    protected final LazyValue<ObjectReader> defaultReader;
+
+    public AbstractServerJacksonMessageBodyReader(Instance<ObjectMapper> mapper) {
+        this.defaultReader = new LazyValue<>(new Supplier<>() {
+            @Override
+            public ObjectReader get() {
+                return mapper.get().reader();
+            }
+        });
+    }
+
+    @Override
+    public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException,
+            WebApplicationException {
+        return doReadFrom(type, genericType, entityStream);
+    }
+
+    protected ObjectReader getEffectiveReader() {
+        return defaultReader.get();
+    }
+
+    private Object doReadFrom(Class<Object> type, Type genericType, InputStream entityStream) throws IOException {
+        if (entityStream instanceof EmptyInputStream) {
+            return null;
+        }
+        ObjectReader reader = getEffectiveReader();
+        return reader.forType(reader.getTypeFactory().constructType(genericType != null ? genericType : type))
+                .readValue(entityStream);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/BasicServerJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/BasicServerJacksonMessageBodyWriter.java
@@ -11,7 +11,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
@@ -24,22 +26,28 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
+import io.quarkus.arc.impl.LazyValue;
 import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
 
 public class BasicServerJacksonMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
 
-    private final ObjectWriter defaultWriter;
+    private final LazyValue<ObjectWriter> defaultWriter;
     private final Map<JavaType, ObjectWriter> genericWriters = new ConcurrentHashMap<>();
 
     @Inject
-    public BasicServerJacksonMessageBodyWriter(ObjectMapper mapper) {
-        this.defaultWriter = createDefaultWriter(mapper);
+    public BasicServerJacksonMessageBodyWriter(Instance<ObjectMapper> mapper) {
+        this.defaultWriter = new LazyValue<>(new Supplier<>() {
+            @Override
+            public ObjectWriter get() {
+                return createDefaultWriter(mapper.get());
+            }
+        });
     }
 
     private ObjectWriter getWriter(Type genericType, Object value) {
         // make sure we properly handle polymorphism in generic collections
         if (value != null && genericType != null) {
-            JavaType rootType = JacksonMapperUtil.getGenericRootType(genericType, defaultWriter);
+            JavaType rootType = JacksonMapperUtil.getGenericRootType(genericType, defaultWriter.get());
             // Check that the determined root type is really assignable from the given entity.
             // A mismatch can happen, if a ServerResponseFilter replaces the response entity with another object
             // that does not match the original signature of the method (see HalServerResponseFilter for an example)
@@ -50,7 +58,7 @@ public class BasicServerJacksonMessageBodyWriter extends ServerMessageBodyWriter
                     writer = genericWriters.computeIfAbsent(rootType, new Function<>() {
                         @Override
                         public ObjectWriter apply(JavaType type) {
-                            return defaultWriter.forType(type);
+                            return defaultWriter.get().forType(type);
                         }
                     });
                 }
@@ -59,7 +67,7 @@ public class BasicServerJacksonMessageBodyWriter extends ServerMessageBodyWriter
         }
 
         // no generic type given, or the generic type is just a class. Use the default writer.
-        return this.defaultWriter;
+        return this.defaultWriter.get();
     }
 
     @Override

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyReader.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
@@ -22,7 +23,6 @@ import jakarta.ws.rs.ext.Providers;
 
 import org.jboss.resteasy.reactive.common.util.StreamUtil;
 import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
-import org.jboss.resteasy.reactive.server.jackson.JacksonBasicMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
@@ -36,10 +36,10 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.quarkus.resteasy.reactive.jackson.runtime.ResteasyReactiveServerJacksonRecorder;
 
-public class FullyFeaturedServerJacksonMessageBodyReader extends JacksonBasicMessageBodyReader
+public class FullyFeaturedServerJacksonMessageBodyReader extends AbstractServerJacksonMessageBodyReader
         implements ServerMessageBodyReader<Object> {
 
-    private final ObjectMapper originalMapper;
+    private final Instance<ObjectMapper> originalMapper;
     private final Providers providers;
     private final ConcurrentMap<String, ObjectReader> perMethodReader = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ObjectReader> perTypeReader = new ConcurrentHashMap<>();
@@ -47,7 +47,7 @@ public class FullyFeaturedServerJacksonMessageBodyReader extends JacksonBasicMes
     private final ConcurrentMap<ObjectMapper, ObjectReader> objectReaderMap = new ConcurrentHashMap<>();
 
     @Inject
-    public FullyFeaturedServerJacksonMessageBodyReader(ObjectMapper mapper, Providers providers) {
+    public FullyFeaturedServerJacksonMessageBodyReader(Instance<ObjectMapper> mapper, Providers providers) {
         super(mapper);
         this.originalMapper = mapper;
         this.providers = providers;
@@ -152,7 +152,7 @@ public class FullyFeaturedServerJacksonMessageBodyReader extends JacksonBasicMes
 
     private ObjectReader getEffectiveReader(Class<Object> type, Type genericType, MediaType responseMediaType) {
         ObjectMapper effectiveMapper = getEffectiveMapper(type, responseMediaType);
-        ObjectReader effectiveReader = defaultReader;
+        ObjectReader effectiveReader = defaultReader.get();
         if (effectiveMapper != originalMapper) {
             // Effective reader based on the context
             effectiveReader = objectReaderMap.computeIfAbsent(effectiveMapper, new Function<>() {
@@ -192,7 +192,7 @@ public class FullyFeaturedServerJacksonMessageBodyReader extends JacksonBasicMes
 
     private ObjectMapper getEffectiveMapper(Class<Object> type, MediaType responseMediaType) {
         if (providers == null) {
-            return originalMapper;
+            return originalMapper.get();
         }
 
         ContextResolver<ObjectMapper> contextResolver = providers.getContextResolver(ObjectMapper.class,
@@ -214,7 +214,7 @@ public class FullyFeaturedServerJacksonMessageBodyReader extends JacksonBasicMes
             }
         }
 
-        return originalMapper;
+        return originalMapper.get();
     }
 
     private static class MethodObjectReaderFunction implements Function<String, ObjectReader> {

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/ServerJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/ServerJacksonMessageBodyReader.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
@@ -12,7 +13,6 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.common.util.StreamUtil;
-import org.jboss.resteasy.reactive.server.jackson.JacksonBasicMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
@@ -24,10 +24,11 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
-public class ServerJacksonMessageBodyReader extends JacksonBasicMessageBodyReader implements ServerMessageBodyReader<Object> {
+public class ServerJacksonMessageBodyReader extends AbstractServerJacksonMessageBodyReader
+        implements ServerMessageBodyReader<Object> {
 
     @Inject
-    public ServerJacksonMessageBodyReader(ObjectMapper mapper) {
+    public ServerJacksonMessageBodyReader(Instance<ObjectMapper> mapper) {
         super(mapper);
     }
 


### PR DESCRIPTION
This is done because the server `MessageBodyReader` and `MessageBodyWriter` classes are created at static init, which means two things:
* The Jackson bean should not be accessed directly as it can still be configured by user provided code (via `ObjectMapperCustomizer`).
* Accessing the Jackson bean directly imposes a rather large hit on startup time (on my machine, it's over 50ms and it's due to Jackson loading a ton of classes when it's first created),  regardless if `MessageBodyReader` / `MessageBodyWriter` are ever used in the application

Fixes: #32969