### PR TITLE
Arc - tweak ContextNotActiveException for session scoped beans to mention optional enablement

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ClientProxies.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ClientProxies.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.SessionScoped;
 import jakarta.enterprise.context.spi.Contextual;
 
 import io.quarkus.arc.Arc;
@@ -66,6 +67,8 @@ public final class ClientProxies {
                 bean.getScope().getSimpleName(), bean);
         if (bean.getScope().equals(RequestScoped.class)) {
             msg += "\n\t- you can activate the request context for a specific method using the @ActivateRequestContext interceptor binding";
+        } else if (bean.getScope().equals(SessionScoped.class)) {
+            msg += "\n\t- @SessionScoped is not supported by default. However, a Quarkus extension implementing session context can be used to enable this functionality (such as Undertow extension).";
         }
         return new ContextNotActiveException(msg);
     }


### PR DESCRIPTION
Fixes #45191

Using the reproducer from original issue, the exception now looks like this:

> jakarta.enterprise.context.ContextNotActiveException: SessionScoped context was not active when trying to obtain a bean instance for a client proxy of PRODUCER_METHOD bean [class=io.quarkus.ts.spring.data.primitivetypes.configuration.AppConfiguration, id=9767shscEaYLEayHF-_VBq-X1Aw]
	- @SessionScoped is not supported by default. However, a Quarkus extension implementing session context can be used to enable this functionality (such as Undertow extension).