### PR TITLE
Update OIDC Redis TokenStateManager to keep access token expires_in

### DIFF
--- a/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/AbstractRedisTokenStateManagerTest.java
+++ b/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/AbstractRedisTokenStateManagerTest.java
@@ -59,7 +59,8 @@ public abstract class AbstractRedisTokenStateManagerTest {
 
             textPage = loginForm.getButtonByName("login").click();
 
-            assertEquals("alice", textPage.getContent());
+            assertEquals("alice, access token: true, access_token_expires_in: true, refresh_token: true",
+                    textPage.getContent());
 
             assertTokenStateCount(1);
 

--- a/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/ProtectedResource.java
+++ b/extensions/oidc-redis-token-state-manager/deployment/src/test/java/io/quarkus/oidc/redis/token/state/manager/deployment/ProtectedResource.java
@@ -6,8 +6,10 @@ import jakarta.ws.rs.Path;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
+import io.quarkus.oidc.AuthorizationCodeTokens;
 import io.quarkus.oidc.IdToken;
 import io.quarkus.security.Authenticated;
+import io.vertx.ext.web.RoutingContext;
 
 @Path("/protected")
 @Authenticated
@@ -17,9 +19,16 @@ public class ProtectedResource {
     @IdToken
     JsonWebToken idToken;
 
+    @Inject
+    RoutingContext context;
+
     @GET
     public String getName() {
-        return idToken.getName();
+        AuthorizationCodeTokens tokens = context.get(AuthorizationCodeTokens.class.getName());
+        return idToken.getName()
+                + ", access token: " + (tokens.getAccessToken() != null)
+                + ", access_token_expires_in: " + (tokens.getAccessTokenExpiresIn() != null)
+                + ", refresh_token: " + (tokens.getRefreshToken() != null);
     }
 
     @GET

--- a/extensions/oidc-redis-token-state-manager/runtime/src/main/java/io/quarkus/oidc/redis/token/state/manager/runtime/OidcRedisTokenStateManager.java
+++ b/extensions/oidc-redis-token-state-manager/runtime/src/main/java/io/quarkus/oidc/redis/token/state/manager/runtime/OidcRedisTokenStateManager.java
@@ -81,14 +81,15 @@ final class OidcRedisTokenStateManager implements TokenStateManager {
         return Instant.now().plusSeconds(event.<Long> get(SESSION_MAX_AGE_PARAM));
     }
 
-    record AuthorizationCodeTokensRecord(String idToken, String accessToken, String refreshToken) {
+    record AuthorizationCodeTokensRecord(String idToken, String accessToken, String refreshToken, Long accessTokenExpiresIn) {
 
         private static AuthorizationCodeTokensRecord of(AuthorizationCodeTokens tokens) {
-            return new AuthorizationCodeTokensRecord(tokens.getIdToken(), tokens.getAccessToken(), tokens.getRefreshToken());
+            return new AuthorizationCodeTokensRecord(tokens.getIdToken(), tokens.getAccessToken(), tokens.getRefreshToken(),
+                    tokens.getAccessTokenExpiresIn());
         }
 
         private AuthorizationCodeTokens toTokens() {
-            return new AuthorizationCodeTokens(idToken, accessToken, refreshToken);
+            return new AuthorizationCodeTokens(idToken, accessToken, refreshToken, accessTokenExpiresIn);
         }
     }
 }


### PR DESCRIPTION
Final PR related to having access_token expires_in stored, now in the OIDC Redis TokenStateManager