### PR TITLE
Restore two JWT decoding methods in OidcUtils

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -126,6 +126,14 @@ public final class OidcUtils {
 
     }
 
+    public static JsonObject decodeJwtContent(String jwt) {
+        return OidcCommonUtils.decodeJwtContent(jwt);
+    }
+
+    public static String getJwtContentPart(String jwt) {
+        return OidcCommonUtils.getJwtContentPart(jwt);
+    }
+
     public static String getSessionCookie(RoutingContext context, OidcTenantConfig oidcTenantConfig) {
         final Map<String, Cookie> cookies = context.request().cookieMap();
         return getSessionCookie(context.data(), cookies, oidcTenantConfig);


### PR DESCRIPTION
Fixes #45948.

Adding a couple of methods related to decoding JWT back to OidcUtils, it is not a big problem to have them in OidcUtils and delegating to OidcCommonUtils