### PR TITLE
Clean up `VirtualThreadsConfig` by removing an unnecessary comment clarifying default values

### DIFF
--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsConfig.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsConfig.java
@@ -14,7 +14,6 @@ public interface VirtualThreadsConfig {
 
     /**
      * Virtual thread name prefix. The name of the virtual thread will be the prefix followed by a unique number.
-     * The default value is "quarkus-virtual-thread-".
      */
     @WithDefault("quarkus-virtual-thread-")
     Optional<String> namePrefix();


### PR DESCRIPTION
- Follow-up to https://github.com/quarkusio/quarkus/pull/45749