### PR TITLE
ArC - recognize conversation scope as built-in scope with no context impl

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinScope.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinScope.java
@@ -3,6 +3,7 @@ package io.quarkus.arc.processor;
 import java.lang.annotation.Annotation;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ConversationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.context.SessionScoped;
@@ -18,7 +19,8 @@ public enum BuiltinScope {
     SINGLETON(Singleton.class, false),
     APPLICATION(ApplicationScoped.class, true),
     REQUEST(RequestScoped.class, true),
-    SESSION(SessionScoped.class, true);
+    SESSION(SessionScoped.class, true),
+    CONVERSATION(ConversationScoped.class, true);
 
     private ScopeInfo info;
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ClientProxies.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ClientProxies.java
@@ -3,6 +3,7 @@ package io.quarkus.arc.impl;
 import java.util.List;
 
 import jakarta.enterprise.context.ContextNotActiveException;
+import jakarta.enterprise.context.ConversationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.enterprise.context.spi.Contextual;
@@ -69,6 +70,8 @@ public final class ClientProxies {
             msg += "\n\t- you can activate the request context for a specific method using the @ActivateRequestContext interceptor binding";
         } else if (bean.getScope().equals(SessionScoped.class)) {
             msg += "\n\t- @SessionScoped is not supported by default. However, a Quarkus extension implementing session context can be used to enable this functionality (such as Undertow extension).";
+        } else if (bean.getScope().equals(ConversationScoped.class)) {
+            msg += "\n\t- @ConversationScoped is not supported in Quarkus or CDI Lite. However, users are still allowed supply their custom context implementation.";
         }
         return new ContextNotActiveException(msg);
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/conversation/ConversationBean.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/conversation/ConversationBean.java
@@ -1,0 +1,10 @@
+package io.quarkus.arc.test.contexts.conversation;
+
+import jakarta.enterprise.context.ConversationScoped;
+
+@ConversationScoped
+public class ConversationBean {
+
+    void ping() {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/conversation/ConversationContextTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/conversation/ConversationContextTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.test.contexts.conversation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.enterprise.context.ContextNotActiveException;
+import jakarta.enterprise.context.ConversationScoped;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+/**
+ * Conversation context is not supported in ArC by default; users can still supply their own context impl though.
+ * We just want to test that it is recognized as a scope and properly fails instead of falling back to @Dependent
+ */
+public class ConversationContextTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(ConversationBean.class);
+
+    @Test
+    public void testContexts() {
+        InstanceHandle<ConversationBean> handle = Arc.container().select(ConversationBean.class).getHandle();
+        assertEquals(ConversationScoped.class, handle.getBean().getScope());
+        ConversationBean conversationBean = handle.get();
+        assertNotNull(conversationBean);
+        // actual attempt to use the bean should result in ContextNotActiveException as we don't provide any impl
+        assertThrows(ContextNotActiveException.class, () -> conversationBean.ping());
+    }
+}


### PR DESCRIPTION
Fixes #45413

This PR allow ArC to properly detect `@ConversationScoped` as built-in scope (instead of accidentally picking up some of those beans as `@Dependent)).
Also adds more sensible `ContextNotActiveException` if this scope is used and adds an automated test.
This approach still allows users/extensions to supply a custom conversation context impl.

I find this approach better than hard-failing when we detect the scope - sure, it'd be faster but it'd also prevent any custom impl.