### PR TITLE
DevUICORSFilter - Do not log errors for Chrome extensions

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
@@ -25,6 +25,7 @@ public class DevUICORSFilter implements Handler<RoutingContext> {
     private static final String HTTPS_LOCAL_HOST = "https://" + LOCAL_HOST;
     private static final String HTTP_LOCAL_HOST_IP = "http://" + LOCAL_HOST_IP;
     private static final String HTTPS_LOCAL_HOST_IP = "https://" + LOCAL_HOST_IP;
+    private static final String CHROME_EXTENSION = "chrome-extension://";
 
     public DevUICORSFilter() {
     }
@@ -53,7 +54,9 @@ public class DevUICORSFilter implements Handler<RoutingContext> {
                     || origin.startsWith(HTTP_LOCAL_HOST_IP) || origin.startsWith(HTTPS_LOCAL_HOST_IP)) {
                 corsFilter().handle(event);
             } else {
-                LOG.errorf("Only localhost origin is allowed, but Origin header value is: %s", origin);
+                if (!origin.startsWith(CHROME_EXTENSION)) {
+                    LOG.errorf("Only localhost origin is allowed, but Origin header value is: %s", origin);
+                }
                 response.setStatusCode(403);
                 response.setStatusMessage("CORS Rejected - Invalid origin");
                 response.end();


### PR DESCRIPTION
This has been annoying me for a while, let's not log an error when a Chrome extension generates a request.

![Screenshot from 2025-01-13 17-49-22](https://github.com/user-attachments/assets/f9b8be24-c136-4311-8a14-4cb735dbbe06)
