### PR TITLE
Elytron security LDAP: Document and test mapping of LDAP groups to SecurityIdentity roles

### DIFF
--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -177,6 +177,18 @@ quarkus.security.ldap.identity-mapping.attribute-mappings."0".filter-base-dn=ou=
 
 The `elytron-security-ldap` extension requires a dir-context and an identity-mapping with at least one attribute-mapping to authenticate the user and its identity.
 
+=== Map LDAP groups to `SecurityIdentity` roles
+
+Previously described application configuration showed how to map `CN` attribute of the LDAP Distinguished Name group to a Quarkus `SecurityIdentity` role.
+More specifically, the `standardRole` CN was mapped to a `SecurityIdentity` role and thus allowed access to the `UserResource#me` endpoint.
+However, required `SecurityIdentity` roles may differ between applications and you may need to map LDAP groups to local `SecurityIdentity` roles like in the example below:
+
+[source,properties]
+----
+quarkus.http.auth.roles-mapping."standardRole"=user <1>
+----
+<1> Map the `standardRole` role to the application-specific `SecurityIdentity` role `user`.
+
 == Testing the Application
 
 The application is now protected and the identities are provided by our LDAP server.

--- a/integration-tests/elytron-security-ldap/src/main/java/io/quarkus/elytron/security/ldap/it/ElytronSecurityLdapResource.java
+++ b/integration-tests/elytron-security-ldap/src/main/java/io/quarkus/elytron/security/ldap/it/ElytronSecurityLdapResource.java
@@ -20,6 +20,8 @@ import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
 
 @Path("/api")
 @ApplicationScoped
@@ -43,6 +45,13 @@ public class ElytronSecurityLdapResource {
     @RolesAllowed("adminRole")
     public String forbidden() {
         return "authorized";
+    }
+
+    @GET
+    @Path("/requiresRootRole")
+    @RolesAllowed("root")
+    public String getPrincipalName(@Context SecurityContext securityContext) {
+        return securityContext.getUserPrincipal().getName();
     }
 
 }

--- a/integration-tests/elytron-security-ldap/src/main/resources/application.properties
+++ b/integration-tests/elytron-security-ldap/src/main/resources/application.properties
@@ -14,3 +14,5 @@ quarkus.security.ldap.identity-mapping.attribute-mappings."0".filter-base-dn=ou=
 quarkus.security.ldap.cache.enabled=true
 quarkus.security.ldap.cache.max-age=60s
 quarkus.security.ldap.cache.size=10
+
+quarkus.http.auth.roles-mapping."adminRole"=root

--- a/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronLdapExtensionTestResources.java
+++ b/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronLdapExtensionTestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.elytron.security.ldap.it;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.ldap.LdapServerTestResource;
-
-@QuarkusTestResource(LdapServerTestResource.class)
-public class ElytronLdapExtensionTestResources {
-}


### PR DESCRIPTION
- LDAP groups are added as `SecurityIdentity` roles, but application roles can and does differ from the LGAP group names; this PR documents and test it
- enhance docs and adds tests for https://issues.redhat.com/browse/QUARKUS-4210
- closes: https://github.com/quarkusio/quarkus/issues/10264