### PR TITLE
Keep track of generated class proxies in BytecodeRecorderImpl to avoid creating several for the same class

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -123,7 +123,8 @@ public class BytecodeRecorderImpl implements RecorderContext {
     private final Map<Class<?>, NewRecorder> existingRecorderValues = new ConcurrentHashMap<>();
     private final List<BytecodeInstruction> storedMethodCalls = new ArrayList<>();
 
-    private final IdentityHashMap<Class<?>, String> classProxies = new IdentityHashMap<>();
+    private final Map<String, String> classProxyNamesToOriginalClassNames = new HashMap<>();
+    private final Map<String, Class<?>> originalClassNamesToClassProxyClasses = new HashMap<>();
     private final Map<Class<?>, SubstitutionHolder> substitutions = new HashMap<>();
     private final Map<Class<?>, NonDefaultConstructorHolder> nonDefaultConstructors = new HashMap<>();
     private final String className;
@@ -273,14 +274,20 @@ public class BytecodeRecorderImpl implements RecorderContext {
                 return void.class;
         }
 
+        Class<?> proxyClass = originalClassNamesToClassProxyClasses.get(name);
+        if (proxyClass != null) {
+            return proxyClass;
+        }
+
         ProxyFactory<Object> factory = new ProxyFactory<>(new ProxyConfiguration<Object>()
                 .setSuperClass(Object.class)
                 .setClassLoader(classLoader)
                 .setAnchorClass(getClass())
                 .setProxyNameSuffix("$$ClassProxy" + COUNT.incrementAndGet()));
-        Class theClass = factory.defineClass();
-        classProxies.put(theClass, name);
-        return theClass;
+        proxyClass = factory.defineClass();
+        classProxyNamesToOriginalClassNames.put(proxyClass.getName(), name);
+        originalClassNamesToClassProxyClasses.put(name, proxyClass);
+        return proxyClass;
     }
 
     @Override
@@ -743,14 +750,10 @@ public class BytecodeRecorderImpl implements RecorderContext {
                             method.load(param.toString()));
                 }
             };
-        } else if (param instanceof Class<?>) {
-            if (!((Class) param).isPrimitive()) {
+        } else if (param instanceof Class<?> clazz) {
+            if (!clazz.isPrimitive()) {
                 // Only try to load the class by name if it is not a primitive class
-                String name = classProxies.get(param);
-                if (name == null) {
-                    name = ((Class) param).getName();
-                }
-                String finalName = name;
+                String finalName = classProxyNamesToOriginalClassNames.getOrDefault(clazz.getName(), clazz.getName());
                 return new DeferredParameter() {
                     @Override
                     ResultHandle doLoad(MethodContext context, MethodCreator method, ResultHandle array) {
@@ -770,7 +773,7 @@ public class BytecodeRecorderImpl implements RecorderContext {
                 return new DeferredParameter() {
                     @Override
                     ResultHandle doLoad(MethodContext context, MethodCreator method, ResultHandle array) {
-                        return method.loadClassFromTCCL((Class) param);
+                        return method.loadClassFromTCCL(clazz);
                     }
                 };
             }


### PR DESCRIPTION
We would generate class proxies for each class even if we already generated one, which is counter productive.
Introduce a cache to avoid that and make things a bit more efficient.

Fixes #45509