### PR TITLE
Disable SmallRye Fault Tolerance testing for now

### DIFF
--- a/extensions/smallrye-fault-tolerance/deployment/pom.xml
+++ b/extensions/smallrye-fault-tolerance/deployment/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
     <name>Quarkus - SmallRye Fault Tolerance - Deployment</name>
 
+    <properties>
+        <skipTests>true</skipTests>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
We have a weird issue that gets the entire build stuck.

I tested a few ITs that have FT around and they didn't get stuck so let's hope it's enough.