### PR TITLE
Improve docs for Hibernate ORM with Kafka to suggest more efficient approaches

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -2956,9 +2956,7 @@ NOTE: If you use Hibernate Reactive, look at <<writing-entities-managed-by-hiber
 
 Because we write to a database, we must run this method in a transaction.
 Yet, sending the entity to Kafka happens asynchronously.
-The operation returns a `CompletionStage` (or a `Uni` if you use a `MutinyEmitter`) reporting when the operation completes.
-We must be sure that the transaction is still running until the object is written.
-Otherwise, you may access the object outside the transaction, which is not allowed.
+We can achieve this by using `.sendAndAwait()` or `.sendAndForget()` on the `MutinyEmitter`, or `.send().toCompletableFuture().join()` on the `Emitter`.
 
 To implement this process, you need the following approach:
 
@@ -2973,26 +2971,29 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
+import io.smallrye.reactive.messaging.MutinyEmitter;
 
 @Path("/")
 public class ResourceSendingToKafka {
 
-    @Channel("kafka") Emitter<Fruit> emitter;
+    @Channel("kafka") MutinyEmitter<Fruit> emitter;
 
     @POST
     @Path("/fruits")
-    @Transactional                                                      // <1>
-    public CompletionStage<Void> storeAndSendToKafka(Fruit fruit) {     // <2>
+    @Transactional                                               // <1>
+    public void storeAndSendToKafka(Fruit fruit) {               // <2>
         fruit.persist();
-        return emitter.send(new FruitDto(fruit));                       // <3>
+        emitter.sendAndAwait(new FruitDto(fruit));               // <3>
     }
 }
 ----
 <1> As we are writing to the database, make sure we run inside a transaction
-<2> The method receives the fruit instance to persist. It returns a `CompletionStage` which is used for the transaction demarcation. The transaction is committed when the return `CompletionStage` completes. In our case, it's when the message is written to Kafka.
+<2> The method receives the fruit instance to persist.
 <3> Wrap the managed entity inside a Data transfer object and send it to Kafka.
 This makes sure that managed entity is not impacted by the Kafka serialization.
+Then await the completion of the operation before returning.
+
+NOTE: You should not return a `CompletionStage` or `Uni` when using `@Transactional`, as all transaction commits will happen on a single thread, which impacts performance.
 
 [[writing-entities-managed-by-hibernate-reactive-to-kafka]]
 === Writing entities managed by Hibernate Reactive to Kafka


### PR DESCRIPTION
The context of this PR is the following discussion: https://github.com/quarkusio/quarkus/discussions/45792

Basically, we have a REST endpoint in our product using Quarkus that uses Hibernate and Kafka message sending. We switched this over from Hibernate Reactive to Hibernate ORM (and therefore got rid of the mutiny stack), and noticed a significant slowdown in throughput that was unrelated to switching away from Mutiny. After some investigations and discussions, we noticed that the performance regression was inherent to how Quarkus suggests you use Hibernate ORM with Emitters, which is suboptimal.

The big thing that happens with the suggested approach is that due to returning an asynchronous call of the message emitter to a function using `@Transactional`, all Hibernate transaction commits happen from the asynchronous thread, which makes all transactions commit on the same thread, which obviously causes a slowdown in throughput.

This PR tries to change 2 things about the suggested approach by the documentation:
1. (less important): Always use the MutinyEmitter since it is more optimised according to @cescoffier: "The MutinyEmitter is way more optimized and should be the standard choice" (https://github.com/quarkusio/quarkus/discussions/45792#discussioncomment-11927708)
2. (more important): Do not commit the transaction in async space.

I would personally say this documentation is definitely still a bit rough. It is an initial suggestion that I maybe can iterate on based on feedback. Some of the things I'm already wondering with this change:
1. Should we use MutinyEmitter for both examples since it should be standard, or should we still show the normal Emitter in the second approach.
2. What is a right balance between the length of the documentation and the number of options covered? Of course there is also for example a MutinyEmitter async approach, and an Emitter sync approach
3. Should the reasons for going with approach one be an itimized list or numbered list
4. More general things: Is the structure good?

Essentially, I look forward to feedback and whether you agree with this documentation change. 