### PR TITLE
Save access token expires_in in the session cookie

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthorizationCodeTokens.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AuthorizationCodeTokens.java
@@ -91,7 +91,6 @@ public class AuthorizationCodeTokens {
     /**
      * Set the access token expires_in value in seconds.
      * It is relative to the time the access token is issued at.
-     * This property is only checked when an authorization code flow grant completes and does not have to be persisted..
      *
      * @param accessTokenExpiresIn access token expires_in value in seconds.
      */


### PR DESCRIPTION
This PR follows #45302 and is a 2nd preparation PR to address #32109.

In #45302 I've only restructured OIDC `DefaultTokenStateManager` to make it easier to understand how ID, access, and refresh tokens are concatenated before being encryped as a single session cookie or as individual cookies.

The plan was, to follow #45302 with the introduction of JSON into `DefaultTokenStateManager`, to make it easier to manage more token properties. I've created a branch, see [this commit](https://github.com/sberyozkin/quarkus/commit/ca729ea5e8550f025ee906abbc10f3a6a8e3e0b8). But after thinking about it, I decided to postpone it because:
* For 3 tokens, and an extra property, and with the encryption, the session cookie gets about 40 extra characters
* And if the encryption is disabled for some internal networks, the size would increase by about 30% because JSON has to be base64url-encoded, and with tokens being quite large, it can easily go over 4K in size

I then looked again at the code, and really, after #45302, it looked much easier to me just to add one more property, access token expires_in to the String. In fact, it is likely to be the last property we will add to the session cookie content.

So this PR only adds an access token expires_in property to the session cookie String payload, if it is available, or an empty string if not, and updates tests to confirm the access token expires_in property is available in the session cookie. 

Next PR will have #32109 resolved.

@michalvavrik, @pedroigor FYI 