### PR TITLE
Dev UI: Add filter for extension cards

### DIFF
--- a/bom/dev-ui/pom.xml
+++ b/bom/dev-ui/pom.xml
@@ -13,7 +13,7 @@
     <description>Dependency management for dev-ui. Importable by third party extension developers.</description>
 
     <properties>
-        <vaadin.version>24.4.10</vaadin.version>
+        <vaadin.version>24.6.1</vaadin.version>
         <lit.version>3.2.1</lit.version>
         <lit-element.version>4.1.1</lit-element.version>
         <lit-html.version>3.2.1</lit-html.version>


### PR DESCRIPTION
Fix #40471

This PR adds a filter option to the extension cards screen, allowing you to filter Favorites, Actives, Inactive

The filter is stored in localstorage, so this will be remembered between restarts

![card-filter](https://github.com/user-attachments/assets/cef025ad-dc59-491b-81dc-fbd56b2c0b1a)
