### PR TITLE
Enhance Quarkus support for Spring @RequestParam annotated parameters. 

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/MapWithParamConverterTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/MapWithParamConverterTest.java
@@ -2,6 +2,8 @@ package io.quarkus.resteasy.reactive.server.test.simple;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
@@ -94,10 +97,26 @@ public class MapWithParamConverterTest {
                 return (T) value;
             }
             try {
-                return genericType != null ? objectMapper.readValue(value, genericType)
-                        : objectMapper.readValue(value, rawType);
+                JsonNode jsonNode = objectMapper.readTree(value);
+                if (jsonNode.isArray()) {
+                    // Process as a list of maps and merge them into a single map
+                    JavaType listType = objectMapper.getTypeFactory()
+                            .constructCollectionType(List.class, rawType);
+                    List<Map<String, Object>> list = objectMapper.readValue(value, listType);
+
+                    Map<String, Object> mergedMap = new LinkedHashMap<>();
+                    for (Map<String, Object> map : list) {
+                        mergedMap.putAll(map);
+                    }
+                    return (T) mergedMap;
+                } else {
+                    // single object
+                    return genericType != null
+                            ? objectMapper.readValue(value, genericType)
+                            : objectMapper.readValue(value, rawType);
+                }
             } catch (JsonProcessingException e) {
-                throw (new RuntimeException(e));
+                throw new RuntimeException(e);
             }
         }
 

--- a/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringMapParamExtractor.java
+++ b/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringMapParamExtractor.java
@@ -1,0 +1,22 @@
+package io.quarkus.spring.web.resteasy.reactive.runtime;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+
+@SuppressWarnings("ForLoopReplaceableByForEach")
+public class SpringMapParamExtractor implements ParameterExtractor {
+
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        Map<String, List<String>> parametersMap = context.serverRequest().getQueryParamsMap();
+        if (parametersMap != null && !parametersMap.isEmpty()) {
+            return parametersMap;
+        }
+        return Collections.emptyMap();
+    }
+
+}

--- a/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringMultiValueListParamExtractor.java
+++ b/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringMultiValueListParamExtractor.java
@@ -1,0 +1,57 @@
+package io.quarkus.spring.web.resteasy.reactive.runtime;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+
+@SuppressWarnings("ForLoopReplaceableByForEach")
+public class SpringMultiValueListParamExtractor implements ParameterExtractor {
+
+    /**
+     * Returns a List containing all query parameters from the request, splitting values by commas if necessary.
+     *
+     * <p>
+     * Spring MVC maps comma-delimited request parameters into a {@code List<String>}.
+     * To maintain compatibility, this method follows the same approach:
+     * If a query parameter contains multiple values, separated by commas, it adds those multiple values; otherwise, it is added
+     * directly.
+     * </p>
+     *
+     * <p>
+     * Example:
+     *
+     * <pre>
+     * ?tags=java,quarkus&amp;category=framework
+     * </pre>
+     *
+     * would produce:
+     *
+     * <pre>
+     * ["java", "quarkus", "framework"]
+     * </pre>
+     * </p>
+     *
+     * @param context The ResteasyReactiveRequestContext containing the HTTP request.
+     * @return An immutable list of all extracted query parameters.
+     */
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        Pattern commaPattern = Pattern.compile(",");
+
+        List<String> allQueryParams = new ArrayList<>();
+        for (String paramName : context.serverRequest().queryParamNames()) {
+            List<String> values = context.serverRequest().getAllQueryParams(paramName);
+            if (values != null) {
+                for (String value : values) {
+                    allQueryParams.addAll(Arrays.asList(commaPattern.split(value)));
+                }
+            }
+        }
+
+        return List.copyOf(allQueryParams);
+    }
+
+}

--- a/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringMultiValueMapParamExtractor.java
+++ b/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringMultiValueMapParamExtractor.java
@@ -1,0 +1,21 @@
+package io.quarkus.spring.web.resteasy.reactive.runtime;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@SuppressWarnings("ForLoopReplaceableByForEach")
+public class SpringMultiValueMapParamExtractor implements ParameterExtractor {
+
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        Map<String, List<String>> parametersMap = context.serverRequest().getQueryParamsMap();
+        MultiValueMap<String, String> springMap = new LinkedMultiValueMap<>();
+        parametersMap.forEach(springMap::put);
+        return springMap;
+    }
+}

--- a/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringRequestParamHandler.java
+++ b/extensions/spring-web/resteasy-reactive/runtime/src/main/java/io/quarkus/spring/web/resteasy/reactive/runtime/SpringRequestParamHandler.java
@@ -1,0 +1,38 @@
+package io.quarkus.spring.web.resteasy.reactive.runtime;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl;
+import org.jboss.resteasy.reactive.common.model.ResourceClass;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.model.ServerResourceMethod;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+/**
+ * In Spring, parameters annotated with {@code @RequestParam} are required by default unless explicitly marked as
+ * optional.
+ * This {@link SpringRequestParamHandler} enforces the required constraint responding with a BAD_REQUEST status.
+ *
+ */
+public class SpringRequestParamHandler implements HandlerChainCustomizer {
+    @Override
+    public List<ServerRestHandler> handlers(HandlerChainCustomizer.Phase phase, ResourceClass resourceClass,
+            ServerResourceMethod resourceMethod) {
+        if (phase == Phase.AFTER_RESPONSE_CREATED) {
+            return Collections.singletonList(new ServerRestHandler() {
+                @Override
+                public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
+                    Map<String, List<String>> parametersMap = requestContext.serverRequest().getQueryParamsMap();
+                    if (parametersMap.isEmpty()) {
+                        ResponseImpl response = (ResponseImpl) requestContext.getResponse().get();
+                        response.setStatus(400);
+                    }
+                }
+            });
+        }
+        return Collections.emptyList();
+    }
+}

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestparam/RequestParamController.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestparam/RequestParamController.java
@@ -1,0 +1,72 @@
+package io.quarkus.spring.web.requestparam;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+public class RequestParamController {
+
+    @GetMapping("/api/foos")
+    @ResponseBody
+    public String getFoos(@RequestParam String id) {
+        return "ID: " + id;
+    }
+
+    @PostMapping("/api/foos")
+    @ResponseBody
+    public String addFoo(@RequestParam(name = "id") String fooId, @RequestParam String name) {
+        return "ID: " + fooId + " Name: " + name;
+    }
+
+    @GetMapping("/api/foos/notParamRequired")
+    @ResponseBody
+    public String getFoosNotParamRequired2(@RequestParam(required = false) String id) {
+        return "ID: " + id;
+    }
+
+    @GetMapping("/api/foos/optional")
+    @ResponseBody
+    public String getFoosOptional(@RequestParam Optional<String> id) {
+        return "ID: " + id.orElseGet(() -> "not provided");
+    }
+
+    @GetMapping("/api/foos/defaultValue")
+    @ResponseBody
+    public String getFoosDefaultValue(@RequestParam(defaultValue = "test") String id) {
+        return "ID: " + id;
+    }
+
+    @PostMapping("/api/foos/map")
+    @ResponseBody
+    public String updateFoosMap(@RequestParam Map<String, String> allParams) {
+        return "Parameters are " + allParams.entrySet();
+    }
+
+    @GetMapping("/api/foos/multivalue")
+    @ResponseBody
+    public String getFoosMultiValue(@RequestParam List<String> id) {
+        return "IDs are " + id;
+    }
+
+    @PostMapping("/api/foos/multiMap")
+    @ResponseBody
+    public String updateFoos(@RequestParam MultiValueMap<String, String> allParams) {
+        String result = "";
+        for (Map.Entry<String, List<String>> entry : allParams.entrySet()) {
+            result = "Parameters are " + entry.getKey() + "=" + entry.getValue().stream().collect(Collectors.joining(", "));
+        }
+        return result;
+    }
+
+}

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestparam/RequestParamControllerTest.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/requestparam/RequestParamControllerTest.java
@@ -1,0 +1,126 @@
+package io.quarkus.spring.web.requestparam;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RequestParamControllerTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(RequestParamController.class));
+
+    @Test
+    public void testSimpleMapping() throws Exception {
+        when().get("/api/foos?id=abc")
+                .then()
+                .statusCode(200)
+                .body(is("ID: abc"));
+
+        // In Spring, method parameters annotated with @RequestParam are required by default.
+        when().get("/api/foos")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testSimpleMappingSpecifyingName() throws Exception {
+        when().post("/api/foos?id=abc&name=bar")
+                .then()
+                .statusCode(200)
+                .body(is("ID: abc Name: bar"));
+
+        when().post("/api/foos")
+                .then()
+                .statusCode(400);
+
+    }
+
+    @Test
+    public void testNotRequiredParam() throws Exception {
+        when().get("/api/foos/notParamRequired?id=abc")
+                .then()
+                .statusCode(200)
+                .body(is("ID: abc"));
+
+        when().get("/api/foos/notParamRequired")
+                .then()
+                .statusCode(200)
+                .body(is("ID: null"));
+    }
+
+    @Test
+    public void testOptionalParam() throws Exception {
+        when().get("/api/foos/optional?id=abc")
+                .then()
+                .statusCode(200)
+                .body(is("ID: abc"));
+
+        when().get("/api/foos/optional")
+                .then()
+                .statusCode(200)
+                .body(is("ID: not provided"));
+    }
+
+    @Test
+    public void testDefaultValueForParam() throws Exception {
+        when().get("/api/foos/defaultValue?id=abc")
+                .then()
+                .statusCode(200)
+                .body(is("ID: abc"));
+
+        when().get("/api/foos/defaultValue")
+                .then()
+                .statusCode(200)
+                .body(is("ID: test"));
+    }
+
+    @Test
+    public void testMultipleMapping() throws Exception {
+        when().post("/api/foos/map?id=abc&name=bar")
+                .then()
+                .statusCode(200)
+                .body(containsString("Parameters are [name=[bar], id=[abc]]"));
+
+        when().post("/api/foos/map")
+                .then()
+                .statusCode(400);
+
+    }
+
+    @Test
+    public void testMultivalue() throws Exception {
+        when().get("/api/foos/multivalue?id=1,2,3")
+                .then()
+                .statusCode(200)
+                .body(containsString("IDs are [1, 2, 3]"));
+
+        when().get("/api/foos/multivalue?id=1,2,3&id=foo")
+                .then()
+                .statusCode(200)
+                .body(containsString("IDs are [1, 2, 3, foo]"));
+
+        when().get("/api/foos/multivalue")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testMultiMap() throws Exception {
+        when().post("/api/foos/multiMap?id=abc&id=123")
+                .then()
+                .statusCode(200)
+                .body(containsString("Parameters are id=abc, 123"));
+
+        when().post("/api/foos/multiMap")
+                .then()
+                .statusCode(400);
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -75,6 +75,7 @@ import org.jboss.resteasy.reactive.server.core.parameters.converters.LoadedParam
 import org.jboss.resteasy.reactive.server.core.parameters.converters.LocalDateParamConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.LocalDateTimeParamConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.LocalTimeParamConverter;
+import org.jboss.resteasy.reactive.server.core.parameters.converters.MapConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.NoopParameterConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.OffsetDateTimeParamConverter;
 import org.jboss.resteasy.reactive.server.core.parameters.converters.OffsetTimeParamConverter;
@@ -532,6 +533,14 @@ public class ServerEndpointIndexer
         ParameterConverterSupplier converter = extractConverter(elementType, index,
                 existingConverters, errorLocation, hasRuntimeConverters, builder.getAnns(), currentMethodInfo);
         builder.setConverter(new SetConverter.SetSupplier(converter));
+    }
+
+    @Override
+    protected void handleMapParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,
+            ServerIndexedParameter builder, String elementType, MethodInfo currentMethodInfo) {
+        ParameterConverterSupplier converter = extractConverter(elementType, index,
+                existingConverters, errorLocation, hasRuntimeConverters, builder.getAnns(), currentMethodInfo);
+        builder.setConverter(new MapConverter.MapSupplier(converter));
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/converters/MapConverter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/converters/MapConverter.java
@@ -1,0 +1,100 @@
+package org.jboss.resteasy.reactive.server.core.parameters.converters;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
+
+public class MapConverter implements ParameterConverter {
+
+    private final ParameterConverter delegate;
+
+    public MapConverter(ParameterConverter delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object convert(Object parameter) {
+        if (parameter instanceof Map) {
+            Map<Object, Object> ret = new HashMap<>();
+            Map<?, ?> map = (Map<?, ?>) parameter;
+            for (Map.Entry entry : map.entrySet()) {
+                if (delegate == null) {
+                    ret.put(entry.getKey(), entry.getValue());
+                } else {
+                    ret.put(entry.getKey(), delegate.convert(entry.getValue()));
+                }
+            }
+            return ret;
+        } else if (parameter instanceof MultivaluedMap<?, ?>) {
+            MultivaluedMap<Object, Object> ret = new MultivaluedHashMap<>();
+            MultivaluedMap<Object, Object> multivaluedMap = (MultivaluedMap<Object, Object>) parameter;
+            for (Map.Entry<Object, List<Object>> entry : multivaluedMap.entrySet()) {
+                List<Object> retValues = new ArrayList<>();
+                for (Object value : entry.getValue()) {
+                    if (delegate == null) {
+                        retValues.add(value);
+                    } else {
+                        retValues.add(delegate.convert(value));
+                    }
+                }
+                ret.put(entry.getKey(), retValues);
+            }
+            return ret;
+        }
+        if (parameter == null) {
+            return Collections.emptyMap();
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public void init(ParamConverterProviders deployment, Class<?> rawType, Type genericType, Annotation[] annotations) {
+        delegate.init(deployment, rawType, genericType, annotations);
+    }
+
+    @Override
+    public boolean isForSingleObjectContainer() {
+        return true;
+    }
+
+    public static class MapSupplier implements DelegatingParameterConverterSupplier {
+        private ParameterConverterSupplier delegate;
+
+        public MapSupplier() {
+        }
+
+        // invoked by reflection for BeanParam in ClassInjectorTransformer
+        public MapSupplier(ParameterConverterSupplier delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String getClassName() {
+            return MapConverter.class.getName();
+        }
+
+        @Override
+        public ParameterConverter get() {
+            return delegate == null ? new MapConverter(null) : new MapConverter(delegate.get());
+        }
+
+        public ParameterConverterSupplier getDelegate() {
+            return delegate;
+        }
+
+        public MapSupplier setDelegate(ParameterConverterSupplier delegate) {
+            this.delegate = delegate;
+            return this;
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpRequest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpRequest.java
@@ -34,6 +34,8 @@ public interface ServerHttpRequest {
 
     String getQueryParam(String name);
 
+    Map<String, List<String>> getQueryParamsMap();
+
     List<String> getAllQueryParams(String name);
 
     String query();


### PR DESCRIPTION
Related to #43705 


Several improvements have been implemented to enhance Quarkus support for Spring @RequestParam annotated parameters.

### Support for Map and Multimap in RESTEasy

The `handleMapParam` method has been added to extract all URL parameters and store them in a Jakarta `Map` or `Multimap`, depending on the user’s code definition.  
A new `ParameterConverter` (`MapConverter`) has been introduced to transform received parameters into a `Map` or `Multimap` when the `ParameterHandler` detects that the endpoint expects this type of structure.  
The `ResteasyReactiveRequestContext.getQueryParameter` method has been modified to support these new data types.

### Retrieving parameters without knowing their names

A new `getParametersMap` method has been added to the API, allowing retrieval of all URL parameters without requiring prior knowledge of their names.  
This method integrates with `ParamExtractor`, which does not work directly with endpoint parameters but instead processes their characteristics (name, single/multi-value, encoding, etc.).  
Since `Map` and `Multimap` cannot always be distinguished (both may contain multiple values per key), the method returns a unified `Map<String, List<String>>`, allowing `ParamHandler` to process it consistently.

### Support for Spring’s MultiValueMap

A dedicated extractor, `SpringMultiValueMapParamExtractor`, has been created to read request parameters and store them in a Spring `MultiValueMap<String, String>`.  
This was implemented using `MethodScannerBuildItem`, which detects methods with `@RequestParam` annotations. If the parameter type is `MultiValueMap<String, String>`, a specific extractor is instantiated to convert request parameters accordingly.  
As a result, users can now define methods in a Quarkus `@RestController` with a `MultiValueMap<String, String>` parameter, and it will behave just like in Spring:

```java
@PostMapping("/api/foos")
@ResponseBody
public String handle(@RequestParam MultiValueMap<String, String> params) {
    return params.toString();
}
```

## Making @RequestParam required by default

In Spring, parameters annotated with `@RequestParam` are required by default unless explicitly marked as optional.  
`MethodScannerBuildItem` is used to enforce this behavior, ensuring that parameters must have a value unless explicitly declared as optional.  
If a required parameter is missing, `SpringRequestParamHandler` handles the response by returning a 400 Bad Request error.

### Supporting multiple values in @RequestParam separated by comma

Spring allows `@RequestParam List<String>` to receive multiple values in a comma-separated format from the URL.  
To replicate this behavior, the `SpringMultiValueListParamExtractor` has been added, which automatically converts these values into a `List<String>`.
