### PR TITLE
Fix how Vert.x routes are identified in metrics and OpenTelemetry

### DIFF
--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -146,6 +146,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-dev-ui-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-testing</artifactId>
             <scope>test</scope>

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriManagementInterfaceTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriManagementInterfaceTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporterProvider;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class OpenTelemetrySuppressNonAppUriManagementInterfaceTest {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloResource.class, TestSpanExporter.class, TestSpanExporterProvider.class)
+                    .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                    .add(new StringAsset(
+                            """
+                                    quarkus.otel.traces.exporter=test-span-exporter
+                                    quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.bsp.export.timeout=1s
+                                    quarkus.otel.bsp.schedule.delay=50
+                                    quarkus.management.enabled=true
+                                    quarkus.management.port=9001
+                                    """),
+                            "application.properties"));
+
+    @Test
+    void test() {
+
+        // Must not be traced
+        RestAssured.given()
+                .get("http://localhost:9001/q/health/")
+                .then()
+                .statusCode(200);
+        RestAssured.given()
+                .get("/q/dev-ui/")
+                .then()
+                .statusCode(200);
+        RestAssured.given()
+                .get("/q/dev-ui/icon/font-awesome.js")
+                .then()
+                .statusCode(200);
+        // Valid trace
+        RestAssured.given()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+        // Get span names
+        List<String> spans = Arrays.asList(
+                RestAssured.given()
+                        .get("/hello/spans")
+                        .then()
+                        .statusCode(200)
+                        .extract().body()
+                        .asString()
+                        .split(";"));
+
+        assertThat(spans).containsExactly("GET /hello");
+    }
+
+    @Path("/hello")
+    public static class HelloResource {
+
+        @Inject
+        TestSpanExporter spanExporter;
+
+        @GET
+        public String greetings() {
+            return "Hello test";
+        }
+
+        /**
+         * Gets a string with the received spans names concatenated by ;
+         *
+         * @return
+         */
+        @GET
+        @Path("/spans")
+        public String greetingsInsertAtLeast() {
+            String spanNames = spanExporter.getFinishedSpanItemsAtLeast(1).stream()
+                    .map(SpanData::getName)
+                    .reduce((s1, s2) -> s1 + ";" + s2).orElse("");
+            System.out.println(spanNames);
+            return spanNames;
+        }
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
@@ -1,0 +1,103 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporterProvider;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class OpenTelemetrySuppressNonAppUriTest {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloResource.class, TestSpanExporter.class, TestSpanExporterProvider.class)
+                    .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                    .add(new StringAsset(
+                            """
+                                    quarkus.otel.traces.exporter=test-span-exporter
+                                    quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.bsp.export.timeout=1s
+                                    quarkus.otel.bsp.schedule.delay=50
+                                    """),
+                            "application.properties"));
+
+    @Test
+    void test() {
+
+        // Must not be traced
+        RestAssured.given()
+                .get("/q/health/")
+                .then()
+                .statusCode(200);
+        RestAssured.given()
+                .get("/q/dev-ui")
+                .then()
+                .statusCode(200);
+        RestAssured.given()
+                .get("/q/dev-ui/icon/font-awesome.js")
+                .then()
+                .statusCode(200);
+        // Valid trace
+        RestAssured.given()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+        // Get span names
+        List<String> spans = Arrays.asList(
+                RestAssured.given()
+                        .get("/hello/spans")
+                        .then()
+                        .statusCode(200)
+                        .extract().body()
+                        .asString()
+                        .split(";"));
+
+        assertThat(spans.size())
+                .withFailMessage("Expected only one span but found: " + spans)
+                .isEqualTo(1);
+
+        assertThat(spans).contains("GET /hello");
+    }
+
+    @Path("/hello")
+    public static class HelloResource {
+
+        @Inject
+        TestSpanExporter spanExporter;
+
+        @GET
+        public String greetings() {
+            return "Hello test";
+        }
+
+        /**
+         * Gets a string with the received spans names concatenated by ;
+         *
+         * @return
+         */
+        @GET
+        @Path("/spans")
+        public String greetingsInsertAtLeast() {
+            String spanNames = spanExporter.getFinishedSpanItemsAtLeast(1).stream()
+                    .map(SpanData::getName)
+                    .reduce((s1, s2) -> s1 + ";" + s2).orElse("");
+            System.out.println(spanNames);
+            return spanNames;
+        }
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriTest.java
@@ -45,7 +45,7 @@ public class OpenTelemetrySuppressNonAppUriTest {
                 .then()
                 .statusCode(200);
         RestAssured.given()
-                .get("/q/dev-ui")
+                .get("/q/dev-ui/")
                 .then()
                 .statusCode(200);
         RestAssured.given()
@@ -67,11 +67,7 @@ public class OpenTelemetrySuppressNonAppUriTest {
                         .asString()
                         .split(";"));
 
-        assertThat(spans.size())
-                .withFailMessage("Expected only one span but found: " + spans)
-                .isEqualTo(1);
-
-        assertThat(spans).contains("GET /hello");
+        assertThat(spans).containsExactly("GET /hello");
     }
 
     @Path("/hello")

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/exporter/TestSpanExporter.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/exporter/TestSpanExporter.java
@@ -69,7 +69,7 @@ public class TestSpanExporter implements SpanExporter {
 
     public void assertSpanAtLeast(int spanCount) {
         await().atMost(5, SECONDS).untilAsserted(
-                () -> assertTrue(spanCount < finishedSpanItems.size(), "Spans: " + finishedSpanItems.toString()));
+                () -> assertTrue(spanCount <= finishedSpanItems.size(), "Spans: " + finishedSpanItems.toString()));
     }
 
     public void reset() {

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/exporter/TestSpanExporter.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/exporter/TestSpanExporter.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.List;
@@ -50,9 +51,25 @@ public class TestSpanExporter implements SpanExporter {
         return finishedSpanItems.stream().collect(toList());
     }
 
+    /**
+     * Careful when retrieving the list of finished spans. There is a chance when the response is already sent to the
+     * client and Vert.x still writing the end of the spans. This means that a response is available to assert from the
+     * test side but not all spans may be available yet. For this reason, this method requires the number of expected
+     * spans.
+     */
+    public List<SpanData> getFinishedSpanItemsAtLeast(int spanCount) {
+        assertSpanAtLeast(spanCount);
+        return finishedSpanItems;
+    }
+
     public void assertSpanCount(int spanCount) {
-        await().atMost(30, SECONDS).untilAsserted(
+        await().atMost(5, SECONDS).untilAsserted(
                 () -> assertEquals(spanCount, finishedSpanItems.size(), "Spans: " + finishedSpanItems.toString()));
+    }
+
+    public void assertSpanAtLeast(int spanCount) {
+        await().atMost(5, SECONDS).untilAsserted(
+                () -> assertTrue(spanCount < finishedSpanItems.size(), "Spans: " + finishedSpanItems.toString()));
     }
 
     public void reset() {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
@@ -5,8 +5,9 @@ import static java.util.Collections.emptyList;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -171,7 +172,7 @@ public interface AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
                                 .orElse(existingSampler);
 
                         //collect default filtering targets (Needed for all samplers)
-                        List<String> dropTargets = new ArrayList<>();
+                        Set<String> dropTargets = new HashSet<>();
                         if (oTelRuntimeConfig.traces().suppressNonApplicationUris()) {//default is true
                             dropTargets.addAll(TracerRecorder.dropNonApplicationUriTargets);
                         }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSampler.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSampler.java
@@ -3,8 +3,10 @@ package io.quarkus.opentelemetry.runtime.tracing;
 import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
 import static io.opentelemetry.semconv.UrlAttributes.URL_QUERY;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
@@ -15,12 +17,18 @@ import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 
 public class DropTargetsSampler implements Sampler {
     private final Sampler sampler;
-    private final Set<String> dropTargets;
+    private final Set<String> dropTargetsExact;
+    private final Set<String> dropTargetsWildcard;
 
     public DropTargetsSampler(final Sampler sampler,
             final Set<String> dropTargets) {
         this.sampler = sampler;
-        this.dropTargets = dropTargets;
+        this.dropTargetsExact = dropTargets.stream().filter(s -> !s.endsWith("*"))
+                .collect(Collectors.toCollection(HashSet::new));
+        this.dropTargetsWildcard = dropTargets.stream()
+                .filter(s -> s.endsWith("*"))
+                .map(s -> s.substring(0, s.length() - 1))
+                .collect(Collectors.toCollection(HashSet::new));
     }
 
     @Override
@@ -49,26 +57,24 @@ public class DropTargetsSampler implements Sampler {
         if ((target == null) || target.isEmpty()) {
             return false;
         }
-        if (safeContains(target)) { // check exact match
+        if (containsExactly(target)) { // check exact match
             return true;
         }
         if (target.charAt(target.length() - 1) == '/') { // check if the path without the ending slash matched
-            if (safeContains(target.substring(0, target.length() - 1))) {
+            if (containsExactly(target.substring(0, target.length() - 1))) {
                 return true;
             }
         }
-        int lastSlashIndex = target.lastIndexOf('/');
-        if (lastSlashIndex != -1) {
-            if (safeContains(target.substring(0, lastSlashIndex) + "*")
-                    || safeContains(target.substring(0, lastSlashIndex) + "/*")) { // check if a wildcard matches
+        for (String dropTargetsWildcard : dropTargetsWildcard) {
+            if (target.startsWith(dropTargetsWildcard)) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean safeContains(String target) {
-        return dropTargets.contains(target);
+    private boolean containsExactly(String target) {
+        return dropTargetsExact.contains(target);
     }
 
     @Override

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSampler.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSampler.java
@@ -4,6 +4,7 @@ import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
 import static io.opentelemetry.semconv.UrlAttributes.URL_QUERY;
 
 import java.util.List;
+import java.util.Set;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
@@ -14,10 +15,10 @@ import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 
 public class DropTargetsSampler implements Sampler {
     private final Sampler sampler;
-    private final List<String> dropTargets;
+    private final Set<String> dropTargets;
 
     public DropTargetsSampler(final Sampler sampler,
-            final List<String> dropTargets) {
+            final Set<String> dropTargets) {
         this.sampler = sampler;
         this.dropTargets = dropTargets;
     }

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSamplerTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSamplerTest.java
@@ -39,6 +39,33 @@ class DropTargetsSamplerTest {
         assertEquals(2, countingSampler.count.get());
     }
 
+    @Test
+    void testDropTargetsWildcards() {
+        CountingSampler countingSampler = new CountingSampler();
+        var sut = new DropTargetsSampler(countingSampler, Set.of("/q/dev-ui", "/q/dev-ui/*"));
+
+        assertEquals(SamplingResult.recordAndSample(), getShouldSample(sut, "/other"));
+        assertEquals(1, countingSampler.count.get());
+
+        assertEquals(SamplingResult.recordAndSample(), getShouldSample(sut, "/q/dev-ui-test"));
+        assertEquals(2, countingSampler.count.get());
+
+        assertEquals(SamplingResult.drop(), getShouldSample(sut, "/q/dev-ui"));
+        assertEquals(2, countingSampler.count.get());
+
+        assertEquals(SamplingResult.drop(), getShouldSample(sut, "/q/dev-ui/"));
+        assertEquals(2, countingSampler.count.get());
+
+        assertEquals(SamplingResult.drop(), getShouldSample(sut, "/q/dev-ui/whatever"));
+        assertEquals(2, countingSampler.count.get());
+
+        assertEquals(SamplingResult.drop(), getShouldSample(sut, "/q/dev-ui/whatever/wherever/whenever"));
+        assertEquals(2, countingSampler.count.get());
+
+        assertEquals(SamplingResult.recordAndSample(), getShouldSample(sut, "/q/test"));
+        assertEquals(3, countingSampler.count.get());
+    }
+
     private static SamplingResult getShouldSample(DropTargetsSampler sut, String target) {
         return sut.shouldSample(null, null, null, SpanKind.SERVER,
                 Attributes.of(URL_PATH, target), null);

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSamplerTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/DropTargetsSamplerTest.java
@@ -1,10 +1,10 @@
 package io.quarkus.opentelemetry.runtime.tracing;
 
 import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
-import static io.quarkus.opentelemetry.runtime.OpenTelemetryUtil.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.Test;
@@ -21,7 +21,7 @@ class DropTargetsSamplerTest {
     @Test
     void testDropTargets() {
         CountingSampler countingSampler = new CountingSampler();
-        var sut = new DropTargetsSampler(countingSampler, List.of("/q/swagger-ui", "/q/swagger-ui*"));
+        var sut = new DropTargetsSampler(countingSampler, Set.of("/q/swagger-ui", "/q/swagger-ui*"));
 
         assertEquals(SamplingResult.recordAndSample(), getShouldSample(sut, "/other"));
         assertEquals(1, countingSampler.count.get());

--- a/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/FrameworkEndpointsBuildItem.java
+++ b/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/FrameworkEndpointsBuildItem.java
@@ -1,17 +1,17 @@
 package io.quarkus.vertx.http.deployment.spi;
 
-import java.util.List;
+import java.util.Set;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class FrameworkEndpointsBuildItem extends SimpleBuildItem {
-    private final List<String> endpoints;
+    private final Set<String> endpoints;
 
-    public FrameworkEndpointsBuildItem(final List<String> endpoints) {
+    public FrameworkEndpointsBuildItem(final Set<String> endpoints) {
         this.endpoints = endpoints;
     }
 
-    public List<String> getEndpoints() {
+    public Set<String> getEndpoints() {
         return endpoints;
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
@@ -270,6 +270,7 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
         private final NonApplicationRootPathBuildItem buildItem;
         private RouteBuildItem.RouteType routeType = RouteBuildItem.RouteType.FRAMEWORK_ROUTE;
         private RouteBuildItem.RouteType routerType = RouteBuildItem.RouteType.FRAMEWORK_ROUTE;
+        private String name;
         private String path;
 
         Builder(NonApplicationRootPathBuildItem buildItem) {
@@ -330,7 +331,13 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
                 this.path = route;
                 this.routerType = RouteBuildItem.RouteType.ABSOLUTE_ROUTE;
             }
-            super.orderedRoute(this.path, order, routeFunction);
+
+            // we normalize the route name to remove trailing *, this is to be consistent with the path
+            // see RouteImpl#setPath()
+            String routeName = route.charAt(route.length() - 1) == '*' ? route.substring(0, route.length() - 1) : route;
+
+            // we pass a route name for proper identification in the metrics
+            super.orderedRoute(routeName, this.path, order, routeFunction);
             return this;
         }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -176,6 +176,20 @@ public final class RouteBuildItem extends MultiBuildItem {
             return this;
         }
 
+        /**
+         * @param name The name of the route. It is used to identify the route in the metrics.
+         * @param route A normalized path used to define a basic route
+         *        (e.g. use HttpRootPathBuildItem to construct/resolve the path value). This path this is also
+         *        used on the "Not Found" page in dev mode.
+         * @param order Priority ordering of the route
+         * @param routeCustomizer Route customizer.
+         */
+        public Builder orderedRoute(String name, String route, Integer order, Consumer<Route> routeCustomizer) {
+            this.routeFunction = new BasicRoute(name, route, order, routeCustomizer);
+            this.notFoundPagePath = this.routePath = route;
+            return this;
+        }
+
         public Builder handler(Handler<RoutingContext> handler) {
             this.handler = handler;
             return this;

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -131,7 +133,7 @@ class VertxHttpProcessor {
     FrameworkEndpointsBuildItem frameworkEndpoints(NonApplicationRootPathBuildItem nonApplicationRootPath,
             ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig, LaunchModeBuildItem launchModeBuildItem,
             List<RouteBuildItem> routes) {
-        List<String> frameworkEndpoints = new ArrayList<>();
+        Set<String> frameworkEndpoints = new HashSet<>();
         for (RouteBuildItem route : routes) {
             if (FRAMEWORK_ROUTE.equals(route.getRouteType())) {
                 if (route.getConfiguredPathInfo() != null) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ConfiguredPathInfo.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ConfiguredPathInfo.java
@@ -33,12 +33,12 @@ public class ConfiguredPathInfo {
 
     public String getEndpointPath(NonApplicationRootPathBuildItem nonAppRoot, ManagementInterfaceBuildTimeConfig mibt,
             LaunchModeBuildItem mode) {
+        if (absolutePath) {
+            return endpointPath;
+        }
         if (management && mibt.enabled) {
             var prefix = NonApplicationRootPathBuildItem.getManagementUrlPrefix(mode);
             return prefix + endpointPath;
-        }
-        if (absolutePath) {
-            return endpointPath;
         } else {
             return TemplateHtmlBuilder.adjustRoot(nonAppRoot.getNormalizedHttpRootPath(), endpointPath);
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BasicRoute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BasicRoute.java
@@ -8,6 +8,8 @@ import io.vertx.ext.web.Router;
 
 public class BasicRoute implements Function<Router, Route> {
 
+    private String name;
+
     private String path;
 
     private Integer order;
@@ -15,21 +17,43 @@ public class BasicRoute implements Function<Router, Route> {
     private Consumer<Route> customizer;
 
     public BasicRoute(String path) {
-        this(path, null);
+        this(null, path);
     }
 
     public BasicRoute(String path, Integer order) {
+        this(null, path, order);
+    }
+
+    public BasicRoute(String path, Integer order, Consumer<Route> customizer) {
+        this(null, path, order, customizer);
+    }
+
+    public BasicRoute(String name, String path) {
+        this(name, path, null);
+    }
+
+    public BasicRoute(String name, String path, Integer order) {
+        this.name = name;
         this.path = path;
         this.order = order;
     }
 
-    public BasicRoute(String path, Integer order, Consumer<Route> customizer) {
+    public BasicRoute(String name, String path, Integer order, Consumer<Route> customizer) {
+        this.name = name;
         this.path = path;
         this.order = order;
         this.customizer = customizer;
     }
 
     public BasicRoute() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getPath() {
@@ -60,6 +84,9 @@ public class BasicRoute implements Function<Router, Route> {
     @Override
     public Route apply(Router router) {
         Route route = router.route(path);
+        if (name != null) {
+            route.setName(name);
+        }
         if (order != null) {
             route.order(order);
         }


### PR DESCRIPTION
Management URLs were prefixed twice when absolute: http://localhost:9000http://localhost:9000/q/health

Which was defeating the logic removing the host when collecting suppressed URIs.

Fixes #36510