### PR TITLE
Move Vert.x HTTP configuration to @ConfigMapping

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/Extension.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/model/Extension.java
@@ -59,7 +59,8 @@ public record Extension(String groupId, String artifactId, String name,
     @Deprecated(forRemoval = true)
     @JsonIgnore
     public boolean isMixedModule() {
-        return "io.quarkus".equals(groupId) && ("quarkus-core".equals(artifactId) || "quarkus-messaging".equals(artifactId));
+        return "io.quarkus".equals(groupId) && ("quarkus-core".equals(artifactId) || "quarkus-vertx-http".equals(artifactId)
+                || "quarkus-messaging".equals(artifactId));
     }
 
     @JsonIgnore

--- a/extensions/funqy/funqy-http/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/http/FunqyHttpBuildStep.java
+++ b/extensions/funqy/funqy-http/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/http/FunqyHttpBuildStep.java
@@ -6,8 +6,6 @@ import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 import java.util.List;
 import java.util.Optional;
 
-import org.jboss.logging.Logger;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
@@ -25,12 +23,11 @@ import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
 public class FunqyHttpBuildStep {
-    private static final Logger log = Logger.getLogger(FunqyHttpBuildStep.class);
     public static final String FUNQY_HTTP_FEATURE = "funqy-http";
 
     @BuildStep
@@ -55,12 +52,12 @@ public class FunqyHttpBuildStep {
     public void staticInit(FunqyHttpBindingRecorder binding,
             BeanContainerBuildItem beanContainer, // dependency
             Optional<FunctionInitializedBuildItem> hasFunctions,
-            HttpBuildTimeConfig httpConfig) throws Exception {
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
         if (!hasFunctions.isPresent() || hasFunctions.get() == null)
             return;
 
         // The context path + the resources path
-        String rootPath = httpConfig.rootPath;
+        String rootPath = httpBuildTimeConfig.rootPath();
         binding.init();
     }
 
@@ -74,14 +71,14 @@ public class FunqyHttpBuildStep {
             Optional<FunctionInitializedBuildItem> hasFunctions,
             List<FunctionBuildItem> functions,
             BeanContainerBuildItem beanContainer,
-            HttpBuildTimeConfig httpConfig,
+            VertxHttpBuildTimeConfig httpConfig,
             ExecutorBuildItem executorBuildItem) throws Exception {
 
         if (!hasFunctions.isPresent() || hasFunctions.get() == null)
             return;
         feature.produce(new FeatureBuildItem(FUNQY_HTTP_FEATURE));
 
-        String rootPath = httpConfig.rootPath;
+        String rootPath = httpConfig.rootPath();
         Handler<RoutingContext> handler = binding.start(rootPath,
                 vertx.getVertx(),
                 shutdown,

--- a/extensions/funqy/funqy-knative-events/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/knative/events/FunqyKnativeEventsBuildStep.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/knative/events/FunqyKnativeEventsBuildStep.java
@@ -27,7 +27,7 @@ import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -75,14 +75,14 @@ public class FunqyKnativeEventsBuildStep {
             BuildProducer<RouteBuildItem> routes,
             CoreVertxBuildItem vertx,
             BeanContainerBuildItem beanContainer,
-            HttpBuildTimeConfig httpConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
             ExecutorBuildItem executorBuildItem) throws Exception {
         if (!hasFunctions.isPresent() || hasFunctions.get() == null)
             return;
 
         feature.produce(new FeatureBuildItem(FUNQY_KNATIVE_FEATURE));
 
-        String rootPath = httpConfig.rootPath;
+        String rootPath = httpBuildTimeConfig.rootPath();
         if (rootPath == null) {
             rootPath = "/";
         } else if (!rootPath.endsWith("/")) {

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devui/GrpcJsonRPCService.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devui/GrpcJsonRPCService.java
@@ -28,7 +28,7 @@ import io.quarkus.grpc.runtime.config.GrpcConfiguration;
 import io.quarkus.grpc.runtime.config.GrpcServerConfiguration;
 import io.quarkus.grpc.runtime.devmode.GrpcServices;
 import io.quarkus.vertx.http.runtime.CertificateConfig;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
@@ -49,7 +49,7 @@ public class GrpcJsonRPCService {
     private Map<String, StreamObserver<Message>> callsInProgress;
 
     @Inject
-    HttpConfiguration httpConfiguration;
+    VertxHttpConfig httpConfig;
 
     @Inject
     GrpcConfiguration grpcConfiguration;
@@ -69,18 +69,18 @@ public class GrpcJsonRPCService {
             this.port = serverConfig.port();
             this.ssl = serverConfig.ssl().certificate().isPresent() || serverConfig.ssl().keyStore().isPresent();
         } else {
-            this.host = httpConfiguration.host;
-            this.port = httpConfiguration.port;
-            this.ssl = isTLSConfigured(httpConfiguration.ssl.certificate);
+            this.host = httpConfig.host();
+            this.port = httpConfig.port();
+            this.ssl = isTLSConfigured(httpConfig.ssl().certificate());
         }
         this.grpcServiceClassInfos = getGrpcServiceClassInfos();
         this.callsInProgress = new HashMap<>();
     }
 
     private boolean isTLSConfigured(CertificateConfig certificate) {
-        return certificate.files.isPresent()
-                || certificate.keyFiles.isPresent()
-                || certificate.keyStoreFile.isPresent();
+        return certificate.files().isPresent()
+                || certificate.keyFiles().isPresent()
+                || certificate.keyStoreFile().isPresent();
     }
 
     public JsonArray getServices() {

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoDevUIProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoDevUIProcessor.java
@@ -9,7 +9,7 @@ import io.quarkus.devui.spi.page.ExternalPageBuilder;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.devui.spi.page.WebComponentPageBuilder;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 
 /**
  * This processor is responsible for the dev ui widget.
@@ -20,11 +20,11 @@ public class InfoDevUIProcessor {
     void create(BuildProducer<CardPageBuildItem> cardPageProducer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             InfoBuildTimeConfig config,
-            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             LaunchModeBuildItem launchModeBuildItem) {
 
         var path = nonApplicationRootPathBuildItem.resolveManagementPath(config.path(),
-                managementInterfaceBuildTimeConfig, launchModeBuildItem);
+                managementBuildTimeConfig, launchModeBuildItem);
 
         WebComponentPageBuilder infoPage = Page.webComponentPageBuilder()
                 .title("Information")

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/DefaultPolicyEnforcerResolver.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/DefaultPolicyEnforcerResolver.java
@@ -22,7 +22,7 @@ import io.quarkus.oidc.runtime.BlockingTaskRunner;
 import io.quarkus.oidc.runtime.TenantConfigBean;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 import io.quarkus.tls.TlsConfigurationRegistry;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
@@ -37,10 +37,10 @@ public class DefaultPolicyEnforcerResolver implements PolicyEnforcerResolver {
     private final OidcTlsSupport tlsSupport;
 
     DefaultPolicyEnforcerResolver(TenantConfigBean tenantConfigBean, KeycloakPolicyEnforcerConfig config,
-            HttpConfiguration httpConfiguration, BlockingSecurityExecutor blockingSecurityExecutor,
+            VertxHttpConfig httpConfig, BlockingSecurityExecutor blockingSecurityExecutor,
             Instance<TenantPolicyConfigResolver> configResolver,
             InjectableInstance<TlsConfigurationRegistry> tlsConfigRegistryInstance) {
-        this.readTimeout = httpConfiguration.readTimeout.toMillis();
+        this.readTimeout = httpConfig.readTimeout().toMillis();
 
         if (tlsConfigRegistryInstance.isResolvable()) {
             this.tlsSupport = OidcTlsSupport.of(tlsConfigRegistryInstance.get());

--- a/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/ManagementRequestPrioritizer.java
+++ b/extensions/load-shedding/runtime/src/main/java/io/quarkus/load/shedding/runtime/ManagementRequestPrioritizer.java
@@ -5,8 +5,8 @@ import jakarta.inject.Singleton;
 
 import io.quarkus.load.shedding.RequestPrioritizer;
 import io.quarkus.load.shedding.RequestPriority;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 import io.vertx.core.http.HttpServerRequest;
 
 @Singleton
@@ -14,21 +14,22 @@ public class ManagementRequestPrioritizer implements RequestPrioritizer<HttpServ
     private final String managementPath;
 
     @Inject
-    public ManagementRequestPrioritizer(HttpBuildTimeConfig httpConfig,
-            ManagementInterfaceBuildTimeConfig managementInterfaceConfig) {
-        if (managementInterfaceConfig.enabled) {
+    public ManagementRequestPrioritizer(
+            VertxHttpBuildTimeConfig buildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig) {
+        if (managementBuildTimeConfig.enabled()) {
             managementPath = null;
             return;
         }
-        if (httpConfig.nonApplicationRootPath.startsWith("/")) {
-            if (httpConfig.nonApplicationRootPath.equals(httpConfig.rootPath)) {
+        if (buildTimeConfig.nonApplicationRootPath().startsWith("/")) {
+            if (buildTimeConfig.nonApplicationRootPath().equals(buildTimeConfig.rootPath())) {
                 managementPath = null;
                 return;
             }
-            managementPath = httpConfig.nonApplicationRootPath;
+            managementPath = buildTimeConfig.nonApplicationRootPath();
             return;
         }
-        managementPath = httpConfig.rootPath + httpConfig.nonApplicationRootPath;
+        managementPath = buildTimeConfig.rootPath() + buildTimeConfig.nonApplicationRootPath();
     }
 
     @Override

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/JsonRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/JsonRegistryProcessor.java
@@ -18,7 +18,7 @@ import io.quarkus.micrometer.runtime.export.JsonRecorder;
 import io.quarkus.micrometer.runtime.registry.json.JsonMeterRegistry;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 
 @BuildSteps(onlyIf = JsonRegistryProcessor.JsonRegistryEnabled.class)
 public class JsonRegistryProcessor {
@@ -41,7 +41,7 @@ public class JsonRegistryProcessor {
             BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<RegistryBuildItem> registries,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             LaunchModeBuildItem launchModeBuildItem,
             JsonRecorder recorder) {
         additionalBeans.produce(AdditionalBeanBuildItem.builder()
@@ -58,7 +58,7 @@ public class JsonRegistryProcessor {
                 .build());
 
         var path = nonApplicationRootPathBuildItem.resolveManagementPath(config.export.json.path,
-                managementInterfaceBuildTimeConfig, launchModeBuildItem);
+                managementBuildTimeConfig, launchModeBuildItem);
         log.debug("Initialized a JSON meter registry on path=" + path);
 
         registries.produce(new RegistryBuildItem("JSON", path));

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
@@ -23,7 +23,7 @@ import io.quarkus.micrometer.runtime.export.exemplars.OpenTelemetryExemplarConte
 import io.quarkus.micrometer.runtime.export.exemplars.OpentelemetryExemplarSamplerProvider;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 
 /**
  * Add support for the Prometheus Meter Registry. Note that the registry may not
@@ -96,7 +96,7 @@ public class PrometheusRegistryProcessor {
             BuildProducer<RegistryBuildItem> registries,
             MicrometerConfig mConfig,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             LaunchModeBuildItem launchModeBuildItem,
             PrometheusRecorder recorder) {
 
@@ -134,7 +134,7 @@ public class PrometheusRegistryProcessor {
                 .build());
 
         var path = nonApplicationRootPathBuildItem.resolveManagementPath(pConfig.path,
-                managementInterfaceBuildTimeConfig, launchModeBuildItem);
+                managementBuildTimeConfig, launchModeBuildItem);
         registries.produce(new RegistryBuildItem("Prometheus", path));
     }
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -97,7 +97,7 @@ import io.quarkus.vertx.http.deployment.EagerSecurityInterceptorBindingBuildItem
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpAuthMechanismAnnotationBuildItem;
 import io.quarkus.vertx.http.deployment.SecurityInformationBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
 import io.smallrye.jwt.auth.cdi.CommonJwtProducer;
 import io.smallrye.jwt.auth.cdi.JsonValueProducer;
@@ -345,11 +345,11 @@ public class OidcBuildStep {
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     public void registerTenantResolverInterceptor(Capabilities capabilities, OidcRecorder recorder,
-            HttpBuildTimeConfig buildTimeConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
             CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<EagerSecurityInterceptorBindingBuildItem> bindingProducer,
             BuildProducer<SystemPropertyBuildItem> systemPropertyProducer) {
-        if (!buildTimeConfig.auth.proactive
+        if (!httpBuildTimeConfig.auth().proactive()
                 && (capabilities.isPresent(Capability.RESTEASY_REACTIVE) || capabilities.isPresent(Capability.RESTEASY))) {
             boolean foundTenantResolver = combinedIndexBuildItem
                     .getIndex()

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
@@ -20,7 +20,7 @@ import io.quarkus.oidc.runtime.devui.OidcDevUiRpcSvcPropertiesBean;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.smallrye.config.ConfigValue;
 
 public abstract class AbstractDevUIProcessor {
@@ -46,7 +46,7 @@ public abstract class AbstractDevUIProcessor {
             Map<String, String> keycloakUsers,
             List<String> keycloakRealms,
             boolean alwaysLogoutUserInDevUiOnReload,
-            HttpConfiguration httpConfiguration, boolean discoverMetadata, String authServerUrl) {
+            VertxHttpConfig httpConfig, boolean discoverMetadata, String authServerUrl) {
         final CardPageBuildItem cardPage = new CardPageBuildItem();
 
         // prepare provider component
@@ -85,7 +85,7 @@ public abstract class AbstractDevUIProcessor {
                 graphqlIsAvailable, swaggerUiPath, graphqlUiPath, alwaysLogoutUserInDevUiOnReload, discoverMetadata,
                 authServerUrl);
 
-        recorder.createJsonRPCService(beanContainer.getValue(), runtimeProperties, httpConfiguration);
+        recorder.createJsonRPCService(beanContainer.getValue(), runtimeProperties, httpConfig);
 
         return cardPage;
     }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
@@ -27,7 +27,7 @@ import io.quarkus.oidc.runtime.providers.KnownOidcProviders;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
 public class OidcDevUIProcessor extends AbstractDevUIProcessor {
 
@@ -49,7 +49,7 @@ public class OidcDevUIProcessor extends AbstractDevUIProcessor {
     @Consume(CoreVertxBuildItem.class) // metadata discovery requires Vertx instance
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     void prepareOidcDevConsole(Capabilities capabilities,
-            HttpConfiguration httpConfiguration,
+            VertxHttpConfig httpConfig,
             BeanContainerBuildItem beanContainer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             BuildProducer<CardPageBuildItem> cardPageProducer,
@@ -93,7 +93,7 @@ public class OidcDevUIProcessor extends AbstractDevUIProcessor {
                     null,
                     null,
                     true,
-                    httpConfiguration, discoverMetadata, authServerUrl);
+                    httpConfig, discoverMetadata, authServerUrl);
             cardPageProducer.produce(cardPage);
         }
     }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
@@ -27,7 +27,7 @@ import io.quarkus.oidc.runtime.devui.OidcDevLoginObserver;
 import io.quarkus.oidc.runtime.devui.OidcDevUiRecorder;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
 public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
 
@@ -38,7 +38,7 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     void produceProviderComponent(Optional<KeycloakDevServicesConfigBuildItem> configProps,
             BuildProducer<KeycloakAdminPageBuildItem> keycloakAdminPageProducer,
-            HttpConfiguration httpConfiguration,
+            VertxHttpConfig httpConfig,
             OidcDevUiRecorder recorder,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             BeanContainerBuildItem beanContainer,
@@ -72,7 +72,7 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
                     users,
                     keycloakRealms,
                     configProps.get().isContainerRestarted(),
-                    httpConfiguration, false, null);
+                    httpConfig, false, null);
             // use same card page so that both pages appear on the same card
             var keycloakAdminPageItem = new KeycloakAdminPageBuildItem(cardPageBuildItem);
             keycloakAdminPageProducer.produce(keycloakAdminPageItem);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
@@ -6,7 +6,7 @@ import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 
 public class OidcDevJsonRpcService {
     private OidcDevUiRpcSvcPropertiesBean props;
-    private HttpConfiguration httpConfiguration;
+    private VertxHttpConfig httpConfig;
 
     @Inject
     OidcDevLoginObserver oidcDevTokensObserver;
@@ -25,7 +25,7 @@ public class OidcDevJsonRpcService {
     @NonBlocking
     public OidcDevUiRuntimePropertiesDTO getProperties() {
         return new OidcDevUiRuntimePropertiesDTO(props.getAuthorizationUrl(), props.getTokenUrl(), props.getLogoutUrl(),
-                ConfigProvider.getConfig(), httpConfiguration.port,
+                ConfigProvider.getConfig(), httpConfig.port(),
                 props.getOidcProviderName(), props.getOidcApplicationType(), props.getOidcGrantType(),
                 props.isIntrospectionIsAvailable(), props.getKeycloakAdminUrl(),
                 props.getKeycloakRealms(), props.isSwaggerIsAvailable(), props.isGraphqlIsAvailable(), props.getSwaggerUiPath(),
@@ -61,8 +61,8 @@ public class OidcDevJsonRpcService {
         return oidcDevTokensObserver.streamOidcLoginEvent();
     }
 
-    void hydrate(OidcDevUiRpcSvcPropertiesBean properties, HttpConfiguration httpConfiguration) {
+    void hydrate(OidcDevUiRpcSvcPropertiesBean properties, VertxHttpConfig httpConfig) {
         this.props = properties;
-        this.httpConfiguration = httpConfiguration;
+        this.httpConfig = httpConfig;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevUiRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevUiRecorder.java
@@ -12,7 +12,7 @@ import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
@@ -33,9 +33,9 @@ public class OidcDevUiRecorder {
     }
 
     public void createJsonRPCService(BeanContainer beanContainer,
-            RuntimeValue<OidcDevUiRpcSvcPropertiesBean> oidcDevUiRpcSvcPropertiesBean, HttpConfiguration httpConfiguration) {
+            RuntimeValue<OidcDevUiRpcSvcPropertiesBean> oidcDevUiRpcSvcPropertiesBean, VertxHttpConfig httpConfig) {
         OidcDevJsonRpcService jsonRpcService = beanContainer.beanInstance(OidcDevJsonRpcService.class);
-        jsonRpcService.hydrate(oidcDevUiRpcSvcPropertiesBean.getValue(), httpConfiguration);
+        jsonRpcService.hydrate(oidcDevUiRpcSvcPropertiesBean.getValue(), httpConfig);
     }
 
     public RuntimeValue<OidcDevUiRpcSvcPropertiesBean> getRpcServiceProperties(String authorizationUrl, String tokenUrl,

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
@@ -99,8 +99,8 @@ import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.RouteDescriptionBuildItem;
 import io.quarkus.vertx.http.runtime.HandlerType;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpCompression;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.web.Param;
 import io.quarkus.vertx.web.Route;
 import io.quarkus.vertx.web.Route.HttpMethod;
@@ -164,7 +164,7 @@ class ReactiveRoutesProcessor {
             BuildProducer<AnnotatedRouteHandlerBuildItem> routeHandlerBusinessMethods,
             BuildProducer<AnnotatedRouteFilterBuildItem> routeFilterBusinessMethods,
             BuildProducer<ValidationErrorBuildItem> errors,
-            HttpBuildTimeConfig httpBuildTimeConfig) {
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) {
 
         // Collect all business methods annotated with @Route and @RouteFilter
         AnnotationStore annotationStore = validationPhase.getContext().get(BuildExtension.Key.ANNOTATION_STORE);
@@ -219,7 +219,7 @@ class ReactiveRoutesProcessor {
                     // access the SecurityIdentity in a synchronous manner
                     final boolean blocking = annotationStore.hasAnnotation(method, DotNames.BLOCKING);
                     final boolean alwaysAuthenticateRoute;
-                    if (!httpBuildTimeConfig.auth.proactive && !blocking) {
+                    if (!httpBuildTimeConfig.auth().proactive() && !blocking) {
                         final DotName returnTypeName = method.returnType().name();
                         // method either returns 'something' in a synchronous manner or void (in which case we can't tell)
                         final boolean possiblySynchronousResponse = !returnTypeName.equals(DotNames.UNI)

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
@@ -9,9 +9,9 @@ import java.util.function.Function;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpCompression;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.DefaultAuthFailureHandler;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.mutiny.Uni;
@@ -25,12 +25,12 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class VertxWebRecorder {
 
-    final RuntimeValue<HttpConfiguration> httpConfiguration;
-    final HttpBuildTimeConfig httpBuildTimeConfig;
+    final RuntimeValue<VertxHttpConfig> httpConfig;
+    final VertxHttpBuildTimeConfig httpBuildTimeConfig;
 
-    public VertxWebRecorder(RuntimeValue<HttpConfiguration> httpConfiguration,
-            HttpBuildTimeConfig httpBuildTimeConfig) {
-        this.httpConfiguration = httpConfiguration;
+    public VertxWebRecorder(RuntimeValue<VertxHttpConfig> httpConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) {
+        this.httpConfig = httpConfig;
         this.httpBuildTimeConfig = httpBuildTimeConfig;
     }
 
@@ -56,10 +56,10 @@ public class VertxWebRecorder {
     }
 
     public Handler<RoutingContext> compressRouteHandler(Handler<RoutingContext> routeHandler, HttpCompression compression) {
-        if (httpBuildTimeConfig.enableCompression) {
+        if (httpBuildTimeConfig.enableCompression()) {
             return new HttpCompressionHandler(routeHandler, compression,
                     compression == HttpCompression.UNDEFINED
-                            ? Set.copyOf(httpBuildTimeConfig.compressMediaTypes.orElse(List.of()))
+                            ? Set.copyOf(httpBuildTimeConfig.compressMediaTypes().orElse(List.of()))
                             : Set.of());
         } else {
             return routeHandler;

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -42,8 +42,8 @@ import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.RouteConstants;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -92,13 +92,12 @@ public class ResteasyStandaloneBuildStep {
             BuildProducer<FilterBuildItem> filterBuildItemBuildProducer,
             CoreVertxBuildItem vertx,
             CombinedIndexBuildItem combinedIndexBuildItem,
-            HttpBuildTimeConfig vertxConfig,
             ResteasyStandaloneBuildItem standalone,
             Optional<RequireVirtualHttpBuildItem> requireVirtual,
             Optional<NonJaxRsClassBuildItem> nonJaxRsClassBuildItem,
             ExecutorBuildItem executorBuildItem,
             ResteasyVertxConfig resteasyVertxConfig,
-            HttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
 
         if (standalone == null) {
             return;
@@ -117,7 +116,7 @@ public class ResteasyStandaloneBuildStep {
         final boolean noCustomAuthCompletionExMapper;
         final boolean noCustomAuthFailureExMapper;
         final boolean noCustomAuthRedirectExMapper;
-        if (vertxConfig.auth.proactive) {
+        if (httpBuildTimeConfig.auth().proactive()) {
             noCustomAuthCompletionExMapper = notFoundCustomExMapper(AuthenticationCompletionException.class.getName(),
                     AuthenticationCompletionExceptionMapper.class.getName(), combinedIndexBuildItem.getIndex());
             noCustomAuthFailureExMapper = notFoundCustomExMapper(AuthenticationFailedException.class.getName(),
@@ -135,7 +134,7 @@ public class ResteasyStandaloneBuildStep {
         // so that user can define failure handlers that precede exception mappers
         final Handler<RoutingContext> failureHandler = recorder.vertxFailureHandler(vertx.getVertx(),
                 executorBuildItem.getExecutorProxy(), resteasyVertxConfig, noCustomAuthCompletionExMapper,
-                noCustomAuthFailureExMapper, noCustomAuthRedirectExMapper, vertxConfig.auth.proactive);
+                noCustomAuthFailureExMapper, noCustomAuthRedirectExMapper, httpBuildTimeConfig.auth().proactive());
         filterBuildItemBuildProducer.produce(FilterBuildItem.ofAuthenticationFailureHandler(failureHandler));
 
         // Exact match for resources matched to the root path

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AbstractSecurityEventTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AbstractSecurityEventTest.java
@@ -31,7 +31,7 @@ import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
 import io.quarkus.security.spi.runtime.SecurityEvent;
 import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.restassured.RestAssured;
 import io.vertx.ext.web.RoutingContext;
 
@@ -47,7 +47,7 @@ public abstract class AbstractSecurityEventTest {
     EventObserver observer;
 
     @Inject
-    HttpBuildTimeConfig httpBuildTimeConfig;
+    VertxHttpBuildTimeConfig httpBuildTimeConfig;
 
     @BeforeEach
     public void clean() {
@@ -64,7 +64,7 @@ public abstract class AbstractSecurityEventTest {
     }
 
     private boolean isProactiveAuth() {
-        return httpBuildTimeConfig.auth.proactive;
+        return httpBuildTimeConfig.auth().proactive();
     }
 
     @Test

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CompressionScanner.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CompressionScanner.java
@@ -17,24 +17,24 @@ import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveCompressionHandler;
 import io.quarkus.vertx.http.Compressed;
 import io.quarkus.vertx.http.Uncompressed;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpCompression;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 
 public class CompressionScanner implements MethodScanner {
 
     static final DotName COMPRESSED = DotName.createSimple(Compressed.class.getName());
     static final DotName UNCOMPRESSED = DotName.createSimple(Uncompressed.class.getName());
 
-    private final HttpBuildTimeConfig httpBuildTimeConfig;
+    private final VertxHttpBuildTimeConfig httpBuildTimeConfig;
 
-    public CompressionScanner(HttpBuildTimeConfig httpBuildTimeConfig) {
+    public CompressionScanner(VertxHttpBuildTimeConfig httpBuildTimeConfig) {
         this.httpBuildTimeConfig = httpBuildTimeConfig;
     }
 
     @Override
     public List<HandlerChainCustomizer> scan(MethodInfo method, ClassInfo actualEndpointClass,
             Map<String, Object> methodContext) {
-        if (!httpBuildTimeConfig.enableCompression) {
+        if (!httpBuildTimeConfig.enableCompression()) {
             return Collections.emptyList();
         }
 
@@ -58,7 +58,7 @@ public class CompressionScanner implements MethodScanner {
             return Collections.emptyList();
         }
         ResteasyReactiveCompressionHandler handler = new ResteasyReactiveCompressionHandler(
-                Set.copyOf(httpBuildTimeConfig.compressMediaTypes.orElse(Collections.emptyList())));
+                Set.copyOf(httpBuildTimeConfig.compressMediaTypes().orElse(Collections.emptyList())));
         handler.setCompression(compression);
         String[] produces = (String[]) methodContext.get(EndpointIndexer.METHOD_PRODUCES);
         if ((produces != null) && (produces.length > 0)) {

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -222,8 +222,8 @@ import io.quarkus.vertx.http.deployment.EagerSecurityInterceptorMethodsBuildItem
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpSecurityUtils;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.RouteConstants;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.security.JaxRsPathMatchingHttpSecurityPolicy;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
@@ -1256,7 +1256,7 @@ public class ResteasyReactiveProcessor {
             ResteasyReactiveRecorder recorder,
             RecorderContext recorderContext,
             ShutdownContextBuildItem shutdownContext,
-            HttpBuildTimeConfig vertxConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
             SetupEndpointsResultBuildItem setupEndpointsResult,
             ServerSerialisersBuildItem serverSerialisersBuildItem,
             List<PreExceptionMapperHandlerBuildItem> preExceptionMapperHandlerBuildItems,
@@ -1396,7 +1396,7 @@ public class ResteasyReactiveProcessor {
         }
 
         RuntimeValue<Deployment> deployment = recorder.createDeployment(deploymentPath, deploymentInfo,
-                beanContainerBuildItem.getValue(), shutdownContext, vertxConfig,
+                beanContainerBuildItem.getValue(), shutdownContext, httpBuildTimeConfig,
                 requestContextFactoryBuildItem.map(RequestContextFactoryBuildItem::getFactory).orElse(null),
                 initClassFactory, launchModeBuildItem.getLaunchMode(), servletPresent);
 
@@ -1410,7 +1410,7 @@ public class ResteasyReactiveProcessor {
             final boolean noCustomAuthCompletionExMapper;
             final boolean noCustomAuthFailureExMapper;
             final boolean noCustomAuthRedirectExMapper;
-            if (vertxConfig.auth.proactive) {
+            if (httpBuildTimeConfig.auth().proactive()) {
                 noCustomAuthCompletionExMapper = notFoundCustomExMapper(AuthenticationCompletionException.class.getName(),
                         AuthenticationCompletionExceptionMapper.class.getName(), exceptionMapping);
                 noCustomAuthFailureExMapper = notFoundCustomExMapper(AuthenticationFailedException.class.getName(),
@@ -1425,7 +1425,7 @@ public class ResteasyReactiveProcessor {
             }
 
             Handler<RoutingContext> failureHandler = recorder.failureHandler(restInitialHandler, noCustomAuthCompletionExMapper,
-                    noCustomAuthFailureExMapper, noCustomAuthRedirectExMapper, vertxConfig.auth.proactive);
+                    noCustomAuthFailureExMapper, noCustomAuthRedirectExMapper, httpBuildTimeConfig.auth().proactive());
 
             // we add failure handler right before QuarkusErrorHandler
             // so that user can define failure handlers that precede exception mappers

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -77,7 +77,7 @@ import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
 import io.quarkus.resteasy.reactive.spi.JaxrsFeatureBuildItem;
 import io.quarkus.resteasy.reactive.spi.ParamConverterBuildItem;
 import io.quarkus.runtime.BlockingOperationNotAllowedException;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 
 /**
  * Processor that handles scanning for types and turning them into build items
@@ -105,7 +105,7 @@ public class ResteasyReactiveScanningProcessor {
     }
 
     @BuildStep
-    public MethodScannerBuildItem compressionSupport(HttpBuildTimeConfig httpBuildTimeConfig) {
+    public MethodScannerBuildItem compressionSupport(VertxHttpBuildTimeConfig httpBuildTimeConfig) {
         return new MethodScannerBuildItem(new CompressionScanner(httpBuildTimeConfig));
     }
 

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AbstractSecurityEventTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AbstractSecurityEventTest.java
@@ -31,7 +31,7 @@ import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
 import io.quarkus.security.spi.runtime.SecurityEvent;
 import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.restassured.RestAssured;
 import io.vertx.ext.web.RoutingContext;
 
@@ -48,7 +48,7 @@ public abstract class AbstractSecurityEventTest {
     EventObserver observer;
 
     @Inject
-    HttpBuildTimeConfig httpBuildTimeConfig;
+    VertxHttpBuildTimeConfig httpBuildTimeConfig;
 
     @BeforeEach
     public void clean() {
@@ -65,7 +65,7 @@ public abstract class AbstractSecurityEventTest {
     }
 
     private boolean isProactiveAuth() {
-        return httpBuildTimeConfig.auth.proactive;
+        return httpBuildTimeConfig.auth().proactive();
     }
 
     @Test

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -73,7 +73,7 @@ import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.devmode.ResourceNotFoundData;
 import io.quarkus.vertx.http.runtime.devmode.RouteDescription;
 import io.quarkus.vertx.http.runtime.devmode.RouteMethodDescription;
@@ -111,7 +111,8 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
 
     public RuntimeValue<Deployment> createDeployment(String applicationPath, DeploymentInfo info,
             BeanContainer beanContainer,
-            ShutdownContext shutdownContext, HttpBuildTimeConfig vertxConfig,
+            ShutdownContext shutdownContext,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
             RequestContextFactory contextFactory,
             BeanFactory<ResteasyReactiveInitialiser> initClassFactory,
             LaunchMode launchMode,
@@ -156,7 +157,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
         RuntimeDeploymentManager runtimeDeploymentManager = new RuntimeDeploymentManager(info, EXECUTOR_SUPPLIER,
                 VTHREAD_EXECUTOR_SUPPLIER,
                 closeTaskHandler, contextFactory, new ArcThreadSetupAction(beanContainer.requestContext()),
-                vertxConfig.rootPath);
+                httpBuildTimeConfig.rootPath());
         Deployment deployment = runtimeDeploymentManager.deploy();
         DisabledRestEndpoints.set(deployment.getDisabledEndpoints());
         initClassFactory.createInstance().getInstance().init(deployment);

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
@@ -12,33 +12,33 @@ import org.jboss.resteasy.reactive.server.spi.RuntimeConfiguration;
 
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
 @Recorder
 public class ResteasyReactiveRuntimeRecorder {
 
-    final HttpConfiguration httpConf;
+    final VertxHttpConfig httpConfig;
 
-    public ResteasyReactiveRuntimeRecorder(HttpConfiguration httpConf) {
-        this.httpConf = httpConf;
+    public ResteasyReactiveRuntimeRecorder(VertxHttpConfig httpConfig) {
+        this.httpConfig = httpConfig;
     }
 
     public Supplier<RuntimeConfiguration> runtimeConfiguration(RuntimeValue<Deployment> deployment,
             ResteasyReactiveServerRuntimeConfig runtimeConf) {
         Optional<Long> maxBodySize;
 
-        if (httpConf.limits.maxBodySize.isPresent()) {
-            maxBodySize = Optional.of(httpConf.limits.maxBodySize.get().asLongValue());
+        if (httpConfig.limits().maxBodySize().isPresent()) {
+            maxBodySize = Optional.of(httpConfig.limits().maxBodySize().get().asLongValue());
         } else {
             maxBodySize = Optional.empty();
         }
 
-        RuntimeConfiguration runtimeConfiguration = new DefaultRuntimeConfiguration(httpConf.readTimeout,
-                httpConf.body.deleteUploadedFilesOnEnd, httpConf.body.uploadsDirectory,
-                httpConf.body.multipart.fileContentTypes.orElse(null),
+        RuntimeConfiguration runtimeConfiguration = new DefaultRuntimeConfiguration(httpConfig.readTimeout(),
+                httpConfig.body().deleteUploadedFilesOnEnd(), httpConfig.body().uploadsDirectory(),
+                httpConfig.body().multipart().fileContentTypes().orElse(null),
                 runtimeConf.multipart().inputPart().defaultCharset(), maxBodySize,
-                httpConf.limits.maxFormAttributeSize.asLongValue(),
-                httpConf.limits.maxParameters);
+                httpConfig.limits().maxFormAttributeSize().asLongValue(),
+                httpConfig.limits().maxParameters());
 
         deployment.getValue().setRuntimeConfiguration(runtimeConfiguration);
 

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityContext.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityContext.java
@@ -30,7 +30,7 @@ import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
 import io.quarkus.security.spi.runtime.MethodDescription;
 import io.quarkus.security.spi.runtime.SecurityCheck;
 import io.quarkus.security.spi.runtime.SecurityEventHelper;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.security.AbstractPathMatchingHttpSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.JaxRsPathMatchingHttpSecurityPolicy;
@@ -53,9 +53,9 @@ public class EagerSecurityContext {
             @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled,
             Event<AuthorizationSuccessEvent> authorizationSuccessEvent, BeanManager beanManager,
             InjectableInstance<CurrentIdentityAssociation> identityAssociation, AuthorizationController authorizationController,
-            HttpBuildTimeConfig buildTimeConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
             JaxRsPathMatchingHttpSecurityPolicy jaxRsPathMatchingPolicy) {
-        this.isProactiveAuthDisabled = !buildTimeConfig.auth.proactive;
+        this.isProactiveAuthDisabled = !httpBuildTimeConfig.auth().proactive();
         this.identityAssociation = identityAssociation;
         this.authorizationController = authorizationController;
         this.eventHelper = new SecurityEventHelper<>(authorizationSuccessEvent, authorizationFailureEvent,

--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
@@ -10,7 +10,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.security.PersistentLoginManager;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
@@ -20,14 +20,14 @@ public class WebAuthnRecorder {
 
     private static final Logger log = Logger.getLogger(WebAuthnRecorder.class);
 
-    final RuntimeValue<HttpConfiguration> httpConfiguration;
+    final RuntimeValue<VertxHttpConfig> httpConfig;
     final RuntimeValue<WebAuthnRunTimeConfig> config;
 
     //the temp encryption key, persistent across dev mode restarts
     static volatile String encryptionKey;
 
-    public WebAuthnRecorder(RuntimeValue<HttpConfiguration> httpConfiguration, RuntimeValue<WebAuthnRunTimeConfig> config) {
-        this.httpConfiguration = httpConfiguration;
+    public WebAuthnRecorder(RuntimeValue<VertxHttpConfig> httpConfig, RuntimeValue<WebAuthnRunTimeConfig> config) {
+        this.httpConfig = httpConfig;
         this.config = config;
     }
 
@@ -59,7 +59,7 @@ public class WebAuthnRecorder {
             @Override
             public WebAuthnAuthenticationMechanism get() {
                 String key;
-                if (!httpConfiguration.getValue().encryptionKey.isPresent()) {
+                if (!httpConfig.getValue().encryptionKey().isPresent()) {
                     if (encryptionKey != null) {
                         //persist across dev mode restarts
                         key = encryptionKey;
@@ -72,7 +72,7 @@ public class WebAuthnRecorder {
                                         + key);
                     }
                 } else {
-                    key = httpConfiguration.getValue().encryptionKey.get();
+                    key = httpConfig.getValue().encryptionKey().get();
                 }
                 WebAuthnRunTimeConfig config = WebAuthnRecorder.this.config.getValue();
                 PersistentLoginManager loginManager = new PersistentLoginManager(key, config.cookieName(),

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -79,7 +79,7 @@ import io.quarkus.vertx.http.deployment.WebsocketSubProtocolsBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResourcesFilter;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.smallrye.config.Converters;
 import io.smallrye.graphql.api.AdaptWith;
 import io.smallrye.graphql.api.Deprecated;
@@ -426,7 +426,7 @@ public class SmallRyeGraphQLProcessor {
             SmallRyeGraphQLConfig graphQLConfig,
             BeanContainerBuildItem beanContainer,
             BuildProducer<WebsocketSubProtocolsBuildItem> webSocketSubProtocols,
-            HttpBuildTimeConfig httpBuildTimeConfig) {
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) {
 
         /*
          * <em>Ugly Hack</em>
@@ -472,7 +472,7 @@ public class SmallRyeGraphQLProcessor {
         // Queries and Mutations
         boolean allowGet = getBooleanConfigValue(ConfigKey.ALLOW_GET, false);
         boolean allowQueryParametersOnPost = getBooleanConfigValue(ConfigKey.ALLOW_POST_WITH_QUERY_PARAMETERS, false);
-        boolean allowCompression = httpBuildTimeConfig.enableCompression && httpBuildTimeConfig.compressMediaTypes
+        boolean allowCompression = httpBuildTimeConfig.enableCompression() && httpBuildTimeConfig.compressMediaTypes()
                 .map(mediaTypes -> mediaTypes.contains(GRAPHQL_MEDIA_TYPE))
                 .orElse(false);
         Handler<RoutingContext> executionHandler = recorder.executionHandler(graphQLInitializedBuildItem.getInitialized(),

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthDevUiProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthDevUiProcessor.java
@@ -9,7 +9,7 @@ import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.smallrye.health.runtime.SmallRyeHealthRecorder;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 
 /**
  * This processor is responsible for the dev ui widget.
@@ -20,13 +20,13 @@ public class SmallRyeHealthDevUiProcessor {
     @Record(ExecutionTime.STATIC_INIT)
     CardPageBuildItem create(NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             SmallRyeHealthBuildTimeConfig config,
-            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             LaunchModeBuildItem launchModeBuildItem,
             SmallRyeHealthRecorder unused) {
         CardPageBuildItem pageBuildItem = new CardPageBuildItem();
 
         String path = nonApplicationRootPathBuildItem.resolveManagementPath(config.rootPath(),
-                managementInterfaceBuildTimeConfig, launchModeBuildItem, config.managementEnabled());
+                managementBuildTimeConfig, launchModeBuildItem, config.managementEnabled());
 
         pageBuildItem.addPage(Page.externalPageBuilder("Health")
                 .icon("font-awesome-solid:heart-circle-bolt")
@@ -34,7 +34,7 @@ public class SmallRyeHealthDevUiProcessor {
                 .isJsonContent());
 
         String uipath = nonApplicationRootPathBuildItem.resolveManagementPath(config.ui().rootPath(),
-                managementInterfaceBuildTimeConfig, launchModeBuildItem, config.managementEnabled());
+                managementBuildTimeConfig, launchModeBuildItem, config.managementEnabled());
         pageBuildItem.addPage(Page.externalPageBuilder("Health UI")
                 .icon("font-awesome-solid:stethoscope")
                 .url(uipath, uipath)

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -71,7 +71,7 @@ import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResourcesFilter;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 import io.smallrye.health.AsyncHealthCheckFactory;
 import io.smallrye.health.SmallRyeHealthReporter;
 import io.smallrye.health.api.HealthGroup;
@@ -288,12 +288,12 @@ class SmallRyeHealthProcessor {
     @BuildStep(onlyIf = OpenAPIIncluded.class)
     public void includeInOpenAPIEndpoint(BuildProducer<AddToOpenAPIDefinitionBuildItem> openAPIProducer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             Capabilities capabilities,
             SmallRyeHealthBuildTimeConfig healthConfig) {
 
         // Add to OpenAPI if OpenAPI is available
-        if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI) && !managementInterfaceBuildTimeConfig.enabled) {
+        if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI) && !managementBuildTimeConfig.enabled()) {
             String healthRootPath = nonApplicationRootPathBuildItem.resolvePath(healthConfig.rootPath());
             HealthOpenAPIFilter filter = new HealthOpenAPIFilter(healthRootPath,
                     nonApplicationRootPathBuildItem.resolveManagementNestedPath(healthRootPath, healthConfig.livenessPath()),
@@ -329,13 +329,13 @@ class SmallRyeHealthProcessor {
     @BuildStep
     public void kubernetes(NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             SmallRyeHealthBuildTimeConfig healthConfig,
-            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             BuildProducer<KubernetesHealthLivenessPathBuildItem> livenessPathItemProducer,
             BuildProducer<KubernetesHealthReadinessPathBuildItem> readinessPathItemProducer,
             BuildProducer<KubernetesHealthStartupPathBuildItem> startupPathItemProducer,
             BuildProducer<KubernetesProbePortNameBuildItem> port) {
 
-        if (managementInterfaceBuildTimeConfig.enabled) {
+        if (managementBuildTimeConfig.enabled()) {
             // Switch to the "management" port
             port.produce(new KubernetesProbePortNameBuildItem("management", selectSchemeForManagement()));
         }
@@ -374,7 +374,7 @@ class SmallRyeHealthProcessor {
     @BuildStep
     void registerUiExtension(
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             SmallRyeHealthBuildTimeConfig healthConfig,
             LaunchModeBuildItem launchModeBuildItem,
             BuildProducer<WebJarBuildItem> webJarBuildProducer) {
@@ -388,7 +388,7 @@ class SmallRyeHealthProcessor {
             }
 
             String healthPath = nonApplicationRootPathBuildItem.resolveManagementPath(healthConfig.rootPath(),
-                    managementInterfaceBuildTimeConfig, launchModeBuildItem, false);
+                    managementBuildTimeConfig, launchModeBuildItem, false);
 
             webJarBuildProducer.produce(
                     WebJarBuildItem.builder().artifactKey(HEALTH_UI_WEBJAR_ARTIFACT_KEY) //

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsDevUiProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsDevUiProcessor.java
@@ -9,7 +9,7 @@ import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.smallrye.metrics.runtime.SmallRyeMetricsRecorder;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 
 /**
  * This processor is responsible for the dev ui widget.
@@ -19,14 +19,14 @@ public class SmallRyeMetricsDevUiProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     @Record(ExecutionTime.STATIC_INIT)
     CardPageBuildItem create(NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             SmallRyeMetricsConfig config,
             LaunchModeBuildItem launchModeBuildItem,
             SmallRyeMetricsRecorder unused) {
         CardPageBuildItem pageBuildItem = new CardPageBuildItem();
 
         var path = nonApplicationRootPathBuildItem.resolveManagementPath(config.path(),
-                managementInterfaceBuildTimeConfig, launchModeBuildItem);
+                managementBuildTimeConfig, launchModeBuildItem);
         pageBuildItem.addPage(Page.externalPageBuilder("All Metrics")
                 .icon("font-awesome-solid:chart-line")
                 .url(path));

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/devui/OpenApiDevUIProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/devui/OpenApiDevUIProcessor.java
@@ -8,22 +8,22 @@ import io.quarkus.devui.spi.page.Page;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.deployment.SwaggerUiConfig;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 
 public class OpenApiDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public CardPageBuildItem pages(NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             LaunchModeBuildItem launchModeBuildItem,
             SwaggerUiConfig swaggerUiConfig,
             SmallRyeOpenApiConfig openApiConfig) {
 
         String uiPath = nonApplicationRootPathBuildItem.resolveManagementPath(swaggerUiConfig.path,
-                managementInterfaceBuildTimeConfig, launchModeBuildItem, openApiConfig.managementEnabled());
+                managementBuildTimeConfig, launchModeBuildItem, openApiConfig.managementEnabled());
 
         String schemaPath = nonApplicationRootPathBuildItem.resolveManagementPath(openApiConfig.path(),
-                managementInterfaceBuildTimeConfig, launchModeBuildItem, openApiConfig.managementEnabled());
+                managementBuildTimeConfig, launchModeBuildItem, openApiConfig.managementEnabled());
 
         CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
 

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -9,7 +9,7 @@ import org.eclipse.microprofile.openapi.OASFilter;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.filters.Filter;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.Route;
@@ -18,14 +18,14 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class OpenApiRecorder {
 
-    final RuntimeValue<HttpConfiguration> configuration;
+    final RuntimeValue<VertxHttpConfig> httpConfig;
 
-    public OpenApiRecorder(RuntimeValue<HttpConfiguration> configuration) {
-        this.configuration = configuration;
+    public OpenApiRecorder(RuntimeValue<VertxHttpConfig> httpConfig) {
+        this.httpConfig = httpConfig;
     }
 
     public Consumer<Route> corsFilter(Filter filter) {
-        if (configuration.getValue().corsEnabled && filter.getHandler() != null) {
+        if (httpConfig.getValue().corsEnabled() && filter.getHandler() != null) {
             return new Consumer<Route>() {
                 @Override
                 public void accept(Route route) {

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -125,7 +125,7 @@ import io.quarkus.undertow.runtime.UndertowHandlersConfServletExtension;
 import io.quarkus.vertx.http.deployment.DefaultRouteBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.FilterInfo;
 import io.undertow.servlet.api.HttpMethodSecurityInfo;
@@ -190,7 +190,7 @@ public class UndertowBuildStep {
             ServletRuntimeConfig servletRuntimeConfig,
             ServletContextPathBuildItem servletContextPathBuildItem,
             Capabilities capabilities,
-            HttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
 
         if (capabilities.isPresent(Capability.SECURITY)) {
             recorder.setupSecurity(servletDeploymentManagerBuildItem.getDeploymentManager());
@@ -397,7 +397,7 @@ public class UndertowBuildStep {
             KnownPathsBuildItem knownPaths,
             LogBuildTimeConfig logBuildTimeConfig,
             Optional<LoggingDecorateBuildItem> loggingDecorateBuildItem,
-            HttpBuildTimeConfig httpBuildTimeConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
             HttpRootPathBuildItem httpRootPath,
             ServletConfig servletConfig,
             final Capabilities capabilities) throws Exception {
@@ -417,7 +417,7 @@ public class UndertowBuildStep {
                 knownPaths.knownDirectories,
                 launchMode.getLaunchMode(), shutdownContext, httpRootPath.relativePath(contextPath),
                 servletConfig.defaultCharset, webMetaData.getRequestCharacterEncoding(),
-                webMetaData.getResponseCharacterEncoding(), httpBuildTimeConfig.auth.proactive,
+                webMetaData.getResponseCharacterEncoding(), httpBuildTimeConfig.auth().proactive(),
                 webMetaData.getWelcomeFileList() != null ? webMetaData.getWelcomeFileList().getWelcomeFiles() : null,
                 hasSecurityCapability(capabilities));
 

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -50,9 +50,9 @@ import io.quarkus.security.UnauthorizedException;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpCompressionHandler;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 import io.quarkus.vertx.http.runtime.devmode.ResourceNotFoundData;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
@@ -158,10 +158,10 @@ public class UndertowDeploymentRecorder {
 
     }
 
-    final RuntimeValue<HttpConfiguration> httpConfiguration;
+    final RuntimeValue<VertxHttpConfig> httpConfig;
 
-    public UndertowDeploymentRecorder(RuntimeValue<HttpConfiguration> httpConfiguration) {
-        this.httpConfiguration = httpConfiguration;
+    public UndertowDeploymentRecorder(RuntimeValue<VertxHttpConfig> httpConfig) {
+        this.httpConfig = httpConfig;
     }
 
     public static void setHotDeploymentResources(List<Path> resources) {
@@ -355,7 +355,7 @@ public class UndertowDeploymentRecorder {
 
     public Handler<RoutingContext> startUndertow(ShutdownContext shutdown, ExecutorService executorService,
             DeploymentManager manager, List<HandlerWrapper> wrappers,
-            ServletRuntimeConfig servletRuntimeConfig, HttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
+            ServletRuntimeConfig servletRuntimeConfig, VertxHttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
 
         shutdown.addShutdownTask(new Runnable() {
             @Override
@@ -390,8 +390,8 @@ public class UndertowDeploymentRecorder {
         undertowOptions.set(UndertowOptions.MAX_PARAMETERS, servletRuntimeConfig.maxParameters);
         UndertowOptionMap undertowOptionMap = undertowOptions.getMap();
 
-        Set<String> compressMediaTypes = httpBuildTimeConfig.enableCompression
-                ? Set.copyOf(httpBuildTimeConfig.compressMediaTypes.get())
+        Set<String> compressMediaTypes = httpBuildTimeConfig.enableCompression()
+                ? Set.copyOf(httpBuildTimeConfig.compressMediaTypes().get())
                 : Collections.emptySet();
 
         return new Handler<RoutingContext>() {
@@ -422,11 +422,11 @@ public class UndertowDeploymentRecorder {
                     });
                 }
 
-                Optional<MemorySize> maxBodySize = httpConfiguration.getValue().limits.maxBodySize;
+                Optional<MemorySize> maxBodySize = httpConfig.getValue().limits().maxBodySize();
                 if (maxBodySize.isPresent()) {
                     exchange.setMaxEntitySize(maxBodySize.get().asLongValue());
                 }
-                Duration readTimeout = httpConfiguration.getValue().readTimeout;
+                Duration readTimeout = httpConfig.getValue().readTimeout();
                 exchange.setReadTimeout(readTimeout.toMillis());
 
                 exchange.setUndertowOptions(undertowOptionMap);

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
@@ -13,7 +13,7 @@ import io.quarkus.deployment.util.UriNormalizationUtil;
 import io.quarkus.vertx.http.deployment.devmode.ConfiguredPathInfo;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.runtime.HandlerType;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
@@ -165,17 +165,17 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
         return UriNormalizationUtil.normalizeWithBase(nonApplicationRootPath, path, false).getPath();
     }
 
-    public String resolveManagementPath(String path, ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+    public String resolveManagementPath(String path, ManagementBuildTimeConfig managementBuildTimeConfig,
             LaunchModeBuildItem mode) {
-        return resolveManagementPath(path, managementInterfaceBuildTimeConfig, mode, true);
+        return resolveManagementPath(path, managementBuildTimeConfig, mode, true);
     }
 
-    public String resolveManagementPath(String path, ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+    public String resolveManagementPath(String path, ManagementBuildTimeConfig managementBuildTimeConfig,
             LaunchModeBuildItem mode, boolean extensionOverride) {
         if (path == null || path.trim().isEmpty()) {
             throw new IllegalArgumentException("Specified path can not be empty");
         }
-        if (managementInterfaceBuildTimeConfig.enabled && extensionOverride) {
+        if (managementBuildTimeConfig.enabled() && extensionOverride) {
             // Best effort
             String prefix = getManagementUrlPrefix(mode);
             if (managementRootPath != null) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ConfiguredPathInfo.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ConfiguredPathInfo.java
@@ -4,7 +4,7 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.runtime.TemplateHtmlBuilder;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
 
 public class ConfiguredPathInfo {
     private final String name;
@@ -31,12 +31,13 @@ public class ConfiguredPathInfo {
         }
     }
 
-    public String getEndpointPath(NonApplicationRootPathBuildItem nonAppRoot, ManagementInterfaceBuildTimeConfig mibt,
+    public String getEndpointPath(NonApplicationRootPathBuildItem nonAppRoot,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
             LaunchModeBuildItem mode) {
         if (absolutePath) {
             return endpointPath;
         }
-        if (management && mibt.enabled) {
+        if (management && managementBuildTimeConfig.enabled()) {
             var prefix = NonApplicationRootPathBuildItem.getManagementUrlPrefix(mode);
             return prefix + endpointPath;
         } else {

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItemTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItemTest.java
@@ -1,13 +1,16 @@
 package io.quarkus.vertx.http.deployment;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.runtime.LaunchMode;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementAuthConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
+import io.vertx.core.http.ClientAuth;
 
 public class NonApplicationRootPathBuildItemTest {
 
@@ -108,62 +111,56 @@ public class NonApplicationRootPathBuildItemTest {
 
     @Test
     void testResolveManagementPathWithRelativeRootPath() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "management";
-
+        ManagementBuildTimeConfig managementBuildTimeConfig = new ManagementBuildTimeConfigImpl(true,
+                "management");
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementBuildTimeConfig.rootPath());
         Assertions.assertEquals("/management/", buildItem.getManagementRootPath());
         Assertions.assertEquals("http://localhost:9000/management/foo",
-                buildItem.resolveManagementPath("foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/management/foo/sub/path",
-                buildItem.resolveManagementPath("foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/foo",
-                buildItem.resolveManagementPath("/foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/foo/sub/path",
-                buildItem.resolveManagementPath("/foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("../foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("../foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("", managementBuildTimeConfig, launchModeBuildItem));
     }
 
     @Test
     void testResolveManagementPathWithRelativeRootPathInTestMode() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "management";
-
+        ManagementBuildTimeConfig managementBuildTimeConfig = new ManagementBuildTimeConfigImpl(true,
+                "management");
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), true);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementBuildTimeConfig.rootPath());
         Assertions.assertEquals("/management/", buildItem.getManagementRootPath());
         Assertions.assertEquals("http://localhost:9001/management/foo",
-                buildItem.resolveManagementPath("foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9001/management/foo/sub/path",
-                buildItem.resolveManagementPath("foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9001/foo",
-                buildItem.resolveManagementPath("/foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9001/foo/sub/path",
-                buildItem.resolveManagementPath("/foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("../foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("../foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("", managementBuildTimeConfig, launchModeBuildItem));
     }
 
     @Test
     void testResolveManagementPathWithRelativeRootPathAndWithManagementDisabled() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = false;
-        managementInterfaceBuildTimeConfig.rootPath = "management";
-
+        ManagementBuildTimeConfig managementBuildTimeConfig = new ManagementBuildTimeConfigImpl(
+                false, "management");
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
 
@@ -171,85 +168,124 @@ public class NonApplicationRootPathBuildItemTest {
 
         Assertions.assertEquals("/q/", buildItem.getManagementRootPath());
         Assertions.assertEquals("/q/foo",
-                buildItem.resolveManagementPath("foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("/q/foo/sub/path",
-                buildItem.resolveManagementPath("foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("/foo",
-                buildItem.resolveManagementPath("/foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("/foo/sub/path",
-                buildItem.resolveManagementPath("/foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("../foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("../foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("", managementBuildTimeConfig, launchModeBuildItem));
     }
 
     @Test
     void testResolveManagementPathWithAbsoluteRootPath() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "/management";
-
+        ManagementBuildTimeConfig managementBuildTimeConfig = new ManagementBuildTimeConfigImpl(true,
+                "/management");
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "/q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementBuildTimeConfig.rootPath());
         Assertions.assertEquals("/management/", buildItem.getManagementRootPath());
         Assertions.assertEquals("http://localhost:9000/management/foo",
-                buildItem.resolveManagementPath("foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/management/foo/sub/path",
-                buildItem.resolveManagementPath("foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/foo",
-                buildItem.resolveManagementPath("/foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/foo/sub/path",
-                buildItem.resolveManagementPath("/foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("../foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("../foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("", managementBuildTimeConfig, launchModeBuildItem));
     }
 
     @Test
     void testResolveManagementPathWithEmptyRootPath() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "";
-
+        ManagementBuildTimeConfig managementBuildTimeConfig = new ManagementBuildTimeConfigImpl(true,
+                "");
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "/q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementBuildTimeConfig.rootPath());
         Assertions.assertEquals("/", buildItem.getManagementRootPath());
         Assertions.assertEquals("http://localhost:9000/foo",
-                buildItem.resolveManagementPath("foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/foo/sub/path",
-                buildItem.resolveManagementPath("foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/foo",
-                buildItem.resolveManagementPath("/foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/foo/sub/path",
-                buildItem.resolveManagementPath("/foo/sub/path", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo/sub/path", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("../foo", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("../foo", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> buildItem.resolveManagementPath("", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                () -> buildItem.resolveManagementPath("", managementBuildTimeConfig, launchModeBuildItem));
     }
 
     @Test
     void testResolveManagementPathWithWithWildcards() {
-        ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-        managementInterfaceBuildTimeConfig.enabled = true;
-        managementInterfaceBuildTimeConfig.rootPath = "/management";
-
+        ManagementBuildTimeConfig managementBuildTimeConfig = new ManagementBuildTimeConfigImpl(true,
+                "/management");
         LaunchModeBuildItem launchModeBuildItem = new LaunchModeBuildItem(LaunchMode.NORMAL, Optional.empty(), false,
                 Optional.empty(), false);
 
         NonApplicationRootPathBuildItem buildItem = new NonApplicationRootPathBuildItem("/", "/q",
-                managementInterfaceBuildTimeConfig.rootPath);
+                managementBuildTimeConfig.rootPath());
         Assertions.assertEquals("http://localhost:9000/management/foo/*",
-                buildItem.resolveManagementPath("foo/*", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("foo/*", managementBuildTimeConfig, launchModeBuildItem));
         Assertions.assertEquals("http://localhost:9000/foo/*",
-                buildItem.resolveManagementPath("/foo/*", managementInterfaceBuildTimeConfig, launchModeBuildItem));
+                buildItem.resolveManagementPath("/foo/*", managementBuildTimeConfig, launchModeBuildItem));
+    }
+
+    private static final class ManagementBuildTimeConfigImpl implements ManagementBuildTimeConfig {
+        private final boolean enabled;
+        private final String rootPath;
+
+        public ManagementBuildTimeConfigImpl(final boolean enabled, final String rootPath) {
+            this.enabled = enabled;
+            this.rootPath = rootPath;
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public ManagementAuthConfig auth() {
+            return null;
+        }
+
+        @Override
+        public ClientAuth tlsClientAuth() {
+            return null;
+        }
+
+        @Override
+        public String rootPath() {
+            return rootPath;
+        }
+
+        @Override
+        public boolean enableCompression() {
+            return false;
+        }
+
+        @Override
+        public boolean enableDecompression() {
+            return false;
+        }
+
+        @Override
+        public OptionalInt compressionLevel() {
+            return OptionalInt.empty();
+        }
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/ArcEndpointTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/ArcEndpointTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -62,13 +62,13 @@ public class ArcEndpointTest {
     public static class Foo {
 
         @Inject
-        HttpBuildTimeConfig httpConfig;
+        VertxHttpBuildTimeConfig httpBuildTimeConfig;
 
         void onStart(@Observes StartupEvent event) {
         }
 
         void addConfigRoute(@Observes Router router) {
-            router.route("/console-path").handler(rc -> rc.response().end(httpConfig.nonApplicationRootPath));
+            router.route("/console-path").handler(rc -> rc.response().end(httpBuildTimeConfig.nonApplicationRootPath()));
         }
 
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/LiveReloadEndpoint.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/LiveReloadEndpoint.java
@@ -5,7 +5,7 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
@@ -15,7 +15,7 @@ import io.vertx.ext.web.client.WebClient;
 public class LiveReloadEndpoint {
 
     @Inject
-    HttpBuildTimeConfig httpConfig;
+    VertxHttpBuildTimeConfig httpBuildTimeConfig;
 
     void addConfigRoute(@Observes Router router) {
         router.route("/test")

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/ParentFirstEndpoint.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/ParentFirstEndpoint.java
@@ -6,7 +6,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.WebClient;
 
@@ -15,7 +15,7 @@ import io.vertx.ext.web.client.WebClient;
 public class ParentFirstEndpoint {
 
     @Inject
-    HttpBuildTimeConfig httpConfig;
+    VertxHttpBuildTimeConfig httpBuildTimeConfig;
 
     void addConfigRoute(@Observes Router router) {
         router.route("/test")

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -131,9 +131,6 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
@@ -1,5 +1,6 @@
 package io.quarkus.devui.runtime;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,12 +34,38 @@ public class DevUICORSFilter implements Handler<RoutingContext> {
     private static CORSFilter corsFilter() {
         int httpPort = ConfigProvider.getConfig().getValue(HTTP_PORT_CONFIG_PROP, int.class);
         int httpsPort = ConfigProvider.getConfig().getValue(HTTPS_PORT_CONFIG_PROP, int.class);
-        CORSConfig config = new CORSConfig();
-        config.origins = Optional.of(List.of(
-                HTTP_LOCAL_HOST + ":" + httpPort,
-                HTTP_LOCAL_HOST_IP + ":" + httpPort,
-                HTTPS_LOCAL_HOST + ":" + httpsPort,
-                HTTPS_LOCAL_HOST_IP + ":" + httpsPort));
+        CORSConfig config = new CORSConfig() {
+            @Override
+            public Optional<List<String>> origins() {
+                return Optional.of(List.of(HTTP_LOCAL_HOST + ":" + httpPort, HTTP_LOCAL_HOST_IP + ":" + httpPort,
+                        HTTPS_LOCAL_HOST + ":" + httpsPort, HTTPS_LOCAL_HOST_IP + ":" + httpsPort));
+            }
+
+            @Override
+            public Optional<List<String>> methods() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<List<String>> headers() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<List<String>> exposedHeaders() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Duration> accessControlMaxAge() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> accessControlAllowCredentials() {
+                return Optional.empty();
+            }
+        };
         return new CORSFilter(config);
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AccessLogConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AccessLogConfig.java
@@ -2,85 +2,77 @@ package io.quarkus.vertx.http.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class AccessLogConfig {
-
+public interface AccessLogConfig {
     /**
      * If access logging is enabled. By default this will log via the standard logging facility
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enabled;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * A regular expression that can be used to exclude some paths from logging.
      */
-    @ConfigItem
-    Optional<String> excludePattern;
+    Optional<String> excludePattern();
 
     /**
      * The access log pattern.
-     *
+     * <p>
      * If this is the string `common`, `combined` or `long` then this will use one of the specified named formats:
-     *
+     * <p>
      * - common: `%h %l %u %t "%r" %s %b`
      * - combined: `%h %l %u %t "%r" %s %b "%{i,Referer}" "%{i,User-Agent}"`
      * - long: `%r\n%{ALL_REQUEST_HEADERS}`
-     *
+     * <p>
      * Otherwise, consult the Quarkus documentation for the full list of variables that can be used.
-     *
-     * @asciidoclet
      */
-    @ConfigItem(defaultValue = "common")
-    public String pattern;
+    @WithDefault("common")
+    String pattern();
 
     /**
      * If logging should be done to a separate file.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean logToFile;
+    @WithDefault("false")
+    boolean logToFile();
 
     /**
      * The access log file base name, defaults to 'quarkus' which will give a log file
      * name of 'quarkus.log'.
      *
      */
-    @ConfigItem(defaultValue = "quarkus")
-    public String baseFileName;
+    @WithDefault("quarkus")
+    String baseFileName();
 
     /**
      * The log directory to use when logging access to a file
-     *
+     * <p>
      * If this is not set then the current working directory is used.
      */
-    @ConfigItem
-    public Optional<String> logDirectory;
+    Optional<String> logDirectory();
 
     /**
      * The log file suffix
      */
-    @ConfigItem(defaultValue = ".log")
-    public String logSuffix;
+    @WithDefault(".log")
+    String logSuffix();
 
     /**
      * The log category to use if logging is being done via the standard log mechanism (i.e. if base-file-name is empty).
      *
      */
-    @ConfigItem(defaultValue = "io.quarkus.http.access-log")
-    public String category;
+    @WithDefault("io.quarkus.http.access-log")
+    String category();
 
     /**
      * If the log should be rotated daily
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean rotate;
+    @WithDefault("true")
+    boolean rotate();
 
     /**
      * If rerouted requests should be consolidated into one log entry
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean consolidateReroutedRequests;
-
+    @WithDefault("false")
+    boolean consolidateReroutedRequests();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
@@ -2,39 +2,35 @@ package io.quarkus.vertx.http.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * Authentication mechanism and SecurityRealm name information used for configuring HTTP auth
  * instance for the deployment.
  */
-@ConfigGroup
-public class AuthConfig {
+public interface AuthConfig {
     /**
      * If basic auth should be enabled. If both basic and form auth is enabled then basic auth will be enabled in silent mode.
-     *
+     * <p>
      * The basic auth is enabled by default if no authentication mechanisms are configured or Quarkus can safely
      * determine that basic authentication is required.
      */
-    @ConfigItem
-    public Optional<Boolean> basic;
+    Optional<Boolean> basic();
 
     /**
      * Form Auth config
      */
-    @ConfigItem
-    public FormAuthConfig form;
+    FormAuthConfig form();
 
     /**
      * If this is true and credentials are present then a user will always be authenticated
      * before the request progresses.
-     *
+     * <p>
      * If this is false then an attempt will only be made to authenticate the user if a permission
      * check is performed or the current user is required for some other reason.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean proactive;
+    @WithDefault("true")
+    boolean proactive();
 
     /**
      * Require that all registered HTTP authentication mechanisms must complete the authentication.
@@ -58,6 +54,6 @@ public class AuthConfig {
      * <p>
      * This property will be ignored if the path specific authentication is enabled.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean inclusive;
+    @WithDefault("false")
+    boolean inclusive();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
@@ -6,26 +6,24 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * Authentication mechanism information used for configuring HTTP auth instance for the deployment.
  */
-@ConfigGroup
-public class AuthRuntimeConfig {
-
+public interface AuthRuntimeConfig {
     /**
      * The HTTP permissions
      */
-    @ConfigItem(name = "permission")
-    public Map<String, PolicyMappingConfig> permissions;
+    @WithName("permission")
+    Map<String, PolicyMappingConfig> permissions();
 
     /**
      * The HTTP role based policies
      */
-    @ConfigItem(name = "policy")
-    public Map<String, PolicyConfig> rolePolicy;
+    @WithName("policy")
+    Map<String, PolicyConfig> rolePolicy();
 
     /**
      * Map the `SecurityIdentity` roles to deployment specific roles and add the matching roles to `SecurityIdentity`.
@@ -34,9 +32,8 @@ public class AuthRuntimeConfig {
      * use this property to map the `user` role to the `UserRole` role, and have `SecurityIdentity` to have
      * both `user` and `UserRole` roles.
      */
-    @ConfigItem
     @ConfigDocMapKey("role-name")
-    public Map<String, List<String>> rolesMapping;
+    Map<String, List<String>> rolesMapping();
 
     /**
      * Client certificate attribute whose values are going to be mapped to the 'SecurityIdentity' roles
@@ -58,8 +55,8 @@ public class AuthRuntimeConfig {
      * </li>
      * </ul>
      */
-    @ConfigItem(defaultValue = "CN")
-    public String certificateRoleAttribute;
+    @WithDefault("CN")
+    String certificateRoleAttribute();
 
     /**
      * Properties file containing the client certificate attribute value to role mappings.
@@ -68,18 +65,15 @@ public class AuthRuntimeConfig {
      * <p/>
      * Properties file is expected to have the `CN_VALUE=role1,role,...,roleN` format and should be encoded using UTF-8.
      */
-    @ConfigItem
-    public Optional<Path> certificateRoleProperties;
+    Optional<Path> certificateRoleProperties();
 
     /**
      * The authentication realm
      */
-    @ConfigItem
-    public Optional<String> realm;
+    Optional<String> realm();
 
     /**
      * Form Auth config
      */
-    @ConfigItem
-    public FormAuthRuntimeConfig form;
+    FormAuthRuntimeConfig form();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BodyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BodyConfig.java
@@ -1,14 +1,11 @@
 package io.quarkus.vertx.http.runtime;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * Request body related settings
  */
-@ConfigGroup
-public class BodyConfig {
-
+public interface BodyConfig {
     /**
      * Whether the files sent using {@code multipart/form-data} will be stored locally.
      * <p>
@@ -18,16 +15,16 @@ public class BodyConfig {
      * will always return an empty collection. Note that even with this option being set to {@code false}, the
      * {@code multipart/form-data} requests will be accepted.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean handleFileUploads;
+    @WithDefault("true")
+    boolean handleFileUploads();
 
     /**
      * The directory where the files sent using {@code multipart/form-data} should be stored.
      * <p>
      * Either an absolute path or a path relative to the current directory of the application process.
      */
-    @ConfigItem(defaultValue = "${java.io.tmpdir}/uploads")
-    public String uploadsDirectory;
+    @WithDefault("${java.io.tmpdir}/uploads")
+    String uploadsDirectory();
 
     /**
      * Whether the form attributes should be added to the request parameters.
@@ -35,8 +32,8 @@ public class BodyConfig {
      * If {@code true}, the form attributes will be added to the request parameters; otherwise the form parameters will
      * not be added to the request parameters
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean mergeFormAttributes;
+    @WithDefault("true")
+    boolean mergeFormAttributes();
 
     /**
      * Whether the uploaded files should be removed after serving the request.
@@ -44,8 +41,8 @@ public class BodyConfig {
      * If {@code true} the uploaded files stored in {@code quarkus.http.body-handler.uploads-directory} will be removed
      * after handling the request. Otherwise, the files will be left there forever.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean deleteUploadedFilesOnEnd;
+    @WithDefault("true")
+    boolean deleteUploadedFilesOnEnd();
 
     /**
      * Whether the body buffer should pre-allocated based on the {@code Content-Length} header value.
@@ -53,12 +50,11 @@ public class BodyConfig {
      * If {@code true} the body buffer is pre-allocated according to the size read from the {@code Content-Length}
      * header. Otherwise, the body buffer is pre-allocated to 1KB, and is resized dynamically
      */
-    @ConfigItem
-    public boolean preallocateBodyBuffer;
+    @WithDefault("false")
+    boolean preallocateBodyBuffer();
 
     /**
      * HTTP multipart request related settings
      */
-    @ConfigItem
-    public MultiPartConfig multipart;
+    MultiPartConfig multipart();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
@@ -8,18 +8,14 @@ import java.util.Optional;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import io.quarkus.credentials.CredentialsProvider;
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
 
 /**
  * A certificate configuration.
  * Provide either the certificate and key files or a keystore.
  */
-@ConfigGroup
-public class CertificateConfig {
-
+public interface CertificateConfig {
     /**
      * The {@linkplain CredentialsProvider}.
      * If this property is configured, then a matching 'CredentialsProvider' will be used
@@ -28,9 +24,7 @@ public class CertificateConfig {
      * Please note that using MicroProfile {@linkplain ConfigSource} which is directly supported by Quarkus Configuration
      * should be preferred unless using `CredentialsProvider` provides for some additional security and dynamism.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<String> credentialsProvider = Optional.empty();
+    Optional<@WithConverter(TrimmedStringConverter.class) String> credentialsProvider();
 
     /**
      * The credentials provider bean name.
@@ -41,16 +35,13 @@ public class CertificateConfig {
      * <p>
      * For Vault, the credentials provider bean name is {@code vault-credentials-provider}.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<String> credentialsProviderName = Optional.empty();
+    Optional<@WithConverter(TrimmedStringConverter.class) String> credentialsProviderName();
 
     /**
      * The list of path to server certificates using the PEM format.
      * Specifying multiple files requires SNI to be enabled.
      */
-    @ConfigItem
-    public Optional<List<Path>> files;
+    Optional<List<Path>> files();
 
     /**
      * The list of path to server certificates private key files using the PEM format.
@@ -58,47 +49,41 @@ public class CertificateConfig {
      * <p>
      * The order of the key files must match the order of the certificates.
      */
-    @ConfigItem
-    public Optional<List<Path>> keyFiles;
+    Optional<List<Path>> keyFiles();
 
     /**
      * An optional keystore that holds the certificate information instead of specifying separate files.
      */
-    @ConfigItem
-    public Optional<Path> keyStoreFile;
+    Optional<Path> keyStoreFile();
 
     /**
      * An optional parameter to specify the type of the keystore file.
      * If not given, the type is automatically detected based on the file name.
      */
-    @ConfigItem
-    public Optional<String> keyStoreFileType;
+    Optional<String> keyStoreFileType();
 
     /**
      * An optional parameter to specify a provider of the keystore file.
      * If not given, the provider is automatically detected based on the keystore file type.
      */
-    @ConfigItem
-    public Optional<String> keyStoreProvider;
+    Optional<String> keyStoreProvider();
 
     /**
      * A parameter to specify the password of the keystore file.
      * If not given, and if it can not be retrieved from {@linkplain CredentialsProvider}.
      *
-     * @see {@link #credentialsProvider}
+     * @see CertificateConfig#credentialsProvider()
      */
-    @ConfigItem(defaultValueDocumentation = "password")
-    public Optional<String> keyStorePassword;
+    Optional<String> keyStorePassword();
 
     /**
      * A parameter to specify a {@linkplain CredentialsProvider} property key,
      * which can be used to get the password of the key
      * store file from {@linkplain CredentialsProvider}.
      *
-     * @see {@link #credentialsProvider}
+     * @see CertificateConfig#credentialsProvider()
      */
-    @ConfigItem
-    public Optional<String> keyStorePasswordKey;
+    Optional<String> keyStorePasswordKey();
 
     /**
      * An optional parameter to select a specific key in the keystore.
@@ -107,111 +92,98 @@ public class CertificateConfig {
      *
      * @deprecated Use {@link #keyStoreAlias} instead.
      */
-    @ConfigItem
     @Deprecated
-    public Optional<String> keyStoreKeyAlias;
+    Optional<String> keyStoreKeyAlias();
 
     /**
      * An optional parameter to select a specific key in the keystore.
      * When SNI is disabled, and the keystore contains multiple
      * keys and no alias is specified; the behavior is undefined.
      */
-    @ConfigItem
-    public Optional<String> keyStoreAlias;
+    Optional<String> keyStoreAlias();
 
     /**
      * An optional parameter to define the password for the key,
      * in case it is different from {@link #keyStorePassword}
      * If not given, it might be retrieved from {@linkplain CredentialsProvider}.
      *
-     * @see {@link #credentialsProvider}.
+     * @see CertificateConfig#credentialsProvider()
      * @deprecated Use {@link #keyStoreAliasPassword} instead.
      */
     @Deprecated
-    @ConfigItem
-    public Optional<String> keyStoreKeyPassword;
+    Optional<String> keyStoreKeyPassword();
 
     /**
      * An optional parameter to define the password for the key,
      * in case it is different from {@link #keyStorePassword}
      * If not given, it might be retrieved from {@linkplain CredentialsProvider}.
      *
-     * @see {@link #credentialsProvider}.
+     * @see CertificateConfig#credentialsProvider()
      */
-    @ConfigItem
-    public Optional<String> keyStoreAliasPassword;
+    Optional<String> keyStoreAliasPassword();
 
     /**
      * A parameter to specify a {@linkplain CredentialsProvider} property key,
      * which can be used to get the password for the alias from {@linkplain CredentialsProvider}.
      *
-     * @see {@link #credentialsProvider}
+     * @see CertificateConfig#credentialsProvider()
      * @deprecated Use {@link #keyStoreAliasPasswordKey} instead.
      */
-    @ConfigItem
     @Deprecated
-    public Optional<String> keyStoreKeyPasswordKey;
+    Optional<String> keyStoreKeyPasswordKey();
 
     /**
      * A parameter to specify a {@linkplain CredentialsProvider} property key,
      * which can be used to get the password for the alias from {@linkplain CredentialsProvider}.
      *
-     * @see {@link #credentialsProvider}
+     * @see CertificateConfig#credentialsProvider()
      */
-    @ConfigItem
-    public Optional<String> keyStoreAliasPasswordKey;
+    Optional<String> keyStoreAliasPasswordKey();
 
     /**
      * An optional trust store that holds the certificate information of the trusted certificates.
      */
-    @ConfigItem
-    public Optional<Path> trustStoreFile;
+    Optional<Path> trustStoreFile();
 
     /**
      * An optional list of trusted certificates using the PEM format.
      * If you pass multiple files, you must use the PEM format.
      */
-    @ConfigItem
-    public Optional<List<Path>> trustStoreFiles;
+    Optional<List<Path>> trustStoreFiles();
 
     /**
      * An optional parameter to specify the type of the trust store file.
      * If not given, the type is automatically detected based on the file name.
      */
-    @ConfigItem
-    public Optional<String> trustStoreFileType;
+    Optional<String> trustStoreFileType();
 
     /**
      * An optional parameter to specify a provider of the trust store file.
      * If not given, the provider is automatically detected based on the trust store file type.
      */
-    @ConfigItem
-    public Optional<String> trustStoreProvider;
+    Optional<String> trustStoreProvider();
 
     /**
      * A parameter to specify the password of the trust store file.
      * If not given, it might be retrieved from {@linkplain CredentialsProvider}.
      *
-     * @see {@link #credentialsProvider}.
+     * @see CertificateConfig#credentialsProvider()
      */
-    @ConfigItem
-    public Optional<String> trustStorePassword;
+    Optional<String> trustStorePassword();
 
     /**
      * A parameter to specify a {@linkplain CredentialsProvider} property key,
      * which can be used to get the password of the trust store file from {@linkplain CredentialsProvider}.
      *
-     * @see {@link #credentialsProvider}
+     * @see CertificateConfig#credentialsProvider()
      */
-    @ConfigItem
-    public Optional<String> trustStorePasswordKey;
+    Optional<String> trustStorePasswordKey();
 
     /**
      * An optional parameter to trust a single certificate from the trust store rather than trusting all certificates in the
      * store.
      */
-    @ConfigItem
-    public Optional<String> trustStoreCertAlias;
+    Optional<String> trustStoreCertAlias();
 
     /**
      * When set, the configured certificate will be reloaded after the given period.
@@ -224,6 +196,5 @@ public class CertificateConfig {
      * IMPORTANT: It's recommended to use the TLS registry to handle the certificate reloading.
      * </p>
      */
-    @ConfigItem
-    public Optional<Duration> reloadPeriod;
+    Optional<Duration> reloadPeriod();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FilterConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FilterConfig.java
@@ -6,34 +6,26 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 
-@ConfigGroup
-public class FilterConfig {
-
+public interface FilterConfig {
     /**
      * A regular expression for the paths matching this configuration
      */
-    @ConfigItem
-    public String matches;
+    String matches();
 
     /**
      * Additional HTTP Headers always sent in the response
      */
-    @ConfigItem
     @ConfigDocMapKey("header-name")
-    public Map<String, String> header;
+    Map<String, String> header();
 
     /**
      * The HTTP methods for this path configuration
      */
-    @ConfigItem
-    public Optional<List<String>> methods;
+    Optional<List<String>> methods();
 
     /**
      * Order in which this path config is applied. Higher priority takes precedence
      */
-    @ConfigItem
-    public OptionalInt order;
+    OptionalInt order();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
@@ -1,24 +1,20 @@
 package io.quarkus.vertx.http.runtime;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * config for the form authentication mechanism
  */
-@ConfigGroup
-public class FormAuthConfig {
-
+public interface FormAuthConfig {
     /**
      * If form authentication is enabled.
      */
-    @ConfigItem
-    public boolean enabled;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * The post location.
      */
-    @ConfigItem(defaultValue = "/j_security_check")
-    public String postLocation;
-
+    @WithDefault("/j_security_check")
+    String postLocation();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
@@ -3,18 +3,16 @@ package io.quarkus.vertx.http.runtime;
 import java.time.Duration;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * config for the form authentication mechanism
  */
-@ConfigGroup
-public class FormAuthRuntimeConfig {
+public interface FormAuthRuntimeConfig {
     /**
      * SameSite attribute values for the session and location cookies.
      */
-    public enum CookieSameSite {
+    enum CookieSameSite {
         STRICT,
         LAX,
         NONE
@@ -23,33 +21,33 @@ public class FormAuthRuntimeConfig {
     /**
      * The login page. Redirect to login page can be disabled by setting `quarkus.http.auth.form.login-page=`.
      */
-    @ConfigItem(defaultValue = "/login.html")
-    public Optional<String> loginPage;
+    @WithDefault("/login.html")
+    Optional<String> loginPage();
 
     /**
      * The username field name.
      */
-    @ConfigItem(defaultValue = "j_username")
-    public String usernameParameter;
+    @WithDefault("j_username")
+    String usernameParameter();
 
     /**
      * The password field name.
      */
-    @ConfigItem(defaultValue = "j_password")
-    public String passwordParameter;
+    @WithDefault("j_password")
+    String passwordParameter();
 
     /**
      * The error page. Redirect to error page can be disabled by setting `quarkus.http.auth.form.error-page=`.
      */
-    @ConfigItem(defaultValue = "/error.html")
-    public Optional<String> errorPage;
+    @WithDefault("/error.html")
+    Optional<String> errorPage();
 
     /**
      * The landing page to redirect to if there is no saved page to redirect back to.
      * Redirect to landing page can be disabled by setting `quarkus.http.auth.form.landing-page=`.
      */
-    @ConfigItem(defaultValue = "/index.html")
-    public Optional<String> landingPage;
+    @WithDefault("/index.html")
+    Optional<String> landingPage();
 
     /**
      * Option to disable redirect to landingPage if there is no saved page to redirect back to. Form Auth POST is followed
@@ -59,72 +57,71 @@ public class FormAuthRuntimeConfig {
      *             (via `quarkus.http.auth.form.landing-page=`). Quarkus will ignore this configuration property
      *             if there is no landing page.
      */
-    @ConfigItem(defaultValue = "true")
+    @WithDefault("true")
     @Deprecated
-    public boolean redirectAfterLogin;
+    boolean redirectAfterLogin();
 
     /**
      * Option to control the name of the cookie used to redirect the user back
      * to the location they want to access.
      */
-    @ConfigItem(defaultValue = "quarkus-redirect-location")
-    public String locationCookie;
+    @WithDefault("quarkus-redirect-location")
+    String locationCookie();
 
     /**
      * The inactivity (idle) timeout
-     *
+     * <p>
      * When inactivity timeout is reached, cookie is not renewed and a new login is enforced.
      */
-    @ConfigItem(defaultValue = "PT30M")
-    public Duration timeout;
+    @WithDefault("PT30M")
+    Duration timeout();
 
     /**
      * How old a cookie can get before it will be replaced with a new cookie with an updated timeout, also
      * referred to as "renewal-timeout".
-     *
+     * <p>
      * Note that smaller values will result in slightly more server load (as new encrypted cookies will be
      * generated more often); however, larger values affect the inactivity timeout because the timeout is set
      * when a cookie is generated.
-     *
+     * <p>
      * For example if this is set to 10 minutes, and the inactivity timeout is 30m, if a user's last request
      * is when the cookie is 9m old then the actual timeout will happen 21m after the last request because the timeout
      * is only refreshed when a new cookie is generated.
-     *
+     * <p>
      * That is, no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie
      * itself, and it is decrypted and parsed with each request.
      */
-    @ConfigItem(defaultValue = "PT1M")
-    public Duration newCookieInterval;
+    @WithDefault("PT1M")
+    Duration newCookieInterval();
 
     /**
      * The cookie that is used to store the persistent session
      */
-    @ConfigItem(defaultValue = "quarkus-credential")
-    public String cookieName;
+    @WithDefault("quarkus-credential")
+    String cookieName();
 
     /**
      * The cookie path for the session and location cookies.
      */
-    @ConfigItem(defaultValue = "/")
-    public Optional<String> cookiePath = Optional.of("/");
+    @WithDefault("/")
+    Optional<String> cookiePath();
 
     /**
      * Set the HttpOnly attribute to prevent access to the cookie via JavaScript.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean httpOnlyCookie;
+    @WithDefault("false")
+    boolean httpOnlyCookie();
 
     /**
      * SameSite attribute for the session and location cookies.
      */
-    @ConfigItem(defaultValue = "strict")
-    public CookieSameSite cookieSameSite = CookieSameSite.STRICT;
+    @WithDefault("strict")
+    CookieSameSite cookieSameSite();
 
     /**
      * Max-Age attribute for the session cookie. This is the amount of time the browser will keep the cookie.
-     *
+     * <p>
      * The default value is empty, which means the cookie will be kept until the browser is closed.
      */
-    @ConfigItem
-    public Optional<Duration> cookieMaxAge;
+    Optional<Duration> cookieMaxAge();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
@@ -44,20 +44,20 @@ public class ForwardingProxyOptions {
         this.enableTrustedProxyHeader = enableTrustedProxyHeader;
     }
 
-    public static ForwardingProxyOptions from(ProxyConfig proxy) {
-        final boolean proxyAddressForwarding = proxy.proxyAddressForwarding;
-        final boolean allowForwarded = proxy.allowForwarded;
-        final boolean allowXForwarded = proxy.allowXForwarded.orElse(!allowForwarded);
-        final boolean enableForwardedHost = proxy.enableForwardedHost;
-        final boolean enableForwardedPrefix = proxy.enableForwardedPrefix;
-        final boolean enableTrustedProxyHeader = proxy.enableTrustedProxyHeader;
-        final boolean strictForwardedControl = proxy.strictForwardedControl;
-        final ForwardedPrecedence forwardedPrecedence = proxy.forwardedPrecedence;
-        final AsciiString forwardedPrefixHeader = AsciiString.cached(proxy.forwardedPrefixHeader);
-        final AsciiString forwardedHostHeader = AsciiString.cached(proxy.forwardedHostHeader);
+    public static ForwardingProxyOptions from(ProxyConfig proxyConfig) {
+        final boolean proxyAddressForwarding = proxyConfig.proxyAddressForwarding();
+        final boolean allowForwarded = proxyConfig.allowForwarded();
+        final boolean allowXForwarded = proxyConfig.allowXForwarded().orElse(!allowForwarded);
+        final boolean enableForwardedHost = proxyConfig.enableForwardedHost();
+        final boolean enableForwardedPrefix = proxyConfig.enableForwardedPrefix();
+        final boolean enableTrustedProxyHeader = proxyConfig.enableTrustedProxyHeader();
+        final boolean strictForwardedControl = proxyConfig.strictForwardedControl();
+        final ForwardedPrecedence forwardedPrecedence = proxyConfig.forwardedPrecedence();
+        final AsciiString forwardedPrefixHeader = AsciiString.cached(proxyConfig.forwardedPrefixHeader());
+        final AsciiString forwardedHostHeader = AsciiString.cached(proxyConfig.forwardedHostHeader());
 
-        final List<TrustedProxyCheckPart> parts = proxy.trustedProxies
-                .isPresent() ? List.copyOf(proxy.trustedProxies.get()) : List.of();
+        final List<TrustedProxyCheckPart> parts = proxyConfig.trustedProxies()
+                .isPresent() ? List.copyOf(proxyConfig.trustedProxies().get()) : List.of();
         final var proxyCheckBuilder = (!allowXForwarded && !allowForwarded)
                 || parts.isEmpty() ? null : TrustedProxyCheckBuilder.builder(parts);
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/GeneratedStaticResourcesRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/GeneratedStaticResourcesRecorder.java
@@ -17,24 +17,24 @@ import io.vertx.ext.web.RoutingContext;
 public class GeneratedStaticResourcesRecorder {
 
     public static final String META_INF_RESOURCES = "META-INF/resources";
-    private final RuntimeValue<HttpConfiguration> httpConfiguration;
-    private final HttpBuildTimeConfig httpBuildTimeConfig;
+    private final RuntimeValue<VertxHttpConfig> httpConfig;
+    private final VertxHttpBuildTimeConfig httpBuildTimeConfig;
 
-    public GeneratedStaticResourcesRecorder(RuntimeValue<HttpConfiguration> httpConfiguration,
-            HttpBuildTimeConfig httpBuildTimeConfig) {
-        this.httpConfiguration = httpConfiguration;
+    public GeneratedStaticResourcesRecorder(RuntimeValue<VertxHttpConfig> httpConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) {
+        this.httpConfig = httpConfig;
         this.httpBuildTimeConfig = httpBuildTimeConfig;
     }
 
     public Handler<RoutingContext> createHandler(Set<String> generatedClasspathResources,
             Map<String, String> generatedFilesResources) {
 
-        StaticResourcesConfig config = httpConfiguration.getValue().staticResources;
+        StaticResourcesConfig config = httpConfig.getValue().staticResources();
 
         DevClasspathStaticHandlerOptions options = new DevClasspathStaticHandlerOptions.Builder()
-                .indexPage(config.indexPage)
+                .indexPage(config.indexPage())
                 .httpBuildTimeConfig(httpBuildTimeConfig)
-                .defaultEncoding(config.contentEncoding)
+                .defaultEncoding(config.contentEncoding())
                 .build();
         return new DevStaticHandler(generatedClasspathResources,
                 generatedFilesResources,

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HeaderConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HeaderConfig.java
@@ -3,30 +3,25 @@ package io.quarkus.vertx.http.runtime;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * Configuration that allows for setting an HTTP header
  */
-@ConfigGroup
-public class HeaderConfig {
-
+public interface HeaderConfig {
     /**
      * The path this header should be applied
      */
-    @ConfigItem(defaultValue = "/*")
-    public String path;
+    @WithDefault("/*")
+    String path();
 
     /**
      * The value for this header configuration
      */
-    @ConfigItem
-    public String value;
+    String value();
 
     /**
      * The HTTP methods for this header configuration
      */
-    @ConfigItem
-    public Optional<List<String>> methods;
+    Optional<List<String>> methods();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -1,0 +1,21 @@
+package io.quarkus.vertx.http.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.configuration.NormalizeRootHttpPathConverter;
+
+/**
+ * @deprecated Use {@link VertxHttpBuildTimeConfig}.
+ */
+@Deprecated(forRemoval = true, since = "3.19")
+@ConfigRoot(name = "http", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class HttpBuildTimeConfig {
+    /**
+     * The HTTP root path. All web content will be served relative to this root path.
+     */
+    @ConfigItem(defaultValue = "/", generateDocumentation = false)
+    @ConvertWith(NormalizeRootHttpPathConverter.class)
+    public String rootPath;
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompression.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompression.java
@@ -18,7 +18,7 @@ public enum HttpCompression {
     OFF,
     /**
      * Compression will be enabled if the response has the {@code Content-Type} header set and the value is listed in
-     * {@link HttpConfiguration#compressMediaTypes}.
+     * {@link VertxHttpConfig#compressMediaTypes}.
      */
     UNDEFINED
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompressionHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompressionHandler.java
@@ -10,7 +10,7 @@ import io.vertx.ext.web.RoutingContext;
 /**
  * A simple wrapping handler that removes the {@code Content-Encoding: identity} HTTP header if the {@code Content-Type}
  * header is set and the value is a compressed media type as configured via
- * {@link io.quarkus.vertx.http.runtime.HttpBuildTimeConfig#compressMediaTypes}.
+ * {@link VertxHttpBuildTimeConfig#compressMediaTypes}.
  */
 public class HttpCompressionHandler implements Handler<RoutingContext> {
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -1,0 +1,40 @@
+package io.quarkus.vertx.http.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * @deprecated Use {@link VertxHttpConfig}.
+ */
+@Deprecated(forRemoval = true, since = "3.19")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public class HttpConfiguration {
+    /**
+     * The HTTP port
+     */
+    @ConfigItem(defaultValue = "8080", generateDocumentation = false)
+    public int port;
+
+    /**
+     * The HTTP host
+     * <p>
+     * In dev/test mode this defaults to localhost, in prod mode this defaults to 0.0.0.0
+     * <p>
+     * Defaulting to 0.0.0.0 makes it easier to deploy Quarkus to container, however it
+     * is not suitable for dev/test mode as other people on the network can connect to your
+     * development machine.
+     * <p>
+     * As an exception, when running in Windows Subsystem for Linux (WSL), the HTTP host
+     * defaults to 0.0.0.0 even in dev/test mode since using localhost makes the application
+     * inaccessible.
+     */
+    @ConfigItem(generateDocumentation = false)
+    public String host;
+
+    /**
+     * The HTTPS port
+     */
+    @ConfigItem(defaultValue = "8443", generateDocumentation = false)
+    public int sslPort;
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/MultiPartConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/MultiPartConfig.java
@@ -3,26 +3,20 @@ package io.quarkus.vertx.http.runtime;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
 
 /**
- * A {@link ConfigGroup} for the settings related to HTTP multipart request handling.
+ * A config for the settings related to HTTP multipart request handling.
  */
-@ConfigGroup
-public class MultiPartConfig {
-
+public interface MultiPartConfig {
     /**
      * A comma-separated list of {@code ContentType} to indicate whether a given multipart field should be handled as a file
      * part.
-     *
+     * <p>
      * You can use this setting to force HTTP-based extensions to parse a message part as a file based on its content type.
-     *
+     * <p>
      * For now, this setting only works when using RESTEasy Reactive.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> fileContentTypes;
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> fileContentTypes();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyConfig.java
@@ -4,31 +4,25 @@ import java.util.List;
 import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
-import io.quarkus.security.StringPermission;
+import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class PolicyConfig {
-
+public interface PolicyConfig {
     /**
      * The roles that are allowed to access resources protected by this policy.
      * By default, access is allowed to any authenticated user.
      */
-    @ConfigItem(defaultValue = "**")
-    @ConvertWith(TrimmedStringConverter.class)
-    public List<String> rolesAllowed;
+    @WithDefault("**")
+    List<@WithConverter(TrimmedStringConverter.class) String> rolesAllowed();
 
     /**
      * Add roles granted to the `SecurityIdentity` based on the roles that the `SecurityIdentity` already have.
      * For example, the Quarkus OIDC extension can map roles from the verified JWT access token, and you may want
      * to remap them to a deployment specific roles.
      */
-    @ConfigItem
     @ConfigDocMapKey("role-name")
-    public Map<String, List<String>> roles;
+    Map<String, List<String>> roles();
 
     /**
      * Permissions granted to the `SecurityIdentity` if this policy is applied successfully
@@ -37,9 +31,8 @@ public class PolicyConfig {
      * `quarkus.http.auth.policy.role-policy1.permissions.admin=perm1:action1,perm1:action2` configuration property.
      * Granted permissions are used for authorization with the `@PermissionsAllowed` annotation.
      */
-    @ConfigItem
     @ConfigDocMapKey("role-name")
-    public Map<String, List<String>> permissions;
+    Map<String, List<String>> permissions();
 
     /**
      * Permissions granted by this policy will be created with a `java.security.Permission` implementation
@@ -47,7 +40,6 @@ public class PolicyConfig {
      * that accepts permission name (`String`) or permission name and actions (`String`, `String[]`).
      * Permission class must be registered for reflection if you run your application in a native mode.
      */
-    @ConfigItem(defaultValue = "io.quarkus.security.StringPermission")
-    public String permissionClass = StringPermission.class.getName();
-
+    @WithDefault("io.quarkus.security.StringPermission")
+    String permissionClass();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyMappingConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PolicyMappingConfig.java
@@ -3,81 +3,74 @@ package io.quarkus.vertx.http.runtime;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class PolicyMappingConfig {
-
+public interface PolicyMappingConfig {
     /**
      * Determines whether the entire permission set is enabled, or not.
-     *
+     * <p>
      * By default, if the permission set is defined, it is enabled.
      */
-    @ConfigItem
-    public Optional<Boolean> enabled;
+    Optional<Boolean> enabled();
 
     /**
      * The HTTP policy that this permission set is linked to.
-     *
+     * <p>
      * There are three built-in policies: permit, deny and authenticated. Role based
      * policies can be defined, and extensions can add their own policies.
      */
-    @ConfigItem
-    public String policy;
+    String policy();
 
     /**
      * The methods that this permission set applies to. If this is not set then they apply to all methods.
-     *
+     * <p>
      * Note that if a request matches any path from any permission set, but does not match the constraint
      * due to the method not being listed then the request will be denied.
-     *
+     * <p>
      * Method specific permissions take precedence over matches that do not have any methods set.
-     *
+     * <p>
      * This means that for example if Quarkus is configured to allow GET and POST requests to /admin to
      * and no other permissions are configured PUT requests to /admin will be denied.
      *
      */
-    @ConfigItem
-    public Optional<List<String>> methods;
+    Optional<List<String>> methods();
 
     /**
      * The paths that this permission check applies to. If the path ends in /* then this is treated
      * as a path prefix, otherwise it is treated as an exact match.
-     *
+     * <p>
      * Matches are done on a length basis, so the most specific path match takes precedence.
-     *
+     * <p>
      * If multiple permission sets match the same path then explicit methods matches take precedence
      * over matches without methods set, otherwise the most restrictive permissions are applied.
      *
      */
-    @ConfigItem
-    public Optional<List<String>> paths;
+    Optional<List<String>> paths();
 
     /**
      * Path specific authentication mechanism which must be used to authenticate a user.
-     * It needs to match {@link HttpCredentialTransport} authentication scheme such as 'basic', 'bearer', 'form', etc.
+     * It needs to match {@link io.quarkus.vertx.http.runtime.security.HttpCredentialTransport} authentication scheme
+     * such as 'basic', 'bearer', 'form', etc.
      */
-    @ConfigItem
-    public Optional<String> authMechanism;
+    Optional<String> authMechanism();
 
     /**
      * Indicates that this policy always applies to the matched paths in addition to the policy with a winning path.
      * Avoid creating more than one shared policy to minimize the performance impact.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean shared;
+    @WithDefault("false")
+    boolean shared();
 
     /**
      * Whether permission check should be applied on all matching paths, or paths specific for the Jakarta REST resources.
      */
-    @ConfigItem(defaultValue = "ALL")
-    public AppliesTo appliesTo;
+    @WithDefault("ALL")
+    AppliesTo appliesTo();
 
     /**
      * Specifies additional criteria on paths that should be checked.
      */
-    public enum AppliesTo {
+    enum AppliesTo {
         /**
          * Apply on all matching paths.
          */

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -3,31 +3,30 @@ package io.quarkus.vertx.http.runtime;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.vertx.http.runtime.TrustedProxyCheck.TrustedProxyCheckPart;
+import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
 
 /**
  * Holds configuration related with proxy addressing forward.
  */
-@ConfigGroup
-public class ProxyConfig {
+public interface ProxyConfig {
     /**
      * Set whether the server should use the HA {@code PROXY} protocol when serving requests from behind a proxy.
      * (see the <a href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt">PROXY Protocol</a>).
      * When set to {@code true}, the remote address returned will be the one from the actual connecting client.
      * If it is set to {@code false} (default), the remote address returned will be the one from the proxy.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean useProxyProtocol;
+    @WithDefault("false")
+    boolean useProxyProtocol();
 
     /**
      * If this is true then the address, scheme etc. will be set from headers forwarded by the proxy server, such as
      * {@code X-Forwarded-For}. This should only be set if you are behind a proxy that sets these headers.
      */
-    @ConfigItem
-    public boolean proxyAddressForwarding;
+    @WithDefault("false")
+    boolean proxyAddressForwarding();
 
     /**
      * If this is true and proxy address forwarding is enabled then the standard {@code Forwarded} header will be used.
@@ -37,8 +36,8 @@ public class ProxyConfig {
      * requests with a forwarded header that is not overwritten by the proxy. Therefore, proxies should strip unexpected
      * `Forwarded` or `X-Forwarded-*` headers from the client.
      */
-    @ConfigItem
-    public boolean allowForwarded;
+    @WithDefault("false")
+    boolean allowForwarded();
 
     /**
      * If either this or {@code allow-forwarded} are true and proxy address forwarding is enabled then the not standard
@@ -49,21 +48,20 @@ public class ProxyConfig {
      * requests with a forwarded header that is not overwritten by the proxy. Therefore, proxies should strip unexpected
      * `Forwarded` or `X-Forwarded-*` headers from the client.
      */
-    @ConfigItem
-    public Optional<Boolean> allowXForwarded;
+    Optional<Boolean> allowXForwarded();
 
     /**
      * When both Forwarded and X-Forwarded headers are enabled with {@link #allowForwarded} and {@link #allowXForwarded}
      * respectively, enforce that the identical headers must have equal values.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean strictForwardedControl;
+    @WithDefault("true")
+    boolean strictForwardedControl();
 
     /**
      * Precedence of Forwarded and X-Forwarded headers when both types of headers are enabled and no strict forwarded control is
      * enforced.
      */
-    public enum ForwardedPrecedence {
+    enum ForwardedPrecedence {
         FORWARDED,
         X_FORWARDED
     }
@@ -78,32 +76,32 @@ public class ProxyConfig {
      * `https`,
      * then the final scheme value is `http`. If X-Forwarded has a precedence, then the final scheme value is 'https'.
      */
-    @ConfigItem(defaultValue = "forwarded")
-    public ForwardedPrecedence forwardedPrecedence;
+    @WithDefault("forwarded")
+    ForwardedPrecedence forwardedPrecedence();
 
     /**
      * Enable override the received request's host through a forwarded host header.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableForwardedHost;
+    @WithDefault("false")
+    boolean enableForwardedHost();
 
     /**
      * Configure the forwarded host header to be used if override enabled.
      */
-    @ConfigItem(defaultValue = "X-Forwarded-Host")
-    public String forwardedHostHeader;
+    @WithDefault("X-Forwarded-Host")
+    String forwardedHostHeader();
 
     /**
      * Enable prefix the received request's path with a forwarded prefix header.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableForwardedPrefix;
+    @WithDefault("false")
+    boolean enableForwardedPrefix();
 
     /**
      * Configure the forwarded prefix header to be used if prefixing enabled.
      */
-    @ConfigItem(defaultValue = "X-Forwarded-Prefix")
-    public String forwardedPrefixHeader;
+    @WithDefault("X-Forwarded-Prefix")
+    String forwardedPrefixHeader();
 
     /**
      * Adds the header `X-Forwarded-Trusted-Proxy` if the request is forwarded by a trusted proxy.
@@ -114,8 +112,8 @@ public class ProxyConfig {
      * <p>
      * The `X-Forwarded-Trusted-Proxy` header is a custom header, not part of the standard `Forwarded` header.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableTrustedProxyHeader;
+    @WithDefault("false")
+    boolean enableTrustedProxyHeader();
 
     /**
      * Configure the list of trusted proxy addresses.
@@ -145,8 +143,6 @@ public class ProxyConfig {
      * <p>
      * Please bear in mind that IPv4 CIDR won't match request sent from the IPv6 address and the other way around.
      */
-    @ConfigItem(defaultValueDocumentation = "All proxy addresses are trusted")
-    @ConvertWith(TrustedProxyCheckPartConverter.class)
-    public Optional<List<TrustedProxyCheckPart>> trustedProxies;
-
+    @ConfigDocDefault("All proxy addresses are trusted")
+    Optional<List<@WithConverter(TrustedProxyCheckPartConverter.class) TrustedProxyCheckPart>> trustedProxies();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -30,6 +30,7 @@ import io.quarkus.security.AuthenticationException;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.UnauthorizedException;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig.PayloadHint;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.MIMEHeader;
@@ -52,18 +53,18 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
 
     private final boolean showStack;
     private final boolean decorateStack;
-    private final Optional<HttpConfiguration.PayloadHint> contentTypeDefault;
+    private final Optional<PayloadHint> contentTypeDefault;
     private final List<ErrorPageAction> actions;
     private final List<String> knowClasses;
     private final String srcMainJava;
 
     public QuarkusErrorHandler(boolean showStack, boolean decorateStack,
-            Optional<HttpConfiguration.PayloadHint> contentTypeDefault) {
+            Optional<PayloadHint> contentTypeDefault) {
         this(showStack, decorateStack, contentTypeDefault, null, List.of(), List.of());
     }
 
     public QuarkusErrorHandler(boolean showStack, boolean decorateStack,
-            Optional<HttpConfiguration.PayloadHint> contentTypeDefault,
+            Optional<PayloadHint> contentTypeDefault,
             String srcMainJava,
             List<String> knowClasses,
             List<ErrorPageAction> actions) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RoutingUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RoutingUtils.java
@@ -58,9 +58,9 @@ public final class RoutingUtils {
      * @param ctx
      * @param path
      */
-    public static void compressIfNeeded(HttpBuildTimeConfig config, Set<String> compressMediaTypes, RoutingContext ctx,
+    public static void compressIfNeeded(VertxHttpBuildTimeConfig config, Set<String> compressMediaTypes, RoutingContext ctx,
             String path) {
-        if (config.enableCompression && isCompressed(compressMediaTypes, path)) {
+        if (config.enableCompression() && isCompressed(compressMediaTypes, path)) {
             // VertxHttpRecorder is adding "Content-Encoding: identity" to all requests if compression is enabled.
             // Handlers can remove the "Content-Encoding: identity" header to enable compression.
             ctx.response().headers().remove(HttpHeaders.CONTENT_ENCODING);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SameSiteCookieConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SameSiteCookieConfig.java
@@ -1,40 +1,36 @@
 package io.quarkus.vertx.http.runtime;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 import io.vertx.core.http.CookieSameSite;
 
 /**
  * Configuration that allows for automatically setting the SameSite attribute on cookies
- *
+ * <p>
  * As some API's (Servlet, JAX-RS) don't current support this attribute this config allows
  * it to be set based on the cookie name pattern.
  */
-@ConfigGroup
-public class SameSiteCookieConfig {
-
+public interface SameSiteCookieConfig {
     /**
      * If the cookie pattern is case-sensitive
      */
-    @ConfigItem
-    public boolean caseSensitive;
+    @WithDefault("false")
+    boolean caseSensitive();
 
     /**
      * The value to set in the samesite attribute
      */
-    @ConfigItem
-    public CookieSameSite value;
+    CookieSameSite value();
 
     /**
      * Some User Agents break when sent SameSite=None, this will detect them and avoid sending the value
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enableClientChecker;
+    @WithDefault("true")
+    boolean enableClientChecker();
 
     /**
      * If this is true then the 'secure' attribute will automatically be sent on
      * cookies with a SameSite attribute of None.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean addSecureForNone;
+    @WithDefault("true")
+    boolean addSecureForNone();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -5,69 +5,66 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.configuration.MemorySize;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class ServerLimitsConfig {
+public interface ServerLimitsConfig {
     /**
      * The maximum length of all headers.
      */
-    @ConfigItem(defaultValue = "20K")
-    public MemorySize maxHeaderSize;
+    @WithDefault("20K")
+    MemorySize maxHeaderSize();
 
     /**
      * The maximum size of a request body.
      */
-    @ConfigItem(defaultValue = "10240K")
-    public Optional<MemorySize> maxBodySize;
+    @WithDefault("10240K")
+    Optional<MemorySize> maxBodySize();
 
     /**
      * The max HTTP chunk size
      */
-    @ConfigItem(defaultValue = "8192")
-    public MemorySize maxChunkSize;
+    @WithDefault("8192")
+    MemorySize maxChunkSize();
 
     /**
      * The maximum length of the initial line (e.g. {@code "GET / HTTP/1.0"}).
      */
-    @ConfigItem(defaultValue = "4096")
-    public int maxInitialLineLength;
+    @WithDefault("4096")
+    int maxInitialLineLength();
 
     /**
      * The maximum length of a form attribute.
      */
-    @ConfigItem(defaultValue = "2048")
-    public MemorySize maxFormAttributeSize;
+    @WithDefault("2048")
+    MemorySize maxFormAttributeSize();
 
     /**
      * Set the maximum number of fields of a form. Set to {@code -1} to allow unlimited number of attributes.
      */
-    @ConfigItem(defaultValue = "256")
-    public int maxFormFields;
+    @WithDefault("256")
+    int maxFormFields();
 
     /**
      * Set the maximum number of bytes a server can buffer when decoding a form.
      * Set to {@code -1} to allow unlimited length
      **/
-    @ConfigItem(defaultValue = "1K")
-    public MemorySize maxFormBufferedBytes;
+    @WithDefault("1K")
+    MemorySize maxFormBufferedBytes();
 
     /**
      * The maximum number of HTTP request parameters permitted for incoming requests.
      * <p>
      * If a client sends more than this number of parameters in a request, the connection is closed.
      */
-    @ConfigItem(defaultValue = "1000")
-    public int maxParameters;
+    @WithDefault("1000")
+    int maxParameters();
 
     /**
      * The maximum number of connections that are allowed at any one time. If this is set
      * it is recommended to set a short idle timeout.
      */
-    @ConfigItem
-    public OptionalInt maxConnections;
+    OptionalInt maxConnections();
 
     /**
      * Set the SETTINGS_HEADER_TABLE_SIZE HTTP/2 setting.
@@ -77,8 +74,7 @@ public class ServerLimitsConfig {
      * specific to the header compression format inside a header block.
      * The initial value is {@code 4,096} octets.
      */
-    @ConfigItem
-    public OptionalLong headerTableSize;
+    OptionalLong headerTableSize();
 
     /**
      * Set SETTINGS_MAX_CONCURRENT_STREAMS HTTP/2 setting.
@@ -87,16 +83,14 @@ public class ServerLimitsConfig {
      * applies to the number of streams that the sender permits the receiver to create. Initially, there is no limit to
      * this value. It is recommended that this value be no smaller than 100, to not unnecessarily limit parallelism.
      */
-    @ConfigItem
-    public OptionalLong maxConcurrentStreams;
+    OptionalLong maxConcurrentStreams();
 
     /**
      * Set the SETTINGS_MAX_FRAME_SIZE HTTP/2 setting.
      * Indicates the size of the largest frame payload that the sender is willing to receive, in octets.
      * The initial value is {@code 2^14} (16,384) octets.
      */
-    @ConfigItem
-    public OptionalInt maxFrameSize;
+    OptionalInt maxFrameSize();
 
     /**
      * Set the SETTINGS_MAX_HEADER_LIST_SIZE HTTP/2 setting.
@@ -105,23 +99,19 @@ public class ServerLimitsConfig {
      * value in octets plus an overhead of 32 octets for each header field.
      * The default value is {@code 8192}
      */
-    @ConfigItem
-    public OptionalLong maxHeaderListSize;
+    OptionalLong maxHeaderListSize();
 
     /**
      * Set the max number of RST frame allowed per time window, this is used to prevent
      * <a href="https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p">HTTP/2 RST frame flood DDOS
      * attacks</a>. The default value is {@code 200}, setting zero or a negative value, disables flood protection.
      */
-    @ConfigItem
-    public OptionalInt rstFloodMaxRstFramePerWindow;
+    OptionalInt rstFloodMaxRstFramePerWindow();
 
     /**
      * Set the duration of the time window when checking the max number of RST frames, this is used to prevent
      * <a href="https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p">HTTP/2 RST frame flood DDOS
      * attacks</a>.. The default value is {@code 30 s}, setting zero or a negative value, disables flood protection.
      */
-    @ConfigItem
-    public Optional<Duration> rstFloodWindowDuration;
-
+    Optional<Duration> rstFloodWindowDuration();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerSslConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerSslConfig.java
@@ -4,25 +4,21 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.DefaultConverter;
+import io.smallrye.config.WithDefault;
 
 /**
  * Shared configuration for setting up server-side SSL.
  */
-@ConfigGroup
-public class ServerSslConfig {
+public interface ServerSslConfig {
     /**
      * The server certificate configuration.
      */
-    public CertificateConfig certificate;
+    CertificateConfig certificate();
 
     /**
      * The cipher suites to use. If none is given, a reasonable default is selected.
      */
-    @ConfigItem
-    public Optional<List<String>> cipherSuites;
+    Optional<List<String>> cipherSuites();
 
     /**
      * Sets the ordered list of enabled SSL/TLS protocols.
@@ -34,15 +30,14 @@ public class ServerSslConfig {
      * Note that setting an empty list, and enabling SSL/TLS is invalid.
      * You must at least have one protocol.
      */
-    @DefaultConverter
-    @ConfigItem(defaultValue = "TLSv1.3,TLSv1.2")
-    public Set<String> protocols;
+    @WithDefault("TLSv1.3,TLSv1.2")
+    Set<String> protocols();
 
     /**
      * Enables Server Name Indication (SNI), an TLS extension allowing the server to use multiple certificates.
      * The client indicate the server name during the TLS handshake, allowing the server to select the right certificate.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean sni;
+    @WithDefault("false")
+    boolean sni();
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesConfig.java
@@ -3,58 +3,54 @@ package io.quarkus.vertx.http.runtime;
 import java.nio.charset.Charset;
 import java.time.Duration;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
-@ConfigGroup
-public class StaticResourcesConfig {
-
+public interface StaticResourcesConfig {
     /**
      * Set the index page when serving static resources.
      */
-    @ConfigItem(defaultValue = "index.html")
-    public String indexPage;
+    @WithDefault("index.html")
+    String indexPage();
 
     /**
      * Set whether hidden files should be served.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean includeHidden;
+    @WithDefault("true")
+    boolean includeHidden();
 
     /**
      * Set whether range requests (resumable downloads; media streaming) should be enabled.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enableRangeSupport;
+    @WithDefault("true")
+    boolean enableRangeSupport();
 
     /**
      * Set whether cache handling is enabled.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean cachingEnabled;
+    @WithDefault("true")
+    boolean cachingEnabled();
 
     /**
      * Set the cache entry timeout. The default is {@code 30} seconds.
      */
-    @ConfigItem(defaultValue = "30S")
-    public Duration cacheEntryTimeout;
+    @WithDefault("30S")
+    Duration cacheEntryTimeout();
 
     /**
      * Set value for max age in caching headers. The default is {@code 24} hours.
      */
-    @ConfigItem(defaultValue = "24H")
-    public Duration maxAge;
+    @WithDefault("24H")
+    Duration maxAge();
 
     /**
      * Set the max cache size.
      */
-    @ConfigItem(defaultValue = "10000")
-    public int maxCacheSize;
+    @WithDefault("10000")
+    int maxCacheSize();
 
     /**
      * Content encoding for text related files
      */
-    @ConfigItem(defaultValue = "UTF-8")
-    public Charset contentEncoding;
-
+    @WithDefault("UTF-8")
+    Charset contentEncoding();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrafficShapingConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrafficShapingConfig.java
@@ -3,9 +3,8 @@ package io.quarkus.vertx.http.runtime;
 import java.time.Duration;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.configuration.MemorySize;
+import io.smallrye.config.WithDefault;
 
 /**
  * Configure the global traffic shaping functionality.
@@ -24,35 +23,30 @@ import io.quarkus.runtime.configuration.MemorySize;
  * Additionally, you can set the maximum time to wait, which specifies an upper bound for time shaping.
  * By default, it is set to 15 seconds.
  */
-@ConfigGroup
-public class TrafficShapingConfig {
-
+public interface TrafficShapingConfig {
     /**
      * Enables the traffic shaping.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enabled;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * Set bandwidth limit in bytes per second for inbound connections.
      * If not set, no limits are applied.
      */
-    @ConfigItem
-    public Optional<MemorySize> inboundGlobalBandwidth;
+    Optional<MemorySize> inboundGlobalBandwidth();
 
     /**
      * Set bandwidth limit in bytes per second for outbound connections.
      * If not set, no limits are applied.
      */
-    @ConfigItem
-    public Optional<MemorySize> outboundGlobalBandwidth;
+    Optional<MemorySize> outboundGlobalBandwidth();
 
     /**
      * Set the maximum delay to wait in case of traffic excess.
      * Default is 15s. Must be less than the HTTP timeout.
      */
-    @ConfigItem
-    public Optional<Duration> maxDelay;
+    Optional<Duration> maxDelay();
 
     /**
      * Set the delay between two computations of performances for channels.
@@ -63,15 +57,12 @@ public class TrafficShapingConfig {
      * <p>
      * If not default, it defaults to 1s.
      */
-    @ConfigItem
-    public Optional<Duration> checkInterval;
+    Optional<Duration> checkInterval();
 
     /**
      * Set the maximum global write size in bytes per second allowed in the buffer globally for all channels before write
      * are suspended.
      * The default value is 400 MB.
      */
-    @ConfigItem
-    public Optional<MemorySize> peakOutboundGlobalBandwidth;
-
+    Optional<MemorySize> peakOutboundGlobalBandwidth();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
@@ -5,26 +5,32 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.NormalizeRootHttpPathConverter;
 import io.quarkus.vertx.http.Compressed;
 import io.quarkus.vertx.http.Uncompressed;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 import io.vertx.core.http.ClientAuth;
 
-@ConfigRoot(name = "http", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class HttpBuildTimeConfig {
-
+@ConfigMapping(prefix = "quarkus.http")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface VertxHttpBuildTimeConfig {
     /**
      * The HTTP root path. All web content will be served relative to this root path.
      */
-    @ConfigItem(defaultValue = "/")
-    @ConvertWith(NormalizeRootHttpPathConverter.class)
-    public String rootPath;
+    @WithDefault("/")
+    @WithConverter(NormalizeRootHttpPathConverter.class)
+    String rootPath();
 
-    public AuthConfig auth;
+    /**
+     * Authentication mechanism and SecurityRealm name information used for configuring HTTP auth instance for the
+     * deployment.
+     */
+    AuthConfig auth();
 
     /**
      * Configures the engine to require/request client authentication.
@@ -34,15 +40,16 @@ public class HttpBuildTimeConfig {
      * plain HTTP port. If `quarkus.http.insecure-requests` is not set, but this parameter is set to {@code REQUIRED}, then,
      * `quarkus.http.insecure-requests` is automatically set to `disabled`.
      */
-    @ConfigItem(name = "ssl.client-auth", defaultValue = "NONE")
-    public ClientAuth tlsClientAuth;
+    @WithName("ssl.client-auth")
+    @WithDefault("NONE")
+    ClientAuth tlsClientAuth();
 
     /**
      * If this is true then only a virtual channel will be set up for vertx web.
      * We have this switch for testing purposes.
      */
-    @ConfigItem
-    public boolean virtual;
+    @WithDefault("false")
+    boolean virtual();
 
     /**
      * A common root path for non-application endpoints. Various extension-provided endpoints such as metrics, health,
@@ -58,17 +65,15 @@ public class HttpBuildTimeConfig {
      * <p>
      * If the management interface is enabled, the root path for the endpoints exposed on the management interface
      * is configured using the `quarkus.management.root-path` property instead of this property.
-     *
-     * @asciidoclet
      */
-    @ConfigItem(defaultValue = "q")
-    public String nonApplicationRootPath;
+    @WithDefault("q")
+    String nonApplicationRootPath();
 
     /**
      * The REST Assured client timeout for testing.
      */
-    @ConfigItem(defaultValue = "30s")
-    public Duration testTimeout;
+    @WithDefault("30s")
+    Duration testTimeout();
 
     /**
      * If enabled then the response body is compressed if the {@code Content-Type} header is set and the value is a compressed
@@ -78,8 +83,8 @@ public class HttpBuildTimeConfig {
      * declaratively using the annotations {@link io.quarkus.vertx.http.Compressed} and
      * {@link io.quarkus.vertx.http.Uncompressed}.
      */
-    @ConfigItem
-    public boolean enableCompression;
+    @WithDefault("false")
+    boolean enableCompression();
 
     /**
      * When enabled, vert.x will decompress the request's body if it's compressed.
@@ -87,8 +92,8 @@ public class HttpBuildTimeConfig {
      * Note that the compression format (e.g., gzip) must be specified in the Content-Encoding header
      * in the request.
      */
-    @ConfigItem
-    public boolean enableDecompression;
+    @WithDefault("false")
+    boolean enableDecompression();
 
     /**
      * If user adds br, then brotli will be added to the list of supported compression algorithms.
@@ -103,19 +108,18 @@ public class HttpBuildTimeConfig {
      * content-encoding: gzip
      *
      */
-    @ConfigItem(defaultValue = "gzip,deflate")
-    public Optional<List<String>> compressors;
+    @WithDefault("gzip,deflate")
+    Optional<List<String>> compressors();
 
     /**
      * List of media types for which the compression should be enabled automatically, unless declared explicitly via
      * {@link Compressed} or {@link Uncompressed}.
      */
-    @ConfigItem(defaultValue = "text/html,text/plain,text/xml,text/css,text/javascript,application/javascript,application/json,application/graphql+json,application/xhtml+xml")
-    public Optional<List<String>> compressMediaTypes;
+    @WithDefault("text/html,text/plain,text/xml,text/css,text/javascript,application/javascript,application/json,application/graphql+json,application/xhtml+xml")
+    Optional<List<String>> compressMediaTypes();
 
     /**
      * The compression level used when compression support is enabled.
      */
-    @ConfigItem
-    public OptionalInt compressionLevel;
+    OptionalInt compressionLevel();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
@@ -7,37 +7,40 @@ import java.util.OptionalInt;
 
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.annotations.ConfigDocSection;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.vertx.http.runtime.cors.CORSConfig;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
+@ConfigMapping(prefix = "quarkus.http")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
-public class HttpConfiguration {
-
+public interface VertxHttpConfig {
     /**
      * Authentication configuration
      */
     @ConfigDocSection(generated = true)
-    public AuthRuntimeConfig auth;
+    AuthRuntimeConfig auth();
 
     /**
      * Enable the CORS filter.
      */
-    @ConfigItem(name = "cors")
-    public boolean corsEnabled;
+    @WithName("cors")
+    @WithDefault("false")
+    boolean corsEnabled();
 
     /**
      * The HTTP port
      */
-    @ConfigItem(defaultValue = "8080")
-    public int port;
+    @WithDefault("8080")
+    int port();
 
     /**
      * The HTTP port used to run tests
      */
-    @ConfigItem(defaultValue = "8081")
-    public int testPort;
+    @WithDefault("8081")
+    int testPort();
 
     /**
      * The HTTP host
@@ -52,40 +55,37 @@ public class HttpConfiguration {
      * defaults to 0.0.0.0 even in dev/test mode since using localhost makes the application
      * inaccessible.
      */
-    @ConfigItem
-    public String host;
+    String host();
 
     /**
      * Used when {@code QuarkusIntegrationTest} is meant to execute against an application that is already running and
      * listening on the host specified by this property.
      */
-    @ConfigItem
-    public Optional<String> testHost;
+    Optional<String> testHost();
 
     /**
      * Enable listening to host:port
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean hostEnabled;
+    @WithDefault("true")
+    boolean hostEnabled();
 
     /**
      * The HTTPS port
      */
-    @ConfigItem(defaultValue = "8443")
-    public int sslPort;
+    @WithDefault("8443")
+    int sslPort();
 
     /**
      * The HTTPS port used to run tests
      */
-    @ConfigItem(defaultValue = "8444")
-    public int testSslPort;
+    @WithDefault("8444")
+    int testSslPort();
 
     /**
      * Used when {@code QuarkusIntegrationTest} is meant to execute against an application that is already running
      * to configure the test to use SSL.
      */
-    @ConfigItem
-    public Optional<Boolean> testSslEnabled;
+    Optional<Boolean> testSslEnabled();
 
     /**
      * If insecure (i.e. http rather than https) requests are allowed. If this is {@code enabled}
@@ -97,35 +97,34 @@ public class HttpConfiguration {
      * {@code quarkus.http.ssl.client-auth=required}).
      * In this case, the default is {@code disabled}.
      */
-    @ConfigItem
-    public Optional<InsecureRequests> insecureRequests;
+    Optional<InsecureRequests> insecureRequests();
 
     /**
      * If this is true (the default) then HTTP/2 will be enabled.
      * <p>
      * Note that for browsers to be able to use it HTTPS must be enabled.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean http2;
+    @WithDefault("true")
+    boolean http2();
 
     /**
      * Enables or Disable the HTTP/2 Push feature.
      * This setting can be used to disable server push. The server will not send a {@code PUSH_PROMISE} frame if it
      * receives this parameter set to {@code false}.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean http2PushEnabled;
+    @WithDefault("true")
+    boolean http2PushEnabled();
 
     /**
      * The CORS config
      */
     @ConfigDocSection(generated = true)
-    public CORSConfig cors;
+    CORSConfig cors();
 
     /**
      * The SSL config
      */
-    public ServerSslConfig ssl;
+    ServerSslConfig ssl();
 
     /**
      * The name of the TLS configuration to use.
@@ -136,21 +135,21 @@ public class HttpConfiguration {
      * <p>
      * If no TLS configuration is set, and {@code quarkus.tls.*} is not configured, then, `quarkus.http.ssl` will be used.
      */
-    @ConfigItem
-    public Optional<String> tlsConfigurationName;
+    Optional<String> tlsConfigurationName();
 
     /**
      * Static Resources.
      */
     @ConfigDocSection(generated = true)
-    public StaticResourcesConfig staticResources;
+    StaticResourcesConfig staticResources();
 
     /**
      * When set to {@code true}, the HTTP server automatically sends `100 CONTINUE`
      * response when the request expects it (with the `Expect: 100-Continue` header).
      */
-    @ConfigItem(defaultValue = "false", name = "handle-100-continue-automatically")
-    public boolean handle100ContinueAutomatically;
+    @WithName("handle-100-continue-automatically")
+    @WithDefault("false")
+    boolean handle100ContinueAutomatically();
 
     /**
      * The number if IO threads used to perform IO. This will be automatically set to a reasonable value based on
@@ -160,33 +159,32 @@ public class HttpConfiguration {
      * In general this should be controlled by setting quarkus.vertx.event-loops-pool-size, this setting should only
      * be used if you want to limit the number of HTTP io threads to a smaller number than the total number of IO threads.
      */
-    @ConfigItem
-    public OptionalInt ioThreads;
+    OptionalInt ioThreads();
 
     /**
      * Server limits.
      */
     @ConfigDocSection(generated = true)
-    public ServerLimitsConfig limits;
+    ServerLimitsConfig limits();
 
     /**
      * Http connection idle timeout
      */
-    @ConfigItem(defaultValue = "30M", name = "idle-timeout")
-    public Duration idleTimeout;
+    @WithDefault("30M")
+    Duration idleTimeout();
 
     /**
      * Http connection read timeout for blocking IO. This is the maximum amount of time
      * a thread will wait for data, before an IOException will be thrown and the connection
      * closed.
      */
-    @ConfigItem(defaultValue = "60s", name = "read-timeout")
-    public Duration readTimeout;
+    @WithDefault("60s")
+    Duration readTimeout();
 
     /**
      * Request body related settings
      */
-    public BodyConfig body;
+    BodyConfig body();
 
     /**
      * The encryption key that is used to store persistent logins (e.g. for form auth). Logins are stored in a persistent
@@ -195,84 +193,82 @@ public class HttpConfiguration {
      * If no key is provided then an in-memory one will be generated, this will change on every restart though so it
      * is not suitable for production environments. This must be more than 16 characters long for security reasons
      */
-    @ConfigItem(name = "auth.session.encryption-key")
-    public Optional<String> encryptionKey;
+    @WithName("auth.session.encryption-key")
+    Optional<String> encryptionKey();
 
     /**
      * Enable socket reuse port (linux/macOs native transport only)
      */
-    @ConfigItem
-    public boolean soReusePort;
+    @WithDefault("false")
+    boolean soReusePort();
 
     /**
      * Enable tcp quick ack (linux native transport only)
      */
-    @ConfigItem
-    public boolean tcpQuickAck;
+    @WithDefault("false")
+    boolean tcpQuickAck();
 
     /**
      * Enable tcp cork (linux native transport only)
      */
-    @ConfigItem
-    public boolean tcpCork;
+    @WithDefault("false")
+    boolean tcpCork();
 
     /**
      * Enable tcp fast open (linux native transport only)
      */
-    @ConfigItem
-    public boolean tcpFastOpen;
+    @WithDefault("false")
+    boolean tcpFastOpen();
 
     /**
      * The accept backlog, this is how many connections can be waiting to be accepted before connections start being rejected
      */
-    @ConfigItem(defaultValue = "-1")
-    public int acceptBacklog;
+    @WithDefault("-1")
+    int acceptBacklog();
 
     /**
      * Set the SETTINGS_INITIAL_WINDOW_SIZE HTTP/2 setting.
      * Indicates the sender's initial window size (in octets) for stream-level flow control.
      * The initial value is {@code 2^16-1} (65,535) octets.
      */
-    @ConfigItem
-    public OptionalInt initialWindowSize;
+    OptionalInt initialWindowSize();
 
     /**
      * Path to a unix domain socket
      */
-    @ConfigItem(defaultValue = "/var/run/io.quarkus.app.socket")
-    public String domainSocket;
+    @WithDefault("/var/run/io.quarkus.app.socket")
+    String domainSocket();
 
     /**
      * Enable listening to host:port
      */
-    @ConfigItem
-    public boolean domainSocketEnabled;
+    @WithDefault("false")
+    boolean domainSocketEnabled();
 
     /**
      * If this is true then the request start time will be recorded to enable logging of total request time.
      * <p>
      * This has a small performance penalty, so is disabled by default.
      */
-    @ConfigItem
-    public boolean recordRequestStartTime;
+    @WithDefault("false")
+    boolean recordRequestStartTime();
 
     /**
      * Access logs.
      */
     @ConfigDocSection(generated = true)
-    public AccessLogConfig accessLog;
+    AccessLogConfig accessLog();
 
     /**
      * Traffic shaping.
      */
     @ConfigDocSection
-    public TrafficShapingConfig trafficShaping;
+    TrafficShapingConfig trafficShaping();
 
     /**
      * Configuration that allows setting the same site attributes for cookies.
      */
-    @ConfigItem
-    public Map<String, SameSiteCookieConfig> sameSiteCookie;
+    Map<String, SameSiteCookieConfig> sameSiteCookie();
 
     /**
      * Provides a hint (optional) for the default content type of responses generated for
@@ -285,50 +281,47 @@ public class HttpConfiguration {
      * Otherwise, it will default to the content type configured here.
      * </p>
      */
-    @ConfigItem
-    public Optional<PayloadHint> unhandledErrorContentTypeDefault;
+    Optional<PayloadHint> unhandledErrorContentTypeDefault();
 
     /**
      * Additional HTTP Headers always sent in the response
      */
-    @ConfigItem
     @ConfigDocSection(generated = true)
-    public Map<String, HeaderConfig> header;
+    Map<String, HeaderConfig> header();
 
     /**
      * Additional HTTP configuration per path
      */
-    @ConfigItem
     @ConfigDocSection(generated = true)
-    public Map<String, FilterConfig> filter;
+    Map<String, FilterConfig> filter();
 
     /**
      * Proxy.
      */
     @ConfigDocSection
-    public ProxyConfig proxy;
+    ProxyConfig proxy();
 
     /**
      * WebSocket Server configuration.
      */
     @ConfigDocSection
-    public WebsocketServerConfig websocketServer;
+    WebsocketServerConfig websocketServer();
 
-    public int determinePort(LaunchMode launchMode) {
-        return launchMode == LaunchMode.TEST ? testPort : port;
+    default int determinePort(LaunchMode launchMode) {
+        return launchMode == LaunchMode.TEST ? testPort() : port();
     }
 
-    public int determineSslPort(LaunchMode launchMode) {
-        return launchMode == LaunchMode.TEST ? testSslPort : sslPort;
+    default int determineSslPort(LaunchMode launchMode) {
+        return launchMode == LaunchMode.TEST ? testSslPort() : sslPort();
     }
 
-    public enum InsecureRequests {
+    enum InsecureRequests {
         ENABLED,
         REDIRECT,
         DISABLED;
     }
 
-    public enum PayloadHint {
+    enum PayloadHint {
         JSON,
         HTML,
         TEXT

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
@@ -26,9 +26,20 @@ public interface VertxHttpConfig {
     /**
      * Enable the CORS filter.
      */
+    @WithName("cors.enabled")
+    @WithDefault("${quarkus.http.cors:false}")
+    boolean corsEnabled();
+
+    /**
+     * Enable the CORS filter.
+     *
+     * @deprecated Use {@link VertxHttpConfig#corsEnabled()}. Deprecated because it requires additional syntax to
+     *             configure with the group {@link VertxHttpConfig#cors()} in YAML config.
+     */
     @WithName("cors")
     @WithDefault("false")
-    boolean corsEnabled();
+    @Deprecated
+    boolean oldCorsEnabled();
 
     /**
      * The HTTP port

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -64,7 +64,6 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.ThreadPoolConfig;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.runtime.configuration.ConfigInstantiator;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.MemorySize;
 import io.quarkus.runtime.logging.LogBuildTimeConfig;
@@ -78,7 +77,7 @@ import io.quarkus.vertx.http.HttpServerOptionsCustomizer;
 import io.quarkus.vertx.http.HttpServerStart;
 import io.quarkus.vertx.http.HttpsServerStart;
 import io.quarkus.vertx.http.ManagementInterface;
-import io.quarkus.vertx.http.runtime.HttpConfiguration.InsecureRequests;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig.InsecureRequests;
 import io.quarkus.vertx.http.runtime.devmode.RemoteSyncHandler;
 import io.quarkus.vertx.http.runtime.devmode.VertxHttpHotReplacementSetup;
 import io.quarkus.vertx.http.runtime.filters.Filter;
@@ -89,14 +88,16 @@ import io.quarkus.vertx.http.runtime.filters.accesslog.AccessLogHandler;
 import io.quarkus.vertx.http.runtime.filters.accesslog.AccessLogReceiver;
 import io.quarkus.vertx.http.runtime.filters.accesslog.DefaultAccessLogReceiver;
 import io.quarkus.vertx.http.runtime.filters.accesslog.JBossLoggingAccessLogReceiver;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceConfiguration;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementConfig;
 import io.quarkus.vertx.http.runtime.options.HttpServerCommonHandlers;
 import io.quarkus.vertx.http.runtime.options.HttpServerOptionsUtils;
 import io.quarkus.vertx.http.runtime.options.TlsCertificateReloader;
 import io.smallrye.common.cpu.ProcessorInfo;
 import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Closeable;
@@ -209,22 +210,23 @@ public class VertxHttpRecorder {
 
     private static final List<Long> refresTaskIds = new CopyOnWriteArrayList<>();
 
-    final HttpBuildTimeConfig httpBuildTimeConfig;
-    final ManagementInterfaceBuildTimeConfig managementBuildTimeConfig;
-    final RuntimeValue<HttpConfiguration> httpConfiguration;
+    final VertxHttpBuildTimeConfig httpBuildTimeConfig;
+    final ManagementBuildTimeConfig managementBuildTimeConfig;
+    final RuntimeValue<VertxHttpConfig> httpConfig;
+    final RuntimeValue<ManagementConfig> managementConfig;
 
-    final RuntimeValue<ManagementInterfaceConfiguration> managementConfiguration;
     private static volatile Handler<HttpServerRequest> managementRouter;
     private static volatile Handler<HttpServerRequest> managementRouterDelegate;
 
-    public VertxHttpRecorder(HttpBuildTimeConfig httpBuildTimeConfig,
-            ManagementInterfaceBuildTimeConfig managementBuildTimeConfig,
-            RuntimeValue<HttpConfiguration> httpConfiguration,
-            RuntimeValue<ManagementInterfaceConfiguration> managementConfiguration) {
+    public VertxHttpRecorder(
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
+            RuntimeValue<VertxHttpConfig> httpConfig,
+            RuntimeValue<ManagementConfig> managementConfig) {
         this.httpBuildTimeConfig = httpBuildTimeConfig;
-        this.httpConfiguration = httpConfiguration;
+        this.httpConfig = httpConfig;
         this.managementBuildTimeConfig = managementBuildTimeConfig;
-        this.managementConfiguration = managementConfiguration;
+        this.managementConfig = managementConfig;
     }
 
     public static void setHotReplacement(Handler<RoutingContext> handler, HotReplacementContext hrc) {
@@ -257,6 +259,16 @@ public class VertxHttpRecorder {
         Vertx vertx;
         SmallRyeConfig config = ConfigUtils.emptyConfigBuilder()
                 .addDiscoveredSources()
+                .withCustomizers(new SmallRyeConfigBuilderCustomizer() {
+                    @Override
+                    public void configBuilder(final SmallRyeConfigBuilder builder) {
+                        new VertxConfigBuilder().configBuilder(builder);
+                    }
+                })
+                .withMapping(VertxHttpBuildTimeConfig.class)
+                .withMapping(VertxHttpConfig.class)
+                .withMapping(ManagementBuildTimeConfig.class)
+                .withMapping(ManagementConfig.class)
                 .withMapping(VertxConfiguration.class)
                 .withMapping(ThreadPoolConfig.class)
                 .withMapping(LiveReloadConfig.class)
@@ -270,22 +282,12 @@ public class VertxHttpRecorder {
         }
 
         try {
-            HttpBuildTimeConfig buildConfig = new HttpBuildTimeConfig();
-            ConfigInstantiator.handleObject(buildConfig);
-            ManagementInterfaceBuildTimeConfig managementBuildTimeConfig = new ManagementInterfaceBuildTimeConfig();
-            ConfigInstantiator.handleObject(managementBuildTimeConfig);
-            HttpConfiguration httpConfiguration = new HttpConfiguration();
-            ConfigInstantiator.handleObject(httpConfiguration);
-            ManagementInterfaceConfiguration managementConfig = new ManagementInterfaceConfiguration();
-            ConfigInstantiator.handleObject(managementConfig);
-            if (httpConfiguration.host == null) {
-                //VertxConfigBuilder does not come into play here
-                httpConfiguration.host = "localhost";
-            }
-            if (managementConfig.host == null) {
-                //VertxConfigBuilder does not come into play here
-                managementConfig.host = "localhost";
-            }
+            VertxHttpBuildTimeConfig httpBuildConfig = config.getConfigMapping(VertxHttpBuildTimeConfig.class);
+            ManagementBuildTimeConfig managementBuildTimeConfig = config
+                    .getConfigMapping(ManagementBuildTimeConfig.class);
+            VertxHttpConfig httpConfig = config.getConfigMapping(VertxHttpConfig.class);
+            ManagementConfig managementConfig = config.getConfigMapping(ManagementConfig.class);
+
             Router router = Router.router(vertx);
             if (hotReplacementHandler != null) {
                 router.route().order(RouteConstants.ROUTE_ORDER_HOT_REPLACEMENT).blockingHandler(hotReplacementHandler);
@@ -300,9 +302,9 @@ public class VertxHttpRecorder {
             }
             rootHandler = root;
 
-            var insecureRequestStrategy = getInsecureRequestStrategy(buildConfig, httpConfiguration.insecureRequests);
+            var insecureRequestStrategy = getInsecureRequestStrategy(httpBuildConfig, httpConfig.insecureRequests());
             //we can't really do
-            doServerStart(vertx, buildConfig, managementBuildTimeConfig, null, httpConfiguration, managementConfig,
+            doServerStart(vertx, httpBuildConfig, managementBuildTimeConfig, null, httpConfig, managementConfig,
                     LaunchMode.DEVELOPMENT,
                     new Supplier<Integer>() {
                         @Override
@@ -353,16 +355,15 @@ public class VertxHttpRecorder {
                 }
             });
         }
-        HttpConfiguration httpConfiguration = this.httpConfiguration.getValue();
-        ManagementInterfaceConfiguration managementConfig = this.managementConfiguration == null ? null
-                : this.managementConfiguration.getValue();
-        if (startSocket && (httpConfiguration.hostEnabled || httpConfiguration.domainSocketEnabled
-                || (managementConfig != null && managementConfig.hostEnabled)
-                || (managementConfig != null && managementConfig.domainSocketEnabled))) {
+        VertxHttpConfig httpConfiguration = this.httpConfig.getValue();
+        ManagementConfig managementConfig = this.managementConfig == null ? null : this.managementConfig.getValue();
+        if (startSocket && (httpConfiguration.hostEnabled() || httpConfiguration.domainSocketEnabled()
+                || (managementConfig != null && managementConfig.hostEnabled())
+                || (managementConfig != null && managementConfig.domainSocketEnabled()))) {
             // Start the server
             if (closeTask == null) {
                 var insecureRequestStrategy = getInsecureRequestStrategy(httpBuildTimeConfig,
-                        httpConfiguration.insecureRequests);
+                        httpConfiguration.insecureRequests());
                 doServerStart(vertx.get(), httpBuildTimeConfig, managementBuildTimeConfig, managementRouter,
                         httpConfiguration, managementConfig, launchMode, ioThreads, websocketSubProtocols,
                         insecureRequestStrategy,
@@ -401,7 +402,7 @@ public class VertxHttpRecorder {
             List<String> knowClasses,
             List<ErrorPageAction> actions,
             Optional<RuntimeValue<SubmissionPublisher<String>>> publisher) {
-        HttpConfiguration httpConfiguration = this.httpConfiguration.getValue();
+        VertxHttpConfig httpConfig = this.httpConfig.getValue();
         // install the default route at the end
         Router httpRouteRouter = httpRouterRuntimeValue.getValue();
 
@@ -435,10 +436,10 @@ public class VertxHttpRecorder {
             defaultRouteHandler.accept(httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_DEFAULT));
         }
 
-        applyCompression(httpBuildTimeConfig.enableCompression, httpRouteRouter);
+        applyCompression(httpBuildTimeConfig.enableCompression(), httpRouteRouter);
         httpRouteRouter.route().last().failureHandler(
                 new QuarkusErrorHandler(launchMode.isDevOrTest(), decorateStacktrace(launchMode, logBuildTimeConfig),
-                        httpConfiguration.unhandledErrorContentTypeDefault, srcMainJava, knowClasses, actions));
+                        httpConfig.unhandledErrorContentTypeDefault(), srcMainJava, knowClasses, actions));
         for (BooleanSupplier requireBodyHandlerCondition : requireBodyHandlerConditions) {
             if (requireBodyHandlerCondition.getAsBoolean()) {
                 //if this is set then everything needs the body handler installed
@@ -454,12 +455,12 @@ public class VertxHttpRecorder {
             }
         }
 
-        HttpServerCommonHandlers.enforceMaxBodySize(httpConfiguration.limits, httpRouteRouter);
+        HttpServerCommonHandlers.enforceMaxBodySize(httpConfig.limits(), httpRouteRouter);
         // Filter Configuration per path
-        var filtersInConfig = httpConfiguration.filter;
+        var filtersInConfig = httpConfig.filter();
         HttpServerCommonHandlers.applyFilters(filtersInConfig, httpRouteRouter);
         // Headers sent on any request, regardless of the response
-        HttpServerCommonHandlers.applyHeaders(httpConfiguration.header, httpRouteRouter);
+        HttpServerCommonHandlers.applyHeaders(httpConfig.header(), httpRouteRouter);
 
         Handler<HttpServerRequest> root;
         if (rootPath.equals("/")) {
@@ -474,8 +475,8 @@ public class VertxHttpRecorder {
             root = mainRouter;
         }
 
-        warnIfProxyAddressForwardingAllowedWithMultipleHeaders(httpConfiguration.proxy);
-        root = HttpServerCommonHandlers.applyProxy(httpConfiguration.proxy, root, vertx);
+        warnIfProxyAddressForwardingAllowedWithMultipleHeaders(httpConfig.proxy());
+        root = HttpServerCommonHandlers.applyProxy(httpConfig.proxy(), root, vertx);
 
         boolean quarkusWrapperNeeded = false;
 
@@ -485,18 +486,18 @@ public class VertxHttpRecorder {
             quarkusWrapperNeeded = true;
         }
 
-        AccessLogConfig accessLog = httpConfiguration.accessLog;
-        if (accessLog.enabled) {
+        AccessLogConfig accessLog = httpConfig.accessLog();
+        if (accessLog.enabled()) {
             AccessLogReceiver receiver;
-            if (accessLog.logToFile) {
-                File outputDir = accessLog.logDirectory.isPresent() ? new File(accessLog.logDirectory.get()) : new File("");
-                receiver = new DefaultAccessLogReceiver(executor, outputDir, accessLog.baseFileName, accessLog.logSuffix,
-                        accessLog.rotate);
+            if (accessLog.logToFile()) {
+                File outputDir = accessLog.logDirectory().isPresent() ? new File(accessLog.logDirectory().get()) : new File("");
+                receiver = new DefaultAccessLogReceiver(executor, outputDir, accessLog.baseFileName(), accessLog.logSuffix(),
+                        accessLog.rotate());
             } else {
-                receiver = new JBossLoggingAccessLogReceiver(accessLog.category);
+                receiver = new JBossLoggingAccessLogReceiver(accessLog.category());
             }
             setupAccessLogHandler(mainRouterRuntimeValue, httpRouterRuntimeValue, frameworkRouter, receiver, rootPath,
-                    nonRootPath, accessLog.pattern, accessLog.consolidateReroutedRequests, accessLog.excludePattern);
+                    nonRootPath, accessLog.pattern(), accessLog.consolidateReroutedRequests(), accessLog.excludePattern());
             quarkusWrapperNeeded = true;
         }
 
@@ -512,14 +513,14 @@ public class VertxHttpRecorder {
             };
 
             setupAccessLogHandler(mainRouterRuntimeValue, httpRouterRuntimeValue, frameworkRouter, receiver, rootPath,
-                    nonRootPath, accessLog.pattern, accessLog.consolidateReroutedRequests,
-                    accessLog.excludePattern.or(() -> Optional.of("^" + nonRootPath + ".*")));
+                    nonRootPath, accessLog.pattern(), accessLog.consolidateReroutedRequests(),
+                    accessLog.excludePattern().or(() -> Optional.of("^" + nonRootPath + ".*")));
             quarkusWrapperNeeded = true;
         }
 
         BiConsumer<Cookie, HttpServerRequest> cookieFunction = null;
-        if (!httpConfiguration.sameSiteCookie.isEmpty()) {
-            cookieFunction = processSameSiteConfig(httpConfiguration.sameSiteCookie);
+        if (!httpConfig.sameSiteCookie().isEmpty()) {
+            cookieFunction = processSameSiteConfig(httpConfig.sameSiteCookie());
             quarkusWrapperNeeded = true;
         }
         BiConsumer<Cookie, HttpServerRequest> cookieConsumer = cookieFunction;
@@ -534,10 +535,10 @@ public class VertxHttpRecorder {
             };
         }
 
-        final boolean mustResumeRequest = httpConfiguration.limits.maxBodySize.isPresent();
+        final boolean mustResumeRequest = httpConfig.limits().maxBodySize().isPresent();
         Handler<HttpServerRequest> delegate = root;
         root = HttpServerCommonHandlers.enforceDuplicatedContext(delegate, mustResumeRequest);
-        if (httpConfiguration.recordRequestStartTime) {
+        if (httpConfig.recordRequestStartTime()) {
             httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_RECORD_START_TIME).handler(new Handler<RoutingContext>() {
                 @Override
                 public void handle(RoutingContext event) {
@@ -562,23 +563,23 @@ public class VertxHttpRecorder {
 
             mr.route().last().failureHandler(
                     new QuarkusErrorHandler(launchMode.isDevOrTest(), decorateStacktrace(launchMode, logBuildTimeConfig),
-                            httpConfiguration.unhandledErrorContentTypeDefault, srcMainJava, knowClasses, actions));
+                            httpConfig.unhandledErrorContentTypeDefault(), srcMainJava, knowClasses, actions));
 
             mr.route().order(RouteConstants.ROUTE_ORDER_BODY_HANDLER_MANAGEMENT)
                     .handler(createBodyHandlerForManagementInterface());
             // We can use "*" here as the management interface is not expected to be used publicly.
             mr.route().order(RouteConstants.ROUTE_ORDER_CORS_MANAGEMENT).handler(CorsHandler.create().addOrigin("*"));
 
-            HttpServerCommonHandlers.applyFilters(managementConfiguration.getValue().filter, mr);
+            HttpServerCommonHandlers.applyFilters(managementConfig.getValue().filter(), mr);
             for (Filter filter : managementInterfaceFilterList) {
                 mr.route().order(filter.getPriority()).handler(filter.getHandler());
             }
 
-            HttpServerCommonHandlers.applyHeaders(managementConfiguration.getValue().header, mr);
-            applyCompression(managementBuildTimeConfig.enableCompression, mr);
+            HttpServerCommonHandlers.applyHeaders(managementConfig.getValue().header(), mr);
+            applyCompression(managementBuildTimeConfig.enableCompression(), mr);
 
             Handler<HttpServerRequest> handler = HttpServerCommonHandlers.enforceDuplicatedContext(mr, mustResumeRequest);
-            handler = HttpServerCommonHandlers.applyProxy(managementConfiguration.getValue().proxy, handler, vertx);
+            handler = HttpServerCommonHandlers.applyProxy(managementConfig.getValue().proxy(), handler, vertx);
 
             int routesBeforeMiEvent = mr.getRoutes().size();
             event.select(ManagementInterface.class).fire(new ManagementInterfaceImpl(mr));
@@ -659,9 +660,9 @@ public class VertxHttpRecorder {
     }
 
     private void warnIfProxyAddressForwardingAllowedWithMultipleHeaders(ProxyConfig proxyConfig) {
-        boolean proxyAddressForwardingActivated = proxyConfig.proxyAddressForwarding;
-        boolean forwardedActivated = proxyConfig.allowForwarded;
-        boolean xForwardedActivated = proxyConfig.allowXForwarded.orElse(!forwardedActivated);
+        boolean proxyAddressForwardingActivated = proxyConfig.proxyAddressForwarding();
+        boolean forwardedActivated = proxyConfig.allowForwarded();
+        boolean xForwardedActivated = proxyConfig.allowXForwarded().orElse(!forwardedActivated);
 
         if (proxyAddressForwardingActivated && forwardedActivated && xForwardedActivated) {
             LOGGER.warn(
@@ -673,11 +674,11 @@ public class VertxHttpRecorder {
     }
 
     private static CompletableFuture<HttpServer> initializeManagementInterfaceWithDomainSocket(Vertx vertx,
-            ManagementInterfaceBuildTimeConfig managementBuildTimeConfig, Handler<HttpServerRequest> managementRouter,
-            ManagementInterfaceConfiguration managementConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig, Handler<HttpServerRequest> managementRouter,
+            ManagementConfig managementConfig,
             List<String> websocketSubProtocols) {
         CompletableFuture<HttpServer> managementInterfaceDomainSocketFuture = new CompletableFuture<>();
-        if (!managementBuildTimeConfig.enabled || managementRouter == null || managementConfig == null) {
+        if (!managementBuildTimeConfig.enabled() || managementRouter == null || managementConfig == null) {
             managementInterfaceDomainSocketFuture.complete(null);
             return managementInterfaceDomainSocketFuture;
         }
@@ -706,13 +707,13 @@ public class VertxHttpRecorder {
     }
 
     private static CompletableFuture<HttpServer> initializeManagementInterface(Vertx vertx,
-            ManagementInterfaceBuildTimeConfig managementBuildTimeConfig, Handler<HttpServerRequest> managementRouter,
-            ManagementInterfaceConfiguration managementConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig, Handler<HttpServerRequest> managementRouter,
+            ManagementConfig managementConfig,
             LaunchMode launchMode,
             List<String> websocketSubProtocols, TlsConfigurationRegistry registry) throws IOException {
         httpManagementServerOptions = null;
         CompletableFuture<HttpServer> managementInterfaceFuture = new CompletableFuture<>();
-        if (!managementBuildTimeConfig.enabled || managementRouter == null || managementConfig == null) {
+        if (!managementBuildTimeConfig.enabled() || managementRouter == null || managementConfig == null) {
             managementInterfaceFuture.complete(null);
             return managementInterfaceFuture;
         }
@@ -738,11 +739,11 @@ public class VertxHttpRecorder {
                                             + httpManagementServerOptions.getPort(), ar.cause()));
                         } else {
                             if (httpManagementServerOptions.isSsl()
-                                    && (managementConfig.ssl.certificate.reloadPeriod.isPresent())) {
+                                    && (managementConfig.ssl().certificate().reloadPeriod().isPresent())) {
                                 try {
                                     long l = TlsCertificateReloader.initCertReloadingAction(
-                                            vertx, ar.result(), httpManagementServerOptions, managementConfig.ssl, registry,
-                                            managementConfig.tlsConfigurationName);
+                                            vertx, ar.result(), httpManagementServerOptions, managementConfig.ssl(), registry,
+                                            managementConfig.tlsConfigurationName());
                                     if (l != -1) {
                                         refresTaskIds.add(l);
                                     }
@@ -755,7 +756,7 @@ public class VertxHttpRecorder {
                             if (httpManagementServerOptions.isSsl()) {
                                 CDI.current().select(HttpCertificateUpdateEventListener.class).get()
                                         .register(ar.result(),
-                                                managementConfig.tlsConfigurationName.orElse(TlsConfig.DEFAULT_NAME),
+                                                managementConfig.tlsConfigurationName().orElse(TlsConfig.DEFAULT_NAME),
                                                 "management interface");
                             }
 
@@ -781,23 +782,23 @@ public class VertxHttpRecorder {
         return managementInterfaceFuture;
     }
 
-    private static CompletableFuture<String> initializeMainHttpServer(Vertx vertx, HttpBuildTimeConfig httpBuildTimeConfig,
-            HttpConfiguration httpConfiguration,
+    private static CompletableFuture<String> initializeMainHttpServer(Vertx vertx, VertxHttpBuildTimeConfig httpBuildTimeConfig,
+            VertxHttpConfig httpConfig,
             LaunchMode launchMode,
             Supplier<Integer> eventLoops, List<String> websocketSubProtocols, InsecureRequests insecureRequestStrategy,
             TlsConfigurationRegistry registry)
             throws IOException {
 
-        if (!httpConfiguration.hostEnabled && !httpConfiguration.domainSocketEnabled) {
+        if (!httpConfig.hostEnabled() && !httpConfig.domainSocketEnabled()) {
             return CompletableFuture.completedFuture(null);
         }
 
         // Http server configuration
-        httpMainServerOptions = createHttpServerOptions(httpBuildTimeConfig, httpConfiguration, launchMode,
+        httpMainServerOptions = createHttpServerOptions(httpBuildTimeConfig, httpConfig, launchMode,
                 websocketSubProtocols);
-        httpMainDomainSocketOptions = createDomainSocketOptions(httpBuildTimeConfig, httpConfiguration,
+        httpMainDomainSocketOptions = createDomainSocketOptions(httpBuildTimeConfig, httpConfig,
                 websocketSubProtocols);
-        HttpServerOptions tmpSslConfig = HttpServerOptionsUtils.createSslOptions(httpBuildTimeConfig, httpConfiguration,
+        HttpServerOptions tmpSslConfig = HttpServerOptionsUtils.createSslOptions(httpBuildTimeConfig, httpConfig,
                 launchMode, websocketSubProtocols, registry);
 
         // Customize
@@ -825,15 +826,15 @@ public class VertxHttpRecorder {
         }
         httpMainSslServerOptions = tmpSslConfig;
 
-        if (insecureRequestStrategy != HttpConfiguration.InsecureRequests.ENABLED
+        if (insecureRequestStrategy != InsecureRequests.ENABLED
                 && httpMainSslServerOptions == null) {
             throw new IllegalStateException("Cannot set quarkus.http.insecure-requests without enabling SSL.");
         }
 
         int eventLoopCount = eventLoops.get();
         final int ioThreads;
-        if (httpConfiguration.ioThreads.isPresent()) {
-            ioThreads = Math.min(httpConfiguration.ioThreads.getAsInt(), eventLoopCount);
+        if (httpConfig.ioThreads().isPresent()) {
+            ioThreads = Math.min(httpConfig.ioThreads().getAsInt(), eventLoopCount);
         } else if (launchMode.isDevOrTest()) {
             ioThreads = Math.min(2, eventLoopCount); //Don't start ~100 threads to run a couple unit tests
         } else {
@@ -852,7 +853,7 @@ public class VertxHttpRecorder {
             @Override
             public Verticle get() {
                 return new WebDeploymentVerticle(httpMainServerOptions, httpMainSslServerOptions, httpMainDomainSocketOptions,
-                        launchMode, insecureRequestStrategy, httpConfiguration, connectionCount, registry, startEventsFired);
+                        launchMode, insecureRequestStrategy, httpConfig, connectionCount, registry, startEventsFired);
             }
         }, new DeploymentOptions().setInstances(ioThreads), new Handler<AsyncResult<String>>() {
             @Override
@@ -885,9 +886,9 @@ public class VertxHttpRecorder {
         return futureResult;
     }
 
-    private static void doServerStart(Vertx vertx, HttpBuildTimeConfig httpBuildTimeConfig,
-            ManagementInterfaceBuildTimeConfig managementBuildTimeConfig, Handler<HttpServerRequest> managementRouter,
-            HttpConfiguration httpConfiguration, ManagementInterfaceConfiguration managementConfig,
+    private static void doServerStart(Vertx vertx, VertxHttpBuildTimeConfig httpBuildTimeConfig,
+            ManagementBuildTimeConfig managementBuildTimeConfig, Handler<HttpServerRequest> managementRouter,
+            VertxHttpConfig httpConfig, ManagementConfig managementConfig,
             LaunchMode launchMode,
             Supplier<Integer> eventLoops, List<String> websocketSubProtocols,
             InsecureRequests insecureRequestStrategy,
@@ -898,7 +899,7 @@ public class VertxHttpRecorder {
             registry = Arc.container().select(TlsConfigurationRegistry.class).orNull();
         }
 
-        var mainServerFuture = initializeMainHttpServer(vertx, httpBuildTimeConfig, httpConfiguration, launchMode, eventLoops,
+        var mainServerFuture = initializeMainHttpServer(vertx, httpBuildTimeConfig, httpConfig, launchMode, eventLoops,
                 websocketSubProtocols, insecureRequestStrategy, registry);
         var managementInterfaceFuture = initializeManagementInterface(vertx, managementBuildTimeConfig, managementRouter,
                 managementConfig, launchMode, websocketSubProtocols, registry);
@@ -1053,84 +1054,84 @@ public class VertxHttpRecorder {
     }
 
     private static HttpServerOptions createHttpServerOptions(
-            HttpBuildTimeConfig buildTimeConfig, HttpConfiguration httpConfiguration,
+            VertxHttpBuildTimeConfig buildTimeConfig, VertxHttpConfig httpConfig,
             LaunchMode launchMode, List<String> websocketSubProtocols) {
-        if (!httpConfiguration.hostEnabled) {
+        if (!httpConfig.hostEnabled()) {
             return null;
         }
         // TODO other config properties
         HttpServerOptions options = new HttpServerOptions();
-        int port = httpConfiguration.determinePort(launchMode);
+        int port = httpConfig.determinePort(launchMode);
         options.setPort(port == 0 ? RANDOM_PORT_MAIN_HTTP : port);
 
-        HttpServerOptionsUtils.applyCommonOptions(options, buildTimeConfig, httpConfiguration, websocketSubProtocols);
+        HttpServerOptionsUtils.applyCommonOptions(options, buildTimeConfig, httpConfig, websocketSubProtocols);
 
-        httpConfiguration.websocketServer.maxFrameSize.ifPresent(s -> options.setMaxWebSocketFrameSize(s));
-        httpConfiguration.websocketServer.maxMessageSize.ifPresent(s -> options.setMaxWebSocketMessageSize(s));
+        httpConfig.websocketServer().maxFrameSize().ifPresent(s -> options.setMaxWebSocketFrameSize(s));
+        httpConfig.websocketServer().maxMessageSize().ifPresent(s -> options.setMaxWebSocketMessageSize(s));
 
         return options;
     }
 
     private static HttpServerOptions createHttpServerOptionsForManagementInterface(
-            ManagementInterfaceBuildTimeConfig buildTimeConfig, ManagementInterfaceConfiguration httpConfiguration,
+            ManagementBuildTimeConfig buildTimeConfig, ManagementConfig httpConfig,
             LaunchMode launchMode, List<String> websocketSubProtocols) {
-        if (!httpConfiguration.hostEnabled) {
+        if (!httpConfig.hostEnabled()) {
             return null;
         }
         HttpServerOptions options = new HttpServerOptions();
-        int port = httpConfiguration.determinePort(launchMode);
+        int port = httpConfig.determinePort(launchMode);
         options.setPort(port == 0 ? RANDOM_PORT_MANAGEMENT : port);
 
-        HttpServerOptionsUtils.applyCommonOptionsForManagementInterface(options, buildTimeConfig, httpConfiguration,
+        HttpServerOptionsUtils.applyCommonOptionsForManagementInterface(options, buildTimeConfig, httpConfig,
                 websocketSubProtocols);
 
         return options;
     }
 
     private static HttpServerOptions createDomainSocketOptions(
-            HttpBuildTimeConfig buildTimeConfig, HttpConfiguration httpConfiguration,
+            VertxHttpBuildTimeConfig buildTimeConfig, VertxHttpConfig httpConfig,
             List<String> websocketSubProtocols) {
-        if (!httpConfiguration.domainSocketEnabled) {
+        if (!httpConfig.domainSocketEnabled()) {
             return null;
         }
         HttpServerOptions options = new HttpServerOptions();
 
-        HttpServerOptionsUtils.applyCommonOptions(options, buildTimeConfig, httpConfiguration, websocketSubProtocols);
+        HttpServerOptionsUtils.applyCommonOptions(options, buildTimeConfig, httpConfig, websocketSubProtocols);
         // Override the host (0.0.0.0 by default) with the configured domain socket.
-        options.setHost(httpConfiguration.domainSocket);
+        options.setHost(httpConfig.domainSocket());
 
         // Check if we can write into the domain socket directory
         // We can do this check using a blocking API as the execution is done from the main thread (not an I/O thread)
-        File file = new File(httpConfiguration.domainSocket);
+        File file = new File(httpConfig.domainSocket());
         if (!file.getParentFile().canWrite()) {
             LOGGER.warnf(
                     "Unable to write in the domain socket directory (`%s`). Binding to the socket is likely going to fail.",
-                    httpConfiguration.domainSocket);
+                    httpConfig.domainSocket());
         }
 
         return options;
     }
 
     private static HttpServerOptions createDomainSocketOptionsForManagementInterface(
-            ManagementInterfaceBuildTimeConfig buildTimeConfig, ManagementInterfaceConfiguration httpConfiguration,
+            ManagementBuildTimeConfig buildTimeConfig, ManagementConfig managementConfig,
             List<String> websocketSubProtocols) {
-        if (!httpConfiguration.domainSocketEnabled) {
+        if (!managementConfig.domainSocketEnabled()) {
             return null;
         }
         HttpServerOptions options = new HttpServerOptions();
 
-        HttpServerOptionsUtils.applyCommonOptionsForManagementInterface(options, buildTimeConfig, httpConfiguration,
+        HttpServerOptionsUtils.applyCommonOptionsForManagementInterface(options, buildTimeConfig, managementConfig,
                 websocketSubProtocols);
         // Override the host (0.0.0.0 by default) with the configured domain socket.
-        options.setHost(httpConfiguration.domainSocket);
+        options.setHost(managementConfig.domainSocket());
 
         // Check if we can write into the domain socket directory
         // We can do this check using a blocking API as the execution is done from the main thread (not an I/O thread)
-        File file = new File(httpConfiguration.domainSocket);
+        File file = new File(managementConfig.domainSocket());
         if (!file.getParentFile().canWrite()) {
             LOGGER.warnf(
                     "Unable to write in the domain socket directory (`%s`). Binding to the socket is likely going to fail.",
-                    httpConfiguration.domainSocket);
+                    managementConfig.domainSocket());
         }
 
         return options;
@@ -1191,22 +1192,22 @@ public class VertxHttpRecorder {
         private volatile boolean clearHttpProperty = false;
         private volatile boolean clearHttpsProperty = false;
         private volatile PortSystemProperties portSystemProperties;
-        private final HttpConfiguration.InsecureRequests insecureRequests;
-        private final HttpConfiguration quarkusConfig;
+        private final InsecureRequests insecureRequests;
+        private final VertxHttpConfig quarkusConfig;
         private final AtomicInteger connectionCount;
         private final List<Long> reloadingTasks = new CopyOnWriteArrayList<>();
         private final AtomicBoolean startEventsFired;
 
         public WebDeploymentVerticle(HttpServerOptions httpOptions, HttpServerOptions httpsOptions,
                 HttpServerOptions domainSocketOptions, LaunchMode launchMode,
-                InsecureRequests insecureRequests, HttpConfiguration quarkusConfig, AtomicInteger connectionCount,
+                InsecureRequests insecureRequests, VertxHttpConfig httpConfig, AtomicInteger connectionCount,
                 TlsConfigurationRegistry registry, AtomicBoolean startEventsFired) {
             this.httpOptions = httpOptions;
             this.httpsOptions = httpsOptions;
             this.launchMode = launchMode;
             this.domainSocketOptions = domainSocketOptions;
             this.insecureRequests = insecureRequests;
-            this.quarkusConfig = quarkusConfig;
+            this.quarkusConfig = httpConfig;
             this.connectionCount = connectionCount;
             this.registry = registry;
             this.startEventsFired = startEventsFired;
@@ -1218,7 +1219,7 @@ public class VertxHttpRecorder {
             assert Context.isOnEventLoopThread();
 
             final AtomicInteger remainingCount = new AtomicInteger(0);
-            boolean httpServerEnabled = httpOptions != null && insecureRequests != HttpConfiguration.InsecureRequests.DISABLED;
+            boolean httpServerEnabled = httpOptions != null && insecureRequests != InsecureRequests.DISABLED;
             if (httpServerEnabled) {
                 remainingCount.incrementAndGet();
             }
@@ -1239,7 +1240,7 @@ public class VertxHttpRecorder {
 
             if (httpServerEnabled) {
                 httpServer = vertx.createHttpServer(httpOptions);
-                if (insecureRequests == HttpConfiguration.InsecureRequests.ENABLED) {
+                if (insecureRequests == InsecureRequests.ENABLED) {
                     httpServer.requestHandler(ACTUAL_ROOT);
                 } else {
                     httpServer.requestHandler(new Handler<HttpServerRequest>() {
@@ -1321,12 +1322,12 @@ public class VertxHttpRecorder {
                 Promise<Void> startFuture, AtomicInteger remainingCount, AtomicInteger currentConnectionCount,
                 ArcContainer container, boolean notifyStartObservers) {
 
-            if (quarkusConfig.limits.maxConnections.isPresent() && quarkusConfig.limits.maxConnections.getAsInt() > 0) {
+            if (quarkusConfig.limits().maxConnections().isPresent() && quarkusConfig.limits().maxConnections().getAsInt() > 0) {
                 var tracker = vertx.isMetricsEnabled()
                         ? ((ExtendedQuarkusVertxHttpMetrics) ((VertxInternal) vertx).metricsSPI()).getHttpConnectionTracker()
                         : ExtendedQuarkusVertxHttpMetrics.NOOP_CONNECTION_TRACKER;
 
-                final int maxConnections = quarkusConfig.limits.maxConnections.getAsInt();
+                final int maxConnections = quarkusConfig.limits().maxConnections().getAsInt();
                 tracker.initialize(maxConnections, currentConnectionCount);
                 httpServer.connectionHandler(new Handler<HttpConnection>() {
 
@@ -1384,11 +1385,11 @@ public class VertxHttpRecorder {
                             portSystemProperties.set(schema, actualPort, launchMode);
                         }
 
-                        if (https && (quarkusConfig.ssl.certificate.reloadPeriod.isPresent())) {
+                        if (https && (quarkusConfig.ssl().certificate().reloadPeriod().isPresent())) {
                             try {
                                 long l = TlsCertificateReloader.initCertReloadingAction(
-                                        vertx, httpsServer, httpsOptions, quarkusConfig.ssl, registry,
-                                        quarkusConfig.tlsConfigurationName);
+                                        vertx, httpsServer, httpsOptions, quarkusConfig.ssl(), registry,
+                                        quarkusConfig.tlsConfigurationName());
                                 if (l != -1) {
                                     reloadingTasks.add(l);
                                 }
@@ -1400,7 +1401,8 @@ public class VertxHttpRecorder {
 
                         if (https) {
                             container.instance(HttpCertificateUpdateEventListener.class).get()
-                                    .register(event.result(), quarkusConfig.tlsConfigurationName.orElse(TlsConfig.DEFAULT_NAME),
+                                    .register(event.result(),
+                                            quarkusConfig.tlsConfigurationName().orElse(TlsConfig.DEFAULT_NAME),
                                             "http server");
                         }
 
@@ -1582,11 +1584,11 @@ public class VertxHttpRecorder {
         if (maxBodySize.isPresent()) {
             bodyHandler.setBodyLimit(maxBodySize.get().asLongValue());
         }
-        bodyHandler.setHandleFileUploads(bodyConfig.handleFileUploads);
-        bodyHandler.setUploadsDirectory(bodyConfig.uploadsDirectory);
-        bodyHandler.setDeleteUploadedFilesOnEnd(bodyConfig.deleteUploadedFilesOnEnd);
-        bodyHandler.setMergeFormAttributes(bodyConfig.mergeFormAttributes);
-        bodyHandler.setPreallocateBodyBuffer(bodyConfig.preallocateBodyBuffer);
+        bodyHandler.setHandleFileUploads(bodyConfig.handleFileUploads());
+        bodyHandler.setUploadsDirectory(bodyConfig.uploadsDirectory());
+        bodyHandler.setDeleteUploadedFilesOnEnd(bodyConfig.deleteUploadedFilesOnEnd());
+        bodyHandler.setMergeFormAttributes(bodyConfig.mergeFormAttributes());
+        bodyHandler.setPreallocateBodyBuffer(bodyConfig.preallocateBodyBuffer());
         return new Handler<RoutingContext>() {
             @Override
             public void handle(RoutingContext event) {
@@ -1626,42 +1628,42 @@ public class VertxHttpRecorder {
     }
 
     public Handler<RoutingContext> createBodyHandler() {
-        Optional<MemorySize> maxBodySize = httpConfiguration.getValue().limits.maxBodySize;
-        return configureAndGetBody(maxBodySize, httpConfiguration.getValue().body);
+        Optional<MemorySize> maxBodySize = httpConfig.getValue().limits().maxBodySize();
+        return configureAndGetBody(maxBodySize, httpConfig.getValue().body());
     }
 
     public Handler<RoutingContext> createBodyHandlerForManagementInterface() {
-        Optional<MemorySize> maxBodySize = managementConfiguration.getValue().limits.maxBodySize;
-        return configureAndGetBody(maxBodySize, managementConfiguration.getValue().body);
+        Optional<MemorySize> maxBodySize = managementConfig.getValue().limits().maxBodySize();
+        return configureAndGetBody(maxBodySize, managementConfig.getValue().body());
     }
 
     private static final List<HttpMethod> CAN_HAVE_BODY = Arrays.asList(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH,
             HttpMethod.DELETE);
 
-    private BiConsumer<Cookie, HttpServerRequest> processSameSiteConfig(Map<String, SameSiteCookieConfig> httpConfiguration) {
+    private BiConsumer<Cookie, HttpServerRequest> processSameSiteConfig(Map<String, SameSiteCookieConfig> cookieConfig) {
 
         List<BiFunction<Cookie, HttpServerRequest, Boolean>> functions = new ArrayList<>();
         BiFunction<Cookie, HttpServerRequest, Boolean> last = null;
 
-        for (Map.Entry<String, SameSiteCookieConfig> entry : new TreeMap<>(httpConfiguration).entrySet()) {
-            Pattern p = Pattern.compile(entry.getKey(), entry.getValue().caseSensitive ? 0 : Pattern.CASE_INSENSITIVE);
+        for (Map.Entry<String, SameSiteCookieConfig> entry : new TreeMap<>(cookieConfig).entrySet()) {
+            Pattern p = Pattern.compile(entry.getKey(), entry.getValue().caseSensitive() ? 0 : Pattern.CASE_INSENSITIVE);
             BiFunction<Cookie, HttpServerRequest, Boolean> biFunction = new BiFunction<Cookie, HttpServerRequest, Boolean>() {
                 @Override
                 public Boolean apply(Cookie cookie, HttpServerRequest request) {
                     if (p.matcher(cookie.getName()).matches()) {
-                        if (entry.getValue().value == CookieSameSite.NONE) {
-                            if (entry.getValue().enableClientChecker) {
+                        if (entry.getValue().value() == CookieSameSite.NONE) {
+                            if (entry.getValue().enableClientChecker()) {
                                 String userAgent = request.getHeader(HttpHeaders.USER_AGENT);
                                 if (userAgent != null
                                         && SameSiteNoneIncompatibleClientChecker.isSameSiteNoneIncompatible(userAgent)) {
                                     return false;
                                 }
                             }
-                            if (entry.getValue().addSecureForNone) {
+                            if (entry.getValue().addSecureForNone()) {
                                 cookie.setSecure(true);
                             }
                         }
-                        cookie.setSameSite(entry.getValue().value);
+                        cookie.setSameSite(entry.getValue().value());
                         return true;
                     }
                     return false;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/WebsocketServerConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/WebsocketServerConfig.java
@@ -2,31 +2,23 @@ package io.quarkus.vertx.http.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-
 /**
  * Configure the Vert.X HTTP Server for WebSocker Server connection.
  */
-@ConfigGroup
-public class WebsocketServerConfig {
-
+public interface WebsocketServerConfig {
     /**
      * The maximum amount of data that can be sent in a single frame.
-     *
+     * <p>
      * Messages larger than this must be broken up into continuation frames.
-     *
+     * <p>
      * Default 65536 (from HttpServerOptions of Vert.X HttpServerOptions)
      */
-    @ConfigItem
-    public Optional<Integer> maxFrameSize;
+    Optional<Integer> maxFrameSize();
 
     /**
      * The maximum WebSocket message size.
-     *
+     * <p>
      * Default 262144 (from HttpServerOptions of Vert.X HttpServerOptions)
      */
-    @ConfigItem
-    public Optional<Integer> maxMessageSize;
-
+    Optional<Integer> maxMessageSize();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/ResponseTimeAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/ResponseTimeAttribute.java
@@ -2,13 +2,14 @@ package io.quarkus.vertx.http.runtime.attribute;
 
 import java.util.concurrent.TimeUnit;
 
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 import io.vertx.ext.web.RoutingContext;
 
 /**
  * The response time
- *
- * This will only work if {@link io.quarkus.vertx.http.runtime.HttpConfiguration#recordRequestStartTime} has been set
+ * <p>
+ * This will only work if {@link VertxHttpConfig#recordRequestStartTime} has been set
  */
 public class ResponseTimeAttribute implements ExchangeAttribute {
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
@@ -4,88 +4,62 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
 
-@ConfigGroup
-public class CORSConfig {
-
+public interface CORSConfig {
     /**
      * The origins allowed for CORS.
-     *
+     * <p>
      * A comma-separated list of valid URLs, such as `http://www.quarkus.io,http://localhost:3000`.
      * URLs enclosed in forward slashes are interpreted as regular expressions.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> origins = Optional.empty();
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> origins();
 
     /**
      * The HTTP methods allowed for CORS requests.
-     *
+     * <p>
      * A comma-separated list of valid HTTP methods, such as `GET,PUT,POST`.
      * If not set, the filter allows any HTTP method by default.
-     *
+     * <p>
      * Default: Any HTTP request method is allowed.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> methods = Optional.empty();
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> methods();
 
     /**
      * The HTTP headers allowed for CORS requests.
-     *
+     * <p>
      * A comma-separated list of valid headers, such as `X-Custom,Content-Disposition`.
      * If not set, the filter allows any header by default.
-     *
+     * <p>
      * Default: Any HTTP request header is allowed.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> headers = Optional.empty();
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> headers();
 
     /**
      * The HTTP headers exposed in CORS responses.
-     *
+     * <p>
      * A comma-separated list of headers to expose, such as `X-Custom,Content-Disposition`.
-     *
+     * <p>
      * Default: No headers are exposed.
      */
-    @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<List<String>> exposedHeaders = Optional.empty();
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> exposedHeaders();
 
     /**
      * The `Access-Control-Max-Age` response header value in {@link java.time.Duration} format.
-     *
+     * <p>
      * Informs the browser how long it can cache the results of a preflight request.
      */
-    @ConfigItem
-    public Optional<Duration> accessControlMaxAge = Optional.empty();
+    Optional<Duration> accessControlMaxAge();
 
     /**
      * The `Access-Control-Allow-Credentials` response header.
-     *
+     * <p>
      * Tells browsers if front-end JavaScript can be allowed to access credentials when the request's credentials mode,
      * `Request.credentials`, is set to `include`.
-     *
+     * <p>
      * Default: `true` if the `quarkus.http.cors.origins` property is set
      * and matches the precise `Origin` header value.
      */
-    @ConfigItem
-    public Optional<Boolean> accessControlAllowCredentials = Optional.empty();
-
-    @Override
-    public String toString() {
-        return "CORSConfig{" +
-                "origins=" + origins +
-                ", methods=" + methods +
-                ", headers=" + headers +
-                ", exposedHeaders=" + exposedHeaders +
-                ", accessControlMaxAge=" + accessControlMaxAge +
-                ", accessControlAllowCredentials=" + accessControlAllowCredentials +
-                '}';
-    }
+    Optional<Boolean> accessControlAllowCredentials();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -39,13 +39,13 @@ public class CORSFilter implements Handler<RoutingContext> {
 
     public CORSFilter(CORSConfig corsConfig) {
         this.corsConfig = corsConfig;
-        this.wildcardOrigin = isOriginConfiguredWithWildcard(this.corsConfig.origins);
-        this.wildcardMethod = isConfiguredWithWildcard(corsConfig.methods);
-        this.allowedOriginsRegex = this.wildcardOrigin ? List.of() : parseAllowedOriginsRegex(this.corsConfig.origins);
-        this.configuredHttpMethods = createConfiguredHttpMethods(this.corsConfig.methods);
-        this.exposedHeaders = createHeaderString(this.corsConfig.exposedHeaders);
-        this.allowedHeaders = createHeaderString(this.corsConfig.headers);
-        this.allowedMethods = createHeaderString(this.corsConfig.methods);
+        this.wildcardOrigin = isOriginConfiguredWithWildcard(this.corsConfig.origins());
+        this.wildcardMethod = isConfiguredWithWildcard(corsConfig.methods());
+        this.allowedOriginsRegex = this.wildcardOrigin ? List.of() : parseAllowedOriginsRegex(this.corsConfig.origins());
+        this.configuredHttpMethods = createConfiguredHttpMethods(this.corsConfig.methods());
+        this.exposedHeaders = createHeaderString(this.corsConfig.exposedHeaders());
+        this.allowedHeaders = createHeaderString(this.corsConfig.headers());
+        this.allowedMethods = createHeaderString(this.corsConfig.methods());
     }
 
     private String createHeaderString(Optional<List<String>> headers) {
@@ -146,10 +146,10 @@ public class CORSFilter implements Handler<RoutingContext> {
 
             //for both normal and preflight requests we need to check the origin
             boolean allowsOrigin = wildcardOrigin;
-            boolean originMatches = !wildcardOrigin && corsConfig.origins.isPresent() &&
-                    (corsConfig.origins.get().contains(origin) || isOriginAllowedByRegex(allowedOriginsRegex, origin));
+            boolean originMatches = !wildcardOrigin && corsConfig.origins().isPresent() &&
+                    (corsConfig.origins().get().contains(origin) || isOriginAllowedByRegex(allowedOriginsRegex, origin));
             if (!allowsOrigin) {
-                if (corsConfig.origins.isPresent()) {
+                if (corsConfig.origins().isPresent()) {
                     allowsOrigin = originMatches || isSameOrigin(request, origin);
                 } else {
                     allowsOrigin = isSameOrigin(request, origin);
@@ -160,7 +160,7 @@ public class CORSFilter implements Handler<RoutingContext> {
                 response.setStatusCode(403);
                 response.setStatusMessage("CORS Rejected - Invalid origin");
             } else {
-                boolean allowCredentials = corsConfig.accessControlAllowCredentials.orElse(originMatches);
+                boolean allowCredentials = corsConfig.accessControlAllowCredentials().orElse(originMatches);
                 response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, String.valueOf(allowCredentials));
                 response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
             }
@@ -209,9 +209,9 @@ public class CORSFilter implements Handler<RoutingContext> {
             boolean allowsOrigin) {
         //see https://fetch.spec.whatwg.org/#http-cors-protocol
 
-        if (corsConfig.accessControlMaxAge.isPresent()) {
+        if (corsConfig.accessControlMaxAge().isPresent()) {
             event.response().putHeader(HttpHeaders.ACCESS_CONTROL_MAX_AGE,
-                    String.valueOf(corsConfig.accessControlMaxAge.get().getSeconds()));
+                    String.valueOf(corsConfig.accessControlMaxAge().get().getSeconds()));
         }
         var response = event.response();
         if (requestedMethods != null) {
@@ -315,7 +315,7 @@ public class CORSFilter implements Handler<RoutingContext> {
     }
 
     private void processPreFlightRequestedHeaders(HttpServerResponse response, String allowHeadersValue) {
-        if (isConfiguredWithWildcard(corsConfig.headers)) {
+        if (isConfiguredWithWildcard(corsConfig.headers())) {
             response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, allowHeadersValue);
         } else {
             response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, allowedHeaders);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSRecorder.java
@@ -1,21 +1,21 @@
 package io.quarkus.vertx.http.runtime.cors;
 
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class CORSRecorder {
-    final HttpConfiguration configuration;
+    final VertxHttpConfig httpConfig;
 
-    public CORSRecorder(HttpConfiguration configuration) {
-        this.configuration = configuration;
+    public CORSRecorder(VertxHttpConfig httpConfig) {
+        this.httpConfig = httpConfig;
     }
 
     public Handler<RoutingContext> corsHandler() {
-        if (configuration.corsEnabled) {
-            return new CORSFilter(configuration.cors);
+        if (httpConfig.corsEnabled()) {
+            return new CORSFilter(httpConfig.cors());
         }
         return null;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/handlers/DevClasspathStaticHandlerOptions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/handlers/DevClasspathStaticHandlerOptions.java
@@ -2,13 +2,13 @@ package io.quarkus.vertx.http.runtime.handlers;
 
 import java.nio.charset.Charset;
 
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 
-public record DevClasspathStaticHandlerOptions(HttpBuildTimeConfig httpBuildTimeConfig, String indexPage,
+public record DevClasspathStaticHandlerOptions(VertxHttpBuildTimeConfig httpBuildTimeConfig, String indexPage,
         Charset defaultEncoding) {
 
     public static class Builder {
-        private HttpBuildTimeConfig httpBuildTimeConfig;
+        private VertxHttpBuildTimeConfig httpBuildTimeConfig;
         private String indexPage;
         private Charset contentEncoding;
 
@@ -22,7 +22,7 @@ public record DevClasspathStaticHandlerOptions(HttpBuildTimeConfig httpBuildTime
             return this;
         }
 
-        public Builder httpBuildTimeConfig(HttpBuildTimeConfig httpBuildTimeConfig) {
+        public Builder httpBuildTimeConfig(VertxHttpBuildTimeConfig httpBuildTimeConfig) {
             this.httpBuildTimeConfig = httpBuildTimeConfig;
             return this;
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/handlers/DevStaticHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/handlers/DevStaticHandler.java
@@ -13,7 +13,7 @@ import org.jboss.logging.Logger;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.vertx.http.runtime.GeneratedStaticResourcesRecorder;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
@@ -39,15 +39,15 @@ public class DevStaticHandler implements Handler<RoutingContext> {
     private final ClassLoader currentClassLoader;
     private final String indexPage;
     private final Charset defaultEncoding;
-    private final HttpBuildTimeConfig httpBuildTimeConfig;
+    private final VertxHttpBuildTimeConfig httpBuildTimeConfig;
 
     public DevStaticHandler(Set<String> generatedClasspathResources, Map<String, String> generatedFilesResources,
             DevClasspathStaticHandlerOptions options) {
         this.generatedClasspathResources = generatedClasspathResources;
         this.generatedFilesResources = generatedFilesResources;
         httpBuildTimeConfig = options.httpBuildTimeConfig();
-        if (httpBuildTimeConfig.enableCompression && httpBuildTimeConfig.compressMediaTypes.isPresent()) {
-            this.compressMediaTypes = Set.copyOf(httpBuildTimeConfig.compressMediaTypes.get());
+        if (httpBuildTimeConfig.enableCompression() && httpBuildTimeConfig.compressMediaTypes().isPresent()) {
+            this.compressMediaTypes = Set.copyOf(httpBuildTimeConfig.compressMediaTypes().get());
         } else {
             this.compressMediaTypes = Set.of();
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementAuthConfig.java
@@ -2,35 +2,30 @@ package io.quarkus.vertx.http.runtime.management;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 /**
  * Authentication for the management interface.
  */
-@ConfigGroup
-public class ManagementAuthConfig {
-
+public interface ManagementAuthConfig {
     /**
      * If authentication for the management interface should be enabled.
      */
-    @ConfigItem(defaultValue = "${quarkus.management.auth.basic:false}")
-    public boolean enabled;
+    @WithDefault("${quarkus.management.auth.basic:false}")
+    boolean enabled();
 
     /**
      * If basic auth should be enabled.
-     *
      */
-    @ConfigItem
-    public Optional<Boolean> basic;
+    Optional<Boolean> basic();
 
     /**
      * If this is true and credentials are present then a user will always be authenticated
      * before the request progresses.
-     *
+     * <p>
      * If this is false then an attempt will only be made to authenticate the user if a permission
      * check is performed or the current user is required for some other reason.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean proactive;
+    @WithDefault("true")
+    boolean proactive();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementBuildTimeConfig.java
@@ -2,43 +2,46 @@ package io.quarkus.vertx.http.runtime.management;
 
 import java.util.OptionalInt;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 import io.vertx.core.http.ClientAuth;
 
 /**
  * Management interface configuration.
  */
-@ConfigRoot(name = "management", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class ManagementInterfaceBuildTimeConfig {
-
+@ConfigMapping(prefix = "quarkus.management")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface ManagementBuildTimeConfig {
     /**
      * Enables / Disables the usage of a separate interface/port to expose the management endpoints.
      * If sets to {@code true}, the management endpoints will be exposed to a different HTTP server.
-     * This avoids exposing the management endpoints on a publicly available server.
+     * This avoids exposing the management endpoints on a y available server(.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enabled;
+    @WithDefault("false")
+    boolean enabled();
 
     /**
      * Authentication configuration
      */
-    public ManagementAuthConfig auth;
+    ManagementAuthConfig auth();
 
     /**
      * Configures the engine to require/request client authentication.
      * NONE, REQUEST, REQUIRED
      */
-    @ConfigItem(name = "ssl.client-auth", defaultValue = "NONE")
-    public ClientAuth tlsClientAuth;
+    @WithName("ssl.client-auth")
+    @WithDefault("NONE")
+    ClientAuth tlsClientAuth();
 
     /**
      * A common root path for management endpoints. Various extension-provided management endpoints such as metrics
      * and health are deployed under this path by default.
      */
-    @ConfigItem(defaultValue = "/q")
-    public String rootPath;
+    @WithDefault("/q")
+    String rootPath();
 
     /**
      * If responses should be compressed.
@@ -50,8 +53,8 @@ public class ManagementInterfaceBuildTimeConfig {
      * <p>
      * Which will tell vert.x not to compress the response.
      */
-    @ConfigItem
-    public boolean enableCompression;
+    @WithDefault("false")
+    boolean enableCompression();
 
     /**
      * When enabled, vert.x will decompress the request's body if it's compressed.
@@ -59,12 +62,11 @@ public class ManagementInterfaceBuildTimeConfig {
      * Note that the compression format (e.g., gzip) must be specified in the Content-Encoding header
      * in the request.
      */
-    @ConfigItem
-    public boolean enableDecompression;
+    @WithDefault("false")
+    boolean enableDecompression();
 
     /**
      * The compression level used when compression support is enabled.
      */
-    @ConfigItem
-    public OptionalInt compressionLevel;
+    OptionalInt compressionLevel();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.LaunchMode;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.vertx.http.runtime.BodyConfig;
@@ -14,31 +13,34 @@ import io.quarkus.vertx.http.runtime.HeaderConfig;
 import io.quarkus.vertx.http.runtime.ProxyConfig;
 import io.quarkus.vertx.http.runtime.ServerLimitsConfig;
 import io.quarkus.vertx.http.runtime.ServerSslConfig;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * Configures the management interface.
  * Note that the management interface must be enabled using the
- * {@link ManagementInterfaceBuildTimeConfig#enabled} build-time property.
+ * {@link ManagementBuildTimeConfig#enabled} build-time property.
  */
-@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "management")
-public class ManagementInterfaceConfiguration {
-
+@ConfigMapping(prefix = "quarkus.management")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface ManagementConfig {
     /**
      * Authentication configuration
      */
-    public ManagementRuntimeAuthConfig auth;
+    ManagementRuntimeAuthConfig auth();
 
     /**
      * The HTTP port
      */
-    @ConfigItem(defaultValue = "9000")
-    public int port;
+    @WithDefault("9000")
+    int port();
 
     /**
      * The HTTP port
      */
-    @ConfigItem(defaultValue = "9001")
-    public int testPort;
+    @WithDefault("9001")
+    int testPort();
 
     /**
      * The HTTP host
@@ -53,19 +55,18 @@ public class ManagementInterfaceConfiguration {
      * defaults to 0.0.0.0 even in dev/test mode since using localhost makes the application
      * inaccessible.
      */
-    @ConfigItem
-    public String host;
+    String host();
 
     /**
      * Enable listening to host:port
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean hostEnabled;
+    @WithDefault("true")
+    boolean hostEnabled();
 
     /**
      * The SSL config
      */
-    public ServerSslConfig ssl;
+    ServerSslConfig ssl();
 
     /**
      * The name of the TLS configuration to use.
@@ -76,66 +77,66 @@ public class ManagementInterfaceConfiguration {
      * <p>
      * If no TLS configuration is set, and {@code quarkus.tls.*} is not configured, then, `quarkus.management.ssl` will be used.
      */
-    @ConfigItem
-    public Optional<String> tlsConfigurationName;
+    Optional<String> tlsConfigurationName();
 
     /**
      * When set to {@code true}, the HTTP server automatically sends `100 CONTINUE`
      * response when the request expects it (with the `Expect: 100-Continue` header).
      */
-    @ConfigItem(defaultValue = "false", name = "handle-100-continue-automatically")
-    public boolean handle100ContinueAutomatically;
+    @WithName("handle-100-continue-automatically")
+    @WithDefault("false")
+    boolean handle100ContinueAutomatically();
 
     /**
      * Server limits configuration
      */
-    public ServerLimitsConfig limits;
+    ServerLimitsConfig limits();
 
     /**
      * Http connection idle timeout
      */
-    @ConfigItem(defaultValue = "30M", name = "idle-timeout")
-    public Duration idleTimeout;
+    @WithDefault("30M")
+    Duration idleTimeout();
 
     /**
      * Request body related settings
      */
-    public BodyConfig body;
+    BodyConfig body();
 
     /**
      * The accept backlog, this is how many connections can be waiting to be accepted before connections start being rejected
      */
-    @ConfigItem(defaultValue = "-1")
-    public int acceptBacklog;
+    @WithDefault("-1")
+    int acceptBacklog();
 
     /**
      * Path to a unix domain socket
      */
-    @ConfigItem(defaultValue = "/var/run/io.quarkus.management.socket")
-    public String domainSocket;
+    @WithDefault("/var/run/io.quarkus.management.socket")
+    String domainSocket();
 
     /**
      * Enable listening to host:port
      */
-    @ConfigItem
-    public boolean domainSocketEnabled;
+    @WithDefault("false")
+    boolean domainSocketEnabled();
 
     /**
      * Additional HTTP Headers always sent in the response
      */
-    @ConfigItem
-    public Map<String, HeaderConfig> header;
+    Map<String, HeaderConfig> header();
 
     /**
      * Additional HTTP configuration per path
      */
-    @ConfigItem
-    public Map<String, FilterConfig> filter;
+    Map<String, FilterConfig> filter();
 
-    public ProxyConfig proxy;
+    /**
+     * Holds configuration related with proxy addressing forward.
+     */
+    ProxyConfig proxy();
 
-    public int determinePort(LaunchMode launchMode) {
-        return launchMode == LaunchMode.TEST ? testPort : port;
+    default int determinePort(LaunchMode launchMode) {
+        return launchMode == LaunchMode.TEST ? testPort() : port();
     }
-
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementRuntimeAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementRuntimeAuthConfig.java
@@ -4,28 +4,25 @@ import java.util.List;
 import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.vertx.http.runtime.PolicyConfig;
 import io.quarkus.vertx.http.runtime.PolicyMappingConfig;
+import io.smallrye.config.WithName;
 
 /**
  * Authentication for the management interface.
  */
-@ConfigGroup
-public class ManagementRuntimeAuthConfig {
-
+public interface ManagementRuntimeAuthConfig {
     /**
      * The HTTP permissions
      */
-    @ConfigItem(name = "permission")
-    public Map<String, PolicyMappingConfig> permissions;
+    @WithName("permission")
+    Map<String, PolicyMappingConfig> permissions();
 
     /**
      * The HTTP role based policies
      */
-    @ConfigItem(name = "policy")
-    public Map<String, PolicyConfig> rolePolicy;
+    @WithName("policy")
+    Map<String, PolicyConfig> rolePolicy();
 
     /**
      * Map the `SecurityIdentity` roles to deployment specific roles and add the matching roles to `SecurityIdentity`.
@@ -34,7 +31,6 @@ public class ManagementRuntimeAuthConfig {
      * use this property to map the `user` role to the `UserRole` role, and have `SecurityIdentity` to have
      * both `user` and `UserRole` roles.
      */
-    @ConfigItem
     @ConfigDocMapKey("role-name")
-    public Map<String, List<String>> rolesMapping;
+    Map<String, List<String>> rolesMapping();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementSecurityRecorder.java
@@ -15,7 +15,7 @@ import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
 @Recorder
-public class ManagementInterfaceSecurityRecorder {
+public class ManagementSecurityRecorder {
 
     public RuntimeValue<AuthenticationHandler> managementAuthenticationHandler(boolean proactiveAuthentication) {
         return new RuntimeValue<>(new AuthenticationHandler(proactiveAuthentication));
@@ -26,9 +26,9 @@ public class ManagementInterfaceSecurityRecorder {
     }
 
     public void initializeAuthenticationHandler(RuntimeValue<AuthenticationHandler> handler,
-            ManagementInterfaceConfiguration runTimeConfig) {
+            ManagementConfig managementConfig) {
         handler.getValue().init(ManagementPathMatchingHttpSecurityPolicy.class,
-                RolesMapping.of(runTimeConfig.auth.rolesMapping));
+                RolesMapping.of(managementConfig.auth().rolesMapping()));
     }
 
     public Handler<RoutingContext> permissionCheckHandler() {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
@@ -34,8 +34,8 @@ import io.vertx.ext.web.RoutingContext;
 
 public class HttpServerCommonHandlers {
     public static void enforceMaxBodySize(ServerLimitsConfig limits, Router httpRouteRouter) {
-        if (limits.maxBodySize.isPresent()) {
-            long limit = limits.maxBodySize.get().asLongValue();
+        if (limits.maxBodySize().isPresent()) {
+            long limit = limits.maxBodySize().get().asLongValue();
             Long limitObj = limit;
             httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_UPLOAD_LIMIT).handler(new Handler<RoutingContext>() {
                 @Override
@@ -92,7 +92,7 @@ public class HttpServerCommonHandlers {
 
     public static Handler<HttpServerRequest> applyProxy(ProxyConfig proxyConfig, Handler<HttpServerRequest> root,
             Supplier<Vertx> vertx) {
-        if (proxyConfig.proxyAddressForwarding) {
+        if (proxyConfig.proxyAddressForwarding()) {
             final ForwardingProxyOptions forwardingProxyOptions = ForwardingProxyOptions.from(proxyConfig);
             final TrustedProxyCheck.TrustedProxyCheckBuilder proxyCheckBuilder = forwardingProxyOptions.trustedProxyCheckBuilder;
             if (proxyCheckBuilder == null) {
@@ -116,10 +116,10 @@ public class HttpServerCommonHandlers {
         if (!filtersInConfig.isEmpty()) {
             for (var entry : filtersInConfig.entrySet()) {
                 var filterConfig = entry.getValue();
-                var matches = filterConfig.matches;
-                var order = filterConfig.order.orElse(Integer.MIN_VALUE);
-                var methods = filterConfig.methods;
-                var headers = filterConfig.header;
+                var matches = filterConfig.matches();
+                var order = filterConfig.order().orElse(Integer.MIN_VALUE);
+                var methods = filterConfig.methods();
+                var headers = filterConfig.header();
                 if (methods.isEmpty()) {
                     httpRouteRouter.routeWithRegex(matches)
                             .order(order)
@@ -175,24 +175,24 @@ public class HttpServerCommonHandlers {
             for (Map.Entry<String, HeaderConfig> entry : headers.entrySet()) {
                 var name = entry.getKey();
                 var config = entry.getValue();
-                if (config.methods.isEmpty()) {
-                    httpRouteRouter.route(config.path)
+                if (config.methods().isEmpty()) {
+                    httpRouteRouter.route(config.path())
                             .order(RouteConstants.ROUTE_ORDER_HEADERS)
                             .handler(new Handler<RoutingContext>() {
                                 @Override
                                 public void handle(RoutingContext event) {
-                                    event.response().headers().set(name, config.value);
+                                    event.response().headers().set(name, config.value());
                                     event.next();
                                 }
                             });
                 } else {
-                    for (String method : config.methods.get()) {
-                        httpRouteRouter.route(HttpMethod.valueOf(method.toUpperCase(Locale.ROOT)), config.path)
+                    for (String method : config.methods().get()) {
+                        httpRouteRouter.route(HttpMethod.valueOf(method.toUpperCase(Locale.ROOT)), config.path())
                                 .order(RouteConstants.ROUTE_ORDER_HEADERS)
                                 .handler(new Handler<RoutingContext>() {
                                     @Override
                                     public void handle(RoutingContext event) {
-                                        event.response().headers().add(name, config.value);
+                                        event.response().headers().add(name, config.value());
                                         event.next();
                                     }
                                 });

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -27,11 +27,12 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.runtime.util.ClassPathUtils;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.TlsConfigurationRegistry;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.http.runtime.ServerSslConfig;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig.InsecureRequests;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementConfig;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.Http2Settings;
@@ -66,37 +67,41 @@ public class HttpServerOptionsUtils {
     /**
      * Get an {@code HttpServerOptions} for this server configuration, or null if SSL should not be enabled
      */
-    public static HttpServerOptions createSslOptions(HttpBuildTimeConfig buildTimeConfig, HttpConfiguration httpConfiguration,
-            LaunchMode launchMode, List<String> websocketSubProtocols, TlsConfigurationRegistry registry)
-            throws IOException {
-        if (!httpConfiguration.hostEnabled) {
+    public static HttpServerOptions createSslOptions(
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
+            VertxHttpConfig httpConfig,
+            LaunchMode launchMode,
+            List<String> websocketSubProtocols,
+            TlsConfigurationRegistry registry) throws IOException {
+
+        if (!httpConfig.hostEnabled()) {
             return null;
         }
 
         final HttpServerOptions serverOptions = new HttpServerOptions();
-        int sslPort = httpConfiguration.determineSslPort(launchMode);
+        int sslPort = httpConfig.determineSslPort(launchMode);
         // -2 instead of -1 (see http) to have vert.x assign two different random ports if both http and https shall be random
         serverOptions.setPort(sslPort == 0 ? RANDOM_PORT_MAIN_TLS : sslPort);
-        serverOptions.setClientAuth(buildTimeConfig.tlsClientAuth);
+        serverOptions.setClientAuth(httpBuildTimeConfig.tlsClientAuth());
 
         if (JdkSSLEngineOptions.isAlpnAvailable()) {
-            serverOptions.setUseAlpn(httpConfiguration.http2);
-            if (httpConfiguration.http2) {
+            serverOptions.setUseAlpn(httpConfig.http2());
+            if (httpConfig.http2()) {
                 serverOptions.setAlpnVersions(Arrays.asList(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1));
             }
         }
-        setIdleTimeout(httpConfiguration, serverOptions);
+        setIdleTimeout(httpConfig, serverOptions);
 
-        TlsConfiguration bucket = getTlsConfiguration(httpConfiguration.tlsConfigurationName, registry);
+        TlsConfiguration bucket = getTlsConfiguration(httpConfig.tlsConfigurationName(), registry);
         if (bucket != null) {
             applyTlsConfigurationToHttpServerOptions(bucket, serverOptions);
-            applyCommonOptions(serverOptions, buildTimeConfig, httpConfiguration, websocketSubProtocols);
+            applyCommonOptions(serverOptions, httpBuildTimeConfig, httpConfig, websocketSubProtocols);
             return serverOptions;
         }
 
         // Legacy configuration:
-        applySslConfigToHttpServerOptions(httpConfiguration.ssl, serverOptions);
-        applyCommonOptions(serverOptions, buildTimeConfig, httpConfiguration, websocketSubProtocols);
+        applySslConfigToHttpServerOptions(httpConfig.ssl(), serverOptions);
+        applyCommonOptions(serverOptions, httpBuildTimeConfig, httpConfig, websocketSubProtocols);
 
         return serverOptions;
     }
@@ -120,72 +125,73 @@ public class HttpServerOptionsUtils {
         return bucket;
     }
 
-    private static void applySslConfigToHttpServerOptions(ServerSslConfig httpConfiguration, HttpServerOptions serverOptions)
+    private static void applySslConfigToHttpServerOptions(ServerSslConfig sslConfig, HttpServerOptions serverOptions)
             throws IOException {
-        ServerSslConfig sslConfig = httpConfiguration;
         // credentials provider
         Map<String, String> credentials = Map.of();
-        if (sslConfig.certificate.credentialsProvider.isPresent()) {
-            String beanName = sslConfig.certificate.credentialsProviderName.orElse(null);
+        if (sslConfig.certificate().credentialsProvider().isPresent()) {
+            String beanName = sslConfig.certificate().credentialsProviderName().orElse(null);
             CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(beanName);
-            String name = sslConfig.certificate.credentialsProvider.get();
+            String name = sslConfig.certificate().credentialsProvider().get();
             credentials = credentialsProvider.getCredentials(name);
         }
 
-        final Optional<String> keyStorePassword = getCredential(sslConfig.certificate.keyStorePassword, credentials,
-                sslConfig.certificate.keyStorePasswordKey);
+        final Optional<String> keyStorePassword = getCredential(sslConfig.certificate().keyStorePassword(), credentials,
+                sslConfig.certificate().keyStorePasswordKey());
 
         Optional<String> keyStoreAliasPassword = Optional.empty();
-        if (sslConfig.certificate.keyStoreAliasPassword.isPresent() || sslConfig.certificate.keyStoreKeyPassword.isPresent()
-                || sslConfig.certificate.keyStoreKeyPasswordKey.isPresent()
-                || sslConfig.certificate.keyStoreAliasPasswordKey.isPresent()) {
-            if (sslConfig.certificate.keyStoreKeyPasswordKey.isPresent()
-                    && sslConfig.certificate.keyStoreAliasPasswordKey.isPresent()) {
+        if (sslConfig.certificate().keyStoreAliasPassword().isPresent()
+                || sslConfig.certificate().keyStoreKeyPassword().isPresent()
+                || sslConfig.certificate().keyStoreKeyPasswordKey().isPresent()
+                || sslConfig.certificate().keyStoreAliasPasswordKey().isPresent()) {
+            if (sslConfig.certificate().keyStoreKeyPasswordKey().isPresent()
+                    && sslConfig.certificate().keyStoreAliasPasswordKey().isPresent()) {
                 throw new ConfigurationException(
                         "You cannot specify both `keyStoreKeyPasswordKey` and `keyStoreAliasPasswordKey` - Use `keyStoreAliasPasswordKey` instead");
             }
-            if (sslConfig.certificate.keyStoreAliasPassword.isPresent()
-                    && sslConfig.certificate.keyStoreKeyPassword.isPresent()) {
+            if (sslConfig.certificate().keyStoreAliasPassword().isPresent()
+                    && sslConfig.certificate().keyStoreKeyPassword().isPresent()) {
                 throw new ConfigurationException(
                         "You cannot specify both `keyStoreKeyPassword` and `keyStoreAliasPassword` - Use `keyStoreAliasPassword` instead");
             }
             keyStoreAliasPassword = getCredential(
-                    or(sslConfig.certificate.keyStoreAliasPassword, sslConfig.certificate.keyStoreKeyPassword),
+                    or(sslConfig.certificate().keyStoreAliasPassword(), sslConfig.certificate().keyStoreKeyPassword()),
                     credentials,
-                    or(sslConfig.certificate.keyStoreAliasPasswordKey, sslConfig.certificate.keyStoreKeyPasswordKey));
+                    or(sslConfig.certificate().keyStoreAliasPasswordKey(), sslConfig.certificate().keyStoreKeyPasswordKey()));
         }
 
-        final Optional<String> trustStorePassword = getCredential(sslConfig.certificate.trustStorePassword, credentials,
-                sslConfig.certificate.trustStorePasswordKey);
+        final Optional<String> trustStorePassword = getCredential(sslConfig.certificate().trustStorePassword(), credentials,
+                sslConfig.certificate().trustStorePasswordKey());
 
-        var kso = computeKeyStoreOptions(sslConfig.certificate, keyStorePassword, keyStoreAliasPassword);
+        var kso = computeKeyStoreOptions(sslConfig.certificate(), keyStorePassword, keyStoreAliasPassword);
         if (kso != null) {
             serverOptions.setKeyCertOptions(kso);
         }
 
-        var to = computeTrustOptions(sslConfig.certificate, trustStorePassword);
+        var to = computeTrustOptions(sslConfig.certificate(), trustStorePassword);
         if (to != null) {
             serverOptions.setTrustOptions(to);
         }
 
-        for (String cipher : sslConfig.cipherSuites.orElse(Collections.emptyList())) {
+        for (String cipher : sslConfig.cipherSuites().orElse(Collections.emptyList())) {
             serverOptions.addEnabledCipherSuite(cipher);
         }
 
-        serverOptions.setEnabledSecureTransportProtocols(sslConfig.protocols);
+        serverOptions.setEnabledSecureTransportProtocols(sslConfig.protocols());
         serverOptions.setSsl(true);
-        serverOptions.setSni(sslConfig.sni);
+        serverOptions.setSni(sslConfig.sni());
         setJdkHeapBufferPooling(serverOptions);
     }
 
     /**
      * Get an {@code HttpServerOptions} for this server configuration, or null if SSL should not be enabled
      */
-    public static HttpServerOptions createSslOptionsForManagementInterface(ManagementInterfaceBuildTimeConfig buildTimeConfig,
-            ManagementInterfaceConfiguration httpConfiguration,
+    public static HttpServerOptions createSslOptionsForManagementInterface(
+            ManagementBuildTimeConfig managementBuildTimeConfig,
+            ManagementConfig managementConfig,
             LaunchMode launchMode, List<String> websocketSubProtocols, TlsConfigurationRegistry registry)
             throws IOException {
-        if (!httpConfiguration.hostEnabled) {
+        if (!managementConfig.hostEnabled()) {
             return null;
         }
 
@@ -194,24 +200,26 @@ public class HttpServerOptionsUtils {
             serverOptions.setUseAlpn(true);
             serverOptions.setAlpnVersions(Arrays.asList(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1));
         }
-        int idleTimeout = (int) httpConfiguration.idleTimeout.toMillis();
+        int idleTimeout = (int) managementConfig.idleTimeout().toMillis();
         serverOptions.setIdleTimeout(idleTimeout);
         serverOptions.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
 
-        int sslPort = httpConfiguration.determinePort(launchMode);
+        int sslPort = managementConfig.determinePort(launchMode);
         serverOptions.setPort(sslPort == 0 ? RANDOM_PORT_MANAGEMENT : sslPort);
-        serverOptions.setClientAuth(buildTimeConfig.tlsClientAuth);
+        serverOptions.setClientAuth(managementBuildTimeConfig.tlsClientAuth());
 
-        TlsConfiguration bucket = getTlsConfiguration(httpConfiguration.tlsConfigurationName, registry);
+        TlsConfiguration bucket = getTlsConfiguration(managementConfig.tlsConfigurationName(), registry);
         if (bucket != null) {
             applyTlsConfigurationToHttpServerOptions(bucket, serverOptions);
-            applyCommonOptionsForManagementInterface(serverOptions, buildTimeConfig, httpConfiguration, websocketSubProtocols);
+            applyCommonOptionsForManagementInterface(serverOptions, managementBuildTimeConfig, managementConfig,
+                    websocketSubProtocols);
             return serverOptions;
         }
 
         // Legacy configuration:
-        applySslConfigToHttpServerOptions(httpConfiguration.ssl, serverOptions);
-        applyCommonOptionsForManagementInterface(serverOptions, buildTimeConfig, httpConfiguration, websocketSubProtocols);
+        applySslConfigToHttpServerOptions(managementConfig.ssl(), serverOptions);
+        applyCommonOptionsForManagementInterface(serverOptions, managementBuildTimeConfig, managementConfig,
+                websocketSubProtocols);
 
         return serverOptions;
     }
@@ -272,35 +280,36 @@ public class HttpServerOptionsUtils {
         }
     }
 
-    public static void applyCommonOptions(HttpServerOptions httpServerOptions,
-            HttpBuildTimeConfig buildTimeConfig,
-            HttpConfiguration httpConfiguration,
+    public static void applyCommonOptions(
+            HttpServerOptions httpServerOptions,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
+            VertxHttpConfig httpConfig,
             List<String> websocketSubProtocols) {
-        httpServerOptions.setHost(httpConfiguration.host);
-        setIdleTimeout(httpConfiguration, httpServerOptions);
-        httpServerOptions.setMaxHeaderSize(httpConfiguration.limits.maxHeaderSize.asBigInteger().intValueExact());
-        httpServerOptions.setMaxChunkSize(httpConfiguration.limits.maxChunkSize.asBigInteger().intValueExact());
-        httpServerOptions.setMaxFormAttributeSize(httpConfiguration.limits.maxFormAttributeSize.asBigInteger().intValueExact());
-        httpServerOptions.setMaxFormFields(httpConfiguration.limits.maxFormFields);
-        httpServerOptions.setMaxFormBufferedBytes(httpConfiguration.limits.maxFormBufferedBytes.asBigInteger().intValue());
+        httpServerOptions.setHost(httpConfig.host());
+        setIdleTimeout(httpConfig, httpServerOptions);
+        httpServerOptions.setMaxHeaderSize(httpConfig.limits().maxHeaderSize().asBigInteger().intValueExact());
+        httpServerOptions.setMaxChunkSize(httpConfig.limits().maxChunkSize().asBigInteger().intValueExact());
+        httpServerOptions.setMaxFormAttributeSize(httpConfig.limits().maxFormAttributeSize().asBigInteger().intValueExact());
+        httpServerOptions.setMaxFormFields(httpConfig.limits().maxFormFields());
+        httpServerOptions.setMaxFormBufferedBytes(httpConfig.limits().maxFormBufferedBytes().asBigInteger().intValue());
         httpServerOptions.setWebSocketSubProtocols(websocketSubProtocols);
-        httpServerOptions.setReusePort(httpConfiguration.soReusePort);
-        httpServerOptions.setTcpQuickAck(httpConfiguration.tcpQuickAck);
-        httpServerOptions.setTcpCork(httpConfiguration.tcpCork);
-        httpServerOptions.setAcceptBacklog(httpConfiguration.acceptBacklog);
-        httpServerOptions.setTcpFastOpen(httpConfiguration.tcpFastOpen);
-        httpServerOptions.setCompressionSupported(buildTimeConfig.enableCompression);
-        if (buildTimeConfig.compressionLevel.isPresent()) {
-            httpServerOptions.setCompressionLevel(buildTimeConfig.compressionLevel.getAsInt());
+        httpServerOptions.setReusePort(httpConfig.soReusePort());
+        httpServerOptions.setTcpQuickAck(httpConfig.tcpQuickAck());
+        httpServerOptions.setTcpCork(httpConfig.tcpCork());
+        httpServerOptions.setAcceptBacklog(httpConfig.acceptBacklog());
+        httpServerOptions.setTcpFastOpen(httpConfig.tcpFastOpen());
+        httpServerOptions.setCompressionSupported(httpBuildTimeConfig.enableCompression());
+        if (httpBuildTimeConfig.compressionLevel().isPresent()) {
+            httpServerOptions.setCompressionLevel(httpBuildTimeConfig.compressionLevel().getAsInt());
         }
-        httpServerOptions.setDecompressionSupported(buildTimeConfig.enableDecompression);
-        httpServerOptions.setMaxInitialLineLength(httpConfiguration.limits.maxInitialLineLength);
-        httpServerOptions.setHandle100ContinueAutomatically(httpConfiguration.handle100ContinueAutomatically);
+        httpServerOptions.setDecompressionSupported(httpBuildTimeConfig.enableDecompression());
+        httpServerOptions.setMaxInitialLineLength(httpConfig.limits().maxInitialLineLength());
+        httpServerOptions.setHandle100ContinueAutomatically(httpConfig.handle100ContinueAutomatically());
 
-        if (buildTimeConfig.compressors.isPresent()) {
+        if (httpBuildTimeConfig.compressors().isPresent()) {
             // Adding defaults too, because mere addition of .addCompressor(brotli) actually
             // overrides the default deflate and gzip capability.
-            for (String compressor : buildTimeConfig.compressors.get()) {
+            for (String compressor : httpBuildTimeConfig.compressors().get()) {
                 if ("gzip".equalsIgnoreCase(compressor)) {
                     // GZip's default compression level is 6 in Netty Codec 4.1, the same
                     // as the default compression level in Vert.x Core 4.5.7's HttpServerOptions.
@@ -316,8 +325,8 @@ public class HttpServerOptionsUtils {
                     final BrotliOptions o = StandardCompressionOptions.brotli();
                     // The default compression level for brotli as of Netty Codec 4.1 is 4,
                     // so we don't pick up Vert.x Core 4.5.7's default of 6. User can override:
-                    if (buildTimeConfig.compressionLevel.isPresent()) {
-                        o.parameters().setQuality(buildTimeConfig.compressionLevel.getAsInt());
+                    if (httpBuildTimeConfig.compressionLevel().isPresent()) {
+                        o.parameters().setQuality(httpBuildTimeConfig.compressionLevel().getAsInt());
                     }
                     httpServerOptions.addCompressor(o);
                 } else {
@@ -326,96 +335,97 @@ public class HttpServerOptionsUtils {
             }
         }
 
-        if (httpConfiguration.http2) {
+        if (httpConfig.http2()) {
             var settings = new Http2Settings();
-            if (httpConfiguration.limits.headerTableSize.isPresent()) {
-                settings.setHeaderTableSize(httpConfiguration.limits.headerTableSize.getAsLong());
+            if (httpConfig.limits().headerTableSize().isPresent()) {
+                settings.setHeaderTableSize(httpConfig.limits().headerTableSize().getAsLong());
             }
-            settings.setPushEnabled(httpConfiguration.http2PushEnabled);
-            if (httpConfiguration.limits.maxConcurrentStreams.isPresent()) {
-                settings.setMaxConcurrentStreams(httpConfiguration.limits.maxConcurrentStreams.getAsLong());
+            settings.setPushEnabled(httpConfig.http2PushEnabled());
+            if (httpConfig.limits().maxConcurrentStreams().isPresent()) {
+                settings.setMaxConcurrentStreams(httpConfig.limits().maxConcurrentStreams().getAsLong());
             }
-            if (httpConfiguration.initialWindowSize.isPresent()) {
-                settings.setInitialWindowSize(httpConfiguration.initialWindowSize.getAsInt());
+            if (httpConfig.initialWindowSize().isPresent()) {
+                settings.setInitialWindowSize(httpConfig.initialWindowSize().getAsInt());
             }
-            if (httpConfiguration.limits.maxFrameSize.isPresent()) {
-                settings.setMaxFrameSize(httpConfiguration.limits.maxFrameSize.getAsInt());
+            if (httpConfig.limits().maxFrameSize().isPresent()) {
+                settings.setMaxFrameSize(httpConfig.limits().maxFrameSize().getAsInt());
             }
-            if (httpConfiguration.limits.maxHeaderListSize.isPresent()) {
-                settings.setMaxHeaderListSize(httpConfiguration.limits.maxHeaderListSize.getAsLong());
+            if (httpConfig.limits().maxHeaderListSize().isPresent()) {
+                settings.setMaxHeaderListSize(httpConfig.limits().maxHeaderListSize().getAsLong());
             }
             httpServerOptions.setInitialSettings(settings);
 
             // RST attack protection - https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p
-            if (httpConfiguration.limits.rstFloodMaxRstFramePerWindow.isPresent()) {
+            if (httpConfig.limits().rstFloodMaxRstFramePerWindow().isPresent()) {
                 httpServerOptions
-                        .setHttp2RstFloodMaxRstFramePerWindow(httpConfiguration.limits.rstFloodMaxRstFramePerWindow.getAsInt());
+                        .setHttp2RstFloodMaxRstFramePerWindow(httpConfig.limits().rstFloodMaxRstFramePerWindow().getAsInt());
             }
-            if (httpConfiguration.limits.rstFloodWindowDuration.isPresent()) {
+            if (httpConfig.limits().rstFloodWindowDuration().isPresent()) {
                 httpServerOptions.setHttp2RstFloodWindowDuration(
-                        (int) httpConfiguration.limits.rstFloodWindowDuration.get().toSeconds());
+                        (int) httpConfig.limits().rstFloodWindowDuration().get().toSeconds());
                 httpServerOptions.setHttp2RstFloodWindowDurationTimeUnit(TimeUnit.SECONDS);
             }
 
         }
 
-        httpServerOptions.setUseProxyProtocol(httpConfiguration.proxy.useProxyProtocol);
-        configureTrafficShapingIfEnabled(httpServerOptions, httpConfiguration);
+        httpServerOptions.setUseProxyProtocol(httpConfig.proxy().useProxyProtocol());
+        configureTrafficShapingIfEnabled(httpServerOptions, httpConfig);
     }
 
     private static void configureTrafficShapingIfEnabled(HttpServerOptions httpServerOptions,
-            HttpConfiguration httpConfiguration) {
-        if (httpConfiguration.trafficShaping.enabled) {
+            VertxHttpConfig httpConfig) {
+        if (httpConfig.trafficShaping().enabled()) {
             TrafficShapingOptions options = new TrafficShapingOptions();
-            if (httpConfiguration.trafficShaping.checkInterval.isPresent()) {
-                options.setCheckIntervalForStats(httpConfiguration.trafficShaping.checkInterval.get().toSeconds());
+            if (httpConfig.trafficShaping().checkInterval().isPresent()) {
+                options.setCheckIntervalForStats(httpConfig.trafficShaping().checkInterval().get().toSeconds());
                 options.setCheckIntervalForStatsTimeUnit(TimeUnit.SECONDS);
             }
-            if (httpConfiguration.trafficShaping.maxDelay.isPresent()) {
-                options.setMaxDelayToWait(httpConfiguration.trafficShaping.maxDelay.get().toSeconds());
+            if (httpConfig.trafficShaping().maxDelay().isPresent()) {
+                options.setMaxDelayToWait(httpConfig.trafficShaping().maxDelay().get().toSeconds());
                 options.setMaxDelayToWaitUnit(TimeUnit.SECONDS);
             }
-            if (httpConfiguration.trafficShaping.inboundGlobalBandwidth.isPresent()) {
-                options.setInboundGlobalBandwidth(httpConfiguration.trafficShaping.inboundGlobalBandwidth.get().asLongValue());
+            if (httpConfig.trafficShaping().inboundGlobalBandwidth().isPresent()) {
+                options.setInboundGlobalBandwidth(httpConfig.trafficShaping().inboundGlobalBandwidth().get().asLongValue());
             }
-            if (httpConfiguration.trafficShaping.outboundGlobalBandwidth.isPresent()) {
+            if (httpConfig.trafficShaping().outboundGlobalBandwidth().isPresent()) {
                 options.setOutboundGlobalBandwidth(
-                        httpConfiguration.trafficShaping.outboundGlobalBandwidth.get().asLongValue());
+                        httpConfig.trafficShaping().outboundGlobalBandwidth().get().asLongValue());
             }
-            if (httpConfiguration.trafficShaping.peakOutboundGlobalBandwidth.isPresent()) {
+            if (httpConfig.trafficShaping().peakOutboundGlobalBandwidth().isPresent()) {
                 options.setPeakOutboundGlobalBandwidth(
-                        httpConfiguration.trafficShaping.peakOutboundGlobalBandwidth.get().asLongValue());
+                        httpConfig.trafficShaping().peakOutboundGlobalBandwidth().get().asLongValue());
             }
             httpServerOptions.setTrafficShapingOptions(options);
         }
     }
 
-    public static void applyCommonOptionsForManagementInterface(HttpServerOptions options,
-            ManagementInterfaceBuildTimeConfig buildTimeConfig,
-            ManagementInterfaceConfiguration httpConfiguration,
+    public static void applyCommonOptionsForManagementInterface(
+            HttpServerOptions options,
+            ManagementBuildTimeConfig managementBuildTimeConfig,
+            ManagementConfig managementConfig,
             List<String> websocketSubProtocols) {
-        options.setHost(httpConfiguration.host);
+        options.setHost(managementConfig.host());
 
-        int idleTimeout = (int) httpConfiguration.idleTimeout.toMillis();
+        int idleTimeout = (int) managementConfig.idleTimeout().toMillis();
         options.setIdleTimeout(idleTimeout);
         options.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
 
-        options.setMaxHeaderSize(httpConfiguration.limits.maxHeaderSize.asBigInteger().intValueExact());
-        options.setMaxChunkSize(httpConfiguration.limits.maxChunkSize.asBigInteger().intValueExact());
-        options.setMaxFormAttributeSize(httpConfiguration.limits.maxFormAttributeSize.asBigInteger().intValueExact());
-        options.setMaxFormFields(httpConfiguration.limits.maxFormFields);
-        options.setMaxFormBufferedBytes(httpConfiguration.limits.maxFormBufferedBytes.asBigInteger().intValue());
-        options.setMaxInitialLineLength(httpConfiguration.limits.maxInitialLineLength);
+        options.setMaxHeaderSize(managementConfig.limits().maxHeaderSize().asBigInteger().intValueExact());
+        options.setMaxChunkSize(managementConfig.limits().maxChunkSize().asBigInteger().intValueExact());
+        options.setMaxFormAttributeSize(managementConfig.limits().maxFormAttributeSize().asBigInteger().intValueExact());
+        options.setMaxFormFields(managementConfig.limits().maxFormFields());
+        options.setMaxFormBufferedBytes(managementConfig.limits().maxFormBufferedBytes().asBigInteger().intValue());
+        options.setMaxInitialLineLength(managementConfig.limits().maxInitialLineLength());
         options.setWebSocketSubProtocols(websocketSubProtocols);
-        options.setAcceptBacklog(httpConfiguration.acceptBacklog);
-        options.setCompressionSupported(buildTimeConfig.enableCompression);
-        if (buildTimeConfig.compressionLevel.isPresent()) {
-            options.setCompressionLevel(buildTimeConfig.compressionLevel.getAsInt());
+        options.setAcceptBacklog(managementConfig.acceptBacklog());
+        options.setCompressionSupported(managementBuildTimeConfig.enableCompression());
+        if (managementBuildTimeConfig.compressionLevel().isPresent()) {
+            options.setCompressionLevel(managementBuildTimeConfig.compressionLevel().getAsInt());
         }
-        options.setDecompressionSupported(buildTimeConfig.enableDecompression);
-        options.setHandle100ContinueAutomatically(httpConfiguration.handle100ContinueAutomatically);
+        options.setDecompressionSupported(managementBuildTimeConfig.enableDecompression());
+        options.setHandle100ContinueAutomatically(managementConfig.handle100ContinueAutomatically());
 
-        options.setUseProxyProtocol(httpConfiguration.proxy.useProxyProtocol);
+        options.setUseProxyProtocol(managementConfig.proxy().useProxyProtocol());
     }
 
     static byte[] getFileContent(Path path) throws IOException {
@@ -438,17 +448,17 @@ public class HttpServerOptionsUtils {
         return is.readAllBytes();
     }
 
-    private static void setIdleTimeout(HttpConfiguration httpConfiguration, HttpServerOptions options) {
-        int idleTimeout = (int) httpConfiguration.idleTimeout.toMillis();
+    private static void setIdleTimeout(VertxHttpConfig httpConfig, HttpServerOptions options) {
+        int idleTimeout = (int) httpConfig.idleTimeout().toMillis();
         options.setIdleTimeout(idleTimeout);
         options.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
     }
 
-    public static HttpConfiguration.InsecureRequests getInsecureRequestStrategy(HttpBuildTimeConfig buildTimeConfig,
-            Optional<HttpConfiguration.InsecureRequests> requests) {
+    public static InsecureRequests getInsecureRequestStrategy(VertxHttpBuildTimeConfig httpBuildTimeConfig,
+            Optional<InsecureRequests> requests) {
         if (requests.isPresent()) {
             var value = requests.get();
-            if (buildTimeConfig.tlsClientAuth == ClientAuth.REQUIRED && value == HttpConfiguration.InsecureRequests.ENABLED) {
+            if (httpBuildTimeConfig.tlsClientAuth() == ClientAuth.REQUIRED && value == InsecureRequests.ENABLED) {
                 Logger.getLogger(HttpServerOptionsUtils.class).warn(
                         "When configuring TLS client authentication to be required, it is recommended to **NOT** set `quarkus.http.insecure-requests` to `enabled`. "
                                 +
@@ -456,13 +466,13 @@ public class HttpServerOptionsUtils {
             }
             return value;
         }
-        if (buildTimeConfig.tlsClientAuth == ClientAuth.REQUIRED) {
+        if (httpBuildTimeConfig.tlsClientAuth() == ClientAuth.REQUIRED) {
             Logger.getLogger(HttpServerOptionsUtils.class).info(
                     "TLS client authentication is required, thus disabling insecure requests. " +
                             "You can switch to `redirect` by setting `quarkus.http.insecure-requests=redirect`.");
-            return HttpConfiguration.InsecureRequests.DISABLED;
+            return InsecureRequests.DISABLED;
         }
-        return HttpConfiguration.InsecureRequests.ENABLED;
+        return InsecureRequests.ENABLED;
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
@@ -47,7 +47,7 @@ public class TlsCertificateReloader {
      * @throws IllegalArgumentException if any of the configuration is invalid
      */
     public static long initCertReloadingAction(Vertx vertx, HttpServer server,
-            HttpServerOptions options, ServerSslConfig configuration,
+            HttpServerOptions options, ServerSslConfig sslConfig,
             TlsConfigurationRegistry registry, Optional<String> tlsConfigurationName) {
 
         if (options == null) {
@@ -78,12 +78,12 @@ public class TlsCertificateReloader {
 
         long period;
         // Validation
-        if (configuration.certificate.reloadPeriod.isPresent()) {
-            if (configuration.certificate.reloadPeriod.get().toMillis() < 30_000) {
+        if (sslConfig.certificate().reloadPeriod().isPresent()) {
+            if (sslConfig.certificate().reloadPeriod().get().toMillis() < 30_000) {
                 throw new IllegalArgumentException(
                         "Unable to configure TLS reloading - The reload period cannot be less than 30 seconds");
             }
-            period = configuration.certificate.reloadPeriod.get().toMillis();
+            period = sslConfig.certificate().reloadPeriod().get().toMillis();
         } else {
             return -1;
         }
@@ -106,7 +106,7 @@ public class TlsCertificateReloader {
                                 return null;
                             }
                         } else {
-                            var c = reloadFileContent(nonRegistryOptions, configuration);
+                            var c = reloadFileContent(nonRegistryOptions, sslConfig);
                             if (c.equals(nonRegistryOptions)) { // No change, skip the update
                                 return null;
                             }
@@ -179,14 +179,14 @@ public class TlsCertificateReloader {
         return CompletableFuture.allOf(futures);
     }
 
-    private static SSLOptions reloadFileContent(SSLOptions ssl, ServerSslConfig configuration) throws IOException {
+    private static SSLOptions reloadFileContent(SSLOptions ssl, ServerSslConfig sslConfig) throws IOException {
         var copy = new SSLOptions(ssl);
 
         final List<Path> keys = new ArrayList<>();
         final List<Path> certificates = new ArrayList<>();
 
-        configuration.certificate.keyFiles.ifPresent(keys::addAll);
-        configuration.certificate.files.ifPresent(certificates::addAll);
+        sslConfig.certificate().keyFiles().ifPresent(keys::addAll);
+        sslConfig.certificate().files().ifPresent(certificates::addAll);
 
         if (!certificates.isEmpty() && !keys.isEmpty()) {
             List<Buffer> certBuffer = new ArrayList<>();
@@ -205,15 +205,15 @@ public class TlsCertificateReloader {
                     .setCertValues(certBuffer)
                     .setKeyValues(keysBuffer);
             copy.setKeyCertOptions(opts);
-        } else if (configuration.certificate.keyStoreFile.isPresent()) {
+        } else if (sslConfig.certificate().keyStoreFile().isPresent()) {
             var opts = ((KeyStoreOptions) copy.getKeyCertOptions());
-            opts.setValue(Buffer.buffer(getFileContent(configuration.certificate.keyStoreFile.get())));
+            opts.setValue(Buffer.buffer(getFileContent(sslConfig.certificate().keyStoreFile().get())));
             copy.setKeyCertOptions(opts);
         }
 
-        if (configuration.certificate.trustStoreFile.isPresent()) {
+        if (sslConfig.certificate().trustStoreFile().isPresent()) {
             var opts = ((KeyStoreOptions) copy.getTrustOptions());
-            opts.setValue(Buffer.buffer(getFileContent(configuration.certificate.trustStoreFile.get())));
+            opts.setValue(Buffer.buffer(getFileContent(sslConfig.certificate().trustStoreFile().get())));
             copy.setTrustOptions(opts);
         }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/BasicAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/BasicAuthenticationMechanism.java
@@ -39,8 +39,8 @@ import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
 import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
@@ -62,7 +62,7 @@ public class BasicAuthenticationMechanism implements HttpAuthenticationMechanism
 
     /**
      * If silent is true then this mechanism will only take effect if there is an Authorization header.
-     *
+     * <p>
      * This allows you to combine basic auth with form auth, so human users will use form based auth, but allows
      * programmatic clients to login using basic auth.
      */
@@ -71,8 +71,8 @@ public class BasicAuthenticationMechanism implements HttpAuthenticationMechanism
     private final Charset charset;
     private final Map<Pattern, Charset> userAgentCharsets;
 
-    BasicAuthenticationMechanism(HttpConfiguration runtimeConfig, HttpBuildTimeConfig buildTimeConfig) {
-        this(runtimeConfig.auth.realm.orElse(null), buildTimeConfig.auth.form.enabled);
+    BasicAuthenticationMechanism(VertxHttpConfig httpConfig, VertxHttpBuildTimeConfig vertxHttpBuildTimeConfig) {
+        this(httpConfig.auth().realm().orElse(null), vertxHttpBuildTimeConfig.auth().form().enabled());
     }
 
     public BasicAuthenticationMechanism(final String realmName) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
@@ -32,8 +32,8 @@ import io.quarkus.security.identity.request.UsernamePasswordAuthenticationReques
 import io.quarkus.security.spi.runtime.SecurityEventHelper;
 import io.quarkus.vertx.http.runtime.FormAuthConfig;
 import io.quarkus.vertx.http.runtime.FormAuthRuntimeConfig;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.vertx.core.Handler;
@@ -68,11 +68,14 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
     static volatile String encryptionKey;
 
     @Inject
-    FormAuthenticationMechanism(HttpConfiguration httpConfiguration, HttpBuildTimeConfig buildTimeConfig,
-            Event<FormAuthenticationEvent> formAuthEvent, BeanManager beanManager,
+    FormAuthenticationMechanism(
+            VertxHttpConfig httpConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
+            Event<FormAuthenticationEvent> formAuthEvent,
+            BeanManager beanManager,
             @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled) {
         String key;
-        if (httpConfiguration.encryptionKey.isEmpty()) {
+        if (httpConfig.encryptionKey().isEmpty()) {
             if (encryptionKey != null) {
                 //persist across dev mode restarts
                 key = encryptionKey;
@@ -83,26 +86,26 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
                 log.warn("Encryption key was not specified for persistent FORM auth, using temporary key " + key);
             }
         } else {
-            key = httpConfiguration.encryptionKey.get();
+            key = httpConfig.encryptionKey().get();
         }
-        FormAuthConfig form = buildTimeConfig.auth.form;
-        FormAuthRuntimeConfig runtimeForm = httpConfiguration.auth.form;
-        this.loginManager = new PersistentLoginManager(key, runtimeForm.cookieName, runtimeForm.timeout.toMillis(),
-                runtimeForm.newCookieInterval.toMillis(), runtimeForm.httpOnlyCookie, runtimeForm.cookieSameSite.name(),
-                runtimeForm.cookiePath.orElse(null), runtimeForm.cookieMaxAge.map(Duration::toSeconds).orElse(-1L));
-        this.loginPage = startWithSlash(runtimeForm.loginPage.orElse(null));
-        this.errorPage = startWithSlash(runtimeForm.errorPage.orElse(null));
-        this.landingPage = startWithSlash(runtimeForm.landingPage.orElse(null));
-        this.postLocation = startWithSlash(form.postLocation);
-        this.usernameParameter = runtimeForm.usernameParameter;
-        this.passwordParameter = runtimeForm.passwordParameter;
-        this.locationCookie = runtimeForm.locationCookie;
-        this.cookiePath = runtimeForm.cookiePath.orElse(null);
-        boolean redirectAfterLogin = runtimeForm.redirectAfterLogin;
+        FormAuthConfig form = httpBuildTimeConfig.auth().form();
+        FormAuthRuntimeConfig runtimeForm = httpConfig.auth().form();
+        this.loginManager = new PersistentLoginManager(key, runtimeForm.cookieName(), runtimeForm.timeout().toMillis(),
+                runtimeForm.newCookieInterval().toMillis(), runtimeForm.httpOnlyCookie(), runtimeForm.cookieSameSite().name(),
+                runtimeForm.cookiePath().orElse(null), runtimeForm.cookieMaxAge().map(Duration::toSeconds).orElse(-1L));
+        this.loginPage = startWithSlash(runtimeForm.loginPage().orElse(null));
+        this.errorPage = startWithSlash(runtimeForm.errorPage().orElse(null));
+        this.landingPage = startWithSlash(runtimeForm.landingPage().orElse(null));
+        this.postLocation = startWithSlash(form.postLocation());
+        this.usernameParameter = runtimeForm.usernameParameter();
+        this.passwordParameter = runtimeForm.passwordParameter();
+        this.locationCookie = runtimeForm.locationCookie();
+        this.cookiePath = runtimeForm.cookiePath().orElse(null);
+        boolean redirectAfterLogin = runtimeForm.redirectAfterLogin();
         this.redirectToLandingPage = landingPage != null && redirectAfterLogin;
         this.redirectToLoginPage = loginPage != null;
         this.redirectToErrorPage = errorPage != null;
-        this.cookieSameSite = CookieSameSite.valueOf(runtimeForm.cookieSameSite.name());
+        this.cookieSameSite = CookieSameSite.valueOf(runtimeForm.cookieSameSite().name());
         this.isFormAuthEventObserver = SecurityEventHelper.isEventObserved(createLoginEvent(null), beanManager,
                 securityEventsEnabled);
         this.formAuthEvent = this.isFormAuthEventObserver ? formAuthEvent : null;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/JaxRsPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/JaxRsPathMatchingHttpSecurityPolicy.java
@@ -10,8 +10,8 @@ import jakarta.enterprise.inject.Instance;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 import io.quarkus.security.spi.runtime.MethodDescription;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.AuthorizationRequestContext;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.CheckResult;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.DefaultAuthorizationRequestContext;
@@ -33,11 +33,11 @@ public class JaxRsPathMatchingHttpSecurityPolicy {
     private final AuthorizationPolicyStorage storage;
 
     JaxRsPathMatchingHttpSecurityPolicy(AuthorizationPolicyStorage storage,
-            Instance<HttpSecurityPolicy> installedPolicies, HttpConfiguration httpConfig,
-            HttpBuildTimeConfig buildTimeConfig, BlockingSecurityExecutor blockingSecurityExecutor) {
+            Instance<HttpSecurityPolicy> installedPolicies, VertxHttpConfig httpConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig, BlockingSecurityExecutor blockingSecurityExecutor) {
         this.storage = storage;
-        this.delegate = new AbstractPathMatchingHttpSecurityPolicy(httpConfig.auth.permissions,
-                httpConfig.auth.rolePolicy, buildTimeConfig.rootPath, installedPolicies, JAXRS);
+        this.delegate = new AbstractPathMatchingHttpSecurityPolicy(httpConfig.auth().permissions(),
+                httpConfig.auth().rolePolicy(), httpBuildTimeConfig.rootPath(), installedPolicies, JAXRS);
         this.foundNoAnnotatedMethods = storage.getMethodToPolicyName().isEmpty();
         this.requestContext = new DefaultAuthorizationRequestContext(blockingSecurityExecutor);
         if (storage.getMethodToPolicyName().isEmpty()) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
@@ -6,21 +6,21 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
 
 import io.quarkus.runtime.Startup;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.management.ManagementInterfaceConfiguration;
+import io.quarkus.vertx.http.runtime.management.ManagementBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.management.ManagementConfig;
 
 /**
  * A security policy that allows for matching of other security policies based on paths.
- *
+ * <p>
  * This is used for the default path/method based RBAC.
  */
 @Startup // do not initialize path matcher during first HTTP request
 @Singleton
 public class ManagementPathMatchingHttpSecurityPolicy extends AbstractPathMatchingHttpSecurityPolicy {
-
-    ManagementPathMatchingHttpSecurityPolicy(ManagementInterfaceBuildTimeConfig buildTimeConfig,
-            ManagementInterfaceConfiguration runTimeConfig, Instance<HttpSecurityPolicy> installedPolicies) {
-        super(runTimeConfig.auth.permissions, runTimeConfig.auth.rolePolicy, buildTimeConfig.rootPath, installedPolicies, ALL);
+    ManagementPathMatchingHttpSecurityPolicy(
+            ManagementBuildTimeConfig managementBuildTimeConfig,
+            ManagementConfig managementConfig, Instance<HttpSecurityPolicy> installedPolicies) {
+        super(managementConfig.auth().permissions(), managementConfig.auth().rolePolicy(), managementBuildTimeConfig.rootPath(),
+                installedPolicies, ALL);
     }
-
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -6,21 +6,22 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
 
 import io.quarkus.runtime.Startup;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
 /**
  * A security policy that allows for matching of other security policies based on paths.
- *
+ * <p>
  * This is used for the default path/method based RBAC.
  */
 @Startup // do not initialize path matcher during first HTTP request
 @Singleton
 public class PathMatchingHttpSecurityPolicy extends AbstractPathMatchingHttpSecurityPolicy implements HttpSecurityPolicy {
-
-    PathMatchingHttpSecurityPolicy(HttpConfiguration httpConfig, HttpBuildTimeConfig buildTimeConfig,
+    PathMatchingHttpSecurityPolicy(
+            VertxHttpConfig httpConfig, VertxHttpBuildTimeConfig httpBuildTimeConfig,
             Instance<HttpSecurityPolicy> installedPolicies) {
-        super(httpConfig.auth.permissions, httpConfig.auth.rolePolicy, buildTimeConfig.rootPath, installedPolicies, ALL);
+        super(httpConfig.auth().permissions(), httpConfig.auth().rolePolicy(), httpBuildTimeConfig.rootPath(),
+                installedPolicies,
+                ALL);
     }
-
 }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandlerTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandlerTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig.PayloadHint;
 import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.impl.ParsableMIMEValue;
@@ -52,7 +53,7 @@ class QuarkusErrorHandlerTest {
     @Test
     public void json_content_type_hint_should_be_respected_if_not_accepted() {
         QuarkusErrorHandler errorHandler = new QuarkusErrorHandler(false, false,
-                Optional.of(HttpConfiguration.PayloadHint.JSON));
+                Optional.of(PayloadHint.JSON));
         Mockito.when(routingContext.failure()).thenReturn(testError);
         Mockito.when(routingContext.parsedHeaders().findBestUserAcceptedIn(any(), any()))
                 .thenReturn(new ParsableMIMEValue("application/foo+json").forceParse());
@@ -64,7 +65,7 @@ class QuarkusErrorHandlerTest {
     @Test
     public void json_content_type_hint_should_be_ignored_if_accepted() {
         QuarkusErrorHandler errorHandler = new QuarkusErrorHandler(false, false,
-                Optional.of(HttpConfiguration.PayloadHint.JSON));
+                Optional.of(PayloadHint.JSON));
         Mockito.when(routingContext.failure()).thenReturn(testError);
         Mockito.when(routingContext.parsedHeaders().findBestUserAcceptedIn(any(), any()))
                 .thenReturn(new ParsableMIMEValue("text/html").forceParse());
@@ -87,7 +88,7 @@ class QuarkusErrorHandlerTest {
     @Test
     public void html_content_type_hint_should_be_respected_if_not_accepted() {
         QuarkusErrorHandler errorHandler = new QuarkusErrorHandler(false, false,
-                Optional.of(HttpConfiguration.PayloadHint.HTML));
+                Optional.of(PayloadHint.HTML));
         Mockito.when(routingContext.failure()).thenReturn(testError);
         Mockito.when(routingContext.parsedHeaders().findBestUserAcceptedIn(any(), any()))
                 .thenReturn(new ParsableMIMEValue("application/foo+json").forceParse());
@@ -98,7 +99,7 @@ class QuarkusErrorHandlerTest {
     @Test
     public void html_content_type_hint_should_be_ignored_if_accepted() {
         QuarkusErrorHandler errorHandler = new QuarkusErrorHandler(false, false,
-                Optional.of(HttpConfiguration.PayloadHint.HTML));
+                Optional.of(PayloadHint.HTML));
         Mockito.when(routingContext.failure()).thenReturn(testError);
         Mockito.when(routingContext.parsedHeaders().findBestUserAcceptedIn(any(), any()))
                 .thenReturn(new ParsableMIMEValue("application/json").forceParse());

--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/devui/WebDependencyLocatorDevModeApiProcessor.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/devui/WebDependencyLocatorDevModeApiProcessor.java
@@ -26,7 +26,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedDependency;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 
 public class WebDependencyLocatorDevModeApiProcessor {
 
@@ -38,19 +38,20 @@ public class WebDependencyLocatorDevModeApiProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public void findWebDependenciesAssets(
-            HttpBuildTimeConfig httpConfig,
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
             CurateOutcomeBuildItem curateOutcome,
             BuildProducer<WebDependencyLibrariesBuildItem> webDependencyLibrariesProducer) {
 
-        final List<WebDependencyLibrary> webJarLibraries = getLibraries(httpConfig, curateOutcome, WEBJARS_PATH);
+        final List<WebDependencyLibrary> webJarLibraries = getLibraries(httpBuildTimeConfig, curateOutcome, WEBJARS_PATH);
         webDependencyLibrariesProducer.produce(new WebDependencyLibrariesBuildItem("webjars", webJarLibraries));
 
-        final List<WebDependencyLibrary> mvnpmLibraries = getLibraries(httpConfig, curateOutcome, MVNPM_PATH);
+        final List<WebDependencyLibrary> mvnpmLibraries = getLibraries(httpBuildTimeConfig, curateOutcome, MVNPM_PATH);
         webDependencyLibrariesProducer.produce(new WebDependencyLibrariesBuildItem("mvnpm", mvnpmLibraries));
 
     }
 
-    private List<WebDependencyLibrary> getLibraries(HttpBuildTimeConfig httpConfig,
+    private List<WebDependencyLibrary> getLibraries(
+            VertxHttpBuildTimeConfig httpBuildTimeConfig,
             CurateOutcomeBuildItem curateOutcome, String path) {
         final List<WebDependencyLibrary> webDependencyLibraries = new ArrayList<>();
         final List<ClassPathElement> providers = QuarkusClassLoader.getElements(PREFIX + path, false);
@@ -62,7 +63,7 @@ public class WebDependencyLocatorDevModeApiProcessor {
                             () -> new HashMap<>(providers.size())));
             if (!webDependencyKeys.isEmpty()) {
                 // The root path of the application
-                final String rootPath = httpConfig.rootPath;
+                final String rootPath = httpBuildTimeConfig.rootPath();
                 // The root path of the webDependencies
                 final String webDependencyRootPath = (rootPath.endsWith("/")) ? rootPath + path + "/"
                         : rootPath + "/" + path + "/";

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/devui/WebSocketNextJsonRPCService.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/devui/WebSocketNextJsonRPCService.java
@@ -16,7 +16,7 @@ import jakarta.enterprise.inject.Instance;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.websockets.next.WebSocketConnection;
 import io.quarkus.websockets.next.runtime.ConnectionManager;
 import io.quarkus.websockets.next.runtime.ConnectionManager.ConnectionListener;
@@ -49,11 +49,11 @@ public class WebSocketNextJsonRPCService implements ConnectionListener {
 
     private final ConcurrentMap<String, DevWebSocket> sockets;
 
-    private final HttpConfiguration httpConfig;
+    private final VertxHttpConfig httpConfig;
 
     private final WebSocketsServerRuntimeConfig.DevMode devModeConfig;
 
-    WebSocketNextJsonRPCService(Instance<ConnectionManager> connectionManager, Vertx vertx, HttpConfiguration httpConfig,
+    WebSocketNextJsonRPCService(Instance<ConnectionManager> connectionManager, Vertx vertx, VertxHttpConfig httpConfig,
             WebSocketsServerRuntimeConfig config) {
         this.connectionStatus = BroadcastProcessor.create();
         this.connectionMessages = BroadcastProcessor.create();
@@ -119,8 +119,8 @@ public class WebSocketNextJsonRPCService implements ConnectionListener {
         String connectionKey = UUID.randomUUID().toString();
         Uni<WebSocket> uni = Uni.createFrom().completionStage(() -> client
                 .connect(new WebSocketConnectOptions()
-                        .setPort(httpConfig.port)
-                        .setHost(httpConfig.host)
+                        .setPort(httpConfig.port())
+                        .setHost(httpConfig.host())
                         .setURI(path)
                         .addHeader(DEVUI_SOCKET_KEY_HEADER, connectionKey))
                 .toCompletionStage());

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
 public class UnknownConfigTest {
     @RegisterExtension
@@ -38,14 +38,14 @@ public class UnknownConfigTest {
     @Inject
     Config config;
     @Inject
-    HttpBuildTimeConfig httpBuildTimeConfig;
+    VertxHttpBuildTimeConfig httpBuildTimeConfig;
     @Inject
-    HttpConfiguration httpConfiguration;
+    VertxHttpConfig httpConfig;
 
     @Test
     void unknown() {
         assertEquals("1234", config.getConfigValue("quarkus.unknown.prop").getValue());
-        assertEquals("/1234", httpBuildTimeConfig.nonApplicationRootPath);
-        assertEquals(4443, httpConfiguration.sslPort);
+        assertEquals("/1234", httpBuildTimeConfig.nonApplicationRootPath());
+        assertEquals(4443, httpConfig.sslPort());
     }
 }


### PR DESCRIPTION
- Fixes #44115 
- Fixes #34292

Kept the old configs for compatibility with `port` and `rootPath`.