### PR TITLE
Bump smallrye-open-api.version from 4.0.6 to 4.0.7

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-config.version>3.11.1</smallrye-config.version>
         <smallrye-health.version>4.1.1</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>4.0.6</smallrye-open-api.version>
+        <smallrye-open-api.version>4.0.7</smallrye-open-api.version>
         <smallrye-graphql.version>2.12.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.7.3</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.1</smallrye-jwt.version>


### PR DESCRIPTION
Update to smallrye-open-api [release 4.0.7](https://github.com/smallrye/smallrye-open-api/releases/tag/4.0.7).

Fixes #45358
Fixes #45708
