### PR TITLE
SmallRye Fault Tolerance: upgrade to 6.7.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -52,7 +52,7 @@
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.5</smallrye-open-api.version>
         <smallrye-graphql.version>2.12.0</smallrye-graphql.version>
-        <smallrye-fault-tolerance.version>6.7.1</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>6.7.2</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.1.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>

--- a/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
@@ -576,7 +576,7 @@ implementation("io.quarkus:quarkus-smallrye-fault-tolerance")
 == Additional resources
 
 SmallRye Fault Tolerance has more features than shown here.
-Please check the link:https://smallrye.io/docs/smallrye-fault-tolerance/6.7.1/index.html[SmallRye Fault Tolerance documentation] to learn about them.
+Please check the link:https://smallrye.io/docs/smallrye-fault-tolerance/6.7.2/index.html[SmallRye Fault Tolerance documentation] to learn about them.
 
 In Quarkus, you can use the SmallRye Fault Tolerance optional features out of the box.
 
@@ -608,7 +608,7 @@ quarkus.fault-tolerance.mp-compatibility=true
 ----
 ====
 
-The link:https://smallrye.io/docs/smallrye-fault-tolerance/6.7.1/reference/programmatic-api.html[programmatic API] is present and integrated with the declarative, annotation-based API.
+The link:https://smallrye.io/docs/smallrye-fault-tolerance/6.7.2/reference/programmatic-api.html[programmatic API] is present and integrated with the declarative, annotation-based API.
 You can use the `Guard`, `TypedGuard` and `@ApplyGuard` APIs out of the box.
 
 Support for Kotlin is present (assuming you use the Quarkus extension for Kotlin), so you can guard your `suspend` functions with fault tolerance annotations.


### PR DESCRIPTION
- https://smallrye.io/blog/fault-tolerance-6-7-2/

Fixes #45061