### PR TITLE
Bump smallrye-open-api.version from 4.0.5 to 4.0.6

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-config.version>3.10.2</smallrye-config.version>
         <smallrye-health.version>4.1.1</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>4.0.5</smallrye-open-api.version>
+        <smallrye-open-api.version>4.0.6</smallrye-open-api.version>
         <smallrye-graphql.version>2.12.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.7.2</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.1</smallrye-jwt.version>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/44773
Fixes https://github.com/quarkusio/quarkus/issues/45150
Required for https://github.com/quarkusio/quarkus/issues/45266