### PR TITLE
Do not rely on Quarkus BOM to resolve the version for analytics

### DIFF
--- a/independent-projects/tools/analytics-common/src/main/java/io/quarkus/analytics/AnalyticsService.java
+++ b/independent-projects/tools/analytics-common/src/main/java/io/quarkus/analytics/AnalyticsService.java
@@ -258,8 +258,8 @@ public class AnalyticsService implements AutoCloseable {
     }
 
     private String getQuarkusVersion(ApplicationModel applicationModel) {
-        return applicationModel.getPlatforms().getImportedPlatformBoms().stream()
-                .filter(artifactCoords -> artifactCoords.getArtifactId().equals("quarkus-bom"))
+        return applicationModel.getDependencies().stream()
+                .filter(artifactCoords -> artifactCoords.getArtifactId().equals("quarkus-bootstrap-core"))
                 .map(ArtifactCoords::getVersion)
                 .findFirst()
                 .orElse("N/A");


### PR DESCRIPTION
Do not rely on Quarkus BOM to resolve the version for analytics

People can have custom BOMs