### PR TITLE
Fix Mongo health checks

### DIFF
--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -102,6 +102,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-deployment</artifactId>
             <scope>test</scope>

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoClientConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoClientConfigTest.java
@@ -1,11 +1,13 @@
 package io.quarkus.mongodb;
 
+import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -96,5 +98,12 @@ public class MongoClientConfigTest extends MongoWithReplicasTestBase {
         assertThat(clientImpl.getSettings().getWriteConcern().getWTimeout(TimeUnit.SECONDS)).isEqualTo(5);
         assertThat(clientImpl.getSettings().getReadConcern()).isEqualTo(new ReadConcern(ReadConcernLevel.SNAPSHOT));
         assertThat(clientImpl.getSettings().getReadPreference()).isEqualTo(ReadPreference.primary());
+    }
+
+    @Test
+    public void healthCheck() {
+        when().get("/q/health/ready")
+                .then()
+                .body("status", CoreMatchers.equalTo("UP"));
     }
 }

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NoConnectionHealthCheckTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/NoConnectionHealthCheckTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.mongodb;
+
+import static io.restassured.RestAssured.when;
+
+import jakarta.inject.Inject;
+
+import org.bson.Document;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.MongoClientException;
+import com.mongodb.client.MongoClient;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class NoConnectionHealthCheckTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.mongodb.connection-string", "mongodb://localhost:9999")
+            // timeouts set to the test doesn't take too long to run
+            .overrideConfigKey("quarkus.mongodb.connect-timeout", "2s")
+            .overrideConfigKey("quarkus.mongodb.server-selection-timeout", "2s")
+            .overrideConfigKey("quarkus.mongodb.read-timeout", "2s");
+
+    @Inject
+    MongoClient mongo;
+
+    @Order(1) // done to ensure the health check runs before any application code touches the database
+    @Test
+    public void healthCheck() {
+        when().get("/q/health/ready")
+                .then()
+                .body("status", CoreMatchers.equalTo("DOWN"));
+    }
+
+    @Order(2)
+    @Test
+    public void tryConnection() {
+        Assertions.assertThrows(MongoClientException.class, () -> {
+            mongo.getDatabase("admin").runCommand(new Document("ping", 1));
+        });
+    }
+
+}

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/health/MongoHealthCheck.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/health/MongoHealthCheck.java
@@ -42,7 +42,7 @@ public class MongoHealthCheck implements HealthCheck {
 
     private static final Document COMMAND = new Document("ping", 1);
 
-    public void configure(MongodbConfig config) {
+    public MongoHealthCheck(MongodbConfig config) {
         Iterable<InstanceHandle<MongoClient>> handle = Arc.container().select(MongoClient.class, Any.Literal.INSTANCE)
                 .handles();
         Iterable<InstanceHandle<ReactiveMongoClient>> reactiveHandlers = Arc.container()
@@ -61,7 +61,7 @@ public class MongoHealthCheck implements HealthCheck {
             }
         }
 
-        config.mongoClientConfigs.forEach(new BiConsumer<String, MongoClientConfig>() {
+        config.mongoClientConfigs.forEach(new BiConsumer<>() {
             @Override
             public void accept(String name, MongoClientConfig cfg) {
                 MongoClient client = getClient(handle, name);
@@ -76,7 +76,6 @@ public class MongoHealthCheck implements HealthCheck {
                 }
             }
         });
-
     }
 
     private MongoClient getClient(Iterable<InstanceHandle<MongoClient>> handle, String name) {

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
@@ -58,12 +58,9 @@ import com.mongodb.event.CommandListener;
 import com.mongodb.event.ConnectionPoolListener;
 import com.mongodb.reactivestreams.client.ReactiveContextProvider;
 
-import io.quarkus.arc.Arc;
-import io.quarkus.arc.InstanceHandle;
 import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.credentials.runtime.CredentialsProviderFinder;
 import io.quarkus.mongodb.MongoClientName;
-import io.quarkus.mongodb.health.MongoHealthCheck;
 import io.quarkus.mongodb.impl.ReactiveMongoClientImpl;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 
@@ -110,17 +107,6 @@ public class MongoClients {
             //force class init to prevent possible deadlock when done by mongo threads
             Class.forName("sun.net.ext.ExtendedSocketOptions", true, ClassLoader.getSystemClassLoader());
         } catch (ClassNotFoundException ignored) {
-        }
-
-        try {
-            Class.forName("org.eclipse.microprofile.health.HealthCheck");
-            InstanceHandle<MongoHealthCheck> instance = Arc.container()
-                    .instance(MongoHealthCheck.class, Any.Literal.INSTANCE);
-            if (instance.isAvailable()) {
-                instance.get().configure(mongodbConfig);
-            }
-        } catch (ClassNotFoundException e) {
-            // Ignored - no health check
         }
     }
 


### PR DESCRIPTION
Prior to this change, the health checks would
erroneously report the connection was up
if the database had yet to be contacted
by the application

- Fixes: #45482