### PR TITLE
Allow anonymous test extension subclasses to share the test state of their parents

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
@@ -57,7 +57,7 @@ public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTe
         QuarkusTestExtensionState state = store.get(QuarkusTestExtensionState.class.getName(), QuarkusTestExtensionState.class);
         if (state != null) {
             Class<?> testingTypeOfState = store.get(IO_QUARKUS_TESTING_TYPE, Class.class);
-            if (!this.getClass().equals(testingTypeOfState)) {
+            if (!this.getTestingType().equals(testingTypeOfState)) {
                 // The current state was created by a different testing type, so we need to renew it, so the new state is
                 // compatible with the current testing type.
                 try {
@@ -78,7 +78,7 @@ public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTe
     protected void setState(ExtensionContext context, QuarkusTestExtensionState state) {
         ExtensionContext.Store store = getStoreFromContext(context);
         store.put(QuarkusTestExtensionState.class.getName(), state);
-        store.put(IO_QUARKUS_TESTING_TYPE, this.getClass());
+        store.put(IO_QUARKUS_TESTING_TYPE, this.getTestingType());
     }
 
     protected ExtensionContext.Store getStoreFromContext(ExtensionContext context) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractTestWithCallbacksExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractTestWithCallbacksExtension.java
@@ -170,4 +170,24 @@ public abstract class AbstractTestWithCallbacksExtension {
             throw e;
         }
     }
+
+    protected Class getTestingType() {
+
+        // In general, the testing type should be the test extension class, but ...
+        Class type = this.getClass();
+
+        // We don't want to pick up the class of anonymous classes, since they're clearly supposed to 'be' the superclass.
+        // We want something like
+        //        @RegisterExtension
+        //        static QuarkusTestExtension TEST = new QuarkusTestExtension() {
+        //        @Override
+        //        // Whatever
+        //  };
+        // to count as a QuarkusTestExtension class
+        if (type.isAnonymousClass()) {
+            return type.getSuperclass();
+        } else {
+            return type;
+        }
+    }
 }


### PR DESCRIPTION
The Quarkus test infrastructure holds state about various things, including references to the currently running Quarkus application. It wants state to be shareable between tests of the same type (normal test, integration test, component test, etc), but not shareable between those different types. To do this, it uses the class name of the test extension as a key. These type all have a common parent, so it needs to be careful with checks based on the hierarchy.

This normally works well, but in my test classloading runs, I hit a problem where state should have been shared, and was not. `HibernatePropertiesTest` uses an anonymous subclass to change the behaviour of `QuarkusTestExtension`. That means it can't share state with other tests in the same project.  

```
  @RegisterExtension
        static QuarkusTestExtension TEST = new QuarkusTestExtension() {
         @Override
          ... 
```

I think we don't want to 'count' the class of anonymous classes as different, since they're clearly supposed to 'be' the superclass.

(Why did I see the problem, when `main` is working fine? It was either because my code changed the test order, or because the new logic is a bit more dependent on the state. I've already forgotten, because it was a whole day ago. However, I think it's possible for other tests running against normal-Quarkus to potentially hit this problem, if they're adventurous enough to do the subclassing. )