### PR TITLE
Make `io.quarkus.builder.Consume` a `record`

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
@@ -179,7 +179,7 @@ public final class BuildChainBuilder {
             for (Map.Entry<ItemId, Consume> entry : stepBuilder.getConsumes().entrySet()) {
                 final Consume consume = entry.getValue();
                 final ItemId id = entry.getKey();
-                if (!consume.getFlags().contains(ConsumeFlag.OPTIONAL) && !id.isMulti()) {
+                if (!consume.flags().contains(ConsumeFlag.OPTIONAL) && !id.isMulti()) {
                     if (!initialIds.contains(id) && !allProduces.containsKey(id)) {
                         throw new ChainBuildException("No producers for required item " + id);
                     }

--- a/core/builder/src/main/java/io/quarkus/builder/BuildStepBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildStepBuilder.java
@@ -236,7 +236,7 @@ public final class BuildStepBuilder {
 
     Set<ItemId> getRealConsumes() {
         final HashMap<ItemId, Consume> map = new HashMap<>(consumes);
-        map.entrySet().removeIf(e -> e.getValue().getConstraint() == Constraint.ORDER_ONLY);
+        map.entrySet().removeIf(e -> e.getValue().constraint() == Constraint.ORDER_ONLY);
         return map.keySet();
     }
 

--- a/core/builder/src/main/java/io/quarkus/builder/Consume.java
+++ b/core/builder/src/main/java/io/quarkus/builder/Consume.java
@@ -1,44 +1,20 @@
 package io.quarkus.builder;
 
-/**
- */
-final class Consume {
-    private final BuildStepBuilder buildStepBuilder;
-    private final ItemId itemId;
-    private final Constraint constraint;
-    private final ConsumeFlags flags;
+import static io.quarkus.builder.Constraint.ORDER_ONLY;
+import static io.quarkus.builder.Constraint.REAL;
+import static io.quarkus.builder.ConsumeFlag.OPTIONAL;
 
-    Consume(final BuildStepBuilder buildStepBuilder, final ItemId itemId, final Constraint constraint,
-            final ConsumeFlags flags) {
-        this.buildStepBuilder = buildStepBuilder;
-        this.itemId = itemId;
-        this.constraint = constraint;
-        this.flags = flags;
-    }
+record Consume(BuildStepBuilder buildStepBuilder, ItemId itemId, Constraint constraint, ConsumeFlags flags) {
 
-    BuildStepBuilder getBuildStepBuilder() {
-        return buildStepBuilder;
-    }
-
-    ItemId getItemId() {
-        return itemId;
-    }
-
-    ConsumeFlags getFlags() {
-        return flags;
-    }
-
-    Consume combine(final Constraint constraint, final ConsumeFlags flags) {
-        final Constraint outputConstraint = constraint == Constraint.REAL || this.constraint == Constraint.REAL
-                ? Constraint.REAL
-                : Constraint.ORDER_ONLY;
-        final ConsumeFlags outputFlags = !flags.contains(ConsumeFlag.OPTIONAL) || !this.flags.contains(ConsumeFlag.OPTIONAL)
-                ? flags.with(this.flags).without(ConsumeFlag.OPTIONAL)
-                : flags.with(this.flags);
-        return new Consume(buildStepBuilder, itemId, outputConstraint, outputFlags);
-    }
-
-    Constraint getConstraint() {
-        return constraint;
+   Consume combine(final Constraint constraint, final ConsumeFlags flags) {
+        return new Consume(
+                buildStepBuilder,
+                itemId,
+                constraint == REAL || this.constraint == REAL
+                        ? REAL
+                        : ORDER_ONLY,
+                !flags.contains(OPTIONAL) || !this.flags.contains(OPTIONAL)
+                        ? flags.with(this.flags).without(OPTIONAL)
+                        : flags.with(this.flags));
     }
 }


### PR DESCRIPTION
This pull request reduces boilerplate code and eliminates unused code, addressing concerns related to code clarity and maintenance.
This change aims to streamline the codebase while maintaining functionality.
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Quarkus - Core 999-SNAPSHOT:
[INFO] 
[INFO] Quarkus - Development mode - SPI ................... SUCCESS [  8.445 s]
[INFO] Quarkus - Core - Class Change Agent ................ SUCCESS [  0.405 s]
[INFO] Quarkus - IDE Launcher ............................. SUCCESS [ 25.755 s]
[INFO] Quarkus - Builder .................................. SUCCESS [  3.064 s]
[INFO] Quarkus - Core ..................................... SUCCESS [  0.098 s]
[INFO] Quarkus - Core - Extension Processor ............... SUCCESS [ 15.461 s]
[INFO] Quarkus - Core - Runtime ........................... SUCCESS [  7.584 s]
[INFO] Quarkus - Core - Deployment ........................ SUCCESS [ 34.227 s]
[INFO] Quarkus - JUnit 4 Mock ............................. SUCCESS [  0.241 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:37 min
[INFO] Finished at: 2025-01-16T08:53:03+01:00
[INFO] ------------------------------------------------------------------------
```