### PR TITLE
Update OIDC DB TokenStateManager to keep access token expires_in

### DIFF
--- a/extensions/oidc-db-token-state-manager/deployment/src/main/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerProcessor.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/main/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerProcessor.java
@@ -44,25 +44,29 @@ public class OidcDbTokenStateManagerProcessor {
         final String[] queryParamPlaceholders;
         switch (sqlClientBuildItem.reactiveClient) {
             case REACTIVE_PG_CLIENT:
-                queryParamPlaceholders = new String[] { "$1", "$2", "$3", "$4", "$5" };
+                queryParamPlaceholders = new String[] { "$1", "$2", "$3", "$4", "$5", "$6" };
                 break;
             case REACTIVE_MSSQL_CLIENT:
-                queryParamPlaceholders = new String[] { "@p1", "@p2", "@p3", "@p4", "@p5" };
+                queryParamPlaceholders = new String[] { "@p1", "@p2", "@p3", "@p4", "@p5", "@p6" };
                 break;
             case REACTIVE_MYSQL_CLIENT:
             case REACTIVE_DB2_CLIENT:
             case REACTIVE_ORACLE_CLIENT:
-                queryParamPlaceholders = new String[] { "?", "?", "?", "?", "?" };
+                queryParamPlaceholders = new String[] { "?", "?", "?", "?", "?", "?" };
                 break;
             default:
                 throw new RuntimeException("Unknown Reactive Sql Client " + sqlClientBuildItem.reactiveClient);
         }
         String deleteStatement = format("DELETE FROM oidc_db_token_state_manager WHERE id = %s", queryParamPlaceholders[0]);
-        String getQuery = format("SELECT id_token, access_token, refresh_token FROM oidc_db_token_state_manager WHERE " +
-                "id = %s", queryParamPlaceholders[0]);
+        String getQuery = format(
+                "SELECT id_token, access_token, refresh_token, access_token_expires_in FROM oidc_db_token_state_manager WHERE "
+                        +
+                        "id = %s",
+                queryParamPlaceholders[0]);
         String insertStatement = format("INSERT INTO oidc_db_token_state_manager (id_token, access_token, refresh_token," +
-                " expires_in, id) VALUES (%s, %s, %s, %s, %s)", queryParamPlaceholders[0], queryParamPlaceholders[1],
-                queryParamPlaceholders[2], queryParamPlaceholders[3], queryParamPlaceholders[4]);
+                " access_token_expires_in, expires_in, id) VALUES (%s, %s, %s, %s, %s, %s)", queryParamPlaceholders[0],
+                queryParamPlaceholders[1],
+                queryParamPlaceholders[2], queryParamPlaceholders[3], queryParamPlaceholders[4], queryParamPlaceholders[5]);
         return SyntheticBeanBuildItem
                 .configure(OidcDbTokenStateManager.class)
                 .alternative(true)
@@ -114,6 +118,7 @@ public class OidcDbTokenStateManagerProcessor {
                         "id_token VARCHAR, " +
                         "access_token VARCHAR, " +
                         "refresh_token VARCHAR, " +
+                        "access_token_expires_in BIGINT, " +
                         "expires_in BIGINT NOT NULL)";
                 supportsIfTableNotExists = true;
                 break;
@@ -123,6 +128,7 @@ public class OidcDbTokenStateManagerProcessor {
                         + "id_token VARCHAR(5000) NULL, "
                         + "access_token VARCHAR(5000) NULL, "
                         + "refresh_token VARCHAR(5000) NULL, "
+                        + "access_token_expires_in BIGINT NULL, "
                         + "expires_in BIGINT NOT NULL, "
                         + "PRIMARY KEY (id))";
                 supportsIfTableNotExists = true;
@@ -133,6 +139,7 @@ public class OidcDbTokenStateManagerProcessor {
                         + "id_token NVARCHAR(MAX), "
                         + "access_token NVARCHAR(MAX), "
                         + "refresh_token NVARCHAR(MAX), "
+                        + "access_token_expires_in BIGINT, "
                         + "expires_in BIGINT NOT NULL)";
                 supportsIfTableNotExists = false;
                 break;
@@ -142,6 +149,7 @@ public class OidcDbTokenStateManagerProcessor {
                         + "id_token VARCHAR(4000), "
                         + "access_token VARCHAR(4000), "
                         + "refresh_token VARCHAR(4000), "
+                        + "access_token_expires_in BIGINT, "
                         + "expires_in BIGINT NOT NULL)";
                 supportsIfTableNotExists = false;
                 break;
@@ -151,6 +159,7 @@ public class OidcDbTokenStateManagerProcessor {
                         + "id_token VARCHAR2(4000), "
                         + "access_token VARCHAR2(4000), "
                         + "refresh_token VARCHAR2(4000), "
+                        + "access_token_expires_in NUMBER, "
                         + "expires_in NUMBER NOT NULL, "
                         + "PRIMARY KEY (id))";
                 supportsIfTableNotExists = true;

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/AbstractDbTokenStateManagerTest.java
@@ -70,7 +70,8 @@ public abstract class AbstractDbTokenStateManagerTest {
 
             textPage = loginForm.getButtonByName("login").click();
 
-            assertEquals("alice", textPage.getContent());
+            assertEquals("alice, access token: true, access_token_expires_in: true, refresh_token: true",
+                    textPage.getContent());
 
             assertTokenStateCount(1);
 

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerEntity.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerEntity.java
@@ -21,6 +21,9 @@ public class OidcDbTokenStateManagerEntity {
     @Column(name = "access_token", length = 4000)
     String accessToken;
 
+    @Column(name = "access_token_expires_in")
+    Long accessTokenExpiresIn;
+
     @Column(name = "expires_in")
     Long expiresIn;
 }

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerResource.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/OidcDbTokenStateManagerResource.java
@@ -26,6 +26,7 @@ public class OidcDbTokenStateManagerResource {
             token.idToken = "ID TOKEN " + i;
             token.accessToken = "ACCESS TOKEN " + i;
             token.refreshToken = "REFRESH TOKEN " + i;
+            token.accessTokenExpiresIn = 10L + i;
             token.expiresIn = expiresIn5Sec;
             token.id = UUID.randomUUID().toString() + Instant.now().getEpochSecond();
             em.persist(token);

--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/ProtectedResource.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/ProtectedResource.java
@@ -6,8 +6,10 @@ import jakarta.ws.rs.Path;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
+import io.quarkus.oidc.AuthorizationCodeTokens;
 import io.quarkus.oidc.IdToken;
 import io.quarkus.security.Authenticated;
+import io.vertx.ext.web.RoutingContext;
 
 @Path("/protected")
 @Authenticated
@@ -17,9 +19,17 @@ public class ProtectedResource {
     @IdToken
     JsonWebToken idToken;
 
+    @Inject
+    RoutingContext context;
+
     @GET
     public String getName() {
-        return idToken.getName();
+        AuthorizationCodeTokens tokens = context.get(AuthorizationCodeTokens.class.getName());
+        return idToken.getName()
+                + ", access token: " + (tokens.getAccessToken() != null)
+                + ", access_token_expires_in: " + (tokens.getAccessTokenExpiresIn() != null)
+                + ", refresh_token: " + (tokens.getRefreshToken() != null);
+
     }
 
     @GET


### PR DESCRIPTION
This PR follows #45327 ( where OIDC DefaultTokenStateManager [stores the access token expires_in property](https://github.com/quarkusio/quarkus/pull/45327/files#diff-ffbb29b8e09574bd6b5c62bd173325f6f87e6bb64af482f28cb2524e0e1ff050) with a similar update to the OIDC DB TokenStateManager.

Michal, do we have to mark it as a breaking change ? This extension is still a preview...