### PR TITLE
Update to HTTP error outputs in Getting Started with Security

### DIFF
--- a/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
@@ -566,11 +566,7 @@ public
 $ curl -i -X GET http://localhost:8080/api/admin
 
 HTTP/1.1 401 Unauthorized
-Content-Length: 14
-Content-Type: text/html;charset=UTF-8
 WWW-Authenticate: Basic
-
-Not authorized
 ----
 ====
 * Connect to a protected endpoint as an authorized user:
@@ -606,10 +602,6 @@ If a resource is protected with `@RolesAllowed("user")`, the user `admin` is not
 $ curl -i -X GET -u admin:admin http://localhost:8080/api/users/me
 
 HTTP/1.1 403 Forbidden
-Content-Length: 34
-Content-Type: text/html;charset=UTF-8
-
-Forbidden
 ----
 
 Finally, the user named `user` is authorized, and the security context contains the principal details, for example, the username.


### PR DESCRIPTION
Sorry for the noise, forgot addressing another comment from Martin Ocenas re the HTTP error output.

Note Quarkus returns lower case of `WWW-Authenticate: Basic` but I think it is not significant for the docs 