### PR TITLE
Expression default for `quarkus.native.builder-image`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -256,7 +256,7 @@ public interface NativeConfig {
          * {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21}.
          */
         @WithParentName
-        @WithDefault("${platform.quarkus.native.builder-image}")
+        @WithDefault("${platform.quarkus.native.builder-image:mandrel}")
         @ConfigDocDefault("mandrel")
         String image();
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
@@ -70,9 +70,6 @@ public final class EffectiveConfig {
                 .withSources(new YamlConfigSourceLoader.InFileSystem())
                 .withSources(new YamlConfigSourceLoader.InClassPath())
                 .addPropertiesSources()
-                // todo: this is due to ApplicationModel#getPlatformProperties not being included in the effective config
-                .withSources(new PropertiesConfigSource(Map.of("platform.quarkus.native.builder-image", "<<ignored>>"),
-                        "NativeConfig#builderImage", 0))
                 .withDefaultValues(builder.defaultProperties)
                 .withProfile(builder.profile)
                 .withMapping(PackageConfig.class)


### PR DESCRIPTION
- Fixes #45472

I don't see any reason not to have an expression default for `quarkus.native.builder-image`, considering that we already advertise a default in the documentation.