### PR TITLE
Ping Mandrel team in native-related issues/PRs

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -407,8 +407,9 @@ triage:
         - integration-tests/google-cloud-functions
     - id: native-image
       labels: [area/native-image]
-      title: "\\bnative\\b"
-      notify: [zakkak]
+      body: "Mandrel or GraalVM version"
+      notify: [zakkak, Karm, galderz]
+      notifyInPullRequest: true
     - id: awt
       labels: [area/graphics]
       expression: |


### PR DESCRIPTION
Follow up to https://github.com/quarkusio/quarkus/pull/45361

Matches
https://github.com/quarkusio/quarkus/blob/main/.github/ISSUE_TEMPLATE/bug_report_native.yml
body about Mandrel or GraalVM being used.

@Karm @galderz please remove yourselves if you don't want to get pinged.