### PR TITLE
Drop FAQ entry about non-existing modules, remove irrelevant mentions about Java 8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -882,10 +882,6 @@ This project is an open source project, please act responsibly, be nice, polite 
 
   See section `IDEA Setup` as there are different possible solutions described.
 
-* IntelliJ does not recognize the project as a Java 17 project
-
-  In the Maven pane, uncheck the `include-jdk-misc` and `compile-java8-release-flag` profiles
-
 * Build hangs with DevMojoIT running infinitely
 
   ```shell

--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroCodeGenProviderBase.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroCodeGenProviderBase.java
@@ -120,8 +120,7 @@ public abstract class AvroCodeGenProviderBase implements CodeGenProvider {
 
         /**
          * The createOptionalGetters parameter enables generating the getOptional...
-         * methods that return an Optional of the requested type. This works ONLY on
-         * Java 8+
+         * methods that return an Optional of the requested type.
          */
         final boolean createOptionalGetters;
 
@@ -138,8 +137,7 @@ public abstract class AvroCodeGenProviderBase implements CodeGenProvider {
 
         /**
          * The gettersReturnOptional parameter enables generating get... methods that
-         * return an Optional of the requested type. This will replace the This works
-         * ONLY on Java 8+
+         * return an Optional of the requested type.
          */
         final boolean gettersReturnOptional;
 
@@ -147,7 +145,7 @@ public abstract class AvroCodeGenProviderBase implements CodeGenProvider {
          * The optionalGettersForNullableFieldsOnly parameter works in conjunction with
          * gettersReturnOptional option. If it is set, Optional getters will be
          * generated only for fields that are nullable. If the field is mandatory,
-         * regular getter will be generated. This works ONLY on Java 8+.
+         * regular getter will be generated.
          */
         final boolean optionalGettersForNullableFieldsOnly;
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeWithManifest.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeWithManifest.java
@@ -33,10 +33,7 @@ public abstract class PathTreeWithManifest implements PathTree {
             List<Integer> list = (List<Integer>) v.getClass().getMethod(versionStr).invoke(v);
             JAVA_VERSION = list.get(0);
         } catch (Exception e) {
-            //version 8
-            throw new IllegalStateException(
-                    "Failed to obtain the Java version from java.lang.Runtime, possibly it's Java 8 which is not supported anymore",
-                    e);
+            throw new IllegalStateException("Failed to obtain the Java version from java.lang.Runtime", e);
         }
     }
 


### PR DESCRIPTION
 * Drop Frequently Asked Questions entry about non-existing modules
   * `CONTRIBUTING.md`
 
 * Remove irrelevant mentions about Java 8 in JavaDoc and Exception message
   * `extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroCodeGenProviderBase.java`
   * `independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeWithManifest.java`