### PR TITLE
Drop expiresIn() from OidcSession, deprecated since 2.12

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcSession.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcSession.java
@@ -17,19 +17,6 @@ public interface OidcSession {
     String getTenantId();
 
     /**
-     * Return an {@linkplain:Instant} indicating how long will it take for the current session to expire.
-     *
-     * @deprecated This method shouldn't be used as it provides an instant corresponding to 1970-01-01T0:0:0Z plus the duration
-     *             of the validity of the token, which is impractical. Please use either {@link #expiresAt()} or
-     *             {@link #validFor()} depending on your requirements. This method will be removed in a later version of
-     *             Quarkus.
-     *
-     * @return Instant
-     */
-    @Deprecated(forRemoval = true, since = "2.12.0")
-    Instant expiresIn();
-
-    /**
      * Return an {@linkplain Instant} representing the current session's expiration time.
      *
      * @return Instant

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcSessionImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcSessionImpl.java
@@ -47,12 +47,6 @@ public class OidcSessionImpl implements OidcSession {
     }
 
     @Override
-    public Instant expiresIn() {
-        final long nowSecs = System.currentTimeMillis() / 1000;
-        return Instant.ofEpochSecond(idToken.getExpirationTime() - nowSecs);
-    }
-
-    @Override
     public Instant expiresAt() {
         return Instant.ofEpochSecond(idToken.getExpirationTime());
     }


### PR DESCRIPTION
Drop `expiresIn()` from `OidcSession`, deprecated since 2.12

I searched GitHub, and no other usage beyond quarkus repo clones was found