### PR TITLE
Don't allow requests into restarting application

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/VertxHttpHotReplacementSetup.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/VertxHttpHotReplacementSetup.java
@@ -135,7 +135,9 @@ public class VertxHttpHotReplacementSetup implements HotReplacementSetup {
             routingContext.request().resume();
             return;
         }
-        if ((nextUpdate > System.currentTimeMillis() && !hotReplacementContext.isTest())
+        if ((nextUpdate > System.currentTimeMillis() &&
+                !hotReplacementContext.isTest() &&
+                !DevConsoleManager.isDoingHttpInitiatedReload()) // if there is a live reload possibly going on we don't want to let a request through to restarting application, this is best effort, but it narrows the window a lot
                 || routingContext.request().headers().contains(HEADER_NAME)) {
             if (hotReplacementContext.getDeploymentProblem() != null) {
                 handleDeploymentProblem(routingContext, hotReplacementContext.getDeploymentProblem());


### PR DESCRIPTION
If the app is restarting then we should not short-circuit the hot reload handler/scan lock logic.

This is not perfect, as there will always be a possible race, but makes it much less likely a request will hit a torn down app.

fixes #29646