### PR TITLE
Avoiding confusing OIDC debug message for default tenant

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -199,7 +199,7 @@ public class DefaultTenantConfigResolver {
     private TenantConfigContext getStaticTenantContext(String tenantId) {
         var configContext = tenantId != null ? tenantConfigBean.getStaticTenant(tenantId) : null;
         if (configContext == null) {
-            if (tenantId != null && !tenantId.isEmpty()) {
+            if (tenantId != null && !tenantId.isEmpty() && !OidcUtils.DEFAULT_TENANT_ID.equals(tenantId)) {
                 LOG.debugf(
                         "Registered TenantResolver has not provided the configuration for tenant '%s', using the default tenant",
                         tenantId);


### PR DESCRIPTION
This PR makes a minor update to avoid

```
Registered TenantResolver has not provided the configuration for tenant Default, using the default tenant`
```

It is only supposed to logged in a multi-tenant setup when TenantResolver resolves a tenant id for example to `tenant-a`, but not for the default OIDC config

