### PR TITLE
Context propagation for Messaging

### DIFF
--- a/docs/src/main/asciidoc/messaging.adoc
+++ b/docs/src/main/asciidoc/messaging.adoc
@@ -488,6 +488,7 @@ public class StreamProcessor {
 }
 ----
 
+[[execution_model]]
 == Execution Model
 
 Quarkus Messaging sits on top of the xref:quarkus-reactive-architecture.adoc#engine[reactive engine] of Quarkus and leverages link:{eclipse-vertx}[Eclipse Vert.x] to dispatch messages for processing.
@@ -559,6 +560,100 @@ This creates four copies of the incoming channel under the hood, wiring them to 
 Depending on the broker technology, this can be useful to increase the application's throughput by processing multiple messages concurrently
 while still preserving the partial order of messages received in different copies.
 This is the case, for example, for Kafka, where multiple consumers can consume different topic partitions.
+
+== Context Propagation
+
+In Quarkus Messaging, the default mechanism for propagating context between different processing stages is the
+link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/message-context[message context].
+This provides a consistent way to pass context information along with the message as it flows through different stages.
+
+=== Interaction with Mutiny and MicroProfile Context Propagation
+
+Mutiny, which is the foundation of reactive programming in Quarkus, is integrated with the MicroProfile Context Propagation.
+This integration enables automatic capturing and restoring of context across asynchronous boundaries.
+To learn more about context propagation in Quarkus and Mutiny, refer to the xref:context-propagation.adoc[Context Propagation] guide.
+
+However, Quarkus Messaging needs to coordinate multiple asynchronous boundaries.
+This is why the default context propagation can result in unexpected behavior in some cases, especially using `Emitters`.
+
+To ensure consistent behavior, Quarkus Messaging disables the propagation of any context during message dispatching, through internal channels or connectors.
+This means that Emitters won't capture the caller context, and incoming channels won't dispatch messages by activating a context (ex. the request context).
+
+For example, you might want to propagate the caller context from an incoming HTTP request to the message processing stage.
+For emitters, instead of using the regular `Emitter` or `MutinyEmitter`, you can inject the `ContextualEmitter` to make sure the message captures the caller context.
+This ensures consistent and predictable behaviour by relying on the message context handling provided by the framework.
+
+For example, let `RequestScopedBean` a request-scoped bean, `ContextualEmitter` can be used to dispatch messages locally through the internal channel `app`:
+
+[source, java]
+----
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.quarkus.logging.Log;
+import io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitter;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/")
+public class Resource {
+
+    @Channel("app")
+    ContextualEmitter<String> emitter;
+
+    @Inject
+    RequestScopedBean requestScopedBean;
+
+    @POST
+    @Path("/send")
+    public void send(String message) {
+        requestScopedBean.setValue("Hello");
+        emitter.sendAndAwait(message);
+    }
+
+}
+----
+
+Then the request-scoped bean can be accessed in the message processing stage, regardless of the <<execution_model>>:
+
+[source, java]
+----
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.quarkus.logging.Log;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+
+
+@ApplicationScoped
+public class Processor {
+
+    @Inject
+    RequestScopedBean requestScopedBean;
+
+    @Incoming("app")
+    @Blocking
+    public void process(String message) {
+        Log.infof("Message %s from request %s", message, requestScopedBean.getValue());
+    }
+
+}
+----
+
+=== Request Context Activation
+
+In some cases, you might need to activate the request context while processing messages consumed from a broker.
+While using `@ActivateRequestContext` on the `@Incoming` method is an option, it's lifecycle does not follow that of a Quarkus Messaging message.
+For incoming channels, you can enable the request scope activation with the build time property `quarkus.messaging.request-scoped.enabled=true`.
+This will activate the request context for each message processed by the incoming channel, and close the context once the message is processed.
 
 == Health Checks
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingBuildTimeConfig.java
@@ -27,4 +27,11 @@ public interface ReactiveMessagingBuildTimeConfig {
     @WithName("auto-connector-attachment")
     @WithDefault("true")
     boolean autoConnectorAttachment();
+
+    /**
+     * Whether to enable the RequestScope context on a message context
+     */
+    @WithName("request-scoped.enabled")
+    @WithDefault("false")
+    boolean activateRequestScopeEnabled();
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -70,6 +70,8 @@ import io.quarkus.smallrye.reactivemessaging.deployment.items.ConnectorManagedCh
 import io.quarkus.smallrye.reactivemessaging.deployment.items.InjectedChannelBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.InjectedEmitterBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.MediatorBuildItem;
+import io.quarkus.smallrye.reactivemessaging.runtime.ContextClearedDecorator;
+import io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitterFactory;
 import io.quarkus.smallrye.reactivemessaging.runtime.DuplicatedContextConnectorFactory;
 import io.quarkus.smallrye.reactivemessaging.runtime.DuplicatedContextConnectorFactoryInterceptor;
 import io.quarkus.smallrye.reactivemessaging.runtime.HealthCenterFilter;
@@ -77,6 +79,7 @@ import io.quarkus.smallrye.reactivemessaging.runtime.HealthCenterInterceptor;
 import io.quarkus.smallrye.reactivemessaging.runtime.QuarkusMediatorConfiguration;
 import io.quarkus.smallrye.reactivemessaging.runtime.QuarkusWorkerPoolRegistry;
 import io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration;
+import io.quarkus.smallrye.reactivemessaging.runtime.RequestScopedDecorator;
 import io.quarkus.smallrye.reactivemessaging.runtime.SmallRyeReactiveMessagingLifecycle;
 import io.quarkus.smallrye.reactivemessaging.runtime.SmallRyeReactiveMessagingRecorder;
 import io.quarkus.smallrye.reactivemessaging.runtime.SmallRyeReactiveMessagingRecorder.SmallRyeReactiveMessagingContext;
@@ -112,11 +115,14 @@ public class SmallRyeReactiveMessagingProcessor {
     }
 
     @BuildStep
-    AdditionalBeanBuildItem beans() {
+    void beans(BuildProducer<AdditionalBeanBuildItem> additionalBean, ReactiveMessagingBuildTimeConfig buildTimeConfig) {
         // We add the connector and channel qualifiers to make them part of the index.
-        return new AdditionalBeanBuildItem(SmallRyeReactiveMessagingLifecycle.class, Connector.class,
+        additionalBean.produce(new AdditionalBeanBuildItem(SmallRyeReactiveMessagingLifecycle.class, Connector.class,
                 Channel.class, io.smallrye.reactive.messaging.annotations.Channel.class,
-                QuarkusWorkerPoolRegistry.class);
+                QuarkusWorkerPoolRegistry.class, ContextualEmitterFactory.class, ContextClearedDecorator.class));
+        if (buildTimeConfig.activateRequestScopeEnabled()) {
+            additionalBean.produce(new AdditionalBeanBuildItem(RequestScopedDecorator.class));
+        }
     }
 
     @BuildStep

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextClearedDecorator.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextClearedDecorator.java
@@ -1,0 +1,39 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.PublisherDecorator;
+
+@ApplicationScoped
+public class ContextClearedDecorator implements PublisherDecorator {
+
+    private final ThreadContext tc;
+
+    public ContextClearedDecorator() {
+        tc = ThreadContext.builder()
+                .propagated(ThreadContext.NONE)
+                .cleared(ThreadContext.ALL_REMAINING)
+                .build();
+    }
+
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, List<String> channelName,
+            boolean isConnector) {
+        if (isConnector) {
+            return publisher.emitOn(tc.currentContextExecutor());
+        }
+        return publisher;
+    }
+
+    @Override
+    public int getPriority() {
+        // Before the io.smallrye.reactive.messaging.providers.locals.ContextDecorator which has the priority 0
+        return -100;
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitter.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitter.java
@@ -1,0 +1,17 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.EmitterType;
+
+public interface ContextualEmitter<T> extends EmitterType {
+
+    Uni<Void> send(T payload);
+
+    void sendAndAwait(T payload);
+
+    <M extends Message<? extends T>> Uni<Void> sendMessage(M msg);
+
+    <M extends Message<? extends T>> void sendMessageAndAwait(M msg);
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterFactory.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterFactory.java
@@ -1,0 +1,36 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Typed;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.EmitterConfiguration;
+import io.smallrye.reactive.messaging.EmitterFactory;
+import io.smallrye.reactive.messaging.annotations.EmitterFactoryFor;
+import io.smallrye.reactive.messaging.providers.extension.ChannelProducer;
+
+@EmitterFactoryFor(ContextualEmitter.class)
+@ApplicationScoped
+public class ContextualEmitterFactory implements EmitterFactory<ContextualEmitterImpl<Object>> {
+
+    @Inject
+    ChannelRegistry channelRegistry;
+
+    @Override
+    public ContextualEmitterImpl<Object> createEmitter(EmitterConfiguration emitterConfiguration, long l) {
+        return new ContextualEmitterImpl<>(emitterConfiguration, l);
+    }
+
+    @Produces
+    @Typed(ContextualEmitter.class)
+    @Channel("") // Stream name is ignored during type-safe resolution
+    <T> ContextualEmitter<T> produceEmitter(InjectionPoint injectionPoint) {
+        String channelName = ChannelProducer.getChannelName(injectionPoint);
+        return channelRegistry.getEmitter(channelName, ContextualEmitter.class);
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterImpl.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterImpl.java
@@ -1,0 +1,72 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import static io.smallrye.reactive.messaging.providers.i18n.ProviderExceptions.ex;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.EmitterConfiguration;
+import io.smallrye.reactive.messaging.providers.extension.AbstractEmitter;
+import io.smallrye.reactive.messaging.providers.locals.LocalContextMetadata;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+public class ContextualEmitterImpl<T> extends AbstractEmitter<T> implements ContextualEmitter<T> {
+
+    public ContextualEmitterImpl(EmitterConfiguration configuration, long defaultBufferSize) {
+        super(configuration, defaultBufferSize);
+    }
+
+    @Override
+    public void sendAndAwait(T payload) {
+        sendMessage(Message.of(payload)).await().indefinitely();
+    }
+
+    @Override
+    public Uni<Void> send(T payload) {
+        return sendMessage(Message.of(payload));
+    }
+
+    @Override
+    public <M extends Message<? extends T>> void sendMessageAndAwait(M msg) {
+        sendMessage(msg).await().indefinitely();
+    }
+
+    @Override
+    @CheckReturnValue
+    public <M extends Message<? extends T>> Uni<Void> sendMessage(M msg) {
+        if (msg == null) {
+            throw ex.illegalArgumentForNullValue();
+        }
+
+        // If we are running on a Vert.x context, we need to capture the context to switch back during the emission.
+        Context context = Vertx.currentContext();
+        Uni<Void> uni = Uni.createFrom().emitter(e -> {
+            try {
+                Message<? extends T> message = msg;
+                if (VertxContext.isDuplicatedContext(context)) {
+                    message = message.addMetadata(new LocalContextMetadata(context));
+                }
+                emit(message.withAck(() -> {
+                    e.complete(null);
+                    return msg.ack();
+                })
+                        .withNack(t -> {
+                            e.fail(t);
+                            return msg.nack(t);
+                        }));
+            } catch (Exception t) {
+                // Capture synchronous exception and nack the message.
+                msg.nack(t);
+                throw t;
+            }
+        });
+        if (context != null) {
+            uni = uni.emitOn(runnable -> context.runOnContext(x -> runnable.run()));
+        }
+        return uni;
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/RequestScopedDecorator.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/RequestScopedDecorator.java
@@ -1,0 +1,55 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.ManagedContext;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.PublisherDecorator;
+import io.smallrye.reactive.messaging.providers.locals.LocalContextMetadata;
+
+@ApplicationScoped
+public class RequestScopedDecorator implements PublisherDecorator {
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, List<String> channelName,
+            boolean isConnector) {
+        if (isConnector) {
+            return publisher.map(message -> {
+                Optional<LocalContextMetadata> localContextMetadata = message.getMetadata(LocalContextMetadata.class);
+                if (localContextMetadata.isPresent() && VertxContext.isOnDuplicatedContext()) {
+                    ManagedContext requestContext = Arc.container().requestContext();
+                    if (!requestContext.isActive()) {
+                        requestContext.activate();
+                        InjectableContext.ContextState state = requestContext.getState();
+                        Message<?> withAck = message.withAckWithMetadata(m -> message.ack(m)
+                                .thenAccept(x -> {
+                                    requestContext.destroy(state);
+                                    requestContext.deactivate();
+                                }));
+                        return withAck.withNackWithMetadata((m, t) -> withAck.nack(m, t)
+                                .thenAccept(x -> {
+                                    requestContext.destroy(state);
+                                    requestContext.deactivate();
+                                }));
+                    }
+                    return message;
+                } else {
+                    return message;
+                }
+            });
+        }
+        return publisher;
+    }
+
+    @Override
+    public int getPriority() {
+        return 100;
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -339,6 +339,7 @@
                 <module>reactive-messaging-rabbitmq-dyn</module>
                 <module>reactive-messaging-hibernate-reactive</module>
                 <module>reactive-messaging-hibernate-orm</module>
+                <module>reactive-messaging-context-propagation</module>
                 <module>rest-client</module>
                 <module>resteasy-reactive-kotlin</module>
                 <module>rest-client-reactive</module>

--- a/integration-tests/reactive-messaging-context-propagation/pom.xml
+++ b/integration-tests/reactive-messaging-context-propagation/pom.xml
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-reactive-messaging-context-propagation</artifactId>
+    <name>Quarkus - Integration Tests - Reactive Messaging - Context Propagation</name>
+    <description>The Reactive Messaging Context Propagation integration tests module</description>
+
+    <properties>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-shared-library</artifactId>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+        </dependency>
+
+        <!-- Health -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+
+        <!-- Micrometer -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <!-- Kafka -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-kafka</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-kafka-companion</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-client-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-kafka-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-kafka</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerContextualResource.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerContextualResource.java
@@ -1,0 +1,122 @@
+package io.quarkus.it.kafka;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.quarkus.logging.Log;
+import io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitter;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/flowers/contextual")
+public class FlowerContextualResource {
+
+    @Channel("contextual-flower")
+    ContextualEmitter<String> emitter;
+
+    @Channel("contextual-flower-blocking")
+    ContextualEmitter<String> emitterBlocking;
+
+    @Channel("contextual-flower-blocking-named")
+    ContextualEmitter<String> emitterBlockingNamed;
+
+    @Channel("contextual-flower-virtual-thread")
+    ContextualEmitter<String> emitterVT;
+
+    @Inject
+    RequestBean reqBean;
+
+    @POST
+    @Path("/uni")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniEventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitter.send(body);
+    }
+
+    @POST
+    @Path("/uni/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniBlocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterBlocking.send(body);
+    }
+
+    @POST
+    @Path("/uni/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniBlockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterBlockingNamed.send(body);
+    }
+
+    @POST
+    @Path("/uni/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniVT(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterVT.send(body);
+    }
+
+    @POST
+    @Path("/")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void eventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitter.sendAndAwait(body);
+    }
+
+    @POST
+    @Path("/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void blocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterBlocking.sendAndAwait(body);
+    }
+
+    @POST
+    @Path("/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void blockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterBlockingNamed.sendAndAwait(body);
+    }
+
+    @POST
+    @Path("/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void vt(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterVT.sendAndAwait(body);
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerProducer.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerProducer.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.smallrye.reactive.messaging.MutinyEmitter;
+
+@Path("/flowers")
+public class FlowerProducer {
+
+    List<String> received = new CopyOnWriteArrayList<>();
+
+    @Channel("flowers-out")
+    MutinyEmitter<String> emitter;
+
+    @POST
+    @Path("/produce")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void produce(String flower) {
+        emitter.sendAndAwait(flower);
+    }
+
+    void addReceived(String flower) {
+        received.add(flower);
+    }
+
+    public List<String> getReceived() {
+        return received;
+    }
+
+    @GET
+    @Path("/received")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> received() {
+        return received;
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerReceivers.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerReceivers.java
@@ -1,0 +1,104 @@
+package io.quarkus.it.kafka;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.jboss.logging.Logger;
+
+import io.quarkus.logging.Log;
+import io.quarkus.test.vertx.VirtualThreadsAssertions;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@ApplicationScoped
+public class FlowerReceivers {
+
+    @Inject
+    RequestBean reqBean;
+
+    @Inject
+    Logger logger;
+
+    @Incoming("flower")
+    void process(String name) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnEventLoopThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Greeting, %s", reqBean.getName());
+    }
+
+    @Blocking
+    @Incoming("flower-blocking")
+    void processBlocking(String name) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Greeting, %s", reqBean.getName());
+    }
+
+    @Blocking("named-pool")
+    @Incoming("flower-blocking-named")
+    void processBlockingNamed(String name) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Greeting, %s", reqBean.getName());
+    }
+
+    @RunOnVirtualThread
+    @Incoming("flower-virtual-thread")
+    void processVT(String name) {
+        Context ctx = Vertx.currentContext();
+        VirtualThreadsAssertions.assertThatItRunsOnVirtualThread();
+        VirtualThreadsAssertions.assertThatItRunsOnADuplicatedContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Greeting, %s", reqBean.getName());
+    }
+
+    @Inject
+    FlowerProducer producer;
+
+    @Incoming("flowers-in")
+    @NonBlocking
+    void receive(String flower) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnEventLoopThread();
+        //        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        System.out.println("Received io: " + flower);
+        producer.addReceived(flower);
+    }
+
+    @Incoming("flowers-in")
+    @Blocking
+    void receiveBlocking(String flower) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        System.out.println("Received blocking: " + flower);
+        producer.addReceived(flower);
+    }
+
+    @Incoming("flowers-in")
+    @RunOnVirtualThread
+    void receiveVT(String flower) {
+        Context ctx = Vertx.currentContext();
+        VirtualThreadsAssertions.assertThatItRunsOnVirtualThread();
+        VirtualThreadsAssertions.assertThatItRunsOnADuplicatedContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        System.out.println("Received vt: " + flower);
+        producer.addReceived(flower);
+    }
+
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerResource.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerResource.java
@@ -1,0 +1,135 @@
+package io.quarkus.it.kafka;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.quarkus.logging.Log;
+import io.smallrye.context.api.CurrentThreadContext;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/flowers")
+public class FlowerResource {
+
+    @Channel("flower")
+    MutinyEmitter<String> emitter;
+
+    @Channel("flower-blocking")
+    MutinyEmitter<String> emitterBlocking;
+
+    @Channel("flower-blocking-named")
+    MutinyEmitter<String> emitterBlockingNamed;
+
+    @Channel("flower-virtual-thread")
+    MutinyEmitter<String> emitterVT;
+
+    @Inject
+    RequestBean reqBean;
+
+    @CurrentThreadContext(cleared = ThreadContext.CDI)
+    void emitWithoutContext(MutinyEmitter<String> emitter, String body) {
+        emitter.sendAndAwait(body);
+    }
+
+    @CurrentThreadContext(cleared = ThreadContext.CDI)
+    Uni<Void> emitWithoutContextUni(MutinyEmitter<String> emitter, String body) {
+        return emitter.send(body);
+    }
+
+    @POST
+    @Path("/uni")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniEventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitWithoutContextUni(emitter, body);
+    }
+
+    @POST
+    @Path("/uni/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniBlocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitWithoutContextUni(emitterBlocking, body);
+    }
+
+    @POST
+    @Path("/uni/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniBlockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitWithoutContextUni(emitterBlockingNamed, body);
+    }
+
+    @POST
+    @Path("/uni/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniVT(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitWithoutContextUni(emitterVT, body);
+    }
+
+    @POST
+    @Path("/")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void eventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitWithoutContext(emitter, body);
+    }
+
+    @POST
+    @Path("/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void blocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitWithoutContext(emitterBlocking, body);
+    }
+
+    @POST
+    @Path("/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void blockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitWithoutContext(emitterBlockingNamed, body);
+    }
+
+    @POST
+    @Path("/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void vt(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitWithoutContext(emitterVT, body);
+    }
+
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowersContextualReceivers.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowersContextualReceivers.java
@@ -1,0 +1,63 @@
+package io.quarkus.it.kafka;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.jboss.logging.Logger;
+
+import io.quarkus.logging.Log;
+import io.quarkus.test.vertx.VirtualThreadsAssertions;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@ApplicationScoped
+public class FlowersContextualReceivers {
+
+    @Inject
+    RequestBean reqBean;
+
+    @Inject
+    Logger logger;
+
+    @Incoming("contextual-flower")
+    void processContextual(String name) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+    }
+
+    @Blocking
+    @Incoming("contextual-flower-blocking")
+    void processContextualBlocking(String name) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+    }
+
+    @Blocking("named-pool")
+    @Incoming("contextual-flower-blocking-named")
+    void processContextualBlockingNamed(String name) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+    }
+
+    @RunOnVirtualThread
+    @Incoming("contextual-flower-virtual-thread")
+    void processContextualVT(String name) {
+        Context ctx = Vertx.currentContext();
+        VirtualThreadsAssertions.assertThatItRunsOnVirtualThread();
+        VirtualThreadsAssertions.assertThatItRunsOnADuplicatedContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/RequestBean.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/RequestBean.java
@@ -1,0 +1,34 @@
+package io.quarkus.it.kafka;
+
+import java.util.UUID;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class RequestBean {
+
+    private final String id;
+    private String name;
+
+    public RequestBean() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    @PostConstruct
+    void construct() {
+        System.out.println("ReqBean constructed " + this.id);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/resources/application.properties
@@ -1,0 +1,21 @@
+quarkus.log.category.kafka.level=WARN
+quarkus.log.category.\"org.apache.kafka\".level=WARN
+quarkus.log.category.\"org.apache.zookeeper\".level=WARN
+
+# enable health check
+quarkus.kafka.health.enabled=true
+
+kafka.auto.offset.reset=earliest
+
+quarkus.micrometer.binder.messaging.enabled=true
+smallrye.messaging.observation.enabled=true
+
+
+smallrye.messaging.worker.named-pool.max-concurrency=2
+
+mp.messaging.incoming.flowers-in.topic=flowers
+# Broadcast to 3 different consume methods
+mp.messaging.incoming.flowers-in.broadcast=true
+mp.messaging.outgoing.flowers-out.topic=flowers
+# Uncomment the following line to enable request-scoped messaging, disabled by default:
+#quarkus.messaging.request-scoped.enabled=true

--- a/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationIT.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationIT.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.kafka;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class KafkaContextPropagationIT extends KafkaContextPropagationTest {
+
+    @Override
+    protected Matcher<String> assertBodyRequestScopedContextWasNotActive() {
+        return Matchers.not(Matchers.blankOrNullString());
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationTest.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationTest.java
@@ -1,0 +1,142 @@
+package io.quarkus.it.kafka;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+
+@QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
+public class KafkaContextPropagationTest {
+
+    @Test
+    void testContextPropagation() {
+        given().body("rose").post("/flowers/contextual").then().statusCode(204);
+    }
+
+    @Test
+    void testContextPropagationUni() {
+        given().body("rose").post("/flowers/contextual/uni").then().statusCode(204);
+    }
+
+    @Test
+    void testContextPropagationBlocking() {
+        given().body("rose").post("/flowers/contextual/blocking").then().statusCode(204);
+    }
+
+    @Test
+    void testContextPropagationBlockingUni() {
+        given().body("rose").post("/flowers/contextual/uni/blocking").then().statusCode(204);
+    }
+
+    @Test
+    void testContextPropagationBlockingNamed() {
+        given().body("rose").post("/flowers/contextual/blocking-named").then().statusCode(204);
+    }
+
+    @Test
+    void testContextPropagationBlockingNamedUni() {
+        given().body("rose").post("/flowers/contextual/uni/blocking-named").then().statusCode(204);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void testContextPropagationVirtualThread() {
+        given().body("rose").post("/flowers/contextual/virtual-thread").then().statusCode(204);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void testContextPropagationVirtualThreadUni() {
+        given().body("rose").post("/flowers/contextual/uni/virtual-thread").then().statusCode(204);
+    }
+
+    @Test
+    void testAbsenceOfContextPropagation() {
+        given().body("rose").post("/flowers").then()
+                .statusCode(500)
+                .body(assertBodyRequestScopedContextWasNotActive());
+    }
+
+    @Test
+    void testAbsenceOfContextPropagationUni() {
+        given().body("rose").post("/flowers/uni").then()
+                .statusCode(500)
+                .body(assertBodyRequestScopedContextWasNotActive());
+    }
+
+    @Test
+    void testAbsenceOfContextPropagationBlocking() {
+        given().body("rose").post("/flowers/blocking").then()
+                .statusCode(500)
+                .body(assertBodyRequestScopedContextWasNotActive());
+    }
+
+    @Test
+    void testAbsenceOfContextPropagationBlockingUni() {
+        given().body("rose").post("/flowers/uni/blocking").then()
+                .statusCode(500)
+                .body(assertBodyRequestScopedContextWasNotActive());
+    }
+
+    @Test
+    void testAbsenceOfContextPropagationBlockingNamed() {
+        given().body("rose").post("/flowers/blocking-named").then()
+                .statusCode(500)
+                .body(assertBodyRequestScopedContextWasNotActive());
+    }
+
+    @Test
+    void testAbsenceOfContextPropagationBlockingNamedUni() {
+        given().body("rose").post("/flowers/uni/blocking-named").then()
+                .statusCode(500)
+                .body(assertBodyRequestScopedContextWasNotActive());
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void testAbsenceOfContextPropagationVirtualThread() {
+        given().body("rose").post("/flowers/virtual-thread").then()
+                .statusCode(500)
+                .body(assertBodyRequestScopedContextWasNotActive());
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void testAbsenceOfContextPropagationVirtualThreadUni() {
+        given().body("rose").post("/flowers/uni/virtual-thread").then()
+                .statusCode(500)
+                .body(assertBodyRequestScopedContextWasNotActive());
+    }
+
+    protected Matcher<String> assertBodyRequestScopedContextWasNotActive() {
+        return containsString("RequestScoped context was not active");
+    }
+
+    @Test
+    void testIncomingFromConnector() {
+        given().body("rose").post("/flowers/produce").then()
+                .statusCode(204);
+        given().body("daisy").post("/flowers/produce").then()
+                .statusCode(204);
+        given().body("peony").post("/flowers/produce").then()
+                .statusCode(204);
+
+        await().pollDelay(5, TimeUnit.SECONDS).untilAsserted(() -> given().get("/flowers/received")
+                .then().body(not(containsString("rose")),
+                        not(containsString("daisy")),
+                        not(containsString("peony"))));
+    }
+
+}


### PR DESCRIPTION
Introduce ContextualEmitter to Quarkus Messaging. This new type of emitter dispatches the message on the caller context, instead of a separate message context

Any other kind of context propagation in Messaging channels is removed via `ContextClearedDecorator`.

Flag for enabling usage of request scoped beans bound to a message duplicated context