### PR TITLE
Override defaults from build time that also apply to runtime

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -474,10 +474,10 @@ public final class BuildTimeConfigurationReader {
         final ConfigTrackingInterceptor buildConfigTracker;
         final Set<String> processedNames = new HashSet<>();
         final Map<Class<?>, Object> objectsByClass = new HashMap<>();
-        final Map<String, String> allBuildTimeValues = new TreeMap<>();
-        final Map<String, String> buildTimeRunTimeValues = new TreeMap<>();
-        final Map<String, String> runTimeDefaultValues = new TreeMap<>();
-        final Map<String, String> runTimeValues = new TreeMap<>();
+        final Map<String, ConfigValue> allBuildTimeValues = new TreeMap<>();
+        final Map<String, ConfigValue> buildTimeRunTimeValues = new TreeMap<>();
+        final Map<String, ConfigValue> runTimeDefaultValues = new TreeMap<>();
+        final Map<String, ConfigValue> runTimeValues = new TreeMap<>();
 
         final Map<ConverterType, Converter<?>> convByType = new HashMap<>();
 
@@ -538,7 +538,7 @@ public final class BuildTimeConfigurationReader {
                     if (matched instanceof FieldContainer) {
                         ConfigValue configValue = config.getConfigValue(propertyName);
                         if (configValue.getValue() != null) {
-                            allBuildTimeValues.put(configValue.getNameProfiled(), configValue.getValue());
+                            allBuildTimeValues.put(configValue.getNameProfiled(), configValue);
                             ni.goToEnd();
                             // cursor is located after group property key (if any)
                             getGroup((FieldContainer) matched, ni);
@@ -557,7 +557,7 @@ public final class BuildTimeConfigurationReader {
                             Field field = matched.findField();
                             Converter<?> converter = getConverter(config, field, ConverterType.of(field));
                             map.put(key, config.convertValue(configValue, converter));
-                            allBuildTimeValues.put(configValue.getNameProfiled(), configValue.getValue());
+                            allBuildTimeValues.put(configValue.getNameProfiled(), configValue);
                         }
                     }
                     // build time (run time visible) patterns
@@ -570,8 +570,8 @@ public final class BuildTimeConfigurationReader {
                             ni.goToEnd();
                             // cursor is located after group property key (if any)
                             getGroup((FieldContainer) matched, ni);
-                            allBuildTimeValues.put(configValue.getNameProfiled(), configValue.getValue());
-                            buildTimeRunTimeValues.put(configValue.getNameProfiled(), configValue.getValue());
+                            allBuildTimeValues.put(configValue.getNameProfiled(), configValue);
+                            buildTimeRunTimeValues.put(configValue.getNameProfiled(), configValue);
                         }
                     } else if (matched != null) {
                         assert matched instanceof MapContainer;
@@ -587,8 +587,8 @@ public final class BuildTimeConfigurationReader {
                             Converter<?> converter = getConverter(config, field, ConverterType.of(field));
                             map.put(key, config.convertValue(configValue, converter));
                             // cache the resolved value
-                            allBuildTimeValues.put(configValue.getNameProfiled(), configValue.getValue());
-                            buildTimeRunTimeValues.put(configValue.getNameProfiled(), configValue.getValue());
+                            allBuildTimeValues.put(configValue.getNameProfiled(), configValue);
+                            buildTimeRunTimeValues.put(configValue.getNameProfiled(), configValue);
                         }
                     }
                     // run time patterns
@@ -599,7 +599,7 @@ public final class BuildTimeConfigurationReader {
                         // it's a run-time default (record for later)
                         ConfigValue configValue = withoutExpansion(() -> runtimeConfig.getConfigValue(propertyName));
                         if (configValue.getValue() != null) {
-                            runTimeValues.put(configValue.getNameProfiled(), configValue.getValue());
+                            runTimeValues.put(configValue.getNameProfiled(), configValue);
                         }
                     }
 
@@ -610,7 +610,7 @@ public final class BuildTimeConfigurationReader {
                     // it's not managed by us; record it
                     ConfigValue configValue = withoutExpansion(() -> runtimeConfig.getConfigValue(propertyName));
                     if (configValue.getValue() != null) {
-                        runTimeValues.put(propertyName, configValue.getValue());
+                        runTimeValues.put(propertyName, configValue);
                     }
 
                     // in the case the user defined compound keys in YAML (or similar config source, that quotes the name)
@@ -638,22 +638,22 @@ public final class BuildTimeConfigurationReader {
                     unknownBuildProperties.remove(property);
                     ConfigValue value = config.getConfigValue(property);
                     if (value.getRawValue() != null) {
-                        allBuildTimeValues.put(value.getNameProfiled(), value.getRawValue());
+                        allBuildTimeValues.put(value.getNameProfiled(), value);
                     }
                 }
                 if (buildTimeRunTimeNames.contains(name)) {
                     unknownBuildProperties.remove(property);
                     ConfigValue value = config.getConfigValue(property);
                     if (value.getRawValue() != null) {
-                        allBuildTimeValues.put(value.getNameProfiled(), value.getRawValue());
-                        buildTimeRunTimeValues.put(value.getNameProfiled(), value.getRawValue());
+                        allBuildTimeValues.put(value.getNameProfiled(), value);
+                        buildTimeRunTimeValues.put(value.getNameProfiled(), value);
                     }
                 }
                 if (runTimeNames.contains(name)) {
                     unknownBuildProperties.remove(property);
                     ConfigValue value = runtimeConfig.getConfigValue(property);
                     if (value.getRawValue() != null) {
-                        runTimeValues.put(value.getNameProfiled(), value.getRawValue());
+                        runTimeValues.put(value.getNameProfiled(), value);
                     }
                 }
             }
@@ -1168,7 +1168,7 @@ public final class BuildTimeConfigurationReader {
             return builder.build();
         }
 
-        private Map<String, String> filterActiveProfileProperties(final Map<String, String> properties) {
+        private Map<String, ConfigValue> filterActiveProfileProperties(final Map<String, ConfigValue> properties) {
             Set<String> propertiesToRemove = new HashSet<>();
             for (String property : properties.keySet()) {
                 for (String profile : config.getProfiles()) {
@@ -1182,16 +1182,16 @@ public final class BuildTimeConfigurationReader {
             return properties;
         }
 
-        private static Map<String, String> getDefaults(final SmallRyeConfig config,
+        private static Map<String, ConfigValue> getDefaults(final SmallRyeConfig config,
                 final ConfigPatternMap<Container> patternMap) {
-            Map<String, String> defaultValues = new TreeMap<>();
+            Map<String, ConfigValue> defaultValues = new TreeMap<>();
             getDefaults(config, defaultValues, new StringBuilder(), patternMap);
             return defaultValues;
         }
 
         private static void getDefaults(
                 final SmallRyeConfig config,
-                final Map<String, String> defaultValues,
+                final Map<String, ConfigValue> defaultValues,
                 final StringBuilder propertyName,
                 final ConfigPatternMap<Container> patternMap) {
 
@@ -1204,10 +1204,17 @@ public final class BuildTimeConfigurationReader {
                 if (defaultValue != null) {
                     // lookup config to make sure we catch relocates or fallbacks and override the value
                     ConfigValue configValue = config.getConfigValue(propertyName.toString());
-                    if (configValue.getValue() != null && !configValue.getName().equals(propertyName.toString())) {
-                        defaultValues.put(propertyName.toString(), configValue.getValue());
+                    if (configValue.getValue() != null && !configValue.getName().contentEquals(propertyName)) {
+                        defaultValues.put(propertyName.toString(), configValue);
                     } else {
-                        defaultValues.put(propertyName.toString(), defaultValue);
+                        defaultValues.put(propertyName.toString(),
+                                ConfigValue.builder()
+                                        .withName(propertyName.toString())
+                                        .withValue(defaultValue)
+                                        .withRawValue(defaultValue)
+                                        .withConfigSourceName("DefaultValuesConfigSource")
+                                        .withConfigSourceOrdinal(Integer.MIN_VALUE)
+                                        .build());
                     }
                 }
             }
@@ -1250,10 +1257,10 @@ public final class BuildTimeConfigurationReader {
     public static final class ReadResult {
         final Map<Class<?>, Object> objectsByClass;
 
-        final Map<String, String> allBuildTimeValues;
-        final Map<String, String> buildTimeRunTimeValues;
-        final Map<String, String> runTimeDefaultValues;
-        final Map<String, String> runTimeValues;
+        final Map<String, ConfigValue> allBuildTimeValues;
+        final Map<String, ConfigValue> buildTimeRunTimeValues;
+        final Map<String, ConfigValue> runTimeDefaultValues;
+        final Map<String, ConfigValue> runTimeValues;
 
         final ConfigPatternMap<Container> buildTimePatternMap;
         final ConfigPatternMap<Container> buildTimeRunTimePatternMap;
@@ -1327,19 +1334,19 @@ public final class BuildTimeConfigurationReader {
             return objectsByClass;
         }
 
-        public Map<String, String> getAllBuildTimeValues() {
+        public Map<String, ConfigValue> getAllBuildTimeValues() {
             return allBuildTimeValues;
         }
 
-        public Map<String, String> getBuildTimeRunTimeValues() {
+        public Map<String, ConfigValue> getBuildTimeRunTimeValues() {
             return buildTimeRunTimeValues;
         }
 
-        public Map<String, String> getRunTimeDefaultValues() {
+        public Map<String, ConfigValue> getRunTimeDefaultValues() {
             return runTimeDefaultValues;
         }
 
-        public Map<String, String> getRunTimeValues() {
+        public Map<String, ConfigValue> getRunTimeValues() {
             return runTimeValues;
         }
 
@@ -1409,10 +1416,10 @@ public final class BuildTimeConfigurationReader {
 
         static class Builder {
             private Map<Class<?>, Object> objectsByClass;
-            private Map<String, String> allBuildTimeValues;
-            private Map<String, String> buildTimeRunTimeValues;
-            private Map<String, String> runTimeDefaultValues;
-            private Map<String, String> runtimeValues;
+            private Map<String, ConfigValue> allBuildTimeValues;
+            private Map<String, ConfigValue> buildTimeRunTimeValues;
+            private Map<String, ConfigValue> runTimeDefaultValues;
+            private Map<String, ConfigValue> runtimeValues;
             private ConfigPatternMap<Container> buildTimePatternMap;
             private ConfigPatternMap<Container> buildTimeRunTimePatternMap;
             private ConfigPatternMap<Container> runTimePatternMap;
@@ -1433,38 +1440,38 @@ public final class BuildTimeConfigurationReader {
                 return this;
             }
 
-            Map<String, String> getAllBuildTimeValues() {
+            Map<String, ConfigValue> getAllBuildTimeValues() {
                 return allBuildTimeValues;
             }
 
-            Builder setAllBuildTimeValues(final Map<String, String> allBuildTimeValues) {
+            Builder setAllBuildTimeValues(final Map<String, ConfigValue> allBuildTimeValues) {
                 this.allBuildTimeValues = allBuildTimeValues;
                 return this;
             }
 
-            Map<String, String> getBuildTimeRunTimeValues() {
+            Map<String, ConfigValue> getBuildTimeRunTimeValues() {
                 return buildTimeRunTimeValues;
             }
 
-            Builder setBuildTimeRunTimeValues(final Map<String, String> buildTimeRunTimeValues) {
+            Builder setBuildTimeRunTimeValues(final Map<String, ConfigValue> buildTimeRunTimeValues) {
                 this.buildTimeRunTimeValues = buildTimeRunTimeValues;
                 return this;
             }
 
-            Map<String, String> getRunTimeDefaultValues() {
+            Map<String, ConfigValue> getRunTimeDefaultValues() {
                 return runTimeDefaultValues;
             }
 
-            Builder setRunTimeDefaultValues(final Map<String, String> runTimeDefaultValues) {
+            Builder setRunTimeDefaultValues(final Map<String, ConfigValue> runTimeDefaultValues) {
                 this.runTimeDefaultValues = runTimeDefaultValues;
                 return this;
             }
 
-            Map<String, String> getRuntimeValues() {
+            Map<String, ConfigValue> getRuntimeValues() {
                 return runtimeValues;
             }
 
-            Builder setRuntimeValues(final Map<String, String> runtimeValues) {
+            Builder setRuntimeValues(final Map<String, ConfigValue> runtimeValues) {
                 this.runtimeValues = runtimeValues;
                 return this;
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -224,10 +224,6 @@ public final class RunTimeConfigurationGenerator {
         final ResultHandle clinitNameBuilder;
         final BuildTimeConfigurationReader.ReadResult buildTimeConfigResult;
         final List<RootDefinition> roots;
-        final Map<String, String> allBuildTimeValues;
-        // default values given in the build configuration
-        final Map<String, String> runTimeDefaultValues;
-        final Map<String, String> buildTimeRunTimeValues;
         final Map<Container, MethodDescriptor> enclosingMemberMethods = new HashMap<>();
         final Map<Class<?>, MethodDescriptor> groupInitMethods = new HashMap<>();
         final Map<Class<?>, FieldDescriptor> configRootsByType = new HashMap<>();
@@ -256,11 +252,6 @@ public final class RunTimeConfigurationGenerator {
             this.liveReloadPossible = builder.liveReloadPossible;
             final BuildTimeConfigurationReader.ReadResult buildTimeReadResult = builder.buildTimeReadResult;
             buildTimeConfigResult = Assert.checkNotNullParam("buildTimeReadResult", buildTimeReadResult);
-            allBuildTimeValues = Assert.checkNotNullParam("allBuildTimeValues", buildTimeReadResult.getAllBuildTimeValues());
-            runTimeDefaultValues = Assert.checkNotNullParam("runTimeDefaultValues",
-                    buildTimeReadResult.getRunTimeDefaultValues());
-            buildTimeRunTimeValues = Assert.checkNotNullParam("buildTimeRunTimeValues",
-                    buildTimeReadResult.getBuildTimeRunTimeValues());
             classOutput = Assert.checkNotNullParam("classOutput", builder.getClassOutput());
             roots = Assert.checkNotNullParam("builder.roots", builder.getBuildTimeReadResult().getAllRoots());
             additionalTypes = Assert.checkNotNullParam("additionalTypes", builder.getAdditionalTypes());

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/tracker/ConfigTrackingWriter.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/tracker/ConfigTrackingWriter.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 import io.quarkus.bootstrap.util.PropertyUtils;
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
 import io.quarkus.runtime.LaunchMode;
+import io.smallrye.config.ConfigValue;
 
 public class ConfigTrackingWriter {
 
@@ -77,8 +78,8 @@ public class ConfigTrackingWriter {
         final List<Pattern> excludePatterns = config.getExcludePatterns();
         final ConfigTrackingValueTransformer valueTransformer = ConfigTrackingValueTransformer.newInstance(config);
 
-        final Map<String, String> allBuildTimeValues = configReadResult.getAllBuildTimeValues();
-        final Map<String, String> buildTimeRuntimeValues = configReadResult.getBuildTimeRunTimeValues();
+        final Map<String, ConfigValue> allBuildTimeValues = configReadResult.getAllBuildTimeValues();
+        final Map<String, ConfigValue> buildTimeRuntimeValues = configReadResult.getBuildTimeRunTimeValues();
         try (BufferedWriter writer = Files.newBufferedWriter(file)) {
             final List<String> names = new ArrayList<>(readOptions.size());
             for (var name : readOptions.keySet()) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
@@ -11,12 +11,12 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SmallRyeConfig;
 
 @Recorder

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
@@ -15,6 +15,7 @@ import io.quarkus.oidc.runtime.devui.OidcDevUiRpcSvcPropertiesBean;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.smallrye.config.ConfigValue;
 
 public abstract class AbstractDevUIProcessor {
     protected static final String CONFIG_PREFIX = "quarkus.oidc.";
@@ -88,27 +89,27 @@ public abstract class AbstractDevUIProcessor {
         // but I wanted to make this bit more robust till we have DEV UI tests
         // that will fail when this get changed in the future, then we can optimize this
 
-        String propertyValue = configurationBuildItem
+        ConfigValue configValue = configurationBuildItem
                 .getReadResult()
                 .getAllBuildTimeValues()
                 .get(propertyKey);
 
-        if (propertyValue == null) {
-            propertyValue = configurationBuildItem
+        if (configValue == null || configValue.getValue() == null) {
+            configValue = configurationBuildItem
                     .getReadResult()
                     .getBuildTimeRunTimeValues()
                     .get(propertyKey);
         } else {
-            return propertyValue;
+            return configValue.getValue();
         }
 
-        if (propertyValue == null) {
-            propertyValue = configurationBuildItem
+        if (configValue == null || configValue.getValue() == null) {
+            configValue = configurationBuildItem
                     .getReadResult()
                     .getRunTimeDefaultValues()
                     .get(propertyKey);
         }
 
-        return propertyValue;
+        return configValue != null ? configValue.getValue() : null;
     }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/EndpointsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/EndpointsProcessor.java
@@ -10,6 +10,7 @@ import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.runtime.devmode.ResourceNotFoundData;
+import io.smallrye.config.ConfigValue;
 
 /**
  * This creates Endpoints Page
@@ -62,27 +63,27 @@ public class EndpointsProcessor {
     private static String getProperty(ConfigurationBuildItem configurationBuildItem,
             String propertyKey) {
 
-        String propertyValue = configurationBuildItem
+        ConfigValue configValue = configurationBuildItem
                 .getReadResult()
                 .getAllBuildTimeValues()
                 .get(propertyKey);
 
-        if (propertyValue == null) {
-            propertyValue = configurationBuildItem
+        if (configValue == null || configValue.getValue() == null) {
+            configValue = configurationBuildItem
                     .getReadResult()
                     .getBuildTimeRunTimeValues()
                     .get(propertyKey);
         } else {
-            return propertyValue;
+            return configValue.getValue();
         }
 
-        if (propertyValue == null) {
-            propertyValue = configurationBuildItem
+        if (configValue == null || configValue.getValue() == null) {
+            configValue = configurationBuildItem
                     .getReadResult()
                     .getRunTimeDefaultValues()
                     .get(propertyKey);
         }
 
-        return propertyValue;
+        return configValue != null ? configValue.getValue() : null;
     }
 }

--- a/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -17,6 +17,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -72,6 +73,7 @@ import io.quarkus.extest.runtime.subst.DSAPublicKeyObjectSubstitution;
 import io.quarkus.extest.runtime.subst.KeyProxy;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.undertow.deployment.ServletBuildItem;
+import io.smallrye.config.ConfigValue;
 
 /**
  * A test extension deployment processor
@@ -337,8 +339,14 @@ public final class TestProcessor {
             ConfigurationBuildItem configItem,
             TestMappingBuildTime testMappingBuildTime,
             TestMappingBuildTimeRunTime testMappingBuildTimeRunTime) {
-        Map<String, String> buildTimeValues = configItem.getReadResult().getAllBuildTimeValues();
-        Map<String, String> buildTimeRunTimeValues = configItem.getReadResult().getBuildTimeRunTimeValues();
+        Map<String, String> buildTimeValues = new HashMap<>();
+        for (Map.Entry<String, ConfigValue> entry : configItem.getReadResult().getAllBuildTimeValues().entrySet()) {
+            buildTimeValues.put(entry.getKey(), entry.getValue().getValue());
+        }
+        Map<String, String> buildTimeRunTimeValues = new HashMap<>();
+        for (Map.Entry<String, ConfigValue> entry : configItem.getReadResult().getBuildTimeRunTimeValues().entrySet()) {
+            buildTimeRunTimeValues.put(entry.getKey(), entry.getValue().getValue());
+        }
 
         if (!testMappingBuildTime.value().equals("value")
                 || !buildTimeValues.getOrDefault("quarkus.mapping.bt.value", "").equals("value")) {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildDefaultInRuntimeTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildDefaultInRuntimeTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.extest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OverrideBuildDefaultInRuntimeTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .addBuildChainCustomizer(b -> {
+                b.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        context.produce(new RunTimeConfigurationDefaultBuildItem("quarkus.log.console.enable", "false"));
+                    }
+                }).produces(RunTimeConfigurationDefaultBuildItem.class).build();
+            });
+
+    @Test
+    public void testConsoleLogging() {
+        assertFalse(ConfigProvider.getConfig().getValue("quarkus.log.console.enable", boolean.class));
+    }
+}


### PR DESCRIPTION
When a default value can be set for both build time and runtime (for instance, logging), the build time default takes priority over `RunTimeConfigurationDefaultBuildItem`. The build item should have priority in this case.

Related conversation:
https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/RunTimeConfigurationDefaultBuildItem.20VS.20.40WithDefault