### PR TITLE
Enable public access to OidcProviderClientImpl#getWebClient

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -466,7 +466,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         return vertx;
     }
 
-    WebClient getWebClient() {
+    public WebClient getWebClient() {
         return client;
     }
 


### PR DESCRIPTION
This fixes quarkus-oidc-proxy compilation failure against main