### PR TITLE
security-openid-connect-multitenancy.adoc - use loginForm.getButtonByName("login") after bump to Keycloak 26

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -501,7 +501,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertTrue(page.asText().contains("tenant"));
         }
@@ -519,7 +519,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            page = loginForm.getInputByName("login").click();
+            page = loginForm.getButtonByName("login").click();
 
             assertTrue(page.asText().contains("alice@tenant-a.org"));
         }


### PR DESCRIPTION
Use `loginForm.getButtonByName("login")` after bump to Keycloak 26

Related to https://github.com/quarkusio/quarkus/pull/44449 changes