### PR TITLE
Remove the use of UUID in startup code

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -46,7 +46,6 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
      * we don't want to generate a new UUID each time as it is slowish. Instead, we just generate one based one
      * and then use a counter.
      */
-    private static final String BASE_ID = UUID.randomUUID() + "-";
 
     private static final AtomicLong ERROR_COUNT = new AtomicLong();
 
@@ -148,7 +147,7 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
             event.response().setStatusCode(event.statusCode() > 0 ? event.statusCode() : 500);
         }
 
-        String uuid = BASE_ID + ERROR_COUNT.incrementAndGet();
+        String uuid = LazyHolder.BASE_ID + ERROR_COUNT.incrementAndGet();
         String details;
         String stack = "";
         Throwable exception = event.failure();
@@ -426,5 +425,9 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
                 return result == null ? null : result.value();
             }
         }
+    }
+
+    private static class LazyHolder {
+        private static final String BASE_ID = UUID.randomUUID() + "-";
     }
 }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -15,8 +15,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
@@ -395,8 +395,7 @@ public class VertxCoreRecorder {
     }
 
     private static File getRandomDirectory(File tmp) {
-        long random = Math.abs(UUID.randomUUID().getMostSignificantBits());
-        File cache = new File(tmp, Long.toString(random));
+        File cache = new File(tmp, Long.toString(new Random().nextLong()));
         if (cache.isDirectory()) {
             // Do not reuse an existing directory.
             return getRandomDirectory(tmp);


### PR DESCRIPTION
Follow up of: #45434

P.S. For this to be effective, we would also need something like https://github.com/geoand/vert.x/commit/e294b83f4feca315a903ab66e866c472679ad58d - if something like that is also included, then we no longer have any usage `UUID.randomUUID()` at startup

I saw this when I stumbled upon

![Screenshot from 2025-01-15 13-07-36](https://github.com/user-attachments/assets/8f1360bb-1965-435e-810a-7676e7979cd1)
