### PR TITLE
Adjust Caffeine extension description to drop Java 8 mention

### DIFF
--- a/extensions/caffeine/runtime/pom.xml
+++ b/extensions/caffeine/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-caffeine</artifactId>
     <name>Quarkus - Caffeine - Runtime</name>
-    <description>A high performance caching library for Java 8+</description>
+    <description>A high performance caching library for Java</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-bom-quarkus-platform-descriptor-999-SNAPSHOT-999-SNAPSHOT.json
+++ b/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-bom-quarkus-platform-descriptor-999-SNAPSHOT-999-SNAPSHOT.json
@@ -32,7 +32,7 @@
     "origins" : [ "io.quarkus:quarkus-bom-quarkus-platform-descriptor:999-SNAPSHOT:json:999-SNAPSHOT" ]
   }, {
     "name" : "Caffeine",
-    "description" : "A high performance caching library for Java 8+",
+    "description" : "A high performance caching library for Java",
     "metadata" : {
       "keywords" : [ "cache" ],
       "categories" : [ "data" ],


### PR DESCRIPTION
Adjust Caffeine extension description to drop Java 8 mention

https://github.com/ben-manes/caffeine says 'A high performance caching library for Java '