### PR TITLE
Lazily access ObjectMapper in Quarkus REST P2

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
@@ -14,7 +14,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
@@ -30,24 +32,30 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
+import io.quarkus.arc.impl.LazyValue;
 import io.quarkus.resteasy.reactive.jackson.runtime.ResteasyReactiveServerJacksonRecorder;
 import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
 
 public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
 
-    private final ObjectMapper originalMapper;
+    private final Instance<ObjectMapper> originalMapper;
     private final Providers providers;
-    private final ObjectWriter defaultWriter;
+    private final LazyValue<ObjectWriter> defaultWriter;
     private final ConcurrentMap<String, ObjectWriter> perMethodWriter = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ObjectWriter> perTypeWriter = new ConcurrentHashMap<>();
     private final ConcurrentMap<Class<?>, ObjectMapper> contextResolverMap = new ConcurrentHashMap<>();
     private final ConcurrentMap<ObjectMapper, ObjectWriter> objectWriterMap = new ConcurrentHashMap<>();
 
     @Inject
-    public FullyFeaturedServerJacksonMessageBodyWriter(ObjectMapper mapper, Providers providers) {
+    public FullyFeaturedServerJacksonMessageBodyWriter(Instance<ObjectMapper> mapper, Providers providers) {
         this.originalMapper = mapper;
-        this.defaultWriter = createDefaultWriter(mapper);
         this.providers = providers;
+        this.defaultWriter = new LazyValue<>(new Supplier<>() {
+            @Override
+            public ObjectWriter get() {
+                return createDefaultWriter(mapper.get());
+            }
+        });
     }
 
     @Override
@@ -122,8 +130,8 @@ public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBo
     }
 
     private ObjectWriter getEffectiveWriter(ObjectMapper effectiveMapper) {
-        if (effectiveMapper == originalMapper) {
-            return defaultWriter;
+        if (effectiveMapper == originalMapper.get()) {
+            return defaultWriter.get();
         }
         return objectWriterMap.computeIfAbsent(effectiveMapper, new Function<>() {
             @Override
@@ -138,7 +146,7 @@ public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBo
      * Otherwise, returns the default {@link ObjectMapper}.
      */
     private ObjectMapper getEffectiveMapper(Object o, ServerRequestContext context) {
-        ObjectMapper effectiveMapper = originalMapper;
+        ObjectMapper effectiveMapper = originalMapper.get();
         ContextResolver<ObjectMapper> contextResolver = providers.getContextResolver(ObjectMapper.class,
                 context.getResponseMediaType());
         if (contextResolver == null) {
@@ -163,7 +171,7 @@ public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBo
     @Override
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        doLegacyWrite(o, annotations, httpHeaders, entityStream, defaultWriter);
+        doLegacyWrite(o, annotations, httpHeaders, entityStream, defaultWriter.get());
     }
 
     private static class MethodObjectWriterFunction implements Function<String, ObjectWriter> {


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/32969

cc @geoand  this fixes my issue with my main app. Following modules used; 

Installed features: [cdi, hibernate-validator, logging-manager, micrometer, quartz, rest, rest-client, rest-client-jackson, rest-jackson, scheduler, smallrye-context-propagation, smallrye-fault-tolerance, smallrye-health, smallrye-openapi, swagger-ui, vertx]