### PR TITLE
Typo in ProxyConfig

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -35,7 +35,7 @@ public class ProxyConfig {
      * the precedence.
      * Activating this together with {@code quarkus.http.proxy.allow-x-forwarded} has security implications as clients can forge
      * requests with a forwarded header that is not overwritten by the proxy. Therefore, proxies should strip unexpected
-     * `X-Forwarded` or `X-Forwarded-*` headers from the client.
+     * `Forwarded` or `X-Forwarded-*` headers from the client.
      */
     @ConfigItem
     public boolean allowForwarded;
@@ -47,7 +47,7 @@ public class ProxyConfig {
      * precedence.
      * Activating this together with {@code quarkus.http.proxy.allow-forwarded} has security implications as clients can forge
      * requests with a forwarded header that is not overwritten by the proxy. Therefore, proxies should strip unexpected
-     * `X-Forwarded` or `X-Forwarded-*` headers from the client.
+     * `Forwarded` or `X-Forwarded-*` headers from the client.
      */
     @ConfigItem
     public Optional<Boolean> allowXForwarded;


### PR DESCRIPTION
Found another couple of instances of #45254.

In this proxy configuration guidance, `X-Forwarded` was intended to be `Forwarded`.