### PR TITLE
Use VertxLogDelegateFactory for internal Vert.x logging

### DIFF
--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -221,6 +221,12 @@ class VertxCoreProcessor {
     }
 
     @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void configureLogging(VertxCoreRecorder recorder) {
+        recorder.configureQuarkusLoggerFactory();
+    }
+
+    @BuildStep
     @Produce(ServiceStartBuildItem.class)
     @Record(value = ExecutionTime.RUNTIME_INIT)
     CoreVertxBuildItem build(VertxCoreRecorder recorder,

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -69,6 +69,8 @@ import io.vertx.core.spi.resolver.ResolverProvider;
 @Recorder
 public class VertxCoreRecorder {
 
+    private static final String LOGGER_FACTORY_NAME_SYS_PROP = "vertx.logger-delegate-factory-class-name";
+
     static {
         System.setProperty("vertx.disableTCCL", "true");
     }
@@ -665,6 +667,13 @@ public class VertxCoreRecorder {
     public static Supplier<Vertx> recoverFailedStart(VertxConfiguration config, ThreadPoolConfig threadPoolConfig) {
         return vertx = new VertxSupplier(LaunchMode.DEVELOPMENT, config, Collections.emptyList(), threadPoolConfig, null);
 
+    }
+
+    public void configureQuarkusLoggerFactory() {
+        String loggerClassName = System.getProperty(LOGGER_FACTORY_NAME_SYS_PROP);
+        if (loggerClassName == null) {
+            System.setProperty(LOGGER_FACTORY_NAME_SYS_PROP, VertxLogDelegateFactory.class.getName());
+        }
     }
 
     static class VertxSupplier implements Supplier<Vertx> {


### PR DESCRIPTION
This is done because I assume that was the original intent, but also because it avoids the non-zero cost
incurred by Vert.x to look up the various supported options

This originally came to my attention by stumbling upon

![Screenshot from 2025-01-15 14-37-26](https://github.com/user-attachments/assets/6e05eb85-8e57-48a1-a52a-ca915170ed61)
