### PR TITLE
Gradle - Resolve platform properties when possible

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -74,7 +74,7 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
             Map<String, Object> props = task.getSystemProperties();
             ApplicationModel appModel = getApplicationModel(TEST);
 
-            SmallRyeConfig config = buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties())
+            SmallRyeConfig config = buildEffectiveConfiguration(appModel)
                     .getConfig();
             config.getOptionalValue(TEST.getProfileKey(), String.class)
                     .ifPresent(value -> props.put(TEST.getProfileKey(), value));

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -74,7 +74,8 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
             Map<String, Object> props = task.getSystemProperties();
             ApplicationModel appModel = getApplicationModel(TEST);
 
-            SmallRyeConfig config = buildEffectiveConfiguration(appModel.getAppArtifact()).getConfig();
+            SmallRyeConfig config = buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties())
+                    .getConfig();
             config.getOptionalValue(TEST.getProfileKey(), String.class)
                     .ifPresent(value -> props.put(TEST.getProfileKey(), value));
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
@@ -117,7 +117,8 @@ public abstract class AbstractQuarkusExtension {
         return baseConfig().manifest();
     }
 
-    protected EffectiveConfig buildEffectiveConfiguration(ResolvedDependency appArtifact) {
+    protected EffectiveConfig buildEffectiveConfiguration(ResolvedDependency appArtifact,
+            Map<String, String> platformProperties) {
         Map<String, Object> properties = new HashMap<>();
         exportCustomManifestProperties(properties);
 
@@ -140,6 +141,7 @@ public abstract class AbstractQuarkusExtension {
         defaultProperties.putIfAbsent("quarkus.application.version", appArtifact.getVersion());
 
         return EffectiveConfig.builder()
+                .withPlatformProperties(platformProperties)
                 .withForcedProperties(forcedPropertiesProperty.get())
                 .withTaskProperties(properties)
                 .withBuildProperties(quarkusBuildProperties.get())

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
@@ -27,6 +27,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.process.JavaForkOptions;
 
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.gradle.dsl.Manifest;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.smallrye.common.expression.Expression;
@@ -117,8 +118,9 @@ public abstract class AbstractQuarkusExtension {
         return baseConfig().manifest();
     }
 
-    protected EffectiveConfig buildEffectiveConfiguration(ResolvedDependency appArtifact,
-            Map<String, String> platformProperties) {
+    protected EffectiveConfig buildEffectiveConfiguration(ApplicationModel appModel) {
+        ResolvedDependency appArtifact = appModel.getAppArtifact();
+
         Map<String, Object> properties = new HashMap<>();
         exportCustomManifestProperties(properties);
 
@@ -141,7 +143,7 @@ public abstract class AbstractQuarkusExtension {
         defaultProperties.putIfAbsent("quarkus.application.version", appArtifact.getVersion());
 
         return EffectiveConfig.builder()
-                .withPlatformProperties(platformProperties)
+                .withPlatformProperties(appModel.getPlatformProperties())
                 .withForcedProperties(forcedPropertiesProperty.get())
                 .withTaskProperties(properties)
                 .withBuildProperties(quarkusBuildProperties.get())

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
@@ -91,8 +91,7 @@ public abstract class Deploy extends QuarkusBuildTask {
     public void checkRequiredExtensions() {
         ApplicationModel appModel = resolveAppModelForBuild();
         Properties sysProps = new Properties();
-        sysProps.putAll(extension().buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties())
-                .getValues());
+        sysProps.putAll(extension().buildEffectiveConfiguration(appModel).getValues());
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
@@ -91,7 +91,8 @@ public abstract class Deploy extends QuarkusBuildTask {
     public void checkRequiredExtensions() {
         ApplicationModel appModel = resolveAppModelForBuild();
         Properties sysProps = new Properties();
-        sysProps.putAll(extension().buildEffectiveConfiguration(appModel.getAppArtifact()).getValues());
+        sysProps.putAll(extension().buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties())
+                .getValues());
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
@@ -144,7 +144,8 @@ public abstract class QuarkusBuildDependencies extends QuarkusBuildTask {
         }
 
         ApplicationModel appModel = resolveAppModelForBuild();
-        SmallRyeConfig config = getExtensionView().buildEffectiveConfiguration(appModel.getAppArtifact(), new HashMap<>())
+        SmallRyeConfig config = getExtensionView()
+                .buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties(), new HashMap<>())
                 .getConfig();
 
         // see https://quarkus.io/guides/class-loading-reference#configuring-class-loading

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildDependencies.java
@@ -145,7 +145,7 @@ public abstract class QuarkusBuildDependencies extends QuarkusBuildTask {
 
         ApplicationModel appModel = resolveAppModelForBuild();
         SmallRyeConfig config = getExtensionView()
-                .buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties(), new HashMap<>())
+                .buildEffectiveConfiguration(appModel, new HashMap<>())
                 .getConfig();
 
         // see https://quarkus.io/guides/class-loading-reference#configuring-class-loading

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -244,8 +244,7 @@ public abstract class QuarkusBuildTask extends QuarkusTask {
 
         ApplicationModel appModel = resolveAppModelForBuild();
         SmallRyeConfig config = getExtensionView()
-                .buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties(),
-                        getAdditionalForcedProperties().get().getProperties())
+                .buildEffectiveConfiguration(appModel, getAdditionalForcedProperties().get().getProperties())
                 .getConfig();
         Map<String, String> quarkusProperties = Expressions.withoutExpansion(() -> {
             Map<String, String> values = new HashMap<>();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -244,7 +244,8 @@ public abstract class QuarkusBuildTask extends QuarkusTask {
 
         ApplicationModel appModel = resolveAppModelForBuild();
         SmallRyeConfig config = getExtensionView()
-                .buildEffectiveConfiguration(appModel.getAppArtifact(), getAdditionalForcedProperties().get().getProperties())
+                .buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties(),
+                        getAdditionalForcedProperties().get().getProperties())
                 .getConfig();
         Map<String, String> quarkusProperties = Expressions.withoutExpansion(() -> {
             Map<String, String> values = new HashMap<>();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -119,8 +119,7 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
     public void generateCode() throws IOException {
         ApplicationModel appModel = ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath());
         Map<String, String> configMap = getExtensionView()
-                .buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties(), new HashMap<>())
-                .getValues();
+                .buildEffectiveConfiguration(appModel, new HashMap<>()).getValues();
 
         File outputPath = getGeneratedOutputDirectory().get().getAsFile();
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -119,7 +119,8 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
     public void generateCode() throws IOException {
         ApplicationModel appModel = ToolingUtils.deserializeAppModel(getApplicationModel().get().getAsFile().toPath());
         Map<String, String> configMap = getExtensionView()
-                .buildEffectiveConfiguration(appModel.getAppArtifact(), new HashMap<>()).getValues();
+                .buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties(), new HashMap<>())
+                .getValues();
 
         File outputPath = getGeneratedOutputDirectory().get().getAsFile();
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
@@ -38,6 +38,7 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.util.GradleVersion;
 
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.gradle.QuarkusPlugin;
 import io.quarkus.gradle.dsl.Manifest;
@@ -209,8 +210,10 @@ public abstract class QuarkusPluginExtensionView {
         }
     }
 
-    protected EffectiveConfig buildEffectiveConfiguration(ResolvedDependency appArtifact,
-            Map<String, String> platformProperties, Map<String, ?> additionalForcedProperties) {
+    protected EffectiveConfig buildEffectiveConfiguration(ApplicationModel appModel,
+            Map<String, ?> additionalForcedProperties) {
+        ResolvedDependency appArtifact = appModel.getAppArtifact();
+
         Map<String, Object> properties = new HashMap<>();
         exportCustomManifestProperties(properties);
 
@@ -235,7 +238,7 @@ public abstract class QuarkusPluginExtensionView {
             forced.put("quarkus.native.enabled", "true");
         }
         return EffectiveConfig.builder()
-                .withPlatformProperties(platformProperties)
+                .withPlatformProperties(appModel.getPlatformProperties())
                 .withForcedProperties(forced)
                 .withTaskProperties(properties)
                 .withBuildProperties(getQuarkusBuildProperties().get())

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
@@ -210,7 +210,7 @@ public abstract class QuarkusPluginExtensionView {
     }
 
     protected EffectiveConfig buildEffectiveConfiguration(ResolvedDependency appArtifact,
-            Map<String, ?> additionalForcedProperties) {
+            Map<String, String> platformProperties, Map<String, ?> additionalForcedProperties) {
         Map<String, Object> properties = new HashMap<>();
         exportCustomManifestProperties(properties);
 
@@ -235,6 +235,7 @@ public abstract class QuarkusPluginExtensionView {
             forced.put("quarkus.native.enabled", "true");
         }
         return EffectiveConfig.builder()
+                .withPlatformProperties(platformProperties)
                 .withForcedProperties(forced)
                 .withTaskProperties(properties)
                 .withBuildProperties(getQuarkusBuildProperties().get())

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
@@ -102,7 +102,8 @@ public abstract class QuarkusRun extends QuarkusBuildTask {
     public void runQuarkus() {
         ApplicationModel appModel = resolveAppModelForBuild();
         Properties sysProps = new Properties();
-        sysProps.putAll(extension().buildEffectiveConfiguration(appModel.getAppArtifact()).getValues());
+        sysProps.putAll(extension().buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties())
+                .getValues());
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
@@ -102,8 +102,7 @@ public abstract class QuarkusRun extends QuarkusBuildTask {
     public void runQuarkus() {
         ApplicationModel appModel = resolveAppModelForBuild();
         Properties sysProps = new Properties();
-        sysProps.putAll(extension().buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties())
-                .getValues());
+        sysProps.putAll(extension().buildEffectiveConfiguration(appModel).getValues());
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
@@ -49,7 +49,7 @@ public abstract class QuarkusShowEffectiveConfig extends QuarkusBuildTask {
         try {
             ApplicationModel appModel = resolveAppModelForBuild();
             EffectiveConfig effectiveConfig = getExtensionView()
-                    .buildEffectiveConfiguration(appModel.getAppArtifact(),
+                    .buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties(),
                             getAdditionalForcedProperties().get().getProperties());
             SmallRyeConfig config = effectiveConfig.getConfig();
             List<String> sourceNames = new ArrayList<>();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
@@ -49,7 +49,7 @@ public abstract class QuarkusShowEffectiveConfig extends QuarkusBuildTask {
         try {
             ApplicationModel appModel = resolveAppModelForBuild();
             EffectiveConfig effectiveConfig = getExtensionView()
-                    .buildEffectiveConfiguration(appModel.getAppArtifact(), appModel.getPlatformProperties(),
+                    .buildEffectiveConfiguration(appModel,
                             getAdditionalForcedProperties().get().getProperties());
             SmallRyeConfig config = effectiveConfig.getConfig();
             List<String> sourceNames = new ArrayList<>();


### PR DESCRIPTION
We were always passing a `<<ignored>>` value for the native builder which is a problem.
We now correctly get the values from the platform properties when possible.

This is a follow-up for https://github.com/quarkusio/quarkus/pull/45637 .