### PR TITLE
Update Derby JDBC driver to 10.16.1.2 - Fixes CVE-2022-46337

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -124,7 +124,7 @@
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
         <adal4j.version>1.6.7</adal4j.version>
         <oracle-jdbc.version>23.5.0.24.07</oracle-jdbc.version>
-        <derby-jdbc.version>10.16.1.1</derby-jdbc.version>
+        <derby-jdbc.version>10.17.1.0</derby-jdbc.version>
         <db2-jdbc.version>12.1.0.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->


### PR DESCRIPTION
is ./mvnw -Dquickly. enough to test? 

https://github.com/quarkusio/quarkus/pull/45386#issuecomment-2575775548

```
[INFO] Quarkus - Integration Tests - Mutiny native JCTools support SUCCESS [  0.126 s]
[INFO] Quarkus - Documentation ............................ SUCCESS [  1.644 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11:39 min
[INFO] Finished at: 2025-01-15T00:21:05+01:00
[INFO] ------------------------------------------------------------------------
[INFO] 14905 goals, 11092 executed, 3813 from cache, saving at least 9m 24s
➜  quarkus git:(derby-jdbc) ./mvnw -Dquickly

```