### PR TITLE
Update google cloud README files in integration-tests to use java21 runtime

### DIFF
--- a/integration-tests/funqy-google-cloud-functions/README.md
+++ b/integration-tests/funqy-google-cloud-functions/README.md
@@ -32,7 +32,7 @@ To deploy a background function that listen to PubSub event, you can use the fol
 ```shell script
 gcloud functions deploy quarkus-funqy-pubsub --entry-point=io.quarkus.funqy.gcp.functions.FunqyBackgroundFunction \
   --trigger-resource hello_topic --trigger-event google.pubsub.topic.publish \
-  --runtime=java11 --source=target/deployment --set-env-vars=QUARKUS_FUNQY_EXPORT=helloPubSubWorld
+  --runtime=java21 --source=target/deployment --set-env-vars=QUARKUS_FUNQY_EXPORT=helloPubSubWorld
 ```
 
 You can then invoke your function via `gcloud`:
@@ -47,8 +47,8 @@ To deploy a background function that listen to Storage event, you can use the fo
 
 ```shell script
 gcloud functions deploy quarkus-funqy-storage --entry-point=io.quarkus.funqy.gcp.functions.FunqyBackgroundFunction \
-  --trigger-resource my_java11_gcs_bucket --trigger-event google.storage.object.finalize \
-  --runtime=java11 --source=target/deployment --set-env-vars=QUARKUS_FUNQY_EXPORT=helloGCSWorld
+  --trigger-resource my_gcs_bucket --trigger-event google.storage.object.finalize \
+  --runtime=java21 --source=target/deployment --set-env-vars=QUARKUS_FUNQY_EXPORT=helloGCSWorld
 ```
 
 You can then invoke your function via `gcloud`:

--- a/integration-tests/google-cloud-functions-http/README.md
+++ b/integration-tests/google-cloud-functions-http/README.md
@@ -20,7 +20,7 @@ Finally, you need to use `gcloud` to deploy the function to Google Cloud
 
 ```shell script
 gcloud functions deploy quarkus-example-http --entry-point=io.quarkus.gcp.functions.http.QuarkusHttpFunction \
-  --runtime=java11 --trigger-http --source=target/deployment
+  --runtime=java21 --trigger-http --source=target/deployment
 ```
 
 ## Testing the endpoints


### PR DESCRIPTION
Update google cloud README files in integration-tests to use java21 runtime

Touches funqy-google-cloud-functions and google-cloud-functions-http in integration-tests

Follows runtime instructions from https://quarkus.io/guides/gcp-functions and https://quarkus.io/guides/gcp-functions-http