### PR TITLE
Improvements to the Grafana LGTM dashboards - part 2

### DIFF
--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
@@ -15,4 +15,12 @@ public final class ContainerConstants {
 
     public static final String OTEL_GRPC_PROTOCOL = "grpc";
     public static final String OTEL_HTTP_PROTOCOL = "http/protobuf";
+
+    // Overrides
+
+    public static final int SCRAPING_INTERVAL = 10;
+    public static final String OTEL_METRIC_EXPORT_INTERVAL = "10s";
+    public static final String OTEL_BSP_SCHEDULE_DELAY = "3s";
+    public static final String OTEL_BLRP_SCHEDULE_DELAY = "1s";
+
 }

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.quarkus.observability.common.ContainerConstants;
+import io.quarkus.runtime.annotations.ConfigDocIgnore;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -37,4 +38,39 @@ public interface LgtmConfig extends GrafanaConfig {
      */
     @WithDefault(ContainerConstants.OTEL_HTTP_PROTOCOL)
     String otlpProtocol();
+
+    /**
+     * The (Prometheus) scraping interval, in seconds.
+     */
+    @WithDefault(ContainerConstants.SCRAPING_INTERVAL + "")
+    int scrapingInterval();
+
+    /**
+     * Do we force scraping.
+     */
+    Optional<Boolean> forceScraping();
+
+    /**
+     * A way to override `quarkus.otel.metric.export.interval` property's default value.
+     */
+    @OverrideProperty("quarkus.otel.metric.export.interval")
+    @WithDefault(ContainerConstants.OTEL_METRIC_EXPORT_INTERVAL)
+    @ConfigDocIgnore
+    String otelMetricExportInterval();
+
+    /**
+     * A way to override `quarkus.otel.bsp.schedule.delay` property's default value.
+     */
+    @OverrideProperty("quarkus.otel.bsp.schedule.delay")
+    @WithDefault(ContainerConstants.OTEL_BSP_SCHEDULE_DELAY)
+    @ConfigDocIgnore
+    String otelBspScheduleDelay();
+
+    /**
+     * A way to override `quarkus.otel.metric.export.interval` property's default value.
+     */
+    @OverrideProperty("quarkus.otel.blrp.schedule.delay")
+    @WithDefault(ContainerConstants.OTEL_BLRP_SCHEDULE_DELAY)
+    @ConfigDocIgnore
+    String otelBlrpScheduleDelay();
 }

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/OverrideProperty.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/OverrideProperty.java
@@ -1,0 +1,21 @@
+package io.quarkus.observability.common.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Override the property in the value,
+ * with the value of the annotated method's return.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+public @interface OverrideProperty {
+    /**
+     * The property key to override.
+     *
+     * @return the property key
+     */
+    String value();
+}

--- a/extensions/observability-devservices/testcontainers/pom.xml
+++ b/extensions/observability-devservices/testcontainers/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devtools-utilities</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-common</artifactId>
         </dependency>
         <dependency>

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
@@ -15,11 +15,12 @@ import org.testcontainers.utility.MountableFile;
 import io.quarkus.observability.common.ContainerConstants;
 import io.quarkus.observability.common.config.AbstractGrafanaConfig;
 import io.quarkus.observability.common.config.LgtmConfig;
+import io.quarkus.runtime.LaunchMode;
 
 public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
     protected static final String LGTM_NETWORK_ALIAS = "ltgm.testcontainer.docker";
 
-    protected static final String PROMETHEUS_CONFIG = """
+    protected static final String PROMETHEUS_CONFIG_DEFAULT = """
             ---
             otlp:
               # Recommended attributes to be promoted to labels.
@@ -47,12 +48,15 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
                 # A 10min time window is enough because it can easily absorb retries and network delays.
                 out_of_order_time_window: 10m
             global:
-              scrape_interval: 5s
+              scrape_interval: %s
               evaluation_interval: 5s
+            """;
+
+    protected static final String PROMETHEUS_CONFIG_SCRAPE = """
             scrape_configs:
               - job_name: '%s'
                 metrics_path: '%s%s'
-                scrape_interval: 5s
+                scrape_interval: %s
                 static_configs:
                   - targets: ['%s:%d']
             """;
@@ -83,12 +87,16 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
                   foldersFromFilesStructure: false
             """;
 
-    public LgtmContainer() {
-        this(new LgtmConfigImpl());
+    private final boolean scrapingRequired;
+
+    public LgtmContainer(boolean scrapingRequired) {
+        this(new LgtmConfigImpl(), scrapingRequired);
     }
 
-    public LgtmContainer(LgtmConfig config) {
+    public LgtmContainer(LgtmConfig config, boolean scrapingRequired) {
         super(config);
+        // do we require scraping
+        this.scrapingRequired = scrapingRequired;
         // always expose both -- since the LGTM image already does that as well
         addExposedPorts(ContainerConstants.OTEL_GRPC_EXPORTER_PORT, ContainerConstants.OTEL_HTTP_EXPORTER_PORT);
 
@@ -157,12 +165,22 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
     }
 
     private String getPrometheusConfig() {
-        Config runtimeConfig = ConfigProvider.getConfig();
-        String rootPath = runtimeConfig.getOptionalValue("quarkus.management.root-path", String.class).orElse("/q");
-        String metricsPath = runtimeConfig.getOptionalValue("quarkus.management.metrics.path", String.class).orElse("/metrics");
-        int httpPort = runtimeConfig.getOptionalValue("quarkus.http.port", Integer.class).orElse(8080); // when not set use default
+        String scraping = config.scrapingInterval() + "s";
+        String prometheusConfig = String.format(PROMETHEUS_CONFIG_DEFAULT, scraping);
+        if (config.forceScraping().orElse(scrapingRequired)) {
+            boolean isTest = LaunchMode.current() == LaunchMode.TEST;
+            Config runtimeConfig = ConfigProvider.getConfig();
+            String rootPath = runtimeConfig.getOptionalValue("quarkus.management.root-path", String.class).orElse("/q");
+            String metricsPath = runtimeConfig.getOptionalValue("quarkus.management.metrics.path", String.class)
+                    .orElse("/metrics");
+            String httpPortKey = isTest ? "quarkus.http.test-port" : "quarkus.http.port";
+            Optional<Integer> optionalValue = runtimeConfig.getOptionalValue(httpPortKey, Integer.class);
+            int httpPort = optionalValue.orElse(isTest ? 8081 : 8080); // when not set use default
 
-        return String.format(PROMETHEUS_CONFIG, config.serviceName(), rootPath, metricsPath, "host.docker.internal", httpPort);
+            prometheusConfig += String.format(PROMETHEUS_CONFIG_SCRAPE, config.serviceName(), rootPath, metricsPath, scraping,
+                    "host.docker.internal", httpPort);
+        }
+        return prometheusConfig;
     }
 
     protected static class LgtmConfigImpl extends AbstractGrafanaConfig implements LgtmConfig {
@@ -182,6 +200,31 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
         @Override
         public String otlpProtocol() {
             return ContainerConstants.OTEL_HTTP_PROTOCOL;
+        }
+
+        @Override
+        public int scrapingInterval() {
+            return ContainerConstants.SCRAPING_INTERVAL;
+        }
+
+        @Override
+        public Optional<Boolean> forceScraping() {
+            return Optional.empty();
+        }
+
+        @Override
+        public String otelMetricExportInterval() {
+            return ContainerConstants.OTEL_METRIC_EXPORT_INTERVAL;
+        }
+
+        @Override
+        public String otelBspScheduleDelay() {
+            return ContainerConstants.OTEL_BSP_SCHEDULE_DELAY;
+        }
+
+        @Override
+        public String otelBlrpScheduleDelay() {
+            return ContainerConstants.OTEL_BLRP_SCHEDULE_DELAY;
         }
     }
 

--- a/extensions/observability-devservices/testlibs/devresource-common/src/main/java/io/quarkus/observability/devresource/ExtensionsCatalog.java
+++ b/extensions/observability-devservices/testlibs/devresource-common/src/main/java/io/quarkus/observability/devresource/ExtensionsCatalog.java
@@ -1,8 +1,13 @@
 package io.quarkus.observability.devresource;
 
+import java.util.function.Function;
+
 /**
  * Relevant Observability extensions present.
  */
-public record ExtensionsCatalog(boolean hasOpenTelemetry,
+public record ExtensionsCatalog(
+        Function<String, Boolean> resourceChecker,
+        Function<String, Boolean> classChecker,
+        boolean hasOpenTelemetry,
         boolean hasMicrometerOtlp) {
 }

--- a/integration-tests/observability-lgtm-prometheus/pom.xml
+++ b/integration-tests/observability-lgtm-prometheus/pom.xml
@@ -10,8 +10,8 @@
         <version>999-SNAPSHOT</version>
     </parent>
 
-    <artifactId>quarkus-integration-test-observability-lgtm</artifactId>
-    <name>Quarkus - Integration Tests - Observability LGTM</name>
+    <artifactId>quarkus-integration-test-observability-lgtm-prometheus</artifactId>
+    <name>Quarkus - Integration Tests - Observability LGTM Prometheus</name>
 
     <dependencies>
         <dependency>
@@ -24,9 +24,8 @@
         </dependency>
         <!-- Add these deps as non-test / plain dependency, so we can run dev mode to check -->
         <dependency>
-            <groupId>io.quarkiverse.micrometer.registry</groupId>
-            <artifactId>quarkus-micrometer-registry-otlp</artifactId>
-            <version>3.2.4</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -95,6 +94,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -107,35 +119,6 @@
                         <goals>
                             <goal>build</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-test</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <!-- These tests seem to leak metaspace memory
-                                 so we run them in a separate, short-lived JVM -->
-                            <excludedGroups>devmode</excludedGroups>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>devmode-test</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <!-- These tests seem to leak metaspace memory
-                                 so we run them in a separate, short-lived JVM -->
-                            <groups>devmode</groups>
-                            <!-- We could consider setting reuseForks=false if we
-                                 really need to run every single test in its own JVM -->
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integration-tests/observability-lgtm-prometheus/src/main/java/io/quarkus/observability/example/SimpleEndpoint.java
+++ b/integration-tests/observability-lgtm-prometheus/src/main/java/io/quarkus/observability/example/SimpleEndpoint.java
@@ -1,0 +1,48 @@
+package io.quarkus.observability.example;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Path("/api")
+public class SimpleEndpoint {
+    private static final Logger log = Logger.getLogger(SimpleEndpoint.class);
+
+    @Inject
+    MeterRegistry registry;
+
+    Random random = new SecureRandom();
+    double[] arr = new double[1];
+
+    @PostConstruct
+    public void start() {
+        String key = System.getProperty("tag-key", "test");
+        Gauge.builder("xvalue", arr, a -> arr[0])
+                .baseUnit("X")
+                .description("Some random x")
+                .tag(key, "x")
+                .register(registry);
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/poke")
+    public String poke(@QueryParam("f") int f) {
+        log.infof("Poke %s", f);
+        double x = random.nextDouble() * f;
+        arr[0] = x;
+        return "poke:" + x;
+    }
+}

--- a/integration-tests/observability-lgtm-prometheus/src/main/resources/application.properties
+++ b/integration-tests/observability-lgtm-prometheus/src/main/resources/application.properties
@@ -2,3 +2,6 @@ quarkus.log.category."io.quarkus.observability".level=DEBUG
 quarkus.log.category."io.quarkus.devservices".level=DEBUG
 
 quarkus.micrometer.binder-enabled-default=false
+
+quarkus.http.access-log.enabled=true
+quarkus.http.access-log.pattern=%h %l %u %t "%r" %s %b %m "%{i,Referer}" "%{i,User-Agent}" "%{i,X-Request-Id}" "%{i,X-Organization-Id}" %D

--- a/integration-tests/observability-lgtm-prometheus/src/main/resources/application.properties
+++ b/integration-tests/observability-lgtm-prometheus/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.log.category."io.quarkus.observability".level=DEBUG
+quarkus.log.category."io.quarkus.devservices".level=DEBUG
+
+quarkus.micrometer.binder-enabled-default=false

--- a/integration-tests/observability-lgtm-prometheus/src/test/java/io/quarkus/observability/test/LgtmTest.java
+++ b/integration-tests/observability-lgtm-prometheus/src/test/java/io/quarkus/observability/test/LgtmTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.observability.test;
+
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.observability.test.utils.GrafanaClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+/**
+ * Duplicated test, similar to observability-lgtm.
+ * The difference is dependencies / classpath,
+ * where this one has / uses Prometheus Micrometer registry.
+ */
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+public class LgtmTest {
+    protected final Logger log = Logger.getLogger(getClass());
+
+    @ConfigProperty(name = "grafana.endpoint")
+    String endpoint;
+
+    @Test
+    public void testPoke() {
+        log.info("Testing Grafana ...");
+        String response = RestAssured.get("/api/poke?f=100").body().asString();
+        log.info("Response: " + response);
+        GrafanaClient client = new GrafanaClient(endpoint, "admin", "admin");
+        Awaitility.await().atMost(61, TimeUnit.SECONDS).until(
+                client::user,
+                u -> "admin".equals(u.login));
+        Awaitility.await().atMost(61, TimeUnit.SECONDS).until(
+                () -> client.query("xvalue_X"),
+                result -> !result.data.result.isEmpty());
+        Awaitility.await().atMost(61, TimeUnit.SECONDS).until(
+                () -> client.traces("quarkus-integration-test-observability-lgtm-prometheus", 20, 3),
+                result -> !result.traces.isEmpty());
+    }
+
+}

--- a/integration-tests/observability-lgtm-prometheus/src/test/java/io/quarkus/observability/test/LgtmTest.java
+++ b/integration-tests/observability-lgtm-prometheus/src/test/java/io/quarkus/observability/test/LgtmTest.java
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -20,6 +21,7 @@ import io.restassured.RestAssured;
  */
 @QuarkusTest
 @DisabledOnOs(OS.WINDOWS)
+@Disabled("Dunno how to scrape from Prometheus container to app, on Linux / CI")
 public class LgtmTest {
     protected final Logger log = Logger.getLogger(getClass());
 

--- a/integration-tests/observability-lgtm-prometheus/src/test/java/io/quarkus/observability/test/LgtmTest.java
+++ b/integration-tests/observability-lgtm-prometheus/src/test/java/io/quarkus/observability/test/LgtmTest.java
@@ -32,6 +32,9 @@ public class LgtmTest {
         String response = RestAssured.get("/api/poke?f=100").body().asString();
         log.info("Response: " + response);
         GrafanaClient client = new GrafanaClient(endpoint, "admin", "admin");
+
+        Awaitility.setDefaultPollInterval(1, TimeUnit.SECONDS); // reduce load on the server. Default is .1s
+
         Awaitility.await().atMost(61, TimeUnit.SECONDS).until(
                 client::user,
                 u -> "admin".equals(u.login));

--- a/integration-tests/observability-lgtm-prometheus/src/test/resources/application.properties
+++ b/integration-tests/observability-lgtm-prometheus/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+# Disable default binders
+quarkus.micrometer.binder-enabled-default=false
+
+quarkus.log.category."io.quarkus.observability".level=DEBUG
+quarkus.log.category."io.quarkus.devservices".level=DEBUG
+
+quarkus.observability.lgtm.timeout=PT3M
+quarkus.observability.lgtm.scraping-interval=2

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmReloadTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmReloadTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.observability.test.support.ConfigEndpoint;
-import io.quarkus.observability.test.support.GrafanaClient;
 import io.quarkus.observability.test.support.ReloadEndpoint;
+import io.quarkus.observability.test.utils.GrafanaClient;
 import io.quarkus.test.QuarkusDevModeTest;
 
 /**

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestHelper.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestHelper.java
@@ -18,6 +18,9 @@ public abstract class LgtmTestHelper {
         String response = RestAssured.get(path + "/poke?f=100").body().asString();
         log.info("Response: " + response);
         GrafanaClient client = new GrafanaClient(grafanaEndpoint(), "admin", "admin");
+
+        Awaitility.setDefaultPollInterval(1, TimeUnit.SECONDS); // reduce load on the server. Default is .1s
+
         Awaitility.await().atMost(61, TimeUnit.SECONDS).until(
                 client::user,
                 u -> "admin".equals(u.login));
@@ -28,5 +31,4 @@ public abstract class LgtmTestHelper {
                 () -> client.traces("quarkus-integration-test-observability-lgtm", 20, 3),
                 result -> !result.traces.isEmpty());
     }
-
 }

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestHelper.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmTestHelper.java
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.jboss.logging.Logger;
 
-import io.quarkus.observability.test.support.GrafanaClient;
+import io.quarkus.observability.test.utils.GrafanaClient;
 import io.restassured.RestAssured;
 
 public abstract class LgtmTestHelper {

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -253,6 +253,7 @@
                 <module>liquibase</module>
                 <module>liquibase-mongodb</module>
                 <module>observability-lgtm</module>
+                <module>observability-lgtm-prometheus</module>
                 <module>oidc</module>
                 <module>oidc-client</module>
                 <module>oidc-client-registration</module>

--- a/test-framework/observability/pom.xml
+++ b/test-framework/observability/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-test-observability</artifactId>
+    <name>Quarkus - Test Framework - Observability test utils</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/GrafanaClient.java
+++ b/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/GrafanaClient.java
@@ -1,4 +1,4 @@
-package io.quarkus.observability.test.support;
+package io.quarkus.observability.test.utils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/GrafanaClient.java
+++ b/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/GrafanaClient.java
@@ -10,11 +10,14 @@ import java.util.Base64;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.logging.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class GrafanaClient {
+    private static final Logger LOG = Logger.getLogger(GrafanaClient.class.getName());
+
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final String url;
@@ -87,7 +90,9 @@ public class GrafanaClient {
                         throw new UncheckedIOException(e);
                     }
                 });
-        return ref.get();
+        User user = ref.get();
+        LOG.info("User: " + user);
+        return user;
     }
 
     public QueryResult query(String query) {
@@ -104,7 +109,9 @@ public class GrafanaClient {
                         throw new UncheckedIOException(e);
                     }
                 });
-        return ref.get();
+        QueryResult queryResult = ref.get();
+        LOG.info("Query: " + queryResult);
+        return queryResult;
     }
 
     public TempoResult traces(String service, int limit, int spss) {
@@ -123,6 +130,8 @@ public class GrafanaClient {
                         throw new UncheckedIOException(e);
                     }
                 });
-        return ref.get();
+        TempoResult tempoResult = ref.get();
+        LOG.info("Traces: " + tempoResult);
+        return tempoResult;
     }
 }

--- a/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/QueryResult.java
+++ b/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/QueryResult.java
@@ -1,4 +1,4 @@
-package io.quarkus.observability.test.support;
+package io.quarkus.observability.test.utils;
 
 import java.util.List;
 

--- a/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/TempoResult.java
+++ b/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/TempoResult.java
@@ -1,4 +1,4 @@
-package io.quarkus.observability.test.support;
+package io.quarkus.observability.test.utils;
 
 import java.util.List;
 import java.util.Map;

--- a/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/User.java
+++ b/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/User.java
@@ -1,4 +1,4 @@
-package io.quarkus.observability.test.support;
+package io.quarkus.observability.test.utils;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/User.java
+++ b/test-framework/observability/src/main/java/io/quarkus/observability/test/utils/User.java
@@ -11,4 +11,13 @@ public class User {
     public String email;
     @JsonProperty
     public String login;
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", email='" + email + '\'' +
+                ", login='" + login + '\'' +
+                '}';
+    }
 }

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -43,6 +43,7 @@
         <module>mongodb</module>
         <module>kafka-companion</module>
         <module>google-cloud-functions</module>
+        <module>observability</module>
     </modules>
 
     <build>


### PR DESCRIPTION
These 3 items from this issue: #43599

- Increase the scraper frequency

- In devmode, increase default output rate so data shows quicker on the dashboards

- Only activate the scraper if the Prometheus registry is present.