### PR TITLE
Apply org.openrewrite.staticanalysis.CommonStaticAnalysis

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/logging/Log.java
+++ b/core/runtime/src/main/java/io/quarkus/logging/Log.java
@@ -18,8 +18,9 @@ public final class Log {
 
     private static boolean shouldFail() {
         // inside Quarkus, all call sites should be rewritten
-        if (Application.currentApplication() != null)
+        if (Application.currentApplication() != null) {
             return true;
+        }
         // outside Quarkus, allow in tests
         try {
             Class.forName("org.junit.jupiter.api.Assertions");

--- a/core/runtime/src/main/java/io/quarkus/runtime/Application.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Application.java
@@ -74,7 +74,7 @@ public abstract class Application implements Closeable {
         final Lock stateLock = this.stateLock;
         stateLock.lock();
         try {
-            loop: for (;;)
+            loop: for (;;) {
                 switch (state) {
                     case ST_INITIAL:
                         break loop; // normal startup
@@ -93,6 +93,7 @@ public abstract class Application implements Closeable {
                         throw new IllegalStateException("The application is stopping");
                     }
                 }
+            }
             state = ST_STARTING;
         } finally {
             stateLock.unlock();
@@ -169,7 +170,7 @@ public abstract class Application implements Closeable {
         final Lock stateLock = this.stateLock;
         stateLock.lock();
         try {
-            loop: for (;;)
+            loop: for (;;) {
                 switch (state) {
                     case ST_INITIAL:
                         throw new IllegalStateException("The application has not been started");
@@ -198,6 +199,7 @@ public abstract class Application implements Closeable {
                     default:
                         throw Assert.impossibleSwitchCase(state);
                 }
+            }
             state = ST_STOPPING;
         } finally {
             stateLock.unlock();

--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -46,7 +46,7 @@ import sun.misc.SignalHandler;
  * This class is static, there can only ever be a single application instance running at any time.
  *
  */
-public class ApplicationLifecycleManager {
+public final class ApplicationLifecycleManager {
 
     // used by ShutdownEvent to propagate the information about shutdown reason
     public static volatile ShutdownEvent.ShutdownReason shutdownReason = ShutdownEvent.ShutdownReason.STANDARD;

--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -124,8 +124,8 @@ public class ExecutorRecorder {
                                 for (Thread thr : runningThreads) {
                                     final StackTraceElement[] stackTrace = thr.getStackTrace();
                                     for (int i = 0; i < stackTrace.length && i < 8; i++) {
-                                        if (stackTrace[i].getClassName().equals("java.lang.System")
-                                                && stackTrace[i].getMethodName().equals("exit")) {
+                                        if ("java.lang.System".equals(stackTrace[i].getClassName())
+                                                && "exit".equals(stackTrace[i].getMethodName())) {
                                             final Throwable t = new Throwable();
                                             t.setStackTrace(stackTrace);
                                             log.errorf(t, "Thread %s is blocked in System.exit(); pooled (Executor) threads "

--- a/core/runtime/src/main/java/io/quarkus/runtime/PreloadClassesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/PreloadClassesRecorder.java
@@ -37,8 +37,9 @@ public class PreloadClassesRecorder {
         }
         InputStream is = PreloadClassesRecorder.class
                 .getResourceAsStream("/META-INF/" + QUARKUS_GENERATED_PRELOAD_CLASSES_FILE);
-        if (is != null)
+        if (is != null) {
             preloadClassesFromStream(is, initialize);
+        }
     }
 
     public static void preloadClassesFromStream(InputStream is, boolean initialize) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
@@ -32,7 +32,7 @@ public class Quarkus {
     //WARNING: this is too early to inject a logger
     //private static final Logger log = Logger.getLogger(Quarkus.class);
 
-    private static Closeable LAUNCHED_FROM_IDE;
+    private static Closeable launchedFromIde;
 
     /**
      * Runs a quarkus application, that will run until the provided {@link QuarkusApplication} has completed.
@@ -111,14 +111,14 @@ public class Quarkus {
             pos++;
         }
         String callingClass = stackTrace[pos].getClassName();
-        LAUNCHED_FROM_IDE = QuarkusLauncher.launch(callingClass,
+        launchedFromIde = QuarkusLauncher.launch(callingClass,
                 quarkusApplication == null ? null : quarkusApplication.getName(), args);
     }
 
     private static void terminateForIDE() {
-        if (LAUNCHED_FROM_IDE != null) {
+        if (launchedFromIde != null) {
             try {
-                LAUNCHED_FROM_IDE.close();
+                launchedFromIde.close();
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -207,7 +207,7 @@ public class Quarkus {
     }
 
     public static boolean isMainThread(Thread thread) {
-        return thread.getThreadGroup().getName().equals("main") &&
+        return "main".equals(thread.getThreadGroup().getName()) &&
                 thread.getName().toLowerCase(Locale.ROOT).contains("main");
     }
 
@@ -230,16 +230,20 @@ public class Quarkus {
      */
     public static void manualInitialize() {
         int tmpState = manualState;
-        if (tmpState == MANUAL_FAILURE)
+        if (tmpState == MANUAL_FAILURE) {
             throw new RuntimeException("Quarkus manual bootstrap failed");
-        if (tmpState > MANUAL_BEGIN)
+        }
+        if (tmpState > MANUAL_BEGIN) {
             return;
+        }
         synchronized (manualLock) {
             tmpState = manualState;
-            if (tmpState == MANUAL_FAILURE)
+            if (tmpState == MANUAL_FAILURE) {
                 throw new RuntimeException("Quarkus manual bootstrap failed");
-            if (tmpState > MANUAL_BEGIN)
+            }
+            if (tmpState > MANUAL_BEGIN) {
                 return;
+            }
             manualState = MANUAL_BEGIN_INITIALIZATION;
         }
 
@@ -269,18 +273,23 @@ public class Quarkus {
      */
     public static void manualStart() {
         int tmpState = manualState;
-        if (tmpState == MANUAL_FAILURE)
+        if (tmpState == MANUAL_FAILURE) {
             throw new IllegalStateException("Quarkus failed to start up");
-        if (tmpState >= MANUAL_STARTING)
+        }
+        if (tmpState >= MANUAL_STARTING) {
             return;
+        }
         synchronized (manualLock) {
             tmpState = manualState;
-            if (tmpState == MANUAL_FAILURE)
+            if (tmpState == MANUAL_FAILURE) {
                 throw new RuntimeException("Quarkus manual bootstrap failed");
-            if (tmpState >= MANUAL_STARTING)
+            }
+            if (tmpState >= MANUAL_STARTING) {
                 return;
-            if (tmpState != MANUAL_INITIALIZED)
+            }
+            if (tmpState != MANUAL_INITIALIZED) {
                 throw new IllegalStateException("Quarkus manual start cannot proceed as warmup did not run");
+            }
             manualState = MANUAL_STARTING;
         }
         try {

--- a/core/runtime/src/main/java/io/quarkus/runtime/ShutdownEvent.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ShutdownEvent.java
@@ -52,6 +52,6 @@ public class ShutdownEvent extends jakarta.enterprise.event.Shutdown {
          * All other cases - {@code SIGINT}, {@code SIGTERM}, {@code System.exit(n} and so on.
          * This includes sending {@code CTRL + C} to running app in terminal.
          */
-        NON_STANDARD;
+        NON_STANDARD
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/SnapStartRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/SnapStartRecorder.java
@@ -8,8 +8,8 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class SnapStartRecorder {
 
-    public static boolean enabled = false;
-    public static boolean fullWarmup = false;
+    public static boolean enabled;
+    public static boolean fullWarmup;
 
     public void register(boolean fw) {
         enabled = true;

--- a/core/runtime/src/main/java/io/quarkus/runtime/TemplateHtmlBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/TemplateHtmlBuilder.java
@@ -13,7 +13,7 @@ import io.quarkus.runtime.logging.DecorateStackUtil;
 import io.quarkus.runtime.util.ExceptionUtil;
 
 public class TemplateHtmlBuilder {
-    private static String CSS = null;
+    private static String css;
 
     private static final String SCRIPT_STACKTRACE_MANIPULATION = """
             <script>
@@ -319,13 +319,12 @@ public class TemplateHtmlBuilder {
             }
 
             result = new StringBuilder(String.format(HTML_TEMPLATE_START, escapeHtml(title),
-                    subTitle == null || subTitle.isEmpty() ? "" : " - " + escapeHtml(subTitle), CSS));
+                    subTitle == null || subTitle.isEmpty() ? "" : " - " + escapeHtml(subTitle), css));
             result.append(String.format(HEADER_TEMPLATE, escapeHtml(title), escapeHtml(details), actionLinks.toString()));
         } else {
             result = new StringBuilder(String.format(HTML_TEMPLATE_START_NO_STACK, escapeHtml(title),
-                    subTitle == null || subTitle.isEmpty() ? "" : " - " + escapeHtml(subTitle), CSS));
-            result.append(
-                    String.format(HEADER_TEMPLATE_NO_STACK, escapeHtml(title), escapeHtml(details), actionLinks.toString()));
+                    subTitle == null || subTitle.isEmpty() ? "" : " - " + escapeHtml(subTitle), css));
+            result.append(String.format(HEADER_TEMPLATE_NO_STACK, escapeHtml(title), escapeHtml(details), actionLinks.toString()));
         }
 
         if (!config.isEmpty()) {
@@ -464,7 +463,7 @@ public class TemplateHtmlBuilder {
 
     public TemplateHtmlBuilder method(String method, String fullPath) {
         fullPath = escapeHtml(fullPath);
-        if (method.equalsIgnoreCase("GET")) {
+        if ("GET".equalsIgnoreCase(method)) {
             if (baseUrl != null) {
                 fullPath = "<a href='" + baseUrl + fullPath.substring(1) + "' target='_blank'>" + fullPath + "</a>";
             } else {
@@ -532,7 +531,7 @@ public class TemplateHtmlBuilder {
         //to make this work we check if the basePath starts with a / or not, and make sure we
         //return the value that follows the same pattern
 
-        if (httpRoot.equals("/")) {
+        if ("/".equals(httpRoot)) {
             //leave it alone
             return basePath;
         }
@@ -549,7 +548,7 @@ public class TemplateHtmlBuilder {
     }
 
     public void loadCssFile() {
-        if (CSS == null) {
+        if (css == null) {
             ClassLoader classLoader = getClass().getClassLoader();
             String cssFilePath = "META-INF/template-html-builder.css";
             try (InputStream inputStream = classLoader.getResourceAsStream(cssFilePath)) {
@@ -560,7 +559,7 @@ public class TemplateHtmlBuilder {
                         while (scanner.hasNextLine()) {
                             stringBuilder.append(scanner.nextLine()).append("\n");
                         }
-                        CSS = stringBuilder.toString();
+                        css = stringBuilder.toString();
                     }
                 }
             } catch (IOException e) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -227,7 +227,7 @@ public final class ConfigDiagnostic {
             @Override
             public void accept(final List<URI> locations) {
                 for (URI location : locations) {
-                    Path path = location.getScheme() != null && location.getScheme().equals("file") ? Paths.get(location)
+                    Path path = "file".equals(location.getScheme()) ? Paths.get(location)
                             : Paths.get(location.getPath());
                     if (Files.isDirectory(path)) {
                         try {

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
@@ -40,7 +40,7 @@ import io.smallrye.config.SmallRyeConfig;
 public class ConfigInstantiator {
 
     // certain well-known classname suffixes that we support
-    private static Set<String> SUPPORTED_CLASS_NAME_SUFFIXES = Set.of("Config", "Configuration");
+    private static final Set<String> SUPPORTED_CLASS_NAME_SUFFIXES = Set.of("Config", "Configuration");
 
     private static final String QUARKUS_PROPERTY_PREFIX = "quarkus.";
 
@@ -67,7 +67,7 @@ public class ConfigInstantiator {
         final Class<?> cls = o.getClass();
         final String name;
         ConfigRoot configRoot = cls.getAnnotation(ConfigRoot.class);
-        if (configRoot != null && !configRoot.name().equals(ConfigItem.HYPHENATED_ELEMENT_NAME)) {
+        if (configRoot != null && !ConfigItem.HYPHENATED_ELEMENT_NAME.equals(configRoot.name())) {
             name = configRoot.name();
             if (name.startsWith("<<")) {
                 throw new IllegalArgumentException("Found unsupported @ConfigRoot.name = " + name + " on " + cls);
@@ -110,9 +110,9 @@ public class ConfigInstantiator {
                     handleObject(prefix + "." + dashify(field.getName()), newInstance, config, quarkusPropertyNames);
                 } else {
                     String name = configItem.name();
-                    if (name.equals(ConfigItem.HYPHENATED_ELEMENT_NAME)) {
+                    if (ConfigItem.HYPHENATED_ELEMENT_NAME.equals(name)) {
                         name = dashify(field.getName());
-                    } else if (name.equals(ConfigItem.ELEMENT_NAME)) {
+                    } else if (ConfigItem.ELEMENT_NAME.equals(name)) {
                         name = field.getName();
                     }
                     String fullName = prefix + "." + name;
@@ -126,7 +126,7 @@ public class ConfigInstantiator {
                         Optional<?> value = config.getOptionalValue(fullName, conv);
                         if (value.isPresent()) {
                             field.set(o, value.get());
-                        } else if (!configItem.defaultValue().equals(ConfigItem.NO_DEFAULT)) {
+                        } else if (!ConfigItem.NO_DEFAULT.equals(configItem.defaultValue())) {
                             //the runtime config source handles default automatically
                             //however this may not have actually been installed depending on where the failure occurred
                             field.set(o, conv.convert(configItem.defaultValue()));

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConverterClassHolder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConverterClassHolder.java
@@ -15,10 +15,12 @@ final class ConverterClassHolder {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
+        if (this == o) {
             return true;
-        if (o == null || getClass() != o.getClass())
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
         ConverterClassHolder that = (ConverterClassHolder) o;
         return Objects.equals(type, that.type) &&
                 Objects.equals(converterType, that.converterType);

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConverterSupport.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConverterSupport.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.config.spi.Converter;
 /**
  * This small utility class holds constants relevant to configuration converters.
  */
-public class ConverterSupport {
+public final class ConverterSupport {
 
     /**
      * Default {@link Converter} priority with value {@value #DEFAULT_SMALLRYE_CONVERTER_PRIORITY}

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/DisableableConfigSource.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/DisableableConfigSource.java
@@ -11,7 +11,7 @@ public class DisableableConfigSource implements ConfigSource {
     private final ConfigSource source;
     private final ConfigSource emptySource;
 
-    private AtomicReference<ConfigSource> activeSource;
+    private final AtomicReference<ConfigSource> activeSource;
 
     public DisableableConfigSource(final ConfigSource source) {
         this.source = source;

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/HyphenateEnumConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/HyphenateEnumConverter.java
@@ -35,7 +35,7 @@ public final class HyphenateEnumConverter<E extends Enum<E>> implements Converte
     }
 
     public static <E extends Enum<E>> HyphenateEnumConverter<E> of(Class<E> enumType) {
-        return new HyphenateEnumConverter<E>(enumType);
+        return new HyphenateEnumConverter<>(enumType);
     }
 
     @Override

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySize.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySize.java
@@ -29,10 +29,12 @@ public final class MemorySize {
 
     @Override
     public boolean equals(Object object) {
-        if (this == object)
+        if (this == object) {
             return true;
-        if (object == null || getClass() != object.getClass())
+        }
+        if (object == null || getClass() != object.getClass()) {
             return false;
+        }
         MemorySize that = (MemorySize) object;
         return Objects.equals(value, that.value);
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/NameIterator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/NameIterator.java
@@ -28,12 +28,14 @@ public final class NameIterator {
 
     public NameIterator(final String name, final int pos) {
         Assert.checkNotNullParam("name", name);
-        if (name.length() > MAX_LENGTH)
+        if (name.length() > MAX_LENGTH) {
             throw new IllegalArgumentException("Name is too long");
+        }
         Assert.checkMinimumParameter("pos", -1, pos);
         Assert.checkMaximumParameter("pos", name.length(), pos);
-        if (pos != -1 && pos != name.length() && name.charAt(pos) != '.')
+        if (pos != -1 && pos != name.length() && name.charAt(pos) != '.') {
             throw new IllegalArgumentException("Position is not located at a delimiter");
+        }
         this.name = name;
         this.pos = pos;
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/PropertiesUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/PropertiesUtil.java
@@ -2,7 +2,7 @@ package io.quarkus.runtime.configuration;
 
 import java.util.Set;
 
-public class PropertiesUtil {
+public final class PropertiesUtil {
     private PropertiesUtil() {
         throw new IllegalStateException("Utility class");
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
@@ -44,7 +44,7 @@ final class Substitutions {
     @TargetClass(ConfigMappingInterface.class)
     static final class Target_ConfigMappingInterface {
         @Alias
-        static ClassValue<Target_ConfigMappingInterface> cv = null;
+        static ClassValue<Target_ConfigMappingInterface> cv;
 
         // ClassValue is substituted by a regular ConcurrentHashMap - java.lang.ClassValue.get(JavaLangSubstitutions.java:514)
         @Substitute
@@ -67,7 +67,7 @@ final class Substitutions {
     @TargetClass(value = ConfigMappingLoader.class, innerClass = "ConfigMappingClass")
     static final class Target_ConfigMappingClass {
         @Alias
-        static ClassValue<Target_ConfigMappingClass> cv = null;
+        static ClassValue<Target_ConfigMappingClass> cv;
 
         // ClassValue is substituted by a regular ConcurrentHashMap - java.lang.ClassValue.get(JavaLangSubstitutions.java:514)
         @Substitute

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/AwtImageIO.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/AwtImageIO.java
@@ -87,7 +87,7 @@ final class Target_javax_imageio_spi_ServiceRegistry {
 final class Target_java_awt_geom_AffineTransform {
     @Substitute
     @TargetElement(name = TargetElement.CONSTRUCTOR_NAME)
-    void AffineTransform() {
+    void affineTransform() {
         throw new UnsupportedOperationException(AwtImageIO.AWT_EXTENSION_HINT);
     }
 }
@@ -104,7 +104,7 @@ final class Target_java_awt_geom_Path2D {
 final class Target_java_awt_image_Kernel {
     @Substitute
     @TargetElement(name = TargetElement.CONSTRUCTOR_NAME)
-    void Kernel(int width, int height, float[] data) {
+    void kernel(int width, int height, float[] data) {
         throw new UnsupportedOperationException(AwtImageIO.AWT_EXTENSION_HINT);
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java
@@ -21,8 +21,9 @@ public final class DiagnosticPrinter {
             w.print("\" #");
             w.print(thread.getId());
             w.print(" ");
-            if (thread.isDaemon())
+            if (thread.isDaemon()) {
                 w.print("daemon ");
+            }
             w.print("prio=");
             w.print(thread.getPriority());
             w.print("   java.lang.thread.State: ");

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -187,7 +187,7 @@ public final class GraalVM {
     public enum Distribution {
         GRAALVM,
         LIBERICA,
-        MANDREL;
+        MANDREL
     }
 }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/TimingReplacement.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/TimingReplacement.java
@@ -10,7 +10,7 @@ import io.quarkus.bootstrap.runner.Timing;
 final class TimingReplacement {
 
     @Alias
-    private static Timing main = null;
+    private static Timing main;
 
     @Substitute
     public static void mainStarted() {

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevel.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevel.java
@@ -16,7 +16,7 @@ public abstract class InheritableLevel {
     }
 
     public static InheritableLevel of(String str) {
-        if (str.equalsIgnoreCase("inherit")) {
+        if ("inherit".equalsIgnoreCase(str)) {
             return Inherited.INSTANCE;
         } else {
             return of(LogContext.getLogContext().getLevelForName(str.toUpperCase(Locale.ROOT)));

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogMetricsHandlerRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogMetricsHandlerRecorder.java
@@ -36,7 +36,7 @@ public class LogMetricsHandlerRecorder {
     }
 
     public Consumer<MetricsFactory> registerMetrics() {
-        return new Consumer<MetricsFactory>() {
+        return new Consumer<>() {
             @Override
             public void accept(MetricsFactory metricsFactory) {
                 for (Level level : STANDARD_LEVELS) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/metrics/MetricsFactory.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/metrics/MetricsFactory.java
@@ -19,10 +19,10 @@ public interface MetricsFactory {
     final String MICROMETER = "micrometer";
 
     /** Registry type or scope. This may not be used by all metrics extensions. */
-    public static enum Type {
+    public enum Type {
         APPLICATION,
         BASE,
-        VENDOR;
+        VENDOR
     }
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/types/GenericArrayTypeImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/types/GenericArrayTypeImpl.java
@@ -26,7 +26,7 @@ public class GenericArrayTypeImpl implements GenericArrayType {
 
     @Override
     public int hashCode() {
-        return ((genericComponentType == null) ? 0 : genericComponentType.hashCode());
+        return genericComponentType == null ? 0 : genericComponentType.hashCode();
     }
 
     @Override

--- a/core/runtime/src/main/java/io/quarkus/runtime/types/WildcardTypeImpl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/types/WildcardTypeImpl.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
  * @author Jozef Hartinger
  *
  */
-public class WildcardTypeImpl implements WildcardType {
+public final class WildcardTypeImpl implements WildcardType {
 
     public static WildcardType defaultInstance() {
         return DEFAULT_INSTANCE;

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ClassPathUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ClassPathUtils.java
@@ -33,7 +33,7 @@ public class ClassPathUtils {
         if (path == null) {
             return null;
         }
-        if (path.getFileSystem().getSeparator().equals("/")) {
+        if ("/".equals(path.getFileSystem().getSeparator())) {
             return path.toString();
         }
         return path.toString().replace(path.getFileSystem().getSeparator(), "/");

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/EnumerationUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/EnumerationUtil.java
@@ -15,7 +15,7 @@ public class EnumerationUtil {
     public static <T> Enumeration<T> from(Iterator<T> iterator) {
         Objects.requireNonNull(iterator);
 
-        return new Enumeration<T>() {
+        return new Enumeration<>() {
             @Override
             public boolean hasMoreElements() {
                 return iterator.hasNext();

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
@@ -7,13 +7,13 @@ public class JavaVersionUtil {
 
     private static final Pattern PATTERN = Pattern.compile("(?:1\\.)?(\\d+)");
 
-    private static boolean IS_JAVA_11_OR_NEWER;
-    private static boolean IS_JAVA_13_OR_NEWER;
-    private static boolean IS_GRAALVM_JDK;
-    private static boolean IS_JAVA_16_OR_OLDER;
-    private static boolean IS_JAVA_17_OR_NEWER;
-    private static boolean IS_JAVA_19_OR_NEWER;
-    private static boolean IS_JAVA_21_OR_NEWER;
+    private static boolean isJava11OrNewer;
+    private static boolean isJava13OrNewer;
+    private static boolean isGraalvmJdk;
+    private static boolean isJava16OrOlder;
+    private static boolean isJava17OrNewer;
+    private static boolean isJava19OrNewer;
+    private static boolean isJava21OrNewer;
 
     static {
         performChecks();
@@ -24,50 +24,50 @@ public class JavaVersionUtil {
         Matcher matcher = PATTERN.matcher(System.getProperty("java.specification.version", ""));
         if (matcher.matches()) {
             int first = Integer.parseInt(matcher.group(1));
-            IS_JAVA_11_OR_NEWER = (first >= 11);
-            IS_JAVA_13_OR_NEWER = (first >= 13);
-            IS_JAVA_16_OR_OLDER = (first <= 16);
-            IS_JAVA_17_OR_NEWER = (first >= 17);
-            IS_JAVA_19_OR_NEWER = (first >= 19);
-            IS_JAVA_21_OR_NEWER = (first >= 21);
+            isJava11OrNewer = first >= 11;
+            isJava13OrNewer = first >= 13;
+            isJava16OrOlder = first <= 16;
+            isJava17OrNewer = first >= 17;
+            isJava19OrNewer = first >= 19;
+            isJava21OrNewer = first >= 21;
         } else {
-            IS_JAVA_11_OR_NEWER = false;
-            IS_JAVA_13_OR_NEWER = false;
-            IS_JAVA_16_OR_OLDER = false;
-            IS_JAVA_17_OR_NEWER = false;
-            IS_JAVA_19_OR_NEWER = false;
-            IS_JAVA_21_OR_NEWER = false;
+            isJava11OrNewer = false;
+            isJava13OrNewer = false;
+            isJava16OrOlder = false;
+            isJava17OrNewer = false;
+            isJava19OrNewer = false;
+            isJava21OrNewer = false;
         }
 
         String vmVendor = System.getProperty("java.vm.vendor");
-        IS_GRAALVM_JDK = (vmVendor != null) && vmVendor.startsWith("GraalVM");
+        isGraalvmJdk = (vmVendor != null) && vmVendor.startsWith("GraalVM");
     }
 
     public static boolean isJava11OrHigher() {
-        return IS_JAVA_11_OR_NEWER;
+        return isJava11OrNewer;
     }
 
     public static boolean isJava13OrHigher() {
-        return IS_JAVA_13_OR_NEWER;
+        return isJava13OrNewer;
     }
 
     public static boolean isJava16OrLower() {
-        return IS_JAVA_16_OR_OLDER;
+        return isJava16OrOlder;
     }
 
     public static boolean isJava17OrHigher() {
-        return IS_JAVA_17_OR_NEWER;
+        return isJava17OrNewer;
     }
 
     public static boolean isJava19OrHigher() {
-        return IS_JAVA_19_OR_NEWER;
+        return isJava19OrNewer;
     }
 
     public static boolean isJava21OrHigher() {
-        return IS_JAVA_21_OR_NEWER;
+        return isJava21OrNewer;
     }
 
     public static boolean isGraalvmJdk() {
-        return IS_GRAALVM_JDK;
+        return isGraalvmJdk;
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/StepTiming.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/StepTiming.java
@@ -15,7 +15,7 @@ public class StepTiming {
     private static long stepTimingStart;
 
     public static void configureEnabled() {
-        stepTimingEnabled = System.getProperty(PRINT_STARTUP_TIMES, "false").equalsIgnoreCase("true");
+        stepTimingEnabled = "true".equalsIgnoreCase(System.getProperty(PRINT_STARTUP_TIMES, "false"));
     }
 
     public static void configureStart() {

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/StringUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/StringUtil.java
@@ -28,7 +28,7 @@ public final class StringUtil {
     }
 
     public static Iterator<String> camelHumpsIterator(String str) {
-        return new Iterator<String>() {
+        return new Iterator<>() {
             int idx;
 
             public boolean hasNext() {
@@ -36,8 +36,9 @@ public final class StringUtil {
             }
 
             public String next() {
-                if (idx == str.length())
+                if (idx == str.length()) {
                     throw new NoSuchElementException();
+                }
                 // known mixed-case rule-breakers
                 if (str.startsWith("JBoss", idx)) {
                     idx += 5;
@@ -102,7 +103,7 @@ public final class StringUtil {
     }
 
     public static Iterator<String> lowerCase(Iterator<String> orig) {
-        return new Iterator<String>() {
+        return new Iterator<>() {
             public boolean hasNext() {
                 return orig.hasNext();
             }
@@ -144,7 +145,7 @@ public final class StringUtil {
     }
 
     public static Iterator<String> lowerCaseFirst(Iterator<String> orig) {
-        return new Iterator<String>() {
+        return new Iterator<>() {
             boolean first = true;
 
             public boolean hasNext() {
@@ -164,13 +165,14 @@ public final class StringUtil {
     }
 
     public static Iterator<String> withoutSuffix(Iterator<String> orig, String... suffixes) {
-        return new Iterator<String>() {
+        return new Iterator<>() {
             String next = null;
 
             public boolean hasNext() {
                 if (next == null) {
-                    if (!orig.hasNext())
+                    if (!orig.hasNext()) {
                         return false;
+                    }
                     final String next = orig.next();
                     if (!orig.hasNext() && arrayContains(next, suffixes)) {
                         return false;
@@ -181,8 +183,9 @@ public final class StringUtil {
             }
 
             public String next() {
-                if (!hasNext())
+                if (!hasNext()) {
                     throw new NoSuchElementException();
+                }
                 final String next = this.next;
                 this.next = null;
                 return next;
@@ -221,8 +224,9 @@ public final class StringUtil {
     @SafeVarargs
     private static <T> boolean arrayContains(final T item, final T... array) {
         for (T arrayItem : array) {
-            if (Objects.equals(arrayItem, item))
+            if (Objects.equals(arrayItem, item)) {
                 return true;
+            }
         }
         return false;
     }

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/MemorySizeConverterTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/MemorySizeConverterTestCase.java
@@ -23,14 +23,14 @@ public class MemorySizeConverterTestCase {
 
     @Test
     public void testValueHasNoSuffixShouldBeConvertedToBytes() {
-        long expectedMemorySize = 100l;
+        long expectedMemorySize = 100L;
         MemorySize memorySize = memorySizeConverter.convert("100");
         assertEquals(expectedMemorySize, memorySize.asLongValue());
     }
 
     @Test
     public void testValueIsInBytes() {
-        long expectedMemorySize = 100l;
+        long expectedMemorySize = 100L;
         MemorySize memorySize = memorySizeConverter.convert("100B");
         assertEquals(expectedMemorySize, memorySize.asLongValue());
         memorySize = memorySizeConverter.convert("100b");

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/NameIteratorTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/NameIteratorTestCase.java
@@ -50,8 +50,9 @@ public class NameIteratorTestCase {
 
     private static String join(String[] str) {
         final int length = str.length;
-        if (length == 0)
+        if (length == 0) {
             return "";
+        }
         StringBuilder b = new StringBuilder(40);
         b.append(str[0]);
         int i = 1;

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/UUIDPropertyTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/UUIDPropertyTest.java
@@ -16,8 +16,7 @@ public class UUIDPropertyTest {
     private SmallRyeConfig buildConfig() {
         final SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
         builder.withDefaultValue(ConfigUtils.UUID_KEY, UUID.randomUUID().toString());
-        final SmallRyeConfig config = builder.build();
-        return config;
+        return builder.build();
     }
 
     @Test


### PR DESCRIPTION
### Resolve common static analysis issues (also known as SAST issues).

https://docs.openrewrite.org/recipes/staticanalysis/commonstaticanalysis

run:
```
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-static-analysis:RELEASE -Drewrite.activeRecipes=org.openrewrite.staticanalysis.CommonStaticAnalysis -Drewrite.exportDatatables=true
```
Estimate time saved: 2h 17m
```
[INFO] --- rewrite:5.47.3:run (default-cli) @ quarkus-core ---
[INFO] Using active recipe(s) [org.openrewrite.staticanalysis.CommonStaticAnalysis]
[INFO] Using active styles(s) []
Downloading from central: https://repo.maven.apache.org/maven2/org/openrewrite/recipe/rewrite-static-analysis/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/openrewrite/recipe/rewrite-static-analysis/maven-metadata.xml (1.7 kB at 3.5 kB/s)
[INFO] Validating active recipes...
[WARNING] This Gauge has been already registered (MeterId{name='cache.size', tags=[tag(cache=Maven POMs - default)]}), the Gauge registration will be ignored. Note that subsequent logs will be logged at debug level.
[INFO] Project [Quarkus - Core - Runtime] Resolving Poms...
[INFO] Project [Quarkus - Core - Runtime] Parsing source files
[INFO] Running recipe(s)...
[INFO] Printing available datatables to: target/rewrite/datatables/2025-01-06_18-13-57-113
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/TemplateHtmlBuilder.java by:
[WARNING]     org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
[WARNING]         org.openrewrite.staticanalysis.EqualsAvoidsNull
[WARNING]             org.openrewrite.staticanalysis.ExplicitInitialization
[WARNING]                 org.openrewrite.staticanalysis.RenamePrivateFieldsToCamelCase
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/metrics/MetricsFactory.java by:
[WARNING]     org.openrewrite.staticanalysis.NestedEnumsAreNotStatic
[WARNING]         org.openrewrite.staticanalysis.RemoveExtraSemicolons
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/MemorySize.java by:
[WARNING]     org.openrewrite.staticanalysis.NeedBraces
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/NameIterator.java by:
[WARNING]     org.openrewrite.staticanalysis.NeedBraces
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java by:
[WARNING]     org.openrewrite.staticanalysis.ExplicitInitialization
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java by:
[WARNING]     org.openrewrite.staticanalysis.EqualsAvoidsNull
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/HyphenateEnumConverter.java by:
[WARNING]     org.openrewrite.staticanalysis.UseDiamondOperator
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java by:
[WARNING]     org.openrewrite.staticanalysis.EqualsAvoidsNull
[WARNING]         org.openrewrite.staticanalysis.FinalizePrivateFields
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/PropertiesUtil.java by:
[WARNING]     org.openrewrite.staticanalysis.FinalClass
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/ConverterClassHolder.java by:
[WARNING]     org.openrewrite.staticanalysis.NeedBraces
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/ConverterSupport.java by:
[WARNING]     org.openrewrite.staticanalysis.FinalClass
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/configuration/DisableableConfigSource.java by:
[WARNING]     org.openrewrite.staticanalysis.FinalizePrivateFields
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/types/WildcardTypeImpl.java by:
[WARNING]     org.openrewrite.staticanalysis.FinalClass
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/types/GenericArrayTypeImpl.java by:
[WARNING]     org.openrewrite.staticanalysis.UnnecessaryParentheses
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/Application.java by:
[WARNING]     org.openrewrite.staticanalysis.NeedBraces
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/PreloadClassesRecorder.java by:
[WARNING]     org.openrewrite.staticanalysis.NeedBraces
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java by:
[WARNING]     org.openrewrite.staticanalysis.RenamePrivateFieldsToCamelCase
[WARNING]         org.openrewrite.staticanalysis.UnnecessaryParentheses
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/util/StringUtil.java by:
[WARNING]     org.openrewrite.staticanalysis.NeedBraces
[WARNING]         org.openrewrite.staticanalysis.UseDiamondOperator
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/util/ClassPathUtils.java by:
[WARNING]     org.openrewrite.staticanalysis.EqualsAvoidsNull
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/util/EnumerationUtil.java by:
[WARNING]     org.openrewrite.staticanalysis.UseDiamondOperator
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/util/StepTiming.java by:
[WARNING]     org.openrewrite.staticanalysis.EqualsAvoidsNull
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java by:
[WARNING]     org.openrewrite.staticanalysis.FinalClass
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/ShutdownEvent.java by:
[WARNING]     org.openrewrite.staticanalysis.RemoveExtraSemicolons
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/SnapStartRecorder.java by:
[WARNING]     org.openrewrite.staticanalysis.ExplicitInitialization
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java by:
[WARNING]     org.openrewrite.staticanalysis.EqualsAvoidsNull
[WARNING]         org.openrewrite.staticanalysis.NeedBraces
[WARNING]             org.openrewrite.staticanalysis.RenamePrivateFieldsToCamelCase
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/logging/LogMetricsHandlerRecorder.java by:
[WARNING]     org.openrewrite.staticanalysis.UseDiamondOperator
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevel.java by:
[WARNING]     org.openrewrite.staticanalysis.EqualsAvoidsNull
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java by:
[WARNING]     org.openrewrite.staticanalysis.EqualsAvoidsNull
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java by:
[WARNING]     org.openrewrite.staticanalysis.NeedBraces
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/graal/AwtImageIO.java by:
[WARNING]     org.openrewrite.staticanalysis.MethodNameCasing
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java by:
[WARNING]     org.openrewrite.staticanalysis.RemoveExtraSemicolons
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/runtime/graal/TimingReplacement.java by:
[WARNING]     org.openrewrite.staticanalysis.ExplicitInitialization
[WARNING] Changes have been made to core/runtime/src/main/java/io/quarkus/logging/Log.java by:
[WARNING]     org.openrewrite.staticanalysis.NeedBraces
[WARNING] Changes have been made to core/runtime/src/test/java/io/quarkus/runtime/configuration/NameIteratorTestCase.java by:
[WARNING]     org.openrewrite.staticanalysis.NeedBraces
[WARNING] Changes have been made to core/runtime/src/test/java/io/quarkus/runtime/configuration/MemorySizeConverterTestCase.java by:
[WARNING]     org.openrewrite.staticanalysis.UpperCaseLiteralSuffixes
[WARNING] Changes have been made to core/runtime/src/test/java/io/quarkus/runtime/configuration/UUIDPropertyTest.java by:
[WARNING]     org.openrewrite.staticanalysis.InlineVariable
[WARNING] Please review and commit the results.
[WARNING] Estimate time saved: 2h 17m
```