### PR TITLE
Register arrays of Hibernate entity ID types for reflection

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -42,6 +42,7 @@ public final class ClassNames {
     public static final DotName ID_CLASS = createConstant("jakarta.persistence.IdClass");
     public static final DotName CONVERTER = createConstant("jakarta.persistence.Converter");
     public static final DotName EMBEDDED = createConstant("jakarta.persistence.Embedded");
+    public static final DotName ID = createConstant("jakarta.persistence.Id");
     public static final DotName EMBEDDED_ID = createConstant("jakarta.persistence.EmbeddedId");
     public static final DotName ELEMENT_COLLECTION = createConstant("jakarta.persistence.ElementCollection");
     public static final DotName PROXY = createConstant("org.hibernate.annotations.Proxy");

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/GraalVMFeatures.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/GraalVMFeatures.java
@@ -29,16 +29,6 @@ public class GraalVMFeatures {
                 .build();
     }
 
-    // Workaround for https://hibernate.atlassian.net/browse/HHH-16809
-    // See https://github.com/hibernate/hibernate-orm/pull/6815#issuecomment-1662197545
-    @BuildStep
-    ReflectiveClassBuildItem registerJdbcArrayTypesForReflection() {
-        return ReflectiveClassBuildItem
-                .builder(ClassNames.JDBC_JAVA_TYPES.stream().map(d -> d.toString() + "[]").toArray(String[]::new))
-                .reason(ClassNames.GRAAL_VM_FEATURES.toString())
-                .build();
-    }
-
     // Workaround for https://hibernate.atlassian.net/browse/HHH-18875
     // See https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/StandardStack.20and.20reflection
     @BuildStep

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
@@ -220,6 +220,11 @@ public final class JpaJandexScavenger {
             collector.entityTypes.add(name);
         }
 
+        var idClass = managed.getIdClass();
+        if (idClass != null) {
+            enlistIdClass(collector, DotName.createSimple(qualifyIfNecessary(packagePrefix, idClass.getClazz())));
+        }
+
         enlistOrmXmlMappingListeners(collector, packagePrefix, managed.getEntityListeners());
     }
 
@@ -409,10 +414,14 @@ public final class JpaJandexScavenger {
         }
 
         for (AnnotationInstance annotation : jpaAnnotations) {
-            DotName targetDotName = annotation.value().asClass().name();
-            addClassHierarchyToReflectiveList(collector, targetDotName);
-            collector.modelTypes.add(targetDotName.toString());
+            DotName valueDotName = annotation.value().asClass().name();
+            enlistIdClass(collector, valueDotName);
         }
+    }
+
+    private void enlistIdClass(Collector collector, DotName idClass) {
+        addClassHierarchyToReflectiveList(collector, idClass);
+        collector.modelTypes.add(idClass.toString());
     }
 
     private void enlistPotentialCdiBeanClasses(Collector collector, DotName dotName) {


### PR DESCRIPTION
WIP, I didn't have time to finish before the holidays.

Creating the PR to not forget about it when I come back in two weeks, because it's important (required?) for the ORM 7 upgrade at #41310 .

But, and here's the catch: I suspect this fixes bugs that we currently have, but just didn't notice. I'll need to write tests relying on multi-id loading (the path that runs `Arrays.newInstance()`) in order to check.