### PR TITLE
Produce `quarkus.uuid` lazily

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -332,7 +332,6 @@ public class ConfigGenerationBuildStep {
     public void suppressNonRuntimeConfigChanged(
             BuildProducer<SuppressNonRuntimeConfigChangedWarningBuildItem> suppressNonRuntimeConfigChanged) {
         suppressNonRuntimeConfigChanged.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.profile"));
-        suppressNonRuntimeConfigChanged.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.uuid"));
         suppressNonRuntimeConfigChanged.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.default-locale"));
         suppressNonRuntimeConfigChanged.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.locales"));
         suppressNonRuntimeConfigChanged.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.test.arg-line"));

--- a/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
@@ -74,14 +74,6 @@ public interface ConfigConfig {
     @WithDefault("warn")
     BuildTimeMismatchAtRuntime buildTimeMismatchAtRuntime();
 
-    /**
-     * A property that allows accessing a generated UUID.
-     * It generates that UUID at startup time. So it changes between two starts including in dev mode.
-     * <br>
-     * Access this generated UUID using expressions: `${quarkus.uuid}`.
-     */
-    Optional<String> uuid();
-
     enum BuildTimeMismatchAtRuntime {
         warn,
         fail

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/RuntimeConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/RuntimeConfigBuilder.java
@@ -1,6 +1,9 @@
 package io.quarkus.runtime.configuration;
 
+import java.util.Set;
 import java.util.UUID;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
@@ -12,7 +15,7 @@ public class RuntimeConfigBuilder implements SmallRyeConfigBuilderCustomizer {
     @Override
     public void configBuilder(final SmallRyeConfigBuilder builder) {
         new QuarkusConfigBuilderCustomizer().configBuilder(builder);
-        builder.withDefaultValue("quarkus.uuid", UUID.randomUUID().toString());
+        builder.withSources(new UuiConfigSource());
 
         builder.forClassLoader(Thread.currentThread().getContextClassLoader())
                 .addDefaultInterceptors()
@@ -22,5 +25,38 @@ public class RuntimeConfigBuilder implements SmallRyeConfigBuilderCustomizer {
     @Override
     public int priority() {
         return Integer.MIN_VALUE;
+    }
+
+    private static class UuiConfigSource implements ConfigSource {
+
+        private static final String QUARKUS_UUID = "quarkus.uuid";
+
+        @Override
+        public Set<String> getPropertyNames() {
+            return Set.of(QUARKUS_UUID);
+        }
+
+        @Override
+        public String getValue(String propertyName) {
+            if (propertyName.equals(QUARKUS_UUID)) {
+                return Holder.UUID_VALUE;
+            }
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return "QuarkusUUIDConfigSource";
+        }
+
+        @Override
+        public int getOrdinal() {
+            return Integer.MIN_VALUE;
+        }
+
+        // acts as a lazy value supplier ensuring that the UUID will only be produced when requested
+        private static class Holder {
+            private static final String UUID_VALUE = UUID.randomUUID().toString();
+        }
     }
 }

--- a/integration-tests/smallrye-config/src/test/java/io/quarkus/it/smallrye/config/QuarkusConfigTest.java
+++ b/integration-tests/smallrye-config/src/test/java/io/quarkus/it/smallrye/config/QuarkusConfigTest.java
@@ -19,13 +19,13 @@ public class QuarkusConfigTest {
                 .then()
                 .statusCode(OK.getStatusCode())
                 .body("value", is(notNullValue()))
-                .body("configSourceName", equalTo("DefaultValuesConfigSource"));
+                .body("configSourceName", equalTo("QuarkusUUIDConfigSource"));
 
         given()
                 .get("/config/uuid")
                 .then()
                 .statusCode(OK.getStatusCode())
                 .body("value", is(notNullValue()))
-                .body("configSourceName", equalTo("DefaultValuesConfigSource"));
+                .body("configSourceName", equalTo("QuarkusUUIDConfigSource"));
     }
 }


### PR DESCRIPTION
This is done because bootstrapping the plumbing
needed by the JDK to produce a UUID value
is expensive, it thus doesn't make sense to
pay this cost when the property isn't actually
needed

The goal is the same as that of #33941