### PR TITLE
Do not automatically label `mandrel` issues with  `area/native-image`

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -405,10 +405,6 @@ triage:
       directories:
         - extensions/google-cloud-functions
         - integration-tests/google-cloud-functions
-    - id: mandrel
-      labels: [area/native-image]
-      titleBody: "mandrel"
-      notify: [galderz, zakkak, Karm]
     - id: native-image
       labels: [area/native-image]
       title: "\\bnative\\b"


### PR DESCRIPTION
Using mandrel does not mean that the issue lies in the native image feature.

eg. https://github.com/quarkusio/quarkus/issues/45358

See https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/quarkus-bot.20falely.20flags.20issues.20as.20.60area.2Fnative-image.60
