### PR TITLE
Use empty default values when building no-op CP instance

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-graphql.version>2.12.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.7.2</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.1</smallrye-jwt.version>
-        <smallrye-context-propagation.version>2.1.2</smallrye-context-propagation.version>
+        <smallrye-context-propagation.version>2.2.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.17.1</smallrye-mutiny-vertx-binding.version>

--- a/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
+++ b/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
@@ -23,6 +23,7 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.context.SmallRyeContextManager;
 import io.smallrye.context.SmallRyeManagedExecutor;
 import io.smallrye.context.SmallRyeThreadContext;
+import io.smallrye.context.impl.DefaultValues;
 
 /**
  * The runtime value service used to create values related to the MP-JWT services
@@ -141,6 +142,7 @@ public class SmallRyeContextPropagationRecorder {
         noContextBuilder.withThreadContextProviders(new ThreadContextProvider[0]);
         noContextBuilder.withContextManagerExtensions(new ContextManagerExtension[0]);
         noContextBuilder.withDefaultExecutorService(NOPE_EXECUTOR_SERVICE);
+        noContextBuilder.withDefaultValues(DefaultValues.empty());
         ContextManagerProvider.instance().registerContextManager(noContextBuilder.build(), null /* not used */);
     }
 


### PR DESCRIPTION
This is done in order to avoid the overhead of
looking up properties that won't be used anyway

~~Requires: https://github.com/smallrye/smallrye-context-propagation/pull/477~~