### PR TITLE
Qute: fix template global class generation in the dev mode

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
@@ -95,12 +95,13 @@ public class BeanArchiveProcessor {
                     knownMissingClasses, Thread.currentThread().getContextClassLoader());
         }
         Set<DotName> generatedClassNames = new HashSet<>();
-        for (GeneratedBeanBuildItem generatedBeanClass : generatedBeans) {
-            IndexingUtil.indexClass(generatedBeanClass.getName(), additionalBeanIndexer, applicationIndex, additionalIndex,
-                    knownMissingClasses, Thread.currentThread().getContextClassLoader(), generatedBeanClass.getData());
-            generatedClassNames.add(DotName.createSimple(generatedBeanClass.getName().replace('/', '.')));
-            generatedClass.produce(new GeneratedClassBuildItem(true, generatedBeanClass.getName(), generatedBeanClass.getData(),
-                    generatedBeanClass.getSource()));
+        for (GeneratedBeanBuildItem generatedBean : generatedBeans) {
+            IndexingUtil.indexClass(generatedBean.getName(), additionalBeanIndexer, applicationIndex, additionalIndex,
+                    knownMissingClasses, Thread.currentThread().getContextClassLoader(), generatedBean.getData());
+            generatedClassNames.add(DotName.createSimple(generatedBean.getName().replace('/', '.')));
+            generatedClass.produce(new GeneratedClassBuildItem(generatedBean.isApplicationClass(), generatedBean.getName(),
+                    generatedBean.getData(),
+                    generatedBean.getSource()));
         }
 
         PersistentClassIndex index = liveReloadBuildItem.getContextObject(PersistentClassIndex.class);

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/GeneratedBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/GeneratedBeanBuildItem.java
@@ -8,6 +8,7 @@ import io.quarkus.builder.item.MultiBuildItem;
  */
 public final class GeneratedBeanBuildItem extends MultiBuildItem {
 
+    private final boolean applicationClass;
     private final String name;
     private final byte[] data;
     private final String source;
@@ -17,9 +18,14 @@ public final class GeneratedBeanBuildItem extends MultiBuildItem {
     }
 
     public GeneratedBeanBuildItem(String name, byte[] data, String source) {
+        this(name, data, source, true);
+    }
+
+    public GeneratedBeanBuildItem(String name, byte[] data, String source, boolean applicationClass) {
         this.name = name;
         this.data = data;
         this.source = source;
+        this.applicationClass = applicationClass;
     }
 
     public String getName() {
@@ -36,6 +42,10 @@ public final class GeneratedBeanBuildItem extends MultiBuildItem {
      */
     public String getSource() {
         return source;
+    }
+
+    public boolean isApplicationClass() {
+        return applicationClass;
     }
 
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/GeneratedBeanGizmoAdaptor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/GeneratedBeanGizmoAdaptor.java
@@ -4,6 +4,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 
 import io.quarkus.bootstrap.BootstrapDebug;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -13,10 +14,23 @@ public class GeneratedBeanGizmoAdaptor implements ClassOutput {
 
     private final BuildProducer<GeneratedBeanBuildItem> classOutput;
     private final Map<String, StringWriter> sources;
+    private final Predicate<String> applicationClassPredicate;
 
     public GeneratedBeanGizmoAdaptor(BuildProducer<GeneratedBeanBuildItem> classOutput) {
+        this(classOutput, new Predicate<String>() {
+
+            @Override
+            public boolean test(String t) {
+                return true;
+            }
+        });
+    }
+
+    public GeneratedBeanGizmoAdaptor(BuildProducer<GeneratedBeanBuildItem> classOutput,
+            Predicate<String> applicationClassPredicate) {
         this.classOutput = classOutput;
         this.sources = BootstrapDebug.debugSourcesDir() != null ? new ConcurrentHashMap<>() : null;
+        this.applicationClassPredicate = applicationClassPredicate;
     }
 
     @Override
@@ -28,7 +42,7 @@ public class GeneratedBeanGizmoAdaptor implements ClassOutput {
                 source = sw.toString();
             }
         }
-        classOutput.produce(new GeneratedBeanBuildItem(className, bytes, source));
+        classOutput.produce(new GeneratedBeanBuildItem(className, bytes, source, applicationClassPredicate.test(className)));
     }
 
     @Override

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteDevModeProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteDevModeProcessor.java
@@ -1,15 +1,26 @@
 package io.quarkus.qute.deployment;
 
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
+import org.jboss.jandex.DotName;
+
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.dev.console.DevConsoleManager;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.qute.TemplateGlobal;
 import io.quarkus.qute.runtime.devmode.QuteErrorPageSetup;
 
 @BuildSteps(onlyIf = IsDevelopment.class)
@@ -26,6 +37,35 @@ public class QuteDevModeProcessor {
         }
         // Set the global that could be used at runtime when a qute error page is rendered
         DevConsoleManager.setGlobal(QuteErrorPageSetup.GENERATED_CONTENTS, contents);
+    }
+
+    // This build step is only used to for a QuarkusDevModeTest that contains the QuteDummyTemplateGlobalMarker interface
+    @BuildStep
+    void generateTestTemplateGlobal(ApplicationIndexBuildItem applicationIndex,
+            BuildProducer<GeneratedBeanBuildItem> generatedBeanClasses) {
+        if (applicationIndex.getIndex().getClassByName(
+                DotName.createSimple("io.quarkus.qute.deployment.devmode.QuteDummyTemplateGlobalMarker")) != null) {
+            // If the marker interface is present then we generate a dummy class annotated with @TemplateGlobal
+            GeneratedBeanGizmoAdaptor gizmoAdaptor = new GeneratedBeanGizmoAdaptor(generatedBeanClasses,
+                    new Predicate<String>() {
+                        @Override
+                        public boolean test(String t) {
+                            return false;
+                        }
+                    });
+            try (ClassCreator classCreator = ClassCreator.builder().className("io.quarkus.qute.test.QuteDummyGlobals")
+                    .classOutput(gizmoAdaptor).build()) {
+                classCreator.addAnnotation(TemplateGlobal.class);
+
+                FieldCreator quteDummyFoo = classCreator.getFieldCreator("quteDummyFoo", String.class);
+                quteDummyFoo.setModifiers(Modifier.STATIC);
+
+                MethodCreator staticInitializer = classCreator.getMethodCreator("<clinit>", void.class);
+                staticInitializer.setModifiers(Modifier.STATIC);
+                staticInitializer.writeStaticField(quteDummyFoo.getFieldDescriptor(), staticInitializer.load("bar"));
+                staticInitializer.returnVoid();
+            }
+        }
     }
 
 }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/ExistingValueResolversDevModeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/ExistingValueResolversDevModeTest.java
@@ -20,7 +20,7 @@ public class ExistingValueResolversDevModeTest {
                     .addClass(TestRoute.class)
                     .addAsResource(new StringAsset(
                             "{#let a = 3}{#let b = a.minus(2)}b={b}{/}{/}"),
-                            "templates/let.html"));
+                            "templates/test.html"));
 
     @Test
     public void testExistingValueResolvers() {
@@ -29,7 +29,7 @@ public class ExistingValueResolversDevModeTest {
                 .statusCode(200)
                 .body(Matchers.equalTo("b=1"));
 
-        config.modifyResourceFile("templates/let.html", t -> t.concat("::MODIFIED"));
+        config.modifyResourceFile("templates/test.html", t -> t.concat("::MODIFIED"));
 
         given().get("test")
                 .then()

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/QuteDummyTemplateGlobalMarker.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/QuteDummyTemplateGlobalMarker.java
@@ -1,0 +1,8 @@
+package io.quarkus.qute.deployment.devmode;
+
+/**
+ * Marker interface for {@link TemplateGlobalDevModeTest}.
+ */
+public interface QuteDummyTemplateGlobalMarker {
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/TemplateGlobalDevModeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/TemplateGlobalDevModeTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.qute.deployment.devmode;
+
+import static io.restassured.RestAssured.given;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+/**
+ * Test that template globals added in the dev mode are generated correctly after live reload.
+ * <p>
+ * The {@link QuteDummyTemplateGlobalMarker} is used to identify an application archive where a dummy built-in class with
+ * template globals is added.
+ */
+public class TemplateGlobalDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(TestRoute.class, QuteDummyTemplateGlobalMarker.class)
+                    .addAsResource(new StringAsset(
+                            "{quteDummyFoo}:{testFoo ?: 'NA'}"),
+                            "templates/test.html"));
+
+    @Test
+    public void testTemplateGlobals() {
+        given().get("test")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("bar:NA"));
+
+        // Add application globals - the priority sequence should be automatically
+        // increased before it's used for TestGlobals
+        config.addSourceFile(TestGlobals.class);
+
+        given().get("test")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("bar:baz"));
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/TestGlobals.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/TestGlobals.java
@@ -1,0 +1,11 @@
+package io.quarkus.qute.deployment.devmode;
+
+import io.quarkus.qute.TemplateGlobal;
+
+@TemplateGlobal
+public class TestGlobals {
+
+    public static String testFoo() {
+        return "baz";
+    }
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/TestRoute.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/devmode/TestRoute.java
@@ -9,11 +9,11 @@ import io.vertx.ext.web.RoutingContext;
 public class TestRoute {
 
     @Inject
-    Template let;
+    Template test;
 
     @Route(path = "test")
     public void test(RoutingContext ctx) {
-        ctx.end(let.render());
+        ctx.end(test.render());
     }
 
 }

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/TemplateGlobalGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/TemplateGlobalGenerator.java
@@ -48,13 +48,13 @@ public class TemplateGlobalGenerator extends AbstractGenerator {
     private final String namespace;
     private int priority;
 
-    public TemplateGlobalGenerator(ClassOutput classOutput, String namespace, int priority, IndexView index) {
+    public TemplateGlobalGenerator(ClassOutput classOutput, String namespace, int initialPriority, IndexView index) {
         super(index, classOutput);
         this.namespace = namespace;
-        this.priority = priority;
+        this.priority = initialPriority;
     }
 
-    public void generate(ClassInfo declaringClass, Map<String, AnnotationTarget> targets) {
+    public String generate(ClassInfo declaringClass, Map<String, AnnotationTarget> targets) {
 
         String baseName;
         if (declaringClass.enclosingClass() != null) {
@@ -65,7 +65,8 @@ public class TemplateGlobalGenerator extends AbstractGenerator {
         }
         String targetPackage = packageName(declaringClass.name());
         String generatedName = generatedNameFromTarget(targetPackage, baseName, SUFFIX);
-        generatedTypes.add(generatedName.replace('/', '.'));
+        String generatedClassName = generatedName.replace('/', '.');
+        generatedTypes.add(generatedClassName);
 
         ClassCreator provider = ClassCreator.builder().classOutput(classOutput).className(generatedName)
                 .interfaces(TemplateGlobalProvider.class).build();
@@ -141,6 +142,7 @@ public class TemplateGlobalGenerator extends AbstractGenerator {
         resolve.returnValue(resolve.invokeStaticMethod(Descriptors.RESULTS_NOT_FOUND_EC, evalContext));
 
         provider.close();
+        return generatedClassName;
     }
 
     public Set<String> getGeneratedTypes() {


### PR DESCRIPTION
- if a non-application template global class is present we have to reflect this fact when assigning the priority for an application template global resolver; otherwise a conflict may occur

This pull request should fix the problem demonstrated by https://github.com/FroMage/roq-qute-repro-globals.

Unfortunately, I don't know how to write an automated test easily. Ideally, we should add a `QuarkusDevModeTest` in Roq (which provides  non-application template globals).