### PR TITLE
Disable kubernetes-service-binding testing on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,7 +252,6 @@ If you have not done so on this machine, you need to:
   * Windows:
     * enable longpaths: `git config --global core.longpaths true`
     * avoid CRLF breaks: `git config --global core.autocrlf false`
-    * enable symlinks: `git config --global core.symlinks true`
 * Install Java SDK 17+ (OpenJDK recommended)
 * Install [GraalVM](https://quarkus.io/guides/building-native-image)
 * Install platform C developer tools:

--- a/extensions/kubernetes-service-binding/runtime/pom.xml
+++ b/extensions/kubernetes-service-binding/runtime/pom.xml
@@ -67,5 +67,55 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>disable-test-compile-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-testResources</id>
+                                <phase>test-resources</phase>
+                                <goals>
+                                    <goal>testResources</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
It uses symlinks and they are complex to allow on Windows. Let's not ask our users to go do crazy things to test this particular module.

Fixes #45860
Related to #42756