### PR TITLE
Allow null for query parameters in Kotlin panache

### DIFF
--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheRepositoryBase.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheRepositoryBase.kt
@@ -115,7 +115,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
-    fun find(query: String, vararg params: Any): PanacheQuery<Entity> =
+    fun find(query: String, vararg params: Any?): PanacheQuery<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -129,7 +129,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
-    fun find(query: String, sort: Sort, vararg params: Any): PanacheQuery<Entity> =
+    fun find(query: String, sort: Sort, vararg params: Any?): PanacheQuery<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -142,7 +142,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
-    fun find(query: String, params: Map<String, Any>): PanacheQuery<Entity> =
+    fun find(query: String, params: Map<String, Any?>): PanacheQuery<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -156,7 +156,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
-    fun find(query: String, sort: Sort, params: Map<String, Any>): PanacheQuery<Entity> =
+    fun find(query: String, sort: Sort, params: Map<String, Any?>): PanacheQuery<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -217,7 +217,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
-    fun list(query: String, vararg params: Any): List<Entity> =
+    fun list(query: String, vararg params: Any?): List<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -232,7 +232,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
-    fun list(query: String, sort: Sort, vararg params: Any): List<Entity> =
+    fun list(query: String, sort: Sort, vararg params: Any?): List<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -246,7 +246,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
-    fun list(query: String, params: Map<String, Any>): List<Entity> =
+    fun list(query: String, params: Map<String, Any?>): List<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -261,7 +261,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
-    fun list(query: String, sort: Sort, params: Map<String, Any>): List<Entity> =
+    fun list(query: String, sort: Sort, params: Map<String, Any?>): List<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -325,7 +325,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
-    fun stream(query: String, vararg params: Any): Stream<Entity> =
+    fun stream(query: String, vararg params: Any?): Stream<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -342,7 +342,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
-    fun stream(query: String, sort: Sort, vararg params: Any): Stream<Entity> =
+    fun stream(query: String, sort: Sort, vararg params: Any?): Stream<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -357,7 +357,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
-    fun stream(query: String, params: Map<String, Any>): Stream<Entity> =
+    fun stream(query: String, params: Map<String, Any?>): Stream<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -373,7 +373,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
-    fun stream(query: String, sort: Sort, params: Map<String, Any>): Stream<Entity> =
+    fun stream(query: String, sort: Sort, params: Map<String, Any?>): Stream<Entity> =
         throw implementationInjectionMissing()
 
     /**
@@ -447,7 +447,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @return the number of entities counted.
      */
     @GenerateBridge
-    fun count(query: String, vararg params: Any): Long = throw implementationInjectionMissing()
+    fun count(query: String, vararg params: Any?): Long = throw implementationInjectionMissing()
 
     /**
      * Counts the number of this type of entity matching the given query, with named parameters.
@@ -457,7 +457,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @return the number of entities counted.
      */
     @GenerateBridge
-    fun count(query: String, params: Map<String, Any>): Long =
+    fun count(query: String, params: Map<String, Any?>): Long =
         throw implementationInjectionMissing()
 
     /**
@@ -493,7 +493,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.deleteAll]
      */
     @GenerateBridge
-    fun delete(query: String, vararg params: Any): Long = throw implementationInjectionMissing()
+    fun delete(query: String, vararg params: Any?): Long = throw implementationInjectionMissing()
 
     /**
      * Delete all entities of this type matching the given query, with named parameters.
@@ -507,7 +507,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [PanacheRepositoryBase.deleteAll]
      */
     @GenerateBridge
-    fun delete(query: String, params: Map<String, Any>): Long =
+    fun delete(query: String, params: Map<String, Any?>): Long =
         throw implementationInjectionMissing()
 
     /**
@@ -567,7 +567,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @return the number of entities updated.
      */
     @GenerateBridge
-    fun update(query: String, vararg params: Any): Int = throw implementationInjectionMissing()
+    fun update(query: String, vararg params: Any?): Int = throw implementationInjectionMissing()
 
     /**
      * Update all entities of this type matching the given query, with named parameters.
@@ -577,7 +577,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @return the number of entities updated.
      */
     @GenerateBridge
-    fun update(query: String, params: Map<String, Any>): Int =
+    fun update(query: String, params: Map<String, Any?>): Int =
         throw implementationInjectionMissing()
 
     /**

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/PanacheRepositoryBase.kt
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/PanacheRepositoryBase.kt
@@ -104,7 +104,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [list] list
      */
     @GenerateBridge
-    fun find(query: String, vararg params: Any): PanacheQuery<Entity> =
+    fun find(query: String, vararg params: Any?): PanacheQuery<Entity> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -117,7 +117,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [list] list
      */
     @GenerateBridge
-    fun find(query: String, sort: Sort, vararg params: Any): PanacheQuery<Entity> =
+    fun find(query: String, sort: Sort, vararg params: Any?): PanacheQuery<Entity> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -129,7 +129,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [list] list
      */
     @GenerateBridge
-    fun find(query: String, params: Map<String, Any>): PanacheQuery<Entity> =
+    fun find(query: String, params: Map<String, Any?>): PanacheQuery<Entity> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -142,7 +142,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      * @see [list] list
      */
     @GenerateBridge
-    fun find(query: String, sort: Sort, params: Map<String, Any>): PanacheQuery<Entity> =
+    fun find(query: String, sort: Sort, params: Map<String, Any?>): PanacheQuery<Entity> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -200,7 +200,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun list(query: String, vararg params: Any): Uni<List<Entity>> =
+    fun list(query: String, vararg params: Any?): Uni<List<Entity>> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -215,7 +215,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun list(query: String, sort: Sort, vararg params: Any): Uni<List<Entity>> =
+    fun list(query: String, sort: Sort, vararg params: Any?): Uni<List<Entity>> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -229,7 +229,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun list(query: String, params: Map<String, Any>): Uni<List<Entity>> =
+    fun list(query: String, params: Map<String, Any?>): Uni<List<Entity>> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -244,7 +244,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun list(query: String, sort: Sort, params: Map<String, Any>): Uni<List<Entity>> =
+    fun list(query: String, sort: Sort, params: Map<String, Any?>): Uni<List<Entity>> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -319,7 +319,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun count(query: String, vararg params: Any): Uni<Long> =
+    fun count(query: String, vararg params: Any?): Uni<Long> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -331,7 +331,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun count(query: String, params: Map<String, Any>): Uni<Long> =
+    fun count(query: String, params: Map<String, Any?>): Uni<Long> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -382,7 +382,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun delete(query: String, vararg params: Any): Uni<Long> =
+    fun delete(query: String, vararg params: Any?): Uni<Long> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -398,7 +398,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun delete(query: String, params: Map<String, Any>): Uni<Long> =
+    fun delete(query: String, params: Map<String, Any?>): Uni<Long> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -453,7 +453,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun update(query: String, vararg params: Any): Uni<Int> =
+    fun update(query: String, vararg params: Any?): Uni<Int> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**
@@ -465,7 +465,7 @@ interface PanacheRepositoryBase<Entity : Any, Id : Any> {
      */
     @CheckReturnValue
     @GenerateBridge
-    fun update(query: String, params: Map<String, Any>): Uni<Int> =
+    fun update(query: String, params: Map<String, Any?>): Uni<Int> =
         throw INSTANCE.implementationInjectionMissing()
 
     /**

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/AddressDao.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/AddressDao.kt
@@ -14,5 +14,5 @@ open class AddressDao(private val dummyService: DummyService) :
         }
     }
 
-    override fun count(query: String, params: Map<String, Any>): Long = shouldBeOverridden()
+    override fun count(query: String, params: Map<String, Any?>): Long = shouldBeOverridden()
 }

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/PersonRepository.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/PersonRepository.kt
@@ -6,7 +6,7 @@ import jakarta.enterprise.context.ApplicationScoped
 
 @ApplicationScoped
 open class PersonRepository : PanacheRepository<Person> {
-    override fun count(query: String, params: Map<String, Any>): Long {
+    override fun count(query: String, params: Map<String, Any?>): Long {
         return INSTANCE.count(Person::class.java, query, params)
     }
 }


### PR DESCRIPTION
Quarkus Panache has Kotlin specific extensions that should be used for Kotlin projects when working with Hibernate and Panache. We recently wanted to migrate our Kotlin project from using the Java panache extensions to the Kotlin panache extensions, however it turned out that they behaved differently.

The big difference is that since Kotlin is non-nullable by default, function signatures such as `vararg params: Any` in Kotlin are different from A java version like `vararg params: Object`, since an Object is nullable but Any is not. This is a problem, because the query can absolutely take nullable parameters.

For example, the following code would work with the Java version, but not the Kotlin version, since all 3 parameters are possibly null within this context:
```kotlin
find("""
    (cast(?1 AS uuid) IS null OR assignment.courseInstanceId = ?1) AND
    (cast(?2 AS uuid) IS null OR groupId                     = ?2) AND 
    (cast(?3 AS uuid) IS null OR assignment.id               = ?3)
""", courseInstanceId, groupId, assignmentId)
```
It is also unreasonable to expect the user to deal with nullability outside of the query, as checking for nullability outside of this query makes the query extremely ugly as you'd need to dynamically construct the query based on whether a parameter is null or not.

This PR converts the `Any` parameter type to `Any?`, to allow for nullable parameters when using the Kotlin extensions (which is absolutely valid for queries), and to bring the Kotlin version in line with the Java version. These changes are made for both the Kotlin Panache for Hibernate ORM extension as well as the Kotlin Panache for Hibernate Reactive extension.