### PR TITLE
Ensure that `quarkus.uuid` is not determined at native image build time

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -65,6 +65,7 @@ import io.quarkus.deployment.builditem.StaticInitConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.SuppressNonRuntimeConfigChangedWarningBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
 import io.quarkus.deployment.configuration.RunTimeConfigurationGenerator;
 import io.quarkus.deployment.configuration.tracker.ConfigTrackingConfig;
@@ -113,6 +114,12 @@ public class ConfigGenerationBuildStep {
     private static final MethodDescriptor WITH_SOURCES = MethodDescriptor.ofMethod(
             SmallRyeConfigBuilder.class, "withSources",
             SmallRyeConfigBuilder.class, ConfigSource[].class);
+
+    @BuildStep
+    void nativeSupport(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClassProducer) {
+        runtimeInitializedClassProducer.produce(new RuntimeInitializedClassBuildItem(
+                "io.quarkus.runtime.configuration.RuntimeConfigBuilder$UuidConfigSource$Holder"));
+    }
 
     @BuildStep
     void buildTimeRunTimeConfig(

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/RuntimeConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/RuntimeConfigBuilder.java
@@ -15,7 +15,7 @@ public class RuntimeConfigBuilder implements SmallRyeConfigBuilderCustomizer {
     @Override
     public void configBuilder(final SmallRyeConfigBuilder builder) {
         new QuarkusConfigBuilderCustomizer().configBuilder(builder);
-        builder.withSources(new UuiConfigSource());
+        builder.withSources(new UuidConfigSource());
 
         builder.forClassLoader(Thread.currentThread().getContextClassLoader())
                 .addDefaultInterceptors()
@@ -27,7 +27,7 @@ public class RuntimeConfigBuilder implements SmallRyeConfigBuilderCustomizer {
         return Integer.MIN_VALUE;
     }
 
-    private static class UuiConfigSource implements ConfigSource {
+    private static class UuidConfigSource implements ConfigSource {
 
         private static final String QUARKUS_UUID = "quarkus.uuid";
 


### PR DESCRIPTION
- Fixes: #45863