### PR TITLE
Check for Java 17 as a base, remove isJava11OrHigher method

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -91,8 +91,8 @@ public class QuarkusAugmentor {
     }
 
     public BuildResult run() throws Exception {
-        if (!JavaVersionUtil.isJava11OrHigher()) {
-            throw new IllegalStateException("Quarkus applications require Java 11 or higher to build");
+        if (!JavaVersionUtil.isJava17OrHigher()) {
+            throw new IllegalStateException("Quarkus applications require Java 17 or higher to build");
         }
         long start = System.nanoTime();
         log.debug("Beginning Quarkus augmentation");

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
@@ -7,7 +7,6 @@ public class JavaVersionUtil {
 
     private static final Pattern PATTERN = Pattern.compile("(?:1\\.)?(\\d+)");
 
-    private static boolean IS_JAVA_11_OR_NEWER;
     private static boolean IS_JAVA_13_OR_NEWER;
     private static boolean IS_GRAALVM_JDK;
     private static boolean IS_JAVA_16_OR_OLDER;
@@ -24,14 +23,12 @@ public class JavaVersionUtil {
         Matcher matcher = PATTERN.matcher(System.getProperty("java.specification.version", ""));
         if (matcher.matches()) {
             int first = Integer.parseInt(matcher.group(1));
-            IS_JAVA_11_OR_NEWER = (first >= 11);
             IS_JAVA_13_OR_NEWER = (first >= 13);
             IS_JAVA_16_OR_OLDER = (first <= 16);
             IS_JAVA_17_OR_NEWER = (first >= 17);
             IS_JAVA_19_OR_NEWER = (first >= 19);
             IS_JAVA_21_OR_NEWER = (first >= 21);
         } else {
-            IS_JAVA_11_OR_NEWER = false;
             IS_JAVA_13_OR_NEWER = false;
             IS_JAVA_16_OR_OLDER = false;
             IS_JAVA_17_OR_NEWER = false;
@@ -41,10 +38,6 @@ public class JavaVersionUtil {
 
         String vmVendor = System.getProperty("java.vm.vendor");
         IS_GRAALVM_JDK = (vmVendor != null) && vmVendor.startsWith("GraalVM");
-    }
-
-    public static boolean isJava11OrHigher() {
-        return IS_JAVA_11_OR_NEWER;
     }
 
     public static boolean isJava13OrHigher() {

--- a/core/runtime/src/test/java/io/quarkus/runtime/util/JavaVersionUtilTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/util/JavaVersionUtilTest.java
@@ -12,7 +12,6 @@ class JavaVersionUtilTest {
     @Test
     void testJava8() {
         testWithVersion("1.8", () -> {
-            assertFalse(JavaVersionUtil.isJava11OrHigher());
             assertFalse(JavaVersionUtil.isJava13OrHigher());
         });
     }
@@ -20,7 +19,6 @@ class JavaVersionUtilTest {
     @Test
     void testJava11() {
         testWithVersion("11", () -> {
-            assertTrue(JavaVersionUtil.isJava11OrHigher());
             assertFalse(JavaVersionUtil.isJava13OrHigher());
         });
     }
@@ -28,7 +26,6 @@ class JavaVersionUtilTest {
     @Test
     void testJava14() {
         testWithVersion("14", () -> {
-            assertTrue(JavaVersionUtil.isJava11OrHigher());
             assertTrue(JavaVersionUtil.isJava13OrHigher());
         });
     }
@@ -36,16 +33,17 @@ class JavaVersionUtilTest {
     @Test
     void testJava17() {
         testWithVersion("17", () -> {
-            assertTrue(JavaVersionUtil.isJava11OrHigher());
             assertTrue(JavaVersionUtil.isJava13OrHigher());
+            assertTrue(JavaVersionUtil.isJava17OrHigher());
+            assertFalse(JavaVersionUtil.isJava21OrHigher());
         });
     }
 
     @Test
     void testJava21() {
         testWithVersion("21", () -> {
-            assertTrue(JavaVersionUtil.isJava11OrHigher());
             assertTrue(JavaVersionUtil.isJava13OrHigher());
+            assertTrue(JavaVersionUtil.isJava21OrHigher());
         });
     }
 


### PR DESCRIPTION
Check for Java 17 as a base, remove isJava11OrHigher method

Quarkus needs Java 17, people get complain like `class file has wrong version 61.0, should be 55.0` when running with Java 11, so I can also remove the method ...