### PR TITLE
Avoid recursive interceptor lookups when the REST Client full name matches the simple name

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/AbstractRestClientConfigBuilder.java
@@ -94,7 +94,9 @@ public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
                         // FQN -> Quoted Config Key -> Quoted Simple Name -> Simple Name
                         quarkusFallbacks.put(quotedFullName, quotedConfigKey);
                         quarkusFallbacks.put(quotedConfigKey, restClient.getSimpleName());
-                        quarkusFallbacks.put(restClient.getSimpleName(), quotedSimpleName);
+                        if (!quotedSimpleName.equals(quotedFullName)) {
+                            quarkusFallbacks.put(restClient.getSimpleName(), quotedSimpleName);
+                        }
                         fullNameRelocates.add(quotedConfigKey);
                         fullNameRelocates.add(restClient.getSimpleName());
                         fullNameRelocates.add(quotedSimpleName);
@@ -103,7 +105,9 @@ public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
                         quarkusFallbacks.put(quotedFullName, configKey);
                         quarkusFallbacks.put(configKey, quotedConfigKey);
                         quarkusFallbacks.put(quotedConfigKey, restClient.getSimpleName());
-                        quarkusFallbacks.put(restClient.getSimpleName(), quotedSimpleName);
+                        if (!quotedSimpleName.equals(quotedFullName)) {
+                            quarkusFallbacks.put(restClient.getSimpleName(), quotedSimpleName);
+                        }
                         fullNameRelocates.add(configKey);
                         fullNameRelocates.add(quotedConfigKey);
                         fullNameRelocates.add(restClient.getSimpleName());
@@ -112,14 +116,18 @@ public abstract class AbstractRestClientConfigBuilder implements ConfigBuilder {
                 } else {
                     // FQN -> Quoted Simple Name -> Simple Name
                     quarkusFallbacks.put(quotedFullName, restClient.getSimpleName());
-                    quarkusFallbacks.put(restClient.getSimpleName(), quotedSimpleName);
+                    if (!quotedSimpleName.equals(quotedFullName)) {
+                        quarkusFallbacks.put(restClient.getSimpleName(), quotedSimpleName);
+                    }
                     fullNameRelocates.add(restClient.getSimpleName());
                     fullNameRelocates.add(quotedSimpleName);
                 }
             } else {
                 // FQN -> Quoted Simple Name -> Simple Name
                 quarkusFallbacks.put(quotedFullName, restClient.getSimpleName());
-                quarkusFallbacks.put(restClient.getSimpleName(), quotedSimpleName);
+                if (!quotedSimpleName.equals(quotedFullName)) {
+                    quarkusFallbacks.put(restClient.getSimpleName(), quotedSimpleName);
+                }
                 fullNameRelocates.add(restClient.getSimpleName());
                 fullNameRelocates.add(quotedSimpleName);
             }

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
@@ -324,6 +324,29 @@ class RestClientConfigTest {
         assertFalse(buildTimeConfig.clients().get(ConfigKeyRestClient.class.getName()).removesTrailingSlash());
     }
 
+    @Test
+    void defaultPackage() {
+        RegisteredRestClient registeredRestClient = new RegisteredRestClient("FullNameRestClient", "FullNameRestClient", null);
+        // application.properties in test/resources
+        SmallRyeConfig config = ConfigUtils.emptyConfigBuilder()
+                .withMapping(RestClientsConfig.class)
+                .withCustomizers(new SmallRyeConfigBuilderCustomizer() {
+                    @Override
+                    public void configBuilder(final SmallRyeConfigBuilder builder) {
+                        new AbstractRestClientConfigBuilder() {
+                            @Override
+                            public List<RegisteredRestClient> getRestClients() {
+                                return List.of(registeredRestClient);
+                            }
+                        }.configBuilder(builder);
+                    }
+                })
+                .build();
+
+        RestClientsConfig restClientsConfig = config.getConfigMapping(RestClientsConfig.class);
+        assertEquals(1, restClientsConfig.clients().size());
+    }
+
     private void verifyConfig(RestClientConfig config) {
         assertTrue(config.url().isPresent());
         assertThat(config.url().get()).isEqualTo("http://localhost:8080");


### PR DESCRIPTION
- Fixes #45662