### PR TITLE
Make `io.quarkus.builder.Consume` a `record`

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
@@ -179,7 +179,7 @@ public final class BuildChainBuilder {
             for (Map.Entry<ItemId, Consume> entry : stepBuilder.getConsumes().entrySet()) {
                 final Consume consume = entry.getValue();
                 final ItemId id = entry.getKey();
-                if (!consume.getFlags().contains(ConsumeFlag.OPTIONAL) && !id.isMulti()) {
+                if (!consume.flags().contains(ConsumeFlag.OPTIONAL) && !id.isMulti()) {
                     if (!initialIds.contains(id) && !allProduces.containsKey(id)) {
                         throw new ChainBuildException("No producers for required item " + id);
                     }

--- a/core/builder/src/main/java/io/quarkus/builder/BuildStepBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildStepBuilder.java
@@ -236,7 +236,7 @@ public final class BuildStepBuilder {
 
     Set<ItemId> getRealConsumes() {
         final HashMap<ItemId, Consume> map = new HashMap<>(consumes);
-        map.entrySet().removeIf(e -> e.getValue().getConstraint() == Constraint.ORDER_ONLY);
+        map.entrySet().removeIf(e -> e.getValue().constraint() == Constraint.ORDER_ONLY);
         return map.keySet();
     }
 

--- a/core/builder/src/main/java/io/quarkus/builder/Consume.java
+++ b/core/builder/src/main/java/io/quarkus/builder/Consume.java
@@ -1,44 +1,20 @@
 package io.quarkus.builder;
 
-/**
- */
-final class Consume {
-    private final BuildStepBuilder buildStepBuilder;
-    private final ItemId itemId;
-    private final Constraint constraint;
-    private final ConsumeFlags flags;
+import static io.quarkus.builder.Constraint.ORDER_ONLY;
+import static io.quarkus.builder.Constraint.REAL;
+import static io.quarkus.builder.ConsumeFlag.OPTIONAL;
 
-    Consume(final BuildStepBuilder buildStepBuilder, final ItemId itemId, final Constraint constraint,
-            final ConsumeFlags flags) {
-        this.buildStepBuilder = buildStepBuilder;
-        this.itemId = itemId;
-        this.constraint = constraint;
-        this.flags = flags;
-    }
+record Consume(BuildStepBuilder buildStepBuilder, ItemId itemId, Constraint constraint, ConsumeFlags flags) {
 
-    BuildStepBuilder getBuildStepBuilder() {
-        return buildStepBuilder;
-    }
-
-    ItemId getItemId() {
-        return itemId;
-    }
-
-    ConsumeFlags getFlags() {
-        return flags;
-    }
-
-    Consume combine(final Constraint constraint, final ConsumeFlags flags) {
-        final Constraint outputConstraint = constraint == Constraint.REAL || this.constraint == Constraint.REAL
-                ? Constraint.REAL
-                : Constraint.ORDER_ONLY;
-        final ConsumeFlags outputFlags = !flags.contains(ConsumeFlag.OPTIONAL) || !this.flags.contains(ConsumeFlag.OPTIONAL)
-                ? flags.with(this.flags).without(ConsumeFlag.OPTIONAL)
-                : flags.with(this.flags);
-        return new Consume(buildStepBuilder, itemId, outputConstraint, outputFlags);
-    }
-
-    Constraint getConstraint() {
-        return constraint;
+   Consume combine(final Constraint constraint, final ConsumeFlags flags) {
+        return new Consume(
+                buildStepBuilder,
+                itemId,
+                constraint == REAL || this.constraint == REAL
+                        ? REAL
+                        : ORDER_ONLY,
+                !flags.contains(OPTIONAL) || !this.flags.contains(OPTIONAL)
+                        ? flags.with(this.flags).without(OPTIONAL)
+                        : flags.with(this.flags));
     }
 }


### PR DESCRIPTION
This pull request reduces boilerplate code and eliminates unused code, addressing concerns related to code clarity and maintenance.
This change aims to streamline the codebase while maintaining functionality.