### PR TITLE
Dev UI: make sure add button works when log is open

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -69,6 +69,7 @@ export class QwcExtensions extends observeState(LitElement) {
             width: 3em;
             height: 3em;
             box-shadow: var(--lumo-shade) 5px 5px 15px 3px;
+            z-index: 9;
         }
         .addExtensionIcon {
             width: 2em;


### PR DESCRIPTION
Small fix, the add button need to be on top of the log, else you can not click it when the log is open