### PR TITLE
[3.15] Bump kubernetes-client-bom from 6.13.4 to 6.13.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Properties below are set in this file because they are used
              in the BOM as well as other POMs (build-parent/pom.xml, docs/pom.xml, ...) -->
         <jacoco.version>0.8.12</jacoco.version>
-        <kubernetes-client.version>6.13.4</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.13.5</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.0</rest-assured.version>
         <hibernate-orm.version>6.6.4.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->


### PR DESCRIPTION
Bump 6.13 version to latest stable patch.

I opened the PR directly to the target LTS branch since main is already using Kubernetes Client v7.

Includes a fix to https://github.com/fabric8io/kubernetes-client/issues/6781 that might be needed by dependent projects.

/cc @metacosm 