### PR TITLE
Drop public usage of StringUtil#join, deprecated since 2019

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/util/StringUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/StringUtil.java
@@ -112,13 +112,13 @@ public final class StringUtil {
     }
 
     /**
-     * @deprecated Use {@link String#join} instead.
+     * Dropped for public usage, kept in place for usage by hyphenate method to avoid need for lambda
+     *
      * @param delim delimiter
      * @param it iterator
      * @return the joined string
      */
-    @Deprecated
-    public static String join(String delim, Iterator<String> it) {
+    private static String join(String delim, Iterator<String> it) {
         final StringBuilder b = new StringBuilder();
         if (it.hasNext()) {
             b.append(it.next());

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesMetadataBuildItem.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesMetadataBuildItem.java
@@ -1,7 +1,6 @@
 package io.quarkus.spring.boot.properties.deployment;
 
 import static io.quarkus.runtime.util.StringUtil.camelHumpsIterator;
-import static io.quarkus.runtime.util.StringUtil.join;
 import static io.quarkus.runtime.util.StringUtil.lowerCase;
 import static io.quarkus.runtime.util.StringUtil.withoutSuffix;
 
@@ -67,11 +66,10 @@ final class ConfigurationPropertiesMetadataBuildItem extends MultiBuildItem {
         return prefix;
     }
 
-    @SuppressWarnings("deprecation")
     private String getPrefixFromClassName(DotName className) {
         String simpleName = className.isInner() ? className.local() : className.withoutPackagePrefix();
-        return join("-",
-                withoutSuffix(lowerCase(camelHumpsIterator(simpleName)), "config", "configuration",
+        return String.join("-",
+                (Iterable<String>) () -> withoutSuffix(lowerCase(camelHumpsIterator(simpleName)), "config", "configuration",
                         "properties", "props"));
     }
 


### PR DESCRIPTION
Drop public usage of StringUtil#join, deprecated since 2019

One class used `join` method, other classes are using `String.join` already
Also checked apache/camel-quarkus, apache/incubator-kie-kogito-runtimes, apache/incubator-kie-drools