### PR TITLE
OpenTelemetry: fix the Redis instrumenter in case of a tainted connection

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/RedisClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/RedisClientInstrumenterVertxTracer.java
@@ -124,8 +124,9 @@ public class RedisClientInstrumenterVertxTracer implements
             return attributes.get(PEER_ADDRESS);
         }
 
-        public long dbIndex() {
-            return Long.parseLong(attributes.get(DB_INSTANCE));
+        public Long dbIndex() {
+            String dbInstance = attributes.get(DB_INSTANCE);
+            return dbInstance != null ? Long.valueOf(dbInstance) : null;
         }
     }
 

--- a/integration-tests/opentelemetry-redis-instrumentation/src/main/java/io/quarkus/io/opentelemetry/RedisResource.java
+++ b/integration-tests/opentelemetry-redis-instrumentation/src/main/java/io/quarkus/io/opentelemetry/RedisResource.java
@@ -68,4 +68,14 @@ public class RedisResource {
                 .replaceWithVoid();
     }
 
+    // tainted
+    @GET
+    @Path("/tainted")
+    public String getTainted() {
+        ds.withConnection(conn -> {
+            conn.select(7); // taints the connection
+            conn.value(String.class).get("foobar");
+        });
+        return "OK";
+    }
 }


### PR DESCRIPTION
The Vert.x Redis client does not always report the database instance number, because sometimes, it simply isn't known. Specifically, that occurs when the connection is tainted; for example, when a custom database is selected using the `SELECT` command.

In this case, the trace simply will not include the dabatase instance number.

Fixes #45167