### PR TITLE
Register public constructors for Narayana classes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -20,6 +20,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private final boolean fields;
     private final boolean classes;
     private final boolean constructors;
+    private final boolean publicConstructors;
     private final boolean queryConstructors;
     private final boolean weak;
     private final boolean serialization;
@@ -46,7 +47,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
             boolean fields, boolean getClasses, boolean weak, boolean serialization, boolean unsafeAllocated, String reason,
             Class<?>... classes) {
-        this(constructors, queryConstructors, methods, queryMethods, fields, getClasses, weak, serialization,
+        this(constructors, false, queryConstructors, methods, queryMethods, fields, getClasses, weak, serialization,
                 unsafeAllocated, reason, stream(classes).map(Class::getName).toArray(String[]::new));
     }
 
@@ -118,11 +119,12 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
             boolean fields, boolean weak, boolean serialization,
             boolean unsafeAllocated, String... className) {
-        this(constructors, queryConstructors, methods, queryMethods, fields, false, weak, serialization, unsafeAllocated,
+        this(constructors, false, queryConstructors, methods, queryMethods, fields, false, weak, serialization, unsafeAllocated,
                 null, className);
     }
 
-    ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
+    ReflectiveClassBuildItem(boolean constructors, boolean publicConstructors, boolean queryConstructors, boolean methods,
+            boolean queryMethods,
             boolean fields, boolean classes, boolean weak, boolean serialization,
             boolean unsafeAllocated, String reason, String... className) {
         for (String i : className) {
@@ -143,6 +145,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this.fields = fields;
         this.classes = classes;
         this.constructors = constructors;
+        this.publicConstructors = publicConstructors;
         if (constructors && queryConstructors) {
             Log.warnf(
                     "Both constructors and queryConstructors are set to true for classes: %s. queryConstructors is redundant and will be ignored",
@@ -181,6 +184,10 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         return constructors;
     }
 
+    public boolean isPublicConstructors() {
+        return publicConstructors;
+    }
+
     public boolean isQueryConstructors() {
         return queryConstructors;
     }
@@ -213,6 +220,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     public static class Builder {
         private String[] className;
         private boolean constructors = true;
+        private boolean publicConstructors = false;
         private boolean queryConstructors;
         private boolean methods;
         private boolean queryMethods;
@@ -242,6 +250,19 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
         public Builder constructors() {
             return constructors(true);
+        }
+
+        /**
+         * Configures whether public constructors should be registered for reflection.
+         * Setting this enables getting all public constructors for the class as well as invoking them reflectively.
+         */
+        public Builder publicConstructors(boolean publicConstructors) {
+            this.publicConstructors = publicConstructors;
+            return this;
+        }
+
+        public Builder publicConstructors() {
+            return publicConstructors(true);
         }
 
         /**
@@ -358,7 +379,8 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         }
 
         public ReflectiveClassBuildItem build() {
-            return new ReflectiveClassBuildItem(constructors, queryConstructors, methods, queryMethods, fields, classes, weak,
+            return new ReflectiveClassBuildItem(constructors, publicConstructors, queryConstructors, methods, queryMethods,
+                    fields, classes, weak,
                     serialization, unsafeAllocated, reason, className);
         }
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
@@ -94,6 +94,9 @@ public class NativeImageReflectConfigStep {
                     extractToJsonArray(info.ctorSet, methodsArray);
                 }
             }
+            if (info.publicConstructors) {
+                json.put("allPublicConstructors", true);
+            }
             if (info.methods) {
                 json.put("allDeclaredMethods", true);
             } else {
@@ -246,6 +249,7 @@ public class NativeImageReflectConfigStep {
 
     static final class ReflectionInfo {
         boolean constructors;
+        boolean publicConstructors;
         boolean queryConstructors;
         boolean methods;
         boolean queryMethods;
@@ -270,6 +274,7 @@ public class NativeImageReflectConfigStep {
             this.classes = classBuildItem.isClasses();
             this.typeReachable = typeReachable;
             this.constructors = classBuildItem.isConstructors();
+            this.publicConstructors = classBuildItem.isPublicConstructors();
             this.queryConstructors = classBuildItem.isQueryConstructors();
             this.serialization = classBuildItem.isSerialization();
             this.unsafeAllocated = classBuildItem.isUnsafeAllocated();

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -138,6 +138,7 @@ class NarayanaJtaProcessor {
                 JTANodeNameXAResourceOrphanFilter.class,
                 JTAActionStatusServiceXAResourceOrphanFilter.class,
                 ExpiredTransactionStatusManagerScanner.class)
+                .publicConstructors()
                 .reason(getClass().getName())
                 .build());
 


### PR DESCRIPTION
- **Add option to register `allPublicConstructors` for reflection**
- **Register public constructors for Narayana classes**

Narayana accesses all public constructors, through `com.arjuna.common.internal.util.ClassloadingUtility.loadAndInstantiateClass`, e.g.:

```
org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively access

   com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple.getConstructors()

without it being registered for runtime reflection. Add com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple.getConstructors() to the reflection metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection for help.
  java.base@25/java.lang.Class.getConstructors(DynamicHub.java:1275)
  com.arjuna.common.internal.util.ClassloadingUtility.loadAndInstantiateClass(ClassloadingUtility.java:111)
  com.arjuna.common.internal.util.ClassloadingUtility.loadAndInstantiateClass(ClassloadingUtility.java:98)
  com.arjuna.ats.jta.common.JTAEnvironmentBean.getTransactionManager(JTAEnvironmentBean.java:172)
  com.arjuna.ats.jta.TransactionManager.transactionManager(TransactionManager.java:47)
  io.quarkus.narayana.jta.runtime.NotifyingTransactionManager.<init>(NotifyingTransactionManager.java:38)
  io.quarkus.narayana.jta.runtime.NarayanaJtaProducers.transactionManager(NarayanaJtaProducers.java:41)
  io.quarkus.narayana.jta.runtime.NarayanaJtaProducers_ProducerMethod_transactionManager_Os6a0HTynkqxcHcQ_YQRuvEP3gk_Bean.doCreate(Unknown Source)
  io.quarkus.narayana.jta.runtime.NarayanaJtaProducers_ProducerMethod_transactionManager_Os6a0HTynkqxcHcQ_YQRuvEP3gk_Bean.create(Unknown Source)
  io.quarkus.narayana.jta.runtime.NarayanaJtaProducers_ProducerMethod_transactionManager_Os6a0HTynkqxcHcQ_YQRuvEP3gk_Bean.create(Unknown Source)
  io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:119)
  io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:38)
  io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:35)
  io.quarkus.arc.impl.LazyValue.get(LazyValue.java:32)
  io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
  io.quarkus.arc.impl.ComputingCacheContextInstances.computeIfAbsent(ComputingCacheContextInstances.java:19)
  io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:35)
  io.quarkus.narayana.jta.runtime.NarayanaJtaProducers_ProducerMethod_transactionManager_Os6a0HTynkqxcHcQ_YQRuvEP3gk_Bean.get(Unknown Source)
  io.quarkus.narayana.jta.runtime.NarayanaJtaProducers_ProducerMethod_transactionManager_Os6a0HTynkqxcHcQ_YQRuvEP3gk_Bean.get(Unknown Source)
  io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired_Bean.doCreate(Unknown Source)

```

Relates to https://github.com/quarkusio/quarkus/issues/41995