### PR TITLE
Avoid using the RuntimeDelegate indirection for MediaType

### DIFF
--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveCompressionHandler.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveCompressionHandler.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 
+import org.jboss.resteasy.reactive.common.util.MediaTypeHelper;
 import org.jboss.resteasy.reactive.server.core.EncodedMediaType;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.spi.ServerHttpResponse;
@@ -65,7 +66,7 @@ public class ResteasyReactiveCompressionHandler implements ServerRestHandler {
                         if (encodedProduces == null) {
                             synchronized (this) {
                                 if (encodedProduces == null) {
-                                    encodedProduces = new EncodedMediaType(MediaType.valueOf(produces));
+                                    encodedProduces = new EncodedMediaType(MediaTypeHelper.valueOf(produces));
                                 }
                             }
                         }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/HeaderUtil.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/HeaderUtil.java
@@ -116,7 +116,7 @@ public class HeaderUtil {
     public static MediaType getMediaType(MultivaluedMap<String, ? extends Object> headers) {
         Object first = headers.getFirst(HttpHeaders.CONTENT_TYPE);
         if (first instanceof String contentType) {
-            return MediaType.valueOf(contentType);
+            return MediaTypeHelper.valueOf(contentType);
         } else {
             return (MediaType) first;
         }
@@ -281,10 +281,10 @@ public class HeaderUtil {
                 StringTokenizer tokenizer = new StringTokenizer(accept, ",");
                 while (tokenizer.hasMoreElements()) {
                     String item = tokenizer.nextToken().trim();
-                    list.add(MediaType.valueOf(item));
+                    list.add(MediaTypeHelper.valueOf(item));
                 }
             } else {
-                list.add(MediaType.valueOf(accept.trim()));
+                list.add(MediaTypeHelper.valueOf(accept.trim()));
             }
         }
         MediaTypeHelper.sortByWeight(list);

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceContextResolver.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceContextResolver.java
@@ -7,6 +7,7 @@ import java.util.List;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ContextResolver;
 
+import org.jboss.resteasy.reactive.common.util.MediaTypeHelper;
 import org.jboss.resteasy.reactive.spi.BeanFactory;
 
 public class ResourceContextResolver {
@@ -48,7 +49,7 @@ public class ResourceContextResolver {
             synchronized (this) {
                 List<MediaType> ret = new ArrayList<>();
                 for (String i : mediaTypeStrings) {
-                    ret.add(MediaType.valueOf(i));
+                    ret.add(MediaTypeHelper.valueOf(i));
                 }
                 mediaTypes = Collections.unmodifiableList(ret);
             }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceReader.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceReader.java
@@ -87,7 +87,7 @@ public class ResourceReader {
             synchronized (this) {
                 List<MediaType> mts = new ArrayList<>(mediaTypeStrings.size());
                 for (int i = 0; i < mediaTypeStrings.size(); i++) {
-                    mts.add(MediaType.valueOf(mediaTypeStrings.get(i)));
+                    mts.add(MediaTypeHelper.valueOf(mediaTypeStrings.get(i)));
                 }
                 mediaTypes = Collections.unmodifiableList(mts);
             }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceWriter.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceWriter.java
@@ -90,7 +90,7 @@ public class ResourceWriter {
             synchronized (this) {
                 List<MediaType> mts = new ArrayList<>(mediaTypeStrings.size());
                 for (int i = 0; i < mediaTypeStrings.size(); i++) {
-                    mts.add(MediaType.valueOf(mediaTypeStrings.get(i)));
+                    mts.add(MediaTypeHelper.valueOf(mediaTypeStrings.get(i)));
                 }
                 mediaTypes = Collections.unmodifiableList(mts);
             }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MediaTypeHelper.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MediaTypeHelper.java
@@ -12,6 +12,8 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import org.jboss.resteasy.reactive.common.headers.MediaTypeHeaderDelegate;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  */
@@ -20,6 +22,14 @@ public class MediaTypeHelper {
     public static final MediaTypeComparator Q_COMPARATOR = new MediaTypeComparator("q");
     public static final MediaTypeComparator QS_COMPARATOR = new MediaTypeComparator("qs");
     private static final String MEDIA_TYPE_SUFFIX_DELIM = "+";
+
+    public static MediaType valueOf(String value) {
+        return MediaTypeHeaderDelegate.INSTANCE.fromString(value);
+    }
+
+    public static String toString(MediaType mediaType) {
+        return MediaTypeHeaderDelegate.INSTANCE.toString(mediaType);
+    }
 
     private static float getQTypeWithParamInfo(MediaType type, String parameterName) {
         if (type.getParameters() != null) {
@@ -212,7 +222,7 @@ public class MediaTypeHelper {
         ArrayList<MediaType> types = new ArrayList<>();
         String[] medias = header.split(",");
         for (String media : medias) {
-            types.add(MediaType.valueOf(media.trim()));
+            types.add(valueOf(media.trim()));
         }
         return types;
     }
@@ -289,7 +299,7 @@ public class MediaTypeHelper {
 
         List<MediaType> list = new ArrayList<>(mediaTypes.length);
         for (String mediaType : mediaTypes) {
-            list.add(MediaType.valueOf(mediaType));
+            list.add(valueOf(mediaType));
         }
 
         return Collections.unmodifiableList(list);

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/ServerMediaType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/ServerMediaType.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 
 import jakarta.ws.rs.core.MediaType;
 
+import org.jboss.resteasy.reactive.common.headers.MediaTypeHeaderDelegate;
+
 /**
  * A representation of a server side media type.
  *
@@ -25,7 +27,7 @@ public class ServerMediaType {
     public static List<MediaType> mediaTypesFromArray(String[] mediaTypesStrs) {
         List<MediaType> mediaTypes = new ArrayList<>(mediaTypesStrs.length);
         for (String mediaTypesStr : mediaTypesStrs) {
-            mediaTypes.add(MediaType.valueOf(mediaTypesStr));
+            mediaTypes.add(MediaTypeHeaderDelegate.INSTANCE.fromString(mediaTypesStr));
         }
         return mediaTypes;
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/EncodedMediaType.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/EncodedMediaType.java
@@ -53,7 +53,7 @@ public class EncodedMediaType implements ContentType {
     @Override
     public String getEncoded() {
         if (encoded == null) {
-            return encoded = mediaType.toString();
+            return encoded = MediaTypeHelper.toString(mediaType);
         }
         return encoded;
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -149,7 +149,7 @@ public class RuntimeResourceDeployment {
         Map<String, Integer> pathParameterIndexes = buildParamIndexMap(classPathTemplate, methodPathTemplate);
         MediaType streamElementType = null;
         if (method.getStreamElementType() != null) {
-            streamElementType = MediaType.valueOf(method.getStreamElementType());
+            streamElementType = MediaTypeHelper.valueOf(method.getStreamElementType());
         }
         List<MediaType> consumesMediaTypes;
         if (method.getConsumes() == null) {
@@ -157,7 +157,7 @@ public class RuntimeResourceDeployment {
         } else {
             consumesMediaTypes = new ArrayList<>(method.getConsumes().length);
             for (String s : method.getConsumes()) {
-                consumesMediaTypes.add(MediaType.valueOf(s));
+                consumesMediaTypes.add(MediaTypeHelper.valueOf(s));
             }
         }
 
@@ -407,7 +407,7 @@ public class RuntimeResourceDeployment {
             if (method.getProduces() != null && method.getProduces().length > 0) {
                 //the method can only produce a single content type, which is the most common case
                 if (method.getProduces().length == 1) {
-                    MediaType mediaType = MediaType.valueOf(method.getProduces()[0]);
+                    MediaType mediaType = MediaTypeHelper.valueOf(method.getProduces()[0]);
                     //its a wildcard type, makes it hard to determine statically
                     if (mediaType.isWildcardType() || mediaType.isWildcardSubtype()) {
                         handlers.add(new VariableProducesHandler(serverMediaType, serialisers));

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
@@ -114,7 +114,7 @@ public class ClassRoutingHandler implements ServerRestHandler {
                 try {
                     if (MediaTypeHelper.getFirstMatch(
                             target.value.getConsumes(),
-                            Collections.singletonList(MediaType.valueOf(contentType))) == null) {
+                            Collections.singletonList(MediaTypeHelper.valueOf(contentType))) == null) {
                         throw new NotSupportedException("The content-type header value did not match the value in @Consumes");
                     }
                 } catch (IllegalArgumentException e) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
@@ -100,7 +100,7 @@ public class MediaTypeMapper implements ServerRestHandler {
         }
         List<MediaType> result = new ArrayList<>(contentTypeList.size());
         for (String s : contentTypeList) {
-            result.add(MediaType.valueOf(s));
+            result.add(MediaTypeHelper.valueOf(s));
         }
         return result;
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RequestDeserializeHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RequestDeserializeHandler.java
@@ -52,7 +52,7 @@ public class RequestDeserializeHandler implements ServerRestHandler {
         Object requestType = requestContext.getHeader(HttpHeaders.CONTENT_TYPE, true);
         if (requestType != null) {
             try {
-                effectiveRequestType = MediaType.valueOf((String) requestType);
+                effectiveRequestType = MediaTypeHelper.valueOf((String) requestType);
             } catch (Exception e) {
                 log.debugv("Incorrect media type", e);
                 throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).build());

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/HttpHeadersImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/HttpHeadersImpl.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.jboss.resteasy.reactive.common.headers.HeaderUtil;
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
+import org.jboss.resteasy.reactive.common.util.MediaTypeHelper;
 import org.jboss.resteasy.reactive.common.util.UnmodifiableMultivaluedMap;
 
 /**
@@ -85,7 +86,7 @@ public class HttpHeadersImpl implements HttpHeaders {
         if (obj == cachedMediaTypeString)
             return cachedMediaType;
         cachedMediaTypeString = obj;
-        cachedMediaType = MediaType.valueOf(obj);
+        cachedMediaType = MediaTypeHelper.valueOf(obj);
         return cachedMediaType;
     }
 


### PR DESCRIPTION
Anything `MediaType` related happens a lot, so there is good reason to avoid the pointless redirection