### PR TITLE
Provide getter for field dataSourceSupport in class DataSourceHealthCheck

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
@@ -1,6 +1,7 @@
 package io.quarkus.agroal.runtime.health;
 
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -79,5 +80,9 @@ public class DataSourceHealthCheck implements HealthCheck {
             }
         }
         return builder.build();
+    }
+
+    protected Map<String, DataSource> getCheckedDataSources() {
+        return Collections.unmodifiableMap(checkedDataSources);
     }
 }


### PR DESCRIPTION
The getter returns an unmodifiable view of checkedDataSources.

Resolves #45833 