### PR TITLE
Remove quarkus-extension-processor from cache-runtime-spi

### DIFF
--- a/extensions/cache/runtime-spi/pom.xml
+++ b/extensions/cache/runtime-spi/pom.xml
@@ -19,27 +19,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <annotationProcessorPaths>
-                                <path>
-                                    <groupId>io.quarkus</groupId>
-                                    <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
-                                </path>
-                            </annotationProcessorPaths>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
-    
 </project>


### PR DESCRIPTION
It is not an extension so it shouldn't be treated as such.

I have no idea why but it causes some issues when building with an empty repository so let's get rid of it given it's useless.

Fixing it as it made the 3.18.0 backport PR fail tonight :/