### PR TITLE
Use Maven log in `quarkus:run`

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/RunMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/RunMojo.java
@@ -88,7 +88,9 @@ public class RunMojo extends QuarkusBootstrapMojo {
                         throw new RuntimeException("Should never reach this!");
                     }
                     List<String> args = (List<String>) cmd.get(0);
-                    System.out.println("Executing \"" + String.join(" ", args) + "\"");
+                    if (getLog().isInfoEnabled()) {
+                        getLog().info("Executing \"" + String.join(" ", args) + "\"");
+                    }
                     Path workingDirectory = (Path) cmd.get(1);
                     try {
                         ProcessBuilder builder = new ProcessBuilder()


### PR DESCRIPTION
This is done in order to respect the --quiet flag
thus making `mvn package quarkus:run` completely
silent