### PR TITLE
OpenTelemetry - Include span name in MDC context

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryMDCTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryMDCTest.java
@@ -117,7 +117,9 @@ public class OpenTelemetryMDCTest {
                 .map(spanData -> new MdcEntry(spanData.getSpanContext().isSampled(),
                         spanData.getParentSpanContext().isValid() ? spanData.getParentSpanId() : "null",
                         spanData.getSpanId(),
-                        spanData.getTraceId()))
+                        spanData.getTraceId(),
+                        // not pretty but the path is normalized so we need to take it into account here
+                        spanData.getName().replace(" /hello", "")))
                 .collect(Collectors.collectingAndThen(Collectors.toList(), l -> {
                     Collections.reverse(l);
                     return l;
@@ -162,7 +164,8 @@ public class OpenTelemetryMDCTest {
                     Boolean.parseBoolean(String.valueOf(MDC.get("sampled"))),
                     String.valueOf(MDC.get("parentId")),
                     String.valueOf(MDC.get("spanId")),
-                    String.valueOf(MDC.get("traceId"))));
+                    String.valueOf(MDC.get("traceId")),
+                    String.valueOf(MDC.get("spanName"))));
         }
 
         public List<MdcEntry> getCapturedMdcEntries() {
@@ -175,12 +178,14 @@ public class OpenTelemetryMDCTest {
         public final String parentId;
         public final String spanId;
         public final String traceId;
+        public final String spanName;
 
-        public MdcEntry(boolean isSampled, String parentId, String spanId, String traceId) {
+        public MdcEntry(boolean isSampled, String parentId, String spanId, String traceId, String spanName) {
             this.isSampled = isSampled;
             this.parentId = parentId;
             this.spanId = spanId;
             this.traceId = traceId;
+            this.spanName = spanName;
         }
 
         @Override
@@ -195,12 +200,19 @@ public class OpenTelemetryMDCTest {
             return isSampled == mdcEntry.isSampled &&
                     Objects.equals(parentId, mdcEntry.parentId) &&
                     Objects.equals(spanId, mdcEntry.spanId) &&
-                    Objects.equals(traceId, mdcEntry.traceId);
+                    Objects.equals(traceId, mdcEntry.traceId) &&
+                    Objects.equals(spanName, mdcEntry.spanName);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(isSampled, parentId, spanId, traceId);
+            return Objects.hash(isSampled, parentId, spanId, traceId, spanName);
+        }
+
+        @Override
+        public String toString() {
+            return "MdcEntry [isSampled=" + isSampled + ", parentId=" + parentId + ", spanId=" + spanId + ", traceId=" + traceId
+                    + ", spanName=" + spanName + "]";
         }
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtil.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtil.java
@@ -19,7 +19,8 @@ public final class OpenTelemetryUtil {
     public static final String SPAN_ID = "spanId";
     public static final String SAMPLED = "sampled";
     public static final String PARENT_ID = "parentId";
-    private static final Set<String> SPAN_DATA_KEYS = Set.of(TRACE_ID, SPAN_ID, SAMPLED, PARENT_ID);
+    public static final String SPAN_NAME = "spanName";
+    private static final Set<String> SPAN_DATA_KEYS = Set.of(TRACE_ID, SPAN_ID, SAMPLED, PARENT_ID, SPAN_NAME);
 
     private OpenTelemetryUtil() {
     }
@@ -89,8 +90,9 @@ public final class OpenTelemetryUtil {
             spanData.put(SPAN_ID, spanContext.getSpanId());
             spanData.put(TRACE_ID, spanContext.getTraceId());
             spanData.put(SAMPLED, Boolean.toString(spanContext.isSampled()));
-            if (span instanceof ReadableSpan) {
-                SpanContext parentSpanContext = ((ReadableSpan) span).getParentSpanContext();
+            if (span instanceof ReadableSpan readableSpan) {
+                spanData.put(SPAN_NAME, readableSpan.getName());
+                SpanContext parentSpanContext = readableSpan.getParentSpanContext();
                 if (parentSpanContext != null && parentSpanContext.isValid()) {
                     spanData.put(PARENT_ID, parentSpanContext.getSpanId());
                 }
@@ -106,9 +108,8 @@ public final class OpenTelemetryUtil {
      */
     public static void clearMDCData(io.vertx.core.Context vertxContext) {
         VertxMDC vertxMDC = VertxMDC.INSTANCE;
-        vertxMDC.remove(TRACE_ID, vertxContext);
-        vertxMDC.remove(SPAN_ID, vertxContext);
-        vertxMDC.remove(PARENT_ID, vertxContext);
-        vertxMDC.remove(SAMPLED, vertxContext);
+        for (String spanDataKey : SPAN_DATA_KEYS) {
+            vertxMDC.remove(spanDataKey, vertxContext);
+        }
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogHandler.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogHandler.java
@@ -26,6 +26,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.Severity;
+import io.quarkus.opentelemetry.runtime.OpenTelemetryUtil;
 
 public class OpenTelemetryLogHandler extends ExtHandler {
 
@@ -69,9 +70,10 @@ public class OpenTelemetryLogHandler extends ExtHandler {
         if (mdcCopy != null) {
             mdcCopy.forEach((k, v) -> {
                 // ignore duplicated span data already in the MDC
-                if (!k.equalsIgnoreCase("spanid") &&
-                        !k.equalsIgnoreCase("traceid") &&
-                        !k.equalsIgnoreCase("sampled")) {
+                if (!k.equalsIgnoreCase(OpenTelemetryUtil.SPAN_ID) &&
+                        !k.equalsIgnoreCase(OpenTelemetryUtil.TRACE_ID) &&
+                        !k.equalsIgnoreCase(OpenTelemetryUtil.SAMPLED) &&
+                        !k.equalsIgnoreCase(OpenTelemetryUtil.SPAN_NAME)) {
                     attributes.put(AttributeKey.stringKey(k), v);
                 }
             });

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtilTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/OpenTelemetryUtilTest.java
@@ -86,11 +86,12 @@ public class OpenTelemetryUtilTest {
         Context contextChild = Context.current().with(child);
 
         Map<String, String> actual = OpenTelemetryUtil.getSpanData(contextChild);
-        assertEquals(4, actual.size());
+        assertEquals(5, actual.size());
         assertEquals(child.getSpanContext().getSpanId(), actual.get("spanId"));
         assertEquals(child.getSpanContext().getTraceId(), actual.get("traceId"));
         assertEquals("true", actual.get("sampled"));
         assertEquals(parent.getSpanContext().getSpanId(), actual.get("parentId"));
+        assertEquals("SpanName", actual.get("spanName"));
     }
 
     @Test
@@ -107,10 +108,11 @@ public class OpenTelemetryUtilTest {
         Context contextChild = Context.current().with(child);
 
         Map<String, String> actual = OpenTelemetryUtil.getSpanData(contextChild);
-        assertEquals(3, actual.size());
+        assertEquals(4, actual.size());
         assertEquals(child.getSpanContext().getSpanId(), actual.get("spanId"));
         assertEquals(child.getSpanContext().getTraceId(), actual.get("traceId"));
         assertEquals("true", actual.get("sampled"));
+        assertEquals("SpanName", actual.get("spanName"));
     }
 
     @Test


### PR DESCRIPTION
This can be very useful in the logs, especially since we push the scheduler jobs' name into the span name.

Fixes #39703