### PR TITLE
DOCS: Add downstream-relevant attributes to facilitate single sourcing 

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -67,5 +67,15 @@
 // .
 :create-app-group-id: org.acme
 :create-cli-group-id: {create-app-group-id}
+// Attributes required for single-sourcing to downstream.
+:jdk-version-other: 17
+:jdk-version-latest: 21
+:jdk-version-all: 17 or 21
+:openshift-long: OpenShift
+:openshift: OpenShift
+:name-image-ubi9-open-jdk-17: registry.access.redhat.com/ubi9/openjdk-17
+:name-image-ubi9-open-jdk-17-short: ubi9/openjdk-17
+:name-image-ubi9-open-jdk-21: registry.access.redhat.com/ubi9/openjdk-21
+:name-image-ubi9-open-jdk-21-short: ubi9/openjdk-21
 // .
 include::_attributes-local.adoc[]


### PR DESCRIPTION
This PR aims to update the upstream __attributes.adoc_ file with the additional attributes needed to migrate the [Red Hat Deploying to OpenShift Container Platform](https://docs.redhat.com/en/documentation/red_hat_build_of_quarkus/3.15/html-single/deploying_your_red_hat_build_of_quarkus_applications_to_openshift_container_platform/index) guide to the upstream Quarkus community and to facilitate the single-sourcing of the guide back downstream. 

For more information, see [QDOCS-1082](https://issues.redhat.com/browse/QDOCS-1082)