### PR TITLE
Include missing Authentication failure messages in HTTP response in devmode

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/LaunchMode.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LaunchMode.java
@@ -20,6 +20,10 @@ public enum LaunchMode {
         return this != NORMAL;
     }
 
+    public static boolean isDev() {
+        return current() == DEVELOPMENT;
+    }
+
     /**
      * Returns true if the current launch is the server side of remote dev.
      */

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AuthenticationFailureResponseBodyDevModeTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AuthenticationFailureResponseBodyDevModeTest.java
@@ -1,0 +1,129 @@
+package io.quarkus.resteasy.test.security;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.AuthenticationCompletionException;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.CertificateAuthenticationRequest;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+public class AuthenticationFailureResponseBodyDevModeTest {
+
+    private static final String RESPONSE_BODY = "failure";
+
+    public enum AuthFailure {
+        AUTH_FAILED_WITH_BODY(() -> new AuthenticationFailedException(RESPONSE_BODY), true),
+        AUTH_COMPLETION_WITH_BODY(() -> new AuthenticationCompletionException(RESPONSE_BODY), true),
+        AUTH_FAILED_WITHOUT_BODY(AuthenticationFailedException::new, false),
+        AUTH_COMPLETION_WITHOUT_BODY(AuthenticationCompletionException::new, false);
+
+        public final Supplier<Throwable> failureSupplier;
+        private final boolean expectBody;
+
+        AuthFailure(Supplier<Throwable> failureSupplier, boolean expectBody) {
+            this.failureSupplier = failureSupplier;
+            this.expectBody = expectBody;
+        }
+    }
+
+    @RegisterExtension
+    static QuarkusDevModeTest runner = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(SecuredResource.class, FailingAuthenticator.class, AuthFailure.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.http.auth.proactive=false
+                            """), "application.properties"));
+
+    @Test
+    public void testAuthenticationFailedExceptionBody() {
+        assertExceptionBody(AuthFailure.AUTH_FAILED_WITHOUT_BODY, false);
+        assertExceptionBody(AuthFailure.AUTH_FAILED_WITHOUT_BODY, true);
+        assertExceptionBody(AuthFailure.AUTH_FAILED_WITH_BODY, false);
+        assertExceptionBody(AuthFailure.AUTH_FAILED_WITH_BODY, true);
+    }
+
+    @Test
+    public void testAuthenticationCompletionExceptionBody() {
+        assertExceptionBody(AuthFailure.AUTH_COMPLETION_WITHOUT_BODY, false);
+        assertExceptionBody(AuthFailure.AUTH_COMPLETION_WITH_BODY, false);
+    }
+
+    private static void assertExceptionBody(AuthFailure failure, boolean challenge) {
+        int statusCode = challenge ? 302 : 401;
+        boolean expectBody = failure.expectBody && statusCode == 401;
+        RestAssured
+                .given()
+                .redirects().follow(false)
+                .header("auth-failure", failure.toString())
+                .header("challenge-data", challenge)
+                .get("/secured")
+                .then()
+                .statusCode(statusCode)
+                .body(expectBody ? Matchers.equalTo(RESPONSE_BODY) : Matchers.not(Matchers.containsString(RESPONSE_BODY)));
+    }
+
+    @Authenticated
+    @Path("secured")
+    public static class SecuredResource {
+
+        @GET
+        public String ignored() {
+            return "ignored";
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class FailingAuthenticator implements HttpAuthenticationMechanism {
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            return Uni.createFrom().failure(getFailureProducer(context));
+        }
+
+        private static Supplier<Throwable> getFailureProducer(RoutingContext context) {
+            return getAuthFailure(context).failureSupplier;
+        }
+
+        private static AuthFailure getAuthFailure(RoutingContext context) {
+            return AuthFailure.valueOf(context.request().getHeader("auth-failure"));
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            // so that we don't need to implement an identity provider
+            return Collections.singleton(CertificateAuthenticationRequest.class);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            if (Boolean.parseBoolean(context.request().getHeader("challenge-data"))) {
+                return Uni.createFrom().item(new ChallengeData(302, null, null));
+            } else {
+                return Uni.createFrom().optional(Optional.empty());
+            }
+        }
+
+    }
+}

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationCompletionExceptionMapper.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationCompletionExceptionMapper.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.ext.Provider;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.security.AuthenticationCompletionException;
 
 @Provider
@@ -16,6 +17,9 @@ public class AuthenticationCompletionExceptionMapper implements ExceptionMapper<
     @Override
     public Response toResponse(AuthenticationCompletionException ex) {
         log.debug("Authentication has failed, returning HTTP status 401");
+        if (LaunchMode.isDev() && ex.getMessage() != null) {
+            return Response.status(401).entity(ex.getMessage()).build();
+        }
         return Response.status(401).build();
     }
 

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationFailedExceptionMapper.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationFailedExceptionMapper.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.ext.Provider;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
@@ -19,7 +20,6 @@ import io.vertx.ext.web.RoutingContext;
 @Priority(Priorities.USER + 1)
 public class AuthenticationFailedExceptionMapper implements ExceptionMapper<AuthenticationFailedException> {
     private static final Logger log = Logger.getLogger(AuthenticationFailedExceptionMapper.class.getName());
-
     private volatile CurrentVertxRequest currentVertxRequest;
 
     CurrentVertxRequest currentVertxRequest() {
@@ -37,17 +37,24 @@ public class AuthenticationFailedExceptionMapper implements ExceptionMapper<Auth
             if (authenticator != null) {
                 ChallengeData challengeData = authenticator.getChallenge(context)
                         .await().indefinitely();
-                Response.ResponseBuilder status = Response.status(challengeData.status);
-                if (challengeData.headerName != null) {
-                    status.header(challengeData.headerName.toString(), challengeData.headerContent);
+                int statusCode = challengeData == null ? 401 : challengeData.status;
+                Response.ResponseBuilder responseBuilder = Response.status(statusCode);
+                if (challengeData != null && challengeData.headerName != null) {
+                    responseBuilder.header(challengeData.headerName.toString(), challengeData.headerContent);
                 }
-                log.debugf("Returning an authentication challenge, status code: %d", challengeData.status);
-                return status.build();
+                if (LaunchMode.isDev() && exception.getMessage() != null && statusCode == 401) {
+                    responseBuilder.entity(exception.getMessage());
+                }
+                log.debugf("Returning an authentication challenge, status code: %d", statusCode);
+                return responseBuilder.build();
             } else {
                 log.error("HttpAuthenticator is not found, returning HTTP status 401");
             }
         } else {
             log.error("RoutingContext is not found, returning HTTP status 401");
+        }
+        if (LaunchMode.isDev() && exception.getMessage() != null) {
+            return Response.status(401).entity(exception.getMessage()).build();
         }
         return Response.status(401).entity("Not Authenticated").build();
     }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AbstractAuthFailureResponseBodyDevModeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AbstractAuthFailureResponseBodyDevModeTest.java
@@ -1,0 +1,119 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.AuthenticationCompletionException;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.CertificateAuthenticationRequest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+public abstract class AbstractAuthFailureResponseBodyDevModeTest {
+
+    private static final String RESPONSE_BODY = "failure";
+
+    public enum AuthFailure {
+        AUTH_FAILED_WITH_BODY(() -> new AuthenticationFailedException(RESPONSE_BODY), true),
+        AUTH_COMPLETION_WITH_BODY(() -> new AuthenticationCompletionException(RESPONSE_BODY), true),
+        AUTH_FAILED_WITHOUT_BODY(AuthenticationFailedException::new, false),
+        AUTH_COMPLETION_WITHOUT_BODY(AuthenticationCompletionException::new, false);
+
+        public final Supplier<Throwable> failureSupplier;
+        private final boolean expectBody;
+
+        AuthFailure(Supplier<Throwable> failureSupplier, boolean expectBody) {
+            this.failureSupplier = failureSupplier;
+            this.expectBody = expectBody;
+        }
+    }
+
+    @Test
+    public void testAuthenticationFailedExceptionBody() {
+        assertExceptionBody(AuthFailure.AUTH_FAILED_WITHOUT_BODY, false);
+        assertExceptionBody(AuthFailure.AUTH_FAILED_WITHOUT_BODY, true);
+        assertExceptionBody(AuthFailure.AUTH_FAILED_WITH_BODY, false);
+        assertExceptionBody(AuthFailure.AUTH_FAILED_WITH_BODY, true);
+    }
+
+    @Test
+    public void testAuthenticationCompletionExceptionBody() {
+        assertExceptionBody(AuthFailure.AUTH_COMPLETION_WITHOUT_BODY, false);
+        assertExceptionBody(AuthFailure.AUTH_COMPLETION_WITH_BODY, false);
+    }
+
+    private static void assertExceptionBody(AuthFailure failure, boolean challenge) {
+        int statusCode = challenge ? 302 : 401;
+        boolean expectBody = failure.expectBody && statusCode == 401;
+        RestAssured
+                .given()
+                .redirects().follow(false)
+                .header("auth-failure", failure.toString())
+                .header("challenge-data", challenge)
+                .get("/secured")
+                .then()
+                .statusCode(statusCode)
+                .body(expectBody ? Matchers.equalTo(RESPONSE_BODY)
+                        : Matchers.not(Matchers.containsString(RESPONSE_BODY)));
+    }
+
+    @Authenticated
+    @Path("secured")
+    public static class SecuredResource {
+
+        @GET
+        public String ignored() {
+            return "ignored";
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class FailingAuthenticator implements HttpAuthenticationMechanism {
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            return Uni.createFrom().failure(getFailureProducer(context));
+        }
+
+        private static Supplier<Throwable> getFailureProducer(RoutingContext context) {
+            return getAuthFailure(context).failureSupplier;
+        }
+
+        private static AuthFailure getAuthFailure(RoutingContext context) {
+            return AuthFailure.valueOf(context.request().getHeader("auth-failure"));
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            // so that we don't need to implement an identity provider
+            return Collections.singleton(CertificateAuthenticationRequest.class);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            if (Boolean.parseBoolean(context.request().getHeader("challenge-data"))) {
+                return Uni.createFrom().item(new ChallengeData(302, null, null));
+            } else {
+                return Uni.createFrom().optional(Optional.empty());
+            }
+        }
+
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/LazyAuthFailureResponseBodyDevModeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/LazyAuthFailureResponseBodyDevModeTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class LazyAuthFailureResponseBodyDevModeTest extends AbstractAuthFailureResponseBodyDevModeTest {
+
+    @RegisterExtension
+    static QuarkusDevModeTest runner = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(SecuredResource.class, FailingAuthenticator.class, AuthFailure.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.http.auth.proactive=false
+                            """), "application.properties"));
+
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ProactiveAuthFailureResponseBodyDevModeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ProactiveAuthFailureResponseBodyDevModeTest.java
@@ -1,0 +1,14 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class ProactiveAuthFailureResponseBodyDevModeTest extends AbstractAuthFailureResponseBodyDevModeTest {
+
+    @RegisterExtension
+    static QuarkusDevModeTest runner = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(SecuredResource.class, FailingAuthenticator.class, AuthFailure.class));
+
+}

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationCompletionExceptionMapper.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationCompletionExceptionMapper.java
@@ -3,12 +3,16 @@ package io.quarkus.resteasy.reactive.server.runtime.exceptionmappers;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.security.AuthenticationCompletionException;
 
 public class AuthenticationCompletionExceptionMapper implements ExceptionMapper<AuthenticationCompletionException> {
 
     @Override
     public Response toResponse(AuthenticationCompletionException ex) {
+        if (LaunchMode.isDev() && ex.getMessage() != null) {
+            return Response.status(Response.Status.UNAUTHORIZED).entity(ex.getMessage()).build();
+        }
         return Response.status(Response.Status.UNAUTHORIZED).build();
     }
 

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationFailedExceptionMapper.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/AuthenticationFailedExceptionMapper.java
@@ -5,6 +5,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.security.AuthenticationFailedException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
@@ -12,7 +13,8 @@ import io.vertx.ext.web.RoutingContext;
 public class AuthenticationFailedExceptionMapper {
 
     @ServerExceptionMapper(value = AuthenticationFailedException.class, priority = Priorities.USER + 1)
-    public Uni<Response> handle(RoutingContext routingContext) {
-        return SecurityExceptionMapperUtil.handleWithAuthenticator(routingContext);
+    public Uni<Response> handle(RoutingContext routingContext, AuthenticationFailedException exception) {
+        return SecurityExceptionMapperUtil.handleWithAuthenticator(routingContext,
+                LaunchMode.isDev() ? exception.getMessage() : null);
     }
 }

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/UnauthorizedExceptionMapper.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/exceptionmappers/UnauthorizedExceptionMapper.java
@@ -13,6 +13,6 @@ public class UnauthorizedExceptionMapper {
 
     @ServerExceptionMapper(value = UnauthorizedException.class, priority = Priorities.USER + 1)
     public Uni<Response> handle(RoutingContext routingContext) {
-        return SecurityExceptionMapperUtil.handleWithAuthenticator(routingContext);
+        return SecurityExceptionMapperUtil.handleWithAuthenticator(routingContext, null);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.http.runtime.security;
 
 import static io.quarkus.security.spi.runtime.SecurityEventHelper.AUTHENTICATION_FAILURE;
 import static io.quarkus.security.spi.runtime.SecurityEventHelper.AUTHENTICATION_SUCCESS;
+import static io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.DefaultAuthFailureHandler.DEV_MODE_AUTHENTICATION_FAILURE_BODY;
 import static io.quarkus.vertx.http.runtime.security.HttpSecurityUtils.SECURITY_IDENTITIES_ATTRIBUTE;
 import static io.quarkus.vertx.http.runtime.security.HttpSecurityUtils.getSecurityIdentities;
 import static io.quarkus.vertx.http.runtime.security.RolesMapping.ROLES_MAPPING_KEY;
@@ -301,7 +302,12 @@ public final class HttpAuthenticator {
                 if (!authDone) {
                     log.debug("Authentication has not been done, returning HTTP status 401");
                     routingContext.response().setStatusCode(401);
-                    routingContext.response().end();
+                    if (routingContext.get(DEV_MODE_AUTHENTICATION_FAILURE_BODY) == null) {
+                        routingContext.response().end();
+                    } else {
+                        final String authenticationFailureBody = routingContext.get(DEV_MODE_AUTHENTICATION_FAILURE_BODY);
+                        routingContext.response().end(authenticationFailureBody);
+                    }
                 }
                 return Uni.createFrom().item(authDone);
             }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -177,6 +177,7 @@ public class HttpSecurityRecorder {
          * the {@link io.quarkus.security.AuthenticationException}.
          */
         private static final String OTHER_AUTHENTICATION_FAILURE = "io.quarkus.vertx.http.runtime.security.other-auth-failure";
+        static final String DEV_MODE_AUTHENTICATION_FAILURE_BODY = "io.quarkus.vertx.http.runtime.security.dev-mode.auth-failure-body";
 
         protected DefaultAuthFailureHandler() {
         }
@@ -187,6 +188,10 @@ public class HttpSecurityRecorder {
                 return;
             }
             throwable = extractRootCause(throwable);
+            if (LaunchMode.isDev() && throwable instanceof AuthenticationException
+                    && throwable.getMessage() != null) {
+                event.put(DEV_MODE_AUTHENTICATION_FAILURE_BODY, throwable.getMessage());
+            }
             //auth failed
             if (throwable instanceof AuthenticationFailedException authenticationFailedException) {
                 getAuthenticator(event).sendChallenge(event).subscribe().with(new Consumer<Boolean>() {


### PR DESCRIPTION
- part of larger initiative tracked in https://github.com/quarkusio/quarkus/issues/37483
- show AuthenticationCompletionException body in DEV mode when proactive auth is disabled, follow-up for the https://github.com/quarkusio/quarkus/pull/42917
- proposes to also show body in DEV mode for AuthenticationFailedException both when proactive auth is enabled and disabled. This wasn't case till now. I found following messages that are not shown:
  - https://github.com/quarkusio/quarkus/blob/aec3f34e9c62243319e02895711b34aad1688a48/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java#L413
  - https://github.com/quarkusio/quarkus/blob/aec3f34e9c62243319e02895711b34aad1688a48/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java#L1404
  - https://github.com/quarkusio/quarkus/blob/aec3f34e9c62243319e02895711b34aad1688a48/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java#L362
  - https://github.com/quarkusio/quarkus/blob/aec3f34e9c62243319e02895711b34aad1688a48/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java#L517
  - https://github.com/quarkusio/quarkus/blob/aec3f34e9c62243319e02895711b34aad1688a48/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java#L355
  - https://github.com/quarkusio/quarkus/blob/aec3f34e9c62243319e02895711b34aad1688a48/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java#L378
  - https://github.com/quarkusio/quarkus/blob/aec3f34e9c62243319e02895711b34aad1688a48/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java#L103
  - https://github.com/quarkusio/quarkus/blob/aec3f34e9c62243319e02895711b34aad1688a48/extensions/oidc-db-token-state-manager/runtime/src/main/java/io/quarkus/oidc/db/token/state/manager/runtime/OidcDbTokenStateManager.java#L69
