### PR TITLE
Prevent Oracle from committing uncommitted transactions on connection close

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -294,6 +294,18 @@ AgroalDataSource defaultDataSource;
 In the above example, the type is `AgroalDataSource`, a `javax.sql.DataSource` subtype.
 Because of this, you can also use `javax.sql.DataSource` as the injected type.
 
+===== Oracle considerations
+
+As documented in https://github.com/quarkusio/quarkus/issues/36265[issue #36265],
+Oracle has a very weird behavior of committing the uncommitted transactions on connection closing.
+
+Which means that when stopping Quarkus for instance, in progress transactions might be committed even if incomplete.
+
+Given that is not the expected behavior and that it could lead to data loss, we added an interceptor that rolls back any unfinished transactions at connection close.
+
+If this behavior introduced in 3.18 causes issues for your specific workload, you can disable it by setting the `-Dquarkus-oracle-no-automatic-rollback-on-connection-close` system property to `true`.
+Please take the time to report your use case in our https://github.com/quarkusio/quarkus/issues[issue tracker] so that we can adjust this behavior if needed.
+
 [[reactive-datasource]]
 ==== Reactive datasource
 

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -301,7 +301,8 @@ Oracle has a very weird behavior of committing the uncommitted transactions on c
 
 Which means that when stopping Quarkus for instance, in progress transactions might be committed even if incomplete.
 
-Given that is not the expected behavior and that it could lead to data loss, we added an interceptor that rolls back any unfinished transactions at connection close.
+Given that is not the expected behavior and that it could lead to data loss, we added an interceptor that rolls back any unfinished transactions at connection close,
+provided you are not using XA (in which case the transaction manager handles things for you).
 
 If this behavior introduced in 3.18 causes issues for your specific workload, you can disable it by setting the `-Dquarkus-oracle-no-automatic-rollback-on-connection-close` system property to `true`.
 Please take the time to report your use case in our https://github.com/quarkusio/quarkus/issues[issue tracker] so that we can adjust this behavior if needed.

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleProcessor.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleProcessor.java
@@ -16,6 +16,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.jdbc.oracle.runtime.OracleAgroalConnectionConfigurer;
 import io.quarkus.jdbc.oracle.runtime.OracleServiceBindingConverter;
+import io.quarkus.jdbc.oracle.runtime.RollbackOnConnectionClosePoolInterceptor;
 
 /**
  * N.B. this processor is relatively simple as we rely on the /META-INF/native-image/
@@ -49,6 +50,12 @@ public class OracleProcessor {
                     .setDefaultScope(BuiltinScope.APPLICATION.getName())
                     .setUnremovable()
                     .build());
+
+            additionalBeans
+                    .produce(new AdditionalBeanBuildItem.Builder().addBeanClass(RollbackOnConnectionClosePoolInterceptor.class)
+                            .setDefaultScope(BuiltinScope.APPLICATION.getName())
+                            .setUnremovable()
+                            .build());
         }
     }
 

--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/RollbackOnConnectionClosePoolInterceptor.java
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/RollbackOnConnectionClosePoolInterceptor.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import org.jboss.logging.Logger;
 
 import io.agroal.api.AgroalPoolInterceptor;
+import io.agroal.pool.wrapper.ConnectionWrapper;
 import oracle.jdbc.OracleConnection;
 
 /**
@@ -36,6 +37,13 @@ public class RollbackOnConnectionClosePoolInterceptor implements AgroalPoolInter
     public void onConnectionDestroy(Connection connection) {
         if (noAutomaticRollback) {
             return;
+        }
+
+        // do not rollback XA connections, they are handled by the transaction manager
+        if (connection instanceof ConnectionWrapper connectionWrapper) {
+            if (connectionWrapper.getHandler().getXaResource() != null) {
+                return;
+            }
         }
 
         try {

--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/RollbackOnConnectionClosePoolInterceptor.java
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/RollbackOnConnectionClosePoolInterceptor.java
@@ -1,0 +1,53 @@
+package io.quarkus.jdbc.oracle.runtime;
+
+import java.sql.Connection;
+
+import org.jboss.logging.Logger;
+
+import io.agroal.api.AgroalPoolInterceptor;
+import oracle.jdbc.OracleConnection;
+
+/**
+ * Oracle has the weird behavior that it performs an implicit commit on normal connection closure (even with auto-commit
+ * disabled),
+ * which happens on application shutdown. To prevent whatever intermittent state we have during shutdown from being committed,
+ * we add an explicit rollback to each connection closure. If the connection has already received a COMMIT, the rollback will
+ * not work, which is fine.
+ * <p>
+ * The code unwraps the {@link Connection} so that we perform the rollback directly on the underlying database connection,
+ * and not on e.g. Agroal's {@link ConnectionWrapper} which can prevent the rollback from actually being executed due to some
+ * safeguards.
+ *
+ * @see https://github.com/quarkusio/quarkus/issues/36265
+ */
+public class RollbackOnConnectionClosePoolInterceptor implements AgroalPoolInterceptor {
+
+    private static final Logger LOG = Logger.getLogger(RollbackOnConnectionClosePoolInterceptor.class);
+
+    private final boolean noAutomaticRollback;
+
+    public RollbackOnConnectionClosePoolInterceptor() {
+        // if you have to use this system property, make sure you open an issue in the Quarkus tracker to explain
+        // why as we might need to adjust things
+        noAutomaticRollback = Boolean.getBoolean("quarkus-oracle-no-automatic-rollback-on-connection-close");
+    }
+
+    @Override
+    public void onConnectionDestroy(Connection connection) {
+        if (noAutomaticRollback) {
+            return;
+        }
+
+        try {
+            if (connection.unwrap(Connection.class) instanceof OracleConnection oracleConnection) {
+                if (connection.isClosed() || connection.getAutoCommit()) {
+                    return;
+                }
+
+                oracleConnection.rollback();
+            }
+        } catch (Exception e) {
+            LOG.trace("Ignoring exception during rollback on connection close", e);
+        }
+    }
+}


### PR DESCRIPTION
When a connection is closed, Oracle will commit the unfinished business, which is a very surprising behavior in most cases and could lead to data loss.

I added a -Dquarkus-oracle-no-automatic-rollback-on-connection-close to disable this behavior if absolutely needed.

If we have feedback that this is not something we should do always, we can add a proper configuration property (with a default value to determine).

Fixes #36265

Wouldn't have been possible without the nice work of @segersb and @Felk.