### PR TITLE
[3.15] Upgrade to ByteBuddy 1.15.11

### DIFF
--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -46,7 +46,7 @@
         <!-- Versions -->
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <jandex.version>3.2.3</jandex.version>
-        <bytebuddy.version>1.14.11</bytebuddy.version>
+        <bytebuddy.version>1.15.11</bytebuddy.version>
         <junit5.version>5.10.3</junit5.version>
         <maven.version>3.9.8</maven.version>
         <assertj.version>3.26.3</assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <rest-assured.version>5.5.0</rest-assured.version>
         <hibernate-orm.version>6.6.1.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
-        <bytebuddy.version>1.14.18</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
+        <bytebuddy.version>1.15.11</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>7.0.3.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>2.4.2.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>


### PR DESCRIPTION
DO NOT MERGE!

Not marking as draft because I need to run the whole CI, but still, do not merge.

This is only to check the impact of the upgrade -- which we are working on in https://github.com/hibernate/hibernate-orm/pull/9478

See https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Bytebuddy.201.2E15