### PR TITLE
Test config creation sometimes delegates to instance variable and sometimes to superclass, causing (v v minor) chaos

### DIFF
--- a/test-framework/junit5-config/src/main/java/io/quarkus/test/config/TestConfigProviderResolver.java
+++ b/test-framework/junit5-config/src/main/java/io/quarkus/test/config/TestConfigProviderResolver.java
@@ -19,6 +19,8 @@ import io.smallrye.config.SmallRyeConfigProviderResolver;
  * classloader.
  */
 public class TestConfigProviderResolver extends SmallRyeConfigProviderResolver {
+
+    // Note that this class both *extends* and *consumes* SmallRyeConfigProviderResolver. Every method in SmallRyeConfigProviderResolver should be replicated here with a delegation to the instance variable, or there will be subtle and horrible bugs.
     private final SmallRyeConfigProviderResolver resolver;
     private final ClassLoader classLoader;
     private final Map<LaunchMode, SmallRyeConfig> configs;
@@ -95,5 +97,10 @@ public class TestConfigProviderResolver extends SmallRyeConfigProviderResolver {
     @Override
     public void releaseConfig(final Config config) {
         resolver.releaseConfig(config);
+    }
+
+    @Override
+    public void releaseConfig(final ClassLoader classLoader) {
+        resolver.releaseConfig(classLoader);
     }
 }


### PR DESCRIPTION
I just spent a while wondering if I was losing my mind, until the debugger helped me out. 

I was staring at code in the `TestConfigProviderResolver` that did this: 

```
                resolver.releaseConfig(classLoader);
                resolver.registerConfig(config, classLoader);
```
                
  ... and it was failing because the config hadn't been released. "How can it not be released? I can see the release call one line above the failing call, and there's no concurrency here!" I wailed.

Working through the problem in a debugger, I realised that the release and register call were being applied to different objects. At this point, I was hollering at the computer "What? how they be different objects? They're the *same* object, I can see it right there!"

The wrinkle in this case, is that TestConfigProviderResolver both extends from another resolver, and holds an instance of it as an instance variable. The superclass and instance variable are not at all guaranteed to be the same object. In this case, one method was going to the superclass, and one was going to the instance variable. I could only spot that by staring at screencaps of the debugger on the release and register calls.

It would be nice if `TestConfigProviderResolver` could implement an interface instead, since that avoids this kind of risk, but I assume that's not possible.