### PR TITLE
Fix PathTreeClassPathElement#toString() implementation

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
@@ -229,6 +229,11 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
                 && manifestEnabled == other.manifestEnabled;
     }
 
+    @Override
+    public String toString() {
+        return archive.toString();
+    }
+
     protected class OpenArchivePathTree extends OpenContainerPathTree {
 
         private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -402,6 +407,11 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         @Override
         public PathTree getOriginalTree() {
             return ArchivePathTree.this;
+        }
+
+        @Override
+        public String toString() {
+            return ArchivePathTree.this.toString();
         }
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/EmptyPathTree.java
@@ -76,4 +76,9 @@ public class EmptyPathTree implements OpenPathTree {
     public PathTree getOriginalTree() {
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "<empty>";
+    }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilePathTree.java
@@ -137,4 +137,13 @@ class FilePathTree implements OpenPathTree {
         FilePathTree other = (FilePathTree) obj;
         return Objects.equals(file, other.file) && Objects.equals(pathFilter, other.pathFilter);
     }
+
+    @Override
+    public String toString() {
+        if (pathFilter == null) {
+            return file.toString();
+        }
+
+        return file + " (filtered)";
+    }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/FilteredPathTree.java
@@ -89,6 +89,11 @@ public class FilteredPathTree implements PathTree {
         return new OpenFilteredPathTree(original.open(), filter);
     }
 
+    @Override
+    public String toString() {
+        return original.toString() + " (filtered)";
+    }
+
     private static class OpenFilteredPathTree extends FilteredPathTree implements OpenPathTree {
 
         private final OpenPathTree original;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class MultiRootPathTree implements OpenPathTree {
 
@@ -191,5 +192,10 @@ public class MultiRootPathTree implements OpenPathTree {
             return false;
         MultiRootPathTree other = (MultiRootPathTree) obj;
         return Arrays.equals(trees, other.trees);
+    }
+
+    @Override
+    public String toString() {
+        return roots.stream().map(p -> p.toString()).collect(Collectors.joining(", ", "[", "]"));
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
@@ -186,4 +186,9 @@ public abstract class OpenContainerPathTree extends PathTreeWithManifest impleme
                 && Objects.equals(pathFilter, other.pathFilter)
                 && manifestEnabled == other.manifestEnabled;
     }
+
+    @Override
+    public String toString() {
+        return getContainerPath().toString();
+    }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
@@ -57,7 +57,7 @@ class SharedArchivePathTree extends ArchivePathTree {
             return new CallerOpenPathTree(lastOpen);
         }
         try {
-            this.lastOpen = new SharedOpenArchivePathTree(archive, openFs());
+            this.lastOpen = new SharedOpenArchivePathTree(openFs());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -68,7 +68,7 @@ class SharedArchivePathTree extends ArchivePathTree {
 
         private final AtomicInteger users = new AtomicInteger(1);
 
-        protected SharedOpenArchivePathTree(Path archivePath, FileSystem fs) {
+        protected SharedOpenArchivePathTree(FileSystem fs) {
             super(fs);
             openCount.incrementAndGet();
         }
@@ -105,6 +105,11 @@ class SharedArchivePathTree extends ArchivePathTree {
             } finally {
                 writeLock().unlock();
             }
+        }
+
+        @Override
+        public String toString() {
+            return SharedArchivePathTree.this.toString();
         }
     }
 
@@ -201,6 +206,11 @@ class SharedArchivePathTree extends ArchivePathTree {
             } finally {
                 delegate.writeLock().unlock();
             }
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
         }
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
@@ -14,7 +14,6 @@ import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -216,13 +215,7 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
         if (getDependencyKey() != null) {
             sb.append(getDependencyKey().toGacString()).append(" ");
         }
-        final Iterator<Path> i = pathTree.getRoots().iterator();
-        if (i.hasNext()) {
-            sb.append(i.next());
-            while (i.hasNext()) {
-                sb.append(",").append(i.next());
-            }
-        }
+        sb.append(pathTree.getOriginalTree().toString());
         sb.append(" runtime=").append(isRuntime());
         final Set<String> resources = this.resources;
         sb.append(" resources=").append(resources == null ? "null" : resources.size());


### PR DESCRIPTION
It was relying on some internal behavior of the path trees and not calling the `getOriginalTree()` method.
But rather than fixing it this way, I think it's more future proof to properly implement `toString()` in the `PathTree` implementations.

Fixes #45650