### PR TITLE
Make response available on error in rest client

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/pom.xml
+++ b/independent-projects/resteasy-reactive/client/runtime/pom.xml
@@ -64,5 +64,17 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 </project>

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/WebClientApplicationException.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/WebClientApplicationException.java
@@ -20,20 +20,25 @@ import org.jboss.resteasy.reactive.ResteasyReactiveClientProblem;
 import org.jboss.resteasy.reactive.common.jaxrs.StatusTypeImpl;
 
 /**
- * Subclass of {@link WebApplicationException} for use by clients, which forbids setting a response that
- * would be used by the server.
- * FIXME: I'd rather this be disjoint from WebApplicationException, so we could store the response info
- * for client usage. Perhaps we can store it in an alternate field?
+ * Subclass of {@link WebApplicationException} for use by clients.
  */
 @SuppressWarnings("serial")
 public class WebClientApplicationException extends WebApplicationException implements ResteasyReactiveClientProblem {
 
     public WebClientApplicationException(int responseStatus) {
-        this(responseStatus, null);
+        this(responseStatus, (String) null);
     }
 
     public WebClientApplicationException(int responseStatus, String responseReasonPhrase) {
         super("Server response is: " + responseStatus, null, new DummyResponse(responseStatus, responseReasonPhrase));
+    }
+
+    public WebClientApplicationException(int responseStatus, Response response) {
+        super("Server response is: " + responseStatus, response);
+    }
+
+    public WebClientApplicationException(int responseStatus, Throwable cause, Response response) {
+        super("Server response is: " + responseStatus, cause, response);
     }
 
     /**

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientResponseCompleteRestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientResponseCompleteRestHandler.java
@@ -23,6 +23,7 @@ import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
 import org.jboss.resteasy.reactive.client.spi.FieldFiller;
 import org.jboss.resteasy.reactive.client.spi.MultipartResponseData;
 import org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl;
+import org.jboss.resteasy.reactive.common.jaxrs.StatusTypeImpl;
 
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.FileUpload;
@@ -38,10 +39,19 @@ public class ClientResponseCompleteRestHandler implements ClientRestHandler {
     public static ResponseImpl mapToResponse(RestClientRequestContext context,
             boolean parseContent)
             throws IOException {
+        ClientResponseContextImpl responseContext = context.getOrCreateClientResponseContext();
+        Response.StatusType statusType = new StatusTypeImpl(responseContext.getStatus(), responseContext.getReasonPhrase());
+        return mapToResponse(context, statusType, parseContent);
+    }
+
+    public static ResponseImpl mapToResponse(RestClientRequestContext context,
+            Response.StatusType effectiveResponseStatus,
+            boolean parseContent)
+            throws IOException {
         Map<Class<?>, MultipartResponseData> multipartDataMap = context.getMultipartResponsesData();
         ClientResponseContextImpl responseContext = context.getOrCreateClientResponseContext();
         ClientResponseBuilderImpl builder = new ClientResponseBuilderImpl();
-        builder.status(responseContext.getStatus(), responseContext.getReasonPhrase());
+        builder.status(effectiveResponseStatus);
         builder.setAllHeaders(responseContext.getHeaders());
         builder.invocationState(context);
         InputStream entityStream = responseContext.getEntityStream();

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSetResponseEntityRestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSetResponseEntityRestHandler.java
@@ -28,8 +28,8 @@ public class ClientSetResponseEntityRestHandler implements ClientRestHandler {
         if (context.isCheckSuccessfulFamily()) {
             StatusType effectiveResponseStatus = determineEffectiveResponseStatus(context, requestContext);
             if (Response.Status.Family.familyOf(effectiveResponseStatus.getStatusCode()) != Response.Status.Family.SUCCESSFUL) {
-                throw new WebClientApplicationException(effectiveResponseStatus.getStatusCode(),
-                        effectiveResponseStatus.getReasonPhrase());
+                Response response = ClientResponseCompleteRestHandler.mapToResponse(context, effectiveResponseStatus, true);
+                throw new WebClientApplicationException(effectiveResponseStatus.getStatusCode(), response);
             }
         }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSetResponseEntityRestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSetResponseEntityRestHandler.java
@@ -29,7 +29,7 @@ public class ClientSetResponseEntityRestHandler implements ClientRestHandler {
             StatusType effectiveResponseStatus = determineEffectiveResponseStatus(context, requestContext);
             if (Response.Status.Family.familyOf(effectiveResponseStatus.getStatusCode()) != Response.Status.Family.SUCCESSFUL) {
                 Response response = ClientResponseCompleteRestHandler.mapToResponse(context, effectiveResponseStatus, true);
-                throw new WebClientApplicationException(effectiveResponseStatus.getStatusCode(), response);
+                throw new WebClientApplicationException(response);
             }
         }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -31,6 +31,7 @@ import jakarta.ws.rs.ext.WriterInterceptor;
 import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties;
+import org.jboss.resteasy.reactive.client.api.WebClientApplicationException;
 import org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartForm;
 import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
 import org.jboss.resteasy.reactive.client.spi.MultipartResponseData;
@@ -199,10 +200,12 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
                         + invokedMethod.getDeclaringClass().getName() + "#"
                         + invokedMethod.getName() + "'";
             }
+            Response response = webApplicationException instanceof WebClientApplicationException wcae ? wcae.getClientResponse()
+                    : webApplicationException.getResponse();
             return new ClientWebApplicationException(message,
                     webApplicationException instanceof ClientWebApplicationException ? webApplicationException.getCause()
                             : webApplicationException,
-                    webApplicationException.getResponse());
+                    response);
         }
         return res;
     }

--- a/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/handlers/ClientResponseCompleteRestHandlerTest.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/handlers/ClientResponseCompleteRestHandlerTest.java
@@ -1,0 +1,112 @@
+package org.jboss.resteasy.reactive.client.handlers;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Map;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import wiremock.com.fasterxml.jackson.core.JsonProcessingException;
+import wiremock.com.fasterxml.jackson.core.type.TypeReference;
+import wiremock.com.fasterxml.jackson.databind.ObjectMapper;
+
+class ClientResponseCompleteRestHandlerTest {
+
+    private static final int MOCK_SERVER_PORT = 9300;
+    private static final WireMockServer wireMockServer = new WireMockServer(MOCK_SERVER_PORT);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final Client httpClient = ClientBuilder.newBuilder().build();
+
+    @BeforeAll
+    static void start() {
+        wireMockServer.stubFor(get(urlPathEqualTo("/get-400"))
+                .willReturn(aResponse().withStatus(400).withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                        .withBody("{\"error\": true, \"message\": \"Invalid parameter\"}")));
+        wireMockServer.stubFor(get(urlPathEqualTo("/get-500"))
+                .willReturn(aResponse().withStatus(500).withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                        .withBody("{\"error\": true, \"message\": \"Unexpected error.\"}")));
+        wireMockServer.start();
+    }
+
+    @AfterAll
+    static void stop() {
+        wireMockServer.stop();
+    }
+
+    private String generateURL(String path) {
+        return UriBuilder.fromUri("http://localhost:" + MOCK_SERVER_PORT).path(path).build().toString();
+    }
+
+    @Test
+    void testResponseOnClientError() throws Exception {
+        try {
+            httpClient.target(generateURL("/get-400")).request().get(String.class);
+            fail("Should have thrown an exception");
+        } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            checkResponse(response);
+            Map<String, Object> parsedResponseContent = readAndParseResponse(response);
+            assertEquals("Invalid parameter", parsedResponseContent.get("message"));
+        }
+
+        // Test when we manually handle the response.
+        try (Response response = httpClient.target(generateURL("/get-400")).request().get()) {
+            checkResponse(response);
+            Map<String, Object> parsedResponseContent = readAndParseResponse(response);
+            assertEquals("Invalid parameter", parsedResponseContent.get("message"));
+        }
+    }
+
+    @Test
+    void testResponseOnServerError() throws Exception {
+        try {
+            httpClient.target(generateURL("/get-500")).request().get(String.class);
+            fail("Should have thrown an exception");
+        } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            checkResponse(response);
+            Map<String, Object> parsedResponseContent = readAndParseResponse(response);
+            assertEquals("Unexpected error.", parsedResponseContent.get("message"));
+        }
+
+        // Test when we manually handle the response.
+        try (Response response = httpClient.target(generateURL("/get-500")).request().get()) {
+            checkResponse(response);
+            Map<String, Object> parsedResponseContent = readAndParseResponse(response);
+            assertEquals("Unexpected error.", parsedResponseContent.get("message"));
+        }
+    }
+
+    private void checkResponse(Response response) {
+        assertNotNull(response);
+        assertEquals(MediaType.APPLICATION_JSON, response.getHeaderString(HttpHeaders.CONTENT_TYPE));
+        assertTrue(response.hasEntity());
+        response.bufferEntity();
+    }
+
+    private Map<String, Object> readAndParseResponse(Response response) throws JsonProcessingException {
+        String responseContent = response.readEntity(String.class);
+        return objectMapper.readValue(responseContent,
+                new TypeReference<>() {
+                });
+    }
+
+}

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -70,6 +70,7 @@
         <smallrye-mutiny-vertx-core.version>3.18.1</smallrye-mutiny-vertx-core.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <mockito.version>5.16.0</mockito.version>
+        <wiremock.version>3.11.0</wiremock.version>
         <mutiny-zero.version>1.1.1</mutiny-zero.version>
 
         <!-- Forbidden API checks -->
@@ -334,6 +335,13 @@
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock-standalone</artifactId>
+                <version>${wiremock.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
Responses cannot be read if the HTTP status is not in the 2xx range and you request that the response is converted to a specific type, like when calling
```
httpClient.target("https://example.com/endpoint").request(MediaType.APPLICATION_JSON_TYPE).get(MyBean.class);
```
In this case, an exception is thrown, but it contains a DummyResponse instance that doesn't give access to the Response object.
Being able to read the response from the server in case of error is extremely valuable in some cases, as it may contain useful information about the problem. Most REST APIs return this information as a JSON object that can be parsed, and the contents examined to see custom error status codes or passing the error message to the user, for example.

This PR sets the response in the exception object, without creating a new field for it, as implementing `ResteasyReactiveClientProblem` should prevent the server from trying to read the response.