### PR TITLE
Register all public methods of lambda handlers for query

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -18,6 +18,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private final List<String> className;
     private final boolean methods;
     private final boolean queryMethods;
+    private final boolean queryPublicMethods;
     private final boolean fields;
     private final boolean classes;
     private final boolean constructors;
@@ -50,7 +51,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
             boolean fields, boolean getClasses, boolean weak, boolean serialization, boolean unsafeAllocated, String reason,
             Class<?>... classes) {
-        this(constructors, false, queryConstructors, methods, queryMethods, fields, getClasses, weak, serialization,
+        this(constructors, false, queryConstructors, methods, queryMethods, false, fields, getClasses, weak, serialization,
                 unsafeAllocated, reason, stream(classes).map(Class::getName).toArray(String[]::new));
     }
 
@@ -122,12 +123,13 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     ReflectiveClassBuildItem(boolean constructors, boolean queryConstructors, boolean methods, boolean queryMethods,
             boolean fields, boolean weak, boolean serialization,
             boolean unsafeAllocated, String... className) {
-        this(constructors, false, queryConstructors, methods, queryMethods, fields, false, weak, serialization, unsafeAllocated,
+        this(constructors, false, queryConstructors, methods, queryMethods, false, fields, false, weak, serialization,
+                unsafeAllocated,
                 null, className);
     }
 
     ReflectiveClassBuildItem(boolean constructors, boolean publicConstructors, boolean queryConstructors, boolean methods,
-            boolean queryMethods,
+            boolean queryMethods, boolean queryPublicMethods,
             boolean fields, boolean classes, boolean weak, boolean serialization,
             boolean unsafeAllocated, String reason, String... className) {
         for (String i : className) {
@@ -145,6 +147,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         } else {
             this.queryMethods = queryMethods;
         }
+        this.queryPublicMethods = queryPublicMethods;
         this.fields = fields;
         this.classes = classes;
         this.constructors = constructors;
@@ -173,6 +176,10 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
     public boolean isQueryMethods() {
         return queryMethods;
+    }
+
+    public boolean isQueryPublicMethods() {
+        return queryPublicMethods;
     }
 
     public boolean isFields() {
@@ -218,6 +225,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         private boolean queryConstructors;
         private boolean methods;
         private boolean queryMethods;
+        private boolean queryPublicMethods;
         private boolean fields;
         private boolean classes;
         private boolean weak;
@@ -300,6 +308,20 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         }
 
         /**
+         * Configures whether all public methods should be registered for reflection, for query purposes only,
+         * i.e. {@link Class#getMethods()}. Setting this enables getting all public methods (including ones defined in
+         * superclasses) for the class but does not allow invoking them reflectively.
+         */
+        public Builder queryPublicMethods(boolean queryPublicMethods) {
+            this.queryPublicMethods = queryPublicMethods;
+            return this;
+        }
+
+        public Builder queryPublicMethods() {
+            return queryPublicMethods(true);
+        }
+
+        /**
          * Configures whether fields should be registered for reflection.
          * Setting this enables getting all declared fields for the class as well as accessing them reflectively.
          */
@@ -365,7 +387,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
         public ReflectiveClassBuildItem build() {
             return new ReflectiveClassBuildItem(constructors, publicConstructors, queryConstructors, methods, queryMethods,
-                    fields, classes, weak,
+                    queryPublicMethods, fields, classes, weak,
                     serialization, unsafeAllocated, reason, className);
         }
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
@@ -110,6 +110,9 @@ public class NativeImageReflectConfigStep {
                     extractToJsonArray(info.queriedMethodSet, queriedMethodsArray);
                 }
             }
+            if (info.queryPublicMethods) {
+                json.put("queryAllPublicMethods", true);
+            }
             if (!methodsArray.isEmpty()) {
                 json.put("methods", methodsArray);
             }
@@ -253,6 +256,7 @@ public class NativeImageReflectConfigStep {
         boolean queryConstructors;
         boolean methods;
         boolean queryMethods;
+        boolean queryPublicMethods;
         boolean fields;
         boolean classes;
         boolean serialization;
@@ -270,6 +274,7 @@ public class NativeImageReflectConfigStep {
         private ReflectionInfo(ReflectiveClassBuildItem classBuildItem, String typeReachable) {
             this.methods = classBuildItem.isMethods();
             this.queryMethods = classBuildItem.isQueryMethods();
+            this.queryPublicMethods = classBuildItem.isQueryPublicMethods();
             this.fields = classBuildItem.isFields();
             this.classes = classBuildItem.isClasses();
             this.typeReachable = typeReachable;

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -115,7 +115,7 @@ public final class AmazonLambdaProcessor {
             final String lambda = name.toString();
             builder.addBeanClass(lambda);
             reflectiveClassBuildItemBuildProducer
-                    .produce(ReflectiveClassBuildItem.builder(lambda).methods().build());
+                    .produce(ReflectiveClassBuildItem.builder(lambda).methods().queryPublicMethods().build());
 
             String cdiName = null;
             AnnotationInstance named = info.declaredAnnotation(NAMED);

--- a/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/NestedLambda.java
+++ b/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/NestedLambda.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.amazon.lambda;
+
+import jakarta.inject.Inject;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class NestedLambda implements RequestHandler<InputObject, OutputObject> {
+
+    @Inject
+    ProcessingService service;
+
+    @Count
+    @Override
+    public OutputObject handleRequest(InputObject input, Context context) {
+        return service.process(input).setRequestId(context.getAwsRequestId());
+    }
+
+}

--- a/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/TestLambda.java
+++ b/integration-tests/amazon-lambda/src/main/java/io/quarkus/it/amazon/lambda/TestLambda.java
@@ -1,20 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
-
 @Named("test")
-public class TestLambda implements RequestHandler<InputObject, OutputObject> {
-
-    @Inject
-    ProcessingService service;
-
-    @Count
-    @Override
-    public OutputObject handleRequest(InputObject input, Context context) {
-        return service.process(input).setRequestId(context.getAwsRequestId());
-    }
+public class TestLambda extends NestedLambda {
 }


### PR DESCRIPTION
- **Improve amazon lambda test by using a nested class**
- **Add ability to register all public methods for query in native**
- **Register all public methods of lambda handlers for query**

Needed in order to [detect the handle method at runtime using `getMethods()`](https://github.com/quarkusio/quarkus/blob/84f1b0923c37d7b41958d551dab831a1a2795da7/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java#L95). Without a `org.graalvm.nativeimage.MissingReflectionRegistrationError` being thrown when using `-H:ThrowMissingRegistrationErrors=`

Related to https://github.com/quarkusio/quarkus/issues/41995