### PR TITLE
Configuration property to make transaction mandatory even for read operations

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/stateless/StatelessSessionWithinRequestScopeDisabledTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/stateless/StatelessSessionWithinRequestScopeDisabledTest.java
@@ -38,14 +38,14 @@ public class StatelessSessionWithinRequestScopeDisabledTest {
         assertThatThrownBy(() -> statelessSession
                 .createSelectionQuery("SELECT entity FROM MyEntity entity WHERE name IS NULL", MyEntity.class).getResultCount())
                 .hasMessageContaining(
-                        "Cannot use the StatelessSession because neither a transaction nor a CDI request context is active");
+                        "Cannot use the StatelessSession because no transaction is active");
     }
 
     @Test
     public void write() {
         assertThatThrownBy(() -> statelessSession.insert(new MyEntity("john")))
                 .hasMessageContaining(
-                        "Cannot use the StatelessSession because neither a transaction nor a CDI request context is active");
+                        "Cannot use the StatelessSession because no transaction is active");
     }
 
     @AfterEach

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/SessionWithinRequestScopeDisabledTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/SessionWithinRequestScopeDisabledTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.hibernate.orm.transaction;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.Session;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.hibernate.orm.naming.PrefixPhysicalNamingStrategy;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SessionWithinRequestScopeDisabledTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class, PrefixPhysicalNamingStrategy.class)
+                    .addAsResource(EmptyAsset.INSTANCE, "import.sql"))
+            .overrideConfigKey("quarkus.hibernate-orm.request-scoped.enabled", "false");
+
+    @Inject
+    Session session;
+
+    @BeforeEach
+    public void activateRequestContext() {
+        Arc.container().requestContext().activate();
+    }
+
+    @Test
+    public void read() {
+        assertThatThrownBy(() -> session
+                .createSelectionQuery("SELECT entity FROM MyEntity entity WHERE name IS NULL", MyEntity.class).getResultCount())
+                .hasMessageContaining(
+                        "Cannot use the EntityManager/Session because neither a transaction nor a CDI request context is active");
+    }
+
+    @Test
+    public void write() {
+        assertThatThrownBy(() -> session.persist(new MyEntity("john")))
+                .hasMessageContaining(
+                        "Cannot use the EntityManager/Session because neither a transaction nor a CDI request context is active");
+    }
+
+    @AfterEach
+    public void terminateRequestContext() {
+        Arc.container().requestContext().terminate();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/SessionWithinRequestScopeDisabledTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/SessionWithinRequestScopeDisabledTest.java
@@ -38,14 +38,14 @@ public class SessionWithinRequestScopeDisabledTest {
         assertThatThrownBy(() -> session
                 .createSelectionQuery("SELECT entity FROM MyEntity entity WHERE name IS NULL", MyEntity.class).getResultCount())
                 .hasMessageContaining(
-                        "Cannot use the EntityManager/Session because neither a transaction nor a CDI request context is active");
+                        "Cannot use the EntityManager/Session because no transaction is active");
     }
 
     @Test
     public void write() {
         assertThatThrownBy(() -> session.persist(new MyEntity("john")))
                 .hasMessageContaining(
-                        "Cannot use the EntityManager/Session because neither a transaction nor a CDI request context is active");
+                        "Cannot use the EntityManager/Session because no transaction is active");
     }
 
     @AfterEach

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
@@ -1,14 +1,16 @@
 package io.quarkus.hibernate.orm.runtime;
 
-import java.util.Map;
-
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
 import io.smallrye.config.WithUnnamedKey;
+
+import java.util.Map;
 
 @ConfigMapping(prefix = "quarkus.hibernate-orm")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
@@ -22,6 +24,19 @@ public interface HibernateOrmRuntimeConfig {
     @WithDefaults
     @ConfigDocMapKey("persistence-unit-name")
     Map<String, HibernateOrmRuntimeConfigPersistenceUnit> persistenceUnits();
+
+    /**
+     * Enable or disable access to a Hibernate ORM `EntityManager`/`Session`/`StatelessSession`
+     * *when no transaction is active* but a request scope is.
+     *
+     * When enabled, the corresponding sessions will be read-only.
+     *
+     * Defaults to enabled for backwards compatibility, but disabling this is recommended,
+     * to avoid inconsistent resulsts caused by queries running outside of transactions.
+     */
+    @WithName("request-scoped.enabled")
+    @WithDefault("true")
+    boolean requestScopedSessionEnabled();
 
     static String extensionPropertyKey(String radical) {
         return "quarkus.hibernate-orm." + radical;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.orm.runtime;
 
+import java.util.Map;
+
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -9,8 +11,6 @@ import io.smallrye.config.WithDefaults;
 import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
 import io.smallrye.config.WithUnnamedKey;
-
-import java.util.Map;
 
 @ConfigMapping(prefix = "quarkus.hibernate-orm")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
@@ -1,13 +1,5 @@
 package io.quarkus.hibernate.orm.runtime;
 
-import io.quarkus.arc.BeanDestroyer;
-import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.inject.Inject;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.Persistence;
-import org.jboss.logging.Logger;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,6 +9,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.BeanDestroyer;
+import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
 
 public class JPAConfig {
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
@@ -1,5 +1,13 @@
 package io.quarkus.hibernate.orm.runtime;
 
+import io.quarkus.arc.BeanDestroyer;
+import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+import org.jboss.logging.Logger;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,22 +18,13 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.inject.Inject;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.Persistence;
-
-import org.jboss.logging.Logger;
-
-import io.quarkus.arc.BeanDestroyer;
-import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
-
 public class JPAConfig {
 
     private static final Logger LOGGER = Logger.getLogger(JPAConfig.class.getName());
 
     private final Map<String, LazyPersistenceUnit> persistenceUnits = new HashMap<>();
     private final Set<String> deactivatedPersistenceUnitNames = new HashSet<>();
+    private final boolean requestScopedSessionEnabled;
 
     @Inject
     public JPAConfig(HibernateOrmRuntimeConfig hibernateOrmRuntimeConfig) {
@@ -40,6 +39,7 @@ public class JPAConfig {
                 persistenceUnits.put(puName, new LazyPersistenceUnit(puName));
             }
         }
+        this.requestScopedSessionEnabled = hibernateOrmRuntimeConfig.requestScopedSessionEnabled();
     }
 
     void startAll() {
@@ -118,6 +118,13 @@ public class JPAConfig {
      */
     public Set<String> getDeactivatedPersistenceUnitNames() {
         return deactivatedPersistenceUnitNames;
+    }
+
+    /**
+     * Returns boolean value for enabling request scoped sessions
+     */
+    public boolean getRequestScopedSessionEnabled() {
+        return this.requestScopedSessionEnabled;
     }
 
     public static class Destroyer implements BeanDestroyer<JPAConfig> {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/TransactionSessions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/TransactionSessions.java
@@ -1,21 +1,19 @@
 package io.quarkus.hibernate.orm.runtime;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.runtime.session.TransactionScopedSession;
+import io.quarkus.hibernate.orm.runtime.session.TransactionScopedStatelessSession;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.TransactionSynchronizationRegistry;
-
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
 
-import io.quarkus.arc.Arc;
-import io.quarkus.hibernate.orm.runtime.session.TransactionScopedSession;
-import io.quarkus.hibernate.orm.runtime.session.TransactionScopedStatelessSession;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 @ApplicationScoped
 public class TransactionSessions {
@@ -45,7 +43,7 @@ public class TransactionSessions {
         return sessions.computeIfAbsent(unitName, (un) -> new TransactionScopedSession(
                 getTransactionManager(), getTransactionSynchronizationRegistry(),
                 jpaConfig.getEntityManagerFactory(un).unwrap(SessionFactory.class), un,
-                requestScopedSession));
+                jpaConfig.getRequestScopedSessionEnabled(), requestScopedSession));
     }
 
     public StatelessSession getStatelessSession(String unitName) {
@@ -56,7 +54,7 @@ public class TransactionSessions {
         return staleSessions.computeIfAbsent(unitName, (un) -> new TransactionScopedStatelessSession(
                 getTransactionManager(), getTransactionSynchronizationRegistry(),
                 jpaConfig.getEntityManagerFactory(un).unwrap(SessionFactory.class), un,
-                requestScopedStatelessSession));
+                jpaConfig.getRequestScopedSessionEnabled(), requestScopedStatelessSession));
     }
 
     private TransactionManager getTransactionManager() {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/TransactionSessions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/TransactionSessions.java
@@ -1,19 +1,21 @@
 package io.quarkus.hibernate.orm.runtime;
 
-import io.quarkus.arc.Arc;
-import io.quarkus.hibernate.orm.runtime.session.TransactionScopedSession;
-import io.quarkus.hibernate.orm.runtime.session.TransactionScopedStatelessSession;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.TransactionSynchronizationRegistry;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.runtime.session.TransactionScopedSession;
+import io.quarkus.hibernate.orm.runtime.session.TransactionScopedStatelessSession;
 
 @ApplicationScoped
 public class TransactionSessions {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
@@ -1,9 +1,8 @@
 package io.quarkus.hibernate.orm.runtime.session;
 
-import io.quarkus.arc.Arc;
-import io.quarkus.hibernate.orm.runtime.RequestScopedSessionHolder;
-import io.quarkus.runtime.BlockingOperationControl;
-import io.quarkus.runtime.BlockingOperationNotAllowedException;
+import java.util.List;
+import java.util.Map;
+
 import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.enterprise.inject.Instance;
 import jakarta.persistence.CacheRetrieveMode;
@@ -20,6 +19,7 @@ import jakarta.persistence.metamodel.Metamodel;
 import jakarta.transaction.Status;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.TransactionSynchronizationRegistry;
+
 import org.hibernate.CacheMode;
 import org.hibernate.Filter;
 import org.hibernate.FlushMode;
@@ -52,8 +52,10 @@ import org.hibernate.query.criteria.JpaCriteriaInsert;
 import org.hibernate.query.criteria.JpaCriteriaInsertSelect;
 import org.hibernate.stat.SessionStatistics;
 
-import java.util.List;
-import java.util.Map;
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.runtime.RequestScopedSessionHolder;
+import io.quarkus.runtime.BlockingOperationControl;
+import io.quarkus.runtime.BlockingOperationNotAllowedException;
 
 public class TransactionScopedSession implements Session {
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
@@ -53,6 +53,7 @@ import org.hibernate.query.criteria.JpaCriteriaInsertSelect;
 import org.hibernate.stat.SessionStatistics;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.RequestScopedSessionHolder;
 import io.quarkus.runtime.BlockingOperationControl;
 import io.quarkus.runtime.BlockingOperationNotAllowedException;
@@ -103,15 +104,23 @@ public class TransactionScopedSession implements Session {
             // - org.hibernate.internal.SessionImpl.beforeTransactionCompletion
             // - org.hibernate.internal.SessionImpl.afterTransactionCompletion
             return new SessionResult(newSession, false, true);
-        } else if (Arc.container().requestContext().isActive() && requestScopedSessionEnabled) {
-            RequestScopedSessionHolder requestScopedSessions = this.requestScopedSessions.get();
-            return new SessionResult(requestScopedSessions.getOrCreateSession(unitName, sessionFactory),
-                    false, false);
+        } else if (requestScopedSessionEnabled) {
+            if (Arc.container().requestContext().isActive()) {
+                RequestScopedSessionHolder requestScopedSessions = this.requestScopedSessions.get();
+                return new SessionResult(requestScopedSessions.getOrCreateSession(unitName, sessionFactory),
+                        false, false);
+            } else {
+                throw new ContextNotActiveException(
+                        "Cannot use the EntityManager/Session because neither a transaction nor a CDI request context is active."
+                                + " Consider adding @Transactional to your method to automatically activate a transaction,"
+                                + " or @ActivateRequestContext if you have valid reasons not to use transactions.");
+            }
         } else {
             throw new ContextNotActiveException(
-                    "Cannot use the EntityManager/Session because neither a transaction nor a CDI request context is active."
+                    "Cannot use the EntityManager/Session because no transaction is active."
                             + " Consider adding @Transactional to your method to automatically activate a transaction,"
-                            + " or @ActivateRequestContext if you have valid reasons not to use transactions.");
+                            + " or set '" + HibernateOrmRuntimeConfig.extensionPropertyKey("request-scoped.enabled")
+                            + "' to 'true' if you have valid reasons not to use transactions.");
         }
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedStatelessSession.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedStatelessSession.java
@@ -1,9 +1,7 @@
 package io.quarkus.hibernate.orm.runtime.session;
 
-import io.quarkus.arc.Arc;
-import io.quarkus.hibernate.orm.runtime.RequestScopedStatelessSessionHolder;
-import io.quarkus.runtime.BlockingOperationControl;
-import io.quarkus.runtime.BlockingOperationNotAllowedException;
+import java.util.List;
+
 import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.enterprise.inject.Instance;
 import jakarta.persistence.EntityGraph;
@@ -14,6 +12,7 @@ import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.transaction.Status;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.TransactionSynchronizationRegistry;
+
 import org.hibernate.Filter;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
@@ -33,7 +32,10 @@ import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
 import org.hibernate.query.criteria.JpaCriteriaInsertSelect;
 
-import java.util.List;
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.runtime.RequestScopedStatelessSessionHolder;
+import io.quarkus.runtime.BlockingOperationControl;
+import io.quarkus.runtime.BlockingOperationNotAllowedException;
 
 public class TransactionScopedStatelessSession implements StatelessSession {
 


### PR DESCRIPTION
Added config property for enabling request scoped sessions. Implemented check for the property value in session initialization method. 

- Fixes: #34016 