### PR TITLE
Register Parallel Database Query related elements for reflection

### DIFF
--- a/extensions/jdbc/jdbc-db2/deployment/src/main/java/io/quarkus/jdbc/db2/deployment/JDBCDB2Processor.java
+++ b/extensions/jdbc/jdbc-db2/deployment/src/main/java/io/quarkus/jdbc/db2/deployment/JDBCDB2Processor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.JPMSExportBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageAllowIncompleteClasspathBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.jdbc.db2.runtime.DB2AgroalConnectionConfigurer;
@@ -66,7 +67,8 @@ public class JDBCDB2Processor {
     }
 
     @BuildStep
-    void registerForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+    void registerForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<NativeImageResourceBuildItem> resource) {
         //Not strictly necessary when using Agroal, as it also registers
         //any JDBC driver being configured explicitly through its configuration.
         //We register it for the sake of people not using Agroal,
@@ -88,6 +90,12 @@ public class JDBCDB2Processor {
                 T4Resources.class)
                 .reason(getClass().getName() + " DB2 JDBC driver classes")
                 .build());
+
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.ibm.pdq.cmx.client.DataSourceFactory")
+                .reason(getClass().getName() + " accessed reflectively by DB2 JDBC driver")
+                .build());
+
+        resource.produce(new NativeImageResourceBuildItem("pdq.properties"));
     }
 
     @BuildStep


### PR DESCRIPTION
Although Quarkus doesn't include PDQ by default the DB2 JDBC driver
still tries to access some PDQ-related elements.

Relates to https://github.com/quarkusio/quarkus/issues/41995
