### PR TITLE
Fix import format gaps

### DIFF
--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/java/org/acme/ApplicationConfigResource.java
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/java/org/acme/ApplicationConfigResource.java
@@ -1,12 +1,11 @@
 package org.acme;
 
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Path("/app-config")
 public class ApplicationConfigResource {

--- a/integration-tests/gradle/src/main/resources/custom-filesystem-provider/application/src/test/java/org/acme/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/main/resources/custom-filesystem-provider/application/src/test/java/org/acme/ExampleResourceTest.java
@@ -1,12 +1,12 @@
 package org.acme;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
-
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
 @QuarkusTestResource(TestResource.class)

--- a/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/runner/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/runner/src/main/java/org/acme/HelloResource.java
@@ -1,13 +1,12 @@
 package org.acme;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Path("/hello")
 public class HelloResource {


### PR DESCRIPTION
It's against the pattern and the JCC, so it's considered technical debt and should be avoided.

Having two blank lines is not common practice; rather, it's an exception to the standard.

<img width="512" alt="image" src="https://github.com/user-attachments/assets/c40e39f5-459e-46c8-af53-663e8a8897aa" />
