### PR TITLE
Observability LGTM dev service filling up logs with services starting

### DIFF
--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/GrafanaContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/GrafanaContainer.java
@@ -1,6 +1,7 @@
 package io.quarkus.observability.testcontainers;
 
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
 import io.quarkus.observability.common.config.GrafanaConfig;
@@ -26,10 +27,15 @@ public abstract class GrafanaContainer<T extends GrafanaContainer<T, C>, C exten
     }
 
     private WaitStrategy grafanaWaitStrategy() {
-        return new HttpWaitStrategy()
-                .forPath("/")
-                .forPort(config.grafanaPort())
-                .forStatusCode(200)
-                .withStartupTimeout(config.timeout());
+        return new WaitAllStrategy()
+                .withStartupTimeout(config.timeout())
+                .withStrategy(
+                        Wait.forHttp("/")
+                                .forPort(config.grafanaPort())
+                                .forStatusCode(200)
+                                .withStartupTimeout(config.timeout()))
+                .withStrategy(
+                        Wait.forLogMessage(".*The OpenTelemetry collector and the Grafana LGTM stack are up and running.*", 1)
+                                .withStartupTimeout(config.timeout()));
     }
 }

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/ObservabilityContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/ObservabilityContainer.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
@@ -37,8 +38,14 @@ public abstract class ObservabilityContainer<T extends ObservabilityContainer<T,
 
     protected abstract String prefix();
 
+    protected Predicate<OutputFrame> getLoggingFilter() {
+        return f -> true;
+    }
+
     protected Consumer<OutputFrame> frameConsumer() {
-        return new JBossLoggingConsumer(log).withPrefix(prefix());
+        return new JBossLoggingConsumer(log)
+                .withPrefix(prefix())
+                .withLoggingFilter(getLoggingFilter());
     }
 
     protected byte[] getResourceAsBytes(String resource) {


### PR DESCRIPTION
At startup the Observability LGTM devservice was filling the console with lots of logs:

![image](https://github.com/user-attachments/assets/ae721761-7c00-4f3a-aabc-d12b69564683)
![image](https://github.com/user-attachments/assets/68facca4-73f8-4955-a1b9-6e8601332862)

Furthermore, the wait strategy was only waiting for the grafana http port to be available, which is available very soon in the container startup lifecycle. Instead, it should be waiting for all the services in the container to start up.

After this change the console now looks like this:

![image](https://github.com/user-attachments/assets/0a0d1ee1-97ad-4eb3-875c-2aaf597a7d78)
![image](https://github.com/user-attachments/assets/700cf342-da96-4027-887c-d4e405a1a747)

And the `Lgtm Dev Services Starting:` message stays at the bottom of the console until its fully up and running.