### PR TITLE
Fix unnecessary memory allocation 

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -245,9 +245,12 @@ public class TestConsoleHandler implements TestListener {
                                     summary.append("\n");
                                 }
                                 if (testclass != null) {
-                                    summary.append(testclass.getClassName() + "#").append(testclass.getMethodName()).append("(").append(testclass.getFileName()).append(":").append(testclass.getLineNumber()).append(") ");
+                                    summary.append(testclass.getClassName() + "#").append(testclass.getMethodName()).append("(")
+                                            .append(testclass.getFileName()).append(":").append(testclass.getLineNumber())
+                                            .append(") ");
                                 }
-                                summary.append(RED).append(test.getDisplayName()).append(RESET).append(" ").append(test.getTestExecutionResult().getThrowable().get().getMessage());
+                                summary.append(RED).append(test.getDisplayName()).append(RESET).append(" ")
+                                        .append(test.getTestExecutionResult().getThrowable().get().getMessage());
                             }
                         }
                     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConsoleHandler.java
@@ -245,12 +245,9 @@ public class TestConsoleHandler implements TestListener {
                                     summary.append("\n");
                                 }
                                 if (testclass != null) {
-                                    summary.append(testclass.getClassName() + "#" + testclass.getMethodName() + "("
-                                            + testclass.getFileName() + ":" + testclass.getLineNumber() + ") ");
+                                    summary.append(testclass.getClassName() + "#").append(testclass.getMethodName()).append("(").append(testclass.getFileName()).append(":").append(testclass.getLineNumber()).append(") ");
                                 }
-                                summary.append(RED
-                                        + test.getDisplayName() + RESET
-                                        + " " + test.getTestExecutionResult().getThrowable().get().getMessage());
+                                summary.append(RED).append(test.getDisplayName()).append(RESET).append(" ").append(test.getTestExecutionResult().getThrowable().get().getMessage());
                             }
                         }
                     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ReportAnalyzer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ReportAnalyzer.java
@@ -138,7 +138,7 @@ public class ReportAnalyzer {
                         attemptedClasses.add(current.className);
                         List<Node> toAdd = constructors.getOrDefault(current.className, new ArrayList<>());
                         runQueue.addAll(toAdd);
-                        sb.append(reason + '\n');
+                        sb.append(reason).append('\n');
                         sb.append("\n");
                         ret.append(sb);
                     }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigProperty.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryConfigProperty.java
@@ -110,21 +110,21 @@ public class DiscoveryConfigProperty {
 
     public String toString(String prefix) {
         StringBuilder sb = new StringBuilder();
-        sb.append(prefix + "name = " + path + "\n");
-        sb.append(prefix + "sourceType = " + sourceType + "\n");
-        sb.append(prefix + "sourceElementName = " + sourceElementName + "\n");
-        sb.append(prefix + "type = " + type + "\n");
+        sb.append(prefix + "name = ").append(path).append("\n");
+        sb.append(prefix + "sourceType = ").append(sourceType).append("\n");
+        sb.append(prefix + "sourceElementName = ").append(sourceElementName).append("\n");
+        sb.append(prefix + "type = ").append(type).append("\n");
         if (defaultValue != null) {
-            sb.append(prefix + "defaultValue = " + defaultValue + "\n");
+            sb.append(prefix + "defaultValue = ").append(defaultValue).append("\n");
         }
         if (defaultValueForDoc != null) {
-            sb.append(prefix + "defaultValueForDoc = " + defaultValueForDoc + "\n");
+            sb.append(prefix + "defaultValueForDoc = ").append(defaultValueForDoc).append("\n");
         }
         if (deprecation != null) {
             sb.append(prefix + "deprecated = true\n");
         }
         if (mapKey != null) {
-            sb.append(prefix + "mapKey = " + mapKey + "\n");
+            sb.append(prefix + "mapKey = ").append(mapKey).append("\n");
         }
         if (unnamedMapKey) {
             sb.append(prefix + "unnamedMapKey = true\n");

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryRootElement.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/discovery/DiscoveryRootElement.java
@@ -59,9 +59,9 @@ public sealed abstract class DiscoveryRootElement permits DiscoveryConfigRoot, D
         sb.append(prefix + "binaryName = " + this.binaryName);
 
         if (!properties.isEmpty()) {
-            sb.append("\n\n" + prefix + "--- Properties ---\n\n");
+            sb.append("\n\n").append(prefix).append("--- Properties ---\n\n");
             for (DiscoveryConfigProperty property : properties.values()) {
-                sb.append(property.toString(prefix) + prefix + "--\n");
+                sb.append(property.toString(prefix)).append(prefix).append("--\n");
             }
         }
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
@@ -117,7 +117,7 @@ public final class JavadocToAsciidocTransformer {
                         sb.append('`');
                         appendEscapedAsciiDoc(sb, content, inlineMacroMode, new Context());
                         sb.append('`');
-                        htmlJavadoc.append("§§" + markerCounter + "§§");
+                        htmlJavadoc.append("§§").append(markerCounter).append("§§");
                         inlineTagsReplacements.put(markerCounter, sb.toString());
                         markerCounter++;
                         break;
@@ -130,7 +130,7 @@ public final class JavadocToAsciidocTransformer {
                         sb.append('`');
                         appendEscapedAsciiDoc(sb, content, inlineMacroMode, new Context());
                         sb.append('`');
-                        htmlJavadoc.append("§§" + markerCounter + "§§");
+                        htmlJavadoc.append("§§").append(markerCounter).append("§§");
                         inlineTagsReplacements.put(markerCounter, sb.toString());
                         markerCounter++;
                         break;

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigCollector.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/scanner/ConfigCollector.java
@@ -103,7 +103,7 @@ public class ConfigCollector {
         sb.append("=======================================================\n\n");
 
         for (DiscoveryConfigRoot configRoot : configRoots.values()) {
-            sb.append("- " + configRoot.getQualifiedName() + "\n");
+            sb.append("- ").append(configRoot.getQualifiedName()).append("\n");
             sb.append(configRoot.toString("  "));
             sb.append("\n\n===\n\n");
         }
@@ -116,7 +116,7 @@ public class ConfigCollector {
         sb.append("=======================================================\n\n");
 
         for (DiscoveryConfigGroup configGroup : resolvedConfigGroups.values()) {
-            sb.append("- " + configGroup.getQualifiedName() + "\n");
+            sb.append("- ").append(configGroup.getQualifiedName()).append("\n");
             sb.append(configGroup.toString("  "));
             sb.append("\n\n===\n\n");
         }

--- a/core/runtime/src/main/java/io/quarkus/runtime/TemplateHtmlBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/TemplateHtmlBuilder.java
@@ -324,8 +324,7 @@ public class TemplateHtmlBuilder {
         } else {
             result = new StringBuilder(String.format(HTML_TEMPLATE_START_NO_STACK, escapeHtml(title),
                     subTitle == null || subTitle.isEmpty() ? "" : " - " + escapeHtml(subTitle), CSS));
-            result.append(
-                    String.format(HEADER_TEMPLATE_NO_STACK, escapeHtml(title), escapeHtml(details), actionLinks.toString()));
+            result.append(String.format(HEADER_TEMPLATE_NO_STACK, escapeHtml(title), escapeHtml(details), actionLinks.toString()));
         }
 
         if (!config.isEmpty()) {


### PR DESCRIPTION
String concatenation within calls to StringBuilder.append() causes unnecessary memory allocation. Except for concatenations of String literals, which are joined together at compile time. Replaces inefficient concatenations with chained calls to StringBuilder.append().

https://docs.openrewrite.org/recipes/staticanalysis/chainstringbuilderappendcalls

is this any good?

maybe its related to: https://github.com/quarkusio/quarkus/pull/45587