### PR TITLE
Update Kotlin to version 2.1.20

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -150,10 +150,10 @@
         <cloudevents-api.version>3.0.0</cloudevents-api.version>
         <azure-functions-java-library.version>3.1.0</azure-functions-java-library.version>
         <azure-functions-java-spi.version>1.0.0</azure-functions-java-spi.version>
-        <kotlin.version>2.0.21</kotlin.version>
-        <kotlin.coroutine.version>1.9.0</kotlin.coroutine.version>
+        <kotlin.version>2.1.20</kotlin.version>
+        <kotlin.coroutine.version>1.10.1</kotlin.coroutine.version>
+        <kotlin-serialization.version>1.8.0</kotlin-serialization.version>
         <azure.toolkit-lib.version>0.27.0</azure.toolkit-lib.version>
-        <kotlin-serialization.version>1.7.3</kotlin-serialization.version>
         <dekorate.version>4.1.4</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.3.0</awaitility.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,7 +20,7 @@
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <compiler-plugin.version>${version.compiler.plugin}</compiler-plugin.version>
-        <kotlin.version>2.0.21</kotlin.version>
+        <kotlin.version>2.1.20</kotlin.version>
         <dokka.version>2.0.0</dokka.version>
         <scala.version>2.13.12</scala.version>
         <scala-maven-plugin.version>4.9.2</scala-maven-plugin.version>

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -105,7 +105,7 @@ public class QuarkusPluginTest {
 
     @Test
     public void shouldNotFailOnProjectDependenciesWithoutMain(@TempDir Path testProjectDir) throws IOException {
-        var kotlinVersion = System.getProperty("kotlin_version", "1.9.23");
+        var kotlinVersion = System.getProperty("kotlin_version", "2.1.20");
         var settingFile = testProjectDir.resolve("settings.gradle.kts");
         var mppProjectDir = testProjectDir.resolve("mpp");
         var quarkusProjectDir = testProjectDir.resolve("quarkus");

--- a/extensions/schema-registry/confluent/pom.xml
+++ b/extensions/schema-registry/confluent/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
-                <version>2.0.21</version>
+                <version>2.1.20</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -53,8 +53,8 @@
         <!-- test versions -->
         <version.assertj>3.27.3</version.assertj>
         <version.junit5>5.10.5</version.junit5>
-        <version.kotlin>2.0.21</version.kotlin>
-        <version.kotlin-coroutines>1.9.0</version.kotlin-coroutines>
+        <version.kotlin>2.1.20</version.kotlin>
+        <version.kotlin-coroutines>1.10.1</version.kotlin-coroutines>
         <version.mockito>5.16.1</version.mockito>
         <!-- TCK versions -->
         <version.arquillian>1.7.0.Final</version.arquillian>

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies-kotlin/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies-kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.9.23"
-    kotlin("plugin.allopen") version "1.9.23"
+    kotlin("jvm") version "2.1.20"
+    kotlin("plugin.allopen") version "2.1.20"
     id("io.quarkus")
 }
 

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-no-java/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-no-java/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "2.0.21"
-    kotlin("plugin.allopen") version "2.0.21"
+    kotlin("jvm") version "2.1.20"
+    kotlin("plugin.allopen") version "2.1.20"
 
     id("io.quarkus") apply false
 }

--- a/integration-tests/kafka-json-schema-apicurio2/pom.xml
+++ b/integration-tests/kafka-json-schema-apicurio2/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
-                <version>2.0.21</version>
+                <version>2.1.20</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>

--- a/integration-tests/kotlin-maven-invoker/src/test/java/io/quarkus/kotlin/maven/it/KotlinDevModeIT.java
+++ b/integration-tests/kotlin-maven-invoker/src/test/java/io/quarkus/kotlin/maven/it/KotlinDevModeIT.java
@@ -123,7 +123,7 @@ public class KotlinDevModeIT extends RunAndCheckMojoTestBase {
         install(externalJarDir, false);
 
         // Change GreetingResource.kt endpoint response to upper case letters
-        filter(greetingResourceKotlin, Map.of(greetingBonjourCall, greetingBonjourCall.concat(".toUpperCase()")));
+        filter(greetingResourceKotlin, Map.of(greetingBonjourCall, greetingBonjourCall.concat(".uppercase()")));
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)

--- a/integration-tests/kotlin/pom.xml
+++ b/integration-tests/kotlin/pom.xml
@@ -13,15 +13,10 @@
     <artifactId>quarkus-integration-test-kotlin</artifactId>
     <name>Quarkus - Integration Tests - Kotlin</name>
 
-    <properties>
-        <serialization.version>1.3.1</serialization.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-kotlin-serialization</artifactId>
-            <version>999-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/CountryNameMessageTransformer.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/CountryNameMessageTransformer.kt
@@ -13,6 +13,6 @@ class CountryNameMessageTransformer {
     @Outgoing("countries-t2-out")
     suspend fun transform(input: Message<Country>): Message<String> {
         delay(100)
-        return input.withPayload(input.payload.name.toLowerCase())
+        return input.withPayload(input.payload.name.lowercase())
     }
 }

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/CountryNamePayloadTransformer.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/CountryNamePayloadTransformer.kt
@@ -12,6 +12,6 @@ class CountryNamePayloadTransformer {
     @Outgoing("countries-t1-out")
     suspend fun transform(country: Country): Country {
         delay(100)
-        return Country(country.name.toUpperCase(), country.capital)
+        return Country(country.name.uppercase(), country.capital)
     }
 }


### PR DESCRIPTION
Update Kotlin to version 2.1.20, Kotlinx Serialization to 1.8.0 and Kotlin Coroutines to 1.10.0

Since the Kotlin update was removed again from PR #45228, I'm opening this PR to add it separately. This is an updated version of the original PR #44809.