### PR TITLE
[3.8] Enforce Ubuntu 22.04 images for 3.8

### DIFF
--- a/.github/matrix-jvm-tests.json
+++ b/.github/matrix-jvm-tests.json
@@ -3,7 +3,7 @@
   "java-version": 17,
   "maven_args": "$JVM_TEST_MAVEN_ARGS",
   "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
-  "os-name": "ubuntu-latest"
+  "os-name": "ubuntu-22.04"
 }
 , {
   "name": "21",
@@ -11,7 +11,7 @@
   "java-version-gradle": 20,
   "maven_args": "$JVM_TEST_MAVEN_ARGS",
   "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
-  "os-name": "ubuntu-latest"
+  "os-name": "ubuntu-22.04"
 }
 , {
   "name": "17 Windows",

--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -4,133 +4,133 @@
             "category": "Main",
             "timeout": 45,
             "test-modules": "main",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Data1",
             "timeout": 95,
             "test-modules": "jpa-h2, jpa-h2-embedded, jpa-mariadb, jpa-mssql, jpa-derby, jpa-without-entity, hibernate-orm-tenancy/datasource, hibernate-orm-tenancy/connection-resolver, hibernate-orm-tenancy/connection-resolver-legacy-qualifiers",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Data2",
             "timeout": 70,
             "test-modules": "jpa, jpa-mapping-xml/legacy-app, jpa-mapping-xml/modern-app, jpa-mysql, jpa-db2, jpa-oracle",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Data3",
             "timeout": 75,
             "test-modules": "flyway, hibernate-orm-panache, hibernate-orm-panache-kotlin, hibernate-orm-envers, liquibase, liquibase-mongodb",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Data4",
             "timeout": 60,
             "test-modules": "mongodb-client, mongodb-devservices, mongodb-panache, mongodb-rest-data-panache, mongodb-panache-kotlin, redis-client, hibernate-orm-rest-data-panache",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Data5",
             "timeout": 70,
             "test-modules": "jpa-postgresql, jpa-postgresql-withxml, narayana-stm, narayana-jta, reactive-pg-client, hibernate-reactive-postgresql, hibernate-orm-tenancy/schema",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Data6",
             "timeout": 95,
             "test-modules": "elasticsearch-rest-client, elasticsearch-java-client, hibernate-search-orm-elasticsearch, hibernate-search-orm-elasticsearch-tenancy, hibernate-search-orm-opensearch, hibernate-search-orm-elasticsearch-outbox-polling",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Data7",
             "timeout": 85,
             "test-modules": "reactive-oracle-client, reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mariadb, hibernate-reactive-mysql, hibernate-reactive-mysql-agroal-flyway, hibernate-reactive-panache, hibernate-reactive-panache-kotlin",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Amazon",
             "timeout": 80,
             "test-modules": "amazon-lambda, amazon-lambda-http, amazon-lambda-rest-funqy, amazon-lambda-rest-servlet, amazon-lambda-rest-reactive-routes, amazon-lambda-rest-resteasy-reactive",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Messaging1",
             "timeout": 115,
             "test-modules": "kafka, kafka-ssl, kafka-sasl, kafka-avro-apicurio2, kafka-json-schema-apicurio2, kafka-snappy, kafka-streams, reactive-messaging-kafka, kafka-oauth-keycloak",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Messaging2",
             "timeout": 80,
             "test-modules": "reactive-messaging-amqp, reactive-messaging-rabbitmq, reactive-messaging-rabbitmq-dyn, reactive-messaging-pulsar",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Security1",
             "timeout": 65,
             "test-modules": "elytron-security-oauth2, elytron-security, elytron-security-jdbc, elytron-undertow, elytron-security-ldap, bouncycastle, bouncycastle-jsse, bouncycastle-fips",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Security2",
             "timeout": 75,
             "test-modules": "oidc, oidc-code-flow, oidc-tenancy, oidc-client, oidc-client-reactive, oidc-token-propagation, oidc-wiremock, oidc-client-wiremock",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Security3",
             "timeout": 55,
             "test-modules": "keycloak-authorization, smallrye-jwt-token-propagation, security-webauthn",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Cache",
             "timeout": 65,
             "test-modules": "infinispan-cache-jpa, infinispan-client, cache, redis-cache",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "HTTP",
             "timeout": 110,
             "test-modules": "elytron-resteasy, resteasy-jackson, elytron-resteasy-reactive, resteasy-mutiny, resteasy-reactive-kotlin/standard, vertx, vertx-http, vertx-web, vertx-web-jackson, vertx-graphql, virtual-http, rest-client, rest-client-reactive, rest-client-reactive-stork, rest-client-reactive-multipart, websockets, management-interface, management-interface-auth",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Misc1",
             "timeout": 70,
             "test-modules": "maven, jackson, jsonb, kotlin-serialization, rest-client-reactive-kotlin-serialization, quartz, qute, logging-min-level-unset, logging-min-level-set, simple with space",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Misc2",
             "timeout": 70,
             "test-modules": "hibernate-validator, test-extension/tests, logging-gelf, mailer, native-config-profile, locales",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Misc3",
             "timeout": 80,
             "test-modules": "kubernetes-client, openshift-client, kubernetes-service-binding-jdbc, smallrye-config, smallrye-graphql, smallrye-graphql-client, smallrye-graphql-client-keycloak, smallrye-metrics",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Misc4",
             "timeout": 125,
             "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, jaxb, opentelemetry, opentelemetry-jdbc-instrumentation, webjars-locator",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Spring",
             "timeout": 60,
             "test-modules": "spring-di, spring-web, spring-data-jpa, spring-boot-properties, spring-cloud-config-client, spring-data-rest",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "gRPC",
             "timeout": 70,
             "test-modules": "grpc-health, grpc-interceptors, grpc-mutual-auth, grpc-plain-text-gzip, grpc-plain-text-mutiny, grpc-proto-v2, grpc-streaming, grpc-tls",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Windows support",
@@ -142,13 +142,13 @@
             "category": "DevTools Integration Tests",
             "timeout": 75,
             "test-modules": "devtools-registry-client",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "AWT, ImageIO and Java2D",
             "timeout": 30,
             "test-modules": "awt, no-awt",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         }
     ]
 }

--- a/.github/virtual-threads-tests.json
+++ b/.github/virtual-threads-tests.json
@@ -4,13 +4,13 @@
             "category": "Main",
             "timeout": 50,
             "test-modules": "virtual-threads-disabled, grpc-virtual-threads, mailer-virtual-threads, redis-virtual-threads, rest-client-reactive-virtual-threads, resteasy-reactive-virtual-threads, vertx-event-bus-virtual-threads, scheduler-virtual-threads, quartz-virtual-threads",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         },
         {
             "category": "Messaging",
             "timeout": 45,
             "test-modules": "amqp-virtual-threads, jms-virtual-threads, kafka-virtual-threads",
-            "os-name": "ubuntu-latest"
+            "os-name": "ubuntu-22.04"
         }
     ]
 }

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -62,7 +62,7 @@ jobs:
   # For more details, see
   # https://github.community/t/pull-request-attribute-empty-in-workflow-run-event-object-for-pr-from-forked-repo/154682
   attach-pr-number:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Attach pull request number
     if: github.event_name == 'pull_request'
     steps:
@@ -77,7 +77,7 @@ jobs:
           retention-days: 1
   ci-sanity-check:
     name: "CI Sanity Check"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Skip main in forks
     if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     steps:
@@ -85,7 +85,7 @@ jobs:
         run: sleep 30
   build-jdk17:
     name: "Initial JDK 17 Build"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Skip main in forks
     # Skip draft PRs and those with WIP in the subject, rerun as soon as its removed
     if: "(github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')) && ( \
@@ -214,7 +214,7 @@ jobs:
 
   calculate-test-jobs:
     name: Calculate Test Jobs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Skip main in forks
     if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     needs: build-jdk17
@@ -420,7 +420,7 @@ jobs:
           - {
             name: "17",
             java-version: 17,
-            os-name: "ubuntu-latest"
+            os-name: "ubuntu-22.04"
           }
           - {
             name: "17 Windows",
@@ -517,7 +517,7 @@ jobs:
           - {
             name: "17",
             java-version: 17,
-            os-name: "ubuntu-latest"
+            os-name: "ubuntu-22.04"
           }
           - {
             name: "17 Windows",
@@ -594,12 +594,12 @@ jobs:
           - {
             name: "17",
             java-version: 17,
-            os-name: "ubuntu-latest"
+            os-name: "ubuntu-22.04"
           }
           - {
             name: "21",
             java-version: 21,
-            os-name: "ubuntu-latest"
+            os-name: "ubuntu-22.04"
           }
           - {
             name: "17 Windows",
@@ -680,12 +680,12 @@ jobs:
           - {
             name: "17",
             java-version: 17,
-            os-name: "ubuntu-latest"
+            os-name: "ubuntu-22.04"
           }
           - {
             name: "21",
             java-version: 21,
-            os-name: "ubuntu-latest"
+            os-name: "ubuntu-22.04"
           }
           - {
             name: "17 Windows",
@@ -766,7 +766,7 @@ jobs:
           - {
             name: "17",
             java-version: 17,
-            os-name: "ubuntu-latest"
+            os-name: "ubuntu-22.04"
           }
     steps:
       - name: Gradle Enterprise environment
@@ -886,7 +886,7 @@ jobs:
     needs: [build-jdk17, calculate-test-jobs]
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_tcks == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 150
     steps:
       - name: Gradle Enterprise environment
@@ -1058,7 +1058,7 @@ jobs:
           retention-days: 7
 
   build-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build report
     needs: [build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,tcks-test,native-tests,virtual-thread-native-tests]
     if: always()

--- a/.github/workflows/ci-fork-mvn-cache.yml
+++ b/.github/workflows/ci-fork-mvn-cache.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   build-jdk17:
     name: "Quick JDK 17 Build"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Skip in main repo
     if: github.repository != 'quarkusio/quarkus'
     steps:

--- a/.github/workflows/ci-istio.yml
+++ b/.github/workflows/ci-istio.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   cache:
     name: Build and save artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'"
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
   kubernetes:
     name: Istio + Kubernetes Integration Tests
     needs: cache
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'"
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-kubernetes.yml
+++ b/.github/workflows/ci-kubernetes.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   cache:
     name: Build and save artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'"
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
   kubernetes:
     name: Kubernetes Integration Tests
     needs: cache
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'"
     strategy:
       fail-fast: false
@@ -91,7 +91,7 @@ jobs:
   knative:
     name: Knative Integration Tests
     needs: cache
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'"
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-sanity-check.yml
+++ b/.github/workflows/ci-sanity-check.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   ci-sanity-check:
     name: "CI Sanity Check"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'quarkusio/quarkus'
     steps:
       - name: Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'quarkusio/quarkus'
 
     strategy:

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   build-and-deploy:
     name: "Build and deploy"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'quarkusio/quarkus'
     env:
       MAVEN_OPTS: -Xmx2048m -XX:MaxMetaspaceSize=1000m

--- a/.github/workflows/develocity-publish-build-scans.yml
+++ b/.github/workflows/develocity-publish-build-scans.yml
@@ -12,7 +12,7 @@ defaults:
 jobs:
   publish-build-scans:
     if: github.repository == 'quarkusio/quarkus' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: write
       pull-requests: write

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -22,14 +22,14 @@ concurrency:
 jobs:
   ci-sanity-check:
     name: "CI Sanity Check"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Build
         run: sleep 30
   build-doc:
     name: "Documentation Build"
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Skip main in forks
     if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
     steps:

--- a/.github/workflows/epicissues.yml
+++ b/.github/workflows/epicissues.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   autolabel:
     if: github.repository == 'quarkusio/quarkus'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: auto label
     steps:
 #      - name: Debug Action

--- a/.github/workflows/jakarta-rewrite.yml.disabled
+++ b/.github/workflows/jakarta-rewrite.yml.disabled
@@ -7,7 +7,7 @@ on:
     - cron: '0 22 * * 1-6'
 jobs:
   rewrite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Rewrite to Jakarta
     if: github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'
     env:

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   linux-jvm-test:
     name: JVM Tests - Early Access JDK ${{ matrix.version }} Build - ${{ matrix.dist }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       # This is complex because we want to use a different matrix when using workflow_dispatch.

--- a/.github/workflows/owasp-check.yml
+++ b/.github/workflows/owasp-check.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   owasp:
     name: OWASP Dependency Check Report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'quarkusio/quarkus'
 
     strategy:

--- a/.github/workflows/podman-build.yml
+++ b/.github/workflows/podman-build.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build-all-the-things:
     name: "JDK 17 Build"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       MAVEN_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=1g"
     # Skip main in forks

--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   preview-teardown:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Teardown surge preview
         id: deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   preview:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-3.0.yml.disabled
+++ b/.github/workflows/publish-3.0.yml.disabled
@@ -8,7 +8,7 @@ on:
         required: true
 jobs:
   rewrite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Rewrite to Jakarta
     env:
       MAVEN_OPTS: -Xmx3g -XX:MaxMetaspaceSize=1g

--- a/.github/workflows/quarkus-github-bot-lint.yml
+++ b/.github/workflows/quarkus-github-bot-lint.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     name: "quarkus-github-bot.yml validation"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: install yamllint

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   build:
     name: "Prepare release"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'quarkusio/quarkus'
     env:
       MAVEN_OPTS: -Xmx2560m

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   vale:
     name: Linting with Vale
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       checks: read


### PR DESCRIPTION
It is not possible to backport some of the changes needed to have things working on Ubuntu 24.