### PR TITLE
Add HTTP response to HttpServerMetricsTagsContributor.Context

### DIFF
--- a/docs/src/main/asciidoc/telemetry-micrometer.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer.adoc
@@ -588,7 +588,9 @@ link:https://micrometer.io/docs/concepts[official documentation].
 
 === Use `HttpServerMetricsTagsContributor` for server HTTP requests
 
-By providing CDI beans that implement `io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor`, user code can contribute arbitrary tags based on the details of HTTP request
+By providing CDI beans that implement `io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor`, user code can contribute arbitrary tags based on the details of HTTP request and responses.
+
+CAUTION: When creating tags using this interface, it's important to limit the cardinality of the values, otherwise there is a risk of severely degrading the metrics system's capacity.
 
 === Use `HttpClientMetricsTagsContributor` for client HTTP requests
 

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/HttpClientMetricsTagsContributor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/HttpClientMetricsTagsContributor.java
@@ -3,6 +3,7 @@ package io.quarkus.micrometer.runtime;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.spi.observability.HttpRequest;
+import io.vertx.core.spi.observability.HttpResponse;
 
 /**
  * Allows code to add additional Micrometer {@link Tags} to the metrics collected for completed HTTP client requests.
@@ -20,5 +21,7 @@ public interface HttpClientMetricsTagsContributor {
 
     interface Context {
         HttpRequest request();
+
+        HttpResponse response();
     }
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/HttpServerMetricsTagsContributor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/HttpServerMetricsTagsContributor.java
@@ -3,6 +3,7 @@ package io.quarkus.micrometer.runtime;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.spi.observability.HttpResponse;
 
 /**
  * Allows code to add additional Micrometer {@link Tags} to the metrics collected for completed HTTP server requests.
@@ -20,5 +21,7 @@ public interface HttpServerMetricsTagsContributor {
 
     interface Context {
         HttpServerRequest request();
+
+        HttpResponse response();
     }
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpClientMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpClientMetrics.java
@@ -172,7 +172,7 @@ class VertxHttpClientMetrics extends VertxTcpClientMetrics
                         .and(HttpCommonTags.status(tracker.response.statusCode()))
                         .and(HttpCommonTags.outcome(tracker.response.statusCode()));
                 if (!httpClientMetricsTagsContributors.isEmpty()) {
-                    HttpClientMetricsTagsContributor.Context context = new DefaultContext(tracker.request);
+                    HttpClientMetricsTagsContributor.Context context = new DefaultContext(tracker.request, tracker.response);
                     for (int i = 0; i < httpClientMetricsTagsContributors.size(); i++) {
                         try {
                             Tags additionalTags = httpClientMetricsTagsContributors.get(i).contribute(context);
@@ -254,6 +254,7 @@ class VertxHttpClientMetrics extends VertxTcpClientMetrics
         }
     }
 
-    private record DefaultContext(HttpRequest request) implements HttpClientMetricsTagsContributor.Context {
+    private record DefaultContext(HttpRequest request,
+            HttpResponse response) implements HttpClientMetricsTagsContributor.Context {
     }
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetrics.java
@@ -205,7 +205,7 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
                     VertxMetricsTags.outcome(response),
                     HttpCommonTags.status(response.statusCode()));
             if (!httpServerMetricsTagsContributors.isEmpty()) {
-                HttpServerMetricsTagsContributor.Context context = new DefaultContext(requestMetric.request());
+                HttpServerMetricsTagsContributor.Context context = new DefaultContext(requestMetric.request(), response);
                 for (int i = 0; i < httpServerMetricsTagsContributors.size(); i++) {
                     try {
                         Tags additionalTags = httpServerMetricsTagsContributors.get(i).contribute(context);
@@ -258,6 +258,7 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
         }
     }
 
-    private record DefaultContext(HttpServerRequest request) implements HttpServerMetricsTagsContributor.Context {
+    private record DefaultContext(HttpServerRequest request,
+            HttpResponse response) implements HttpServerMetricsTagsContributor.Context {
     }
 }

--- a/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/ResponseHeaderTag.java
+++ b/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/ResponseHeaderTag.java
@@ -1,0 +1,20 @@
+package io.quarkus;
+
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.Tags;
+import io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor;
+
+@Singleton
+public class ResponseHeaderTag implements HttpServerMetricsTagsContributor {
+
+    @Override
+    public Tags contribute(Context context) {
+        var headerValue = context.response().headers().get("foo-response");
+        String value = "UNSET";
+        if ((headerValue != null) && !headerValue.isEmpty()) {
+            value = headerValue;
+        }
+        return Tags.of("foo-response", value);
+    }
+}

--- a/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/it/micrometer/prometheus/FruitResource.java
+++ b/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/it/micrometer/prometheus/FruitResource.java
@@ -6,6 +6,8 @@ import jakarta.transaction.Transactional;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
+import org.jboss.resteasy.reactive.RestResponse;
+
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.smallrye.common.annotation.Blocking;
 
@@ -26,9 +28,13 @@ public class FruitResource {
 
     @GET
     @Path("all")
-    public void retrieveAll() {
+    public RestResponse<Object> retrieveAll() {
         PanacheQuery<Fruit> query = Fruit.find(
                 "select name from Fruit");
         List<Fruit> all = query.list();
+
+        return RestResponse.ResponseBuilder.noContent()
+                .header("foo-response", "value")
+                .build();
     }
 }

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ExemplarTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ExemplarTest.java
@@ -24,7 +24,7 @@ public class ExemplarTest {
         when().get("/example/prime/7919").then().statusCode(200);
 
         String metricMatch = "http_server_requests_seconds_count{dummy=\"value\",env=\"test\"," +
-                "env2=\"test\",foo=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\"," +
+                "env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\"," +
                 "registry=\"prometheus\",status=\"200\",uri=\"/example/prime/{number}\"} 2.0 # {span_id=\"";
 
         await().atMost(5, SECONDS).untilAsserted(() -> {

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
@@ -134,14 +134,15 @@ class PrometheusMetricsRegistryTest {
                 .body(containsString("outcome=\"SUCCESS\""))
                 .body(containsString("dummy=\"value\""))
                 .body(containsString("foo=\"bar\""))
+                .body(containsString("foo_response=\"value\""))
                 .body(containsString("uri=\"/message/match/{id}/{sub}\""))
                 .body(containsString("uri=\"/message/match/{other}\""))
 
                 .body(containsString(
-                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
+                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
 
                 .body(containsString(
-                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/root/{rootParam}/sub/{subParam}\""))
+                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/root/{rootParam}/sub/{subParam}\""))
 
                 // Verify Hibernate Metrics
                 .body(containsString(
@@ -233,7 +234,7 @@ class PrometheusMetricsRegistryTest {
                 .body(containsString("uri=\"/message/match/{other}\""))
 
                 .body(containsString(
-                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
+                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
 
                 // Verify Hibernate Metrics
                 .body(containsString(


### PR DESCRIPTION
This is useful for creating tags based on HTTP response headers for example

- Closes: #45717