### PR TITLE
Fix generate ca command in tls guide

### DIFF
--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -1151,7 +1151,7 @@ Note that the generated CA is only valid for development purposes and can only b
 To generate a development CA:
 [source,shell]
 ----
-quarkus tls generate-ca-certificate --install \   <1>
+quarkus tls generate-quarkus-ca --install \   <1>
      --renew \     <2>
      --truststore  <3>
 ----


### PR DESCRIPTION
```
$ quarkus tls
Install and Manage TLS development certificates
Usage: tls [-hV] [COMMAND]
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  generate-quarkus-ca   Generate Quarkus Dev CA certificate and private key.
  generate-certificate  Generate a TLS certificate with the Quarkus Dev CA if
                          available.
  lets-encrypt          Prepare, generate and renew Let's Encrypt Certificates
```