### PR TITLE
Disable MongoDB Dev Services when the hosts property is provided

### DIFF
--- a/docs/src/main/asciidoc/mongodb-dev-services.adoc
+++ b/docs/src/main/asciidoc/mongodb-dev-services.adoc
@@ -6,8 +6,8 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Dev Services for MongoDB
 
 Quarkus supports a feature called Dev Services that allows you to create various datasources without any config. In the case of MongoDB this support extends to the default MongoDB connection.
-What that means practically, is that if you have not configured `quarkus.mongodb.connection-string`, Quarkus will automatically start a MongoDB container when running tests or in dev mode,
-and automatically configure the connection.
+What that means practically, is that if you have not configured `quarkus.mongodb.connection-string` nor `quarkus.mongodb.hosts`, Quarkus will automatically start a MongoDB container when
+running tests or in dev mode, and automatically configure the connection.
 
 MongoDB Dev Services is based on link:https://www.testcontainers.org/modules/databases/mongodb/[Testcontainers MongoDB module] that will start a single node replicaset.
 

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -161,12 +161,12 @@ public class DevServicesMongoProcessor {
 
         String configPrefix = getConfigPrefix(connectionName);
 
-        // TODO: do we need to check the hosts as well?
-        boolean needToStart = !ConfigUtils.isPropertyNonEmpty(configPrefix + "connection-string");
+        boolean needToStart = !ConfigUtils.isPropertyNonEmpty(configPrefix + "connection-string")
+                && !ConfigUtils.isPropertyNonEmpty(configPrefix + "hosts");
         if (!needToStart) {
             // a connection string has been provided
             log.debug("Not starting devservices for " + (isDefault(connectionName) ? "default datasource" : connectionName)
-                    + " as a connection string has been provided");
+                    + " as a connection string and/or server addresses have been provided");
             return null;
         }
 

--- a/integration-tests/mongodb-devservices/src/main/resources/application.properties
+++ b/integration-tests/mongodb-devservices/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 quarkus.mongodb.parameter-injection.write-concern.journal=true
+
+quarkus.mongodb.with-connection-string.connection-string=mongodb://localhost:27017
+
+quarkus.mongodb.with-hosts.hosts=localhost:27017

--- a/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/DevServicesStartTest.java
+++ b/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/DevServicesStartTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.it.mongodb;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.mongodb.client.MongoClient;
+
+import io.quarkus.mongodb.MongoClientName;
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.mongodb.MongoTestResource;
+
+@QuarkusTest
+@QuarkusTestResource(value = MongoTestResource.class)
+public class DevServicesStartTest {
+
+    DevServicesContext context;
+
+    @Inject
+    @MongoClientName("with-connection-string")
+    MongoClient clientWithConnectionString;
+
+    @Inject
+    @MongoClientName("with-hosts")
+    MongoClient clientWithHosts;
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "quarkus.mongodb.with-connection-string.connection-string",
+            "quarkus.mongodb.with-hosts.connection-string"
+    })
+    public void testDevServicesNotStarted(String property) {
+        assertThat(context.devServicesProperties(), not(hasKey(property)));
+    }
+
+    @Test
+    public void testDevServicesStarted() {
+        assertThat(context.devServicesProperties(), hasKey("quarkus.mongodb.connection-string"));
+    }
+}


### PR DESCRIPTION
Do not automatically start MongoDB Dev Services when `quarkus.mongodb.hosts` is present.

This should close #40414.

Even if [they were not required](https://github.com/quarkusio/quarkus/issues/40414#issuecomment-2108021441), I added some integration tests to check for the desired behavior. However, they are in a separate commit, to allow an easy edit to remove them.

The integration tests access [DevServicesContext.devServicesProperties](https://quarkus.io/guides/getting-started-testing#testing-dev-services) to indirectly check whether MongoDB Dev Services have been started. I tried to use an invalid connection string, but that caused random failures in [BookResourceTest.health](https://github.com/quarkusio/quarkus/blob/main/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java).