### PR TITLE
Change how JPAConfig cleans up its resources

### DIFF
--- a/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
@@ -52,6 +52,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-h2</artifactId>
             <scope>test</scope>
         </dependency>
@@ -171,6 +176,32 @@
                         <configuration>
                             <skip>false</skip>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- These tests seem to leak metaspace memory
+                                         so we run them in a separate, short-lived JVM -->
+                                    <excludedGroups>devmode</excludedGroups>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>devmode-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- These tests seem to leak metaspace memory
+                                         so we run them in a separate, short-lived JVM -->
+                                    <groups>devmode</groups>
+                                    <!-- We could consider setting reuseForks=false if we
+                                         really need to run every single test in its own JVM -->
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>

--- a/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/coordination/outboxpolling/HibernateSearchDevModeTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/coordination/outboxpolling/HibernateSearchDevModeTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.it.hibernate.search.orm.elasticsearch.coordination.outboxpolling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+@Tag("devmode")
+public class HibernateSearchDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HibernateSearchOutboxPollingTestResource.class, Person.class, OutboxPollingTestUtils.class)
+                    .addAsResource("application.properties", "application.properties"))
+            .setLogRecordPredicate(r -> true);
+
+    @Test
+    public void smoke() {
+        String[] schemaManagementStrategies = { "drop-and-create-and-drop", "drop-and-create" };
+
+        RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        for (int i = 0; i < 3; i++) {
+            int current = i;
+            config.modifyResourceFile(
+                    "application.properties",
+                    s -> s.replace(
+                            "quarkus.hibernate-search-orm.schema-management.strategy="
+                                    + schemaManagementStrategies[current % 2],
+                            "quarkus.hibernate-search-orm.schema-management.strategy="
+                                    + schemaManagementStrategies[(current + 1) % 2]));
+
+            RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                    .statusCode(200)
+                    .body(is("OK"));
+        }
+
+        assertThat(config.getLogRecords()).noneSatisfy(
+                r -> assertThat(r.getMessage()).contains("Unable to shut down Hibernate Search"));
+    }
+}


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/34547

As we discussed in the linked issue, the order in which beans are destroyed is not guaranteed. With this patch, JPAConfig will observe the shutdown event and clean up the resources then. 
Since persistent units are now going to be closed prior to datasource being destroyed this should allow Hibernate Search to stop things cleanly. 

For the observer priority I've initially used the `ObserverMethod.DEFAULT_PRIORITY` as the base value but then noticed that it uses the one from the `jakarta.interceptor.Interceptor.Priority` and thought that:

> Start of range for late interceptors defined by extension libraries.

might be the one applicable here 😃 