### PR TITLE
Use StringBuilder instead of indyfied concat

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/FixedProducesHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/FixedProducesHandler.java
@@ -29,8 +29,11 @@ public class FixedProducesHandler implements ServerRestHandler {
     public FixedProducesHandler(MediaType mediaType, EntityWriter writer) {
         this.mediaType = new EncodedMediaType(mediaType);
         this.writer = writer;
-        this.mediaTypeString = mediaType.getType() + "/" + mediaType.getSubtype();
-        this.mediaTypeSubstring = mediaType.getType() + "/*";
+        // we want to avoid the small startup cost incurred by JEP 280 and that shows up in the startup cpu flamegraph
+        this.mediaTypeString = new StringBuilder(mediaType.getType().length() + 1 + mediaType.getSubtype().length())
+                .append(mediaType.getType()).append("/").append(mediaType.getSubtype()).toString();
+        this.mediaTypeSubstring = new StringBuilder(mediaType.getType().length() + 2).append(mediaType.getType()).append("/*")
+                .toString();
     }
 
     @Override


### PR DESCRIPTION
This is done because the latter has a very small
startup overhead (which one can see in a
CPU time flamegraph obtained from a startup
of a REST application)

The original flamegraph looks like:

![Screenshot from 2025-01-14 19-58-39](https://github.com/user-attachments/assets/7f893d49-d07b-4104-aa4f-0d7b57dc4353)
