### PR TITLE
Fix documentation for connecting to multiple devservice databases

### DIFF
--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -212,9 +212,9 @@ Login credentials are the same for most databases, except when the database requ
 |Database |Username |Password |Database name
 
 |PostgreSQL, MariaDB, MySQL, IBM Db2, H2
+|`quarkus`
+|`quarkus`
 |`quarkus` for the default datasource or name of the datasource
-|`quarkus`
-|`quarkus`
 
 |Microsoft SQL Server
 |`SA`


### PR DESCRIPTION
I had some difficulties connecting to the devservices databases of a service with multiple datasources because the [documentation in the Dev Services for Databases guide](https://quarkus.io/guides/databases-dev-services#connect-to-database-run-as-a-dev-service) is wrong.

### How to verify

Inspect the devservice database containers of a multi-datasource application with `docker inspect`.

Here are the env vars of the postgres container for the named datasource "db1":

```shell
$ docker container inspect unruffled_franklin --format '{{json .Config.Env}}' | jq -r '.[]' | grep POSTGRES
POSTGRES_USER=quarkus
POSTGRES_PASSWORD=quarkus
POSTGRES_DB=db1
```

For reference, these are the corresponding env vars from a devservices container for the default database in a single-datasource setup:
```shell
$ docker container inspect clever_murdock --format '{{json .Config.Env}}' | jq -r '.[]' | grep POSTGRES
POSTGRES_USER=quarkus
POSTGRES_PASSWORD=quarkus
POSTGRES_DB=quarkus
```

This PR fixes the issue.