### PR TITLE
Allow extensions to contribute datasouces

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AggregatedDataSourceBuildTimeConfigBuildItem.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AggregatedDataSourceBuildTimeConfigBuildItem.java
@@ -5,7 +5,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 
-final class AggregatedDataSourceBuildTimeConfigBuildItem extends MultiBuildItem {
+public final class AggregatedDataSourceBuildTimeConfigBuildItem extends MultiBuildItem {
 
     private final String name;
 
@@ -17,7 +17,7 @@ final class AggregatedDataSourceBuildTimeConfigBuildItem extends MultiBuildItem 
 
     private final String resolvedDriverClass;
 
-    AggregatedDataSourceBuildTimeConfigBuildItem(String name, DataSourceBuildTimeConfig dataSourceConfig,
+    public AggregatedDataSourceBuildTimeConfigBuildItem(String name, DataSourceBuildTimeConfig dataSourceConfig,
             DataSourceJdbcBuildTimeConfig jdbcConfig,
             String dbKind,
             String resolvedDriverClass) {


### PR DESCRIPTION
Making this build item public should allow extension to contribute extensions at build time. This allows the possiblity of defining datasources as code rather than config.

Runtime attributes still need to be provided as config, however it is already possible for extensions to provide runtime config so this is not really a concern.