### PR TITLE
Assorted @WithTestResource fixes

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1224,20 +1224,20 @@ public @interface WithRepeatableTestResource {
 }
 ----
 
-=== Usage of `@WithTestResources`
+=== Usage of `@WithTestResource`
 
-While test resources provided by `@QuarkusTestResource` are available either globally or restricted to the annotated test class (`restrictToAnnotatedClass`), the annotation `@WithTestResources` allows to additionally group tests by test resources for execution.
-`@WithTestResources` has a `scope` property that takes a `TestResourceScope` enum value:
+While test resources provided by `@QuarkusTestResource` are available either globally or restricted to the annotated test class (`restrictToAnnotatedClass`), the annotation `@WithTestResource` allows to additionally group tests by test resources for execution.
+`@WithTestResource` has a `scope` property that takes a `TestResourceScope` enum value:
 
 - `TestResourceScope.MATCHING_RESOURCES` (default): Quarkus will group tests with the same test resources and run them together. After a group has been executed, all test resources will be stopped, and the next group will be executed.
 - `TestResourceScope.RESTRICTED_TO_CLASS`: The test resource is available only for the annotated test class and will be stopped after the test class has been executed.
-- `TestResourceScope.GLOBAL`: Test resources apply to all tests in the testsuite
+- `TestResourceScope.GLOBAL`: Test resources apply to all tests in the test suite
 
 Quarkus needs to restart if one of the following is true:
 
-- At least one the existing test resources is restricted to the test class
-- At least one the next test resources is restricted to the test class
-- Different {@code MATCHING_RESOURCE} scoped test resources are being used
+- At least one of the test resources of the current test is restricted to the test class
+- At least one of the test resources of the next test is restricted to the test class
+- Different `MATCHING_RESOURCES` scoped test resources are being used
 
 == Hang Detection
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -106,8 +106,7 @@ public class TestResourceManager implements Closeable {
 
         this.testResourceComparisonInfo = new HashSet<>();
         for (TestResourceClassEntry uniqueEntry : uniqueEntries) {
-            testResourceComparisonInfo.add(new TestResourceComparisonInfo(
-                    uniqueEntry.testResourceLifecycleManagerClass().getName(), uniqueEntry.getScope(), uniqueEntry.args));
+            testResourceComparisonInfo.add(prepareTestResourceComparisonInfo(uniqueEntry));
         }
 
         Set<TestResourceClassEntry> remainingUniqueEntries = initParallelTestResources(uniqueEntries);
@@ -331,7 +330,7 @@ public class TestResourceManager implements Closeable {
     }
 
     /**
-     * Allows Quarkus to extra basic information about which test resources a test class will require
+     * Allows Quarkus to extract basic information about which test resources a test class will require
      */
     public static Set<TestResourceManager.TestResourceComparisonInfo> testResourceComparisonInfo(Class<?> testClass,
             Path testClassLocation, List<TestResourceClassEntry> entriesFromProfile) {
@@ -343,14 +342,22 @@ public class TestResourceManager implements Closeable {
         allEntries.addAll(entriesFromProfile);
         Set<TestResourceManager.TestResourceComparisonInfo> result = new HashSet<>(allEntries.size());
         for (TestResourceClassEntry entry : allEntries) {
-            Map<String, String> args = new HashMap<>(entry.args);
-            if (entry.configAnnotation != null) {
-                args.put("configAnnotation", entry.configAnnotation.annotationType().getName());
-            }
-            result.add(new TestResourceComparisonInfo(entry.testResourceLifecycleManagerClass().getName(), entry.getScope(),
-                    args));
+            result.add(prepareTestResourceComparisonInfo(entry));
         }
         return result;
+    }
+
+    private static TestResourceComparisonInfo prepareTestResourceComparisonInfo(TestResourceClassEntry entry) {
+        Map<String, String> args;
+        if (entry.configAnnotation != null) {
+            args = new HashMap<>(entry.args);
+            args.put("configAnnotation", entry.configAnnotation.annotationType().getName());
+        } else {
+            args = entry.args;
+        }
+
+        return new TestResourceComparisonInfo(entry.testResourceLifecycleManagerClass().getName(), entry.getScope(),
+                args);
     }
 
     private static Set<TestResourceClassEntry> getUniqueTestResourceClassEntries(Class<?> testClass,

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
@@ -122,12 +122,12 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
                 })
                 .orElseGet(ClassName::new).orderClasses(context);
 
-        var classDecriptors = context.getClassDescriptors();
-        var firstPassIndexMap = IntStream.range(0, classDecriptors.size()).boxed()
-                .collect(Collectors.toMap(classDecriptors::get, i -> String.format("%06d", i)));
+        var classDescriptors = context.getClassDescriptors();
+        var firstPassIndexMap = IntStream.range(0, classDescriptors.size()).boxed()
+                .collect(Collectors.toMap(classDescriptors::get, i -> String.format("%06d", i)));
 
         // second pass: apply the actual Quarkus aware ordering logic, using the first pass indices as order key suffixes
-        classDecriptors.sort(Comparator.comparing(classDescriptor -> {
+        classDescriptors.sort(Comparator.comparing(classDescriptor -> {
             var secondaryOrderSuffix = firstPassIndexMap.get(classDescriptor);
             Optional<String> customOrderKey = getCustomOrderKey(classDescriptor, context, secondaryOrderSuffix)
                     .or(() -> getCustomOrderKey(classDescriptor, context));


### PR DESCRIPTION
The first two commit are just some doc fixes and a typo fix... but the third one is actually a real bug fix.

When determining if Quarkus should be restarted or not in a test, we were comparing items in which we were injecting an additional `configAnnotation` entry with items for which we didn't. Which led to some unnecessary restarts.

I stumbled upon this while working on a modified version of `@WithKubernetesTestServer` which was not restricted to class.