### PR TITLE
Remove references to removed WithOpenShiftTestServer functionality

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -474,41 +474,35 @@ public class OpenShiftClientProducer {
 }
 ----
 
-Mock support is also provided in a similar fashion:
+Mock support is also provided in a similar fashion by using the `@WithKubernetesTestServer` explained in the previous section:
 
 [source, java]
 ----
-@QuarkusTestResource(OpenShiftMockServerTestResource.class)
+@WithKubernetesTestServer
 @QuarkusTest
 public class OpenShiftClientTest {
 
-    @MockServer
-    private OpenShiftMockServer mockServer;
-...
+    @KubernetesTestServer
+    KubernetesServer mockServer;
+    @Inject
+    OpenShiftClient client;
+
+    @Test
+    public void testInteractionWithAPIServer() {
+        RestAssured.when().get("/route/test").then()
+                .body("size()", is(2));
+    }
+}
 ----
 
-Or by using the `@WithOpenShiftTestServer` similar to the `@WithKubernetesTestServer` explained in the
-previous section:
-
-[source, java]
-----
-@WithOpenShiftTestServer
-@QuarkusTest
-public class OpenShiftClientTest {
-
-    @OpenShiftTestServer
-    private OpenShiftServer mockOpenShiftServer;
-...
-----
-
-To use this feature, you have to add a dependency on `quarkus-test-openshift-client`:
+To use this feature, you have to add a dependency on `quarkus-test-kubernetes-client`:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-test-openshift-client</artifactId>
+    <artifactId>quarkus-test-kubernetes-client</artifactId>
     <scope>test</scope>
 </dependency>
 ----
@@ -516,7 +510,7 @@ To use this feature, you have to add a dependency on `quarkus-test-openshift-cli
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-testImplementation("io.quarkus:quarkus-test-openshift-client")
+testImplementation("io.quarkus:quarkus-test-kubernetes-client")
 ----
 
 == Configuration Reference

--- a/integration-tests/openshift-client/src/test/java/io/quarkus/it/openshift/client/KubernetesTestServerTest.java
+++ b/integration-tests/openshift-client/src/test/java/io/quarkus/it/openshift/client/KubernetesTestServerTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.it.openshift.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.openshift.api.model.RouteBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+
+@WithKubernetesTestServer
+@QuarkusTest
+public class KubernetesTestServerTest {
+
+    @KubernetesTestServer
+    KubernetesServer mockServer;
+    @Inject
+    KubernetesClient kubernetesClient;
+    @Inject
+    OpenShiftClient openShiftClient;
+
+    @Test
+    public void clientsInjectedWithValidConfiguration() {
+        assertThat(kubernetesClient)
+                .isSameAs(openShiftClient)
+                .extracting(c -> c.getConfiguration().getMasterUrl())
+                .isEqualTo(mockServer.getKubernetesMockServer().url("/"));
+    }
+
+    @Test
+    public void openShiftClientInjectionWorks() throws InterruptedException {
+        openShiftClient.routes().resource(
+                new RouteBuilder()
+                        .withNewMetadata().withName("the-route").endMetadata()
+                        .withNewSpec().withHost("example.com").endSpec()
+                        .build())
+                .createOr(NonDeletingOperation::update);
+        assertThat(mockServer.getLastRequest().getPath())
+                .isEqualTo("/apis/route.openshift.io/v1/namespaces/test/routes");
+    }
+}

--- a/integration-tests/openshift-client/src/test/java/io/quarkus/it/openshift/client/OpenShiftClientTest.java
+++ b/integration-tests/openshift-client/src/test/java/io/quarkus/it/openshift/client/OpenShiftClientTest.java
@@ -6,22 +6,21 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.PodListBuilder;
-import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.kubernetes.client.KubernetesMockServerTestResource;
-import io.quarkus.test.kubernetes.client.MockServer;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KubernetesMockServerTestResource.class)
+@WithKubernetesTestServer
 @QuarkusTest
 public class OpenShiftClientTest {
 
-    @MockServer
-    private KubernetesMockServer mockServer;
+    @KubernetesTestServer
+    KubernetesServer mockServer;
 
     @Test
     void createRoute() {
@@ -36,9 +35,10 @@ public class OpenShiftClientTest {
                 .andReturn(200, expectedRoute)
                 .once();
 
-        NamespacedOpenShiftClient openShiftClient = mockServer.createClient().adapt(NamespacedOpenShiftClient.class);
+        NamespacedOpenShiftClient openShiftClient = mockServer.getClient().adapt(NamespacedOpenShiftClient.class);
         openShiftClient.routes()
-                .create(new RouteBuilder().withNewMetadata().withName("myroute").withNamespace("test").endMetadata().build());
+                .resource(new RouteBuilder().withNewMetadata().withName("myroute").withNamespace("test").endMetadata().build())
+                .create();
         Route route = openShiftClient.routes().inNamespace("test").withName("myroute").get();
         Assertions.assertNotNull(route);
     }


### PR DESCRIPTION
## Description

Follows up on #45259 as part of #44899 

Remove/Replace mentions in the kubernetes-client guide of OpenShift mockserver (`quarkus-test-openshift-client`).

Additionally added a test to ensure that OpenShift client injection from the Kubernetes MockServer works as expected.

/cc @metacosm 