### PR TITLE
Consistent report of unknown properties between JVM and Native mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -99,10 +99,10 @@ public final class RunTimeConfigurationGenerator {
     static final MethodDescriptor CD_MISSING_VALUE = MethodDescriptor.ofMethod(ConfigDiagnostic.class, "missingValue",
             void.class, String.class, NoSuchElementException.class);
     static final MethodDescriptor CD_RESET_ERROR = MethodDescriptor.ofMethod(ConfigDiagnostic.class, "resetError", void.class);
-    static final MethodDescriptor CD_UNKNOWN_PROPERTIES = MethodDescriptor.ofMethod(ConfigDiagnostic.class, "unknownProperties",
+    static final MethodDescriptor CD_REPORT_UNKNOWN = MethodDescriptor.ofMethod(ConfigDiagnostic.class, "reportUnknown",
             void.class, Set.class);
-    static final MethodDescriptor CD_UNKNOWN_PROPERTIES_RT = MethodDescriptor.ofMethod(ConfigDiagnostic.class,
-            "unknownPropertiesRuntime", void.class, Set.class);
+    static final MethodDescriptor CD_REPORT_UNKNOWN_RUNTIME = MethodDescriptor.ofMethod(ConfigDiagnostic.class,
+            "reportUnknownRuntime", void.class, Set.class);
 
     static final MethodDescriptor CONVS_NEW_ARRAY_CONVERTER = MethodDescriptor.ofMethod(Converters.class,
             "newArrayConverter", Converter.class, Converter.class, Class.class);
@@ -449,14 +449,14 @@ public final class RunTimeConfigurationGenerator {
 
             // generate sweep for clinit
             configSweepLoop(siParserBody, clinit, clinitConfig, getRegisteredRoots(BUILD_AND_RUN_TIME_FIXED), Type.BUILD_TIME);
-            clinit.invokeStaticMethod(CD_UNKNOWN_PROPERTIES, clinit.readStaticField(C_UNKNOWN));
+            clinit.invokeStaticMethod(CD_REPORT_UNKNOWN, clinit.readStaticField(C_UNKNOWN));
 
             if (liveReloadPossible) {
                 configSweepLoop(siParserBody, readConfig, runTimeConfig, getRegisteredRoots(RUN_TIME), Type.RUNTIME);
             }
             // generate sweep for run time
             configSweepLoop(rtParserBody, readConfig, runTimeConfig, getRegisteredRoots(RUN_TIME), Type.RUNTIME);
-            readConfig.invokeStaticMethod(CD_UNKNOWN_PROPERTIES_RT, readConfig.readStaticField(C_UNKNOWN_RUNTIME));
+            readConfig.invokeStaticMethod(CD_REPORT_UNKNOWN_RUNTIME, readConfig.readStaticField(C_UNKNOWN_RUNTIME));
 
             // generate ensure-initialized method
             // the point of this method is simply to initialize the Config class

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -142,21 +142,14 @@ public final class ConfigDiagnostic {
         }
     }
 
-    public static void unknownRunTime(String name) {
-        if (ImageMode.current() == ImageMode.NATIVE_RUN) {
-            // only warn at run time for native images, otherwise the user will get warned twice for every property
-            unknown(name);
-        }
-    }
-
-    public static void unknownRunTime(NameIterator name) {
-        unknownRunTime(name.getName());
-    }
-
-    public static void unknownPropertiesRuntime(Set<String> properties) {
-        if (ImageMode.current() == ImageMode.NATIVE_RUN) {
+    public static void reportUnknown(Set<String> properties) {
+        if (ImageMode.current() == ImageMode.NATIVE_BUILD) {
             unknownProperties(properties);
         }
+    }
+
+    public static void reportUnknownRuntime(Set<String> properties) {
+        unknownProperties(properties);
     }
 
     /**


### PR DESCRIPTION
To avoid reporting unknown properties twice in JVM mode, the report was executed at static init (to cover the native image build) and then at runtime only for native image. In most cases, this works fine, except if a runtime-only source is available and the unknown property is not caught in the static init check (because the property does not exist yet).


This now reports for both at runtime and only reports static init at image build time.

Related with https://github.com/quarkusio/quarkus/issues/45495
