### PR TITLE
Mark quarkus-oidc-client-registration as experimental in doc

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
@@ -9,6 +9,9 @@ include::_attributes.adoc[]
 :categories: security
 :topics: security,oidc,client
 :extensions: io.quarkus:quarkus-oidc-client-registration
+:extension-status: experimental
+
+include::{includes}/extension-status.adoc[]
 
 Typically, you have to register an OIDC client (application) manually in your OIDC provider's dashboard.
 During this process, you specify the human readable application name, allowed redirect and post logout URLs, and other properties.


### PR DESCRIPTION
It's marked as experimental in the metadata of the extension but not in the documentation.