### PR TITLE
Docs enhancement: Add warning about multiple Reactive Mongodb Clients

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -116,6 +116,8 @@ The `@MongoEntity` annotation allows configuring:
 * the name of the database, otherwise the `quarkus.mongodb.database` property or a link:{mongodb-doc-root-url}#multitenancy[`MongoDatabaseResolver`] implementation will be used.
 * the name of the collection, otherwise the simple name of the class will be used.
 
+WARNING: Creating multiple Reactive MongoDB clients using property `quarkus.mongodb.<client_name>.connection-string` currently is not supported.
+
 For advanced configuration of the MongoDB client, you can follow the xref:mongodb.adoc#configuring-the-mongodb-database[Configuring the MongoDB database guide].
 
 == Solution 1: using the active record pattern


### PR DESCRIPTION
I was trying to create multiple reactive MongoDB clients using following configuration property:
```yaml
quarkus.mongodb.client1.connection-string=mongodb://localhost:27017/db1
quarkus.mongodb.client2.connection-string=mongodb://localhost:27017/db2
```
And then using them two different Entities:
```java
@MongoEntity(clientName = "client1")
...
@MongoEntity(clientName = "client2")
```
I quickly found out that it is not possible but couldn't find anything in the docs about it. To avoid confusion I propose this doc enhancement.