### PR TITLE
Improve error message when no sources with Gradle

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -346,7 +346,9 @@ public abstract class QuarkusDev extends QuarkusTask {
     @TaskAction
     public void startDev() {
         if (!sourcesExist()) {
-            throw new GradleException("The `src/main/java` directory is required, please create it.");
+            throw new GradleException(
+                    "At least one source directory (e.g. src/main/java, src/main/kotlin) should contain sources before starting Quarkus in dev mode when using Gradle. "
+                            + "Please initialize your project a bit further before restarting Quarkus in dev mode.");
         }
 
         if (!classesExist()) {


### PR DESCRIPTION
This is unfortunate but we probably need to spend a lot more time to fully understand all the consequences of lifting this restriction.

Related to #45169