### PR TITLE
Remove lambdas from Arc that are used at startup

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCacheContextInstances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCacheContextInstances.java
@@ -37,7 +37,7 @@ public class ComputingCacheContextInstances implements ContextInstances {
     @Override
     public void removeEach(Consumer<? super ContextInstanceHandle<?>> action) {
         if (action != null) {
-            instances.getPresentValues().forEach(action);
+            instances.forEachExistingValue(action);
         }
         instances.clear();
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentManagedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentManagedContext.java
@@ -173,7 +173,12 @@ public abstract class CurrentManagedContext implements ManagedContext {
             CurrentContextState currentState = ((CurrentContextState) state);
             if (currentState.invalidate()) {
                 fireIfNotNull(beforeDestroyedNotifier);
-                currentState.contextInstances.removeEach(ContextInstanceHandle::destroy);
+                currentState.contextInstances.removeEach(new Consumer<>() {
+                    @Override
+                    public void accept(ContextInstanceHandle<?> contextInstanceHandle) {
+                        contextInstanceHandle.destroy();
+                    }
+                });
                 fireIfNotNull(destroyedNotifier);
             }
         } else {


### PR DESCRIPTION
These have a small effect on startup time, so
we let's remove them without losing any functionality

Before this change, a flamegraph of hello world REST application looks like:

![old](https://github.com/user-attachments/assets/3dad4eec-e5f5-4820-af9b-61eeae7a0e3b)

while after applying it, we have:

![new](https://github.com/user-attachments/assets/9712fc15-4f29-4e2a-82a2-da80d589b789)
