### PR TITLE
Use StringBuilder instead of String concat for startup code

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusConfigBuilderCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusConfigBuilderCustomizer.java
@@ -61,12 +61,21 @@ public class QuarkusConfigBuilderCustomizer implements SmallRyeConfigBuilderCust
 
                         if (name.startsWith("%") && name.endsWith(SMALLRYE_CONFIG_LOCATIONS)) {
                             io.smallrye.config.NameIterator ni = new io.smallrye.config.NameIterator(name);
-                            return ni.getNextSegment() + "." + "quarkus.config.locations";
+                            return new StringBuilder(ni.getNextSegment().length() + 1 + "quarkus.config.locations".length())
+                                    .append(ni.getNextSegment())
+                                    .append(".")
+                                    .append("quarkus.config.locations")
+                                    .toString();
                         }
 
                         if (name.startsWith("%") && name.endsWith(SMALLRYE_CONFIG_PROFILE_PARENT)) {
                             io.smallrye.config.NameIterator ni = new NameIterator(name);
-                            return ni.getNextSegment() + "." + "quarkus.config.profile.parent";
+                            return new StringBuilder(
+                                    ni.getNextSegment().length() + 1 + "quarkus.config.profile.parent".length())
+                                    .append(ni.getNextSegment())
+                                    .append(".")
+                                    .append("quarkus.config.profile.parent")
+                                    .toString();
                         }
 
                         return name;


### PR DESCRIPTION
Unfortunately the JDK's indyfied String concatenation has a slight performance penalty at startup, so for code we know will always be run at startup, let's not pay that unnecessary price

For this to have an effect, we would also need https://github.com/smallrye/smallrye-config/pull/1292.

@franz1981 @radcortez I don't really know how I feel about this one. On one hand it does make a difference as the following before and after flamegraphs show:

_before_
![concat-unpatched](https://github.com/user-attachments/assets/cf0f339d-ba93-4079-9ad3-d0d830f0cc7d)

_after_
![concat-patched](https://github.com/user-attachments/assets/9703a189-4951-4f34-9bc1-5f9077120c64)

but on the other hand:

* The code is much uglier
* The can turn into a continuous Whac-A-Mole
