### PR TITLE
Fix a few minor things in TLS CLI

### DIFF
--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCACommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCACommand.java
@@ -68,7 +68,7 @@ public class GenerateCACommand implements Callable<Integer> {
             LOGGER.log(INFO, "✅ Truststore generated successfully.");
         }
 
-        LOGGER.log(INFO, "✅ Quarkus Development CA generated and installed");
+        LOGGER.log(INFO, "✅ Quarkus Dev CA certificate generated and installed");
 
         return 0;
     }

--- a/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/SelfSignedGenerationTest.java
+++ b/extensions/tls-registry/cli/src/test/java/io/quarkus/tls/cli/SelfSignedGenerationTest.java
@@ -2,6 +2,7 @@ package io.quarkus.tls.cli;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.file.Path;
 import java.security.KeyStore;
 
 import org.junit.jupiter.api.AfterAll;
@@ -25,7 +26,7 @@ public class SelfSignedGenerationTest {
         command.name = "test";
         command.renew = true;
         command.selfSigned = true;
-        command.directory = "target";
+        command.directory = Path.of("target");
         command.password = "password";
         command.call();
 


### PR DESCRIPTION
- Avoid storing absolute paths in .env when using relative paths: it makes the project directory not movable at all
- Fix indentation of last log line
- Improve consistency of log message for CA generation

Noticed while working on another issue.