### PR TITLE
Add new state-based method for deciding if tests should run in a new classloader

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -567,6 +568,12 @@ public class TestResourceManager implements Closeable {
 
         // the sets contain the same objects, so no need to reload
         return false;
+    }
+
+    public static String getReloadGroupIdentifier(Set<TestResourceComparisonInfo> existing) {
+        // For now, we reload if it's restricted to class scope, and don't otherwise
+        String uniquenessModifier = anyResourceRestrictedToClass(existing) ? UUID.randomUUID().toString() : "";
+        return existing.stream().map(Object::toString).sorted().collect(Collectors.joining()) + uniquenessModifier;
     }
 
     private static boolean anyResourceRestrictedToClass(Set<TestResourceComparisonInfo> testResources) {

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerReloadTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerReloadTest.java
@@ -1,8 +1,13 @@
 package io.quarkus.test.common;
 
+import static io.quarkus.test.common.TestResourceManager.getReloadGroupIdentifier;
 import static io.quarkus.test.common.TestResourceManager.testResourcesRequireReload;
-import static io.quarkus.test.common.TestResourceScope.*;
+import static io.quarkus.test.common.TestResourceScope.GLOBAL;
+import static io.quarkus.test.common.TestResourceScope.MATCHING_RESOURCES;
+import static io.quarkus.test.common.TestResourceScope.RESTRICTED_TO_CLASS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
@@ -17,93 +22,129 @@ public class TestResourceManagerReloadTest {
 
     @Test
     public void emptyResources() {
-        assertFalse(testResourcesRequireReload(Collections.emptySet(), Set.of()));
+        Set<TestResourceComparisonInfo> existing = Collections.emptySet();
+        Set<TestResourceComparisonInfo> next = Set.of();
+        assertFalse(testResourcesRequireReload(existing, next));
+        assertEquals(getReloadGroupIdentifier(existing), getReloadGroupIdentifier(next));
     }
 
     @Test
     public void differentCount() {
-        assertTrue(testResourcesRequireReload(Collections.emptySet(),
-                Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS, Map.of()))));
+        Set<TestResourceComparisonInfo> existing = Collections.emptySet();
+        Set<TestResourceComparisonInfo> next = Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS, Map.of()));
 
-        assertTrue(testResourcesRequireReload(Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS, Map.of())),
-                Collections.emptySet()));
+        assertTrue(testResourcesRequireReload(existing, next));
+        assertTrue(testResourcesRequireReload(next, existing));
+
+        assertNotEquals(getReloadGroupIdentifier(existing), getReloadGroupIdentifier(next));
     }
 
     @Test
     public void sameSingleRestrictedToClassResource() {
-        assertTrue(testResourcesRequireReload(
-                Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS, Map.of())),
-                Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS, Map.of()))));
+        Set<TestResourceComparisonInfo> existing = Set
+                .of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS, Map.of()));
+        Set<TestResourceComparisonInfo> next = Set.of(new TestResourceComparisonInfo("test", RESTRICTED_TO_CLASS, Map.of()));
+        assertTrue(testResourcesRequireReload(existing, next));
+
+        assertNotEquals(getReloadGroupIdentifier(existing), getReloadGroupIdentifier(next));
     }
 
     @Test
     public void sameSingleMatchingResource() {
-        assertFalse(testResourcesRequireReload(
-                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of())),
-                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()))));
+        Set<TestResourceComparisonInfo> existing = Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()));
+        Set<TestResourceComparisonInfo> next = Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()));
+
+        assertFalse(testResourcesRequireReload(existing, next));
+
+        assertEquals(getReloadGroupIdentifier(existing), getReloadGroupIdentifier(next));
     }
 
     @Test
     public void sameSingleMatchingResourceWithArgs() {
-        assertFalse(testResourcesRequireReload(
-                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "b"))),
-                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "b")))));
+        Set<TestResourceComparisonInfo> existing = Set
+                .of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "b")));
+        Set<TestResourceComparisonInfo> next = Set
+                .of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "b")));
+
+        assertFalse(testResourcesRequireReload(existing, next));
+
+        assertEquals(getReloadGroupIdentifier(existing), getReloadGroupIdentifier(next));
     }
 
     @Test
     public void sameSingleResourceDifferentArgs() {
-        assertTrue(testResourcesRequireReload(
-                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of())),
-                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "b")))));
+        Set<TestResourceComparisonInfo> existing = Set
+                .of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "b")));
+        Set<TestResourceComparisonInfo> next = Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()));
+
+        assertTrue(testResourcesRequireReload(existing, next));
+
+        assertNotEquals(getReloadGroupIdentifier(existing), getReloadGroupIdentifier(next));
     }
 
     @Test
     public void sameSingleResourceDifferentArgValues() {
-        assertTrue(testResourcesRequireReload(
-                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "b"))),
-                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "c")))));
+        Set<TestResourceComparisonInfo> existing = Set
+                .of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "b")));
+        Set<TestResourceComparisonInfo> next = Set
+                .of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of("a", "x")));
+
+        assertTrue(testResourcesRequireReload(existing, next));
+
+        assertNotEquals(getReloadGroupIdentifier(existing), getReloadGroupIdentifier(next));
     }
 
     @Test
     public void differentSingleMatchingResource() {
-        assertTrue(testResourcesRequireReload(
-                Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of())),
-                Set.of(new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()))));
+        Set<TestResourceComparisonInfo> existing = Set.of(new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()));
+        Set<TestResourceComparisonInfo> next = Set.of(new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()));
+        assertTrue(testResourcesRequireReload(existing, next));
+
+        assertNotEquals(getReloadGroupIdentifier(existing), getReloadGroupIdentifier(next));
     }
 
     @Test
     public void sameMultipleMatchingResource() {
-        assertFalse(testResourcesRequireReload(
-                Set.of(
-                        new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()),
-                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
-                        new TestResourceComparisonInfo("test3", GLOBAL, Map.of())),
-                Set.of(new TestResourceComparisonInfo("test3", GLOBAL, Map.of()),
-                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
-                        new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()))));
+        Set<TestResourceComparisonInfo> existing = Set.of(
+                new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()),
+                new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
+                new TestResourceComparisonInfo("test3", GLOBAL, Map.of()));
+        Set<TestResourceComparisonInfo> next = Set.of(new TestResourceComparisonInfo("test3", GLOBAL, Map.of()),
+                new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
+                new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()));
+
+        assertFalse(testResourcesRequireReload(existing, next));
+        assertEquals(getReloadGroupIdentifier(existing), getReloadGroupIdentifier(next));
+
     }
 
     @Test
     public void differentMultipleMatchingResource() {
-        assertTrue(testResourcesRequireReload(
-                Set.of(
-                        new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()),
-                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
-                        new TestResourceComparisonInfo("test3", GLOBAL, Map.of())),
-                Set.of(new TestResourceComparisonInfo("test3", GLOBAL, Map.of()),
-                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
-                        new TestResourceComparisonInfo("TEST", MATCHING_RESOURCES, Map.of()))));
+        Set<TestResourceComparisonInfo> existing = Set.of(
+                new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()),
+                new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
+                new TestResourceComparisonInfo("test3", GLOBAL, Map.of()));
+        Set<TestResourceComparisonInfo> next = Set.of(new TestResourceComparisonInfo("test3", GLOBAL, Map.of()),
+                new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
+                new TestResourceComparisonInfo("TEST", MATCHING_RESOURCES, Map.of()));
+        assertTrue(testResourcesRequireReload(existing, next));
+        assertNotEquals(getReloadGroupIdentifier(existing),
+                getReloadGroupIdentifier(next));
     }
 
     @Test
     public void differentGlobalMultipleMatchingResource() {
-        assertTrue(testResourcesRequireReload(
-                Set.of(
-                        new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()),
-                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
-                        new TestResourceComparisonInfo("test4", GLOBAL, Map.of())),
-                Set.of(new TestResourceComparisonInfo("test3", GLOBAL, Map.of()),
-                        new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
-                        new TestResourceComparisonInfo("TEST", MATCHING_RESOURCES, Map.of()))));
+        Set<TestResourceComparisonInfo> existing = Set.of(
+                new TestResourceComparisonInfo("test", MATCHING_RESOURCES, Map.of()),
+                new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
+                new TestResourceComparisonInfo("test4", GLOBAL, Map.of()));
+        Set<TestResourceComparisonInfo> next = Set.of(new TestResourceComparisonInfo("test3", GLOBAL, Map.of()),
+                new TestResourceComparisonInfo("test2", MATCHING_RESOURCES, Map.of()),
+                new TestResourceComparisonInfo("TEST", MATCHING_RESOURCES, Map.of()));
+
+        assertTrue(testResourcesRequireReload(existing, next));
+        assertNotEquals(getReloadGroupIdentifier(existing),
+                getReloadGroupIdentifier(next));
+
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/TestResourceUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/TestResourceUtil.java
@@ -80,6 +80,28 @@ final class TestResourceUtil {
                 .testResourceComparisonInfo(requiredTestClass, getTestClassesLocation(requiredTestClass), entriesFromProfile);
     }
 
+    public static String getReloadGroupIdentifier(Class<?> requiredTestClass,
+            Class<? extends QuarkusTestProfile> profileClass) {
+        return TestResourceManager
+                .getReloadGroupIdentifier(nextTestResources(requiredTestClass, instantiateProfile(profileClass)));
+    }
+
+    private static QuarkusTestProfile instantiateProfile(Class<? extends QuarkusTestProfile> nextTestClassProfile) {
+        if (nextTestClassProfile != null) {
+            // The class we are given could be in the app classloader, so swap it over
+            // All this reflective classloading is a bit wasteful, so it would be ideal if the implementation was less picky about classloaders (that's not just moving the reflection further down the line)
+            try {
+                if (nextTestClassProfile.getClassLoader() != TestResourceUtil.class.getClassLoader()) {
+                    nextTestClassProfile = (Class<? extends QuarkusTestProfile>) Class.forName(nextTestClassProfile.getName());
+                }
+                return nextTestClassProfile.getConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return null;
+    }
+
     /**
      * Contains a bunch of utilities that are needed for handling {@link TestResourceManager}
      * via reflection (due to different classloaders)

--- a/test-framework/junit5/src/test/java/io/quarkus/test/junit/TestResourceUtilTest.java
+++ b/test-framework/junit5/src/test/java/io/quarkus/test/junit/TestResourceUtilTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.test.junit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class TestResourceUtilTest {
+
+    // Basic sense check, since most of the heavy lifting is done by TestResourceManager#getReloadGroupIdentifier
+    @Test
+    public void testReloadGroupIdentifierIsEqualForTestsWithNoResources() {
+        String identifier1 = TestResourceUtil.getReloadGroupIdentifier(TestClass.class, ProfileClass.class);
+        String identifier2 = TestResourceUtil.getReloadGroupIdentifier(TestClass.class, AnotherProfileClass.class);
+        assertEquals(identifier2, identifier1);
+    }
+
+    @Test
+    public void testReloadGroupIdentifierIsEqualForTestsWithIdenticalResources() {
+        String identifier1 = TestResourceUtil.getReloadGroupIdentifier(TestClass.class, ProfileClassWithResources.class);
+        String identifier2 = TestResourceUtil.getReloadGroupIdentifier(TestClass.class, AnotherProfileClassWithResources.class);
+        assertEquals(identifier2, identifier1);
+    }
+
+    @Test
+    public void testReloadGroupIdentifierIsEqualForTestsWithDifferentResources() {
+        String identifier1 = TestResourceUtil.getReloadGroupIdentifier(TestClass.class, ProfileClassWithResources.class);
+        String identifier2 = TestResourceUtil.getReloadGroupIdentifier(TestClass.class, ProfileClass.class);
+        assertNotEquals(identifier2, identifier1);
+    }
+}
+
+class TestClass {
+
+}
+
+class ProfileClass implements QuarkusTestProfile {
+
+    public ProfileClass() {
+    }
+}
+
+class AnotherProfileClass implements QuarkusTestProfile {
+
+    public AnotherProfileClass() {
+    }
+}
+
+class ProfileClassWithResources implements QuarkusTestProfile {
+
+    public ProfileClassWithResources() {
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Collections.singletonList(
+                new TestResourceEntry(
+                        Dummy.class, Map.of()));
+    }
+}
+
+class AnotherProfileClassWithResources implements QuarkusTestProfile {
+
+    public AnotherProfileClassWithResources() {
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Collections.singletonList(
+                new TestResourceEntry(
+                        Dummy.class, Map.of()));
+    }
+}
+
+abstract class Dummy implements QuarkusTestResourceLifecycleManager {
+}


### PR DESCRIPTION
In the current test model, we order tests, and then, at the point of execution, decide if a new classloader is needed. In the post-https://github.com/orgs/quarkusio/projects/30 world, we decide if a new classloader is needed when we load the tests, which is before ordering. 

Since we call it before the orderer is called, there’s no notion of a sequence. This means moving from a sequence-based calculation to a state-based calculation. (I know the current parameter is literally called “state,” but really what’s being looked at is the sequence.)

I've implemented this by generating a uniqueness key for every test. 

## But this new code isn't used anywhere

This code isn't used yet, but once https://github.com/quarkusio/quarkus/pull/34681 drops, it will be. I'm being optimistic, and starting to pull incremental chunks. 

My new method could be used in the implementation of `testResourcesRequireReload`. I didn’t yet, for two reasons:

- I was a bit worried that creating strings and then comparing would be less performant than the ‘raw’ comparisons done in that method
- If I replace `testResourcesRequireReload`, I wouldn’t have anything to compare behaviour against in unit tests :) I guess this doesn’t actually matter since there are unit tests and as long as the unit tests pass, we can assume the new behaviour is good, but it made me hesitate.

I think this method perhaps could and should also be called in the junit orderer, because it can be used to group and sort test classes. That would ensure consistency across all three paths – the ordering in the orderer, the grouping in the `FacadeClassLoader` (coming soon ™), and the reload decision in the test extensions. I didn’t do this yet, just to keep things incremental and get feedback first. 

If it’s used on the orderer, it would also needs to look at the profile (and not just the profile resources), but that’s doable, as long as we didn't accidentally conflate it with the reload decision and reload for every profile.


