### PR TITLE
ArC: add InjectableBean.hasPriority()

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -2179,10 +2179,13 @@ public class BeanGenerator extends AbstractGenerator {
 
     protected void implementGetPriority(BeanInfo bean, ClassCreator beanCreator) {
         if (bean.getPriority() != null) {
+            MethodCreator hasPriority = beanCreator.getMethodCreator("hasPriority", boolean.class)
+                    .setModifiers(ACC_PUBLIC);
+            hasPriority.returnBoolean(true);
+
             MethodCreator getPriority = beanCreator.getMethodCreator("getPriority", int.class)
                     .setModifiers(ACC_PUBLIC);
-            getPriority
-                    .returnValue(getPriority.load(bean.getPriority()));
+            getPriority.returnInt(bean.getPriority());
         }
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableBean.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableBean.java
@@ -130,6 +130,21 @@ public interface InjectableBean<T> extends Bean<T>, InjectableReferenceProvider<
     }
 
     /**
+     * Returns whether this bean has an explicitly assigned priority. This is typically
+     * done using the {@link jakarta.annotation.Priority @Priority} annotation.
+     * <p>
+     * Calling {@link #getPriority()} is not enough to determine if a bean has an explicitly
+     * assigned priority, because that method returns {@code 0} when no priority was assigned.
+     * That is not distinguishable from a situation when a bean has explicitly assigned
+     * priority of {@code 0}.
+     *
+     * @return whether this bean has an explicitly assigned priority
+     */
+    default boolean hasPriority() {
+        return false;
+    }
+
+    /**
      * A bean may have a priority assigned.
      * <p>
      * Class-based beans and producer beans can specify the priority declaratively via {@link jakarta.annotation.Priority}.

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/priority/BeanHasPriorityTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/priority/BeanHasPriorityTest.java
@@ -1,0 +1,126 @@
+package io.quarkus.arc.test.bean.priority;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class BeanHasPriorityTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(NoPriority.class, ExplicitPriority0.class,
+            ExplicitPriority1.class, Producers.class);
+
+    @Test
+    public void test() throws IOException {
+        InjectableBean<?> bean = Arc.container().instance(NoPriority.class).getBean();
+        assertFalse(bean.hasPriority());
+        assertEquals(0, bean.getPriority());
+
+        bean = Arc.container().instance(ExplicitPriority0.class).getBean();
+        assertTrue(bean.hasPriority());
+        assertEquals(0, bean.getPriority());
+
+        bean = Arc.container().instance(ExplicitPriority1.class).getBean();
+        assertTrue(bean.hasPriority());
+        assertEquals(1, bean.getPriority());
+
+        bean = Arc.container().instance(Foo.class).getBean();
+        assertFalse(bean.hasPriority());
+        assertEquals(0, bean.getPriority());
+
+        bean = Arc.container().instance(Bar.class).getBean();
+        assertTrue(bean.hasPriority());
+        assertEquals(0, bean.getPriority());
+
+        bean = Arc.container().instance(Baz.class).getBean();
+        assertTrue(bean.hasPriority());
+        assertEquals(1, bean.getPriority());
+
+        bean = Arc.container().instance(Qux.class).getBean();
+        assertFalse(bean.hasPriority());
+        assertEquals(0, bean.getPriority());
+
+        bean = Arc.container().instance(Quux.class).getBean();
+        assertTrue(bean.hasPriority());
+        assertEquals(0, bean.getPriority());
+
+        bean = Arc.container().instance(Quuux.class).getBean();
+        assertTrue(bean.hasPriority());
+        assertEquals(1, bean.getPriority());
+    }
+
+    static class Foo {
+    }
+
+    static class Bar {
+    }
+
+    static class Baz {
+    }
+
+    static class Qux {
+    }
+
+    static class Quux {
+    }
+
+    static class Quuux {
+    }
+
+    @Singleton
+    static class NoPriority {
+    }
+
+    @Singleton
+    @Priority(0)
+    static class ExplicitPriority0 {
+    }
+
+    @Singleton
+    @Priority(1)
+    static class ExplicitPriority1 {
+    }
+
+    @Singleton
+    static class Producers {
+        @Produces
+        Foo noPriority = new Foo();
+
+        @Produces
+        @Priority(0)
+        Bar explicitPriority0 = new Bar();
+
+        @Produces
+        @Priority(1)
+        Baz explicitPriority1 = new Baz();
+
+        @Produces
+        Qux noPriority() {
+            return new Qux();
+        }
+
+        @Produces
+        @Priority(0)
+        Quux explicitPriority0() {
+            return new Quux();
+        }
+
+        @Produces
+        @Priority(1)
+        Quuux explicitPriority1() {
+            return new Quuux();
+        }
+    }
+}


### PR DESCRIPTION
This method allows distinguishing beans that do not have an explicitly assigned priority from beans that have an explicitly assigned priority of 0. That wasn't possible before, because `getPriority()` returns 0 in both cases.