### PR TITLE
Use access token expires_in to refresh code flow tokens

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -819,9 +819,10 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
 
         /**
          * Internal ID token lifespan.
-         * This property is only checked when an internal IdToken is generated when Oauth2 providers do not return IdToken.
+         * This property is only checked when an internal IdToken is generated when OAuth2 providers do not return IdToken.
+         * If this property is not configured then an access token `expires_in` property
+         * in the OAuth2 authorization code flow response is used to set an internal IdToken lifespan.
          */
-        @ConfigDocDefault("5M")
         Optional<Duration> internalIdTokenLifespan();
 
         /**

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionExpiresInResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionExpiresInResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.oidc.TokenIntrospection;
+import io.quarkus.security.Authenticated;
+
+@Path("/code-flow-token-introspection-expires-in")
+@Authenticated
+public class CodeFlowTokenIntrospectionExpiresInResource {
+
+    @Inject
+    TokenIntrospection tokenIntrospection;
+
+    @GET
+    public String access() {
+        return tokenIntrospection.getUsername();
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -159,6 +159,17 @@ quarkus.oidc.code-flow-token-introspection.client-id=quarkus-web-app
 quarkus.oidc.code-flow-token-introspection.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.code-flow-token-introspection.code-grant.headers.X-Custom=XTokenIntrospection
 
+quarkus.oidc.code-flow-token-introspection-expires-in.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.code-flow-token-introspection-expires-in.application-type=web-app
+quarkus.oidc.code-flow-token-introspection-expires-in.authentication.user-info-required=false
+quarkus.oidc.code-flow-token-introspection-expires-in.authorization-path=/
+quarkus.oidc.code-flow-token-introspection-expires-in.token-path=/access_token_expires_in
+quarkus.oidc.code-flow-token-introspection-expires-in.introspection-path=/introspect_expires_in
+quarkus.oidc.code-flow-token-introspection-expires-in.token.refresh-expired=true
+quarkus.oidc.code-flow-token-introspection-expires-in.authentication.verify-access-token=true
+quarkus.oidc.code-flow-token-introspection-expires-in.client-id=quarkus-web-app
+quarkus.oidc.code-flow-token-introspection-expires-in.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+
 quarkus.oidc.token-cache.max-size=1
 
 quarkus.oidc.bearer.auth-server-url=${keycloak.url}/realms/quarkus/

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.PrivateKey;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -349,7 +350,7 @@ public class CodeFlowAuthorizationTest {
 
             Cookie stateCookie = getStateCookie(webClient, "code-flow-user-info-github-cached-in-idtoken");
             Date stateCookieDate = stateCookie.getExpires();
-            final long nowInSecs = System.currentTimeMillis() / 1000;
+            final long nowInSecs = nowInSecs();
             final long sessionCookieLifespan = stateCookieDate.toInstant().getEpochSecond() - nowInSecs;
             // 5 mins is default
             assertTrue(sessionCookieLifespan >= 299 && sessionCookieLifespan <= 304);
@@ -489,7 +490,8 @@ public class CodeFlowAuthorizationTest {
     }
 
     @Test
-    public void testCodeFlowTokenIntrospection() throws Exception {
+    public void testCodeFlowTokenIntrospectionActiveRefresh() throws Exception {
+        // This stub does not return an access token expires_in property
         defineCodeFlowTokenIntrospectionStub();
         try (final WebClient webClient = createWebClient()) {
             webClient.getOptions().setRedirectEnabled(true);
@@ -503,10 +505,43 @@ public class CodeFlowAuthorizationTest {
 
             assertEquals("alice:alice", textPage.getContent());
 
-            // refresh
+            // Refresh
+            // The internal ID token lifespan is 5 mins
+            // Configured refresh token skew is 298 secs = 5 mins - 2 secs
+            // Therefore, after waiting for 3 secs, an active refresh is happening
             Thread.sleep(3000);
             textPage = webClient.getPage("http://localhost:8081/code-flow-token-introspection");
             assertEquals("admin:admin", textPage.getContent());
+
+            webClient.getCookieManager().clearCookies();
+        }
+
+        clearCache();
+    }
+
+    @Test
+    public void testCodeFlowTokenIntrospectionExpiresInRefresh() throws Exception {
+        // This stub does return an access token expires_in property
+        defineCodeFlowTokenIntrospectionExpiresInStub();
+        try (final WebClient webClient = createWebClient()) {
+            webClient.getOptions().setRedirectEnabled(true);
+            HtmlPage page = webClient.getPage("http://localhost:8081/code-flow-token-introspection-expires-in");
+
+            HtmlForm form = page.getFormByName("form");
+            form.getInputByName("username").type("alice");
+            form.getInputByName("password").type("alice");
+
+            TextPage textPage = form.getInputByValue("login").click();
+
+            assertEquals("alice", textPage.getContent());
+
+            // Refresh the expired token
+            // The internal ID token lifespan is 5 mins, refresh token skew is not configured,
+            // code flow access token expires in 3 seconds from now. Therefore, after waiting for 5 secs
+            // the refresh is triggered because it is allowed in the config and token expires_in property is returned.
+            Thread.sleep(5000);
+            textPage = webClient.getPage("http://localhost:8081/code-flow-token-introspection-expires-in");
+            assertEquals("bob", textPage.getContent());
 
             webClient.getCookieManager().clearCookies();
         }
@@ -738,6 +773,61 @@ public class CodeFlowAuthorizationTest {
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +
                                         "  \"access_token\": \"admin\""
+                                        + "}")));
+    }
+
+    private static long nowInSecs() {
+        return Instant.now().getEpochSecond();
+    }
+
+    private void defineCodeFlowTokenIntrospectionExpiresInStub() {
+        wireMockServer
+                .stubFor(WireMock.post("/auth/realms/quarkus/access_token_expires_in")
+                        .withRequestBody(containing("authorization_code"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "  \"id_token\": \"" +
+                                        OidcWiremockTestResource.generateJwtToken("alice", Set.of(), "sub", "ID",
+                                                Set.of("quarkus-web-app"))
+                                        + "\","
+                                        + "  \"access_token\": \"alice\","
+                                        + "  \"expires_in\":" + 3 + ","
+                                        + "  \"refresh_token\": \"refresh_expires_in\""
+                                        + "}")));
+
+        wireMockServer
+                .stubFor(WireMock.post("/auth/realms/quarkus/introspect_expires_in")
+                        .withRequestBody(containing("token=alice"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n"
+                                        + "  \"username\": \"alice\","
+                                        + "  \"exp\":" + (nowInSecs() + 3) + ","
+                                        + "  \"active\": true"
+                                        + "}")));
+
+        wireMockServer
+                .stubFor(WireMock.post("/auth/realms/quarkus/introspect_expires_in")
+                        .withRequestBody(containing("token=bob"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n"
+                                        + "  \"username\": \"bob\","
+                                        + "  \"active\": true"
+                                        + "}")));
+
+        wireMockServer
+                .stubFor(WireMock.post("/auth/realms/quarkus/access_token_expires_in")
+                        .withRequestBody(containing("refresh_token=refresh_expires_in"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "  \"access_token\": \"bob\","
+                                        + "  \"id_token\": \"" +
+                                        OidcWiremockTestResource.generateJwtToken("bob", Set.of(), "sub", "ID",
+                                                Set.of("quarkus-web-app"))
+                                        + "\""
                                         + "}")));
     }
 


### PR DESCRIPTION
Fixes #32109.

This PR follows #45327 and #45302. Those 2 PRs were only about cleaning up the default OIDC token state manager code and keeping the `expires_in` property in the session cookie.

This PR does a few updates to make sure that when the authorization code flow token is introspected remotely and the token status is inactive, the token expiry stored in the session is also checked to initiate a token refresh if possible, thus improving the user experience (see the #45093 discussion).

The code changes have been easy, I simply made available the `expires_in` property stored in the session to the token introspection code, this property is relative to the current time as opposed to the JWT or introspection `exp` claim, which is the only thing I had to be aware of. 

The design issue was that if the introspection should even go ahead for opaque tokens if we know the `expires_in` time, but for now I've decided not to change anything in this regard, since, when the introspection is enabled, there may be expectations that the introspection requests are made. It can be optimized later if proves necessary.

It took me many hours though to get the test passing, to emulate the case that when the one code flow access token has expired, the introspection response with inactive token status will trigger a token refresh request if the stored `expires_in` property proves the token has actually expired. 

I just got it passing and was about to open this PR for review, but then I remembered the OIDC DB and Redis token state managers which are shipped with Quarkus also have to be updated, so I'll do it later.