### PR TITLE
Add more details to OIDC guides

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -50,6 +50,14 @@ For information about how to support multiple tenants, see xref:security-openid-
 
 == Using the authorization code flow mechanism
 
+=== Configuring Quarkus to support authorization code flow
+
+To enable an authorization code flow authentication, the `quarkus.oidc.application-type` property must be set to `web-app`.
+Usually, the Quarkus OIDC ``web-app`` application type must be set when your Quarkus application is a frontend application which serves HTML pages and requires an OIDC single sign-on login.
+For the Quarkus OIDC `web-app` application, the authorization code flow is defined as the preferred method for authenticating users.
+When your application serves HTML pages and provides REST API at the same time, and requires both the authorization code flow authentication and xref:security-oidc-bearer-token-authentication.adoc[the bearer access token authentication], the `quarkus.oidc.application-type` property can be set to `hybrid` instead.
+In this case, the authorization code flow is only triggered  when an HTTP `Authorization` request header with a `Bearer` authorization scheme containing a bearer access token is not set.
+
 === Configuring access to the OIDC provider endpoint
 
 The OIDC `web-app` application requires URLs of the OIDC provider's authorization, token, `JsonWebKey` (JWK) set, and possibly the `UserInfo`, introspection and end-session (RP-initiated logout) endpoints.

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -53,7 +53,7 @@ For information about how to support multiple tenants, see xref:security-openid-
 === Configuring Quarkus to support authorization code flow
 
 To enable an authorization code flow authentication, the `quarkus.oidc.application-type` property must be set to `web-app`.
-Usually, the Quarkus OIDC ``web-app`` application type must be set when your Quarkus application is a frontend application which serves HTML pages and requires an OIDC single sign-on login.
+Usually, the Quarkus OIDC `web-app` application type must be set when your Quarkus application is a frontend application which serves HTML pages and requires an OIDC single sign-on login.
 For the Quarkus OIDC `web-app` application, the authorization code flow is defined as the preferred method for authenticating users.
 When your application serves HTML pages and provides REST API at the same time, and requires both the authorization code flow authentication and xref:security-oidc-bearer-token-authentication.adoc[the bearer access token authentication], the `quarkus.oidc.application-type` property can be set to `hybrid` instead.
 In this case, the authorization code flow is only triggered  when an HTTP `Authorization` request header with a `Bearer` authorization scheme containing a bearer access token is not set.

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -130,8 +130,7 @@ Choose the *With ID Token* option in such cases.
 ====
 When you import custom Keycloak realms, you may find, after inspecting both the access and ID tokens in Dev UI, that only the access token contains the list of roles in its `groups` claim.
 This information is important for accessing endpoints that are secured with the `@RolesAllowed` annotation.
-To tell Keycloak to include this information in the ID token as well, add the
-`microprofile-jwt` scope to the list of client scopes in the Keycloak admin console.
+To tell Keycloak to include this information in the ID token, add the `microprofile-jwt` scope to the list of client scopes in the Keycloak admin console.
 Alternatively, add the `microprofile-jwt` scope to the list of required scopes using the `quarkus.oidc.authentication.scopes` property.
 
 For more information, see the https://www.keycloak.org/docs/latest/server_admin/#protocol[Keycloak server administration guide].

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -128,11 +128,13 @@ Choose the *With ID Token* option in such cases.
 
 [NOTE]
 ====
-Inspect both tokens in the dev UI and you will find that only the access token contains the list of roles.
+When you import custom Keycloak realms, you may find, after inspecting both the access and ID tokens in Dev UI, that only the access token contains the list of roles in its `groups` claim.
 This information is important for accessing endpoints that are secured with the `@RolesAllowed` annotation.
 To tell Keycloak to include this information in the ID token as well, add the
-`microprofile-jwt` scope to the list of scopes using the `quarkus.oidc.authentication.scopes` property. For more information, see the
-https://www.keycloak.org/docs/latest/server_admin/#protocol[Keycloak server administration guide].
+`microprofile-jwt` scope to the list of client scopes in the Keycloak admin console.
+Alternatively, add the `microprofile-jwt` scope to the list of required scopes using the `quarkus.oidc.authentication.scopes` property.
+
+For more information, see the https://www.keycloak.org/docs/latest/server_admin/#protocol[Keycloak server administration guide].
 ====
 
 Manually entering the service paths is not ideal.

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -126,6 +126,15 @@ Sometimes, ID tokens are forwarded to application frontends as bearer tokens.
 This helps endpoints identify the user logged into SPA or perform out-of-band token verification.
 Choose the *With ID Token* option in such cases.
 
+[NOTE]
+====
+Inspect both tokens in the dev UI and you will find that only the access token contains the list of roles.
+This information is important for accessing endpoints that are secured with the `@RolesAllowed` annotation.
+To tell Keycloak to include this information in the ID token as well, add the
+`microprofile-jwt` scope to the list of scopes using the `quarkus.oidc.authentication.scopes` property. For more information, see the
+https://www.keycloak.org/docs/latest/server_admin/#protocol[Keycloak server administration guide].
+====
+
 Manually entering the service paths is not ideal.
 For information about enabling Swagger or GraphQL UI for testing the service with the access token already acquired by the OIDC Dev UI, see the <<test-with-swagger-graphql,Test with Swagger UI or GraphQL UI>> section.
 


### PR DESCRIPTION
Hi, I have worked through some OIDC guides and have struggled at some points. In both cases, I was eventually able to find the information I was missing by reading more guides, but I think having that info in more places (i.e. in the guide and the tutorial) would make them more self-contained.