### PR TITLE
Request re-authentication if the OIDC session key is unresolved

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1421,6 +1421,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         }
 
         @Override
+        public boolean failOnUnresolvedKid() {
+            return failOnUnresolvedKid;
+        }
+
+        @Override
         public Optional<Boolean> userInfoRequired() {
             return userInfoRequired;
         }
@@ -1683,6 +1688,22 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
          * risk of browser redirect loops.
          */
         public boolean failOnMissingStateParam = false;
+
+        /**
+         * Fail with the HTTP 401 error if the ID token signature can not be verified during the re-authentication only due to
+         * an unresolved token key identifier (`kid`).
+         * <p>
+         * This property might need to be disabled when multiple tab authentications are allowed, with one of the tabs keeping
+         * an expired ID token with its `kid`
+         * unresolved due to the verification key set refreshed due to another tab initiating an authorization code flow. In
+         * such cases, instead of failing with the HTTP 401 error,
+         * redirecting the user to re-authenticate with the HTTP 302 status may provide better user experience.
+         * <p>
+         * Note that the HTTP 401 error is always returned if the ID token signature can not be verified due to an unresolved
+         * kid during an initial ID token verification
+         * following the authorization code flow completion, before a session cookie is created.
+         */
+        public boolean failOnUnresolvedKid = true;
 
         /**
          * If this property is set to `true`, an OIDC UserInfo endpoint is called.
@@ -2042,6 +2063,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             cookieSameSite = CookieSameSite.valueOf(mapping.cookieSameSite().toString());
             allowMultipleCodeFlows = mapping.allowMultipleCodeFlows();
             failOnMissingStateParam = mapping.failOnMissingStateParam();
+            failOnUnresolvedKid = mapping.failOnUnresolvedKid();
             userInfoRequired = mapping.userInfoRequired();
             sessionAgeExtension = mapping.sessionAgeExtension();
             stateCookieAge = mapping.stateCookieAge();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -757,6 +757,19 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         boolean failOnMissingStateParam();
 
         /**
+         * Fail with the HTTP 401 error if the ID token signature can not be verified during the re-authentication only due to
+         * an unresolved token key identifier (`kid`).
+         * <p>
+         * This property might need to be disabled when multiple tab authentications are allowed, with one of the tabs keeping
+         * an expired ID token with its `kid`
+         * unresolved due to the verification key set refreshed due to another tab initiating an authorization code flow. In
+         * such cases, instead of failing with the HTTP 401 error,
+         * redirecting the user to re-authenticate with the HTTP 302 status may provide better user experience.
+         */
+        @WithDefault("true")
+        boolean failOnUnresolvedKid();
+
+        /**
          * If this property is set to `true`, an OIDC UserInfo endpoint is called.
          * <p>
          * This property is enabled automatically if `quarkus.oidc.roles.source` is set to `userinfo`

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/AuthenticationConfigBuilder.java
@@ -26,7 +26,8 @@ public final class AuthenticationConfigBuilder {
             Optional<Boolean> addOpenidScope, Map<String, String> extraParams, Optional<List<String>> forwardParams,
             boolean cookieForceSecure, Optional<String> cookieSuffix, String cookiePath, Optional<String> cookiePathHeader,
             Optional<String> cookieDomain, CookieSameSite cookieSameSite, boolean allowMultipleCodeFlows,
-            boolean failOnMissingStateParam, Optional<Boolean> userInfoRequired, Duration sessionAgeExtension,
+            boolean failOnMissingStateParam, boolean failOnUnresolvedKid, Optional<Boolean> userInfoRequired,
+            Duration sessionAgeExtension,
             Duration stateCookieAge, boolean javaScriptAutoRedirect, Optional<Boolean> idTokenRequired,
             Optional<Duration> internalIdTokenLifespan, Optional<Boolean> pkceRequired, Optional<String> pkceSecret,
             Optional<String> stateSecret) implements Authentication {
@@ -55,6 +56,7 @@ public final class AuthenticationConfigBuilder {
     private CookieSameSite cookieSameSite;
     private boolean allowMultipleCodeFlows;
     private boolean failOnMissingStateParam;
+    private boolean failOnUnresolvedKid;
     private Optional<Boolean> userInfoRequired;
     private Duration sessionAgeExtension;
     private Duration stateCookieAge;
@@ -98,6 +100,7 @@ public final class AuthenticationConfigBuilder {
         this.cookieSameSite = authentication.cookieSameSite();
         this.allowMultipleCodeFlows = authentication.allowMultipleCodeFlows();
         this.failOnMissingStateParam = authentication.failOnMissingStateParam();
+        this.failOnUnresolvedKid = authentication.failOnUnresolvedKid();
         this.userInfoRequired = authentication.userInfoRequired();
         this.sessionAgeExtension = authentication.sessionAgeExtension();
         this.stateCookieAge = authentication.stateCookieAge();
@@ -406,6 +409,24 @@ public final class AuthenticationConfigBuilder {
     }
 
     /**
+     * Sets {@link Authentication#failOnUnreslvedKid()} to true.
+     *
+     * @return this builder
+     */
+    public AuthenticationConfigBuilder failOnUnresolvedKid() {
+        return failOnUnresolvedKid(true);
+    }
+
+    /**
+     * @param failOnUnresolvedKid {@link Authentication#failOnUnreslvedKid()}
+     * @return this builder
+     */
+    public AuthenticationConfigBuilder failOnUnresolvedKid(boolean failOnUnresolvedKid) {
+        this.failOnUnresolvedKid = failOnUnresolvedKid;
+        return this;
+    }
+
+    /**
      * Sets {@link Authentication#userInfoRequired()} to true.
      *
      * @return this builder
@@ -554,6 +575,7 @@ public final class AuthenticationConfigBuilder {
                 sessionExpiredPath, verifyAccessToken, forceRedirectHttpsScheme, optionalScopes, scopeSeparator, nonceRequired,
                 addOpenidScope, Map.copyOf(extraParams), optionalForwardParams, cookieForceSecure, cookieSuffix, cookiePath,
                 cookiePathHeader, cookieDomain, cookieSameSite, allowMultipleCodeFlows, failOnMissingStateParam,
+                failOnUnresolvedKid,
                 userInfoRequired, sessionAgeExtension, stateCookieAge, javaScriptAutoRedirect, idTokenRequired,
                 internalIdTokenLifespan, pkceRequired, pkceSecret, stateSecret);
     }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -142,6 +142,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         AUTHENTICATION_COOKIE_SAME_SITE,
         AUTHENTICATION_ALLOW_MULTIPLE_CODE_FLOWS,
         AUTHENTICATION_FAIL_ON_MISSING_STATE_PARAM,
+        AUTHENTICATION_FAIL_ON_UNRESOLVED_KID,
         AUTHENTICATION_USER_INFO_REQUIRED,
         AUTHENTICATION_SESSION_AGE_EXTENSION,
         AUTHENTICATION_STATE_COOKIE_AGE,
@@ -703,6 +704,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             @Override
             public boolean failOnMissingStateParam() {
                 invocationsRecorder.put(ConfigMappingMethods.AUTHENTICATION_FAIL_ON_MISSING_STATE_PARAM, true);
+                return false;
+            }
+
+            @Override
+            public boolean failOnUnresolvedKid() {
+                invocationsRecorder.put(ConfigMappingMethods.AUTHENTICATION_FAIL_ON_UNRESOLVED_KID, true);
                 return false;
             }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.keycloak.devservices.create-realm=false
 quarkus.keycloak.devservices.show-logs=true
-# Default tenant configurationf
+# Default tenant configuration
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.authentication.scopes=profile,email
@@ -10,9 +10,11 @@ quarkus.oidc.authentication.cookie-path-header=some-header
 quarkus.oidc.authentication.cookie-domain=localhost
 quarkus.oidc.authentication.extra-params.max-age=60
 quarkus.oidc.authentication.extra-params.scope=phone
+quarkus.oidc.authentication.fail-on-unresolved-kid=false
 quarkus.oidc.application-type=web-app
 quarkus.oidc.authentication.cookie-suffix=test
 quarkus.oidc.token-state-manager.encryption-required=false
+quarkus.oidc.token.allow-jwt-introspection=false
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
@@ -127,6 +129,9 @@ quarkus.oidc.tenant-nonce.authentication.redirect-path=/tenant-nonce
 quarkus.oidc.tenant-nonce.application-type=web-app
 quarkus.oidc.tenant-nonce.authentication.nonce-required=true
 quarkus.oidc.tenant-nonce.authentication.state-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
+quarkus.oidc.tenant-nonce.token-state-manager.encryption-required=false
+quarkus.oidc.tenant-nonce.token.allow-jwt-introspection=false
+
 
 quarkus.oidc.tenant-javascript.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-javascript.client-id=quarkus-app


### PR DESCRIPTION
This PR is about improving the OIDC user experience in a multi-tab application.

First, a minor clarification how OIDC session cookie signatures are verified: 

When an already authenticated user returns with the session cookie, the ID token's key identifier is used to find a matching key in a key set fetched from the OIDC provider. If no matching key can be found, the key set is refreshed and a new key set is fetched. If no matching key is found at this stage, 401 is returned to the user, an empty screen in prod.   

As explained in #45582, what might happen in a multi-tab application, is that one of the open tabs which an already authenticated user has opened may get stale, where the session cookie's ID token key id has no matching verification key due to the key set refreshed after the same user accessed Quarkus from another tab.
The end result of it is that one tab works, another tab returns 401 (which is returned after the process described above).

This PR, instead of terminating the flow with 401 for the session cookie with non-matching key, instead redirects the user to re-authenticate which improves the experience.

The only thing that I'm not quite happy about is that I'm allowing to do it by default, it makes sense to return 302 in the case described in #45582, but Quarkus OIDC, when it sees a token with a non-matched key, can not be sure that the token has no matching key due to the case in #45582, in general a non-matching key can be a pretty serious error deserving the flow termination.

So what I'm saying, that as much as I'm concerned about growing an already large set of OIDC properties, I'll have to add one more property to allow `soft` redirects in case of unmatched keys during the session re-authentication... And then the PR will be ready for review without any concerns on my part.

@geoand @pedroigor, FYI 
