### PR TITLE
Make scheduler timezone documentation consistent with javadoc

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -156,7 +156,7 @@ Property Expressions.
 .Time Zone Configuration Property Example
 [source,java]
 ----
-@Scheduled(cron = "0 15 10 * * ?", timeZone = "{myMethod.timeZone}")
+@Scheduled(cron = "0 15 10 * * ?", timeZone = "${myMethod.timeZone}")
 void myMethod() { }
 ----
 


### PR DESCRIPTION
All other configuration properties in scheduler documentation reference properties with `$`, and also javadoc uses it with `$`:
```
The value can be a property expression. In this case, the scheduler attempts to use the configured value instead:
  * {@code @Scheduled(timeZone = "${myJob.timeZone}")}. Additionally, the property expression can specify a default value:
  * {@code @Scheduled(timeZone = "${myJob.timeZone:Europe/Prague}")}.
```
This commit makes it consistent with other references.