### PR TITLE
Consider quarkus.test.arg-line as a string

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -185,7 +185,7 @@ public interface TestConfig {
      * When the artifact is a {@code container}, this string is passed right after the {@code docker run} command.
      * When the artifact is a {@code native binary}, this string is passed right after the native binary name.
      */
-    Optional<@WithConverter(TrimmedStringConverter.class) List<String>> argLine();
+    Optional<@WithConverter(TrimmedStringConverter.class) String> argLine();
 
     /**
      * Additional environment variables to be set in the process that {@code @QuarkusIntegrationTest} launches.

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestConfigUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestConfigUtil.java
@@ -18,6 +18,22 @@ public final class TestConfigUtil {
     private TestConfigUtil() {
     }
 
+    public static List<String> argLineValues(String argLine) {
+        if (argLine == null || argLine.isBlank()) {
+            return List.of();
+        }
+        String[] parts = argLine.split("\\s+");
+        List<String> result = new ArrayList<>(parts.length);
+        for (String s : parts) {
+            String trimmed = s.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            result.add(trimmed);
+        }
+        return result;
+    }
+
     @Deprecated(forRemoval = true, since = "3.17")
     public static List<String> argLineValue(Config config) {
         String strValue = config.getOptionalValue("quarkus.test.arg-line", String.class)

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.DefaultDockerContainerLauncher;
 import io.quarkus.test.common.DockerContainerArtifactLauncher;
+import io.quarkus.test.common.TestConfigUtil;
 import io.smallrye.config.SmallRyeConfig;
 
 public class DockerContainerLauncherProvider implements ArtifactLauncherProvider {
@@ -88,7 +89,7 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
                 config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                 testConfig.waitTime(),
                 testConfig.integrationTestProfile(),
-                testConfig.argLine().orElse(List.of()),
+                TestConfigUtil.argLineValues(testConfig.argLine().orElse("")),
                 testConfig.env(),
                 context.devServicesLaunchResult(),
                 containerImage,

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/JarLauncherProvider.java
@@ -18,6 +18,7 @@ import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.DefaultJarLauncher;
 import io.quarkus.test.common.JarArtifactLauncher;
+import io.quarkus.test.common.TestConfigUtil;
 import io.smallrye.config.SmallRyeConfig;
 
 public class JarLauncherProvider implements ArtifactLauncherProvider {
@@ -47,7 +48,7 @@ public class JarLauncherProvider implements ArtifactLauncherProvider {
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                     testConfig.waitTime(),
                     testConfig.integrationTestProfile(),
-                    testConfig.argLine().orElse(List.of()),
+                    TestConfigUtil.argLineValues(testConfig.argLine().orElse("")),
                     testConfig.env(),
                     context.devServicesLaunchResult(),
                     context.buildOutputDirectory().resolve(pathStr)));

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
@@ -17,6 +17,7 @@ import io.quarkus.deployment.dev.testing.TestConfig;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.DefaultNativeImageLauncher;
 import io.quarkus.test.common.NativeImageLauncher;
+import io.quarkus.test.common.TestConfigUtil;
 import io.smallrye.config.SmallRyeConfig;
 
 public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
@@ -45,7 +46,7 @@ public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
                     config.getValue("quarkus.http.test-ssl-port", OptionalInt.class).orElse(DEFAULT_HTTPS_PORT),
                     testConfig.waitTime(),
                     testConfig.nativeImageProfile(),
-                    testConfig.argLine().orElse(List.of()),
+                    TestConfigUtil.argLineValues(testConfig.argLine().orElse("")),
                     testConfig.env(),
                     context.devServicesLaunchResult(),
                     System.getProperty("native.image.path"),


### PR DESCRIPTION
We don't want to split it on commas but spaces so here is a quick fix for it.
We could write a specific converter but I'm not really sure it's worth it.

Fixes #45878