### PR TITLE
Enable new scripts config in Swagger UI

### DIFF
--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiConfig.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiConfig.java
@@ -257,6 +257,12 @@ public class SwaggerUiConfig {
     Optional<List<String>> plugins;
 
     /**
+     * A list of external scripts (usually plugins) to use in Swagger UI.
+     */
+    @ConfigItem
+    Optional<List<String>> scripts;
+
+    /**
      * A list of presets to use in Swagger UI.
      */
     @ConfigItem

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -348,6 +348,11 @@ public class SwaggerUiProcessor {
             options.put(Option.plugins, plugins);
         }
 
+        if (swaggerUiConfig.scripts.isPresent()) {
+            String scripts = String.join(",", swaggerUiConfig.scripts.get());
+            options.put(Option.scripts, scripts);
+        }
+
         if (swaggerUiConfig.presets.isPresent()) {
             String presets = swaggerUiConfig.presets.get().toString();
             options.put(Option.presets, presets);

--- a/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/SwaggerOptionsTest.java
+++ b/extensions/swagger-ui/deployment/src/test/java/io/quarkus/swaggerui/deployment/SwaggerOptionsTest.java
@@ -22,7 +22,7 @@ public class SwaggerOptionsTest {
 
     @Test
     public void customOptions() {
-        RestAssured.when().get("/q/swagger-ui").then().statusCode(200)
+        RestAssured.when().get("/q/swagger-ui").then().log().all().and().statusCode(200)
                 .body(
                         containsString("Testing title"),
                         containsString("/openapi"),
@@ -33,7 +33,9 @@ public class SwaggerOptionsTest {
                         containsString("validatorUrl: 'localhost'"),
                         containsString("displayRequestDuration: true"),
                         containsString("supportedSubmitMethods: ['get', 'post']"),
-                        containsString("plugins: [Plugin1, Plugin2]"));
+                        containsString("plugins: [Plugin1, Plugin2]"),
+                        containsString("https://unpkg.com/swagger-ui-plugin-hierarchical-tags"),
+                        containsString("/some/local/script.js"));
 
     }
 
@@ -61,5 +63,7 @@ public class SwaggerOptionsTest {
         PROPERTIES.put("quarkus.swagger-ui.display-request-duration", "true");
         PROPERTIES.put("quarkus.swagger-ui.supported-submit-methods", "get,post");
         PROPERTIES.put("quarkus.swagger-ui.plugins", "Plugin1,Plugin2");
+        PROPERTIES.put("quarkus.swagger-ui.scripts",
+                "https://unpkg.com/swagger-ui-plugin-hierarchical-tags,/some/local/script.js");
     }
 }


### PR DESCRIPTION
Related to https://github.com/smallrye/smallrye-open-api/pull/2132

This allows configuring external plugins via scripts, example:

```
quarkus.swagger-ui.scripts=https://unpkg.com/swagger-ui-plugin-hierarchical-tags,https://unpkg.com/swagger-ui-plugin-disable-try-it-out-without-servers
quarkus.swagger-ui.plugins=SwaggerUIBundle.plugins.DownloadUrl,HierarchicalTagsPlugin,DisableTryItOutWithoutServersPlugin
```

This will add two external plugins and the DownloadUrl internal plugin

Fix #45266
