### PR TITLE
Analytics: report Quarkus platform as CUSTOM when it's not recognized

### DIFF
--- a/independent-projects/tools/analytics-common/src/main/java/io/quarkus/analytics/AnalyticsService.java
+++ b/independent-projects/tools/analytics-common/src/main/java/io/quarkus/analytics/AnalyticsService.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.TextStyle;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -258,10 +259,15 @@ public class AnalyticsService implements AutoCloseable {
     }
 
     private String getQuarkusVersion(ApplicationModel applicationModel) {
-        return applicationModel.getPlatforms().getImportedPlatformBoms().stream()
+        final Collection<ArtifactCoords> platformBoms = applicationModel.getPlatforms().getImportedPlatformBoms();
+        if (platformBoms.isEmpty()) {
+            // Typically, this situation should result in a build error, but it's not up to this service to fail it
+            return "N/A";
+        }
+        return platformBoms.stream()
                 .filter(artifactCoords -> artifactCoords.getArtifactId().equals("quarkus-bom"))
                 .map(ArtifactCoords::getVersion)
                 .findFirst()
-                .orElse("N/A");
+                .orElse("CUSTOM");
     }
 }


### PR DESCRIPTION
Report Quarkus platform version as `N/A` when there are no platform BOMs detected and `CUSTOM` when platform BOMs are detected but the `quarkus-bom` is not among them