### PR TITLE
gRPC: Perform authentication when gRPC server runs on the same server and root path is different than '/'

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -21,6 +21,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
 import jakarta.transaction.Transaction;
@@ -90,9 +91,14 @@ import io.quarkus.grpc.runtime.supports.exc.ExceptionInterceptor;
 import io.quarkus.kubernetes.spi.KubernetesPortBuildItem;
 import io.quarkus.netty.deployment.MinNettyAllocatorMaxOrderBuildItem;
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
+import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.VertxWebRouterBuildItem;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
 
 public class GrpcServerProcessor {
 
@@ -683,7 +689,8 @@ public class GrpcServerProcessor {
             List<RecorderBeanInitializedBuildItem> orderEnforcer,
             LaunchModeBuildItem launchModeBuildItem,
             VertxWebRouterBuildItem routerBuildItem,
-            VertxBuildItem vertx, Capabilities capabilities) {
+            VertxBuildItem vertx, Capabilities capabilities,
+            List<FilterBuildItem> filterBuildItems) {
 
         // Build the list of blocking methods per service implementation
         Map<String, List<String>> blocking = new HashMap<>();
@@ -702,10 +709,23 @@ public class GrpcServerProcessor {
         if (!bindables.isEmpty()
                 || (LaunchMode.current() == LaunchMode.DEVELOPMENT && buildTimeConfig.devMode.forceServerStart)) {
             //Uses mainrouter when the 'quarkus.http.root-path' is not '/'
-            recorder.initializeGrpcServer(vertx.getVertx(),
-                    routerBuildItem.getMainRouter() != null ? routerBuildItem.getMainRouter() : routerBuildItem.getHttpRouter(),
+            Map<Integer, Handler<RoutingContext>> securityHandlers = null;
+            final RuntimeValue<Router> routerRuntimeValue;
+            if (routerBuildItem.getMainRouter() != null) {
+                routerRuntimeValue = routerBuildItem.getMainRouter();
+                if (capabilities.isPresent(Capability.SECURITY)) {
+                    securityHandlers = filterBuildItems
+                            .stream()
+                            .filter(filter -> filter.getPriority() == FilterBuildItem.AUTHENTICATION
+                                    || filter.getPriority() == FilterBuildItem.AUTHORIZATION)
+                            .collect(Collectors.toMap(f -> f.getPriority() * -1, FilterBuildItem::getHandler));
+                }
+            } else {
+                routerRuntimeValue = routerBuildItem.getHttpRouter();
+            }
+            recorder.initializeGrpcServer(vertx.getVertx(), routerRuntimeValue,
                     config, shutdown, blocking, virtuals, launchModeBuildItem.getLaunchMode(),
-                    capabilities.isPresent(Capability.SECURITY));
+                    capabilities.isPresent(Capability.SECURITY), securityHandlers);
             return new ServiceStartBuildItem(GRPC_SERVER);
         }
         return null;

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/auth/GrpcAuthCustomRootPathTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/auth/GrpcAuthCustomRootPathTest.java
@@ -1,0 +1,17 @@
+package io.quarkus.grpc.auth;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GrpcAuthCustomRootPathTest extends GrpcAuthTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createQuarkusUnitTest("""
+            quarkus.grpc.server.use-separate-server=false
+            quarkus.grpc.clients.securityClient.host=localhost
+            quarkus.grpc.clients.securityClient.port=8081
+            quarkus.http.root-path=/api
+            """, true);
+
+}


### PR DESCRIPTION
- fixes https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Quarkus.20gRPC.20Security.20and.20http.2Eroot.2Epath
- main router doesn't have authentication and authorization handlers, we attach them to the HTTP router, however gRPC is attached to a main router when the root path is different than '/'