### PR TITLE
OIDC: document and use OidcTestClient to get access token from Dev Services for OIDC

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -857,6 +857,48 @@ For a test like this to work, the test `Auth0` application must have the `passwo
 This example code also shows how to pass additional parameters.
 For `Auth0`, these are the `audience` and `scope` parameters.
 
+===== Test OIDC DevService
+
+You can also use `OidcTestClient` to test Quarkus endpoints supported by xref:security-openid-connect-dev-services.adoc#dev-services-for-oidc[Dev Services for OIDC].
+No configuration in the `application.properties` file is needed, Quarkus will configure `OidcTestClient` for you:
+
+[source, java]
+----
+package org.acme;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.oidc.client.OidcTestClient;
+
+@QuarkusTest
+public class GreetingResourceTest {
+
+    static final OidcTestClient oidcTestClient = new OidcTestClient();
+
+    @AfterAll
+    public static void close() {
+        oidcTestClient.close();
+    }
+
+    @Test
+    public void testHelloEndpoint() {
+        String accessToken = oidcTestClient.getAccessToken("alice", "alice");
+        given()
+          .auth().oauth2(accessToken)
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("Hello, Alice"));
+    }
+
+}
+----
+
 ifndef::no-deprecated-test-resource[]
 [[bearer-token-integration-testing-keycloak]]
 ==== `KeycloakTestResourceLifecycleManager`

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -380,6 +380,7 @@ This document refers to the `http://localhost:8080/q/dev-ui` Dev UI URL in sever
 If you customize `quarkus.http.root-path` or `quarkus.http.non-application-root-path` properties, then replace `q` accordingly.
 For more information, see the https://quarkus.io/blog/path-resolution-in-quarkus/[Path resolution in Quarkus] blog post.
 
+[[dev-services-for-oidc]]
 == Dev Services for OIDC
 
 When you work with Keycloak in production, <<dev-services-for-keycloak>> provides the best dev mode experience.

--- a/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesConfig.java
+++ b/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesConfig.java
@@ -25,9 +25,7 @@ public interface OidcDevServicesConfig {
     /**
      * A map of roles for OIDC identity provider users.
      * <p>
-     * If empty, default roles are assigned: `alice` receives `admin` and `user` roles, while other users receive
-     * `user` role.
-     * This map is used for role creation when no realm file is found at the `realm-path`.
+     * If empty, default roles are assigned: user `alice` receives `admin` and `user` roles and user `bob` receives role `user`.
      */
     @ConfigDocMapKey("role-name")
     Map<String, List<String>> roles();

--- a/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
+++ b/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
@@ -192,9 +192,6 @@ public class OidcDevServicesProcessor {
         router.get("/logout").handler(OidcDevServicesProcessor::logout);
         router.get("/userinfo").handler(OidcDevServicesProcessor::userInfo);
 
-        // can be used for testing of bearer token authentication
-        router.get("/testing/generate/access-token").handler(OidcDevServicesProcessor::generateAccessToken);
-
         KeyPairGenerator kpg;
         try {
             kpg = KeyPairGenerator.getInstance("RSA");
@@ -204,22 +201,6 @@ public class OidcDevServicesProcessor {
         kpg.initialize(2048);
         kp = kpg.generateKeyPair();
         kid = createKeyId();
-    }
-
-    private static void generateAccessToken(RoutingContext rc) {
-        String user = rc.request().getParam("user");
-        if (user == null || user.isEmpty()) {
-            rc.response().setStatusCode(400).endAndForget("Missing required parameter: user");
-            return;
-        }
-        String rolesParam = rc.request().getParam("roles");
-        Set<String> roles = new HashSet<>();
-        if (rolesParam == null || rolesParam.isEmpty()) {
-            roles.addAll(getUserRoles(user));
-        } else {
-            roles.addAll(Arrays.asList(rolesParam.split(",")));
-        }
-        rc.response().endAndForget(createAccessToken(user, roles, Set.of("openid", "email")));
     }
 
     private static List<String> getUsers() {

--- a/integration-tests/oidc-dev-services/pom.xml
+++ b/integration-tests/oidc-dev-services/pom.xml
@@ -44,6 +44,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-oidc-server</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/oidc-dev-services/src/main/resources/application.properties
+++ b/integration-tests/oidc-dev-services/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 quarkus.oidc.devservices.enabled=true
+quarkus.oidc.devservices.roles.Ronald=admin
 
+%code-flow.quarkus.oidc.devservices.roles.alice=admin,user
+%code-flow.quarkus.oidc.devservices.roles.bob=user
 %code-flow.quarkus.oidc.application-type=web-app


### PR DESCRIPTION
I realized when working on other PR that tests I added for Dev Services for OIDC should use `OidcTestClient` to get bearer access token. I also added docs for someone else to mention it as well. Docs addition is not important, I can drop the docs if you deem it useless.