### PR TITLE
Logging configuration for specific declarative RestClient using named "client" properties aka quarkus.rest-client."client".logging.*

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1845,6 +1845,9 @@ As HTTP messages can have large bodies, we limit the amount of body characters l
 
 NOTE: REST Client is logging the traffic with level DEBUG and does not alter logger properties. You may need to adjust your logger configuration to use this feature.
 
+These configuration properties work globally for all clients injected by CDI.
+If you want configure logging for a specific declarative client, you should do it by specifying named "client" properties, also known as `quarkus.rest-client."client".logging.*` properties.
+
 An example logging configuration:
 
 [source,properties]
@@ -1852,7 +1855,10 @@ An example logging configuration:
 quarkus.rest-client.logging.scope=request-response
 quarkus.rest-client.logging.body-limit=50
 
+quarkus.rest-client.extensions-api.scope=all
+
 quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG
+quarkus.log.console.level=DEBUG
 ----
 
 [TIP]

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -621,6 +621,11 @@ public interface RestClientsConfig {
          */
         @WithDefault("${microprofile.rest.client.disable.default.mapper:false}")
         Boolean disableDefaultMapper();
+
+        /**
+         * Logging configuration.
+         */
+        Optional<RestClientLoggingConfig> logging();
     }
 
     class RestClientKeysProvider implements Supplier<Iterable<String>> {

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -24,6 +24,7 @@ import javax.net.ssl.HostnameVerifier;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
+import org.jboss.resteasy.reactive.client.api.LoggingScope;
 import org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties;
 import org.jboss.resteasy.reactive.client.impl.multipart.PausableHttpPostRequestEncoder;
 
@@ -81,7 +82,17 @@ public class RestClientCDIDelegateBuilder<T> {
         configureQueryParamStyle(builder);
         configureProxy(builder);
         configureShared(builder);
+        configureLogging(builder);
         configureCustomProperties(builder);
+    }
+
+    private void configureLogging(QuarkusRestClientBuilder builder) {
+        if (restClientConfig.logging().isPresent()) {
+            RestClientsConfig.RestClientLoggingConfig loggingConfig = restClientConfig.logging().get();
+            builder.property(QuarkusRestClientProperties.LOGGING_SCOPE,
+                    loggingConfig.scope().isPresent() ? LoggingScope.forName(loggingConfig.scope().get()) : LoggingScope.NONE);
+            builder.property(QuarkusRestClientProperties.LOGGING_BODY_LIMIT, loggingConfig.bodyLimit());
+        }
     }
 
     private void configureCustomProperties(QuarkusRestClientBuilder builder) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
@@ -85,4 +85,29 @@ public class QuarkusRestClientProperties {
      */
     public static final String CAPTURE_STACKTRACE = "io.quarkus.rest.client.capture-stacktrace";
 
+    /**
+     * Scope of logging for the client.
+     * <br/>
+     * WARNING: beware of logging sensitive data
+     * <br/>
+     * The possible values are:
+     * <ul>
+     * <li>{@code request-response} - enables logging request and responses, including redirect responses</li>
+     * <li>{@code all} - enables logging requests and responses and lower-level logging</li>
+     * <li>{@code none} - no additional logging</li>
+     * </ul>
+     *
+     * This property is applicable to reactive REST clients only.
+     */
+    public static final String LOGGING_SCOPE = "io.quarkus.rest.client.logging.scope";
+
+    /**
+     * How many characters of the body should be logged. Message body can be large and can easily pollute the logs.
+     * <p>
+     * By default, set to 100.
+     * <p>
+     * This property is applicable to reactive REST clients only.
+     */
+    public static final String LOGGING_BODY_LIMIT = "io.quarkus.rest.client.logging.body-limit";
+
 }


### PR DESCRIPTION
Closes: #45519 