### PR TITLE
Properly order tests annotated with `@WithTestResource`

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
@@ -2,7 +2,9 @@ package io.quarkus.test.junit.util;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -57,11 +59,14 @@ import io.quarkus.test.junit.main.QuarkusMainTest;
 public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST = "20_";
+    protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_MATCHING_RES = "30_";
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE = "40_";
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES = "45_";
     protected static final String DEFAULT_ORDER_PREFIX_NON_QUARKUS_TEST = "60_";
 
     static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST = "junit.quarkus.orderer.prefix.quarkus-test";
+
+    static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_MATCHING_RES = "junit.quarkus.orderer.prefix.quarkus-test-with-matching-resource";
 
     static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE = "junit.quarkus.orderer.prefix.quarkus-test-with-profile";
 
@@ -74,6 +79,7 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
     private final String prefixQuarkusTest;
     private final String prefixQuarkusTestWithProfile;
     private final String prefixQuarkusTestWithRestrictedResource;
+    private final String prefixQuarkusTestWithMatchingResource;
     private final String prefixNonQuarkusTest;
     private final Optional<String> secondaryOrderer;
 
@@ -81,6 +87,9 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
         Config config = ConfigProvider.getConfig();
         this.prefixQuarkusTest = config.getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_TEST, String.class)
                 .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST);
+        this.prefixQuarkusTestWithMatchingResource = config
+                .getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_MATCHING_RES, String.class)
+                .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_MATCHING_RES);
         this.prefixQuarkusTestWithProfile = config.getOptionalValue(CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE, String.class)
                 .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE);
         this.prefixQuarkusTestWithRestrictedResource = config
@@ -93,11 +102,13 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
     QuarkusTestProfileAwareClassOrderer(
             final String prefixQuarkusTest,
+            final String prefixQuarkusTestWithMatchingResource,
             final String prefixQuarkusTestWithProfile,
             final String prefixQuarkusTestWithRestrictedResource,
             final String prefixNonQuarkusTest,
             final Optional<String> secondaryOrderer) {
         this.prefixQuarkusTest = prefixQuarkusTest;
+        this.prefixQuarkusTestWithMatchingResource = prefixQuarkusTestWithMatchingResource;
         this.prefixQuarkusTestWithProfile = prefixQuarkusTestWithProfile;
         this.prefixQuarkusTestWithRestrictedResource = prefixQuarkusTestWithRestrictedResource;
         this.prefixNonQuarkusTest = prefixNonQuarkusTest;
@@ -141,23 +152,65 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
                         .map(TestProfile::value)
                         .map(profileClass -> prefixQuarkusTestWithProfile + profileClass.getName() + "@" + secondaryOrderSuffix)
                         .orElseGet(() -> {
-                            var prefix = hasRestrictedResource(classDescriptor)
-                                    ? prefixQuarkusTestWithRestrictedResource
-                                    : prefixQuarkusTest;
-                            return prefix + secondaryOrderSuffix;
+                            String prefix = prefixQuarkusTest;
+                            String suffix = "";
+                            TestResourceScope mostLimitedScope = mostLimitedScope(classDescriptor);
+                            if (mostLimitedScope != null) {
+                                if (mostLimitedScope == TestResourceScope.RESTRICTED_TO_CLASS) {
+                                    prefix = prefixQuarkusTestWithRestrictedResource;
+                                } else {
+                                    prefix = prefixQuarkusTestWithMatchingResource;
+                                    suffix = String.join(",",
+                                            lifecycleManagerClassNamesForNonRestricted(classDescriptor));
+                                }
+                            }
+                            return prefix + suffix + secondaryOrderSuffix;
                         });
             }
             return prefixNonQuarkusTest + secondaryOrderSuffix;
         }));
     }
 
-    private boolean hasRestrictedResource(ClassDescriptor classDescriptor) {
-        return classDescriptor.findRepeatableAnnotations(WithTestResource.class).stream()
-                .anyMatch(
-                        res -> res.scope() == TestResourceScope.RESTRICTED_TO_CLASS || isMetaTestResource(res, classDescriptor))
-                ||
-                classDescriptor.findRepeatableAnnotations(QuarkusTestResource.class).stream()
-                        .anyMatch(res -> res.restrictToAnnotatedClass() || isMetaTestResource(res, classDescriptor));
+    private TestResourceScope mostLimitedScope(ClassDescriptor classDescriptor) {
+        TestResourceScope result = null;
+        for (WithTestResource annotation : classDescriptor.findRepeatableAnnotations(WithTestResource.class)) {
+            if (isMetaTestResource(annotation, classDescriptor)) {
+                result = TestResourceScope.RESTRICTED_TO_CLASS;
+            } else {
+                TestResourceScope scope = annotation.scope();
+                if ((result == null) || (scope.compareTo(result) < 0)) {
+                    result = scope;
+                }
+            }
+        }
+
+        for (QuarkusTestResource annotation : classDescriptor.findRepeatableAnnotations(QuarkusTestResource.class)) {
+            if (isMetaTestResource(annotation, classDescriptor) || annotation.restrictToAnnotatedClass()) {
+                result = TestResourceScope.RESTRICTED_TO_CLASS;
+            } else {
+                result = TestResourceScope.GLOBAL;
+            }
+        }
+
+        return result;
+    }
+
+    private Set<String> lifecycleManagerClassNamesForNonRestricted(ClassDescriptor classDescriptor) {
+        Set<String> result = new HashSet<>();
+        for (WithTestResource annotation : classDescriptor.findRepeatableAnnotations(WithTestResource.class)) {
+            TestResourceScope scope = annotation.scope();
+            if ((scope != TestResourceScope.RESTRICTED_TO_CLASS) && !isMetaTestResource(annotation, classDescriptor)) {
+                result.add(annotation.value().getSimpleName());
+            }
+        }
+
+        for (QuarkusTestResource annotation : classDescriptor.findRepeatableAnnotations(QuarkusTestResource.class)) {
+            if (!annotation.restrictToAnnotatedClass() && !isMetaTestResource(annotation, classDescriptor)) {
+                result.add(annotation.value().getSimpleName());
+            }
+        }
+
+        return result;
     }
 
     @Deprecated(forRemoval = true)

--- a/test-framework/junit5/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
+++ b/test-framework/junit5/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
@@ -51,11 +51,17 @@ class QuarkusTestProfileAwareClassOrdererTest {
     @Test
     void allVariants() {
         ClassDescriptor quarkusTest1Desc = quarkusDescriptorMock(Test01.class, null);
-        ClassDescriptor quarkusTestWithUnrestrictedResourceDesc = quarkusDescriptorMock(Test02.class, Manager3.class, false,
+        ClassDescriptor quarkusTest2b = quarkusDescriptorMock(Test02b.class, Manager3.class, false,
                 WithTestResource.class);
-        ClassDescriptor quarkusTestWithUnrestrictedQuarkusTestResourceDesc = quarkusDescriptorMock(Test02a.class,
+        ClassDescriptor quarkusTest2a = quarkusDescriptorMock(Test02a.class,
                 Manager3.class, false, QuarkusTestResource.class);
-        ClassDescriptor quarkusTest2Desc = quarkusDescriptorMock(Test03.class, null);
+        ClassDescriptor quarkusTest2Desc = quarkusDescriptorMock(Test02.class, Manager3.class, false, WithTestResource.class);
+        ClassDescriptor quarkusTest3Desc = quarkusDescriptorMock(Test03.class, Manager3.class, false,
+                QuarkusTestResource.class);
+        ClassDescriptor quarkusTest3aDesc = quarkusDescriptorMock(Test03a.class, Manager4.class, false, WithTestResource.class);
+        ClassDescriptor quarkusTest3bDesc = quarkusDescriptorMock(Test03b.class, Manager4.class, false,
+                QuarkusTestResource.class);
+        ClassDescriptor quarkusTest1aDesc = quarkusDescriptorMock(Test01a.class, null);
         ClassDescriptor quarkusTestWithProfile1Desc = quarkusDescriptorMock(Test04.class, Profile1.class);
         ClassDescriptor quarkusTestWithProfile2Test4Desc = quarkusDescriptorMock(Test05.class, Profile2.class);
         ClassDescriptor quarkusTestWithProfile2Test5Desc = quarkusDescriptorMock(Test06.class, Profile2.class);
@@ -72,26 +78,34 @@ class QuarkusTestProfileAwareClassOrdererTest {
         List<ClassDescriptor> input = Arrays.asList(
                 quarkusTestWithRestrictedResourceDesc,
                 nonQuarkusTest2Desc,
+                quarkusTest2Desc,
                 quarkusTestWithRestrictedResourceDesc2,
                 quarkusTestWithProfile2Test5Desc,
-                quarkusTest2Desc,
+                quarkusTest1aDesc,
                 nonQuarkusTest1Desc,
                 quarkusTestWithMetaResourceDesc,
                 quarkusTest1Desc,
                 quarkusTestWithProfile2Test4Desc,
                 quarkusTestWithMetaResourceDesc2,
-                quarkusTestWithUnrestrictedResourceDesc,
+                quarkusTest3Desc,
+                quarkusTest2b,
                 quarkusTestWithProfile1Desc,
-                quarkusTestWithUnrestrictedQuarkusTestResourceDesc);
+                quarkusTest2a,
+                quarkusTest3bDesc,
+                quarkusTest3aDesc);
         doReturn(input).when(contextMock).getClassDescriptors();
 
         new QuarkusTestProfileAwareClassOrderer().orderClasses(contextMock);
 
         assertThat(input).containsExactly(
                 quarkusTest1Desc,
-                quarkusTestWithUnrestrictedResourceDesc,
-                quarkusTestWithUnrestrictedQuarkusTestResourceDesc,
+                quarkusTest1aDesc,
                 quarkusTest2Desc,
+                quarkusTest2a,
+                quarkusTest2b,
+                quarkusTest3Desc,
+                quarkusTest3aDesc,
+                quarkusTest3bDesc,
                 quarkusTestWithProfile1Desc,
                 quarkusTestWithProfile2Test4Desc,
                 quarkusTestWithProfile2Test5Desc,
@@ -106,11 +120,11 @@ class QuarkusTestProfileAwareClassOrdererTest {
     @Test
     void configuredPrefix() {
         ClassDescriptor quarkusTestDesc = quarkusDescriptorMock(Test01.class, null);
-        ClassDescriptor nonQuarkusTestDesc = descriptorMock(Test03.class);
+        ClassDescriptor nonQuarkusTestDesc = descriptorMock(Test01a.class);
         List<ClassDescriptor> input = Arrays.asList(quarkusTestDesc, nonQuarkusTestDesc);
         doReturn(input).when(contextMock).getClassDescriptors();
 
-        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "45_", "01_", Optional.empty()).orderClasses(contextMock);
+        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "45_", "01_", Optional.empty()).orderClasses(contextMock);
 
         assertThat(input).containsExactly(nonQuarkusTestDesc, quarkusTestDesc);
     }
@@ -129,7 +143,7 @@ class QuarkusTestProfileAwareClassOrdererTest {
                 quarkusTest1Desc);
         doReturn(input).when(contextMock).getClassDescriptors();
 
-        new QuarkusTestProfileAwareClassOrderer("20_", "40_", "45_", "60_",
+        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "45_", "60_",
                 Optional.of(ClassOrderer.OrderAnnotation.class.getName())).orderClasses(contextMock);
 
         assertThat(input).containsExactly(
@@ -141,7 +155,7 @@ class QuarkusTestProfileAwareClassOrdererTest {
     @Test
     void customOrderKey() {
         ClassDescriptor quarkusTest1Desc = quarkusDescriptorMock(Test01.class, null);
-        ClassDescriptor quarkusTest2Desc = quarkusDescriptorMock(Test03.class, null);
+        ClassDescriptor quarkusTest2Desc = quarkusDescriptorMock(Test01a.class, null);
         List<ClassDescriptor> input = Arrays.asList(quarkusTest1Desc, quarkusTest2Desc);
         doReturn(input).when(contextMock).getClassDescriptors();
 
@@ -213,7 +227,7 @@ class QuarkusTestProfileAwareClassOrdererTest {
     // this single made-up test class needs an actual annotation since the orderer will have to do the meta-check directly
     // because ClassDescriptor does not offer any details whether an annotation is directly annotated or meta-annotated
     @WithTestResource(value = Manager3.class, scope = TestResourceScope.GLOBAL)
-    private static class Test02 {
+    private static class Test02b {
     }
 
     @QuarkusTestResource(Manager3.class)
@@ -221,7 +235,27 @@ class QuarkusTestProfileAwareClassOrdererTest {
 
     }
 
+    @WithTestResource(Manager3.class)
+    private static class Test02 {
+
+    }
+
+    @QuarkusTestResource(Manager3.class)
     private static class Test03 {
+
+    }
+
+    @WithTestResource(Manager4.class)
+    private static class Test03a {
+
+    }
+
+    @QuarkusTestResource(Manager4.class)
+    private static class Test03b {
+
+    }
+
+    private static class Test01a {
     }
 
     private static class Test04 {
@@ -258,5 +292,8 @@ class QuarkusTestProfileAwareClassOrdererTest {
     }
 
     private static interface Manager3 extends QuarkusTestResourceLifecycleManager {
+    }
+
+    private static interface Manager4 extends QuarkusTestResourceLifecycleManager {
     }
 }


### PR DESCRIPTION
The configured lifecycle manager is now taken into account so test using the same managers don't require a restart. This results in much faster test execution when
multiple different tests with different @WithTestResource configurations are used.

Originally mentioned [here](https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/.40WithTestResource.28.2E.2E.2C.20scope.3DMATCHING_RESOURCES.29/near/495321926) 