### PR TITLE
Switch to runtime initialization instead of rerun

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/NioSocketImplProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/NioSocketImplProcessor.java
@@ -1,14 +1,14 @@
 package io.quarkus.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 
 public class NioSocketImplProcessor {
 
     // Workaround till https://github.com/oracle/graal/pull/10431 gets merged and backported to all supported versions
     @BuildStep
-    RuntimeInitializedClassBuildItem reinitializeClass() {
-        return new RuntimeInitializedClassBuildItem("sun.nio.ch.NioSocketImpl");
+    RuntimeReinitializedClassBuildItem reinitializeClass() {
+        return new RuntimeReinitializedClassBuildItem("sun.nio.ch.NioSocketImpl");
     }
 
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/RuntimeReinitializedClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/RuntimeReinitializedClassBuildItem.java
@@ -5,7 +5,11 @@ import io.quarkus.builder.item.MultiBuildItem;
 /**
  * A class that will be reinitialized at runtime in native mode. This will result in the static
  * initializer running twice.
+ *
+ * @deprecated Starting with Mandrel/GraalVM 23.1 for JDK 21 this is functionally the same with
+ *             {@link RuntimeInitializedClassBuildItem}.
  */
+@Deprecated(since = "3.18")
 public final class RuntimeReinitializedClassBuildItem extends MultiBuildItem {
 
     private final String className;


### PR DESCRIPTION
They both have the same result starting with 23.1. Runtime
initialization is public API while rerun is not, and will soon be
deprecated and at some point removed in future releases.

See https://github.com/oracle/graal/issues/5013#issuecomment-1944747803
and https://github.com/oracle/graal/pull/8323/

Keeping as draft until it's tested with both:

* Mandrel 23.1 for JDK 21: https://github.com/zakkak/quarkus/actions/runs/12789427486

and
 
* Mandrel 23.0 for JDK 17: https://github.com/graalvm/mandrel/actions/runs/12788108291

Closes https://github.com/quarkusio/quarkus/issues/25975