### PR TITLE
Transition `VirtualThreadsConfig` to use `@ConfigMapping`

### DIFF
--- a/extensions/virtual-threads/deployment/pom.xml
+++ b/extensions/virtual-threads/deployment/pom.xml
@@ -43,9 +43,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/virtual-threads/runtime/pom.xml
+++ b/extensions/virtual-threads/runtime/pom.xml
@@ -60,9 +60,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsConfig.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsConfig.java
@@ -3,32 +3,35 @@ package io.quarkus.virtual.threads;
 import java.time.Duration;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
+@ConfigMapping(prefix = "quarkus.virtual-threads")
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class VirtualThreadsConfig {
+public interface VirtualThreadsConfig {
 
     /**
-     * Virtual thread name prefix. If left blank virtual threads will be unnamed.
+     * Virtual thread name prefix. The name of the virtual thread will be the prefix followed by a unique number.
+     * The default value is "quarkus-virtual-thread-".
      */
-    @ConfigItem(defaultValue = "quarkus-virtual-thread-")
-    Optional<String> namePrefix;
+    @WithDefault("quarkus-virtual-thread-")
+    Optional<String> namePrefix();
 
     /**
      * The shutdown timeout. If all pending work has not been completed by this time
      * then any pending tasks will be interrupted, and the shutdown process will continue
      */
-    @ConfigItem(defaultValue = "1M")
-    public Duration shutdownTimeout;
+    @WithDefault("1M")
+    Duration shutdownTimeout();
 
     /**
      * The frequency at which the status of the executor service should be checked during shutdown.
-     * Setting this key to an empty value disables the shutdown check interval.
+     * Setting this key to an empty value will use the same value as the shutdown timeout.
      */
-    @ConfigItem(defaultValue = "5s")
-    public Optional<Duration> shutdownCheckInterval;
+    @WithDefault("5s")
+    Optional<Duration> shutdownCheckInterval();
 
     /**
      * A flag to explicitly disabled virtual threads, even if the JVM support them.
@@ -37,6 +40,6 @@ public class VirtualThreadsConfig {
      * This flag is intended to be used when running with virtual threads become more expensive than plain worker threads,
      * because of pinning, monopolization or thread-based object pool.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enabled;
+    @WithDefault("true")
+    boolean enabled();
 }

--- a/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
+++ b/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
@@ -6,7 +6,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -19,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
+import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.vertx.core.Context;
@@ -28,9 +28,10 @@ class VirtualThreadExecutorSupplierTest {
 
     @BeforeEach
     void configRecorder() {
-        VirtualThreadsRecorder.config = new VirtualThreadsConfig();
-        VirtualThreadsRecorder.config.enabled = true;
-        VirtualThreadsRecorder.config.namePrefix = Optional.empty();
+        VirtualThreadsRecorder.config = new SmallRyeConfigBuilder()
+                .addDiscoveredConverters()
+                .withMapping(VirtualThreadsConfig.class)
+                .build().getConfigMapping(VirtualThreadsConfig.class);
     }
 
     @Test


### PR DESCRIPTION
- Remove legacy configuration compiler arguments from Maven POM files to streamline build configuration.
