### PR TITLE
Fix incomplete config on re-used LGTM containers

### DIFF
--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
@@ -100,18 +100,22 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
     }
 
     public int getOtlpPort() {
-        int port = getOtlpPortInternal();
+        int port = getPrivateOtlpPort();
         return getMappedPort(port);
     }
 
-    private int getOtlpPortInternal() {
+    private int getPrivateOtlpPort() {
+        return getPrivateOtlpPort(getOtlpProtocol());
+    }
+
+    public static int getPrivateOtlpPort(String otlpProtocol) {
         // use ignore-case here; grpc == gRPC
-        if (ContainerConstants.OTEL_GRPC_PROTOCOL.equalsIgnoreCase(getOtlpProtocol())) {
+        if (ContainerConstants.OTEL_GRPC_PROTOCOL.equalsIgnoreCase(otlpProtocol)) {
             return ContainerConstants.OTEL_GRPC_EXPORTER_PORT;
-        } else if (ContainerConstants.OTEL_HTTP_PROTOCOL.equals(getOtlpProtocol())) {
+        } else if (ContainerConstants.OTEL_HTTP_PROTOCOL.equals(otlpProtocol)) {
             return ContainerConstants.OTEL_HTTP_EXPORTER_PORT;
         } else {
-            throw new IllegalArgumentException("Unsupported OTEL protocol: " + getOtlpProtocol());
+            throw new IllegalArgumentException("Unsupported OTEL protocol: " + otlpProtocol);
         }
     }
 

--- a/extensions/observability-devservices/testlibs/devresource-common/src/main/java/io/quarkus/observability/devresource/DevResourceLifecycleManager.java
+++ b/extensions/observability-devservices/testlibs/devresource-common/src/main/java/io/quarkus/observability/devresource/DevResourceLifecycleManager.java
@@ -75,8 +75,8 @@ public interface DevResourceLifecycleManager<T extends ContainerConfig> extends 
     }
 
     /**
-     * Deduct current config from params.
-     * If port are too dynamic / configured, it's hard to deduct,
+     * Deduce current config from params.
+     * If port are too dynamic / configured, it's hard to deduce,
      * since configuration is not part of the devservice state.
      * e.g. different ports then usual - Grafana UI is 3000, if you do not use 3000,
      * it's hard or impossible to know which port belongs to certain property.


### PR DESCRIPTION
I have created a problem where containers in the LGTM integration tests are not cleaned up properly. Obviously, I need to fix this, but it exposed another problem. 

When the LGTM dev service is started fresh, the config is something like this:

```
Dev Service Lgtm started, config: {grafana.endpoint=http://localhost:35865, quarkus.otel.exporter.otlp.endpoint=http://localhost:37417, otel-collector.url=localhost:37417, quarkus.micrometer.export.otlp.url=http://localhost:37417/v1/metrics, quarkus.otel.exporter.otlp.protocol=http/protobuf}
```

When it’s re-used, it’s 

``` 
Dev Service Lgtm re-used, config: {grafana.endpoint=http://localhost:35725, otel-collector.url=localhost:41111}
```

Three pieces of config are missing. This causes the test to fail trying to connect to the default, non-mapped, OTLP endpoint and metrics endpoint. On investigation, there’s a `//FIXME` at the problem line of code. So I fixed it. :)

I didn’t achieve perfect consolidation of the two methods, but it’s more consolidated (and the config is complete in the re-use case). The consolidated code is also longer than the non-consolidated code, but we won't mention that.

Please do check it carefully, because it’s not an area I know well and it would be easy for me to swap constants or muddle theintended  `switch` logic. I left the (now unused) method on `LGTMContainer` to get the OTLP port, since it looked potentially useful, but we could consider deleting it. 