### PR TITLE
OIDC: reuse shared Vert.x instance in DEV and test mode whenever it is possible

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
@@ -46,7 +46,7 @@ public abstract class AbstractDevUIProcessor {
             Map<String, String> keycloakUsers,
             List<String> keycloakRealms,
             boolean alwaysLogoutUserInDevUiOnReload,
-            HttpConfiguration httpConfiguration) {
+            HttpConfiguration httpConfiguration, boolean discoverMetadata, String authServerUrl) {
         final CardPageBuildItem cardPage = new CardPageBuildItem();
 
         // prepare provider component
@@ -82,7 +82,8 @@ public abstract class AbstractDevUIProcessor {
                 authorizationUrl, tokenUrl, logoutUrl, webClientTimeout, grantOptions,
                 keycloakUsers, oidcProviderName, oidcApplicationType, oidcGrantType,
                 introspectionIsAvailable, keycloakAdminUrl, keycloakRealms, swaggerIsAvailable,
-                graphqlIsAvailable, swaggerUiPath, graphqlUiPath, alwaysLogoutUserInDevUiOnReload);
+                graphqlIsAvailable, swaggerUiPath, graphqlUiPath, alwaysLogoutUserInDevUiOnReload, discoverMetadata,
+                authServerUrl);
 
         recorder.createJsonRPCService(beanContainer.getValue(), runtimeProperties, httpConfiguration);
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
@@ -72,7 +72,7 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
                     users,
                     keycloakRealms,
                     configProps.get().isContainerRestarted(),
-                    httpConfiguration);
+                    httpConfiguration, false, null);
             // use same card page so that both pages appear on the same card
             var keycloakAdminPageItem = new KeycloakAdminPageBuildItem(cardPageBuildItem);
             keycloakAdminPageProducer.produce(keycloakAdminPageItem);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
@@ -2,8 +2,6 @@ package io.quarkus.oidc.runtime.devui;
 
 import static io.quarkus.oidc.runtime.devui.OidcDevServicesUtils.getTokens;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -21,17 +19,8 @@ public class OidcDevJsonRpcService {
     @Inject
     OidcDevLoginObserver oidcDevTokensObserver;
 
-    private Vertx vertx;
-
-    @PostConstruct
-    public void startup() {
-        vertx = Vertx.vertx();
-    }
-
-    @PreDestroy
-    public void shutdown() {
-        vertx.close();
-    }
+    @Inject
+    Vertx vertx;
 
     @NonBlocking
     public OidcDevUiRuntimePropertiesDTO getProperties() {
@@ -72,7 +61,7 @@ public class OidcDevJsonRpcService {
         return oidcDevTokensObserver.streamOidcLoginEvent();
     }
 
-    public void hydrate(OidcDevUiRpcSvcPropertiesBean properties, HttpConfiguration httpConfiguration) {
+    void hydrate(OidcDevUiRpcSvcPropertiesBean properties, HttpConfiguration httpConfiguration) {
         this.props = properties;
         this.httpConfiguration = httpConfiguration;
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevUiRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevUiRecorder.java
@@ -4,16 +4,27 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
+import io.vertx.mutiny.ext.web.client.WebClient;
 
 @Recorder
 public class OidcDevUiRecorder {
+
+    private static final Logger LOG = Logger.getLogger(OidcDevUiRecorder.class);
 
     private final RuntimeValue<OidcConfig> oidcConfigRuntimeValue;
 
@@ -31,8 +42,18 @@ public class OidcDevUiRecorder {
             String logoutUrl, Duration webClientTimeout, Map<String, Map<String, String>> grantOptions,
             Map<String, String> oidcUsers, String oidcProviderName, String oidcApplicationType, String oidcGrantType,
             boolean introspectionIsAvailable, String keycloakAdminUrl, List<String> keycloakRealms, boolean swaggerIsAvailable,
-            boolean graphqlIsAvailable, String swaggerUiPath, String graphqlUiPath, boolean alwaysLogoutUserInDevUiOnReload) {
-
+            boolean graphqlIsAvailable, String swaggerUiPath, String graphqlUiPath, boolean alwaysLogoutUserInDevUiOnReload,
+            boolean discoverMetadata, String authServerUrl) {
+        if (discoverMetadata) {
+            JsonObject metadata = discoverMetadata(authServerUrl);
+            if (metadata != null) {
+                authorizationUrl = metadata.getString("authorization_endpoint");
+                tokenUrl = metadata.getString("token_endpoint");
+                logoutUrl = metadata.getString("end_session_endpoint");
+                introspectionIsAvailable = metadata.containsKey("introspection_endpoint")
+                        || metadata.containsKey("userinfo_endpoint");
+            }
+        }
         return new RuntimeValue<OidcDevUiRpcSvcPropertiesBean>(
                 new OidcDevUiRpcSvcPropertiesBean(authorizationUrl, tokenUrl, logoutUrl,
                         webClientTimeout, grantOptions, oidcUsers, oidcProviderName, oidcApplicationType, oidcGrantType,
@@ -48,4 +69,25 @@ public class OidcDevUiRecorder {
         return new OidcDevSessionLogoutHandler();
     }
 
+    private static JsonObject discoverMetadata(String authServerUrl) {
+        WebClient client = OidcDevServicesUtils.createWebClient(VertxCoreRecorder.getVertx().get());
+        try {
+            String metadataUrl = authServerUrl + OidcConstants.WELL_KNOWN_CONFIGURATION;
+            LOG.infof("OIDC Dev Console: discovering the provider metadata at %s", metadataUrl);
+
+            HttpResponse<Buffer> resp = client.getAbs(metadataUrl)
+                    .putHeader(HttpHeaders.ACCEPT.toString(), "application/json").send().await().indefinitely();
+            if (resp.statusCode() == 200) {
+                return resp.bodyAsJsonObject();
+            } else {
+                LOG.errorf("OIDC metadata discovery failed: %s", resp.bodyAsString());
+                return null;
+            }
+        } catch (Throwable t) {
+            LOG.infof("OIDC metadata can not be discovered: %s", t.toString());
+            return null;
+        } finally {
+            client.close();
+        }
+    }
 }


### PR DESCRIPTION
For OIDC extensions in DEV and test mode, this PR propposes using managed Vertx when it is possible because creating of a new Vertx is expensive and it should be preferred to reuse Vertx. Sadly I added some runtime code required in a DEV mode, but I don't think it matters as soon classes used for a DEV UI will only affect the DEV mode https://github.com/quarkusio/quarkus/pull/45053.

context: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Using.20managed.20.28shared.29.20Vert.2Ex.20instance.20to.20create.20WebClient