### PR TITLE
Replace the id label with a name label for Netty allocator

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
@@ -28,19 +28,18 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
 import io.micrometer.core.instrument.binder.netty4.NettyEventExecutorMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
+import io.quarkus.micrometer.runtime.binder.netty.NettyAllocatorMetrics;
+import io.quarkus.micrometer.runtime.binder.netty.NettyMetricsProvider;
+import io.quarkus.micrometer.runtime.binder.netty.VertxNettyAllocatorMetricsProvider;
 import io.quarkus.micrometer.test.HelloResource;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.impl.VertxByteBufAllocator;
 import io.vertx.core.impl.VertxInternal;
 
 public class NettyMetricsTest {
@@ -72,44 +71,31 @@ public class NettyMetricsTest {
     Vertx vertx;
 
     private static final Set<Tag> NAM_PBBA_TAGS = Tags.of(
-            "id", String.valueOf(PooledByteBufAllocator.DEFAULT.hashCode()),
+            "name", NettyMetricsProvider.NETTY_DEFAULT_POOLED_ALLOCATOR_NAME,
             "allocator.type", "PooledByteBufAllocator")
             .stream()
             .collect(Collectors.toSet());
 
     private static final Set<Tag> NAM_UNPBBA_TAGS = Tags.of(
-            "id", String.valueOf(UnpooledByteBufAllocator.DEFAULT.hashCode()),
+            "name", NettyMetricsProvider.NETTY_DEFAULT_UNPOOLED_ALLOCATOR_NAME,
             "allocator.type", "UnpooledByteBufAllocator")
             .stream()
             .collect(Collectors.toSet());
 
     private static final Set<Tag> VX_NAM_PBBA_TAGS = Tags.of(
-            "id", String.valueOf(VertxByteBufAllocator.POOLED_ALLOCATOR.hashCode()),
+            "name", VertxNettyAllocatorMetricsProvider.VERTX_POOLED_ALLOCATOR_NAME,
             "allocator.type", "PooledByteBufAllocator")
             .stream()
             .collect(Collectors.toSet());
 
     private static final Set<Tag> VX_NAM_UNPBBA_TAGS = Tags.of(
-            "id", String.valueOf(VertxByteBufAllocator.UNPOOLED_ALLOCATOR.hashCode()),
+            "name", VertxNettyAllocatorMetricsProvider.VERTX_UNPOOLED_ALLOCATOR_NAME,
             "allocator.type", "UnpooledByteBufAllocator")
             .stream()
             .collect(Collectors.toSet());
 
     private static final Tag HEAP_MEMORY = Tag.of(AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "heap");
     private static final Tag DIRECT_MEMORY = Tag.of(AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "direct");
-
-    enum AllocatorKeyNames implements KeyName {
-        ID {
-            public String asString() {
-                return "id";
-            }
-        },
-        ALLOCATOR_TYPE {
-            public String asString() {
-                return "allocator.type";
-            }
-        };
-    }
 
     enum AllocatorMemoryKeyNames implements KeyName {
         MEMORY_TYPE {

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/NettyAllocatorMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/NettyAllocatorMetrics.java
@@ -1,0 +1,105 @@
+package io.quarkus.micrometer.runtime.binder.netty;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.netty.buffer.ByteBufAllocatorMetric;
+import io.netty.buffer.ByteBufAllocatorMetricProvider;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocatorMetric;
+
+/**
+ * {@link MeterBinder} for Netty memory allocators.
+ * <p>
+ * This class is based on the MicroMeter NettyAllocatorMetrics class, but remove the "id" from the tags are it's
+ * computed from the `hashCode` which does not allow aggregation across processed.
+ * Instead, it gets a {@code name} label indicating an unique name for the allocator.
+ */
+public class NettyAllocatorMetrics implements MeterBinder {
+
+    private final ByteBufAllocatorMetricProvider allocator;
+    private final String name;
+
+    /**
+     * Create a binder instance for the given allocator.
+     *
+     * @param name the unique name for the allocator
+     * @param allocator the {@code ByteBuf} allocator to instrument
+     */
+    public NettyAllocatorMetrics(String name, ByteBufAllocatorMetricProvider allocator) {
+        this.name = name;
+        this.allocator = allocator;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        ByteBufAllocatorMetric allocatorMetric = this.allocator.metric();
+        Tags tags = Tags.of(
+                NettyMeters.AllocatorKeyNames.NAME.asString(), this.name,
+                NettyMeters.AllocatorKeyNames.ALLOCATOR_TYPE.asString(), this.allocator.getClass().getSimpleName());
+
+        Gauge
+                .builder(NettyMeters.ALLOCATOR_MEMORY_USED.getName(), allocatorMetric,
+                        ByteBufAllocatorMetric::usedHeapMemory)
+                .tags(tags.and(NettyMeters.AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "heap"))
+                .register(registry);
+
+        Gauge
+                .builder(NettyMeters.ALLOCATOR_MEMORY_USED.getName(), allocatorMetric,
+                        ByteBufAllocatorMetric::usedDirectMemory)
+                .tags(tags.and(NettyMeters.AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "direct"))
+                .register(registry);
+
+        if (this.allocator instanceof PooledByteBufAllocator pooledByteBufAllocator) {
+            PooledByteBufAllocatorMetric pooledAllocatorMetric = pooledByteBufAllocator.metric();
+
+            Gauge
+                    .builder(NettyMeters.ALLOCATOR_MEMORY_PINNED.getName(), pooledByteBufAllocator,
+                            PooledByteBufAllocator::pinnedHeapMemory)
+                    .tags(tags.and(NettyMeters.AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "heap"))
+                    .register(registry);
+
+            Gauge
+                    .builder(NettyMeters.ALLOCATOR_MEMORY_PINNED.getName(), pooledByteBufAllocator,
+                            PooledByteBufAllocator::pinnedDirectMemory)
+                    .tags(tags.and(NettyMeters.AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "direct"))
+                    .register(registry);
+
+            Gauge
+                    .builder(NettyMeters.ALLOCATOR_POOLED_ARENAS.getName(), pooledAllocatorMetric,
+                            PooledByteBufAllocatorMetric::numHeapArenas)
+                    .tags(tags.and(NettyMeters.AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "heap"))
+                    .register(registry);
+            Gauge
+                    .builder(NettyMeters.ALLOCATOR_POOLED_ARENAS.getName(), pooledAllocatorMetric,
+                            PooledByteBufAllocatorMetric::numDirectArenas)
+                    .tags(tags.and(NettyMeters.AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "direct"))
+                    .register(registry);
+
+            Gauge
+                    .builder(NettyMeters.ALLOCATOR_POOLED_CACHE_SIZE.getName(), pooledAllocatorMetric,
+                            PooledByteBufAllocatorMetric::normalCacheSize)
+                    .tags(tags.and(NettyMeters.AllocatorPooledCacheKeyNames.CACHE_TYPE.asString(), "normal"))
+                    .register(registry);
+            Gauge
+                    .builder(NettyMeters.ALLOCATOR_POOLED_CACHE_SIZE.getName(), pooledAllocatorMetric,
+                            PooledByteBufAllocatorMetric::smallCacheSize)
+                    .tags(tags.and(NettyMeters.AllocatorPooledCacheKeyNames.CACHE_TYPE.asString(), "small"))
+                    .register(registry);
+
+            Gauge
+                    .builder(NettyMeters.ALLOCATOR_POOLED_THREADLOCAL_CACHES.getName(), pooledAllocatorMetric,
+                            PooledByteBufAllocatorMetric::numThreadLocalCaches)
+                    .tags(tags)
+                    .register(registry);
+
+            Gauge
+                    .builder(NettyMeters.ALLOCATOR_POOLED_CHUNK_SIZE.getName(), pooledAllocatorMetric,
+                            PooledByteBufAllocatorMetric::chunkSize)
+                    .tags(tags)
+                    .register(registry);
+        }
+    }
+
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/NettyMeters.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/NettyMeters.java
@@ -1,0 +1,239 @@
+package io.quarkus.micrometer.runtime.binder.netty;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.docs.MeterDocumentation;
+
+/**
+ * Copy of the {@link NettyMeters} enum from the MicroMeter NettyMetrics class in oder to replace the {@code ID} tag
+ * with {@code NAME}.
+ */
+public enum NettyMeters implements MeterDocumentation {
+
+    /**
+     * Size of memory used by the allocator, in bytes.
+     */
+    ALLOCATOR_MEMORY_USED {
+        @Override
+        public String getName() {
+            return "netty.allocator.memory.used";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.GAUGE;
+        }
+
+        @Override
+        public String getBaseUnit() {
+            return BaseUnits.BYTES;
+        }
+
+        @Override
+        public KeyName[] getKeyNames() {
+            return KeyName.merge(AllocatorKeyNames.values(), AllocatorMemoryKeyNames.values());
+        }
+    },
+
+    /**
+     * Size of memory used by allocated buffers, in bytes.
+     */
+    ALLOCATOR_MEMORY_PINNED {
+        @Override
+        public String getName() {
+            return "netty.allocator.memory.pinned";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.GAUGE;
+        }
+
+        @Override
+        public String getBaseUnit() {
+            return BaseUnits.BYTES;
+        }
+
+        @Override
+        public KeyName[] getKeyNames() {
+            return KeyName.merge(AllocatorKeyNames.values(), AllocatorMemoryKeyNames.values());
+        }
+    },
+
+    /**
+     * Number of arenas for a pooled allocator.
+     */
+    ALLOCATOR_POOLED_ARENAS {
+        @Override
+        public String getName() {
+            return "netty.allocator.pooled.arenas";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.GAUGE;
+        }
+
+        @Override
+        public KeyName[] getKeyNames() {
+            return KeyName.merge(AllocatorKeyNames.values(), AllocatorMemoryKeyNames.values());
+        }
+    },
+
+    /**
+     * Size of the cache for a pooled allocator, in bytes.
+     */
+    ALLOCATOR_POOLED_CACHE_SIZE {
+        @Override
+        public String getName() {
+            return "netty.allocator.pooled.cache.size";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.GAUGE;
+        }
+
+        @Override
+        public String getBaseUnit() {
+            return BaseUnits.BYTES;
+        }
+
+        @Override
+        public KeyName[] getKeyNames() {
+            return KeyName.merge(AllocatorKeyNames.values(), AllocatorPooledCacheKeyNames.values());
+        }
+    },
+
+    /**
+     * Number of ThreadLocal caches for a pooled allocator.
+     */
+    ALLOCATOR_POOLED_THREADLOCAL_CACHES {
+        @Override
+        public String getName() {
+            return "netty.allocator.pooled.threadlocal.caches";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.GAUGE;
+        }
+
+        @Override
+        public KeyName[] getKeyNames() {
+            return AllocatorKeyNames.values();
+        }
+    },
+
+    /**
+     * Size of memory chunks for a pooled allocator, in bytes.
+     */
+    ALLOCATOR_POOLED_CHUNK_SIZE {
+        @Override
+        public String getName() {
+            return "netty.allocator.pooled.chunk.size";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.GAUGE;
+        }
+
+        @Override
+        public String getBaseUnit() {
+            return BaseUnits.BYTES;
+        }
+
+        @Override
+        public KeyName[] getKeyNames() {
+            return AllocatorKeyNames.values();
+        }
+    },
+
+    /**
+     * Number of pending tasks in the event executor.
+     */
+    EVENT_EXECUTOR_TASKS_PENDING {
+        @Override
+        public String getName() {
+            return "netty.eventexecutor.tasks.pending";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.GAUGE;
+        }
+
+        @Override
+        public KeyName[] getKeyNames() {
+            return EventExecutorTasksPendingKeyNames.values();
+        }
+    };
+
+    enum AllocatorKeyNames implements KeyName {
+
+        /**
+         * Unique runtime identifier for the allocator.
+         */
+        NAME {
+            @Override
+            public String asString() {
+                return "name";
+            }
+        },
+        /**
+         * Allocator's class simple name.
+         */
+        ALLOCATOR_TYPE {
+            @Override
+            public String asString() {
+                return "allocator.type";
+            }
+        }
+
+    }
+
+    enum AllocatorMemoryKeyNames implements KeyName {
+
+        /**
+         * Type of memory allocated: {@code "heap"} memory or {@code "direct"} memory.
+         */
+        MEMORY_TYPE {
+            @Override
+            public String asString() {
+                return "memory.type";
+            }
+        }
+
+    }
+
+    enum AllocatorPooledCacheKeyNames implements KeyName {
+
+        /**
+         * Type of cache pages for this cache.
+         */
+        CACHE_TYPE {
+            @Override
+            public String asString() {
+                return "cache.type";
+            }
+        }
+
+    }
+
+    enum EventExecutorTasksPendingKeyNames implements KeyName {
+
+        /**
+         * Event loop name.
+         */
+        NAME {
+            @Override
+            public String asString() {
+                return "name";
+            }
+        }
+
+    }
+
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/NettyMetricsProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/NettyMetricsProvider.java
@@ -4,23 +4,26 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
 import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 
 @Singleton
 public class NettyMetricsProvider {
 
+    public static final String NETTY_DEFAULT_POOLED_ALLOCATOR_NAME = "pooled";
+
+    public static final String NETTY_DEFAULT_UNPOOLED_ALLOCATOR_NAME = "unpooled";
+
     @Produces
     @Singleton
     public MeterBinder pooledByteBufAllocatorMetrics() {
-        return new NettyAllocatorMetrics(PooledByteBufAllocator.DEFAULT);
+        return new NettyAllocatorMetrics(NETTY_DEFAULT_POOLED_ALLOCATOR_NAME, PooledByteBufAllocator.DEFAULT);
     }
 
     @Produces
     @Singleton
     public MeterBinder unpooledByteBufAllocatorMetrics() {
-        return new NettyAllocatorMetrics(UnpooledByteBufAllocator.DEFAULT);
+        return new NettyAllocatorMetrics(NETTY_DEFAULT_UNPOOLED_ALLOCATOR_NAME, UnpooledByteBufAllocator.DEFAULT);
     }
 
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/ReactiveNettyMetricsProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/ReactiveNettyMetricsProvider.java
@@ -6,11 +6,12 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
 import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
 import io.netty.buffer.ByteBufAllocatorMetricProvider;
 
 @Singleton
 public class ReactiveNettyMetricsProvider {
+
+    public static final String MULTIPART_ALLOCATOR_NAME = "quarkus-multipart-form-upload";
 
     @Produces
     @Singleton
@@ -20,7 +21,7 @@ public class ReactiveNettyMetricsProvider {
         Field af = clazz.getDeclaredField("ALLOC");
         af.setAccessible(true);
         ByteBufAllocatorMetricProvider provider = (ByteBufAllocatorMetricProvider) af.get(null);
-        return new NettyAllocatorMetrics(provider);
+        return new NettyAllocatorMetrics(MULTIPART_ALLOCATOR_NAME, provider);
     }
 
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/VertxNettyAllocatorMetricsProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/VertxNettyAllocatorMetricsProvider.java
@@ -4,23 +4,34 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
 import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
 import io.netty.buffer.ByteBufAllocatorMetricProvider;
 import io.vertx.core.buffer.impl.VertxByteBufAllocator;
 
 @Singleton
 public class VertxNettyAllocatorMetricsProvider {
 
+    /**
+     * The name of the Vert.x pooled allocator.
+     */
+    public static final String VERTX_POOLED_ALLOCATOR_NAME = "vertx-pooled";
+
+    /**
+     * The name of the Vert.x unpooled allocator.
+     */
+    public static final String VERTX_UNPOOLED_ALLOCATOR_NAME = "vertx-unpooled";
+
     @Produces
     @Singleton
     public MeterBinder vertxPooledByteBufAllocatorMetrics() {
-        return new NettyAllocatorMetrics((ByteBufAllocatorMetricProvider) VertxByteBufAllocator.POOLED_ALLOCATOR);
+        return new NettyAllocatorMetrics(VERTX_POOLED_ALLOCATOR_NAME,
+                (ByteBufAllocatorMetricProvider) VertxByteBufAllocator.POOLED_ALLOCATOR);
     }
 
     @Produces
     @Singleton
     public MeterBinder vertxUnpooledByteBufAllocatorMetrics() {
-        return new NettyAllocatorMetrics((ByteBufAllocatorMetricProvider) VertxByteBufAllocator.UNPOOLED_ALLOCATOR);
+        return new NettyAllocatorMetrics(VERTX_UNPOOLED_ALLOCATOR_NAME,
+                (ByteBufAllocatorMetricProvider) VertxByteBufAllocator.UNPOOLED_ALLOCATOR);
     }
 
 }


### PR DESCRIPTION
The Netty allocator metrics exposed an `id` label using the allocator hashcode. However, this does not make a lot of sense when you need to aggregate metrics from multiple metrics.
Thus, this commit replaces the `id` with a `name` label with stable names for the different allocators.

Unfortunately, the initial code was in micrometer. This commit forks the 2 classes required to replace `id` with `name` and adds stable names to the different allocators.

- Fixes: https://github.com/quarkusio/quarkus/issues/45847
