### PR TITLE
Register JPA static metamodel classes for reflection

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
@@ -108,6 +108,11 @@ public final class JpaJandexScavenger {
         managedClassNames.addAll(collector.modelTypes);
         for (String className : managedClassNames) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
+            // Register static metamodel classes as well, so that their `class_` attribute can be populated.
+            // See org.hibernate.metamodel.internal.MetadataContext.populateStaticMetamodel
+            // Note: registering classes that do not exist is not a problem -- and is necessary if the application
+            //       tries to access these classes via reflection anyway (which it will, through Hibernate ORM).
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(className + "_").fields().build());
         }
 
         if (!collector.enumTypes.isEmpty()) {


### PR DESCRIPTION
Fixes #45503 

So that Hibernate ORM can populate their `class_` attribute.

Alternatively we could have prevented Hibernate ORM from populating the class_ attribute, but this would have been a breaking change in JVM mode or for applications that already enabled reflection on the static metamodel. This is safer.

I'm not adding a test because another pending PR is going to tighten up native compilation checks, and those would fail if this PR doesn't work, so we'll know.