### PR TITLE
Fix missing addChannel flag usage

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientBuildItem.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientBuildItem.java
@@ -30,7 +30,9 @@ public final class GrpcClientBuildItem extends MultiBuildItem {
 
     public void addClient(ClientInfo client, boolean addChannel) {
         clients.add(client);
-        clients.add(new ClientInfo(GrpcDotNames.CHANNEL, ClientType.CHANNEL, client.interceptors));
+        if (addChannel) {
+            clients.add(new ClientInfo(GrpcDotNames.CHANNEL, ClientType.CHANNEL, client.interceptors));
+        }
     }
 
     public String getClientName() {


### PR DESCRIPTION
A minor fix -- so that ClientType.CHANNEL doesn't add same ClientInfo twice.
Now it works due to ClientInfo having proper `equals` method.