### PR TITLE
Rebalance native CI jobs so that Misc4 is not twice the duration of other jobs

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -99,25 +99,25 @@
         {
             "category": "Misc1",
             "timeout": 70,
-            "test-modules": "maven, jackson, jsonb, kotlin, rest-client-reactive-kotlin-serialization, quartz, qute, logging-min-level-unset, logging-min-level-set, simple with space",
+            "test-modules": "jackson, jsonb, kotlin, rest-client-reactive-kotlin-serialization, quartz, qute, logging-min-level-unset, logging-min-level-set, simple with space, web-dependency-locator",
             "os-name": "ubuntu-latest"
         },
         {
             "category": "Misc2",
             "timeout": 75,
-            "test-modules": "hibernate-validator, test-extension/tests, logging-gelf, mailer, native-config-profile, locales/all, locales/some, locales/default",
+            "test-modules": "hibernate-validator, test-extension/tests, logging-gelf, mailer, native-config-profile, locales/all, locales/some, locales/default, jaxp, jaxb",
             "os-name": "ubuntu-latest"
         },
         {
             "category": "Misc3",
             "timeout": 80,
-            "test-modules": "kubernetes-client, openshift-client, kubernetes-service-binding-jdbc, smallrye-config, smallrye-graphql, smallrye-graphql-client, smallrye-graphql-client-keycloak, smallrye-metrics",
+            "test-modules": "kubernetes-client, openshift-client, kubernetes-service-binding-jdbc, smallrye-config, smallrye-graphql, smallrye-graphql-client, smallrye-graphql-client-keycloak,  picocli-native",
             "os-name": "ubuntu-latest"
         },
         {
-            "category": "Misc4",
+            "category": "Observability",
             "timeout": 130,
-            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, jaxb, observability-lgtm, opentelemetry, opentelemetry-jdbc-instrumentation, opentelemetry-mongodb-client-instrumentation, opentelemetry-redis-instrumentation, web-dependency-locator, micrometer-opentelemetry",
+            "test-modules": "smallrye-metrics, micrometer-mp-metrics, micrometer-prometheus, logging-json, observability-lgtm, opentelemetry, opentelemetry-jdbc-instrumentation, opentelemetry-mongodb-client-instrumentation, opentelemetry-redis-instrumentation, micrometer-opentelemetry",
             "os-name": "ubuntu-latest"
         },
         {
@@ -139,9 +139,9 @@
             "os-name": "windows-latest"
         },
         {
-            "category": "DevTools Integration Tests",
+            "category": "Build tools and DevTools",
             "timeout": 75,
-            "test-modules": "devtools-registry-client",
+            "test-modules": "maven, gradle, devtools-registry-client",
             "os-name": "ubuntu-latest"
         },
         {


### PR DESCRIPTION
This PR aims to help these problems:
- The Misc4 job takes much longer than the other native jobs, meaning feedback on that job is slower
- The slow feedback matters because the Gradle project is in the job, and it seems to be one of the more likely projects to fail 
- The Misc grouping name doesn’t give much insight into what’s in the bucket
- The Native Devtools job is so short it's a bit of a waste of a machine

To address these, I moved the gradle tests to the Devtools job, since it’s one of the fastest. Then I noticed that almost everything that was left was observability-related, so I renamed the job and distributed the non-observability projects through the other jobs. I also moved maven in with gradle, since they seem like a logical grouping. 

I think there are a few risks with this kind of change 

- Syntax errors causing build failures, because the PR will not exercise the new yaml. To mitigate, I tested on my fork: https://github.com/holly-cummins/quarkus/actions/runs/12884686079
- Jobs getting accidentally removed. I think we can only mitigate this by careful inspection (and maybe by keeping rebalances small and incremental so they’re easier to inspect). 
- Name changes causing confusion for people looking at jobs, or for develocity analysis. I think this is not too big a problem.
- Making the balance worse. To check this, I made a change in core, which I’m hoping would clear the caches, and ran my test build. 

@brunobat could you validate the contents of the observability bucket look like a complete-ish consistent set?

Here’s the timings I observed on my test runs. The codebases are a bit different between the two, but it shows the ratios. 

[Old](https://github.com/holly-cummins/quarkus/actions/runs/12883673385/job/35919279284)

Misc 1: 31m
Misc 2: 22m
Misc 3: 30m
Misc 4: 54m (often it’s over an hour for me)
DevTools: 4m (!)

[New](https://github.com/holly-cummins/quarkus/actions/runs/12884686079/job/35922302153)

Misc 1: 26m
Misc 2: 29m 
Misc 3: 28m 
Observability: 35m
Build tools and DevTools: 29m