### PR TITLE
Drop comment about Java 11 and loom

### DIFF
--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
@@ -130,8 +130,6 @@ public class VirtualThreadsRecorder {
     /**
      * This method uses reflection in order to allow developers to quickly test quarkus-loom without needing to
      * change --release, --source, --target flags and to enable previews.
-     * Since we try to load the "Loom-preview" classes/methods at runtime, the application can even be compiled
-     * using java 11 and executed with a loom-compliant JDK.
      */
     private static ExecutorService createExecutor() {
         if (config.enabled) {


### PR DESCRIPTION
Drop comment about Java 11 and loom

Java 17 is the base since Quarkus 3.5 - https://quarkus.io/blog/quarkus-3-5-0-released/