### PR TITLE
Use explicit String.concat in OTelDurationConverter

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
@@ -162,9 +162,9 @@ public class OpenTelemetryRecorder {
             }
 
             try {
-                return duration.toMillis() + "ms";
+                return String.valueOf(duration.toMillis()).concat("ms");
             } catch (Exception ignored) {
-                return duration.toSeconds() + "s";
+                return String.valueOf(duration.toSeconds()).concat("s");
             }
         }
     }


### PR DESCRIPTION
This is done because `OTelDurationConverter` is used at startup and concatenation with `+` forces the use of `StringConcatFactory` via an `invokedynamic` instructon and this whole dance is rather heavy,  while not beneficial in this simple case.

The flamegraph showing this is:

![old](https://github.com/user-attachments/assets/ed6d3fd7-c44f-4f0b-a13a-68d3f3576bd5)
