### PR TITLE
prevent critical CVE findings by trivy

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -124,7 +124,7 @@
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
         <adal4j.version>1.6.7</adal4j.version>
         <oracle-jdbc.version>23.5.0.24.07</oracle-jdbc.version>
-        <derby-jdbc.version>10.16.1.1</derby-jdbc.version>
+        <derby-jdbc.version>10.17.1.0</derby-jdbc.version>
         <db2-jdbc.version>11.5.8.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -124,7 +124,7 @@
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
         <adal4j.version>1.6.7</adal4j.version>
         <oracle-jdbc.version>23.5.0.24.07</oracle-jdbc.version>
-        <derby-jdbc.version>10.17.1.0</derby-jdbc.version>
+        <derby-jdbc.version>10.16.1.1</derby-jdbc.version>
         <db2-jdbc.version>11.5.8.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->

--- a/pom.xml
+++ b/pom.xml
@@ -179,26 +179,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>tech.orla</groupId>
-                <artifactId>trivy-maven-plugin</artifactId>
-                <version>1.0.1</version>
-                <configuration>
-                    <vulnType>os,library</vulnType>
-                    <severity>CRITICAL</severity>
-                    <ignoreUnfixed>true</ignoreUnfixed>
-                </configuration>
-                <executions>
-                    <execution>
-                        <!--                        <phase>verify</phase>-->
-                        <goals>
-                            <goal>trivy-scan</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
         <extensions>
             <extension>
                 <groupId>io.quarkus.bot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,26 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>tech.orla</groupId>
+                <artifactId>trivy-maven-plugin</artifactId>
+                <version>1.0.1</version>
+                <configuration>
+                    <vulnType>os,library</vulnType>
+                    <severity>CRITICAL</severity>
+                    <ignoreUnfixed>true</ignoreUnfixed>
+                </configuration>
+                <executions>
+                    <execution>
+                        <!--                        <phase>verify</phase>-->
+                        <goals>
+                            <goal>trivy-scan</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <extensions>
             <extension>
                 <groupId>io.quarkus.bot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <!--                        <phase>verify</phase>-->
+                        <phase>verify</phase>
                         <goals>
                             <goal>trivy-scan</goal>
                         </goals>


### PR DESCRIPTION
check for CVE
```
trivy filesystem --scanners vuln --include-dev-deps . -s CRITICAL
```
## TODO
Investigate the root cause of CVE-2022-46337 and CVE-2024-1597 vulnerabilities, as they seem to be indirectly included as I did not found them.
```
bck-i-search: _              trivy filesystem --scanners vuln --include-dev-deps . -s CRITICAL
2025-01-05T11:59:36+01:00       INFO    [vuln] Vulnerability scanning is enabled
2025-01-05T11:59:37+01:00       WARN    [pom] Dependency version cannot be determined. Child dependencies will not be found.    details="https://aquasecurity.github.io/trivy/v0.57/docs/coverage/language/java#empty-dependency-version"
2025-01-05T12:06:23+01:00       INFO    Number of language-specific files       num=1704
2025-01-05T12:06:23+01:00       INFO    [pom] Detecting vulnerabilities...

extensions/devservices/derby/pom.xml (pom)

Total: 1 (CRITICAL: 1)

┌────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │ Status │ Installed Version │              Fixed Version               │                            Title                             │
├────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.derby:derby │ CVE-2022-46337 │ CRITICAL │ fixed  │ 10.16.1.1         │ 10.14.3, 10.15.2.1, 10.16.1.2, 10.17.1.0 │ A cleverly devised username might bypass LDAP authentication │
│                        │                │          │        │                   │                                          │ checks. I ...                                                │
│                        │                │          │        │                   │                                          │ https://avd.aquasec.com/nvd/cve-2022-46337                   │
└────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘

extensions/devservices/pom.xml (pom)

Total: 1 (CRITICAL: 1)

┌────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │ Status │ Installed Version │              Fixed Version               │                            Title                             │
├────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.derby:derby │ CVE-2022-46337 │ CRITICAL │ fixed  │ 10.16.1.1         │ 10.14.3, 10.15.2.1, 10.16.1.2, 10.17.1.0 │ A cleverly devised username might bypass LDAP authentication │
│                        │                │          │        │                   │                                          │ checks. I ...                                                │
│                        │                │          │        │                   │                                          │ https://avd.aquasec.com/nvd/cve-2022-46337                   │
└────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘

extensions/pom.xml (pom)

Total: 1 (CRITICAL: 1)

┌────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │ Status │ Installed Version │              Fixed Version               │                            Title                             │
├────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.derby:derby │ CVE-2022-46337 │ CRITICAL │ fixed  │ 10.16.1.1         │ 10.14.3, 10.15.2.1, 10.16.1.2, 10.17.1.0 │ A cleverly devised username might bypass LDAP authentication │
│                        │                │          │        │                   │                                          │ checks. I ...                                                │
│                        │                │          │        │                   │                                          │ https://avd.aquasec.com/nvd/cve-2022-46337                   │
└────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘

integration-tests/hibernate-orm-compatibility-5.6/database-generator/pom.xml (pom)

Total: 1 (CRITICAL: 1)

┌───────────────────────────┬───────────────┬──────────┬────────┬───────────────────┬─────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Status │ Installed Version │                  Fixed Version                  │                            Title                             │
├───────────────────────────┼───────────────┼──────────┼────────┼───────────────────┼─────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.postgresql:postgresql │ CVE-2024-1597 │ CRITICAL │ fixed  │ 42.5.3            │ 42.2.28, 42.3.9, 42.4.4, 42.5.5, 42.6.1, 42.7.2 │ pgjdbc: PostgreSQL JDBC Driver allows attacker to inject SQL │
│                           │               │          │        │                   │                                                 │ if using PreferQueryMode=SIMPLE...                           │
│                           │               │          │        │                   │                                                 │ https://avd.aquasec.com/nvd/cve-2024-1597                    │
└───────────────────────────┴───────────────┴──────────┴────────┴───────────────────┴─────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘

test-framework/derby/pom.xml (pom)

Total: 1 (CRITICAL: 1)

┌────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │ Status │ Installed Version │              Fixed Version               │                            Title                             │
├────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.derby:derby │ CVE-2022-46337 │ CRITICAL │ fixed  │ 10.16.1.1         │ 10.14.3, 10.15.2.1, 10.16.1.2, 10.17.1.0 │ A cleverly devised username might bypass LDAP authentication │
│                        │                │          │        │                   │                                          │ checks. I ...                                                │
│                        │                │          │        │                   │                                          │ https://avd.aquasec.com/nvd/cve-2022-46337                   │
└────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘

test-framework/pom.xml (pom)

Total: 1 (CRITICAL: 1)

┌────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │ Status │ Installed Version │              Fixed Version               │                            Title                             │
├────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.derby:derby │ CVE-2022-46337 │ CRITICAL │ fixed  │ 10.16.1.1         │ 10.14.3, 10.15.2.1, 10.16.1.2, 10.17.1.0 │ A cleverly devised username might bypass LDAP authentication │
│                        │                │          │        │                   │                                          │ checks. I ...                                                │
│                        │                │          │        │                   │                                          │ https://avd.aquasec.com/nvd/cve-2022-46337                   │
└────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```