### PR TITLE
ConfigMapping of GraphQL Client config

### DIFF
--- a/extensions/smallrye-graphql-client/deployment/pom.xml
+++ b/extensions/smallrye-graphql-client/deployment/pom.xml
@@ -112,9 +112,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
+++ b/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
@@ -221,7 +221,7 @@ public class SmallRyeGraphQLClientProcessor {
     void buildClientModel(CombinedIndexBuildItem index, SmallRyeGraphQLClientRecorder recorder,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans, GraphQLClientBuildConfig quarkusConfig) {
         if (!index.getIndex().getAnnotations(GRAPHQL_CLIENT_API).isEmpty()) {
-            ClientModels clientModels = (quarkusConfig.enableBuildTimeScanning) ? ClientModelBuilder.build(index.getIndex())
+            ClientModels clientModels = (quarkusConfig.enableBuildTimeScanning()) ? ClientModelBuilder.build(index.getIndex())
                     : new ClientModels(); // empty Client Model(s)
             RuntimeValue<ClientModels> modelRuntimeClientModel = recorder.getRuntimeClientModel(clientModels);
             DotName supportClassName = DotName.createSimple(ClientModels.class.getName());
@@ -252,7 +252,7 @@ public class SmallRyeGraphQLClientProcessor {
     @BuildStep
     void setAdditionalClassesToIndex(BuildProducer<AdditionalIndexedClassesBuildItem> additionalClassesToIndex,
             GraphQLClientBuildConfig quarkusConfig) {
-        if (quarkusConfig.enableBuildTimeScanning) {
+        if (quarkusConfig.enableBuildTimeScanning()) {
             additionalClassesToIndex.produce(new AdditionalIndexedClassesBuildItem(Closeable.class.getName()));
             additionalClassesToIndex.produce(new AdditionalIndexedClassesBuildItem(AutoCloseable.class.getName()));
             additionalClassesToIndex.produce(new AdditionalIndexedClassesBuildItem(Input.class.getName()));

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/GraphQLClientEnvVarConfigTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/GraphQLClientEnvVarConfigTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.smallrye.graphql.client.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.graphql.Query;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import graphql.AssertException;
+import io.quarkus.smallrye.graphql.client.deployment.other.MyEnvSource;
+import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientBuildConfig;
+import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientConfig;
+import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientsConfig;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+
+public class GraphQLClientEnvVarConfigTest {
+
+    private static final String URL = "http://localhost:8080/graphql";
+    private static final String CONFIG_KEY = "key";
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyGraphQLClient.class, MyEnvSource.class)
+                    .addAsServiceProvider(ConfigSource.class, MyEnvSource.class));
+
+    @Inject
+    GraphQLClientsConfig config; // runtime
+
+    @Inject
+    GraphQLClientBuildConfig buildConfig; // buildtime
+
+    @Test
+    void testConfigFromEnvVar() {
+        assertFalse(buildConfig.enableBuildTimeScanning());
+        GraphQLClientConfig client = config.clients().get(CONFIG_KEY);
+        assertNotNull(client);
+        assertEquals(URL,
+                client.url().orElseThrow(() -> new AssertException("URL not found in '%s' config".formatted(CONFIG_KEY))));
+    }
+
+    @GraphQLClientApi(configKey = CONFIG_KEY)
+    public interface MyGraphQLClient {
+        @Query
+        String hello();
+    }
+}

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/other/MyEnvSource.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/other/MyEnvSource.java
@@ -1,0 +1,14 @@
+package io.quarkus.smallrye.graphql.client.deployment.other;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.StaticInitSafe;
+import io.smallrye.config.EnvConfigSource;
+
+@StaticInitSafe
+public class MyEnvSource extends EnvConfigSource {
+    public MyEnvSource() {
+        super(Map.of("QUARKUS_SMALLRYE_GRAPHQL_CLIENT__KEY__URL", "http://localhost:8080/graphql", // runtime property
+                "QUARKUS_SMALLRYE_GRAPHQL_CLIENT_ENABLE_BUILD_TIME_SCANNING", "FALSE"), ORDINAL); // build–time property
+    }
+}

--- a/extensions/smallrye-graphql-client/runtime/pom.xml
+++ b/extensions/smallrye-graphql-client/runtime/pom.xml
@@ -85,9 +85,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientBuildConfig.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientBuildConfig.java
@@ -1,16 +1,18 @@
 package io.quarkus.smallrye.graphql.client.runtime;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "smallrye-graphql-client", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class GraphQLClientBuildConfig {
+@ConfigMapping(prefix = "quarkus.smallrye-graphql-client")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface GraphQLClientBuildConfig {
 
     /**
      * Configuration item to enable build-time scanning in Quarkus for generating typesafe GraphQL client models.
      * If true, build-time scanning is enabled. By default, it is true.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enableBuildTimeScanning;
+    @WithDefault("true")
+    boolean enableBuildTimeScanning();
 }

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientCertificateUpdateEventListener.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientCertificateUpdateEventListener.java
@@ -24,11 +24,11 @@ public class GraphQLClientCertificateUpdateEventListener {
     public void onCertificateUpdate(@Observes CertificateUpdatedEvent event) {
         String updatedTlsConfigurationName = event.name();
         TlsConfiguration updatedTlsConfiguration = event.tlsConfiguration();
-        graphQLClientsConfig.clients
+        graphQLClientsConfig.clients()
                 .forEach((configKey, clientConfig) -> {
                     GraphQLClientConfiguration graphQLClientConfiguration = GraphQLClientsConfiguration.getInstance()
                             .getClient(configKey);
-                    clientConfig.tlsConfigurationName.ifPresentOrElse(tlsConfigurationName -> {
+                    clientConfig.tlsConfigurationName().ifPresentOrElse(tlsConfigurationName -> {
                         if (tlsConfigurationName.equals(updatedTlsConfigurationName)) {
                             updateConfiguration(updatedTlsConfigurationName, updatedTlsConfiguration,
                                     graphQLClientConfiguration, configKey);

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
@@ -7,23 +7,23 @@ import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 @ConfigGroup
-public class GraphQLClientConfig {
+public interface GraphQLClientConfig {
 
     /**
      * The URL location of the target GraphQL service.
      */
-    @ConfigItem
-    public Optional<String> url;
+    Optional<String> url();
 
     /**
      * HTTP headers to add when communicating with the target GraphQL service.
      */
-    @ConfigItem(name = "header")
+    @WithName("header")
     @ConfigDocMapKey("header-name")
-    public Map<String, String> headers;
+    public Map<String, String> headers();
 
     /**
      * WebSocket subprotocols that should be supported by this client for running GraphQL operations over websockets.
@@ -33,138 +33,123 @@ public class GraphQLClientConfig {
      * If multiple protocols are provided, the actual protocol to be used will be subject to negotiation with
      * the server.
      */
-    @ConfigItem(defaultValue = "graphql-transport-ws")
-    public Optional<List<String>> subprotocols;
+    @WithDefault("graphql-transport-ws")
+    Optional<List<String>> subprotocols();
 
     /**
      * If true, then queries and mutations will run over the websocket transport rather than pure HTTP.
      * Off by default, because it has higher overhead.
      */
-    @ConfigItem
-    public Optional<Boolean> executeSingleResultOperationsOverWebsocket;
+    Optional<Boolean> executeSingleResultOperationsOverWebsocket();
 
     /**
      * Maximum time in milliseconds that will be allowed to wait for the server to acknowledge a websocket connection
      * (send a subprotocol-specific ACK message).
      */
-    @ConfigItem
-    public OptionalInt websocketInitializationTimeout;
+    OptionalInt websocketInitializationTimeout();
 
     /**
      * The trust store location. Can point to either a classpath resource or a file.
      *
      * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
      *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."client-name".tls-bucket-name}.
+     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
      */
-    @ConfigItem
     @Deprecated(forRemoval = true, since = "3.16.0")
-    public Optional<String> trustStore;
+    Optional<String> trustStore();
 
     /**
      * The trust store password.
      *
      * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
      *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."client-name".tls-bucket-name}.
+     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
      */
-    @ConfigItem
     @Deprecated(forRemoval = true, since = "3.16.0")
-    public Optional<String> trustStorePassword;
+    Optional<String> trustStorePassword();
 
     /**
      * The type of the trust store. Defaults to "JKS".
      *
      * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
      *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."client-name".tls-bucket-name}.
+     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
      */
-    @ConfigItem
     @Deprecated(forRemoval = true, since = "3.16.0")
-    public Optional<String> trustStoreType;
+    Optional<String> trustStoreType();
 
     /**
      * The key store location. Can point to either a classpath resource or a file.
      *
      * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
      *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."client-name".tls-bucket-name}.
+     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
      */
-    @ConfigItem
     @Deprecated(forRemoval = true, since = "3.16.0")
-    public Optional<String> keyStore;
+    Optional<String> keyStore();
 
     /**
      * The key store password.
      *
      * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
      *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."client-name".tls-bucket-name}.
+     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
      */
-    @ConfigItem
     @Deprecated(forRemoval = true, since = "3.16.0")
-    public Optional<String> keyStorePassword;
+    Optional<String> keyStorePassword();
 
     /**
      * The type of the key store. Defaults to "JKS".
      *
      * @deprecated This configuration property is deprecated. Consider using the Quarkus TLS registry.
      *             Set the desired TLS bucket name using the following configuration property:
-     *             {@code quarkus.smallrye-graphql-client."client-name".tls-bucket-name}.
+     *             {@code quarkus.smallrye-graphql-client."config-key".tls-bucket-name}.
      *
      */
-    @ConfigItem
     @Deprecated(forRemoval = true, since = "3.16.0")
-    public Optional<String> keyStoreType;
+    Optional<String> keyStoreType();
 
     /**
      * Hostname of the proxy to use.
      */
-    @ConfigItem
-    public Optional<String> proxyHost;
+    Optional<String> proxyHost();
 
     /**
      * Port number of the proxy to use.
      */
-    @ConfigItem
-    public OptionalInt proxyPort;
+    OptionalInt proxyPort();
 
     /**
      * Username for the proxy to use.
      */
-    @ConfigItem
-    public Optional<String> proxyUsername;
+    Optional<String> proxyUsername();
 
     /**
      * Password for the proxy to use.
      */
-    @ConfigItem
-    public Optional<String> proxyPassword;
+    Optional<String> proxyPassword();
 
     /**
      * Maximum number of redirects to follow.
      */
-    @ConfigItem
-    public OptionalInt maxRedirects;
+    OptionalInt maxRedirects();
 
     /**
      * Additional payload sent on websocket initialization.
      */
-    @ConfigItem(name = "init-payload")
+    @WithName("init-payload")
     @ConfigDocMapKey("property-name")
-    public Map<String, String> initPayload;
+    Map<String, String> initPayload();
 
     /**
      * Allowing unexpected fields in response.
      * If true, there will be warning log of an unexpected field.
      * Else it throws an error.
      */
-    @ConfigItem
-    public Optional<Boolean> allowUnexpectedResponseFields;
+    Optional<Boolean> allowUnexpectedResponseFields();
 
     /**
      * The name of the TLS configuration (bucket) used for client authentication in the TLS registry.
      */
-    @ConfigItem
-    public Optional<String> tlsConfigurationName;
+    Optional<String> tlsConfigurationName();
 }

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientsConfig.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientsConfig.java
@@ -2,12 +2,15 @@ package io.quarkus.smallrye.graphql.client.runtime;
 
 import java.util.Map;
 
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
 
-@ConfigRoot(name = "smallrye-graphql-client", phase = ConfigPhase.RUN_TIME)
-public class GraphQLClientsConfig {
+@ConfigMapping(prefix = "quarkus.smallrye-graphql-client")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface GraphQLClientsConfig {
 
     /**
      * Configurations of named GraphQL client instances.
@@ -19,7 +22,7 @@ public class GraphQLClientsConfig {
      * `@GraphQLClientApi` annotation, or the name of a class bearing that annotation, in which case
      * it is possible to use the short name, as well as fully qualified.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, GraphQLClientConfig> clients;
-
+    @ConfigDocMapKey("config-key")
+    @WithParentName
+    Map<String, GraphQLClientConfig> clients();
 }

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/SmallRyeGraphQLClientRecorder.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/SmallRyeGraphQLClientRecorder.java
@@ -59,7 +59,7 @@ public class SmallRyeGraphQLClientRecorder {
 
     public void mergeClientConfigurations(GraphQLClientSupport support, GraphQLClientsConfig quarkusConfiguration) {
         GraphQLClientsConfiguration upstreamConfigs = GraphQLClientsConfiguration.getInstance();
-        for (Map.Entry<String, GraphQLClientConfig> client : quarkusConfiguration.clients.entrySet()) {
+        for (Map.Entry<String, GraphQLClientConfig> client : quarkusConfiguration.clients().entrySet()) {
             // the raw config key provided in the config, this might be a short class name,
             // so translate that into the fully qualified name if applicable
             String rawConfigKey = client.getKey();
@@ -117,11 +117,11 @@ public class SmallRyeGraphQLClientRecorder {
     // by SmallRye GraphQL
     private GraphQLClientConfiguration toSmallRyeNativeConfiguration(GraphQLClientConfig quarkusConfig) {
         GraphQLClientConfiguration transformed = new GraphQLClientConfiguration();
-        transformed.setHeaders(quarkusConfig.headers);
-        transformed.setInitPayload(Optional.ofNullable(quarkusConfig.initPayload)
+        transformed.setHeaders(quarkusConfig.headers());
+        transformed.setInitPayload(Optional.ofNullable(quarkusConfig.initPayload())
                 .map(m -> new HashMap<String, Object>(m)).orElse(null));
-        quarkusConfig.url.ifPresent(transformed::setUrl);
-        transformed.setWebsocketSubprotocols(quarkusConfig.subprotocols.orElse(new ArrayList<>()));
+        quarkusConfig.url().ifPresent(transformed::setUrl);
+        transformed.setWebsocketSubprotocols(quarkusConfig.subprotocols().orElse(new ArrayList<>()));
         resolveTlsConfigurationForRegistry(quarkusConfig)
                 .ifPresentOrElse(tlsConfiguration -> {
                     transformed.setTlsKeyStoreOptions(tlsConfiguration.getKeyStoreOptions());
@@ -132,22 +132,22 @@ public class SmallRyeGraphQLClientRecorder {
                     transformed.setUsesSni(Boolean.valueOf(tlsConfiguration.usesSni()));
                 }, () -> {
                     // DEPRECATED
-                    quarkusConfig.keyStore.ifPresent(transformed::setKeyStore);
-                    quarkusConfig.keyStoreType.ifPresent(transformed::setKeyStoreType);
-                    quarkusConfig.keyStorePassword.ifPresent(transformed::setKeyStorePassword);
-                    quarkusConfig.trustStore.ifPresent(transformed::setTrustStore);
-                    quarkusConfig.trustStoreType.ifPresent(transformed::setTrustStoreType);
-                    quarkusConfig.trustStorePassword.ifPresent(transformed::setTrustStorePassword);
+                    quarkusConfig.keyStore().ifPresent(transformed::setKeyStore);
+                    quarkusConfig.keyStoreType().ifPresent(transformed::setKeyStoreType);
+                    quarkusConfig.keyStorePassword().ifPresent(transformed::setKeyStorePassword);
+                    quarkusConfig.trustStore().ifPresent(transformed::setTrustStore);
+                    quarkusConfig.trustStoreType().ifPresent(transformed::setTrustStoreType);
+                    quarkusConfig.trustStorePassword().ifPresent(transformed::setTrustStorePassword);
                 });
-        quarkusConfig.proxyHost.ifPresent(transformed::setProxyHost);
-        quarkusConfig.proxyPort.ifPresent(transformed::setProxyPort);
-        quarkusConfig.proxyUsername.ifPresent(transformed::setProxyUsername);
-        quarkusConfig.proxyPassword.ifPresent(transformed::setProxyPassword);
-        quarkusConfig.maxRedirects.ifPresent(transformed::setMaxRedirects);
-        quarkusConfig.executeSingleResultOperationsOverWebsocket
+        quarkusConfig.proxyHost().ifPresent(transformed::setProxyHost);
+        quarkusConfig.proxyPort().ifPresent(transformed::setProxyPort);
+        quarkusConfig.proxyUsername().ifPresent(transformed::setProxyUsername);
+        quarkusConfig.proxyPassword().ifPresent(transformed::setProxyPassword);
+        quarkusConfig.maxRedirects().ifPresent(transformed::setMaxRedirects);
+        quarkusConfig.executeSingleResultOperationsOverWebsocket()
                 .ifPresent(transformed::setExecuteSingleOperationsOverWebsocket);
-        quarkusConfig.websocketInitializationTimeout.ifPresent(transformed::setWebsocketInitializationTimeout);
-        quarkusConfig.allowUnexpectedResponseFields.ifPresent(transformed::setAllowUnexpectedResponseFields);
+        quarkusConfig.websocketInitializationTimeout().ifPresent(transformed::setWebsocketInitializationTimeout);
+        quarkusConfig.allowUnexpectedResponseFields().ifPresent(transformed::setAllowUnexpectedResponseFields);
         transformed.setDynamicHeaders(new HashMap<>());
         return transformed;
     }
@@ -172,7 +172,7 @@ public class SmallRyeGraphQLClientRecorder {
                                 || tlsConfigurationRegistry.getDefault().get().isTrustAll())) {
                     return tlsConfigurationRegistry.getDefault();
                 }
-                return TlsConfiguration.from(tlsConfigurationRegistry, quarkusConfig.tlsConfigurationName);
+                return TlsConfiguration.from(tlsConfigurationRegistry, quarkusConfig.tlsConfigurationName());
             }
         }
         return Optional.empty();


### PR DESCRIPTION
/cc @radcortez 
With that, I also added a simple test for Env Vars transformation; despite it not being implemented on our side, I wanted to make sure that the migration works.
~~The `GraphQLClientEnvUrlTest` test fails due to url not mapping correctly to the specified client config.~~ edit: fixed

