### PR TITLE
Qute: introduce the TemplateContents annotation

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -2095,6 +2095,44 @@ class ItemService {
 
 NOTE: You can specify `@CheckedTemplate#ignoreFragments=true` in order to disable this feature, i.e. a dollar sign `$` in the method name will not result in a checked fragment method.
 
+[[template_contents]]
+==== Template Contents
+
+It is also possible to specify the contents for a type-safe template directly in your Java code.
+A `static native` method of a class annotated with `@CheckedTemplate` or a Java record that implements `TemplateInstance` may be annotated with `@io.quarkus.qute.TemplateContents`.
+The annotation value is used as the template contents.
+The template id/path is derived from the type-safe template.
+
+.Template Contents Example
+[source,java]
+----
+package org.acme.quarkus.sample;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.qute.TemplateContents;
+import io.quarkus.qute.TemplateInstance;
+
+@Path("hello")
+public class HelloResource {
+
+    @TemplateContents("Hello {name}!") <1>
+    record Hello(String name) implements TemplateInstance {} 
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public TemplateInstance get(@QueryParam("name") String name) {
+        return new Hello(name); 
+    }
+}
+----
+<1> Defines the contents for the type-safe template represented by the `Hello` record. The derived template id is `HelloResource/Hello`.
+
 [[template_extension_methods]]
 === Template Extension Methods
 

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/Names.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/Names.java
@@ -17,6 +17,7 @@ import io.quarkus.qute.NamespaceResolver;
 import io.quarkus.qute.ParserHook;
 import io.quarkus.qute.SectionHelperFactory;
 import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateContents;
 import io.quarkus.qute.TemplateEnum;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.TemplateLocator;
@@ -54,6 +55,7 @@ final class Names {
     static final DotName VALUE_RESOLVER = DotName.createSimple(ValueResolver.class.getName());
     static final DotName NAMESPACE_RESOLVER = DotName.createSimple(NamespaceResolver.class.getName());
     static final DotName PARSER_HOOK = DotName.createSimple(ParserHook.class);
+    static final DotName TEMPLATE_CONTENTS = DotName.createSimple(TemplateContents.class);
 
     private Names() {
     }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/contents/TemplateContentsCheckedTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/contents/TemplateContentsCheckedTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.qute.deployment.contents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.ExecutionException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.TemplateContents;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TemplateContentsCheckedTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClass(Templates.class));
+
+    @Inject
+    Engine engine;
+
+    @Test
+    public void testTemplateContents() throws InterruptedException, ExecutionException {
+        assertEquals("Hello 42!", Templates.helloInt(42).render());
+        assertEquals("Hello 1!", engine.getTemplate("TemplateContentsCheckedTest/helloInt").data("val", 1).render());
+    }
+
+    @CheckedTemplate
+    static class Templates {
+
+        @TemplateContents("Hello {val}!")
+        static native TemplateInstance helloInt(int val);
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/contents/TemplateContentsRecordTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/contents/TemplateContentsRecordTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.qute.deployment.contents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.ExecutionException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.TemplateContents;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TemplateContentsRecordTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClass(helloInt.class));
+
+    @Inject
+    Engine engine;
+
+    @Test
+    public void testTemplateContents() throws InterruptedException, ExecutionException {
+        assertEquals("Hello 42!", new helloInt(42).render());
+        assertEquals("Hello 1!", engine.getTemplate("TemplateContentsRecordTest/helloInt").data("val", 1).render());
+        assertEquals("Hello 42!", new helloLong(42).render());
+        assertEquals("Hello 1!", engine.getTemplate("foo/helloLong").data("val", 1).render());
+
+        assertEquals("<p>Hello &quot;Martin&quot;!</p>", new helloHtml("\"Martin\"").render());
+        assertEquals("<p>Hello Lu!</p>",
+                engine.getTemplate("TemplateContentsRecordTest/helloHtml.html").data("name", "Lu").render());
+    }
+
+    @TemplateContents("Hello {val}!")
+    record helloInt(int val) implements TemplateInstance {
+    }
+
+    @CheckedTemplate(basePath = "foo")
+    @TemplateContents("Hello {val}!")
+    record helloLong(long val) implements TemplateInstance {
+    }
+
+    @TemplateContents(value = "<p>Hello {name}!</p>", suffix = "html")
+    record helloHtml(String name) implements TemplateInstance {
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateContents.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateContents.java
@@ -1,0 +1,34 @@
+package io.quarkus.qute;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * <strong>IMPORTANT: This annotation only works in a fully integrated environment; such as a Quarkus application.</strong>
+ * </p>
+ *
+ * This annotation can be used to specify the contents for a type-safe template, i.e. for a method of a class annotated with
+ * {@link CheckedTemplate} or a Java record that implements {@link TemplateInstance}.
+ */
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface TemplateContents {
+
+    /**
+     * The contents.
+     */
+    String value();
+
+    /**
+     * The suffix is used to determine the content type of a template. This is useful when working with template variants.
+     * <p>
+     * By default, the {@code txt} value, which corresponds to {@code text/plain}, is used. For the {@code text/html} content
+     * type the {@code html} suffix should be used.
+     */
+    String suffix() default "txt";
+}


### PR DESCRIPTION
- that can be used to specify the contents of a type-safe template directly in Java code

Also discussed on zulip: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/qute.20quote.20in.20jsonstrings.3F