### PR TITLE
Reapply "Switch Vert.x HTTP to @ConfigMapping"

### DIFF
--- a/extensions/funqy/funqy-http/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/http/FunqyHttpBuildStep.java
+++ b/extensions/funqy/funqy-http/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/http/FunqyHttpBuildStep.java
@@ -60,7 +60,7 @@ public class FunqyHttpBuildStep {
             return;
 
         // The context path + the resources path
-        String rootPath = httpConfig.rootPath;
+        String rootPath = httpConfig.rootPath();
         binding.init();
     }
 
@@ -81,7 +81,7 @@ public class FunqyHttpBuildStep {
             return;
         feature.produce(new FeatureBuildItem(FUNQY_HTTP_FEATURE));
 
-        String rootPath = httpConfig.rootPath;
+        String rootPath = httpConfig.rootPath();
         Handler<RoutingContext> handler = binding.start(rootPath,
                 vertx.getVertx(),
                 shutdown,

--- a/extensions/funqy/funqy-knative-events/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/knative/events/FunqyKnativeEventsBuildStep.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/knative/events/FunqyKnativeEventsBuildStep.java
@@ -82,7 +82,7 @@ public class FunqyKnativeEventsBuildStep {
 
         feature.produce(new FeatureBuildItem(FUNQY_KNATIVE_FEATURE));
 
-        String rootPath = httpConfig.rootPath;
+        String rootPath = httpConfig.rootPath();
         if (rootPath == null) {
             rootPath = "/";
         } else if (!rootPath.endsWith("/")) {

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devui/GrpcJsonRPCService.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devui/GrpcJsonRPCService.java
@@ -69,18 +69,18 @@ public class GrpcJsonRPCService {
             this.port = serverConfig.port;
             this.ssl = serverConfig.ssl.certificate.isPresent() || serverConfig.ssl.keyStore.isPresent();
         } else {
-            this.host = httpConfiguration.host;
-            this.port = httpConfiguration.port;
-            this.ssl = isTLSConfigured(httpConfiguration.ssl.certificate);
+            this.host = httpConfiguration.host();
+            this.port = httpConfiguration.port();
+            this.ssl = isTLSConfigured(httpConfiguration.ssl().certificate());
         }
         this.grpcServiceClassInfos = getGrpcServiceClassInfos();
         this.callsInProgress = new HashMap<>();
     }
 
     private boolean isTLSConfigured(CertificateConfig certificate) {
-        return certificate.files.isPresent()
-                || certificate.keyFiles.isPresent()
-                || certificate.keyStoreFile.isPresent();
+        return certificate.files().isPresent()
+                || certificate.keyFiles().isPresent()
+                || certificate.keyStoreFile().isPresent();
     }
 
     public JsonArray getServices() {

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/DefaultPolicyEnforcerResolver.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/DefaultPolicyEnforcerResolver.java
@@ -40,7 +40,7 @@ public class DefaultPolicyEnforcerResolver implements PolicyEnforcerResolver {
             HttpConfiguration httpConfiguration, BlockingSecurityExecutor blockingSecurityExecutor,
             Instance<TenantPolicyConfigResolver> configResolver,
             InjectableInstance<TlsConfigurationRegistry> tlsConfigRegistryInstance) {
-        this.readTimeout = httpConfiguration.readTimeout.toMillis();
+        this.readTimeout = httpConfiguration.readTimeout().toMillis();
 
         if (tlsConfigRegistryInstance.isResolvable()) {
             this.tlsSupport = OidcTlsSupport.of(tlsConfigRegistryInstance.get());

--- a/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/ManagementRequestPrioritizer.java
+++ b/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/ManagementRequestPrioritizer.java
@@ -16,19 +16,19 @@ public class ManagementRequestPrioritizer implements RequestPrioritizer<HttpServ
     @Inject
     public ManagementRequestPrioritizer(HttpBuildTimeConfig httpConfig,
             ManagementInterfaceBuildTimeConfig managementInterfaceConfig) {
-        if (managementInterfaceConfig.enabled) {
+        if (managementInterfaceConfig.enabled()) {
             managementPath = null;
             return;
         }
-        if (httpConfig.nonApplicationRootPath.startsWith("/")) {
-            if (httpConfig.nonApplicationRootPath.equals(httpConfig.rootPath)) {
+        if (httpConfig.nonApplicationRootPath().startsWith("/")) {
+            if (httpConfig.nonApplicationRootPath().equals(httpConfig.rootPath())) {
                 managementPath = null;
                 return;
             }
-            managementPath = httpConfig.nonApplicationRootPath;
+            managementPath = httpConfig.nonApplicationRootPath();
             return;
         }
-        managementPath = httpConfig.rootPath + httpConfig.nonApplicationRootPath;
+        managementPath = httpConfig.rootPath() + httpConfig.nonApplicationRootPath();
     }
 
     @Override

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -334,7 +334,7 @@ public class OidcBuildStep {
             CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<EagerSecurityInterceptorBindingBuildItem> bindingProducer,
             BuildProducer<SystemPropertyBuildItem> systemPropertyProducer) {
-        if (!buildTimeConfig.auth.proactive
+        if (!buildTimeConfig.auth().proactive()
                 && (capabilities.isPresent(Capability.RESTEASY_REACTIVE) || capabilities.isPresent(Capability.RESTEASY))) {
             boolean foundTenantResolver = combinedIndexBuildItem
                     .getIndex()

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
@@ -31,7 +31,7 @@ public class OidcDevJsonRpcService {
     @NonBlocking
     public OidcDevUiRuntimePropertiesDTO getProperties() {
         return new OidcDevUiRuntimePropertiesDTO(props.getAuthorizationUrl(), props.getTokenUrl(), props.getLogoutUrl(),
-                ConfigProvider.getConfig(), httpConfiguration.port,
+                ConfigProvider.getConfig(), httpConfiguration.port(),
                 props.getOidcProviderName(), props.getOidcApplicationType(), props.getOidcGrantType(),
                 props.isIntrospectionIsAvailable(), props.getKeycloakAdminUrl(),
                 props.getKeycloakRealms(), props.isSwaggerIsAvailable(), props.isGraphqlIsAvailable(), props.getSwaggerUiPath(),

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
@@ -219,7 +219,7 @@ class ReactiveRoutesProcessor {
                     // access the SecurityIdentity in a synchronous manner
                     final boolean blocking = annotationStore.hasAnnotation(method, DotNames.BLOCKING);
                     final boolean alwaysAuthenticateRoute;
-                    if (!httpBuildTimeConfig.auth.proactive && !blocking) {
+                    if (!httpBuildTimeConfig.auth().proactive() && !blocking) {
                         final DotName returnTypeName = method.returnType().name();
                         // method either returns 'something' in a synchronous manner or void (in which case we can't tell)
                         final boolean possiblySynchronousResponse = !returnTypeName.equals(DotNames.UNI)

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
@@ -56,10 +56,10 @@ public class VertxWebRecorder {
     }
 
     public Handler<RoutingContext> compressRouteHandler(Handler<RoutingContext> routeHandler, HttpCompression compression) {
-        if (httpBuildTimeConfig.enableCompression) {
+        if (httpBuildTimeConfig.enableCompression()) {
             return new HttpCompressionHandler(routeHandler, compression,
                     compression == HttpCompression.UNDEFINED
-                            ? Set.copyOf(httpBuildTimeConfig.compressMediaTypes.orElse(List.of()))
+                            ? Set.copyOf(httpBuildTimeConfig.compressMediaTypes().orElse(List.of()))
                             : Set.of());
         } else {
             return routeHandler;

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -117,7 +117,7 @@ public class ResteasyStandaloneBuildStep {
         final boolean noCustomAuthCompletionExMapper;
         final boolean noCustomAuthFailureExMapper;
         final boolean noCustomAuthRedirectExMapper;
-        if (vertxConfig.auth.proactive) {
+        if (vertxConfig.auth().proactive()) {
             noCustomAuthCompletionExMapper = notFoundCustomExMapper(AuthenticationCompletionException.class.getName(),
                     AuthenticationCompletionExceptionMapper.class.getName(), combinedIndexBuildItem.getIndex());
             noCustomAuthFailureExMapper = notFoundCustomExMapper(AuthenticationFailedException.class.getName(),
@@ -135,7 +135,7 @@ public class ResteasyStandaloneBuildStep {
         // so that user can define failure handlers that precede exception mappers
         final Handler<RoutingContext> failureHandler = recorder.vertxFailureHandler(vertx.getVertx(),
                 executorBuildItem.getExecutorProxy(), resteasyVertxConfig, noCustomAuthCompletionExMapper,
-                noCustomAuthFailureExMapper, noCustomAuthRedirectExMapper, vertxConfig.auth.proactive);
+                noCustomAuthFailureExMapper, noCustomAuthRedirectExMapper, vertxConfig.auth().proactive());
         filterBuildItemBuildProducer.produce(FilterBuildItem.ofAuthenticationFailureHandler(failureHandler));
 
         // Exact match for resources matched to the root path

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AbstractSecurityEventTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AbstractSecurityEventTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractSecurityEventTest {
     }
 
     private boolean isProactiveAuth() {
-        return httpBuildTimeConfig.auth.proactive;
+        return httpBuildTimeConfig.auth().proactive();
     }
 
     @Test

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
@@ -100,10 +100,10 @@ public class ResteasyStandaloneRecorder {
         if (deployment != null) {
             Handler<RoutingContext> handler = new VertxRequestHandler(vertx.get(), deployment, contextPath,
                     new ResteasyVertxAllocator(config.responseBufferSize), executor,
-                    readTimeout.getValue().readTimeout.toMillis());
+                    readTimeout.getValue().readTimeout().toMillis());
 
-            Set<String> compressMediaTypes = httpBuildTimeConfig.compressMediaTypes.map(Set::copyOf).orElse(Set.of());
-            if (httpBuildTimeConfig.enableCompression && !compressMediaTypes.isEmpty()) {
+            Set<String> compressMediaTypes = httpBuildTimeConfig.compressMediaTypes().map(Set::copyOf).orElse(Set.of());
+            if (httpBuildTimeConfig.enableCompression() && !compressMediaTypes.isEmpty()) {
                 // If compression is enabled and the set of compressed media types is not empty then wrap the standalone handler
                 handler = new HttpCompressionHandler(handler, compressMediaTypes);
             }
@@ -129,7 +129,7 @@ public class ResteasyStandaloneRecorder {
             // used when auth failed before RESTEasy Classic began processing the request
             return new VertxRequestHandler(vertx.get(), deployment, contextPath,
                     new ResteasyVertxAllocator(config.responseBufferSize), executor,
-                    readTimeout.getValue().readTimeout.toMillis()) {
+                    readTimeout.getValue().readTimeout().toMillis()) {
 
                 @Override
                 public void handle(RoutingContext request) {

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CompressionScanner.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CompressionScanner.java
@@ -34,7 +34,7 @@ public class CompressionScanner implements MethodScanner {
     @Override
     public List<HandlerChainCustomizer> scan(MethodInfo method, ClassInfo actualEndpointClass,
             Map<String, Object> methodContext) {
-        if (!httpBuildTimeConfig.enableCompression) {
+        if (!httpBuildTimeConfig.enableCompression()) {
             return Collections.emptyList();
         }
 
@@ -58,7 +58,7 @@ public class CompressionScanner implements MethodScanner {
             return Collections.emptyList();
         }
         ResteasyReactiveCompressionHandler handler = new ResteasyReactiveCompressionHandler(
-                Set.copyOf(httpBuildTimeConfig.compressMediaTypes.orElse(Collections.emptyList())));
+                Set.copyOf(httpBuildTimeConfig.compressMediaTypes().orElse(Collections.emptyList())));
         handler.setCompression(compression);
         String[] produces = (String[]) methodContext.get(EndpointIndexer.METHOD_PRODUCES);
         if ((produces != null) && (produces.length > 0)) {

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -1405,7 +1405,7 @@ public class ResteasyReactiveProcessor {
             final boolean noCustomAuthCompletionExMapper;
             final boolean noCustomAuthFailureExMapper;
             final boolean noCustomAuthRedirectExMapper;
-            if (vertxConfig.auth.proactive) {
+            if (vertxConfig.auth().proactive()) {
                 noCustomAuthCompletionExMapper = notFoundCustomExMapper(AuthenticationCompletionException.class.getName(),
                         AuthenticationCompletionExceptionMapper.class.getName(), exceptionMapping);
                 noCustomAuthFailureExMapper = notFoundCustomExMapper(AuthenticationFailedException.class.getName(),
@@ -1420,7 +1420,7 @@ public class ResteasyReactiveProcessor {
             }
 
             Handler<RoutingContext> failureHandler = recorder.failureHandler(restInitialHandler, noCustomAuthCompletionExMapper,
-                    noCustomAuthFailureExMapper, noCustomAuthRedirectExMapper, vertxConfig.auth.proactive);
+                    noCustomAuthFailureExMapper, noCustomAuthRedirectExMapper, vertxConfig.auth().proactive());
 
             // we add failure handler right before QuarkusErrorHandler
             // so that user can define failure handlers that precede exception mappers

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AbstractSecurityEventTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AbstractSecurityEventTest.java
@@ -65,7 +65,7 @@ public abstract class AbstractSecurityEventTest {
     }
 
     private boolean isProactiveAuth() {
-        return httpBuildTimeConfig.auth.proactive;
+        return httpBuildTimeConfig.auth().proactive();
     }
 
     @Test

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -154,7 +154,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
         RuntimeDeploymentManager runtimeDeploymentManager = new RuntimeDeploymentManager(info, EXECUTOR_SUPPLIER,
                 VTHREAD_EXECUTOR_SUPPLIER,
                 closeTaskHandler, contextFactory, new ArcThreadSetupAction(beanContainer.requestContext()),
-                vertxConfig.rootPath);
+                vertxConfig.rootPath());
         Deployment deployment = runtimeDeploymentManager.deploy();
         DisabledRestEndpoints.set(deployment.getDisabledEndpoints());
         initClassFactory.createInstance().getInstance().init(deployment);

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
@@ -27,18 +27,18 @@ public class ResteasyReactiveRuntimeRecorder {
             ResteasyReactiveServerRuntimeConfig runtimeConf) {
         Optional<Long> maxBodySize;
 
-        if (httpConf.limits.maxBodySize.isPresent()) {
-            maxBodySize = Optional.of(httpConf.limits.maxBodySize.get().asLongValue());
+        if (httpConf.limits().maxBodySize().isPresent()) {
+            maxBodySize = Optional.of(httpConf.limits().maxBodySize().get().asLongValue());
         } else {
             maxBodySize = Optional.empty();
         }
 
-        RuntimeConfiguration runtimeConfiguration = new DefaultRuntimeConfiguration(httpConf.readTimeout,
-                httpConf.body.deleteUploadedFilesOnEnd, httpConf.body.uploadsDirectory,
-                httpConf.body.multipart.fileContentTypes.orElse(null),
+        RuntimeConfiguration runtimeConfiguration = new DefaultRuntimeConfiguration(httpConf.readTimeout(),
+                httpConf.body().deleteUploadedFilesOnEnd(), httpConf.body().uploadsDirectory(),
+                httpConf.body().multipart().fileContentTypes().orElse(null),
                 runtimeConf.multipart().inputPart().defaultCharset(), maxBodySize,
-                httpConf.limits.maxFormAttributeSize.asLongValue(),
-                httpConf.limits.maxParameters);
+                httpConf.limits().maxFormAttributeSize().asLongValue(),
+                httpConf.limits().maxParameters());
 
         deployment.getValue().setRuntimeConfiguration(runtimeConfiguration);
 

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityContext.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityContext.java
@@ -52,7 +52,7 @@ public class EagerSecurityContext {
             InjectableInstance<CurrentIdentityAssociation> identityAssociation, AuthorizationController authorizationController,
             HttpBuildTimeConfig buildTimeConfig,
             JaxRsPathMatchingHttpSecurityPolicy jaxRsPathMatchingPolicy) {
-        this.isProactiveAuthDisabled = !buildTimeConfig.auth.proactive;
+        this.isProactiveAuthDisabled = !buildTimeConfig.auth().proactive();
         this.identityAssociation = identityAssociation;
         this.authorizationController = authorizationController;
         this.eventHelper = new SecurityEventHelper<>(authorizationSuccessEvent, authorizationFailureEvent,

--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
@@ -59,7 +59,7 @@ public class WebAuthnRecorder {
             @Override
             public WebAuthnAuthenticationMechanism get() {
                 String key;
-                if (!httpConfiguration.getValue().encryptionKey.isPresent()) {
+                if (!httpConfiguration.getValue().encryptionKey().isPresent()) {
                     if (encryptionKey != null) {
                         //persist across dev mode restarts
                         key = encryptionKey;
@@ -72,7 +72,7 @@ public class WebAuthnRecorder {
                                         + key);
                     }
                 } else {
-                    key = httpConfiguration.getValue().encryptionKey.get();
+                    key = httpConfiguration.getValue().encryptionKey().get();
                 }
                 WebAuthnRunTimeConfig config = WebAuthnRecorder.this.config.getValue();
                 PersistentLoginManager loginManager = new PersistentLoginManager(key, config.cookieName(),

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -472,7 +472,7 @@ public class SmallRyeGraphQLProcessor {
         // Queries and Mutations
         boolean allowGet = getBooleanConfigValue(ConfigKey.ALLOW_GET, false);
         boolean allowQueryParametersOnPost = getBooleanConfigValue(ConfigKey.ALLOW_POST_WITH_QUERY_PARAMETERS, false);
-        boolean allowCompression = httpBuildTimeConfig.enableCompression && httpBuildTimeConfig.compressMediaTypes
+        boolean allowCompression = httpBuildTimeConfig.enableCompression() && httpBuildTimeConfig.compressMediaTypes()
                 .map(mediaTypes -> mediaTypes.contains(GRAPHQL_MEDIA_TYPE))
                 .orElse(false);
         Handler<RoutingContext> executionHandler = recorder.executionHandler(graphQLInitializedBuildItem.getInitialized(),

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -296,7 +296,7 @@ class SmallRyeHealthProcessor {
             SmallRyeHealthConfig healthConfig) {
 
         // Add to OpenAPI if OpenAPI is available
-        if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI) && !managementInterfaceBuildTimeConfig.enabled) {
+        if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI) && !managementInterfaceBuildTimeConfig.enabled()) {
             String healthRootPath = nonApplicationRootPathBuildItem.resolvePath(healthConfig.rootPath);
             HealthOpenAPIFilter filter = new HealthOpenAPIFilter(healthRootPath,
                     nonApplicationRootPathBuildItem.resolveManagementNestedPath(healthRootPath, healthConfig.livenessPath),
@@ -338,7 +338,7 @@ class SmallRyeHealthProcessor {
             BuildProducer<KubernetesHealthStartupPathBuildItem> startupPathItemProducer,
             BuildProducer<KubernetesProbePortNameBuildItem> port) {
 
-        if (managementInterfaceBuildTimeConfig.enabled) {
+        if (managementInterfaceBuildTimeConfig.enabled()) {
             // Switch to the "management" port
             port.produce(new KubernetesProbePortNameBuildItem("management", selectSchemeForManagement()));
         }

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -346,7 +346,7 @@ public class SmallRyeOpenApiProcessor {
         String managementRoot = nonApplicationRootPathBuildItem.resolveManagementPath("/",
                 managementInterfaceBuildTimeConfig, launch, openApiConfig.managementEnabled);
 
-        return managementRoot.split(managementInterfaceBuildTimeConfig.rootPath)[0];
+        return managementRoot.split(managementInterfaceBuildTimeConfig.rootPath())[0];
 
     }
 
@@ -454,7 +454,7 @@ public class SmallRyeOpenApiProcessor {
     private boolean isManagement(ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
             SmallRyeOpenApiConfig smallRyeOpenApiConfig,
             LaunchModeBuildItem launchModeBuildItem) {
-        return managementInterfaceBuildTimeConfig.enabled && smallRyeOpenApiConfig.managementEnabled
+        return managementInterfaceBuildTimeConfig.enabled() && smallRyeOpenApiConfig.managementEnabled
                 && launchModeBuildItem.getLaunchMode().equals(LaunchMode.DEVELOPMENT);
     }
 

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -26,7 +26,7 @@ public class OpenApiRecorder {
     }
 
     public Consumer<Route> corsFilter(Filter filter) {
-        if (configuration.getValue().corsEnabled && filter.getHandler() != null) {
+        if (configuration.getValue().corsEnabled() && filter.getHandler() != null) {
             return new Consumer<Route>() {
                 @Override
                 public void accept(Route route) {

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -417,7 +417,7 @@ public class UndertowBuildStep {
                 knownPaths.knownDirectories,
                 launchMode.getLaunchMode(), shutdownContext, httpRootPath.relativePath(contextPath),
                 servletConfig.defaultCharset, webMetaData.getRequestCharacterEncoding(),
-                webMetaData.getResponseCharacterEncoding(), httpBuildTimeConfig.auth.proactive,
+                webMetaData.getResponseCharacterEncoding(), httpBuildTimeConfig.auth().proactive(),
                 webMetaData.getWelcomeFileList() != null ? webMetaData.getWelcomeFileList().getWelcomeFiles() : null,
                 hasSecurityCapability(capabilities));
 

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -390,8 +390,8 @@ public class UndertowDeploymentRecorder {
         undertowOptions.set(UndertowOptions.MAX_PARAMETERS, servletRuntimeConfig.maxParameters);
         UndertowOptionMap undertowOptionMap = undertowOptions.getMap();
 
-        Set<String> compressMediaTypes = httpBuildTimeConfig.enableCompression
-                ? Set.copyOf(httpBuildTimeConfig.compressMediaTypes.get())
+        Set<String> compressMediaTypes = httpBuildTimeConfig.enableCompression()
+                ? Set.copyOf(httpBuildTimeConfig.compressMediaTypes().get())
                 : Collections.emptySet();
 
         return new Handler<RoutingContext>() {
@@ -422,11 +422,11 @@ public class UndertowDeploymentRecorder {
                     });
                 }
 
-                Optional<MemorySize> maxBodySize = httpConfiguration.getValue().limits.maxBodySize;
+                Optional<MemorySize> maxBodySize = httpConfiguration.getValue().limits().maxBodySize();
                 if (maxBodySize.isPresent()) {
                     exchange.setMaxEntitySize(maxBodySize.get().asLongValue());
                 }
-                Duration readTimeout = httpConfiguration.getValue().readTimeout;
+                Duration readTimeout = httpConfiguration.getValue().readTimeout();
                 exchange.setReadTimeout(readTimeout.toMillis());
 
                 exchange.setUndertowOptions(undertowOptionMap);

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -114,6 +114,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
@@ -167,9 +172,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -528,7 +528,7 @@ public class BuildTimeContentProcessor {
         footerTabs.add(testLog);
 
         // This is only needed when extension developers work on an extension, so we only included it if you build from source.
-        if (Version.getVersion().equalsIgnoreCase("999-SNAPSHOT") || devUIConfig.showJsonRpcLog) {
+        if (Version.getVersion().equalsIgnoreCase("999-SNAPSHOT") || devUIConfig.showJsonRpcLog()) {
             Page devUiLog = Page.webComponentPageBuilder().internal()
                     .namespace("devui-jsonrpcstream")
                     .title("Dev UI")

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
@@ -4,23 +4,25 @@ import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "dev-ui")
-public class DevUIConfig {
+@ConfigMapping(prefix = "quarkus.dev-ui")
+@ConfigRoot
+public interface DevUIConfig {
 
     /**
      * The number of history log entries to remember.
      */
-    @ConfigItem(defaultValue = "50")
-    public int historySize;
+    @WithDefault("50")
+    int historySize();
 
     /**
      * Show the JsonRPC Log. Useful for extension developers
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean showJsonRpcLog;
+    @WithDefault("false")
+    boolean showJsonRpcLog();
 
     /**
      * More hosts allowed for Dev UI
@@ -29,22 +31,21 @@ public class DevUIConfig {
      * (This can also be a regex)
      * By default localhost and 127.0.0.1 will always be allowed
      */
-    @ConfigItem
-    public Optional<List<String>> hosts = Optional.empty();
+    Optional<List<String>> hosts();
 
     /**
      * CORS configuration.
      */
-    public Cors cors = new Cors();
+    Cors cors();
 
     @ConfigGroup
-    public static class Cors {
+    public interface Cors {
 
         /**
          * Enable CORS filter.
          */
-        @ConfigItem(defaultValue = "true")
-        public boolean enabled = true;
+        @WithDefault("true")
+        boolean enabled();
     }
 
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -146,10 +146,10 @@ public class DevUIProcessor {
 
         routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                 .orderedRoute(DEVUI + SLASH_ALL, -2 * FilterBuildItem.CORS)
-                .handler(recorder.createLocalHostOnlyFilter(devUIConfig.hosts.orElse(null)))
+                .handler(recorder.createLocalHostOnlyFilter(devUIConfig.hosts().orElse(null)))
                 .build());
 
-        if (devUIConfig.cors.enabled) {
+        if (devUIConfig.cors().enabled()) {
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                     .orderedRoute(DEVUI + SLASH_ALL, -1 * FilterBuildItem.CORS)
                     .handler(new DevUICORSFilter())

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ManagementInterfaceSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ManagementInterfaceSecurityProcessor.java
@@ -34,7 +34,7 @@ public class ManagementInterfaceSecurityProcessor {
     SyntheticBeanBuildItem initBasicAuth(
             ManagementInterfaceSecurityRecorder recorder,
             ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig) {
-        if (managementInterfaceBuildTimeConfig.auth.basic.orElse(false)) {
+        if (managementInterfaceBuildTimeConfig.auth().basic().orElse(false)) {
             SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
                     .configure(BasicAuthenticationMechanism.class)
                     .types(HttpAuthenticationMechanism.class)
@@ -74,9 +74,9 @@ public class ManagementInterfaceSecurityProcessor {
     void createManagementAuthMechHandler(ManagementInterfaceSecurityRecorder recorder, Capabilities capabilities,
             ManagementInterfaceBuildTimeConfig buildTimeConfig,
             BuildProducer<ManagementAuthenticationHandlerBuildItem> managementAuthMechHandlerProducer) {
-        if (buildTimeConfig.auth.enabled && capabilities.isPresent(Capability.SECURITY)) {
+        if (buildTimeConfig.auth().enabled() && capabilities.isPresent(Capability.SECURITY)) {
             managementAuthMechHandlerProducer.produce(new ManagementAuthenticationHandlerBuildItem(
-                    recorder.managementAuthenticationHandler(buildTimeConfig.auth.proactive)));
+                    recorder.managementAuthenticationHandler(buildTimeConfig.auth().proactive())));
         }
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
@@ -175,7 +175,7 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
         if (path == null || path.trim().isEmpty()) {
             throw new IllegalArgumentException("Specified path can not be empty");
         }
-        if (managementInterfaceBuildTimeConfig.enabled && extensionOverride) {
+        if (managementInterfaceBuildTimeConfig.enabled() && extensionOverride) {
             // Best effort
             String prefix = getManagementUrlPrefix(mode);
             if (managementRootPath != null) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -100,7 +100,7 @@ class VertxHttpProcessor {
 
     @BuildStep
     HttpRootPathBuildItem httpRoot(HttpBuildTimeConfig httpBuildTimeConfig) {
-        return new HttpRootPathBuildItem(httpBuildTimeConfig.rootPath);
+        return new HttpRootPathBuildItem(httpBuildTimeConfig.rootPath());
     }
 
     @BuildStep
@@ -120,10 +120,10 @@ class VertxHttpProcessor {
     NonApplicationRootPathBuildItem frameworkRoot(HttpBuildTimeConfig httpBuildTimeConfig,
             ManagementInterfaceBuildTimeConfig managementBuildTimeConfig) {
         String mrp = null;
-        if (managementBuildTimeConfig.enabled) {
-            mrp = managementBuildTimeConfig.rootPath;
+        if (managementBuildTimeConfig.enabled()) {
+            mrp = managementBuildTimeConfig.rootPath();
         }
-        return new NonApplicationRootPathBuildItem(httpBuildTimeConfig.rootPath, httpBuildTimeConfig.nonApplicationRootPath,
+        return new NonApplicationRootPathBuildItem(httpBuildTimeConfig.rootPath(), httpBuildTimeConfig.nonApplicationRootPath(),
                 mrp);
     }
 
@@ -183,7 +183,7 @@ class VertxHttpProcessor {
 
     @BuildStep
     UseManagementInterfaceBuildItem useManagementInterfaceBuildItem(ManagementInterfaceBuildTimeConfig config) {
-        if (config.enabled) {
+        if (config.enabled()) {
             return new UseManagementInterfaceBuildItem();
         }
         return null;
@@ -213,7 +213,7 @@ class VertxHttpProcessor {
     public KubernetesPortBuildItem kubernetesForManagement(
             ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig) {
         return KubernetesPortBuildItem.fromRuntimeConfiguration("management", "quarkus.management.port", 9000,
-                managementInterfaceBuildTimeConfig.enabled);
+                managementInterfaceBuildTimeConfig.enabled());
     }
 
     @BuildStep
@@ -268,7 +268,7 @@ class VertxHttpProcessor {
         boolean frameworkRouterCreated = false;
         boolean mainRouterCreated = false;
 
-        boolean isManagementInterfaceEnabled = managementBuildTimeConfig.enabled;
+        boolean isManagementInterfaceEnabled = managementBuildTimeConfig.enabled();
         if (isManagementInterfaceEnabled) {
             managementRouter = recorder.initializeRouter(vertx.getVertx());
         }
@@ -300,7 +300,7 @@ class VertxHttpProcessor {
          * To create mainrouter when `${quarkus.http.root-path}` is not {@literal /}
          * Refer https://github.com/quarkusio/quarkus/issues/34261
          */
-        if (!httpBuildTimeConfig.rootPath.equals("/") && !mainRouterCreated) {
+        if (!httpBuildTimeConfig.rootPath().equals("/") && !mainRouterCreated) {
             mainRouter = recorder.initializeRouter(vertx.getVertx());
         }
 
@@ -462,7 +462,7 @@ class VertxHttpProcessor {
             List<WebsocketSubProtocolsBuildItem> websocketSubProtocols,
             Capabilities capabilities,
             VertxHttpRecorder recorder) throws IOException {
-        boolean startVirtual = requireVirtual.isPresent() || httpBuildTimeConfig.virtual;
+        boolean startVirtual = requireVirtual.isPresent() || httpBuildTimeConfig.virtual();
         if (startVirtual) {
             reflectiveClass
                     .produce(ReflectiveClassBuildItem.builder(VirtualServerChannel.class).reason(getClass().getName()).build());
@@ -555,8 +555,8 @@ class VertxHttpProcessor {
 
     @BuildStep
     NativeImageFeatureBuildItem Brotli4jFeature(HttpBuildTimeConfig httpBuildTimeConfig) {
-        if (httpBuildTimeConfig.compressors.isPresent()
-                && httpBuildTimeConfig.compressors.get().stream().anyMatch(s -> s.equalsIgnoreCase("br"))) {
+        if (httpBuildTimeConfig.compressors().isPresent()
+                && httpBuildTimeConfig.compressors().get().stream().anyMatch(s -> s.equalsIgnoreCase("br"))) {
             return new NativeImageFeatureBuildItem(Brotli4jFeature.class.getName());
         }
         return null;

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ConfiguredPathInfo.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ConfiguredPathInfo.java
@@ -33,7 +33,7 @@ public class ConfiguredPathInfo {
 
     public String getEndpointPath(NonApplicationRootPathBuildItem nonAppRoot, ManagementInterfaceBuildTimeConfig mibt,
             LaunchModeBuildItem mode) {
-        if (management && mibt.enabled) {
+        if (management && mibt.enabled()) {
             var prefix = NonApplicationRootPathBuildItem.getManagementUrlPrefix(mode);
             return prefix + endpointPath;
         }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
@@ -21,7 +21,7 @@ import io.quarkus.vertx.http.security.PathHandler;
 public class CORSWildcardSecurityTestCase {
 
     private static final String APP_PROPS = "" +
-            "quarkus.http.cors=true\n" +
+            "quarkus.http.cors.enabled=true\n" +
             "quarkus.http.cors.origins=*\n" +
             "quarkus.http.auth.basic=true\n" +
             "quarkus.http.auth.policy.r1.roles-allowed=test\n" +

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItemTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItemTest.java
@@ -1,5 +1,8 @@
 package io.quarkus.vertx.http.deployment;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
@@ -108,15 +111,15 @@ public class NonApplicationRootPathBuildItemTest {
 
     @Test
     void testResolveManagementPathWithRelativeRootPath() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "management";
+        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = mock(ManagementInterfaceBuildTimeConfig.class);
+        when(managementInterfaceBuildTimeConfig.enabled()).thenReturn(true);
+        when(managementInterfaceBuildTimeConfig.rootPath()).thenReturn("management");
 
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementInterfaceBuildTimeConfig.rootPath());
         Assertions.assertEquals("/management/", buildItem.getManagementRootPath());
         Assertions.assertEquals("http://localhost:9000/management/foo",
                 buildItem.resolveManagementPath("foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
@@ -134,15 +137,15 @@ public class NonApplicationRootPathBuildItemTest {
 
     @Test
     void testResolveManagementPathWithRelativeRootPathInTestMode() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "management";
+        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = mock(ManagementInterfaceBuildTimeConfig.class);
+        when(managementInterfaceBuildTimeConfig.enabled()).thenReturn(true);
+        when(managementInterfaceBuildTimeConfig.rootPath()).thenReturn("management");
 
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), true);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementInterfaceBuildTimeConfig.rootPath());
         Assertions.assertEquals("/management/", buildItem.getManagementRootPath());
         Assertions.assertEquals("http://localhost:9001/management/foo",
                 buildItem.resolveManagementPath("foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
@@ -160,9 +163,9 @@ public class NonApplicationRootPathBuildItemTest {
 
     @Test
     void testResolveManagementPathWithRelativeRootPathAndWithManagementDisabled() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = false;
-        managementInterfaceBuildTimeConfig.rootPath = "management";
+        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = mock(ManagementInterfaceBuildTimeConfig.class);
+        when(managementInterfaceBuildTimeConfig.enabled()).thenReturn(false);
+        when(managementInterfaceBuildTimeConfig.rootPath()).thenReturn("management");
 
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
@@ -186,15 +189,15 @@ public class NonApplicationRootPathBuildItemTest {
 
     @Test
     void testResolveManagementPathWithAbsoluteRootPath() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "/management";
+        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = mock(ManagementInterfaceBuildTimeConfig.class);
+        when(managementInterfaceBuildTimeConfig.enabled()).thenReturn(true);
+        when(managementInterfaceBuildTimeConfig.rootPath()).thenReturn("/management");
 
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "/q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementInterfaceBuildTimeConfig.rootPath());
         Assertions.assertEquals("/management/", buildItem.getManagementRootPath());
         Assertions.assertEquals("http://localhost:9000/management/foo",
                 buildItem.resolveManagementPath("foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
@@ -212,15 +215,15 @@ public class NonApplicationRootPathBuildItemTest {
 
     @Test
     void testResolveManagementPathWithEmptyRootPath() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "";
+        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = mock(ManagementInterfaceBuildTimeConfig.class);
+        when(managementInterfaceBuildTimeConfig.enabled()).thenReturn(true);
+        when(managementInterfaceBuildTimeConfig.rootPath()).thenReturn("");
 
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "/q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementInterfaceBuildTimeConfig.rootPath());
         Assertions.assertEquals("/", buildItem.getManagementRootPath());
         Assertions.assertEquals("http://localhost:9000/foo",
                 buildItem.resolveManagementPath("foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
@@ -238,15 +241,15 @@ public class NonApplicationRootPathBuildItemTest {
 
     @Test
     void testResolveManagementPathWithWithWildcards() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "/management";
+        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = mock(ManagementInterfaceBuildTimeConfig.class);
+        when(managementInterfaceBuildTimeConfig.enabled()).thenReturn(true);
+        when(managementInterfaceBuildTimeConfig.rootPath()).thenReturn("/management");
 
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "/q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementInterfaceBuildTimeConfig.rootPath());
         Assertions.assertEquals("http://localhost:9000/management/foo/*",
                 buildItem.resolveManagementPath("foo/*", managementInterfaceBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/foo/*",

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/ArcEndpointTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/ArcEndpointTest.java
@@ -60,7 +60,6 @@ public class ArcEndpointTest {
     @Named
     @ApplicationScoped
     public static class Foo {
-
         @Inject
         HttpBuildTimeConfig httpConfig;
 
@@ -68,8 +67,7 @@ public class ArcEndpointTest {
         }
 
         void addConfigRoute(@Observes Router router) {
-            router.route("/console-path").handler(rc -> rc.response().end(httpConfig.nonApplicationRootPath));
+            router.route("/console-path").handler(rc -> rc.response().end(httpConfig.nonApplicationRootPath()));
         }
-
     }
 }

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -131,9 +131,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
@@ -1,5 +1,6 @@
 package io.quarkus.devui.runtime;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,12 +33,38 @@ public class DevUICORSFilter implements Handler<RoutingContext> {
     private static CORSFilter corsFilter() {
         int httpPort = ConfigProvider.getConfig().getValue(HTTP_PORT_CONFIG_PROP, int.class);
         int httpsPort = ConfigProvider.getConfig().getValue(HTTPS_PORT_CONFIG_PROP, int.class);
-        CORSConfig config = new CORSConfig();
-        config.origins = Optional.of(List.of(
-                HTTP_LOCAL_HOST + ":" + httpPort,
-                HTTP_LOCAL_HOST_IP + ":" + httpPort,
-                HTTPS_LOCAL_HOST + ":" + httpsPort,
-                HTTPS_LOCAL_HOST_IP + ":" + httpsPort));
+        CORSConfig config = new CORSConfig() {
+            @Override
+            public Optional<List<String>> origins() {
+                return Optional.of(List.of(HTTP_LOCAL_HOST + ":" + httpPort, HTTP_LOCAL_HOST_IP + ":" + httpPort,
+                        HTTPS_LOCAL_HOST + ":" + httpsPort, HTTPS_LOCAL_HOST_IP + ":" + httpsPort));
+            }
+
+            @Override
+            public Optional<List<String>> methods() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<List<String>> headers() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<List<String>> exposedHeaders() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Duration> accessControlMaxAge() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> accessControlAllowCredentials() {
+                return Optional.empty();
+            }
+        };
         return new CORSFilter(config);
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AccessLogConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AccessLogConfig.java
@@ -2,23 +2,19 @@ package io.quarkus.vertx.http.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class AccessLogConfig {
-
+public interface AccessLogConfig {
     /**
      * If access logging is enabled. By default this will log via the standard logging facility
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enabled;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * A regular expression that can be used to exclude some paths from logging.
      */
-    @ConfigItem
-    Optional<String> excludePattern;
+    Optional<String> excludePattern();
 
     /**
      * The access log pattern.
@@ -33,54 +29,53 @@ public class AccessLogConfig {
      *
      * @asciidoclet
      */
-    @ConfigItem(defaultValue = "common")
-    public String pattern;
+    @WithDefault("common")
+    String pattern();
 
     /**
      * If logging should be done to a separate file.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean logToFile;
+    @WithDefault("false")
+    boolean logToFile();
 
     /**
      * The access log file base name, defaults to 'quarkus' which will give a log file
      * name of 'quarkus.log'.
      *
      */
-    @ConfigItem(defaultValue = "quarkus")
-    public String baseFileName;
+    @WithDefault("quarkus")
+    String baseFileName();
 
     /**
      * The log directory to use when logging access to a file
      *
      * If this is not set then the current working directory is used.
      */
-    @ConfigItem
-    public Optional<String> logDirectory;
+    Optional<String> logDirectory();
 
     /**
      * The log file suffix
      */
-    @ConfigItem(defaultValue = ".log")
-    public String logSuffix;
+    @WithDefault(".log")
+    String logSuffix();
 
     /**
      * The log category to use if logging is being done via the standard log mechanism (i.e. if base-file-name is empty).
      *
      */
-    @ConfigItem(defaultValue = "io.quarkus.http.access-log")
-    public String category;
+    @WithDefault("io.quarkus.http.access-log")
+    String category();
 
     /**
      * If the log should be rotated daily
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean rotate;
+    @WithDefault("true")
+    boolean rotate();
 
     /**
      * If rerouted requests should be consolidated into one log entry
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean consolidateReroutedRequests;
+    @WithDefault("false")
+    boolean consolidateReroutedRequests();
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
@@ -2,29 +2,25 @@ package io.quarkus.vertx.http.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * Authentication mechanism and SecurityRealm name information used for configuring HTTP auth
  * instance for the deployment.
  */
-@ConfigGroup
-public class AuthConfig {
+public interface AuthConfig {
     /**
      * If basic auth should be enabled. If both basic and form auth is enabled then basic auth will be enabled in silent mode.
      *
      * The basic auth is enabled by default if no authentication mechanisms are configured or Quarkus can safely
      * determine that basic authentication is required.
      */
-    @ConfigItem
-    public Optional<Boolean> basic;
+    Optional<Boolean> basic();
 
     /**
      * Form Auth config
      */
-    @ConfigItem
-    public FormAuthConfig form;
+    FormAuthConfig form();
 
     /**
      * If this is true and credentials are present then a user will always be authenticated
@@ -33,8 +29,8 @@ public class AuthConfig {
      * If this is false then an attempt will only be made to authenticate the user if a permission
      * check is performed or the current user is required for some other reason.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean proactive;
+    @WithDefault("true")
+    boolean proactive();
 
     /**
      * Require that all registered HTTP authentication mechanisms must complete the authentication.
@@ -58,6 +54,6 @@ public class AuthConfig {
      * <p>
      * This property will be ignored if the path specific authentication is enabled.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean inclusive;
+    @WithDefault("false")
+    boolean inclusive();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
@@ -7,25 +7,26 @@ import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * Authentication mechanism information used for configuring HTTP auth instance for the deployment.
  */
 @ConfigGroup
-public class AuthRuntimeConfig {
+public interface AuthRuntimeConfig {
 
     /**
      * The HTTP permissions
      */
-    @ConfigItem(name = "permission")
-    public Map<String, PolicyMappingConfig> permissions;
+    @WithName("permission")
+    Map<String, PolicyMappingConfig> permissions();
 
     /**
      * The HTTP role based policies
      */
-    @ConfigItem(name = "policy")
-    public Map<String, PolicyConfig> rolePolicy;
+    @WithName("policy")
+    Map<String, PolicyConfig> rolePolicy();
 
     /**
      * Map the `SecurityIdentity` roles to deployment specific roles and add the matching roles to `SecurityIdentity`.
@@ -34,9 +35,8 @@ public class AuthRuntimeConfig {
      * use this property to map the `user` role to the `UserRole` role, and have `SecurityIdentity` to have
      * both `user` and `UserRole` roles.
      */
-    @ConfigItem
     @ConfigDocMapKey("role-name")
-    public Map<String, List<String>> rolesMapping;
+    Map<String, List<String>> rolesMapping();
 
     /**
      * Client certificate attribute whose values are going to be mapped to the 'SecurityIdentity' roles
@@ -58,8 +58,8 @@ public class AuthRuntimeConfig {
      * </li>
      * </ul>
      */
-    @ConfigItem(defaultValue = "CN")
-    public String certificateRoleAttribute;
+    @WithDefault("CN")
+    String certificateRoleAttribute();
 
     /**
      * Properties file containing the client certificate attribute value to role mappings.
@@ -68,18 +68,15 @@ public class AuthRuntimeConfig {
      * <p/>
      * Properties file is expected to have the `CN_VALUE=role1,role,...,roleN` format and should be encoded using UTF-8.
      */
-    @ConfigItem
-    public Optional<Path> certificateRoleProperties;
+    Optional<Path> certificateRoleProperties();
 
     /**
      * The authentication realm
      */
-    @ConfigItem
-    public Optional<String> realm;
+    Optional<String> realm();
 
     /**
      * Form Auth config
      */
-    @ConfigItem
-    public FormAuthRuntimeConfig form;
+    FormAuthRuntimeConfig form();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BodyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BodyConfig.java
@@ -1,14 +1,11 @@
 package io.quarkus.vertx.http.runtime;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * Request body related settings
  */
-@ConfigGroup
-public class BodyConfig {
-
+public interface BodyConfig {
     /**
      * Whether the files sent using {@code multipart/form-data} will be stored locally.
      * <p>
@@ -18,16 +15,16 @@ public class BodyConfig {
      * will always return an empty collection. Note that even with this option being set to {@code false}, the
      * {@code multipart/form-data} requests will be accepted.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean handleFileUploads;
+    @WithDefault("true")
+    boolean handleFileUploads();
 
     /**
      * The directory where the files sent using {@code multipart/form-data} should be stored.
      * <p>
      * Either an absolute path or a path relative to the current directory of the application process.
      */
-    @ConfigItem(defaultValue = "${java.io.tmpdir}/uploads")
-    public String uploadsDirectory;
+    @WithDefault("${java.io.tmpdir}/uploads")
+    String uploadsDirectory();
 
     /**
      * Whether the form attributes should be added to the request parameters.
@@ -35,8 +32,8 @@ public class BodyConfig {
      * If {@code true}, the form attributes will be added to the request parameters; otherwise the form parameters will
      * not be added to the request parameters
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean mergeFormAttributes;
+    @WithDefault("true")
+    boolean mergeFormAttributes();
 
     /**
      * Whether the uploaded files should be removed after serving the request.
@@ -44,8 +41,8 @@ public class BodyConfig {
      * If {@code true} the uploaded files stored in {@code quarkus.http.body-handler.uploads-directory} will be removed
      * after handling the request. Otherwise, the files will be left there forever.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean deleteUploadedFilesOnEnd;
+    @WithDefault("true")
+    boolean deleteUploadedFilesOnEnd();
 
     /**
      * Whether the body buffer should pre-allocated based on the {@code Content-Length} header value.
@@ -53,12 +50,11 @@ public class BodyConfig {
      * If {@code true} the body buffer is pre-allocated according to the size read from the {@code Content-Length}
      * header. Otherwise, the body buffer is pre-allocated to 1KB, and is resized dynamically
      */
-    @ConfigItem
-    public boolean preallocateBodyBuffer;
+    @WithDefault("false")
+    boolean preallocateBodyBuffer();
 
     /**
      * HTTP multipart request related settings
      */
-    @ConfigItem
-    public MultiPartConfig multipart;
+    MultiPartConfig multipart();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
@@ -9,17 +9,15 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
 
 /**
  * A certificate configuration.
  * Provide either the certificate and key files or a keystore.
  */
 @ConfigGroup
-public class CertificateConfig {
-
+public interface CertificateConfig {
     /**
      * The {@linkplain CredentialsProvider}.
      * If this property is configured, then a matching 'CredentialsProvider' will be used
@@ -28,9 +26,8 @@ public class CertificateConfig {
      * Please note that using MicroProfile {@linkplain ConfigSource} which is directly supported by Quarkus Configuration
      * should be preferred unless using `CredentialsProvider` provides for some additional security and dynamism.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<String> credentialsProvider = Optional.empty();
+    @WithConverter(TrimmedStringConverter.class)
+    Optional<String> credentialsProvider();
 
     /**
      * The credentials provider bean name.
@@ -41,16 +38,14 @@ public class CertificateConfig {
      * <p>
      * For Vault, the credentials provider bean name is {@code vault-credentials-provider}.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<String> credentialsProviderName = Optional.empty();
+    @WithConverter(TrimmedStringConverter.class)
+    Optional<String> credentialsProviderName();
 
     /**
      * The list of path to server certificates using the PEM format.
      * Specifying multiple files requires SNI to be enabled.
      */
-    @ConfigItem
-    public Optional<List<Path>> files;
+    Optional<List<Path>> files();
 
     /**
      * The list of path to server certificates private key files using the PEM format.
@@ -58,28 +53,24 @@ public class CertificateConfig {
      * <p>
      * The order of the key files must match the order of the certificates.
      */
-    @ConfigItem
-    public Optional<List<Path>> keyFiles;
+    Optional<List<Path>> keyFiles();
 
     /**
      * An optional keystore that holds the certificate information instead of specifying separate files.
      */
-    @ConfigItem
-    public Optional<Path> keyStoreFile;
+    Optional<Path> keyStoreFile();
 
     /**
      * An optional parameter to specify the type of the keystore file.
      * If not given, the type is automatically detected based on the file name.
      */
-    @ConfigItem
-    public Optional<String> keyStoreFileType;
+    Optional<String> keyStoreFileType();
 
     /**
      * An optional parameter to specify a provider of the keystore file.
      * If not given, the provider is automatically detected based on the keystore file type.
      */
-    @ConfigItem
-    public Optional<String> keyStoreProvider;
+    Optional<String> keyStoreProvider();
 
     /**
      * A parameter to specify the password of the keystore file.
@@ -87,8 +78,7 @@ public class CertificateConfig {
      *
      * @see {@link #credentialsProvider}
      */
-    @ConfigItem(defaultValueDocumentation = "password")
-    public Optional<String> keyStorePassword;
+    Optional<String> keyStorePassword();
 
     /**
      * A parameter to specify a {@linkplain CredentialsProvider} property key,
@@ -97,8 +87,7 @@ public class CertificateConfig {
      *
      * @see {@link #credentialsProvider}
      */
-    @ConfigItem
-    public Optional<String> keyStorePasswordKey;
+    Optional<String> keyStorePasswordKey();
 
     /**
      * An optional parameter to select a specific key in the keystore.
@@ -107,17 +96,15 @@ public class CertificateConfig {
      *
      * @deprecated Use {@link #keyStoreAlias} instead.
      */
-    @ConfigItem
     @Deprecated
-    public Optional<String> keyStoreKeyAlias;
+    Optional<String> keyStoreKeyAlias();
 
     /**
      * An optional parameter to select a specific key in the keystore.
      * When SNI is disabled, and the keystore contains multiple
      * keys and no alias is specified; the behavior is undefined.
      */
-    @ConfigItem
-    public Optional<String> keyStoreAlias;
+    Optional<String> keyStoreAlias();
 
     /**
      * An optional parameter to define the password for the key,
@@ -128,8 +115,7 @@ public class CertificateConfig {
      * @deprecated Use {@link #keyStoreAliasPassword} instead.
      */
     @Deprecated
-    @ConfigItem
-    public Optional<String> keyStoreKeyPassword;
+    Optional<String> keyStoreKeyPassword();
 
     /**
      * An optional parameter to define the password for the key,
@@ -138,8 +124,7 @@ public class CertificateConfig {
      *
      * @see {@link #credentialsProvider}.
      */
-    @ConfigItem
-    public Optional<String> keyStoreAliasPassword;
+    Optional<String> keyStoreAliasPassword();
 
     /**
      * A parameter to specify a {@linkplain CredentialsProvider} property key,
@@ -148,9 +133,8 @@ public class CertificateConfig {
      * @see {@link #credentialsProvider}
      * @deprecated Use {@link #keyStoreAliasPasswordKey} instead.
      */
-    @ConfigItem
     @Deprecated
-    public Optional<String> keyStoreKeyPasswordKey;
+    Optional<String> keyStoreKeyPasswordKey();
 
     /**
      * A parameter to specify a {@linkplain CredentialsProvider} property key,
@@ -158,35 +142,30 @@ public class CertificateConfig {
      *
      * @see {@link #credentialsProvider}
      */
-    @ConfigItem
-    public Optional<String> keyStoreAliasPasswordKey;
+    Optional<String> keyStoreAliasPasswordKey();
 
     /**
      * An optional trust store that holds the certificate information of the trusted certificates.
      */
-    @ConfigItem
-    public Optional<Path> trustStoreFile;
+    Optional<Path> trustStoreFile();
 
     /**
      * An optional list of trusted certificates using the PEM format.
      * If you pass multiple files, you must use the PEM format.
      */
-    @ConfigItem
-    public Optional<List<Path>> trustStoreFiles;
+    Optional<List<Path>> trustStoreFiles();
 
     /**
      * An optional parameter to specify the type of the trust store file.
      * If not given, the type is automatically detected based on the file name.
      */
-    @ConfigItem
-    public Optional<String> trustStoreFileType;
+    Optional<String> trustStoreFileType();
 
     /**
      * An optional parameter to specify a provider of the trust store file.
      * If not given, the provider is automatically detected based on the trust store file type.
      */
-    @ConfigItem
-    public Optional<String> trustStoreProvider;
+    Optional<String> trustStoreProvider();
 
     /**
      * A parameter to specify the password of the trust store file.
@@ -194,8 +173,7 @@ public class CertificateConfig {
      *
      * @see {@link #credentialsProvider}.
      */
-    @ConfigItem
-    public Optional<String> trustStorePassword;
+    Optional<String> trustStorePassword();
 
     /**
      * A parameter to specify a {@linkplain CredentialsProvider} property key,
@@ -203,15 +181,13 @@ public class CertificateConfig {
      *
      * @see {@link #credentialsProvider}
      */
-    @ConfigItem
-    public Optional<String> trustStorePasswordKey;
+    Optional<String> trustStorePasswordKey();
 
     /**
      * An optional parameter to trust a single certificate from the trust store rather than trusting all certificates in the
      * store.
      */
-    @ConfigItem
-    public Optional<String> trustStoreCertAlias;
+    Optional<String> trustStoreCertAlias();
 
     /**
      * When set, the configured certificate will be reloaded after the given period.
@@ -224,6 +200,5 @@ public class CertificateConfig {
      * IMPORTANT: It's recommended to use the TLS registry to handle the certificate reloading.
      * </p>
      */
-    @ConfigItem
-    public Optional<Duration> reloadPeriod;
+    Optional<Duration> reloadPeriod();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FilterConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FilterConfig.java
@@ -7,32 +7,28 @@ import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 
 @ConfigGroup
-public class FilterConfig {
+public interface FilterConfig {
 
     /**
      * A regular expression for the paths matching this configuration
      */
-    @ConfigItem
-    public String matches;
+    String matches();
 
     /**
      * Additional HTTP Headers always sent in the response
      */
-    @ConfigItem
     @ConfigDocMapKey("header-name")
-    public Map<String, String> header;
+    Map<String, String> header();
 
     /**
      * The HTTP methods for this path configuration
      */
-    @ConfigItem
-    public Optional<List<String>> methods;
+    Optional<List<String>> methods();
 
     /**
      * Order in which this path config is applied. Higher priority takes precedence
      */
-    public OptionalInt order;
+    OptionalInt order();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
@@ -1,24 +1,24 @@
 package io.quarkus.vertx.http.runtime;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * config for the form authentication mechanism
  */
 @ConfigGroup
-public class FormAuthConfig {
+public interface FormAuthConfig {
 
     /**
      * If form authentication is enabled.
      */
-    @ConfigItem
-    public boolean enabled;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * The post location.
      */
-    @ConfigItem(defaultValue = "/j_security_check")
-    public String postLocation;
+    @WithDefault("/j_security_check")
+    String postLocation();
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
@@ -4,13 +4,13 @@ import java.time.Duration;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * config for the form authentication mechanism
  */
 @ConfigGroup
-public class FormAuthRuntimeConfig {
+public interface FormAuthRuntimeConfig {
     /**
      * SameSite attribute values for the session and location cookies.
      */
@@ -23,33 +23,33 @@ public class FormAuthRuntimeConfig {
     /**
      * The login page. Redirect to login page can be disabled by setting `quarkus.http.auth.form.login-page=`.
      */
-    @ConfigItem(defaultValue = "/login.html")
-    public Optional<String> loginPage;
+    @WithDefault("/login.html")
+    Optional<String> loginPage();
 
     /**
      * The username field name.
      */
-    @ConfigItem(defaultValue = "j_username")
-    public String usernameParameter;
+    @WithDefault("j_username")
+    String usernameParameter();
 
     /**
      * The password field name.
      */
-    @ConfigItem(defaultValue = "j_password")
-    public String passwordParameter;
+    @WithDefault("j_password")
+    String passwordParameter();
 
     /**
      * The error page. Redirect to error page can be disabled by setting `quarkus.http.auth.form.error-page=`.
      */
-    @ConfigItem(defaultValue = "/error.html")
-    public Optional<String> errorPage;
+    @WithDefault("/error.html")
+    Optional<String> errorPage();
 
     /**
      * The landing page to redirect to if there is no saved page to redirect back to.
      * Redirect to landing page can be disabled by setting `quarkus.http.auth.form.landing-page=`.
      */
-    @ConfigItem(defaultValue = "/index.html")
-    public Optional<String> landingPage;
+    @WithDefault("/index.html")
+    Optional<String> landingPage();
 
     /**
      * Option to disable redirect to landingPage if there is no saved page to redirect back to. Form Auth POST is followed
@@ -59,24 +59,24 @@ public class FormAuthRuntimeConfig {
      *             (via `quarkus.http.auth.form.landing-page=`). Quarkus will ignore this configuration property
      *             if there is no landing page.
      */
-    @ConfigItem(defaultValue = "true")
+    @WithDefault("true")
     @Deprecated
-    public boolean redirectAfterLogin;
+    boolean redirectAfterLogin();
 
     /**
      * Option to control the name of the cookie used to redirect the user back
      * to the location they want to access.
      */
-    @ConfigItem(defaultValue = "quarkus-redirect-location")
-    public String locationCookie;
+    @WithDefault("quarkus-redirect-location")
+    String locationCookie();
 
     /**
      * The inactivity (idle) timeout
      *
      * When inactivity timeout is reached, cookie is not renewed and a new login is enforced.
      */
-    @ConfigItem(defaultValue = "PT30M")
-    public Duration timeout;
+    @WithDefault("PT30M")
+    Duration timeout();
 
     /**
      * How old a cookie can get before it will be replaced with a new cookie with an updated timeout, also
@@ -93,38 +93,37 @@ public class FormAuthRuntimeConfig {
      * That is, no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie
      * itself, and it is decrypted and parsed with each request.
      */
-    @ConfigItem(defaultValue = "PT1M")
-    public Duration newCookieInterval;
+    @WithDefault("PT1M")
+    Duration newCookieInterval();
 
     /**
      * The cookie that is used to store the persistent session
      */
-    @ConfigItem(defaultValue = "quarkus-credential")
-    public String cookieName;
+    @WithDefault("quarkus-credential")
+    String cookieName();
 
     /**
      * The cookie path for the session and location cookies.
      */
-    @ConfigItem(defaultValue = "/")
-    public Optional<String> cookiePath = Optional.of("/");
+    @WithDefault("/")
+    Optional<String> cookiePath();
 
     /**
      * Set the HttpOnly attribute to prevent access to the cookie via JavaScript.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean httpOnlyCookie;
+    @WithDefault("false")
+    boolean httpOnlyCookie();
 
     /**
      * SameSite attribute for the session and location cookies.
      */
-    @ConfigItem(defaultValue = "strict")
-    public CookieSameSite cookieSameSite = CookieSameSite.STRICT;
+    @WithDefault("strict")
+    CookieSameSite cookieSameSite();
 
     /**
      * Max-Age attribute for the session cookie. This is the amount of time the browser will keep the cookie.
      *
      * The default value is empty, which means the cookie will be kept until the browser is closed.
      */
-    @ConfigItem
-    public Optional<Duration> cookieMaxAge;
+    Optional<Duration> cookieMaxAge();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
@@ -45,19 +45,19 @@ public class ForwardingProxyOptions {
     }
 
     public static ForwardingProxyOptions from(ProxyConfig proxy) {
-        final boolean proxyAddressForwarding = proxy.proxyAddressForwarding;
-        final boolean allowForwarded = proxy.allowForwarded;
-        final boolean allowXForwarded = proxy.allowXForwarded.orElse(!allowForwarded);
-        final boolean enableForwardedHost = proxy.enableForwardedHost;
-        final boolean enableForwardedPrefix = proxy.enableForwardedPrefix;
-        final boolean enableTrustedProxyHeader = proxy.enableTrustedProxyHeader;
-        final boolean strictForwardedControl = proxy.strictForwardedControl;
-        final ForwardedPrecedence forwardedPrecedence = proxy.forwardedPrecedence;
-        final AsciiString forwardedPrefixHeader = AsciiString.cached(proxy.forwardedPrefixHeader);
-        final AsciiString forwardedHostHeader = AsciiString.cached(proxy.forwardedHostHeader);
+        final boolean proxyAddressForwarding = proxy.proxyAddressForwarding();
+        final boolean allowForwarded = proxy.allowForwarded();
+        final boolean allowXForwarded = proxy.allowXForwarded().orElse(!allowForwarded);
+        final boolean enableForwardedHost = proxy.enableForwardedHost();
+        final boolean enableForwardedPrefix = proxy.enableForwardedPrefix();
+        final boolean enableTrustedProxyHeader = proxy.enableTrustedProxyHeader();
+        final boolean strictForwardedControl = proxy.strictForwardedControl();
+        final ForwardedPrecedence forwardedPrecedence = proxy.forwardedPrecedence();
+        final AsciiString forwardedPrefixHeader = AsciiString.cached(proxy.forwardedPrefixHeader());
+        final AsciiString forwardedHostHeader = AsciiString.cached(proxy.forwardedHostHeader());
 
-        final List<TrustedProxyCheckPart> parts = proxy.trustedProxies
-                .isPresent() ? List.copyOf(proxy.trustedProxies.get()) : List.of();
+        final List<TrustedProxyCheckPart> parts = proxy.trustedProxies()
+                .isPresent() ? List.copyOf(proxy.trustedProxies().get()) : List.of();
         final var proxyCheckBuilder = (!allowXForwarded && !allowForwarded)
                 || parts.isEmpty() ? null : TrustedProxyCheckBuilder.builder(parts);
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/GeneratedStaticResourcesRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/GeneratedStaticResourcesRecorder.java
@@ -30,16 +30,16 @@ public class GeneratedStaticResourcesRecorder {
     public Handler<RoutingContext> createHandler(Set<String> generatedClasspathResources,
             Map<String, String> generatedFilesResources) {
 
-        if (httpBuildTimeConfig.enableCompression && httpBuildTimeConfig.compressMediaTypes.isPresent()) {
-            this.compressMediaTypes = Set.copyOf(httpBuildTimeConfig.compressMediaTypes.get());
+        if (httpBuildTimeConfig.enableCompression() && httpBuildTimeConfig.compressMediaTypes().isPresent()) {
+            this.compressMediaTypes = Set.copyOf(httpBuildTimeConfig.compressMediaTypes().get());
         }
-        StaticResourcesConfig config = httpConfiguration.getValue().staticResources;
+        StaticResourcesConfig config = httpConfiguration.getValue().staticResources();
 
         DevClasspathStaticHandlerOptions options = new DevClasspathStaticHandlerOptions.Builder()
-                .indexPage(config.indexPage)
-                .enableCompression(httpBuildTimeConfig.enableCompression)
+                .indexPage(config.indexPage())
+                .enableCompression(httpBuildTimeConfig.enableCompression())
                 .compressMediaTypes(compressMediaTypes)
-                .defaultEncoding(config.contentEncoding).build();
+                .defaultEncoding(config.contentEncoding()).build();
         return new DevStaticHandler(generatedClasspathResources,
                 generatedFilesResources,
                 options);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HeaderConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HeaderConfig.java
@@ -3,30 +3,26 @@ package io.quarkus.vertx.http.runtime;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * Configuration that allows for setting an HTTP header
  */
-@ConfigGroup
-public class HeaderConfig {
+public interface HeaderConfig {
 
     /**
      * The path this header should be applied
      */
-    @ConfigItem(defaultValue = "/*")
-    public String path;
+    @WithDefault("/*")
+    String path();
 
     /**
      * The value for this header configuration
      */
-    @ConfigItem
-    public String value;
+    String value();
 
     /**
      * The HTTP methods for this header configuration
      */
-    @ConfigItem
-    public Optional<List<String>> methods;
+    Optional<List<String>> methods();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -5,26 +5,31 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.NormalizeRootHttpPathConverter;
 import io.quarkus.vertx.http.Compressed;
 import io.quarkus.vertx.http.Uncompressed;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 import io.vertx.core.http.ClientAuth;
 
-@ConfigRoot(name = "http", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class HttpBuildTimeConfig {
-
+@ConfigMapping(prefix = "quarkus.http")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface HttpBuildTimeConfig {
     /**
      * The HTTP root path. All web content will be served relative to this root path.
      */
-    @ConfigItem(defaultValue = "/")
-    @ConvertWith(NormalizeRootHttpPathConverter.class)
-    public String rootPath;
+    @WithDefault("/")
+    @WithConverter(NormalizeRootHttpPathConverter.class)
+    String rootPath();
 
-    public AuthConfig auth;
+    /**
+     * Authentication configuration.
+     */
+    AuthConfig auth();
 
     /**
      * Configures the engine to require/request client authentication.
@@ -34,15 +39,16 @@ public class HttpBuildTimeConfig {
      * plain HTTP port. If `quarkus.http.insecure-requests` is not set, but this parameter is set to {@code REQUIRED}, then,
      * `quarkus.http.insecure-requests` is automatically set to `disabled`.
      */
-    @ConfigItem(name = "ssl.client-auth", defaultValue = "NONE")
-    public ClientAuth tlsClientAuth;
+    @WithName("ssl.client-auth")
+    @WithDefault("NONE")
+    ClientAuth tlsClientAuth();
 
     /**
      * If this is true then only a virtual channel will be set up for vertx web.
      * We have this switch for testing purposes.
      */
-    @ConfigItem
-    public boolean virtual;
+    @WithDefault("false")
+    boolean virtual();
 
     /**
      * A common root path for non-application endpoints. Various extension-provided endpoints such as metrics, health,
@@ -61,14 +67,14 @@ public class HttpBuildTimeConfig {
      *
      * @asciidoclet
      */
-    @ConfigItem(defaultValue = "q")
-    public String nonApplicationRootPath;
+    @WithDefault("q")
+    String nonApplicationRootPath();
 
     /**
      * The REST Assured client timeout for testing.
      */
-    @ConfigItem(defaultValue = "30s")
-    public Duration testTimeout;
+    @WithDefault("30s")
+    Duration testTimeout();
 
     /**
      * If enabled then the response body is compressed if the {@code Content-Type} header is set and the value is a compressed
@@ -78,8 +84,8 @@ public class HttpBuildTimeConfig {
      * declaratively using the annotations {@link io.quarkus.vertx.http.Compressed} and
      * {@link io.quarkus.vertx.http.Uncompressed}.
      */
-    @ConfigItem
-    public boolean enableCompression;
+    @WithDefault("false")
+    boolean enableCompression();
 
     /**
      * When enabled, vert.x will decompress the request's body if it's compressed.
@@ -87,8 +93,8 @@ public class HttpBuildTimeConfig {
      * Note that the compression format (e.g., gzip) must be specified in the Content-Encoding header
      * in the request.
      */
-    @ConfigItem
-    public boolean enableDecompression;
+    @WithDefault("false")
+    boolean enableDecompression();
 
     /**
      * If user adds br, then brotli will be added to the list of supported compression algorithms.
@@ -103,19 +109,18 @@ public class HttpBuildTimeConfig {
      * content-encoding: gzip
      *
      */
-    @ConfigItem(defaultValue = "gzip,deflate")
-    public Optional<List<String>> compressors;
+    @WithDefault("gzip,deflate")
+    Optional<List<String>> compressors();
 
     /**
      * List of media types for which the compression should be enabled automatically, unless declared explicitly via
      * {@link Compressed} or {@link Uncompressed}.
      */
-    @ConfigItem(defaultValue = "text/html,text/plain,text/xml,text/css,text/javascript,application/javascript,application/json,application/graphql+json,application/xhtml+xml")
-    public Optional<List<String>> compressMediaTypes;
+    @WithDefault("text/html,text/plain,text/xml,text/css,text/javascript,application/javascript,application/json,application/graphql+json,application/xhtml+xml")
+    Optional<List<String>> compressMediaTypes();
 
     /**
      * The compression level used when compression support is enabled.
      */
-    @ConfigItem
-    public OptionalInt compressionLevel;
+    OptionalInt compressionLevel();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -7,37 +7,51 @@ import java.util.OptionalInt;
 
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.annotations.ConfigDocSection;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.vertx.http.runtime.cors.CORSConfig;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
+@ConfigMapping(prefix = "quarkus.http")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
-public class HttpConfiguration {
+public interface HttpConfiguration {
+    /**
+     * Enable the CORS filter.
+     *
+     * @deprecated Use {@link HttpConfiguration#corsEnabled()}. Deprecated because it requires additional syntax to
+     *             configure with the group {@link HttpConfiguration#cors()} in YAML config.
+     */
+    @WithName("cors")
+    @WithDefault("false")
+    @Deprecated
+    boolean oldCorsEnabled();
 
     /**
      * Authentication configuration
      */
     @ConfigDocSection(generated = true)
-    public AuthRuntimeConfig auth;
+    AuthRuntimeConfig auth();
 
     /**
      * Enable the CORS filter.
      */
-    @ConfigItem(name = "cors")
-    public boolean corsEnabled;
+    @WithName("cors.enabled")
+    @WithDefault("${quarkus.http.cors:false}")
+    boolean corsEnabled();
 
     /**
      * The HTTP port
      */
-    @ConfigItem(defaultValue = "8080")
-    public int port;
+    @WithDefault("8080")
+    int port();
 
     /**
      * The HTTP port used to run tests
      */
-    @ConfigItem(defaultValue = "8081")
-    public int testPort;
+    @WithDefault("8081")
+    int testPort();
 
     /**
      * The HTTP host
@@ -52,40 +66,37 @@ public class HttpConfiguration {
      * defaults to 0.0.0.0 even in dev/test mode since using localhost makes the application
      * inaccessible.
      */
-    @ConfigItem
-    public String host;
+    String host();
 
     /**
      * Used when {@code QuarkusIntegrationTest} is meant to execute against an application that is already running and
      * listening on the host specified by this property.
      */
-    @ConfigItem
-    public Optional<String> testHost;
+    Optional<String> testHost();
 
     /**
      * Enable listening to host:port
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean hostEnabled;
+    @WithDefault("true")
+    boolean hostEnabled();
 
     /**
      * The HTTPS port
      */
-    @ConfigItem(defaultValue = "8443")
-    public int sslPort;
+    @WithDefault("8443")
+    int sslPort();
 
     /**
      * The HTTPS port used to run tests
      */
-    @ConfigItem(defaultValue = "8444")
-    public int testSslPort;
+    @WithDefault("8444")
+    int testSslPort();
 
     /**
      * Used when {@code QuarkusIntegrationTest} is meant to execute against an application that is already running
      * to configure the test to use SSL.
      */
-    @ConfigItem
-    public Optional<Boolean> testSslEnabled;
+    Optional<Boolean> testSslEnabled();
 
     /**
      * If insecure (i.e. http rather than https) requests are allowed. If this is {@code enabled}
@@ -97,8 +108,7 @@ public class HttpConfiguration {
      * {@code quarkus.http.ssl.client-auth=required}).
      * In this case, the default is {@code disabled}.
      */
-    @ConfigItem
-    public Optional<InsecureRequests> insecureRequests;
+    Optional<InsecureRequests> insecureRequests();
 
     /**
      * If this is true (the default) then HTTP/2 will be enabled.
@@ -107,27 +117,27 @@ public class HttpConfiguration {
      * and you must be running on JDK11 or above, as JDK8 does not support
      * ALPN.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean http2;
+    @WithDefault("true")
+    boolean http2();
 
     /**
      * Enables or Disable the HTTP/2 Push feature.
      * This setting can be used to disable server push. The server will not send a {@code PUSH_PROMISE} frame if it
      * receives this parameter set to @{code false}.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean http2PushEnabled;
+    @WithDefault("true")
+    boolean http2PushEnabled();
 
     /**
      * The CORS config
      */
     @ConfigDocSection(generated = true)
-    public CORSConfig cors;
+    CORSConfig cors();
 
     /**
      * The SSL config
      */
-    public ServerSslConfig ssl;
+    ServerSslConfig ssl();
 
     /**
      * The name of the TLS configuration to use.
@@ -138,21 +148,21 @@ public class HttpConfiguration {
      * <p>
      * If no TLS configuration is set, and {@code quarkus.tls.*} is not configured, then, `quarkus.http.ssl` will be used.
      */
-    @ConfigItem
-    public Optional<String> tlsConfigurationName;
+    Optional<String> tlsConfigurationName();
 
     /**
      * Static Resources.
      */
     @ConfigDocSection(generated = true)
-    public StaticResourcesConfig staticResources;
+    StaticResourcesConfig staticResources();
 
     /**
      * When set to {@code true}, the HTTP server automatically sends `100 CONTINUE`
      * response when the request expects it (with the `Expect: 100-Continue` header).
      */
-    @ConfigItem(defaultValue = "false", name = "handle-100-continue-automatically")
-    public boolean handle100ContinueAutomatically;
+    @WithName("handle-100-continue-automatically")
+    @WithDefault("false")
+    boolean handle100ContinueAutomatically();
 
     /**
      * The number if IO threads used to perform IO. This will be automatically set to a reasonable value based on
@@ -162,33 +172,34 @@ public class HttpConfiguration {
      * In general this should be controlled by setting quarkus.vertx.event-loops-pool-size, this setting should only
      * be used if you want to limit the number of HTTP io threads to a smaller number than the total number of IO threads.
      */
-    @ConfigItem
-    public OptionalInt ioThreads;
+    OptionalInt ioThreads();
 
     /**
      * Server limits.
      */
     @ConfigDocSection(generated = true)
-    public ServerLimitsConfig limits;
+    ServerLimitsConfig limits();
 
     /**
      * Http connection idle timeout
      */
-    @ConfigItem(defaultValue = "30M", name = "idle-timeout")
-    public Duration idleTimeout;
+    @WithName("idle-timeout")
+    @WithDefault("30M")
+    Duration idleTimeout();
 
     /**
      * Http connection read timeout for blocking IO. This is the maximum amount of time
      * a thread will wait for data, before an IOException will be thrown and the connection
      * closed.
      */
-    @ConfigItem(defaultValue = "60s", name = "read-timeout")
-    public Duration readTimeout;
+    @WithName("read-timeout")
+    @WithDefault("60s")
+    Duration readTimeout();
 
     /**
      * Request body related settings
      */
-    public BodyConfig body;
+    BodyConfig body();
 
     /**
      * The encryption key that is used to store persistent logins (e.g. for form auth). Logins are stored in a persistent
@@ -197,84 +208,82 @@ public class HttpConfiguration {
      * If no key is provided then an in-memory one will be generated, this will change on every restart though so it
      * is not suitable for production environments. This must be more than 16 characters long for security reasons
      */
-    @ConfigItem(name = "auth.session.encryption-key")
-    public Optional<String> encryptionKey;
+    @WithName("auth.session.encryption-key")
+    Optional<String> encryptionKey();
 
     /**
      * Enable socket reuse port (linux/macOs native transport only)
      */
-    @ConfigItem
-    public boolean soReusePort;
+    @WithDefault("false")
+    boolean soReusePort();
 
     /**
      * Enable tcp quick ack (linux native transport only)
      */
-    @ConfigItem
-    public boolean tcpQuickAck;
+    @WithDefault("false")
+    boolean tcpQuickAck();
 
     /**
      * Enable tcp cork (linux native transport only)
      */
-    @ConfigItem
-    public boolean tcpCork;
+    @WithDefault("false")
+    boolean tcpCork();
 
     /**
      * Enable tcp fast open (linux native transport only)
      */
-    @ConfigItem
-    public boolean tcpFastOpen;
+    @WithDefault("false")
+    boolean tcpFastOpen();
 
     /**
      * The accept backlog, this is how many connections can be waiting to be accepted before connections start being rejected
      */
-    @ConfigItem(defaultValue = "-1")
-    public int acceptBacklog;
+    @WithDefault("-1")
+    int acceptBacklog();
 
     /**
      * Set the SETTINGS_INITIAL_WINDOW_SIZE HTTP/2 setting.
      * Indicates the sender's initial window size (in octets) for stream-level flow control.
      * The initial value is {@code 2^16-1} (65,535) octets.
      */
-    @ConfigItem
-    public OptionalInt initialWindowSize;
+    OptionalInt initialWindowSize();
 
     /**
      * Path to a unix domain socket
      */
-    @ConfigItem(defaultValue = "/var/run/io.quarkus.app.socket")
-    public String domainSocket;
+    @WithDefault("/var/run/io.quarkus.app.socket")
+    String domainSocket();
 
     /**
      * Enable listening to host:port
      */
-    @ConfigItem
-    public boolean domainSocketEnabled;
+    @WithDefault("false")
+    boolean domainSocketEnabled();
 
     /**
      * If this is true then the request start time will be recorded to enable logging of total request time.
      * <p>
      * This has a small performance penalty, so is disabled by default.
      */
-    @ConfigItem
-    public boolean recordRequestStartTime;
+    @WithDefault("false")
+    boolean recordRequestStartTime();
 
     /**
      * Access logs.
      */
     @ConfigDocSection(generated = true)
-    public AccessLogConfig accessLog;
+    AccessLogConfig accessLog();
 
     /**
      * Traffic shaping.
      */
     @ConfigDocSection
-    public TrafficShapingConfig trafficShaping;
+    TrafficShapingConfig trafficShaping();
 
     /**
      * Configuration that allows setting the same site attributes for cookies.
      */
-    @ConfigItem
-    public Map<String, SameSiteCookieConfig> sameSiteCookie;
+    Map<String, SameSiteCookieConfig> sameSiteCookie();
 
     /**
      * Provides a hint (optional) for the default content type of responses generated for
@@ -287,50 +296,47 @@ public class HttpConfiguration {
      * Otherwise, it will default to the content type configured here.
      * </p>
      */
-    @ConfigItem
-    public Optional<PayloadHint> unhandledErrorContentTypeDefault;
+    Optional<PayloadHint> unhandledErrorContentTypeDefault();
 
     /**
      * Additional HTTP Headers always sent in the response
      */
-    @ConfigItem
     @ConfigDocSection(generated = true)
-    public Map<String, HeaderConfig> header;
+    Map<String, HeaderConfig> header();
 
     /**
      * Additional HTTP configuration per path
      */
-    @ConfigItem
     @ConfigDocSection(generated = true)
-    public Map<String, FilterConfig> filter;
+    Map<String, FilterConfig> filter();
 
     /**
      * Proxy.
      */
     @ConfigDocSection
-    public ProxyConfig proxy;
+    ProxyConfig proxy();
 
     /**
      * WebSocket Server configuration.
      */
     @ConfigDocSection
-    public WebsocketServerConfig websocketServer;
+    WebsocketServerConfig websocketServer();
 
-    public int determinePort(LaunchMode launchMode) {
-        return launchMode == LaunchMode.TEST ? testPort : port;
+    default int determinePort(LaunchMode launchMode) {
+        return launchMode == LaunchMode.TEST ? testPort() : port();
     }
 
-    public int determineSslPort(LaunchMode launchMode) {
-        return launchMode == LaunchMode.TEST ? testSslPort : sslPort;
+    default int determineSslPort(LaunchMode launchMode) {
+        return launchMode == LaunchMode.TEST ? testSslPort() : sslPort();
     }
 
-    public enum InsecureRequests {
+    enum InsecureRequests {
         ENABLED,
         REDIRECT,
         DISABLED;
     }
 
-    public enum PayloadHint {
+    enum PayloadHint {
         JSON,
         HTML,
         TEXT

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/MultiPartConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/MultiPartConfig.java
@@ -4,16 +4,13 @@ import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
 
 /**
  * A {@link ConfigGroup} for the settings related to HTTP multipart request handling.
  */
-@ConfigGroup
-public class MultiPartConfig {
-
+public interface MultiPartConfig {
     /**
      * A comma-separated list of {@code ContentType} to indicate whether a given multipart field should be handled as a file
      * part.
@@ -22,7 +19,5 @@ public class MultiPartConfig {
      *
      * For now, this setting only works when using RESTEasy Reactive.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> fileContentTypes;
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> fileContentTypes();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyConfig.java
@@ -4,31 +4,26 @@ import java.util.List;
 import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
-import io.quarkus.security.StringPermission;
+import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class PolicyConfig {
-
+public interface PolicyConfig {
     /**
      * The roles that are allowed to access resources protected by this policy.
      * By default, access is allowed to any authenticated user.
      */
-    @ConfigItem(defaultValue = "**")
-    @ConvertWith(TrimmedStringConverter.class)
-    public List<String> rolesAllowed;
+    @WithDefault("**")
+    @WithConverter(TrimmedStringConverter.class)
+    List<String> rolesAllowed();
 
     /**
      * Add roles granted to the `SecurityIdentity` based on the roles that the `SecurityIdentity` already have.
      * For example, the Quarkus OIDC extension can map roles from the verified JWT access token, and you may want
      * to remap them to a deployment specific roles.
      */
-    @ConfigItem
     @ConfigDocMapKey("role-name")
-    public Map<String, List<String>> roles;
+    Map<String, List<String>> roles();
 
     /**
      * Permissions granted to the `SecurityIdentity` if this policy is applied successfully
@@ -37,9 +32,8 @@ public class PolicyConfig {
      * `quarkus.http.auth.policy.role-policy1.permissions.admin=perm1:action1,perm1:action2` configuration property.
      * Granted permissions are used for authorization with the `@PermissionsAllowed` annotation.
      */
-    @ConfigItem
     @ConfigDocMapKey("role-name")
-    public Map<String, List<String>> permissions;
+    Map<String, List<String>> permissions();
 
     /**
      * Permissions granted by this policy will be created with a `java.security.Permission` implementation
@@ -47,7 +41,6 @@ public class PolicyConfig {
      * that accepts permission name (`String`) or permission name and actions (`String`, `String[]`).
      * Permission class must be registered for reflection if you run your application in a native mode.
      */
-    @ConfigItem(defaultValue = "io.quarkus.security.StringPermission")
-    public String permissionClass = StringPermission.class.getName();
-
+    @WithDefault("io.quarkus.security.StringPermission")
+    String permissionClass();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyMappingConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyMappingConfig.java
@@ -3,19 +3,15 @@ package io.quarkus.vertx.http.runtime;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class PolicyMappingConfig {
-
+public interface PolicyMappingConfig {
     /**
      * Determines whether the entire permission set is enabled, or not.
      *
      * By default, if the permission set is defined, it is enabled.
      */
-    @ConfigItem
-    public Optional<Boolean> enabled;
+    Optional<Boolean> enabled();
 
     /**
      * The HTTP policy that this permission set is linked to.
@@ -23,8 +19,7 @@ public class PolicyMappingConfig {
      * There are three built-in policies: permit, deny and authenticated. Role based
      * policies can be defined, and extensions can add their own policies.
      */
-    @ConfigItem
-    public String policy;
+    String policy();
 
     /**
      * The methods that this permission set applies to. If this is not set then they apply to all methods.
@@ -38,8 +33,7 @@ public class PolicyMappingConfig {
      * and no other permissions are configured PUT requests to /admin will be denied.
      *
      */
-    @ConfigItem
-    public Optional<List<String>> methods;
+    Optional<List<String>> methods();
 
     /**
      * The paths that this permission check applies to. If the path ends in /* then this is treated
@@ -51,28 +45,26 @@ public class PolicyMappingConfig {
      * over matches without methods set, otherwise the most restrictive permissions are applied.
      *
      */
-    @ConfigItem
-    public Optional<List<String>> paths;
+    Optional<List<String>> paths();
 
     /**
      * Path specific authentication mechanism which must be used to authenticate a user.
      * It needs to match {@link HttpCredentialTransport} authentication scheme such as 'basic', 'bearer', 'form', etc.
      */
-    @ConfigItem
-    public Optional<String> authMechanism;
+    public Optional<String> authMechanism();
 
     /**
      * Indicates that this policy always applies to the matched paths in addition to the policy with a winning path.
      * Avoid creating more than one shared policy to minimize the performance impact.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean shared;
+    @WithDefault("false")
+    boolean shared();
 
     /**
      * Whether permission check should be applied on all matching paths, or paths specific for the Jakarta REST resources.
      */
-    @ConfigItem(defaultValue = "ALL")
-    public AppliesTo appliesTo;
+    @WithDefault("all")
+    AppliesTo appliesTo();
 
     /**
      * Specifies additional criteria on paths that should be checked.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -3,31 +3,30 @@ package io.quarkus.vertx.http.runtime;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.vertx.http.runtime.TrustedProxyCheck.TrustedProxyCheckPart;
+import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
 
 /**
  * Holds configuration related with proxy addressing forward.
  */
-@ConfigGroup
-public class ProxyConfig {
+public interface ProxyConfig {
+
     /**
      * Set whether the server should use the HA {@code PROXY} protocol when serving requests from behind a proxy.
      * (see the <a href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt">PROXY Protocol</a>).
      * When set to {@code true}, the remote address returned will be the one from the actual connecting client.
      * If it is set to {@code false} (default), the remote address returned will be the one from the proxy.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean useProxyProtocol;
+    @WithDefault("false")
+    boolean useProxyProtocol();
 
     /**
      * If this is true then the address, scheme etc. will be set from headers forwarded by the proxy server, such as
      * {@code X-Forwarded-For}. This should only be set if you are behind a proxy that sets these headers.
      */
-    @ConfigItem
-    public boolean proxyAddressForwarding;
+    @WithDefault("false")
+    boolean proxyAddressForwarding();
 
     /**
      * If this is true and proxy address forwarding is enabled then the standard {@code Forwarded} header will be used.
@@ -37,8 +36,8 @@ public class ProxyConfig {
      * requests with a forwarded header that is not overwritten by the proxy. Therefore, proxies should strip unexpected
      * `Forwarded` or `X-Forwarded-*` headers from the client.
      */
-    @ConfigItem
-    public boolean allowForwarded;
+    @WithDefault("false")
+    boolean allowForwarded();
 
     /**
      * If either this or {@code allow-forwarded} are true and proxy address forwarding is enabled then the not standard
@@ -49,15 +48,14 @@ public class ProxyConfig {
      * requests with a forwarded header that is not overwritten by the proxy. Therefore, proxies should strip unexpected
      * `Forwarded` or `X-Forwarded-*` headers from the client.
      */
-    @ConfigItem
-    public Optional<Boolean> allowXForwarded;
+    Optional<Boolean> allowXForwarded();
 
     /**
      * When both Forwarded and X-Forwarded headers are enabled with {@link #allowForwarded} and {@link #allowXForwarded}
      * respectively, enforce that the identical headers must have equal values.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean strictForwardedControl;
+    @WithDefault("true")
+    boolean strictForwardedControl();
 
     /**
      * Precedence of Forwarded and X-Forwarded headers when both types of headers are enabled and no strict forwarded control is
@@ -78,32 +76,32 @@ public class ProxyConfig {
      * `https`,
      * then the final scheme value is `http`. If X-Forwarded has a precedence, then the final scheme value is 'https'.
      */
-    @ConfigItem(defaultValue = "forwarded")
-    public ForwardedPrecedence forwardedPrecedence;
+    @WithDefault("forwarded")
+    ForwardedPrecedence forwardedPrecedence();
 
     /**
      * Enable override the received request's host through a forwarded host header.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableForwardedHost;
+    @WithDefault("false")
+    boolean enableForwardedHost();
 
     /**
      * Configure the forwarded host header to be used if override enabled.
      */
-    @ConfigItem(defaultValue = "X-Forwarded-Host")
-    public String forwardedHostHeader;
+    @WithDefault("X-Forwarded-Host")
+    String forwardedHostHeader();
 
     /**
      * Enable prefix the received request's path with a forwarded prefix header.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableForwardedPrefix;
+    @WithDefault("false")
+    boolean enableForwardedPrefix();
 
     /**
      * Configure the forwarded prefix header to be used if prefixing enabled.
      */
-    @ConfigItem(defaultValue = "X-Forwarded-Prefix")
-    public String forwardedPrefixHeader;
+    @WithDefault("X-Forwarded-Prefix")
+    String forwardedPrefixHeader();
 
     /**
      * Adds the header `X-Forwarded-Trusted-Proxy` if the request is forwarded by a trusted proxy.
@@ -114,8 +112,8 @@ public class ProxyConfig {
      * <p>
      * The `X-Forwarded-Trusted-Proxy` header is a custom header, not part of the standard `Forwarded` header.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableTrustedProxyHeader;
+    @WithDefault("false")
+    boolean enableTrustedProxyHeader();
 
     /**
      * Configure the list of trusted proxy addresses.
@@ -145,8 +143,5 @@ public class ProxyConfig {
      * <p>
      * Please bear in mind that IPv4 CIDR won't match request sent from the IPv6 address and the other way around.
      */
-    @ConfigItem(defaultValueDocumentation = "All proxy addresses are trusted")
-    @ConvertWith(TrustedProxyCheckPartConverter.class)
-    public Optional<List<TrustedProxyCheckPart>> trustedProxies;
-
+    Optional<List<@WithConverter(TrustedProxyCheckPartConverter.class) TrustedProxyCheckPart>> trustedProxies();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SameSiteCookieConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SameSiteCookieConfig.java
@@ -1,7 +1,6 @@
 package io.quarkus.vertx.http.runtime;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 import io.vertx.core.http.CookieSameSite;
 
 /**
@@ -10,31 +9,28 @@ import io.vertx.core.http.CookieSameSite;
  * As some API's (Servlet, JAX-RS) don't current support this attribute this config allows
  * it to be set based on the cookie name pattern.
  */
-@ConfigGroup
-public class SameSiteCookieConfig {
-
+public interface SameSiteCookieConfig {
     /**
      * If the cookie pattern is case-sensitive
      */
-    @ConfigItem
-    public boolean caseSensitive;
+    @WithDefault("false")
+    boolean caseSensitive();
 
     /**
      * The value to set in the samesite attribute
      */
-    @ConfigItem
-    public CookieSameSite value;
+    CookieSameSite value();
 
     /**
      * Some User Agents break when sent SameSite=None, this will detect them and avoid sending the value
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enableClientChecker;
+    @WithDefault("true")
+    boolean enableClientChecker();
 
     /**
      * If this is true then the 'secure' attribute will automatically be sent on
      * cookies with a SameSite attribute of None.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean addSecureForNone;
+    @WithDefault("true")
+    boolean addSecureForNone();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -5,69 +5,66 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.configuration.MemorySize;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class ServerLimitsConfig {
+public interface ServerLimitsConfig {
     /**
      * The maximum length of all headers.
      */
-    @ConfigItem(defaultValue = "20K")
-    public MemorySize maxHeaderSize;
+    @WithDefault("20K")
+    MemorySize maxHeaderSize();
 
     /**
      * The maximum size of a request body.
      */
-    @ConfigItem(defaultValue = "10240K")
-    public Optional<MemorySize> maxBodySize;
+    @WithDefault("10240K")
+    Optional<MemorySize> maxBodySize();
 
     /**
      * The max HTTP chunk size
      */
-    @ConfigItem(defaultValue = "8192")
-    public MemorySize maxChunkSize;
+    @WithDefault("8192")
+    MemorySize maxChunkSize();
 
     /**
      * The maximum length of the initial line (e.g. {@code "GET / HTTP/1.0"}).
      */
-    @ConfigItem(defaultValue = "4096")
-    public int maxInitialLineLength;
+    @WithDefault("4096")
+    int maxInitialLineLength();
 
     /**
      * The maximum length of a form attribute.
      */
-    @ConfigItem(defaultValue = "2048")
-    public MemorySize maxFormAttributeSize;
+    @WithDefault("2048")
+    MemorySize maxFormAttributeSize();
 
     /**
      * Set the maximum number of fields of a form. Set to {@code -1} to allow unlimited number of attributes.
      */
-    @ConfigItem(defaultValue = "256")
-    public int maxFormFields;
+    @WithDefault("256")
+    int maxFormFields();
 
     /**
      * Set the maximum number of bytes a server can buffer when decoding a form.
      * Set to {@code -1} to allow unlimited length
      **/
-    @ConfigItem(defaultValue = "1K")
-    public MemorySize maxFormBufferedBytes;
+    @WithDefault("1K")
+    MemorySize maxFormBufferedBytes();
 
     /**
      * The maximum number of HTTP request parameters permitted for incoming requests.
      * <p>
      * If a client sends more than this number of parameters in a request, the connection is closed.
      */
-    @ConfigItem(defaultValue = "1000")
-    public int maxParameters;
+    @WithDefault("1000")
+    int maxParameters();
 
     /**
      * The maximum number of connections that are allowed at any one time. If this is set
      * it is recommended to set a short idle timeout.
      */
-    @ConfigItem
-    public OptionalInt maxConnections;
+    OptionalInt maxConnections();
 
     /**
      * Set the SETTINGS_HEADER_TABLE_SIZE HTTP/2 setting.
@@ -77,8 +74,7 @@ public class ServerLimitsConfig {
      * specific to the header compression format inside a header block.
      * The initial value is {@code 4,096} octets.
      */
-    @ConfigItem
-    public OptionalLong headerTableSize;
+    OptionalLong headerTableSize();
 
     /**
      * Set SETTINGS_MAX_CONCURRENT_STREAMS HTTP/2 setting.
@@ -87,16 +83,14 @@ public class ServerLimitsConfig {
      * applies to the number of streams that the sender permits the receiver to create. Initially, there is no limit to
      * this value. It is recommended that this value be no smaller than 100, to not unnecessarily limit parallelism.
      */
-    @ConfigItem
-    public OptionalLong maxConcurrentStreams;
+    OptionalLong maxConcurrentStreams();
 
     /**
      * Set the SETTINGS_MAX_FRAME_SIZE HTTP/2 setting.
      * Indicates the size of the largest frame payload that the sender is willing to receive, in octets.
      * The initial value is {@code 2^14} (16,384) octets.
      */
-    @ConfigItem
-    public OptionalInt maxFrameSize;
+    OptionalInt maxFrameSize();
 
     /**
      * Set the SETTINGS_MAX_HEADER_LIST_SIZE HTTP/2 setting.
@@ -105,23 +99,20 @@ public class ServerLimitsConfig {
      * value in octets plus an overhead of 32 octets for each header field.
      * The default value is {@code 8192}
      */
-    @ConfigItem
-    public OptionalLong maxHeaderListSize;
+    OptionalLong maxHeaderListSize();
 
     /**
      * Set the max number of RST frame allowed per time window, this is used to prevent
      * <a href="https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p">HTTP/2 RST frame flood DDOS
      * attacks</a>. The default value is {@code 200}, setting zero or a negative value, disables flood protection.
      */
-    @ConfigItem
-    public OptionalInt rstFloodMaxRstFramePerWindow;
+    OptionalInt rstFloodMaxRstFramePerWindow();
 
     /**
      * Set the duration of the time window when checking the max number of RST frames, this is used to prevent
      * <a href="https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p">HTTP/2 RST frame flood DDOS
      * attacks</a>.. The default value is {@code 30 s}, setting zero or a negative value, disables flood protection.
      */
-    @ConfigItem
-    public Optional<Duration> rstFloodWindowDuration;
+    Optional<Duration> rstFloodWindowDuration();
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerSslConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerSslConfig.java
@@ -4,25 +4,21 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.DefaultConverter;
+import io.smallrye.config.WithDefault;
 
 /**
  * Shared configuration for setting up server-side SSL.
  */
-@ConfigGroup
-public class ServerSslConfig {
+public interface ServerSslConfig {
     /**
      * The server certificate configuration.
      */
-    public CertificateConfig certificate;
+    CertificateConfig certificate();
 
     /**
      * The cipher suites to use. If none is given, a reasonable default is selected.
      */
-    @ConfigItem
-    public Optional<List<String>> cipherSuites;
+    Optional<List<String>> cipherSuites();
 
     /**
      * Sets the ordered list of enabled SSL/TLS protocols.
@@ -34,15 +30,13 @@ public class ServerSslConfig {
      * Note that setting an empty list, and enabling SSL/TLS is invalid.
      * You must at least have one protocol.
      */
-    @DefaultConverter
-    @ConfigItem(defaultValue = "TLSv1.3,TLSv1.2")
-    public Set<String> protocols;
+    @WithDefault("TLSv1.3,TLSv1.2")
+    Set<String> protocols();
 
     /**
      * Enables Server Name Indication (SNI), an TLS extension allowing the server to use multiple certificates.
      * The client indicate the server name during the TLS handshake, allowing the server to select the right certificate.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean sni;
-
+    @WithDefault("false")
+    boolean sni();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesConfig.java
@@ -3,58 +3,55 @@ package io.quarkus.vertx.http.runtime;
 import java.nio.charset.Charset;
 import java.time.Duration;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class StaticResourcesConfig {
-
+public interface StaticResourcesConfig {
     /**
      * Set the index page when serving static resources.
      */
-    @ConfigItem(defaultValue = "index.html")
-    public String indexPage;
+    @WithDefault("index.html")
+    String indexPage();
 
     /**
      * Set whether hidden files should be served.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean includeHidden;
+    @WithDefault("true")
+    boolean includeHidden();
 
     /**
      * Set whether range requests (resumable downloads; media streaming) should be enabled.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enableRangeSupport;
+    @WithDefault("true")
+    boolean enableRangeSupport();
 
     /**
      * Set whether cache handling is enabled.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean cachingEnabled;
+    @WithDefault("true")
+    boolean cachingEnabled();
 
     /**
      * Set the cache entry timeout. The default is {@code 30} seconds.
      */
-    @ConfigItem(defaultValue = "30S")
-    public Duration cacheEntryTimeout;
+    @WithDefault("30S")
+    Duration cacheEntryTimeout();
 
     /**
      * Set value for max age in caching headers. The default is {@code 24} hours.
      */
-    @ConfigItem(defaultValue = "24H")
-    public Duration maxAge;
+    @WithDefault("24H")
+    Duration maxAge();
 
     /**
      * Set the max cache size.
      */
-    @ConfigItem(defaultValue = "10000")
-    public int maxCacheSize;
+    @WithDefault("10000")
+    int maxCacheSize();
 
     /**
      * Content encoding for text related files
      */
-    @ConfigItem(defaultValue = "UTF-8")
-    public Charset contentEncoding;
+    @WithDefault("UTF-8")
+    Charset contentEncoding();
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
@@ -39,21 +39,21 @@ public class StaticResourcesRecorder {
     }
 
     public Consumer<Route> start(Set<String> knownPaths) {
-        if (httpBuildTimeConfig.enableCompression && httpBuildTimeConfig.compressMediaTypes.isPresent()) {
-            this.compressMediaTypes = Set.copyOf(httpBuildTimeConfig.compressMediaTypes.get());
+        if (httpBuildTimeConfig.enableCompression() && httpBuildTimeConfig.compressMediaTypes().isPresent()) {
+            this.compressMediaTypes = Set.copyOf(httpBuildTimeConfig.compressMediaTypes().get());
         }
         List<Handler<RoutingContext>> handlers = new ArrayList<>();
-        StaticResourcesConfig config = httpConfiguration.getValue().staticResources;
+        StaticResourcesConfig config = httpConfiguration.getValue().staticResources();
 
         if (hotDeploymentResourcePaths != null && !hotDeploymentResourcePaths.isEmpty()) {
             for (Path resourcePath : hotDeploymentResourcePaths) {
                 String root = resourcePath.toAbsolutePath().toString();
                 StaticHandler staticHandler = StaticHandler.create(FileSystemAccess.ROOT, root)
-                        .setDefaultContentEncoding(config.contentEncoding.name())
+                        .setDefaultContentEncoding(config.contentEncoding().name())
                         .setCachingEnabled(false)
-                        .setIndexPage(config.indexPage)
-                        .setIncludeHidden(config.includeHidden)
-                        .setEnableRangeSupport(config.enableRangeSupport);
+                        .setIndexPage(config.indexPage())
+                        .setIncludeHidden(config.includeHidden())
+                        .setEnableRangeSupport(config.enableRangeSupport());
                 handlers.add(new Handler<>() {
                     @Override
                     public void handle(RoutingContext ctx) {
@@ -73,18 +73,18 @@ public class StaticResourcesRecorder {
             ClassLoader currentCl = Thread.currentThread().getContextClassLoader();
             StaticHandler staticHandler = StaticHandler.create(META_INF_RESOURCES)
                     .setDefaultContentEncoding("UTF-8")
-                    .setCachingEnabled(config.cachingEnabled)
-                    .setIndexPage(config.indexPage)
-                    .setIncludeHidden(config.includeHidden)
-                    .setEnableRangeSupport(config.enableRangeSupport)
-                    .setMaxCacheSize(config.maxCacheSize)
-                    .setCacheEntryTimeout(config.cacheEntryTimeout.toMillis())
-                    .setMaxAgeSeconds(config.maxAge.toSeconds());
+                    .setCachingEnabled(config.cachingEnabled())
+                    .setIndexPage(config.indexPage())
+                    .setIncludeHidden(config.includeHidden())
+                    .setEnableRangeSupport(config.enableRangeSupport())
+                    .setMaxCacheSize(config.maxCacheSize())
+                    .setCacheEntryTimeout(config.cacheEntryTimeout().toMillis())
+                    .setMaxAgeSeconds(config.maxAge().toSeconds());
             // normalize index page like StaticHandler because its not expose
             // TODO: create a converter to normalize filename in config.indexPage?
-            final String indexPage = (config.indexPage.charAt(0) == '/')
-                    ? config.indexPage.substring(1)
-                    : config.indexPage;
+            final String indexPage = (config.indexPage().charAt(0) == '/')
+                    ? config.indexPage().substring(1)
+                    : config.indexPage();
             handlers.add(new Handler<>() {
                 @Override
                 public void handle(RoutingContext ctx) {
@@ -122,7 +122,7 @@ public class StaticResourcesRecorder {
     }
 
     private void compressIfNeeded(RoutingContext ctx, String path) {
-        if (httpBuildTimeConfig.enableCompression && isCompressed(path)) {
+        if (httpBuildTimeConfig.enableCompression() && isCompressed(path)) {
             // VertxHttpRecorder is adding "Content-Encoding: identity" to all requests if compression is enabled.
             // Handlers can remove the "Content-Encoding: identity" header to enable compression.
             ctx.response().headers().remove(HttpHeaders.CONTENT_ENCODING);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrafficShapingConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrafficShapingConfig.java
@@ -4,8 +4,8 @@ import java.time.Duration;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.configuration.MemorySize;
+import io.smallrye.config.WithDefault;
 
 /**
  * Configure the global traffic shaping functionality.
@@ -25,34 +25,31 @@ import io.quarkus.runtime.configuration.MemorySize;
  * By default, it is set to 15 seconds.
  */
 @ConfigGroup
-public class TrafficShapingConfig {
+public interface TrafficShapingConfig {
 
     /**
      * Enables the traffic shaping.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enabled;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * Set bandwidth limit in bytes per second for inbound connections.
      * If not set, no limits are applied.
      */
-    @ConfigItem
-    public Optional<MemorySize> inboundGlobalBandwidth;
+    Optional<MemorySize> inboundGlobalBandwidth();
 
     /**
      * Set bandwidth limit in bytes per second for outbound connections.
      * If not set, no limits are applied.
      */
-    @ConfigItem
-    public Optional<MemorySize> outboundGlobalBandwidth;
+    Optional<MemorySize> outboundGlobalBandwidth();
 
     /**
      * Set the maximum delay to wait in case of traffic excess.
      * Default is 15s. Must be less than the HTTP timeout.
      */
-    @ConfigItem
-    public Optional<Duration> maxDelay;
+    Optional<Duration> maxDelay();
 
     /**
      * Set the delay between two computations of performances for channels.
@@ -63,15 +60,13 @@ public class TrafficShapingConfig {
      * <p>
      * If not default, it defaults to 1s.
      */
-    @ConfigItem
-    public Optional<Duration> checkInterval;
+    Optional<Duration> checkInterval();
 
     /**
      * Set the maximum global write size in bytes per second allowed in the buffer globally for all channels before write
      * are suspended.
      * The default value is 400 MB.
      */
-    @ConfigItem
-    public Optional<MemorySize> peakOutboundGlobalBandwidth;
+    Optional<MemorySize> peakOutboundGlobalBandwidth();
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/WebsocketServerConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/WebsocketServerConfig.java
@@ -3,13 +3,12 @@ package io.quarkus.vertx.http.runtime;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 
 /**
  * Configure the Vert.X HTTP Server for WebSocker Server connection.
  */
 @ConfigGroup
-public class WebsocketServerConfig {
+public interface WebsocketServerConfig {
 
     /**
      * The maximum amount of data that can be sent in a single frame.
@@ -18,15 +17,13 @@ public class WebsocketServerConfig {
      *
      * Default 65536 (from HttpServerOptions of Vert.X HttpServerOptions)
      */
-    @ConfigItem
-    public Optional<Integer> maxFrameSize;
+    Optional<Integer> maxFrameSize();
 
     /**
      * The maximum WebSocket message size.
      *
      * Default 262144 (from HttpServerOptions of Vert.X HttpServerOptions)
      */
-    @ConfigItem
-    public Optional<Integer> maxMessageSize;
+    Optional<Integer> maxMessageSize();
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
@@ -4,23 +4,17 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
 
-@ConfigGroup
-public class CORSConfig {
-
+public interface CORSConfig {
     /**
      * The origins allowed for CORS.
      *
      * A comma-separated list of valid URLs, such as `http://www.quarkus.io,http://localhost:3000`.
      * URLs enclosed in forward slashes are interpreted as regular expressions.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> origins = Optional.empty();
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> origins();
 
     /**
      * The HTTP methods allowed for CORS requests.
@@ -30,9 +24,7 @@ public class CORSConfig {
      *
      * Default: Any HTTP request method is allowed.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> methods = Optional.empty();
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> methods();
 
     /**
      * The HTTP headers allowed for CORS requests.
@@ -42,9 +34,7 @@ public class CORSConfig {
      *
      * Default: Any HTTP request header is allowed.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> headers = Optional.empty();
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> headers();
 
     /**
      * The HTTP headers exposed in CORS responses.
@@ -53,17 +43,14 @@ public class CORSConfig {
      *
      * Default: No headers are exposed.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> exposedHeaders = Optional.empty();
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> exposedHeaders();
 
     /**
      * The `Access-Control-Max-Age` response header value in {@link java.time.Duration} format.
      *
      * Informs the browser how long it can cache the results of a preflight request.
      */
-    @ConfigItem
-    public Optional<Duration> accessControlMaxAge = Optional.empty();
+    Optional<Duration> accessControlMaxAge();
 
     /**
      * The `Access-Control-Allow-Credentials` response header.
@@ -74,18 +61,5 @@ public class CORSConfig {
      * Default: `true` if the `quarkus.http.cors.origins` property is set
      * and matches the precise `Origin` header value.
      */
-    @ConfigItem
-    public Optional<Boolean> accessControlAllowCredentials = Optional.empty();
-
-    @Override
-    public String toString() {
-        return "CORSConfig{" +
-                "origins=" + origins +
-                ", methods=" + methods +
-                ", headers=" + headers +
-                ", exposedHeaders=" + exposedHeaders +
-                ", accessControlMaxAge=" + accessControlMaxAge +
-                ", accessControlAllowCredentials=" + accessControlAllowCredentials +
-                '}';
-    }
+    Optional<Boolean> accessControlAllowCredentials();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -39,13 +39,13 @@ public class CORSFilter implements Handler<RoutingContext> {
 
     public CORSFilter(CORSConfig corsConfig) {
         this.corsConfig = corsConfig;
-        this.wildcardOrigin = isOriginConfiguredWithWildcard(this.corsConfig.origins);
-        this.wildcardMethod = isConfiguredWithWildcard(corsConfig.methods);
-        this.allowedOriginsRegex = this.wildcardOrigin ? List.of() : parseAllowedOriginsRegex(this.corsConfig.origins);
-        this.configuredHttpMethods = createConfiguredHttpMethods(this.corsConfig.methods);
-        this.exposedHeaders = createHeaderString(this.corsConfig.exposedHeaders);
-        this.allowedHeaders = createHeaderString(this.corsConfig.headers);
-        this.allowedMethods = createHeaderString(this.corsConfig.methods);
+        this.wildcardOrigin = isOriginConfiguredWithWildcard(this.corsConfig.origins());
+        this.wildcardMethod = isConfiguredWithWildcard(corsConfig.methods());
+        this.allowedOriginsRegex = this.wildcardOrigin ? List.of() : parseAllowedOriginsRegex(this.corsConfig.origins());
+        this.configuredHttpMethods = createConfiguredHttpMethods(this.corsConfig.methods());
+        this.exposedHeaders = createHeaderString(this.corsConfig.exposedHeaders());
+        this.allowedHeaders = createHeaderString(this.corsConfig.headers());
+        this.allowedMethods = createHeaderString(this.corsConfig.methods());
     }
 
     private String createHeaderString(Optional<List<String>> headers) {
@@ -146,10 +146,10 @@ public class CORSFilter implements Handler<RoutingContext> {
 
             //for both normal and preflight requests we need to check the origin
             boolean allowsOrigin = wildcardOrigin;
-            boolean originMatches = !wildcardOrigin && corsConfig.origins.isPresent() &&
-                    (corsConfig.origins.get().contains(origin) || isOriginAllowedByRegex(allowedOriginsRegex, origin));
+            boolean originMatches = !wildcardOrigin && corsConfig.origins().isPresent() &&
+                    (corsConfig.origins().get().contains(origin) || isOriginAllowedByRegex(allowedOriginsRegex, origin));
             if (!allowsOrigin) {
-                if (corsConfig.origins.isPresent()) {
+                if (corsConfig.origins().isPresent()) {
                     allowsOrigin = originMatches || isSameOrigin(request, origin);
                 } else {
                     allowsOrigin = isSameOrigin(request, origin);
@@ -160,7 +160,7 @@ public class CORSFilter implements Handler<RoutingContext> {
                 response.setStatusCode(403);
                 response.setStatusMessage("CORS Rejected - Invalid origin");
             } else {
-                boolean allowCredentials = corsConfig.accessControlAllowCredentials.orElse(originMatches);
+                boolean allowCredentials = corsConfig.accessControlAllowCredentials().orElse(originMatches);
                 response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, String.valueOf(allowCredentials));
                 response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
             }
@@ -209,9 +209,9 @@ public class CORSFilter implements Handler<RoutingContext> {
             boolean allowsOrigin) {
         //see https://fetch.spec.whatwg.org/#http-cors-protocol
 
-        if (corsConfig.accessControlMaxAge.isPresent()) {
+        if (corsConfig.accessControlMaxAge().isPresent()) {
             event.response().putHeader(HttpHeaders.ACCESS_CONTROL_MAX_AGE,
-                    String.valueOf(corsConfig.accessControlMaxAge.get().getSeconds()));
+                    String.valueOf(corsConfig.accessControlMaxAge().get().getSeconds()));
         }
         var response = event.response();
         if (requestedMethods != null) {
@@ -315,7 +315,7 @@ public class CORSFilter implements Handler<RoutingContext> {
     }
 
     private void processPreFlightRequestedHeaders(HttpServerResponse response, String allowHeadersValue) {
-        if (isConfiguredWithWildcard(corsConfig.headers)) {
+        if (isConfiguredWithWildcard(corsConfig.headers())) {
             response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, allowHeadersValue);
         } else {
             response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, allowedHeaders);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSRecorder.java
@@ -14,8 +14,8 @@ public class CORSRecorder {
     }
 
     public Handler<RoutingContext> corsHandler() {
-        if (configuration.corsEnabled) {
-            return new CORSFilter(configuration.cors);
+        if (configuration.corsEnabled()) {
+            return new CORSFilter(configuration.cors());
         }
         return null;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementAuthConfig.java
@@ -3,26 +3,25 @@ package io.quarkus.vertx.http.runtime.management;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * Authentication for the management interface.
  */
 @ConfigGroup
-public class ManagementAuthConfig {
+public interface ManagementAuthConfig {
 
     /**
      * If authentication for the management interface should be enabled.
      */
-    @ConfigItem(defaultValue = "${quarkus.management.auth.basic:false}")
-    public boolean enabled;
+    @WithDefault("${quarkus.management.auth.basic:false}")
+    boolean enabled();
 
     /**
      * If basic auth should be enabled.
      *
      */
-    @ConfigItem
-    public Optional<Boolean> basic;
+    Optional<Boolean> basic();
 
     /**
      * If this is true and credentials are present then a user will always be authenticated
@@ -31,6 +30,6 @@ public class ManagementAuthConfig {
      * If this is false then an attempt will only be made to authenticate the user if a permission
      * check is performed or the current user is required for some other reason.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean proactive;
+    @WithDefault("true")
+    boolean proactive();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceBuildTimeConfig.java
@@ -2,43 +2,46 @@ package io.quarkus.vertx.http.runtime.management;
 
 import java.util.OptionalInt;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 import io.vertx.core.http.ClientAuth;
 
 /**
  * Management interface configuration.
  */
-@ConfigRoot(name = "management", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class ManagementInterfaceBuildTimeConfig {
-
+@ConfigMapping(prefix = "quarkus.management")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface ManagementInterfaceBuildTimeConfig {
     /**
      * Enables / Disables the usage of a separate interface/port to expose the management endpoints.
      * If sets to {@code true}, the management endpoints will be exposed to a different HTTP server.
      * This avoids exposing the management endpoints on a publicly available server.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enabled;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * Authentication configuration
      */
-    public ManagementAuthConfig auth;
+    ManagementAuthConfig auth();
 
     /**
      * Configures the engine to require/request client authentication.
      * NONE, REQUEST, REQUIRED
      */
-    @ConfigItem(name = "ssl.client-auth", defaultValue = "NONE")
-    public ClientAuth tlsClientAuth;
+    @WithDefault("NONE")
+    @WithName("ssl.client-auth")
+    ClientAuth tlsClientAuth();
 
     /**
      * A common root path for management endpoints. Various extension-provided management endpoints such as metrics
      * and health are deployed under this path by default.
      */
-    @ConfigItem(defaultValue = "/q")
-    public String rootPath;
+    @WithDefault("/q")
+    String rootPath();
 
     /**
      * If responses should be compressed.
@@ -50,8 +53,8 @@ public class ManagementInterfaceBuildTimeConfig {
      * <p>
      * Which will tell vert.x not to compress the response.
      */
-    @ConfigItem
-    public boolean enableCompression;
+    @WithDefault("false")
+    boolean enableCompression();
 
     /**
      * When enabled, vert.x will decompress the request's body if it's compressed.
@@ -59,12 +62,11 @@ public class ManagementInterfaceBuildTimeConfig {
      * Note that the compression format (e.g., gzip) must be specified in the Content-Encoding header
      * in the request.
      */
-    @ConfigItem
-    public boolean enableDecompression;
+    @WithDefault("false")
+    boolean enableDecompression();
 
     /**
      * The compression level used when compression support is enabled.
      */
-    @ConfigItem
-    public OptionalInt compressionLevel;
+    OptionalInt compressionLevel();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceConfiguration.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.LaunchMode;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.vertx.http.runtime.BodyConfig;
@@ -14,31 +14,35 @@ import io.quarkus.vertx.http.runtime.HeaderConfig;
 import io.quarkus.vertx.http.runtime.ProxyConfig;
 import io.quarkus.vertx.http.runtime.ServerLimitsConfig;
 import io.quarkus.vertx.http.runtime.ServerSslConfig;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * Configures the management interface.
  * Note that the management interface must be enabled using the
  * {@link ManagementInterfaceBuildTimeConfig#enabled} build-time property.
  */
-@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "management")
-public class ManagementInterfaceConfiguration {
+@ConfigMapping(prefix = "quarkus.management")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface ManagementInterfaceConfiguration {
+    /**
+     * The HTTP port
+     */
+    @WithDefault("9000")
+    int port();
 
     /**
      * Authentication configuration
      */
-    public ManagementRuntimeAuthConfig auth;
+    @ConfigDocSection
+    ManagementRuntimeAuthConfig auth();
 
     /**
      * The HTTP port
      */
-    @ConfigItem(defaultValue = "9000")
-    public int port;
-
-    /**
-     * The HTTP port
-     */
-    @ConfigItem(defaultValue = "9001")
-    public int testPort;
+    @WithDefault("9001")
+    int testPort();
 
     /**
      * The HTTP host
@@ -53,19 +57,18 @@ public class ManagementInterfaceConfiguration {
      * defaults to 0.0.0.0 even in dev/test mode since using localhost makes the application
      * inaccessible.
      */
-    @ConfigItem
-    public String host;
+    String host();
 
     /**
      * Enable listening to host:port
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean hostEnabled;
+    @WithDefault("true")
+    boolean hostEnabled();
 
     /**
      * The SSL config
      */
-    public ServerSslConfig ssl;
+    ServerSslConfig ssl();
 
     /**
      * The name of the TLS configuration to use.
@@ -76,66 +79,67 @@ public class ManagementInterfaceConfiguration {
      * <p>
      * If no TLS configuration is set, and {@code quarkus.tls.*} is not configured, then, `quarkus.management.ssl` will be used.
      */
-    @ConfigItem
-    public Optional<String> tlsConfigurationName;
+    Optional<String> tlsConfigurationName();
 
     /**
      * When set to {@code true}, the HTTP server automatically sends `100 CONTINUE`
      * response when the request expects it (with the `Expect: 100-Continue` header).
      */
-    @ConfigItem(defaultValue = "false", name = "handle-100-continue-automatically")
-    public boolean handle100ContinueAutomatically;
+    @WithName("handle-100-continue-automatically")
+    @WithDefault("false")
+    boolean handle100ContinueAutomatically();
 
     /**
      * Server limits configuration
      */
-    public ServerLimitsConfig limits;
+    ServerLimitsConfig limits();
 
     /**
      * Http connection idle timeout
      */
-    @ConfigItem(defaultValue = "30M", name = "idle-timeout")
-    public Duration idleTimeout;
+    @WithName("idle-timeout")
+    @WithDefault("30M")
+    Duration idleTimeout();
 
     /**
      * Request body related settings
      */
-    public BodyConfig body;
+    BodyConfig body();
 
     /**
      * The accept backlog, this is how many connections can be waiting to be accepted before connections start being rejected
      */
-    @ConfigItem(defaultValue = "-1")
-    public int acceptBacklog;
+    @WithDefault("-1")
+    int acceptBacklog();
 
     /**
      * Path to a unix domain socket
      */
-    @ConfigItem(defaultValue = "/var/run/io.quarkus.management.socket")
-    public String domainSocket;
+    @WithDefault("/var/run/io.quarkus.management.socket")
+    String domainSocket();
 
     /**
      * Enable listening to host:port
      */
-    @ConfigItem
-    public boolean domainSocketEnabled;
+    @WithDefault("false")
+    boolean domainSocketEnabled();
 
     /**
      * Additional HTTP Headers always sent in the response
      */
-    @ConfigItem
-    public Map<String, HeaderConfig> header;
+    Map<String, HeaderConfig> header();
 
     /**
      * Additional HTTP configuration per path
      */
-    @ConfigItem
-    public Map<String, FilterConfig> filter;
+    Map<String, FilterConfig> filter();
 
-    public ProxyConfig proxy;
+    /**
+     * Proxy configuration.
+     */
+    ProxyConfig proxy();
 
-    public int determinePort(LaunchMode launchMode) {
-        return launchMode == LaunchMode.TEST ? testPort : port;
+    default int determinePort(LaunchMode launchMode) {
+        return launchMode == LaunchMode.TEST ? testPort() : port();
     }
-
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceSecurityRecorder.java
@@ -28,7 +28,7 @@ public class ManagementInterfaceSecurityRecorder {
     public void initializeAuthenticationHandler(RuntimeValue<AuthenticationHandler> handler,
             ManagementInterfaceConfiguration runTimeConfig) {
         handler.getValue().init(ManagementPathMatchingHttpSecurityPolicy.class,
-                RolesMapping.of(runTimeConfig.auth.rolesMapping));
+                RolesMapping.of(runTimeConfig.auth().rolesMapping()));
     }
 
     public Handler<RoutingContext> permissionCheckHandler() {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementRuntimeAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementRuntimeAuthConfig.java
@@ -5,27 +5,27 @@ import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.vertx.http.runtime.PolicyConfig;
 import io.quarkus.vertx.http.runtime.PolicyMappingConfig;
+import io.smallrye.config.WithName;
 
 /**
  * Authentication for the management interface.
  */
 @ConfigGroup
-public class ManagementRuntimeAuthConfig {
+public interface ManagementRuntimeAuthConfig {
 
     /**
      * The HTTP permissions
      */
-    @ConfigItem(name = "permission")
-    public Map<String, PolicyMappingConfig> permissions;
+    @WithName("permission")
+    Map<String, PolicyMappingConfig> permissions();
 
     /**
      * The HTTP role based policies
      */
-    @ConfigItem(name = "policy")
-    public Map<String, PolicyConfig> rolePolicy;
+    @WithName("policy")
+    Map<String, PolicyConfig> rolePolicy();
 
     /**
      * Map the `SecurityIdentity` roles to deployment specific roles and add the matching roles to `SecurityIdentity`.
@@ -34,7 +34,6 @@ public class ManagementRuntimeAuthConfig {
      * use this property to map the `user` role to the `UserRole` role, and have `SecurityIdentity` to have
      * both `user` and `UserRole` roles.
      */
-    @ConfigItem
     @ConfigDocMapKey("role-name")
-    public Map<String, List<String>> rolesMapping;
+    Map<String, List<String>> rolesMapping();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
@@ -34,8 +34,8 @@ import io.vertx.ext.web.RoutingContext;
 
 public class HttpServerCommonHandlers {
     public static void enforceMaxBodySize(ServerLimitsConfig limits, Router httpRouteRouter) {
-        if (limits.maxBodySize.isPresent()) {
-            long limit = limits.maxBodySize.get().asLongValue();
+        if (limits.maxBodySize().isPresent()) {
+            long limit = limits.maxBodySize().get().asLongValue();
             Long limitObj = limit;
             httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_UPLOAD_LIMIT).handler(new Handler<RoutingContext>() {
                 @Override
@@ -91,7 +91,7 @@ public class HttpServerCommonHandlers {
 
     public static Handler<HttpServerRequest> applyProxy(ProxyConfig proxyConfig, Handler<HttpServerRequest> root,
             Supplier<Vertx> vertx) {
-        if (proxyConfig.proxyAddressForwarding) {
+        if (proxyConfig.proxyAddressForwarding()) {
             final ForwardingProxyOptions forwardingProxyOptions = ForwardingProxyOptions.from(proxyConfig);
             final TrustedProxyCheck.TrustedProxyCheckBuilder proxyCheckBuilder = forwardingProxyOptions.trustedProxyCheckBuilder;
             if (proxyCheckBuilder == null) {
@@ -115,10 +115,10 @@ public class HttpServerCommonHandlers {
         if (!filtersInConfig.isEmpty()) {
             for (var entry : filtersInConfig.entrySet()) {
                 var filterConfig = entry.getValue();
-                var matches = filterConfig.matches;
-                var order = filterConfig.order.orElse(Integer.MIN_VALUE);
-                var methods = filterConfig.methods;
-                var headers = filterConfig.header;
+                var matches = filterConfig.matches();
+                var order = filterConfig.order().orElse(Integer.MIN_VALUE);
+                var methods = filterConfig.methods();
+                var headers = filterConfig.header();
                 if (methods.isEmpty()) {
                     httpRouteRouter.routeWithRegex(matches)
                             .order(order)
@@ -174,24 +174,24 @@ public class HttpServerCommonHandlers {
             for (Map.Entry<String, HeaderConfig> entry : headers.entrySet()) {
                 var name = entry.getKey();
                 var config = entry.getValue();
-                if (config.methods.isEmpty()) {
-                    httpRouteRouter.route(config.path)
+                if (config.methods().isEmpty()) {
+                    httpRouteRouter.route(config.path())
                             .order(RouteConstants.ROUTE_ORDER_HEADERS)
                             .handler(new Handler<RoutingContext>() {
                                 @Override
                                 public void handle(RoutingContext event) {
-                                    event.response().headers().set(name, config.value);
+                                    event.response().headers().set(name, config.value());
                                     event.next();
                                 }
                             });
                 } else {
-                    for (String method : config.methods.get()) {
-                        httpRouteRouter.route(HttpMethod.valueOf(method.toUpperCase(Locale.ROOT)), config.path)
+                    for (String method : config.methods().get()) {
+                        httpRouteRouter.route(HttpMethod.valueOf(method.toUpperCase(Locale.ROOT)), config.path())
                                 .order(RouteConstants.ROUTE_ORDER_HEADERS)
                                 .handler(new Handler<RoutingContext>() {
                                     @Override
                                     public void handle(RoutingContext event) {
-                                        event.response().headers().add(name, config.value);
+                                        event.response().headers().add(name, config.value());
                                         event.next();
                                     }
                                 });

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
@@ -78,12 +78,12 @@ public class TlsCertificateReloader {
 
         long period;
         // Validation
-        if (configuration.certificate.reloadPeriod.isPresent()) {
-            if (configuration.certificate.reloadPeriod.get().toMillis() < 30_000) {
+        if (configuration.certificate().reloadPeriod().isPresent()) {
+            if (configuration.certificate().reloadPeriod().get().toMillis() < 30_000) {
                 throw new IllegalArgumentException(
                         "Unable to configure TLS reloading - The reload period cannot be less than 30 seconds");
             }
-            period = configuration.certificate.reloadPeriod.get().toMillis();
+            period = configuration.certificate().reloadPeriod().get().toMillis();
         } else {
             return -1;
         }
@@ -185,8 +185,8 @@ public class TlsCertificateReloader {
         final List<Path> keys = new ArrayList<>();
         final List<Path> certificates = new ArrayList<>();
 
-        configuration.certificate.keyFiles.ifPresent(keys::addAll);
-        configuration.certificate.files.ifPresent(certificates::addAll);
+        configuration.certificate().keyFiles().ifPresent(keys::addAll);
+        configuration.certificate().files().ifPresent(certificates::addAll);
 
         if (!certificates.isEmpty() && !keys.isEmpty()) {
             List<Buffer> certBuffer = new ArrayList<>();
@@ -205,15 +205,15 @@ public class TlsCertificateReloader {
                     .setCertValues(certBuffer)
                     .setKeyValues(keysBuffer);
             copy.setKeyCertOptions(opts);
-        } else if (configuration.certificate.keyStoreFile.isPresent()) {
+        } else if (configuration.certificate().keyStoreFile().isPresent()) {
             var opts = ((KeyStoreOptions) copy.getKeyCertOptions());
-            opts.setValue(Buffer.buffer(getFileContent(configuration.certificate.keyStoreFile.get())));
+            opts.setValue(Buffer.buffer(getFileContent(configuration.certificate().keyStoreFile().get())));
             copy.setKeyCertOptions(opts);
         }
 
-        if (configuration.certificate.trustStoreFile.isPresent()) {
+        if (configuration.certificate().trustStoreFile().isPresent()) {
             var opts = ((KeyStoreOptions) copy.getKeyCertOptions());
-            opts.setValue(Buffer.buffer(getFileContent(configuration.certificate.trustStoreFile.get())));
+            opts.setValue(Buffer.buffer(getFileContent(configuration.certificate().trustStoreFile().get())));
             copy.setTrustOptions(opts);
         }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsUtils.java
@@ -29,26 +29,26 @@ public class TlsUtils {
     public static KeyCertOptions computeKeyStoreOptions(CertificateConfig certificates, Optional<String> keyStorePassword,
             Optional<String> keyStoreAliasPassword) throws IOException {
 
-        if (certificates.keyFiles.isPresent() || certificates.files.isPresent()) {
-            if (certificates.keyFiles.isEmpty()) {
+        if (certificates.keyFiles().isPresent() || certificates.files().isPresent()) {
+            if (certificates.keyFiles().isEmpty()) {
                 throw new IllegalArgumentException("You must specify the key files when specifying the certificate files");
             }
-            if (certificates.files.isEmpty()) {
+            if (certificates.files().isEmpty()) {
                 throw new IllegalArgumentException("You must specify the certificate files when specifying the key files");
             }
-            if (certificates.files.get().size() != certificates.keyFiles.get().size()) {
+            if (certificates.files().get().size() != certificates.keyFiles().get().size()) {
                 throw new IllegalArgumentException(
                         "The number of certificate files and key files must be the same, and be given in the same order");
             }
-            return createPemKeyCertOptions(certificates.files.get(), certificates.keyFiles.get());
-        } else if (certificates.keyStoreFile.isPresent()) {
-            var type = getKeyStoreType(certificates.keyStoreFile.get(), certificates.keyStoreFileType);
+            return createPemKeyCertOptions(certificates.files().get(), certificates.keyFiles().get());
+        } else if (certificates.keyStoreFile().isPresent()) {
+            var type = getKeyStoreType(certificates.keyStoreFile().get(), certificates.keyStoreFileType());
             return createKeyStoreOptions(
-                    certificates.keyStoreFile.get(),
+                    certificates.keyStoreFile().get(),
                     keyStorePassword,
                     type,
-                    certificates.keyStoreProvider,
-                    or(certificates.keyStoreAlias, certificates.keyStoreKeyAlias),
+                    certificates.keyStoreProvider(),
+                    or(certificates.keyStoreAlias(), certificates.keyStoreKeyAlias()),
                     keyStoreAliasPassword);
         }
         return null;
@@ -60,7 +60,7 @@ public class TlsUtils {
         Path singleTrustStoreFile = getSingleTrustStoreFile(certificates);
 
         if (singleTrustStoreFile != null) { // We have a single trust store file.
-            String type = getTruststoreType(singleTrustStoreFile, certificates.trustStoreFileType);
+            String type = getTruststoreType(singleTrustStoreFile, certificates.trustStoreFileType());
             if (type.equalsIgnoreCase("pem")) {
                 byte[] cert = getFileContent(singleTrustStoreFile);
                 return new PemTrustOptions()
@@ -69,7 +69,7 @@ public class TlsUtils {
 
             if ((type.equalsIgnoreCase("pkcs12") || type.equalsIgnoreCase("jks"))) {
                 // We cannot assume that custom type configured by the user requires a password.
-                if (certificates.trustStorePassword.isEmpty() && trustStorePassword.isEmpty()) {
+                if (certificates.trustStorePassword().isEmpty() && trustStorePassword.isEmpty()) {
                     throw new IllegalArgumentException("No trust store password provided");
                 }
             }
@@ -78,16 +78,16 @@ public class TlsUtils {
                     singleTrustStoreFile,
                     trustStorePassword,
                     type,
-                    certificates.trustStoreProvider,
-                    certificates.trustStoreCertAlias,
+                    certificates.trustStoreProvider(),
+                    certificates.trustStoreCertAlias(),
                     Optional.empty());
         }
 
         // We have multiple trust store files (PEM).
-        if (certificates.trustStoreFiles.isPresent() && !certificates.trustStoreFiles.get().isEmpty()) {
+        if (certificates.trustStoreFiles().isPresent() && !certificates.trustStoreFiles().get().isEmpty()) {
             // Assuming PEM, as it's the only format with multiple files
             PemTrustOptions pemKeyCertOptions = new PemTrustOptions();
-            for (Path path : certificates.trustStoreFiles.get()) {
+            for (Path path : certificates.trustStoreFiles().get()) {
                 byte[] cert = getFileContent(path);
                 pemKeyCertOptions.addCertValue(Buffer.buffer(cert));
             }
@@ -99,15 +99,15 @@ public class TlsUtils {
 
     private static Path getSingleTrustStoreFile(CertificateConfig certificates) {
         Path singleTrustStoreFile = null;
-        if (certificates.trustStoreFile.isPresent()) {
-            singleTrustStoreFile = certificates.trustStoreFile.get();
+        if (certificates.trustStoreFile().isPresent()) {
+            singleTrustStoreFile = certificates.trustStoreFile().get();
         }
-        if (certificates.trustStoreFiles.isPresent()) {
+        if (certificates.trustStoreFiles().isPresent()) {
             if (singleTrustStoreFile != null) {
                 throw new IllegalArgumentException("You cannot specify both `trustStoreFile` and `trustStoreFiles`");
             }
-            if (certificates.trustStoreFiles.get().size() == 1) {
-                singleTrustStoreFile = certificates.trustStoreFiles.get().get(0);
+            if (certificates.trustStoreFiles().get().size() == 1) {
+                singleTrustStoreFile = certificates.trustStoreFiles().get().get(0);
             }
         }
         return singleTrustStoreFile;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/BasicAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/BasicAuthenticationMechanism.java
@@ -77,7 +77,7 @@ public class BasicAuthenticationMechanism implements HttpAuthenticationMechanism
 
     @Inject
     BasicAuthenticationMechanism(HttpConfiguration runtimeConfig, HttpBuildTimeConfig buildTimeConfig) {
-        this(runtimeConfig.auth.realm.orElse(null), buildTimeConfig.auth.form.enabled);
+        this(runtimeConfig.auth().realm().orElse(null), buildTimeConfig.auth().form().enabled());
     }
 
     public BasicAuthenticationMechanism(final String realmName) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
@@ -72,7 +72,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
             Event<FormAuthenticationEvent> formAuthEvent, BeanManager beanManager,
             @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled) {
         String key;
-        if (httpConfiguration.encryptionKey.isEmpty()) {
+        if (httpConfiguration.encryptionKey().isEmpty()) {
             if (encryptionKey != null) {
                 //persist across dev mode restarts
                 key = encryptionKey;
@@ -83,26 +83,26 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
                 log.warn("Encryption key was not specified for persistent FORM auth, using temporary key " + key);
             }
         } else {
-            key = httpConfiguration.encryptionKey.get();
+            key = httpConfiguration.encryptionKey().get();
         }
-        FormAuthConfig form = buildTimeConfig.auth.form;
-        FormAuthRuntimeConfig runtimeForm = httpConfiguration.auth.form;
-        this.loginManager = new PersistentLoginManager(key, runtimeForm.cookieName, runtimeForm.timeout.toMillis(),
-                runtimeForm.newCookieInterval.toMillis(), runtimeForm.httpOnlyCookie, runtimeForm.cookieSameSite.name(),
-                runtimeForm.cookiePath.orElse(null), runtimeForm.cookieMaxAge.map(Duration::toSeconds).orElse(-1L));
-        this.loginPage = startWithSlash(runtimeForm.loginPage.orElse(null));
-        this.errorPage = startWithSlash(runtimeForm.errorPage.orElse(null));
-        this.landingPage = startWithSlash(runtimeForm.landingPage.orElse(null));
-        this.postLocation = startWithSlash(form.postLocation);
-        this.usernameParameter = runtimeForm.usernameParameter;
-        this.passwordParameter = runtimeForm.passwordParameter;
-        this.locationCookie = runtimeForm.locationCookie;
-        this.cookiePath = runtimeForm.cookiePath.orElse(null);
-        boolean redirectAfterLogin = runtimeForm.redirectAfterLogin;
+        FormAuthConfig form = buildTimeConfig.auth().form();
+        FormAuthRuntimeConfig runtimeForm = httpConfiguration.auth().form();
+        this.loginManager = new PersistentLoginManager(key, runtimeForm.cookieName(), runtimeForm.timeout().toMillis(),
+                runtimeForm.newCookieInterval().toMillis(), runtimeForm.httpOnlyCookie(), runtimeForm.cookieSameSite().name(),
+                runtimeForm.cookiePath().orElse(null), runtimeForm.cookieMaxAge().map(Duration::toSeconds).orElse(-1L));
+        this.loginPage = startWithSlash(runtimeForm.loginPage().orElse(null));
+        this.errorPage = startWithSlash(runtimeForm.errorPage().orElse(null));
+        this.landingPage = startWithSlash(runtimeForm.landingPage().orElse(null));
+        this.postLocation = startWithSlash(form.postLocation());
+        this.usernameParameter = runtimeForm.usernameParameter();
+        this.passwordParameter = runtimeForm.passwordParameter();
+        this.locationCookie = runtimeForm.locationCookie();
+        this.cookiePath = runtimeForm.cookiePath().orElse(null);
+        boolean redirectAfterLogin = runtimeForm.redirectAfterLogin();
         this.redirectToLandingPage = landingPage != null && redirectAfterLogin;
         this.redirectToLoginPage = loginPage != null;
         this.redirectToErrorPage = errorPage != null;
-        this.cookieSameSite = CookieSameSite.valueOf(runtimeForm.cookieSameSite.name());
+        this.cookieSameSite = CookieSameSite.valueOf(runtimeForm.cookieSameSite().name());
         this.isFormAuthEventObserver = SecurityEventHelper.isEventObserved(createLoginEvent(null), beanManager,
                 securityEventsEnabled);
         this.formAuthEvent = this.isFormAuthEventObserver ? formAuthEvent : null;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
@@ -94,7 +94,7 @@ public final class HttpAuthenticator {
         this.securityEventHelper = new SecurityEventHelper<>(authSuccessEvent, authFailureEvent, AUTHENTICATION_SUCCESS,
                 AUTHENTICATION_FAILURE, beanManager, securityEventsEnabled);
         this.identityProviderManager = identityProviderManager;
-        this.inclusiveAuth = httpBuildTimeConfig.auth.inclusive;
+        this.inclusiveAuth = httpBuildTimeConfig.auth().inclusive();
         List<HttpAuthenticationMechanism> mechanisms = new ArrayList<>();
         for (HttpAuthenticationMechanism mechanism : httpAuthenticationMechanism) {
             if (mechanism.getCredentialTypes().isEmpty()) {
@@ -121,7 +121,7 @@ public final class HttpAuthenticator {
             if (found) {
                 mechanisms.add(mechanism);
             } else if (BasicAuthenticationMechanism.class.equals(mechanism.getClass())
-                    && httpBuildTimeConfig.auth.basic.isEmpty()) {
+                    && httpBuildTimeConfig.auth().basic().isEmpty()) {
                 log.debug("""
                         BasicAuthenticationMechanism has been enabled because no other authentication mechanism has been
                         detected, but there is no IdentityProvider based on username and password. Please use
@@ -493,8 +493,8 @@ public final class HttpAuthenticator {
         if (Boolean.getBoolean(BASIC_AUTH_ANNOTATION_DETECTED)) {
             return false;
         }
-        for (var policy : Arc.container().instance(HttpConfiguration.class).get().auth.permissions.values()) {
-            if (BasicAuthentication.AUTH_MECHANISM_SCHEME.equals(policy.authMechanism.orElse(null))) {
+        for (var policy : Arc.container().instance(HttpConfiguration.class).get().auth().permissions().values()) {
+            if (BasicAuthentication.AUTH_MECHANISM_SCHEME.equals(policy.authMechanism().orElse(null))) {
                 return false;
             }
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -66,7 +66,7 @@ public class HttpSecurityRecorder {
     public void initializeHttpAuthenticatorHandler(RuntimeValue<AuthenticationHandler> handlerRuntimeValue,
             HttpConfiguration httpConfig) {
         handlerRuntimeValue.getValue().init(PathMatchingHttpSecurityPolicy.class,
-                RolesMapping.of(httpConfig.auth.rolesMapping));
+                RolesMapping.of(httpConfig.auth().rolesMapping()));
     }
 
     public Handler<RoutingContext> permissionCheckHandler() {
@@ -426,8 +426,8 @@ public class HttpSecurityRecorder {
     public void setMtlsCertificateRoleProperties(HttpConfiguration config) {
         InstanceHandle<MtlsAuthenticationMechanism> mtls = Arc.container().instance(MtlsAuthenticationMechanism.class);
 
-        if (mtls.isAvailable() && config.auth.certificateRoleProperties.isPresent()) {
-            Path rolesPath = config.auth.certificateRoleProperties.get();
+        if (mtls.isAvailable() && config.auth().certificateRoleProperties().isPresent()) {
+            Path rolesPath = config.auth().certificateRoleProperties().get();
             URL rolesResource = null;
             if (Files.exists(rolesPath)) {
                 try {
@@ -456,7 +456,7 @@ public class HttpSecurityRecorder {
                 }
 
                 if (!roles.isEmpty()) {
-                    var certRolesAttribute = new CertificateRoleAttribute(config.auth.certificateRoleAttribute, roles);
+                    var certRolesAttribute = new CertificateRoleAttribute(config.auth().certificateRoleAttribute(), roles);
                     mtls.get().setCertificateToRolesMapper(certRolesAttribute.rolesMapper());
                 }
             } catch (Exception e) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/JaxRsPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/JaxRsPathMatchingHttpSecurityPolicy.java
@@ -36,8 +36,8 @@ public class JaxRsPathMatchingHttpSecurityPolicy {
             Instance<HttpSecurityPolicy> installedPolicies, HttpConfiguration httpConfig,
             HttpBuildTimeConfig buildTimeConfig, BlockingSecurityExecutor blockingSecurityExecutor) {
         this.storage = storage;
-        this.delegate = new AbstractPathMatchingHttpSecurityPolicy(httpConfig.auth.permissions,
-                httpConfig.auth.rolePolicy, buildTimeConfig.rootPath, installedPolicies, JAXRS);
+        this.delegate = new AbstractPathMatchingHttpSecurityPolicy(httpConfig.auth().permissions(),
+                httpConfig.auth().rolePolicy(), buildTimeConfig.rootPath(), installedPolicies, JAXRS);
         this.foundNoAnnotatedMethods = storage.getMethodToPolicyName().isEmpty();
         this.requestContext = new DefaultAuthorizationRequestContext(blockingSecurityExecutor);
         if (storage.getMethodToPolicyName().isEmpty()) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
@@ -20,7 +20,8 @@ public class ManagementPathMatchingHttpSecurityPolicy extends AbstractPathMatchi
 
     ManagementPathMatchingHttpSecurityPolicy(ManagementInterfaceBuildTimeConfig buildTimeConfig,
             ManagementInterfaceConfiguration runTimeConfig, Instance<HttpSecurityPolicy> installedPolicies) {
-        super(runTimeConfig.auth.permissions, runTimeConfig.auth.rolePolicy, buildTimeConfig.rootPath, installedPolicies, ALL);
+        super(runTimeConfig.auth().permissions(), runTimeConfig.auth().rolePolicy(), buildTimeConfig.rootPath(),
+                installedPolicies, ALL);
     }
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -20,7 +20,8 @@ public class PathMatchingHttpSecurityPolicy extends AbstractPathMatchingHttpSecu
 
     PathMatchingHttpSecurityPolicy(HttpConfiguration httpConfig, HttpBuildTimeConfig buildTimeConfig,
             Instance<HttpSecurityPolicy> installedPolicies) {
-        super(httpConfig.auth.permissions, httpConfig.auth.rolePolicy, buildTimeConfig.rootPath, installedPolicies, ALL);
+        super(httpConfig.auth().permissions(), httpConfig.auth().rolePolicy(), buildTimeConfig.rootPath(), installedPolicies,
+                ALL);
     }
 
 }

--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
@@ -263,7 +263,7 @@ public class WebDependencyLocatorProcessor {
 
     private String getRootPath(HttpBuildTimeConfig httpConfig, String path) {
         // The context path + the resources path
-        String rootPath = httpConfig.rootPath;
+        String rootPath = httpConfig.rootPath();
         return (rootPath.endsWith("/")) ? rootPath + path + "/" : rootPath + "/" + path + "/";
     }
 

--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/devui/WebDependencyLocatorDevModeApiProcessor.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/devui/WebDependencyLocatorDevModeApiProcessor.java
@@ -62,7 +62,7 @@ public class WebDependencyLocatorDevModeApiProcessor {
                             () -> new HashMap<>(providers.size())));
             if (!webDependencyKeys.isEmpty()) {
                 // The root path of the application
-                final String rootPath = httpConfig.rootPath;
+                final String rootPath = httpConfig.rootPath();
                 // The root path of the webDependencies
                 final String webDependencyRootPath = (rootPath.endsWith("/")) ? rootPath + path + "/"
                         : rootPath + "/" + path + "/";

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/devui/WebSocketNextJsonRPCService.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/devui/WebSocketNextJsonRPCService.java
@@ -119,8 +119,8 @@ public class WebSocketNextJsonRPCService implements ConnectionListener {
         String connectionKey = UUID.randomUUID().toString();
         Uni<WebSocket> uni = Uni.createFrom().completionStage(() -> client
                 .connect(new WebSocketConnectOptions()
-                        .setPort(httpConfig.port)
-                        .setHost(httpConfig.host)
+                        .setPort(httpConfig.port())
+                        .setHost(httpConfig.host())
                         .setURI(path)
                         .addHeader(DEVUI_SOCKET_KEY_HEADER, connectionKey))
                 .toCompletionStage());

--- a/integration-tests/oidc/src/main/resources/application.properties
+++ b/integration-tests/oidc/src/main/resources/application.properties
@@ -27,7 +27,7 @@ quarkus.oidc.tls.key-store-password=password
 
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.p12
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 
 quarkus.http.auth.basic=true

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
@@ -45,7 +45,7 @@ public class UnknownConfigTest {
     @Test
     void unknown() {
         assertEquals("1234", config.getConfigValue("quarkus.unknown.prop").getValue());
-        assertEquals("/1234", httpBuildTimeConfig.nonApplicationRootPath);
-        assertEquals(4443, httpConfiguration.sslPort);
+        assertEquals("/1234", httpBuildTimeConfig.nonApplicationRootPath());
+        assertEquals(4443, httpConfiguration.sslPort());
     }
 }


### PR DESCRIPTION
This reverts commit 5f90f04945cef466a2230bf0d7208412ab5e54d4 and reapply the `Switch Vert.x HTTP to @ConfigMapping` change.

This was originally written by Roberto, it conflicted all around with all the new changes that got in so it was a lot of fun rebasing :)

@radcortez I don't know if you remember but this change broke quite a lot of extensions out there. I wonder if we should apply the same trick and have the interface with a new name and keep the old config as deprecated with maybe only the ports? I think if we keep the compatibility for the ports, we fix 99% of the breaking change. We might need to add a few more such as `rootPath` but I would rather be conservative and get the feedback from Ecosystem CI first.

Note that I will have a look at the consequences of this change this afternoon so that we hopefully don't have to revert later.

Fixes #44115