### PR TITLE
Ensure there are no jdbc spans if otel sdk is disabled

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalRecorder.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalRecorder.java
@@ -55,13 +55,15 @@ public class AgroalRecorder {
 
     public Function<SyntheticCreationalContext<AgroalDataSource>, AgroalDataSource> agroalDataSourceSupplier(
             String dataSourceName,
-            @SuppressWarnings("unused") DataSourcesRuntimeConfig dataSourcesRuntimeConfig) {
+            @SuppressWarnings("unused") DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
+            Optional<RuntimeValue<Boolean>> otelEnabled) {
         return new Function<>() {
             @SuppressWarnings("deprecation")
             @Override
             public AgroalDataSource apply(SyntheticCreationalContext<AgroalDataSource> context) {
                 DataSources dataSources = context.getInjectedReference(DataSources.class);
-                return dataSources.createDataSource(dataSourceName);
+                return dataSources.createDataSource(dataSourceName,
+                        otelEnabled.isPresent() ? otelEnabled.get().getValue() : false);
             }
         };
     }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -138,7 +138,7 @@ public class DataSources {
     }
 
     @SuppressWarnings("resource")
-    public AgroalDataSource createDataSource(String dataSourceName) {
+    public AgroalDataSource createDataSource(String dataSourceName, boolean otelEnabled) {
         if (!agroalDataSourceSupport.entries.containsKey(dataSourceName)) {
             throw new IllegalArgumentException("No datasource named '" + dataSourceName + "' exists");
         }
@@ -221,7 +221,9 @@ public class DataSources {
             dataSource.setPoolInterceptors(interceptorList);
         }
 
-        if (dataSourceJdbcBuildTimeConfig.telemetry() && dataSourceJdbcRuntimeConfig.telemetry().orElse(true)) {
+        if (dataSourceJdbcBuildTimeConfig.telemetry() &&
+                dataSourceJdbcRuntimeConfig.telemetry().orElse(true) &&
+                otelEnabled) {
             // activate OpenTelemetry JDBC instrumentation by wrapping AgroalDatasource
             // use an optional CDI bean as we can't reference optional OpenTelemetry classes here
             dataSource = agroalOpenTelemetryWrapper.get().apply(dataSource);

--- a/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/OpenTelemetryInitBuildItem.java
+++ b/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/OpenTelemetryInitBuildItem.java
@@ -1,9 +1,0 @@
-package io.quarkus.agroal.spi;
-
-import io.quarkus.builder.item.EmptyBuildItem;
-
-/**
- * Marker build item that indicates that the OpenTelemetry extension has been initialized.
- */
-public final class OpenTelemetryInitBuildItem extends EmptyBuildItem {
-}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/OpenTelemetrySdkBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/OpenTelemetrySdkBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.arc.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+
+public final class OpenTelemetrySdkBuildItem extends SimpleBuildItem {
+
+    private final RuntimeValue<Boolean> runtimeEnabled;
+
+    public OpenTelemetrySdkBuildItem(RuntimeValue<Boolean> sdkEnabled) {
+        this.runtimeEnabled = sdkEnabled;
+    }
+
+    /**
+     * True if the OpenTelemetry SDK is enabled at build and runtime.
+     */
+    public RuntimeValue<Boolean> isRuntimeEnabled() {
+        return runtimeEnabled;
+    }
+
+    public static Optional<RuntimeValue<Boolean>> isOtelSdkEnabled(Optional<OpenTelemetrySdkBuildItem> buildItem) {
+        // optional is empty if the extension is disabled at build time
+        return buildItem.isPresent() ? Optional.of(buildItem.get().isRuntimeEnabled()) : Optional.empty();
+    }
+}

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/logging/LogHandlerProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/logging/LogHandlerProcessor.java
@@ -8,8 +8,8 @@ import org.jboss.jandex.DotName;
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
-import io.quarkus.agroal.spi.OpenTelemetryInitBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.OpenTelemetrySdkBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -45,7 +45,7 @@ class LogHandlerProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    @Consume(OpenTelemetryInitBuildItem.class)
+    @Consume(OpenTelemetrySdkBuildItem.class)
     LogHandlerBuildItem build(OpenTelemetryLogRecorder recorder,
             OTelRuntimeConfig config,
             BeanContainerBuildItem beanContainerBuildItem) {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
@@ -19,6 +19,7 @@ import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.annotations.RuntimeInit;
 import io.quarkus.runtime.annotations.StaticInit;
@@ -36,6 +37,11 @@ public class OpenTelemetryRecorder {
     public void resetGlobalOpenTelemetryForDevMode() {
         GlobalOpenTelemetry.resetForTest();
         GlobalEventLoggerProvider.resetForTest();
+    }
+
+    @RuntimeInit
+    public RuntimeValue<Boolean> isOtelSdkEnabled(OTelRuntimeConfig oTelRuntimeConfig) {
+        return new RuntimeValue<>(!oTelRuntimeConfig.sdkDisabled());
     }
 
     @RuntimeInit

--- a/integration-tests/opentelemetry-jdbc-instrumentation/pom.xml
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/pom.xml
@@ -56,6 +56,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
@@ -205,6 +209,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-db2-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/main/java/io/quarkus/it/opentelemetry/PingPongResource.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/main/java/io/quarkus/it/opentelemetry/PingPongResource.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.it.opentelemetry.model.Hit;
 import io.quarkus.it.opentelemetry.model.db2.Db2Hit;
+import io.quarkus.it.opentelemetry.model.h2.H2Hit;
 import io.quarkus.it.opentelemetry.model.mariadb.MariaDbHit;
 import io.quarkus.it.opentelemetry.model.oracle.OracleHit;
 import io.quarkus.it.opentelemetry.model.pg.PgHit;
@@ -39,6 +40,9 @@ public class PingPongResource {
             case "db2":
                 persist(Db2Hit::new, id);
                 return Db2Hit.findById(id);
+            case "h2":
+                persist(H2Hit::new, id);
+                return H2Hit.findById(id);
             default:
                 throw new IllegalArgumentException();
         }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/main/java/io/quarkus/it/opentelemetry/model/h2/H2Hit.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/main/java/io/quarkus/it/opentelemetry/model/h2/H2Hit.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.opentelemetry.model.h2;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.it.opentelemetry.model.Hit;
+
+@Entity
+public class H2Hit extends PanacheEntityBase implements Hit {
+
+    @Id
+    public Long id;
+
+    public String message;
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
@@ -41,6 +41,14 @@ quarkus.datasource.db2.db-kind=db2
 quarkus.datasource.db2.jdbc.max-size=1
 quarkus.datasource.db2.jdbc.telemetry=true
 
+# H2 data source
+quarkus.hibernate-orm.h2.datasource=h2
+quarkus.hibernate-orm.h2.packages=${model-base-dir}h2
+quarkus.hibernate-orm.h2.database.generation=none
+quarkus.datasource.h2.db-kind=h2
+quarkus.datasource.h2.jdbc.max-size=1
+quarkus.datasource.h2.jdbc.telemetry=true
+
 # speed up build
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2LifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2LifecycleManager.java
@@ -31,6 +31,7 @@ public class Db2LifecycleManager implements QuarkusTestResourceLifecycleManager 
         properties.put("quarkus.hibernate-orm.oracle.active", "false");
         properties.put("quarkus.hibernate-orm.postgresql.active", "false");
         properties.put("quarkus.hibernate-orm.mariadb.active", "false");
+        properties.put("quarkus.hibernate-orm.h2.active", "false");
 
         return properties;
     }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/H2DatabaseTestResource.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/H2DatabaseTestResource.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.opentelemetry;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.h2.tools.Server;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class H2DatabaseTestResource implements QuarkusTestResourceLifecycleManager {
+
+    public static final String QUARKUS_OTEL_SDK_DISABLED = "quarkus.otel.sdk.disabled";
+    private Server tcpServer;
+    private Map<String, String> initProperties;
+
+    @Override
+    public void init(Map<String, String> initArgs) {
+        initProperties = initArgs;
+    }
+
+    @Override
+    public Map<String, String> start() {
+
+        try {
+            tcpServer = Server.createTcpServer("-ifNotExists");
+            tcpServer.start();
+            System.out.println("[INFO] H2 database started in TCP server mode; server status: " + tcpServer.getStatus());
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        Map<String, String> properties = new HashMap<>(initProperties);
+        properties.put("quarkus.datasource.h2.jdbc.url", "jdbc:h2:tcp://localhost/mem:test");
+        properties.put("quarkus.hibernate-orm.h2.database.generation", "drop-and-create");
+        properties.put("quarkus.hibernate-orm.postgresql.active", "false");
+        properties.put("quarkus.hibernate-orm.oracle.active", "false");
+        properties.put("quarkus.hibernate-orm.mariadb.active", "false");
+        properties.put("quarkus.hibernate-orm.db2.active", "false");
+
+        return properties;
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (tcpServer != null) {
+            tcpServer.stop();
+            System.out.println("[INFO] H2 database was shut down; server status: " + tcpServer.getStatus());
+            tcpServer = null;
+        }
+    }
+}

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/H2OpenTelemetryOffJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/H2OpenTelemetryOffJdbcInstrumentationTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.opentelemetry;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = true, initArgs = {
+        @ResourceArg(name = H2DatabaseTestResource.QUARKUS_OTEL_SDK_DISABLED, value = "true")
+})
+public class H2OpenTelemetryOffJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
+
+    @Test
+    void testSqlQueryNotTraced() {
+        // When OpenTelemetry is disabled at runtime, the queries should not be traced
+        testQueryNotTraced("h2");
+    }
+}

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbLifecycleManager.java
@@ -31,6 +31,7 @@ public class MariaDbLifecycleManager implements QuarkusTestResourceLifecycleMana
         properties.put("quarkus.hibernate-orm.oracle.active", "false");
         properties.put("quarkus.hibernate-orm.postgresql.active", "false");
         properties.put("quarkus.hibernate-orm.db2.active", "false");
+        properties.put("quarkus.hibernate-orm.h2.active", "false");
 
         return properties;
     }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryJdbcInstrumentationTest.java
@@ -68,4 +68,16 @@ public abstract class OpenTelemetryJdbcInstrumentationTest {
         });
     }
 
+    protected void testQueryNotTraced(String dbKind) {
+        given()
+                .queryParam("id", 1)
+                .when().post("/hit/" + dbKind)
+                .then()
+                .statusCode(200)
+                .body("message", Matchers.equalTo("Hit message."));
+
+        Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertTrue(getSpans().isEmpty(), "No spans should be recorded when OpenTelemetry is disabled.");
+        });
+    }
 }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleLifecycleManager.java
@@ -18,6 +18,7 @@ public class OracleLifecycleManager implements QuarkusTestResourceLifecycleManag
         properties.put("quarkus.hibernate-orm.mariadb.active", "false");
         properties.put("quarkus.hibernate-orm.postgresql.active", "false");
         properties.put("quarkus.hibernate-orm.db2.active", "false");
+        properties.put("quarkus.hibernate-orm.h2.active", "false");
 
         return properties;
     }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgreSqlLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgreSqlLifecycleManager.java
@@ -31,6 +31,7 @@ public class PostgreSqlLifecycleManager implements QuarkusTestResourceLifecycleM
         properties.put("quarkus.hibernate-orm.oracle.active", "false");
         properties.put("quarkus.hibernate-orm.mariadb.active", "false");
         properties.put("quarkus.hibernate-orm.db2.active", "false");
+        properties.put("quarkus.hibernate-orm.h2.active", "false");
 
         return properties;
     }


### PR DESCRIPTION
During the OTel performance work I noticed that the OTel jdbc wrapper was being run even if the OTel SDK was disabled at runtime. 
The PR fixes the unnecessary execution of the span creation, therefore improving performance.

Also found that if the OTel extension was disabled at build time, quarkus would fail to start if the wrapper was present.
Could not create a test because `NoNettyDataSourceConfigTest` doesn't like the OTel extension.