### PR TITLE
Make IdentityProviderManagerCreator a `@Dependent` bean as we don't need it once bean producer methods were used

### DIFF
--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/IdentityProviderManagerCreator.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/IdentityProviderManagerCreator.java
@@ -6,7 +6,6 @@ import java.util.function.Supplier;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
-import jakarta.inject.Inject;
 
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.runtime.ExecutorRecorder;
@@ -19,17 +18,7 @@ import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 /**
  * CDI bean than manages the lifecycle of the {@link io.quarkus.security.identity.IdentityProviderManager}
  */
-@ApplicationScoped
 public class IdentityProviderManagerCreator {
-
-    @Inject
-    Instance<IdentityProvider<?>> identityProviders;
-
-    @Inject
-    Instance<SecurityIdentityAugmentor> augmentors;
-
-    @Inject
-    BlockingSecurityExecutor blockingExecutor;
 
     @ApplicationScoped
     @DefaultBean
@@ -45,7 +34,8 @@ public class IdentityProviderManagerCreator {
 
     @Produces
     @ApplicationScoped
-    public IdentityProviderManager ipm() {
+    public IdentityProviderManager ipm(Instance<IdentityProvider<?>> identityProviders,
+            Instance<SecurityIdentityAugmentor> augmentors, BlockingSecurityExecutor blockingExecutor) {
         boolean customAnon = false;
         QuarkusIdentityProviderManagerImpl.Builder builder = QuarkusIdentityProviderManagerImpl.builder();
         for (var i : identityProviders) {


### PR DESCRIPTION
The `IdentityProviderManagerCreator` is application scoped, but I don't see a point of keeping it inside CDI container later as both beans that are produced are application scoped as well (so created once at most). This PR makes it a dependent bean. Injection points are moved to method parameters as `defaultBlockingExecutor` doesn't need them, therefore there it avoids injection if it is ever called. Most of the time this default bean producer is not called anyway because we always replace the bean with the executor from Vert.x HTTP extension.