### PR TITLE
Change Keycloak admin login ENV variables

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -298,8 +298,8 @@ To start a Keycloak server, use the following Docker command:
 [source,bash,subs=attributes+]
 ----
 docker run --name keycloak \
-  -e KEYCLOAK_ADMIN=admin \
-  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+  -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
   -p 8543:8443 \
   -v "$(pwd)"/config/keycloak-keystore.jks:/etc/keycloak-keystore.jks \
   quay.io/keycloak/keycloak:{keycloak.version} \ <1>

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -214,7 +214,7 @@ For more information, see the <<bearer-token-tutorial-keycloak-dev-mode>> sectio
 ====
 [source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
+docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 ====
 * Where the `keycloak.version` is set to version `26.0.7` or later.

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -198,7 +198,7 @@ To start a Keycloak server, use Docker and run the following command:
 
 [source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
+docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
 where `keycloak.version` is set to `26.0.7` or later.

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -502,7 +502,7 @@ To start a Keycloak Server, you can use Docker and just run the following comman
 
 [source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
+docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
 Set `{keycloak.version}` to `26.0.7` or later.

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -343,7 +343,7 @@ To start a Keycloak server, you can use Docker and run the following command:
 
 [source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
+docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
 where `keycloak.version` is set to `26.0.7` or higher.

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -109,8 +109,8 @@ public class KeycloakDevServicesProcessor {
 
     // Properties recognized by Quarkus-powered Keycloak
     private static final String KEYCLOAK_QUARKUS_HOSTNAME = "KC_HOSTNAME";
-    private static final String KEYCLOAK_QUARKUS_ADMIN_PROP = "KEYCLOAK_ADMIN";
-    private static final String KEYCLOAK_QUARKUS_ADMIN_PASSWORD_PROP = "KEYCLOAK_ADMIN_PASSWORD";
+    private static final String KEYCLOAK_QUARKUS_ADMIN_PROP = "KC_BOOTSTRAP_ADMIN_USERNAME";
+    private static final String KEYCLOAK_QUARKUS_ADMIN_PASSWORD_PROP = "KC_BOOTSTRAP_ADMIN_PASSWORD";
     private static final String KEYCLOAK_QUARKUS_START_CMD = "start --http-enabled=true --hostname-strict=false "
             + "--spi-user-profile-declarative-user-profile-config-file=/opt/keycloak/upconfig.json";
 

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakContainer.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakContainer.java
@@ -37,8 +37,8 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
         withExposedPorts(8080, 8443);
         // Keycloak env vars
         withEnv("KC_HTTP_ENABLED", "true");
-        withEnv("KEYCLOAK_ADMIN", "admin");
-        withEnv("KEYCLOAK_ADMIN_PASSWORD", "admin");
+        withEnv("KC_BOOTSTRAP_ADMIN_USERNAME", "admin");
+        withEnv("KC_BOOTSTRAP_ADMIN_PASSWORD", "admin");
         withEnv("KC_HOSTNAME_STRICT", "false");
         withEnv("KC_HOSTNAME_STRICT_HTTPS", "false");
         withEnv("KC_STORAGE", "chm");


### PR DESCRIPTION
The `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD` were depracated with Keycloak 26. I spot this message when looking at container log. 

**Don't know if we want to move now** as the new ENV variables are not available at older version of Keycloak.

The change happend in https://github.com/keycloak/keycloak/pull/31114 and it's documented [here](https://github.com/keycloak/keycloak/blob/release/26.0/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc#admin-bootstrapping-and-recovery) (Somehow this one paragraph miss the release notes so I miss it when bumping the Keycloak version)