### PR TITLE
Fix split packages in Credentials extension by moving deployment module classes to a deployment module

### DIFF
--- a/extensions/credentials/deployment/src/main/java/io/quarkus/credentials/deployment/CredentialsProcessor.java
+++ b/extensions/credentials/deployment/src/main/java/io/quarkus/credentials/deployment/CredentialsProcessor.java
@@ -1,6 +1,7 @@
-package io.quarkus.credentials;
+package io.quarkus.credentials.deployment;
 
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.deployment.annotations.BuildStep;
 
 public class CredentialsProcessor {


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/44714