### PR TITLE
Mark docker and podman container image extensions as stable

### DIFF
--- a/extensions/container-image/container-image-docker/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/container-image/container-image-docker/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,6 +8,6 @@ metadata:
     - "image"
   categories:
     - "cloud"
-  status: "preview"
+  status: "stable"
   config:
     - "quarkus.docker."

--- a/extensions/container-image/container-image-podman/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/container-image/container-image-podman/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,6 +9,6 @@ metadata:
   guide: "https://quarkus.io/guides/container-image"
   categories:
     - "cloud"
-  status: "preview"
+  status: "stable"
   config:
     - "quarkus.podman."


### PR DESCRIPTION
This have changed very little and seem to be working fine, so let's mark them as stable