### PR TITLE
Remove legacy @DisabledOnJre(JRE.JAVA_8)

### DIFF
--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/HttpCommonTagsTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/HttpCommonTagsTest.java
@@ -7,7 +7,6 @@ import io.micrometer.core.instrument.Tag;
 
 /**
  * Test tag creation
- * Disabled on Java 8 because of Mocks
  */
 public class HttpCommonTagsTest {
 

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetricsTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetricsTest.java
@@ -5,17 +5,11 @@ import java.util.concurrent.atomic.LongAdder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 import org.mockito.Mockito;
 
 import io.vertx.core.http.impl.HttpServerRequestInternal;
 import io.vertx.ext.web.RoutingContext;
 
-/**
- * Disabled on Java 8 because of Mocks
- */
-@DisabledOnJre(JRE.JAVA_8)
 public class VertxHttpServerMetricsTest {
 
     RoutingContext routingContext;


### PR DESCRIPTION
Remove legacy `@DisabledOnJre(JRE.JAVA_8)`

Tests are normally executed, removals have no effect on tests execution. Java 17 is the baseline.