### PR TITLE
Avoid ambiguous names when matching unknown configuration

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -1274,7 +1274,6 @@ public final class BuildTimeConfigurationReader {
         final List<ConfigClass> runTimeMappings;
         final List<ConfigClass> allMappings;
         final Map<Class<?>, ConfigClass> allMappingsByClass;
-        final Map<PropertyName, String> allMappingsNames;
 
         final Set<String> unknownBuildProperties;
         final Set<String> deprecatedRuntimeProperties;
@@ -1300,7 +1299,6 @@ public final class BuildTimeConfigurationReader {
             this.runTimeMappings = builder.getRunTimeMappings();
             this.allMappings = new ArrayList<>(mappingsToMap(builder).values());
             this.allMappingsByClass = mappingsToMap(builder);
-            this.allMappingsNames = ReadOperation.mappingsToNames(allMappings);
 
             this.unknownBuildProperties = builder.getUnknownBuildProperties();
             this.deprecatedRuntimeProperties = builder.deprecatedRuntimeProperties;
@@ -1388,10 +1386,6 @@ public final class BuildTimeConfigurationReader {
 
         public Map<Class<?>, ConfigClass> getAllMappingsByClass() {
             return allMappingsByClass;
-        }
-
-        public Map<PropertyName, String> getAllMappingsNames() {
-            return allMappingsNames;
         }
 
         public Set<String> getUnknownBuildProperties() {


### PR DESCRIPTION
- Fixes #45584

There are ambiguous names in the REST Client configuration:
- `quarkus.rest-client.logging.scope` https://github.com/quarkusio/quarkus/blob/f12169bd07f16967f66146c1a4c20b7b9444eb59/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java#L332
- `quarkus.rest-client.*.scope` https://github.com/quarkusio/quarkus/blob/5a2d46c9f578a3cc24f77bd401bb09080d12c2d8/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsBuildTimeConfig.java#L55

Usually, it is ok when these are part of the same tree. If not, SR Config issues a warning about this, but in this case, the mappings are never loaded simultaneously in SR Config because one is build time only and the other one is runtime.

Why does this relate to unknows? SR Config has a mechanism to check for unknowns, but unfortunately, we cannot rely on that one. The build time configuration is not available in the runtime SR Config instance,  but we cannot also report it as unknown, so the unknown check is done on the side, by collecting and generating checks against all the known names (build time, static, and runtime). 

In a previous version, all names were listed, but that was causing an increase of allocs, so  I rewrote the matching algorithm to avoid allocating `PropertyName`, and I've also reused some of our split strings to avoid having to recreate the entire property name String. I've added a new equal to match by region. Due to the ambiguous name described earlier, `quarkus.rest-client.logging.scope` was not included, because it was matched by `quarkus.rest-client.*.scope`.