### PR TITLE
Adjust logging level for JDBC resource leak warnings

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalEventLoggingListener.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalEventLoggingListener.java
@@ -67,7 +67,12 @@ final class AgroalEventLoggingListener implements AgroalDataSourceListener {
 
     @Override
     public void onWarning(String warning) {
-        log.warnv("{0}: {1}", datasourceName, warning);
+        // See https://github.com/quarkusio/quarkus/issues/44047
+        if (warning != null && warning.contains("JDBC resources leaked")) {
+            log.debugv("{0}: {1}", datasourceName, warning);
+        } else {
+            log.warnv("{0}: {1}", datasourceName, warning);
+        }
     }
 
     @Override


### PR DESCRIPTION
- Adjust JDBC resource leak logging to use debug level instead of warnings for better log granularity.
- Enhance developer experience by reducing noise in application logs.
- Fixes #44047
