### PR TITLE
Improving Qute Escaper to be as branch-free as possible

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/CharReplacementResultMapper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/CharReplacementResultMapper.java
@@ -12,21 +12,23 @@ abstract class CharReplacementResultMapper implements ResultMapper {
         return escape(result.toString());
     }
 
-    String escape(CharSequence value) {
+    String escape(String value) {
         if (value.length() == 0) {
-            return value.toString();
+            return value;
         }
         for (int i = 0; i < value.length(); i++) {
             String replacement = replacementFor(value.charAt(i));
             if (replacement != null) {
-                // In most cases we will not need to escape the value at all
-                return doEscape(value, i, new StringBuilder(value.subSequence(0, i)).append(replacement));
+                var builder = new StringBuilder(replacement.length() + (value.length() - 1));
+                builder.append(value, 0, i);
+                builder.append(replacement);
+                return doEscape(value, i, builder);
             }
         }
         return value.toString();
     }
 
-    private String doEscape(CharSequence value, int index, StringBuilder builder) {
+    private String doEscape(String value, int index, StringBuilder builder) {
         int length = value.length();
         while (++index < length) {
             char c = value.charAt(index);

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/HtmlEscaper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/HtmlEscaper.java
@@ -8,6 +8,58 @@ import io.quarkus.qute.TemplateNode.Origin;
 public class HtmlEscaper extends CharReplacementResultMapper {
 
     private final List<String> escapedContentTypes;
+    // NOTE: this holding 8 values to allow the JIT to remove the bound checks since
+    // the replacement id is always in range [0, 7] due to the REPLACEMENT_ID_MASK value
+    private static final String[] REPLACEMENTS = { null, "&quot;", "&#39;", "&amp;", "&lt;", "&gt;", null, null };
+    // We use 4 bits to pack the replacement id for each Latin character in the [0, 255] range.
+    // We could have used 3 bits but that would require more complex bit manipulation since 3 doesn't divide 8
+    private static final byte[] LATIN_REPLACEMENT_ID_TABLE = createLatinReplacementData();
+    private static final int REPLACEMENT_ID_MASK = 0b111;
+
+    private static byte[] createLatinReplacementData() {
+        byte[] data = new byte[256];
+        // by default we don't escape anything i.e. the escaped index is 0!
+        setLatinReplacementId(data, '"', 1);
+        setLatinReplacementId(data, '\'', 2);
+        setLatinReplacementId(data, '&', 3);
+        setLatinReplacementId(data, '<', 4);
+        setLatinReplacementId(data, '>', 5);
+        assert getLatinReplacementId(data, '"') == 1;
+        assert getLatinReplacementId(data, '\'') == 2;
+        assert getLatinReplacementId(data, '&') == 3;
+        assert getLatinReplacementId(data, '<') == 4;
+        assert getLatinReplacementId(data, '>') == 5;
+        return data;
+    }
+
+    private static void setLatinReplacementId(byte[] data, int c, int id) {
+        if (c > 255) {
+            throw new IllegalArgumentException("Only Latin characters are supported: " + c);
+        }
+        if (id < 0 || id > 15) {
+            throw new IllegalArgumentException("Replacement ID must be in range [0, 15] but was: " + id);
+        }
+        data[c] = (byte) id;
+    }
+
+    private static int getLatinReplacementId(byte[] data, int c) {
+        return data[c] & REPLACEMENT_ID_MASK;
+    }
+
+    private static String replacementOf(char c) {
+        if (c > 255) {
+            return null;
+        }
+        int replacementId = getLatinReplacementId(LATIN_REPLACEMENT_ID_TABLE, c & 0xFF);
+        // in the super class we still have to perform a null check vs String, which means
+        // we can have a branch misprediction there.
+        // Here we anticipate such cost and if this method is going to be inlined we could still
+        // correctly predict if the subsequent null check is going to be taken or not.
+        if (replacementId == 0) {
+            return null;
+        }
+        return REPLACEMENTS[replacementId];
+    }
 
     public HtmlEscaper(List<String> escapedContentTypes) {
         this.escapedContentTypes = escapedContentTypes;
@@ -38,21 +90,9 @@ public class HtmlEscaper extends CharReplacementResultMapper {
         return false;
     }
 
+    @Override
     protected String replacementFor(char c) {
-        switch (c) {
-            case '"':
-                return "&quot;";
-            case '\'':
-                return "&#39;";
-            case '&':
-                return "&amp;";
-            case '<':
-                return "&lt;";
-            case '>':
-                return "&gt;";
-            default:
-                return null;
-        }
+        return replacementOf(c);
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/JsonEscaper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/JsonEscaper.java
@@ -1,10 +1,176 @@
 package io.quarkus.qute;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 import io.quarkus.qute.TemplateNode.Origin;
 
-public class JsonEscaper extends CharReplacementResultMapper {
+public final class JsonEscaper implements ResultMapper {
+
+    private static final int LENGTH_BITS_OFFSET = 24;
+    private static final int SECOND_CHAR_OFFSET = 8;
+    private static final int MAX_LATIN_CHAR = 255;
+    private static final int NO_REPLACEMENT_DATA = packReplacementData(0, 0, 1);
+    private static final int[] REPLACEMENTS_DATA = createReplacementData();
+
+    /**
+     * Packs the replacement data into a single int.<br>
+     * The replacement data is packed as follows:<br>
+     * write an ASCII art of the int:<br>
+     * The visual order chosen reflect what Integer::toHexString would print since Java ints are stored big-endian.<br>
+     *
+     * <pre>
+     *         |----------|-----------|-------------|------------|
+     *  bits   |   24-31  |   16-23   |    8-15     |    0-7     |
+     *  field  |  length  |  padding  |   2nd char  |  1st char  |
+     *  values |  {1,2,6} |    [0]    |   [0-255]   |   [0-255]  |
+     *         |----------|-----------|-------------|------------|
+     * </pre>
+     *
+     */
+    private static int packReplacementData(int first, int second, int length) {
+        if (length != 1 && length != 2 && length != 6) {
+            throw new IllegalArgumentException("Length must be 1, 2 or 6 but was: " + length);
+        }
+        if (first < 0 || first > 255) {
+            throw new IllegalArgumentException("First char must be in range [0, 255] but was: " + first);
+        }
+        if (second < 0 || second > 255) {
+            throw new IllegalArgumentException("Second char must be in range [0, 255] but was: " + second);
+        }
+        return (first | (second << SECOND_CHAR_OFFSET)) | (length << LENGTH_BITS_OFFSET);
+    }
+
+    private static int replacementLength(int replacementData) {
+        // length isn't bigger than 127, which means preserving sign (which is faster) won't affect the shift
+        return replacementData >> LENGTH_BITS_OFFSET;
+    }
+
+    private static char secondChar(int replacementData) {
+        // since past the second char we have padding === 0 we can just cast to char
+        return (char) (replacementData >> SECOND_CHAR_OFFSET);
+    }
+
+    private static char firstChar(int replacementData) {
+        // we need to filter the first byte
+        return (char) (replacementData & 0xFF);
+    }
+
+    private static int toLatinChar(int c) {
+        return c & 0xFF;
+    }
+
+    private static int replacementDataOf(char c) {
+        // NOTE: char type cannot be negative
+        // Both non latin and latin char with length 1 doesn't need replacement
+        if (c > MAX_LATIN_CHAR) {
+            return NO_REPLACEMENT_DATA;
+        }
+        return REPLACEMENTS_DATA[toLatinChar(c)];
+    }
+
+    private static void writeReplacementData(char[] out, int pos, int replacementData) {
+        out[pos] = firstChar(replacementData);
+        out[pos + 1] = secondChar(replacementData);
+    }
+
+    /**
+     * All Unicode characters may be placed within the quotation marks,
+     * except for the characters that MUST be escaped: quotation mark,
+     * reverse solidus, and the control characters (U+0000 through U+001F).
+     * See also https://datatracker.ietf.org/doc/html/rfc8259#autoid-10
+     */
+    private static int[] createReplacementData() {
+        int[] table = new int[256];
+        // by default ctrl ASCII chars replace 6 chars
+        Arrays.fill(table, 0, 32, packReplacementData(0, 0, 6));
+        // default Latin chars just replace themselves
+        for (int i = 32; i < 256; i++) {
+            table[i] = packReplacementData(i, 0, 1);
+        }
+        // special ASCII chars - which include some control chars: replace 2 chars
+        table['"'] = packReplacementData('\\', '"', 2);
+        table['\\'] = packReplacementData('\\', '\\', 2);
+        table['\r'] = packReplacementData('\\', 'r', 2);
+        table['\b'] = packReplacementData('\\', 'b', 2);
+        table['\n'] = packReplacementData('\\', 'n', 2);
+        table['\t'] = packReplacementData('\\', 't', 2);
+        table['\f'] = packReplacementData('\\', 'f', 2);
+        table['/'] = packReplacementData('\\', '/', 2);
+        return table;
+    }
+
+    // This is a cache for the control chars replacements, which are [0-31]
+    private static final char[][] CTRL_REPLACEMENTS = new char[32][];
+
+    private static char[] doEscapeCtrl(int c) {
+        var replacement = CTRL_REPLACEMENTS[c];
+        if (replacement == null) {
+            replacement = String.format("\\u%04x", c).toCharArray();
+            assert replacement.length == 6;
+            CTRL_REPLACEMENTS[c] = replacement;
+        }
+        return replacement;
+    }
+
+    static String escape(String toEscape) {
+        for (int i = 0; i < toEscape.length(); i++) {
+            char c = toEscape.charAt(i);
+            int replacementLength = replacementLength(replacementDataOf(c));
+            if (replacementLength > 1) {
+                return doEscape(toEscape, i, replacementLength);
+            }
+        }
+        return toEscape;
+    }
+
+    private static String doEscape(String value, int firstToReplace, int firstReplacementLength) {
+        assert firstReplacementLength > 1;
+        int remainingChars = (value.length() - firstToReplace);
+        assert remainingChars >= 1;
+        // assume we want to replace all remaining chars with 2 chars
+        char[] buffer = new char[firstToReplace + firstReplacementLength + ((remainingChars - 1) * 2)];
+        value.getChars(0, firstToReplace, buffer, 0);
+        int outputLength = firstToReplace;
+        for (int i = 0; i < remainingChars; i++) {
+            char c = value.charAt(firstToReplace + i);
+            if (c <= MAX_LATIN_CHAR) {
+                int latinChar = toLatinChar(c);
+                int replacementData = REPLACEMENTS_DATA[latinChar];
+                int replacementLength = replacementLength(replacementData);
+                if (replacementLength == 6) {
+                    var ctrlEscape = doEscapeCtrl(c);
+                    buffer = ensureCapacity(buffer, outputLength, 6, (remainingChars - i) - 1);
+                    System.arraycopy(ctrlEscape, 0, buffer, outputLength, ctrlEscape.length);
+                    outputLength += 6;
+                } else {
+                    assert replacementLength == 1 || replacementLength == 2;
+                    buffer = ensureCapacity(buffer, outputLength, 2, (remainingChars - i) - 1);
+                    writeReplacementData(buffer, outputLength, replacementData);
+                    outputLength += replacementLength;
+                }
+            } else {
+                buffer = ensureCapacity(buffer, outputLength, 1, (remainingChars - i) - 1);
+                buffer[outputLength++] = c;
+            }
+        }
+        return new String(buffer, 0, outputLength);
+    }
+
+    private static char[] ensureCapacity(char[] buffer, int currentLength, int additionalLength, int remainingChars) {
+        if (currentLength + additionalLength > buffer.length) {
+            assert remainingChars >= 0;
+            return enlargeBuffer(buffer, currentLength, additionalLength, remainingChars);
+        }
+        return buffer;
+    }
+
+    private static char[] enlargeBuffer(char[] buffer, int currentLength, int additionalLength, int remainingChars) {
+        int newLength = currentLength + additionalLength + (remainingChars * 2);
+        char[] newBuffer = new char[newLength];
+        System.arraycopy(buffer, 0, newBuffer, 0, currentLength);
+        return newBuffer;
+    }
 
     @Override
     public boolean appliesTo(Origin origin, Object result) {
@@ -21,30 +187,8 @@ public class JsonEscaper extends CharReplacementResultMapper {
         return false;
     }
 
-    protected String replacementFor(char c) {
-        // All Unicode characters may be placed within the quotation marks,
-        // except for the characters that MUST be escaped: quotation mark,
-        // reverse solidus, and the control characters (U+0000 through U+001F).
-        // See also https://datatracker.ietf.org/doc/html/rfc8259#autoid-10
-        switch (c) {
-            case '"':
-                return "\\\"";
-            case '\\':
-                return "\\\\";
-            case '\r':
-                return "\\r";
-            case '\b':
-                return "\\b";
-            case '\n':
-                return "\\n";
-            case '\t':
-                return "\\t";
-            case '\f':
-                return "\\f";
-            case '/':
-                return "\\/";
-            default:
-                return c < 32 ? String.format("\\u%04x", (int) c) : null;
-        }
+    @Override
+    public String map(Object result, Expression expression) {
+        return escape(result.toString());
     }
 }


### PR DESCRIPTION
This is a show case of the approach at https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/pull/116 but biased for the one and two replacement latin chars case.
It could be expanded to cover for non-latin and the 6 bytes replacement too, with more painfull and complex (in term of logic) changes - but it looks already complex as it is IMO.

Feedbacks are wellcome as questions. 
I didn't yet benchmarked it (is sadly low in my prio list - so IDK when I'll have time to contribute a proper bench which stress the branch-predictor in qute-benchmark) - and there's a good chance my "bet" to use `StringBuilder` to simplify it, making use of the horrible `setLength` in the hot path, won't pay off.
In such unfortunate case, I will move to using char[] despite it requires latinness checks due to compact string, on String construction :"(