### PR TITLE
Take follow-redirects config into account for programmatic client created

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/redirect/RedirectTestForProgrammaticClientWithGlobalConfigTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/redirect/RedirectTestForProgrammaticClientWithGlobalConfigTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.rest.client.reactive.redirect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class RedirectTestForProgrammaticClientWithGlobalConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, RedirectingResource.class))
+            .overrideRuntimeConfigKey("quarkus.rest-client.follow-redirects", "true");
+
+    @TestHTTPResource
+    URI uri;
+
+    @Test
+    void shouldRedirect() {
+        Client client = RestClientBuilder.newBuilder().baseUri(uri).build(Client.class);
+        Response call = client.call(3);
+        assertThat(call.getStatus()).isEqualTo(200);
+    }
+
+    @RegisterRestClient(configKey = "cl")
+    @Path("/redirect/302")
+    public interface Client {
+        @GET
+        Response call(@QueryParam("redirects") Integer redirects);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -71,7 +71,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
     private final List<ParamConverterProvider> paramConverterProviders = new ArrayList<>();
 
     private URI uri;
-    private boolean followRedirects;
+    private Boolean followRedirects;
     private QueryParamStyle queryParamStyle;
     private MultivaluedMap<String, Object> headers = new CaseInsensitiveMap<>();
 
@@ -438,7 +438,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
         exceptionMappers.sort(Comparator.comparingInt(ResponseExceptionMapper::getPriority));
         redirectHandlers.sort(Comparator.comparingInt(RedirectHandler::getPriority));
         clientBuilder.register(new MicroProfileRestClientResponseFilter(exceptionMappers));
-        clientBuilder.followRedirects(followRedirects);
+        clientBuilder.followRedirects(followRedirects != null ? followRedirects : restClients.followRedirects().orElse(false));
 
         RestClientsConfig.RestClientLoggingConfig logging = restClients.logging();
 


### PR DESCRIPTION
This property (as other config properties) is meant to apply to all clients, including ones created
programmatically.
Users can still override this by using `.followRedirects()` on the client builder