### PR TITLE
Use StringBuilder instead of String concat for startup code

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -296,6 +296,8 @@
                             </annotationProcessorPaths>
                             <compilerArgs>
                                 <arg>-AsplitOnConfigRootDescription=true</arg>
+                                <!-- As string concatenation has a non-zero impact on startup, let's disable it for this module -->
+                                <arg>-XDstringConcat=inline</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Unfortunately the JDK's indyfied String concatenation has a slight performance penalty at startup, so for code we know will always be run at startup, let's not pay that unnecessary price.
With this change we force javac to use the
StringBuilder strategy

- Replaces: #45638