### PR TITLE
Configure QuarkusBot to notify Stuart less

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -470,7 +470,7 @@ triage:
       notify: [radcortez]
     - id: core
       labels: [area/core]
-      notify: [aloubyansky, gsmet, geoand, radcortez, Sanne, stuartwdouglas]
+      notify: [aloubyansky, gsmet, geoand, radcortez, Sanne]
       directories:
         - core/
     - id: dependencies
@@ -624,7 +624,7 @@ triage:
     - id: rest
       labels: [area/rest]
       title: resteasy.reactive
-      notify: [geoand, FroMage, stuartwdouglas]
+      notify: [geoand, FroMage]
       directories:
         - extensions/resteasy-reactive/
     - id: scala
@@ -719,11 +719,11 @@ triage:
     - id: continuous-testing
       labels: [area/continuous-testing]
       title: "continuous.testing"
-      notify: [stuartwdouglas]
+      notify: [holly-cummins, geoand]
     - id: devservices
       labels: [area/devservices]
       title: "dev.?services?"
-      notify: [stuartwdouglas, geoand]
+      notify: [geoand]
     - id: jdbc
       labels: [area/jdbc]
       title: "jdbc"


### PR DESCRIPTION
I noticed that Stuart is getting quite a few notifications from QuarkusBot still, despite the focus of his work – and his employer :) – having shifted. I thought I'd tidy that up, but of course we should leave them if @stuartwdouglas still wants them. WDYT, @stuartwdouglas?