### PR TITLE
Disable MongoDB testing on Windows

### DIFF
--- a/integration-tests/mongodb-client/pom.xml
+++ b/integration-tests/mongodb-client/pom.xml
@@ -113,4 +113,32 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Flapdoodle sometimes hangs on Windows so we have to disable these tests for now -->
+        <profile>
+            <id>no-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/integration-tests/mongodb-panache-kotlin/pom.xml
+++ b/integration-tests/mongodb-panache-kotlin/pom.xml
@@ -199,5 +199,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Flapdoodle sometimes hangs on Windows so we have to disable these tests for now -->
+        <profile>
+            <id>no-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/integration-tests/mongodb-panache/pom.xml
+++ b/integration-tests/mongodb-panache/pom.xml
@@ -159,5 +159,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Flapdoodle sometimes hangs on Windows so we have to disable these tests for now -->
+        <profile>
+            <id>no-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/integration-tests/mongodb-rest-data-panache/pom.xml
+++ b/integration-tests/mongodb-rest-data-panache/pom.xml
@@ -154,5 +154,30 @@
                 <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
+        <!-- Flapdoodle sometimes hangs on Windows so we have to disable these tests for now -->
+        <profile>
+            <id>no-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Flapdoodle is highly unreliable with latest MongoDB versions on Windows so we have to disable it.

It can hang forever when shutting down the MongoDB server, which is kinda unpractical...

Got this in one of the hang. I wonder if somehow a lock is kept on a file descriptor, either in MongoDB or Flapdoodle.

```
2025-01-04T03:05:45.5111079Z     java.base@17.0.13/java.io.FileDescriptor.close0(Native Method)
2025-01-04T03:05:45.5112007Z     java.base@17.0.13/java.io.FileDescriptor.close(FileDescriptor.java:297)
2025-01-04T03:05:45.5113144Z     java.base@17.0.13/java.io.FileInputStream$1.close(FileInputStream.java:459)
2025-01-04T03:05:45.5114650Z     java.base@17.0.13/java.io.FileDescriptor.closeAll(FileDescriptor.java:355)
2025-01-04T03:05:45.5115811Z     java.base@17.0.13/java.io.FileInputStream.close(FileInputStream.java:457)
2025-01-04T03:05:45.5117098Z     de.flapdoodle.embed.process.runtime.ProcessControl.closeIOAndDestroy(ProcessControl.java:89)
2025-01-04T03:05:45.5118507Z     de.flapdoodle.embed.process.runtime.ProcessControl.stopOrDestroyProcess(ProcessControl.java:128)
2025-01-04T03:05:45.5119583Z     de.flapdoodle.embed.process.runtime.ProcessControl.waitForProcessGotKilled(ProcessControl.java:157)
2025-01-04T03:05:45.5120321Z     de.flapdoodle.embed.process.runtime.ProcessControl.stop(ProcessControl.java:77)
2025-01-04T03:05:45.5120939Z     de.flapdoodle.embed.process.types.RunningProcessImpl.stop(RunningProcessImpl.java:53)
2025-01-04T03:05:45.5121635Z     de.flapdoodle.embed.mongo.transitions.RunningMongoProcess.stop(RunningMongoProcess.java:87)
2025-01-04T03:05:45.5122636Z     de.flapdoodle.embed.mongo.transitions.MongoServerStarter$$Lambda$4492/0x00000282933f29c0.onTearDown(Unknown Source)
2025-01-04T03:05:45.5123295Z     de.flapdoodle.reverse.TearDown.lambda$null$1(TearDown.java:41)
2025-01-04T03:05:45.5123836Z     de.flapdoodle.reverse.TearDown$$Lambda$5524/0x0000028293a6f730.accept(Unknown Source)
2025-01-04T03:05:45.5124379Z     java.base@17.0.13/java.util.Arrays$ArrayList.forEach(Arrays.java:4204)
2025-01-04T03:05:45.5124881Z     de.flapdoodle.reverse.TearDown.lambda$aggregate$2(TearDown.java:41)
2025-01-04T03:05:45.5125428Z     de.flapdoodle.reverse.TearDown$$Lambda$4444/0x00000282933dae68.onTearDown(Unknown Source)
2025-01-04T03:05:45.5125996Z     de.flapdoodle.reverse.State.lambda$tearDown$0(State.java:51)
2025-01-04T03:05:45.5126515Z     de.flapdoodle.reverse.State$$Lambda$5523/0x0000028293a6f500.accept(Unknown Source)
2025-01-04T03:05:45.5127014Z     java.base@17.0.13/java.util.Optional.ifPresent(Optional.java:178)
2025-01-04T03:05:45.5127436Z     de.flapdoodle.reverse.State.tearDown(State.java:51)
2025-01-04T03:05:45.5127911Z     de.flapdoodle.reverse.TransitionWalker.lambda$null$7(TransitionWalker.java:279)
2025-01-04T03:05:45.5128516Z     de.flapdoodle.reverse.TransitionWalker$$Lambda$5521/0x0000028293a6f0a0.accept(Unknown Source)
2025-01-04T03:05:45.5129154Z     java.base@17.0.13/java.util.ArrayList.forEach(ArrayList.java:1511)
2025-01-04T03:05:45.5129664Z     de.flapdoodle.reverse.TransitionWalker.lambda$tearDown$8(TransitionWalker.java:276)
2025-01-04T03:05:45.5130261Z     de.flapdoodle.reverse.TransitionWalker$$Lambda$5520/0x0000028293a6ee70.accept(Unknown Source)
2025-01-04T03:05:45.5130864Z     java.base@17.0.13/java.util.ArrayList.forEach(ArrayList.java:1511)
2025-01-04T03:05:45.5131359Z     de.flapdoodle.reverse.TransitionWalker.tearDown(TransitionWalker.java:276)
2025-01-04T03:05:45.5131915Z     de.flapdoodle.reverse.TransitionWalker.access$300(TransitionWalker.java:32)
2025-01-04T03:05:45.5132650Z     de.flapdoodle.reverse.TransitionWalker$ReachedState.close(TransitionWalker.java:251)
2025-01-04T03:05:45.5133440Z     io.quarkus.test.mongodb.MongoReplicaSetTestResource.stop(MongoReplicaSetTestResource.java:177)
2025-01-04T03:05:45.5134080Z     io.quarkus.test.common.TestResourceManager.close(TestResourceManager.java:238)
2025-01-04T03:05:45.5134651Z     io.quarkus.runner.bootstrap.StartupActionImpl$3.close(StartupActionImpl.java:319)
2025-01-04T03:05:45.5135310Z     io.quarkus.runner.bootstrap.RunningQuarkusApplicationImpl.close(RunningQuarkusApplicationImpl.java:35)
2025-01-04T03:05:45.5136015Z     app//io.quarkus.test.junit.QuarkusTestExtension$4.close(QuarkusTestExtension.java:259)
2025-01-04T03:05:45.5136678Z     app//io.quarkus.test.junit.QuarkusTestExtension$ExtensionState.doClose(QuarkusTestExtension.java:1134)
2025-01-04T03:05:45.5137351Z     app//io.quarkus.test.junit.QuarkusTestExtensionState.close(QuarkusTestExtensionState.java:44)
2025-01-04T03:05:45.5138117Z     app//org.junit.jupiter.engine.descriptor.AbstractExtensionContext.lambda$static$0(AbstractExtensionContext.java:45)
2025-01-04T03:05:45.5139004Z     app//org.junit.jupiter.engine.descriptor.AbstractExtensionContext$$Lambda$410/0x000002829216b490.close(Unknown Source)
2025-01-04T03:05:45.5139912Z     app//org.junit.platform.engine.support.store.NamespacedHierarchicalStore$EvaluatedValue.close(NamespacedHierarchicalStore.java:333)
2025-01-04T03:05:45.5140887Z     app//org.junit.platform.engine.support.store.NamespacedHierarchicalStore$EvaluatedValue.access$800(NamespacedHierarchicalStore.java:317)
2025-01-04T03:05:45.5141858Z     app//org.junit.platform.engine.support.store.NamespacedHierarchicalStore.lambda$close$3(NamespacedHierarchicalStore.java:98)
2025-01-04T03:05:45.5142965Z     app//org.junit.platform.engine.support.store.NamespacedHierarchicalStore$$Lambda$2505/0x0000028292b57760.execute(Unknown Source)
2025-01-04T03:05:45.5143792Z     app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
2025-01-04T03:05:45.5144660Z     app//org.junit.platform.engine.support.store.NamespacedHierarchicalStore.lambda$close$4(NamespacedHierarchicalStore.java:98)
2025-01-04T03:05:45.5145578Z     app//org.junit.platform.engine.support.store.NamespacedHierarchicalStore$$Lambda$2504/0x0000028292b57530.accept(Unknown Source)
2025-01-04T03:05:45.5146320Z     java.base@17.0.13/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
2025-01-04T03:05:45.5146933Z     java.base@17.0.13/java.util.stream.SortedOps$RefSortingSink$$Lambda$455/0x00000282920ef918.accept(Unknown Source)
2025-01-04T03:05:45.5147510Z     java.base@17.0.13/java.util.ArrayList.forEach(ArrayList.java:1511)
2025-01-04T03:05:45.5147997Z     java.base@17.0.13/java.util.stream.SortedOps$RefSortingSink.end(SortedOps.java:395)
2025-01-04T03:05:45.5151472Z     java.base@17.0.13/java.util.stream.Sink$ChainedReference.end(Sink.java:258)
2025-01-04T03:05:45.5151981Z     java.base@17.0.13/java.util.stream.Sink$ChainedReference.end(Sink.java:258)
2025-01-04T03:05:45.5152685Z     java.base@17.0.13/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
2025-01-04T03:05:45.5153315Z     java.base@17.0.13/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
2025-01-04T03:05:45.5153955Z     java.base@17.0.13/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
2025-01-04T03:05:45.5154676Z     java.base@17.0.13/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
2025-01-04T03:05:45.5155300Z     java.base@17.0.13/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
2025-01-04T03:05:45.5155936Z     java.base@17.0.13/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
2025-01-04T03:05:45.5156678Z     app//org.junit.platform.engine.support.store.NamespacedHierarchicalStore.close(NamespacedHierarchicalStore.java:98)
2025-01-04T03:05:45.5157508Z     app//org.junit.jupiter.engine.descriptor.AbstractExtensionContext.close(AbstractExtensionContext.java:87)
2025-01-04T03:05:45.5158350Z     app//org.junit.jupiter.engine.execution.JupiterEngineExecutionContext.close(JupiterEngineExecutionContext.java:53)
2025-01-04T03:05:45.5159235Z     app//org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor.cleanUp(JupiterEngineDescriptor.java:70)
2025-01-04T03:05:45.5159999Z     app//org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor.cleanUp(JupiterEngineDescriptor.java:31)
2025-01-04T03:05:45.5160793Z     app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$cleanUp$10(NodeTestTask.java:172)
2025-01-04T03:05:45.5161588Z     app//org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda$2496/0x0000028292b55fa0.execute(Unknown Source)
2025-01-04T03:05:45.5162583Z     app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
2025-01-04T03:05:45.5163317Z     app//org.junit.platform.engine.support.hierarchical.NodeTestTask.cleanUp(NodeTestTask.java:172)
2025-01-04T03:05:45.5164070Z     app//org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:103)
2025-01-04T03:05:45.5165052Z     app//org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
2025-01-04T03:05:45.5166127Z     app//org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
2025-01-04T03:05:45.5166991Z     app//org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
2025-01-04T03:05:45.5167849Z     app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
2025-01-04T03:05:45.5168675Z     app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
2025-01-04T03:05:45.5169473Z     app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
2025-01-04T03:05:45.5170329Z     app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
2025-01-04T03:05:45.5171175Z     app//org.junit.platform.launcher.core.EngineExecutionOrchestrator$$Lambda$348/0x00000282921431a8.accept(Unknown Source)
2025-01-04T03:05:45.5172075Z     app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
2025-01-04T03:05:45.5173159Z     app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
2025-01-04T03:05:45.5173916Z     app//org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
2025-01-04T03:05:45.5174546Z     app//org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85)
2025-01-04T03:05:45.5175168Z     app//org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
2025-01-04T03:05:45.5175828Z     app//org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
2025-01-04T03:05:45.5176544Z     app//org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
2025-01-04T03:05:45.5177379Z     app//org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
2025-01-04T03:05:45.5178244Z     app//org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
2025-01-04T03:05:45.5179028Z     app//org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
2025-01-04T03:05:45.5179661Z     app//org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
2025-01-04T03:05:45.5180205Z     app//org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
2025-01-04T03:05:45.5180755Z     app//org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
```