### PR TITLE
Don't load JDBC drivers through the service loader without using them

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -1,12 +1,9 @@
 package io.quarkus.agroal.runtime;
 
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.Statement;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -156,9 +153,6 @@ public class DataSources {
             throw new IllegalArgumentException(
                     "Datasource " + dataSourceName + " does not have a JDBC URL and should not be created");
         }
-
-        // we first make sure that all available JDBC drivers are loaded in the current TCCL
-        loadDriversInTCCL();
 
         AgroalDataSourceSupport.Entry matchingSupportEntry = agroalDataSourceSupport.entries.get(dataSourceName);
         String resolvedDriverClass = matchingSupportEntry.resolvedDriverClass;
@@ -354,21 +348,4 @@ public class DataSources {
         poolConfiguration.flushOnClose(dataSourceJdbcRuntimeConfig.flushOnClose());
     }
 
-    /**
-     * Uses the {@link ServiceLoader#load(Class) ServiceLoader to load the JDBC drivers} in context
-     * of the current {@link Thread#getContextClassLoader() TCCL}
-     */
-    private static void loadDriversInTCCL() {
-        // load JDBC drivers in the current TCCL
-        final ServiceLoader<Driver> drivers = ServiceLoader.load(Driver.class);
-        final Iterator<Driver> iterator = drivers.iterator();
-        while (iterator.hasNext()) {
-            try {
-                // load the driver
-                iterator.next();
-            } catch (Throwable t) {
-                // ignore
-            }
-        }
-    }
 }


### PR DESCRIPTION
This was introduced in https://github.com/quarkusio/quarkus/pull/7089, which was specifically about a bug when using opentracing, which no longer has an extension in core,
and even its Quarkiverse extension is no longer maintained: https://github.com/quarkiverse/quarkus-smallrye-opentracing
The bug was also specific to Java 8.

The service loading is also causing problems with https://github.com/quarkusio/quarkus/issues/41995

So, let's not do it at all, assuming tests passes.