### PR TITLE
Remove erroneous state tracking from client readers/writers

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/rest-client-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyReader.java
@@ -19,34 +19,40 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.jboss.resteasy.reactive.client.impl.RestClientRequestContext;
-import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
+import org.jboss.resteasy.reactive.client.spi.ClientMessageBodyReader;
+import org.jboss.resteasy.reactive.common.providers.serialisers.AbstractJsonMessageBodyReader;
 import org.jboss.resteasy.reactive.common.util.EmptyInputStream;
-import org.jboss.resteasy.reactive.server.jackson.JacksonBasicMessageBodyReader;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
-public class ClientJacksonMessageBodyReader extends JacksonBasicMessageBodyReader implements ClientRestHandler {
+public class ClientJacksonMessageBodyReader extends AbstractJsonMessageBodyReader implements ClientMessageBodyReader<Object> {
 
     private static final Logger log = Logger.getLogger(ClientJacksonMessageBodyReader.class);
 
     private final ConcurrentMap<ObjectMapper, ObjectReader> objectReaderMap = new ConcurrentHashMap<>();
-    private RestClientRequestContext context;
+    private final ObjectReader defaultReader;
 
     @Inject
     public ClientJacksonMessageBodyReader(ObjectMapper mapper) {
-        super(mapper);
+        this.defaultReader = mapper.reader();
     }
 
     @Override
     public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        return doRead(type, genericType, mediaType, entityStream, null);
+    }
+
+    private Object doRead(Class<Object> type, Type genericType, MediaType mediaType, InputStream entityStream,
+            RestClientRequestContext context)
+            throws IOException {
         try {
             if (entityStream instanceof EmptyInputStream) {
                 return null;
             }
-            ObjectReader reader = getEffectiveReader(mediaType);
+            ObjectReader reader = getEffectiveReader(mediaType, context);
             return reader.forType(reader.getTypeFactory().constructType(genericType != null ? genericType : type))
                     .readValue(entityStream);
 
@@ -57,14 +63,18 @@ public class ClientJacksonMessageBodyReader extends JacksonBasicMessageBodyReade
     }
 
     @Override
-    public void handle(RestClientRequestContext requestContext) {
-        this.context = requestContext;
+    public Object readFrom(Class<Object> type, Type genericType,
+            Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders,
+            InputStream entityStream,
+            RestClientRequestContext context) throws java.io.IOException, jakarta.ws.rs.WebApplicationException {
+        return doRead(type, genericType, mediaType, entityStream, context);
     }
 
-    private ObjectReader getEffectiveReader(MediaType responseMediaType) {
+    private ObjectReader getEffectiveReader(MediaType responseMediaType, RestClientRequestContext context) {
         ObjectMapper effectiveMapper = getObjectMapperFromContext(responseMediaType, context);
         if (effectiveMapper == null) {
-            return getEffectiveReader();
+            return defaultReader;
         }
 
         return objectReaderMap.computeIfAbsent(effectiveMapper, new Function<>() {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientReaderInterceptorContextImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientReaderInterceptorContextImpl.java
@@ -19,7 +19,7 @@ import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
 
-import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
+import org.jboss.resteasy.reactive.client.spi.ClientMessageBodyReader;
 import org.jboss.resteasy.reactive.client.spi.MissingMessageBodyReaderErrorMessageContextualizer;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
@@ -76,15 +76,16 @@ public class ClientReaderInterceptorContextImpl extends AbstractClientIntercepto
             for (MessageBodyReader<?> reader : readers) {
                 if (reader.isReadable(entityClass, entityType, annotations, mediaType)) {
                     try {
-                        if (reader instanceof ClientRestHandler) {
-                            try {
-                                ((ClientRestHandler) reader).handle(clientRequestContext);
-                            } catch (Exception e) {
-                                throw new WebApplicationException("Can't inject the client request context", e);
-                            }
+                        if (reader instanceof ClientMessageBodyReader) {
+                            return ((ClientMessageBodyReader) reader).readFrom(entityClass, entityType, annotations, mediaType,
+                                    headers,
+                                    inputStream, clientRequestContext);
+                        } else {
+                            return ((MessageBodyReader) reader).readFrom(entityClass, entityType, annotations, mediaType,
+                                    headers,
+                                    inputStream);
                         }
-                        return ((MessageBodyReader) reader).readFrom(entityClass, entityType, annotations, mediaType, headers,
-                                inputStream);
+
                     } catch (IOException e) {
                         throw new ProcessingException(e);
                     }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientWriterInterceptorContextImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientWriterInterceptorContextImpl.java
@@ -16,7 +16,7 @@ import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
 
-import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
+import org.jboss.resteasy.reactive.client.spi.ClientMessageBodyWriter;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
 
@@ -70,16 +70,14 @@ public class ClientWriterInterceptorContextImpl extends AbstractClientIntercepto
                 effectiveWriter = newWriters.get(0);
             }
 
-            if (effectiveWriter instanceof ClientRestHandler) {
-                try {
-                    ((ClientRestHandler) effectiveWriter).handle(clientRequestContext);
-                } catch (Exception e) {
-                    throw new WebApplicationException("Can't inject the client request context", e);
-                }
+            if (effectiveWriter instanceof ClientMessageBodyWriter cw) {
+                cw.writeTo(entity, entityClass, entityType,
+                        annotations, mediaType, headers, outputStream, clientRequestContext);
+            } else {
+                effectiveWriter.writeTo(entity, entityClass, entityType,
+                        annotations, mediaType, headers, outputStream);
             }
 
-            effectiveWriter.writeTo(entity, entityClass, entityType,
-                    annotations, mediaType, headers, outputStream);
             outputStream.close();
             result = Buffer.buffer(baos.toByteArray());
             done = true;

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/spi/ClientMessageBodyReader.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/spi/ClientMessageBodyReader.java
@@ -1,0 +1,20 @@
+package org.jboss.resteasy.reactive.client.spi;
+
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+
+import org.jboss.resteasy.reactive.client.impl.RestClientRequestContext;
+
+public interface ClientMessageBodyReader<T> extends MessageBodyReader<T> {
+
+    T readFrom(Class<T> type, Type genericType,
+            Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders,
+            InputStream entityStream,
+            RestClientRequestContext context) throws java.io.IOException, jakarta.ws.rs.WebApplicationException;
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/spi/ClientMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/spi/ClientMessageBodyWriter.java
@@ -1,0 +1,22 @@
+package org.jboss.resteasy.reactive.client.spi;
+
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import org.jboss.resteasy.reactive.client.impl.RestClientRequestContext;
+
+public interface ClientMessageBodyWriter<T> extends MessageBodyWriter<T> {
+
+    void writeTo(T t, Class<?> type, Type genericType, Annotation[] annotations,
+            MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders,
+            OutputStream entityStream,
+            RestClientRequestContext context)
+            throws java.io.IOException, jakarta.ws.rs.WebApplicationException;
+
+}


### PR DESCRIPTION
`MessageBodyReader` and `MessageBodyWriter`  are effectively singletons and should not have state

- Relates to: #45122