### PR TITLE
Do not check log categories without named handlers

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -261,7 +261,8 @@ public class LoggingSetupRecorder {
 
             namedHandlers.putAll(additionalNamedHandlersMap);
 
-            setUpCategoryLoggers(buildConfig, categoryDefaultMinLevels, categories, logContext, errorManager, namedHandlers);
+            setUpCategoryLoggers(buildConfig, categoryDefaultMinLevels, categories, logContext, errorManager, namedHandlers,
+                    true);
         }
 
         for (RuntimeValue<Optional<Handler>> additionalHandler : additionalHandlers) {
@@ -344,7 +345,7 @@ public class LoggingSetupRecorder {
                 emptyList(), emptyList(), emptyList(), emptyList(), errorManager, logCleanupFilter,
                 emptyMap(), launchMode, dummy, false);
 
-        setUpCategoryLoggers(buildConfig, categoryDefaultMinLevels, categories, logContext, errorManager, namedHandlers);
+        setUpCategoryLoggers(buildConfig, categoryDefaultMinLevels, categories, logContext, errorManager, namedHandlers, false);
 
         addNamedHandlersToRootHandlers(config.handlers(), namedHandlers, handlers, errorManager);
         InitialConfigurator.DELAYED_HANDLER.setAutoFlush(false);
@@ -482,7 +483,8 @@ public class LoggingSetupRecorder {
     private static void addNamedHandlersToCategory(
             CategoryConfig categoryConfig, Map<String, Handler> namedHandlers,
             Logger categoryLogger,
-            ErrorManager errorManager) {
+            ErrorManager errorManager,
+            boolean checkHandlerLinks) {
         for (String categoryNamedHandler : categoryConfig.handlers().get()) {
             Handler handler = namedHandlers.get(categoryNamedHandler);
             if (handler != null) {
@@ -493,7 +495,7 @@ public class LoggingSetupRecorder {
                         categoryLogger.removeHandler(handler);
                     }
                 });
-            } else {
+            } else if (checkHandlerLinks) {
                 errorManager.error(String.format("Handler with name '%s' is linked to a category but not configured.",
                         categoryNamedHandler), null, ErrorManager.GENERIC_FAILURE);
             }
@@ -506,7 +508,8 @@ public class LoggingSetupRecorder {
             final Map<String, CategoryConfig> categories,
             final LogContext logContext,
             final ErrorManager errorManager,
-            final Map<String, Handler> namedHandlers) {
+            final Map<String, Handler> namedHandlers,
+            final boolean checkHandlerLinks) {
 
         for (Entry<String, CategoryConfig> entry : categories.entrySet()) {
             String categoryName = entry.getKey();
@@ -532,7 +535,7 @@ public class LoggingSetupRecorder {
             }
             categoryLogger.setUseParentHandlers(categoryConfig.useParentHandlers());
             if (categoryConfig.handlers().isPresent()) {
-                addNamedHandlersToCategory(categoryConfig, namedHandlers, categoryLogger, errorManager);
+                addNamedHandlersToCategory(categoryConfig, namedHandlers, categoryLogger, errorManager, checkHandlerLinks);
             }
         }
     }


### PR DESCRIPTION
In #initializeBuildTimeLogging, do not check the log handlers associaciated to categories are valid, as it only considers the core handlers. The check is re-done in #initializeLogging, where all handlers are taken into account.

Fixes #45645