### PR TITLE
Deprecate @ConfigItem and deprecated attributes of @ConfigRoot

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigItem.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigItem.java
@@ -11,10 +11,13 @@ import java.util.Optional;
 
 /**
  * A single container configuration item.
+ *
+ * @deprecated Use interface-based {@code @ConfigMapping} instead.
  */
 @Retention(RUNTIME)
 @Target({ FIELD, PARAMETER })
 @Documented
+@Deprecated(since = "3.19", forRemoval = true)
 public @interface ConfigItem {
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigRoot.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigRoot.java
@@ -21,7 +21,10 @@ public @interface ConfigRoot {
      * Determine the prefix key of the configuration root.
      *
      * @return the prefix key name
+     * @deprecated Use interface-based {@code @ConfigMapping} instead. When moving to {@code @ConfigMapping}, the prefix has to
+     *             be included in the {@code @ConfigMapping#prefix} together with the name.
      */
+    @Deprecated(since = "3.19", forRemoval = true)
     String prefix() default "quarkus";
 
     /**
@@ -35,6 +38,10 @@ public @interface ConfigRoot {
      * Determine the base key of the configuration root.
      *
      * @return the base key name
+     * @deprecated Use interface-based {@code @ConfigMapping} instead. Be careful, {@code @ConfigRoot(name = "extension")} may
+     *             be migrated to {@code @ConfigMapping(prefix = "quarkus.extension")}. If no name was defined, make sure to
+     *             define a prefix in {@code @ConfigMapping} as it's mandatory.
      */
+    @Deprecated(since = "3.19", forRemoval = true)
     String name() default ConfigItem.HYPHENATED_ELEMENT_NAME;
 }


### PR DESCRIPTION
We will be phasing out these elements at some point in the future so let's mark them deprecated early so that they are documented as such in the next LTS.