### PR TITLE
Switch to UBI 9 by default

### DIFF
--- a/.github/workflows/native-cron-build.yml.disabled
+++ b/.github/workflows/native-cron-build.yml.disabled
@@ -20,7 +20,7 @@ jobs:
         run: sudo systemctl stop mysql
 
       - name: Pull docker image
-        run: docker pull quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java${{ matrix.java }}
+        run: docker pull quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:22.3-java${{ matrix.java }}
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
@@ -55,7 +55,7 @@ jobs:
         run: ./mvnw -B install -DskipTests -DskipITs -Dformat.skip
 
       - name: Run integration tests in native
-        run: ./mvnw -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Dtest-containers -Dstart-containers -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java${{ matrix.java }} -pl '!io.quarkus:quarkus-integration-test-google-cloud-functions-http,!io.quarkus:quarkus-integration-test-google-cloud-functions,!io.quarkus:quarkus-integration-test-funqy-google-cloud-functions'
+        run: ./mvnw -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Dtest-containers -Dstart-containers -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:22.3-java${{ matrix.java }} -pl '!io.quarkus:quarkus-integration-test-google-cloud-functions-http,!io.quarkus:quarkus-integration-test-google-cloud-functions,!io.quarkus:quarkus-integration-test-funqy-google-cloud-functions'
 
       - name: Report
         if: always()

--- a/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
@@ -99,14 +99,24 @@ public class ContainerImages {
     // === Native Builder images
 
     // Mandrel Builder Image - https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags
-    public static final String MANDREL_BUILDER_IMAGE_NAME = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image";
-    public static final String MANDREL_BUILDER_VERSION = NATIVE_BUILDER_VERSION;
-    public static final String MANDREL_BUILDER = MANDREL_BUILDER_IMAGE_NAME + ":" + MANDREL_BUILDER_VERSION;
+    public static final String UBI8_MANDREL_BUILDER_IMAGE_NAME = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image";
+    public static final String UBI8_MANDREL_BUILDER_VERSION = NATIVE_BUILDER_VERSION;
+    public static final String UBI8_MANDREL_BUILDER = UBI8_MANDREL_BUILDER_IMAGE_NAME + ":" + UBI8_MANDREL_BUILDER_VERSION;
+
+    // Mandrel Builder Image - https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags
+    public static final String UBI9_MANDREL_BUILDER_IMAGE_NAME = "quay.io/quarkus/ubi9-quarkus-mandrel-builder-image";
+    public static final String UBI9_MANDREL_BUILDER_VERSION = NATIVE_BUILDER_VERSION;
+    public static final String UBI9_MANDREL_BUILDER = UBI9_MANDREL_BUILDER_IMAGE_NAME + ":" + UBI9_MANDREL_BUILDER_VERSION;
 
     // GraalVM CE Builder Image - https://quay.io/repository/quarkus/ubi-quarkus-graalvmce-builder-image?tab=tags
-    public static final String GRAALVM_BUILDER_IMAGE_NAME = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image";
-    public static final String GRAALVM_BUILDER_VERSION = NATIVE_BUILDER_VERSION;
-    public static final String GRAALVM_BUILDER = GRAALVM_BUILDER_IMAGE_NAME + ":" + GRAALVM_BUILDER_VERSION;
+    public static final String UBI8_GRAALVM_BUILDER_IMAGE_NAME = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image";
+    public static final String UBI8_GRAALVM_BUILDER_VERSION = NATIVE_BUILDER_VERSION;
+    public static final String UBI8_GRAALVM_BUILDER = UBI8_GRAALVM_BUILDER_IMAGE_NAME + ":" + UBI8_GRAALVM_BUILDER_VERSION;
+
+    // GraalVM CE Builder Image - https://quay.io/repository/quarkus/ubi9-quarkus-graalvmce-builder-image?tab=tags
+    public static final String UBI9_GRAALVM_BUILDER_IMAGE_NAME = "quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image";
+    public static final String UBI9_GRAALVM_BUILDER_VERSION = NATIVE_BUILDER_VERSION;
+    public static final String UBI9_GRAALVM_BUILDER = UBI9_GRAALVM_BUILDER_IMAGE_NAME + ":" + UBI9_GRAALVM_BUILDER_VERSION;
 
     public static String getDefaultJvmImage(CompiledJavaVersionBuildItem.JavaVersion version) {
         switch (version.isJava21OrHigher()) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
@@ -7,9 +7,9 @@ import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
  * <p>
  * For each image, the image name and version are defined as constants:
  * <p>
- * - {@code x_IMAGE_NAME} - the name of the image without the version (e.g. {@code registry.access.redhat.com/ubi8/ubi-minimal})
- * - {@code x_VERSION} - the version of the image (e.g. {@code 8.10})
- * - {@code x} - the full image name (e.g. {@code registry.access.redhat.com/ubi8/ubi-minimal:8.10})
+ * - {@code x_IMAGE_NAME} - the name of the image without the version (e.g. {@code registry.access.redhat.com/ubi9/ubi-minimal})
+ * - {@code x_VERSION} - the version of the image (e.g. {@code 9.5})
+ * - {@code x} - the full image name (e.g. {@code registry.access.redhat.com/ubi9/ubi-minimal:9.5})
  */
 public class ContainerImages {
 
@@ -21,14 +21,19 @@ public class ContainerImages {
     public static final String UBI8_VERSION = "8.10";
 
     /**
-     * UBI 8 version
+     * UBI 9 version
      */
-    public static final String UBI9_VERSION = "9.4";
+    public static final String UBI9_VERSION = "9.5";
 
     /**
-     * Version used for more UBI Java images.
+     * Version used for more UBI8 Java images.
      */
-    public static final String UBI8_JAVA_VERSION = "1.20";
+    public static final String UBI8_JAVA_VERSION = "1.21";
+
+    /**
+     * Version used for more UBI9 Java images.
+     */
+    public static final String UBI9_JAVA_VERSION = "1.21";
 
     /**
      * Version uses for the native builder image.
@@ -66,12 +71,12 @@ public class ContainerImages {
 
     // UBI 9 OpenJDK 17 Runtime - https://catalog.redhat.com/software/containers/ubi9/openjdk-17-runtime/61ee7d45384a3eb331996bee
     public static final String UBI9_JAVA_17_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-17-runtime";
-    public static final String UBI9_JAVA_17_VERSION = UBI8_JAVA_VERSION;
+    public static final String UBI9_JAVA_17_VERSION = UBI9_JAVA_VERSION;
     public static final String UBI9_JAVA_17 = UBI9_JAVA_17_IMAGE_NAME + ":" + UBI9_JAVA_17_VERSION;
 
     // UBI 9 OpenJDK 21 Runtime - https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
     public static final String UBI9_JAVA_21_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-21-runtime";
-    public static final String UBI9_JAVA_21_VERSION = UBI8_JAVA_VERSION;
+    public static final String UBI9_JAVA_21_VERSION = UBI9_JAVA_VERSION;
     public static final String UBI9_JAVA_21 = UBI9_JAVA_21_IMAGE_NAME + ":" + UBI9_JAVA_21_VERSION;
 
     // === Source To Image images
@@ -81,14 +86,14 @@ public class ContainerImages {
     public static final String QUARKUS_BINARY_S2I_VERSION = "2.0";
     public static final String QUARKUS_BINARY_S2I = QUARKUS_BINARY_S2I_IMAGE_NAME + ":" + QUARKUS_BINARY_S2I_VERSION;
 
-    // Java 17 Source To Image - https://catalog.redhat.com/software/containers/ubi8/openjdk-17/618bdbf34ae3739687568813
-    public static final String S2I_JAVA_17_IMAGE_NAME = "registry.access.redhat.com/ubi8/openjdk-17";
-    public static final String S2I_JAVA_17_VERSION = UBI8_JAVA_VERSION;
+    // Java 17 Source To Image - https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6
+    public static final String S2I_JAVA_17_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-17";
+    public static final String S2I_JAVA_17_VERSION = UBI9_JAVA_VERSION;
     public static final String S2I_JAVA_17 = S2I_JAVA_17_IMAGE_NAME + ":" + S2I_JAVA_17_VERSION;
 
-    // Java Source To Image - https://catalog.redhat.com/software/containers/ubi8/openjdk-21/653fb7e21b2ec10f7dfc10d0?q=openjdk%2021&architecture=amd64&image=66bcc007a3857fbc34f4dce1
-    public static final String S2I_JAVA_21_IMAGE_NAME = "registry.access.redhat.com/ubi8/openjdk-21";
-    public static final String S2I_JAVA_21_VERSION = UBI8_JAVA_VERSION;
+    // Java Source To Image - https://catalog.redhat.com/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814
+    public static final String S2I_JAVA_21_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-21";
+    public static final String S2I_JAVA_21_VERSION = UBI9_JAVA_VERSION;
     public static final String S2I_JAVA_21 = S2I_JAVA_21_IMAGE_NAME + ":" + S2I_JAVA_21_VERSION;
 
     // === Native Builder images
@@ -106,9 +111,9 @@ public class ContainerImages {
     public static String getDefaultJvmImage(CompiledJavaVersionBuildItem.JavaVersion version) {
         switch (version.isJava21OrHigher()) {
             case TRUE:
-                return UBI8_JAVA_21;
+                return UBI9_JAVA_21;
             default:
-                return UBI8_JAVA_17;
+                return UBI9_JAVA_17;
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -114,7 +114,7 @@ public interface NativeConfig {
 
     /**
      * Defines the file encoding as in {@code -Dfile.encoding=...}.
-     *
+     * <p>
      * Native image runtime uses the host's (i.e. build time) value of {@code file.encoding}
      * system property. We intentionally default this to UTF-8 to avoid platform specific
      * defaults to be picked up which can then result in inconsistent behavior in the
@@ -253,7 +253,16 @@ public interface NativeConfig {
     interface BuilderImageConfig {
         /**
          * The docker image to use to do the image build. It can be one of `graalvm`, `mandrel`, or the full image path, e.g.
-         * {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21}.
+         * {@code quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21}.
+         * <p>
+         * <strong>Note:</strong> Builder images are available using UBI 8 and UBI 9 base images, for example:
+         * <ul>
+         * <li>UBI 8: {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21} (UBI 8)</li>
+         * <li>UBI 9: {@code quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21} (UBI 9)</li>
+         * </ul>
+         * <p>
+         * You need to be aware that if you use a builder image using UBI9 and you plan to build a container, you must
+         * ensure that the base image used in the container is also UBI9.
          */
         @WithParentName
         @WithDefault("${platform.quarkus.native.builder-image}")
@@ -278,9 +287,9 @@ public interface NativeConfig {
         default String getEffectiveImage() {
             final String builderImageName = this.image().toUpperCase();
             if (builderImageName.equals(BuilderImageProvider.GRAALVM.name())) {
-                return ContainerImages.GRAALVM_BUILDER;
+                return ContainerImages.UBI9_GRAALVM_BUILDER;
             } else if (builderImageName.equals(BuilderImageProvider.MANDREL.name())) {
-                return ContainerImages.MANDREL_BUILDER;
+                return ContainerImages.UBI9_MANDREL_BUILDER;
             } else {
                 return this.image();
             }
@@ -346,7 +355,7 @@ public interface NativeConfig {
      * If errors should be reported at runtime. This is a more relaxed setting, however it is not recommended as it
      * means
      * your application may fail at runtime if an unsupported feature is used by accident.
-     *
+     * <p>
      * Note that the use of this flag may result in build time failures due to {@code ClassNotFoundException}s.
      * Reason most likely being that the Quarkus extension already optimized it away or do not actually need it.
      * In such cases you should explicitly add the corresponding dependency providing the missing classes as a
@@ -357,9 +366,9 @@ public interface NativeConfig {
 
     /**
      * Don't build a native image if it already exists.
-     *
+     * <p>
      * This is useful if you have already built an image and you want to use Quarkus to deploy it somewhere.
-     *
+     * <p>
      * Note that this is not able to detect if the existing image is outdated, if you have modified source
      * or config and want a new image you must not use this flag.
      */
@@ -387,7 +396,7 @@ public interface NativeConfig {
          * <pre>
          * quarkus.native.resources.includes = foo/**,bar/**&#47;*.txt
          * </pre>
-         *
+         * <p>
          * the files {@code src/main/resources/foo/selected.png} and {@code bar/some.txt} will be included in the native
          * image, while {@code src/main/resources/ignored.png} will not be included.
          * <p>
@@ -467,7 +476,7 @@ public interface NativeConfig {
          * quarkus.native.resources.includes = **&#47;*.png
          * quarkus.native.resources.excludes = foo/**,**&#47;green.png
          * </pre>
-         *
+         * <p>
          * the resource {@code red.png} will be available in the native image while the resources {@code foo/green.png}
          * and {@code bar/blue.png} will not be available in the native image.
          */
@@ -532,7 +541,7 @@ public interface NativeConfig {
         /**
          * Allows passing extra arguments to the UPX command line (like --brute).
          * The arguments are comma-separated.
-         *
+         * <p>
          * The exhaustive list of parameters can be found in
          * <a href="https://github.com/upx/upx/blob/devel/doc/upx.pod">https://github.com/upx/upx/blob/devel/doc/upx.pod</a>.
          */

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
@@ -8,20 +8,20 @@ class NativeConfigTest {
 
     @Test
     public void testBuilderImageProperlyDetected() {
-        assertThat(createConfig("graalvm").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("graalvm").builderImage().getEffectiveImage()).contains("ubi9-quarkus-graalvmce-builder-image")
                 .contains("jdk-21");
-        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi9-quarkus-graalvmce-builder-image")
                 .contains("jdk-21");
-        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi9-quarkus-graalvmce-builder-image")
                 .contains("jdk-21");
-        assertThat(createConfig("GRAALVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("GRAALVM").builderImage().getEffectiveImage()).contains("ubi9-quarkus-graalvmce-builder-image")
                 .contains("jdk-21");
 
-        assertThat(createConfig("mandrel").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
+        assertThat(createConfig("mandrel").builderImage().getEffectiveImage()).contains("ubi9-quarkus-mandrel-builder-image")
                 .contains("jdk-21");
-        assertThat(createConfig("Mandrel").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
+        assertThat(createConfig("Mandrel").builderImage().getEffectiveImage()).contains("ubi9-quarkus-mandrel-builder-image")
                 .contains("jdk-21");
-        assertThat(createConfig("MANDREL").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
+        assertThat(createConfig("MANDREL").builderImage().getEffectiveImage()).contains("ubi9-quarkus-mandrel-builder-image")
                 .contains("jdk-21");
 
         assertThat(createConfig("aRandomString").builderImage().getEffectiveImage()).isEqualTo("aRandomString");

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
@@ -29,7 +29,7 @@ class NativeImageBuildContainerRunnerTest {
                 Collections.emptyList());
         found = false;
         for (String part : command) {
-            if (part.contains("ubi-quarkus-graalvmce-builder-image")) {
+            if (part.contains("ubi9-quarkus-graalvmce-builder-image")) {
                 found = true;
                 break;
             }
@@ -42,7 +42,7 @@ class NativeImageBuildContainerRunnerTest {
                 Collections.emptyList());
         found = false;
         for (String part : command) {
-            if (part.contains("ubi-quarkus-mandrel-builder-image")) {
+            if (part.contains("ubi9-quarkus-mandrel-builder-image")) {
                 found = true;
                 break;
             }

--- a/docs/src/main/asciidoc/aws-lambda.adoc
+++ b/docs/src/main/asciidoc/aws-lambda.adoc
@@ -586,7 +586,7 @@ To extract the required ssl, you must start up a Docker container in the backgro
 First, let's start the GraalVM container, noting the container id output.
 [source,bash,subs=attributes+]
 ----
-docker run -it -d --entrypoint bash quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}
+docker run -it -d --entrypoint bash quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}
 
 # This will output a container id, like 6304eea6179522aff69acb38eca90bedfd4b970a5475aa37ccda3585bc2abdde
 # Note this value as we will need it for the commands below

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -510,13 +510,13 @@ ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
 .Quarkus Micro Image?
 ====
 The Quarkus Micro Image is a small container image providing the right set of dependencies to run your native application.
-It is based on https://catalog.redhat.com/software/containers/ubi8-micro/601a84aadd19c7786c47c8ea?container-tabs=overview[UBI Micro].
+It is based on https://catalog.redhat.com/software/containers/ubi9-micro/61832b36dd607bfc82e66399?container-tabs=overview[UBI Micro].
 This base image has been tailored to work perfectly in containers.
 
 You can read more about UBI images on:
 
 * https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Introduction to Universal Base Image]
-* https://catalog.redhat.com/software/container-stacks/detail/5ec53f50ef29fd35586d9a56[Red Hat Universal Base Image 8]
+* https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e[Red Hat Universal Base Image 9]
 
 UBI images can be used without any limitations.
 
@@ -543,7 +543,7 @@ The project generation has also provided a `Dockerfile.native` in the `src/main/
 
 [source,dockerfile]
 ----
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -255,7 +255,7 @@ To see the `GreetingResourceIT` run against the native executable, use `./mvnw v
 $ ./mvnw verify -Dnative
 ...
 Finished generating 'getting-started-1.0.0-SNAPSHOT-runner' in 22.0s.
-[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] docker run --env LANG=C --rm --user 1000:1000 -v /home/zakkak/code/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} -c objcopy --strip-debug getting-started-1.0.0-SNAPSHOT-runner
+[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] docker run --env LANG=C --rm --user 1000:1000 -v /home/zakkak/code/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} -c objcopy --strip-debug getting-started-1.0.0-SNAPSHOT-runner
 [INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 70686ms
 [INFO]
 [INFO] --- maven-failsafe-plugin:3.0.0-M7:integration-test (default) @ getting-started ---
@@ -421,6 +421,25 @@ These are regular Quarkus config properties, so if you always want to build in a
 it is recommended you add these to your `application.properties` in order to avoid specifying them every time.
 ====
 
+Executable built that way with the container runtime will be a 64-bit Linux executable, so depending on your operating system it may no longer be runnable.
+
+[IMPORTANT]
+====
+Starting with Quarkus 3.19+, the _builder_ image used to build the native executable is based on UBI 9.
+It means that the native executable produced by the container build will be based on UBI 9 as well.
+So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 9.
+The native executable will not run on UBI 8 base images.
+
+You can configure the builder image used for the container build by setting the `quarkus.native.builder-image` property.
+For example to switch back to an UBI8 _builder image_ you can use:
+
+`quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
+
+You can see the available tags for UBI8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here]
+and for UBI9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)])
+
+====
+
 [[tip-quarkus-native-remote-container-build]]
 [TIP]
 ====
@@ -434,6 +453,7 @@ In this case, use the parameter `-Dquarkus.native.remote-container-build=true` i
 The reason for this is that the local build driver invoked through `-Dquarkus.native.container-build=true` uses volume mounts to make the JAR available in the build container, but volume mounts do not work with remote daemons. The remote container build driver copies the necessary files instead of mounting them. Note that even though the remote driver also works with local daemons, the local driver should be preferred in the local case because mounting is usually more performant than copying.
 ====
 
+
 [TIP]
 ====
 Building with GraalVM instead of Mandrel requires a custom builder image parameter to be passed additionally:
@@ -446,7 +466,8 @@ Please note that the above command points to a floating tag.
 It is highly recommended to use the floating tag,
 so that your builder image remains up-to-date and secure.
 If you absolutely must, you may hard-code to a specific tag
-(see https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here] for available tags),
+(see https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here (UBI 8)]
+and  https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)] for available tags),
 but be aware that you won't get security updates that way and it's unsupported.
 ====
 
@@ -493,7 +514,7 @@ The project generation has provided a `Dockerfile.native-micro` in the `src/main
 
 [source,dockerfile]
 ----
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
@@ -583,7 +604,7 @@ Sample Dockerfile for building with Maven:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
+FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
 COPY --chown=quarkus:quarkus --chmod=0755 mvnw /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn
 COPY --chown=quarkus:quarkus pom.xml /code/
@@ -594,7 +615,7 @@ COPY src /code/src
 RUN ./mvnw package -Dnative
 
 ## Stage 2 : create the docker final image
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 COPY --from=build /code/target/*-runner /work/application
 
@@ -621,7 +642,7 @@ Sample Dockerfile for building with Gradle:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
+FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
 USER root
 RUN microdnf install findutils
 COPY --chown=quarkus:quarkus gradlew /code/gradlew
@@ -635,7 +656,7 @@ COPY src /code/src
 RUN ./gradlew build -Dquarkus.native.enabled=true
 
 ## Stage 2 : create the docker final image
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 COPY --from=build /code/build/*-runner /work/application
 RUN chmod 775 /work
@@ -666,7 +687,7 @@ Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With N
 
 [NOTE,subs=attributes+]
 ====
-To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
+To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
 ====
 
 === Using a Distroless base image
@@ -707,7 +728,7 @@ Sample multistage Dockerfile for building an image from `scratch`:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
+FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
 USER root
 RUN microdnf install make gcc
 COPY --chown=quarkus:quarkus mvnw /code/mvnw

--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -48,7 +48,7 @@ For example, the presence of `src/main/jib/foo/bar` would result in  `/foo/bar` 
 
 There are cases where the built container image may need to have Java debugging conditionally enabled at runtime.
 
-When the base image has not been changed (and therefore `ubi8/openjdk-11-runtime`,  `ubi8/openjdk-17-runtime`, or `ubi8/openjdk-21-runtime` is used), then the `quarkus.jib.jvm-additional-arguments` configuration property can be used in order to
+When the base image has not been changed (and therefore `ubi9/openjdk-17-runtime`, or `ubi9/openjdk-21-runtime` is used), then the `quarkus.jib.jvm-additional-arguments` configuration property can be used in order to
 make the JVM listen on the debug port at startup.
 
 The exact configuration is:
@@ -64,7 +64,7 @@ Other base images might provide launch scripts that enable debugging when an env
 
 The `quarkus.jib.jvm-entrypoint` configuration property can be used to completely override the container entry point and can thus be used to either hard code the JVM debug configuration or point to a script that handles the details.
 
-For example, if the base images `ubi8/openjdk-11-runtime`, `ubi8/openjdk-17-runtime` or  `ubi8/openjdk-21-runtime` are used to build the container, the entry point can be hard-coded on the application properties file.
+For example, if the base images `ubi9/openjdk-17-runtime` or  `ubi9/openjdk-21-runtime` are used to build the container, the entry point can be hard-coded on the application properties file.
 
 .Example application.properties
 [source,properties]
@@ -89,7 +89,7 @@ java \
   -jar quarkus-run.jar
 ----
 
-NOTE: `/home/jboss` is the WORKDIR for all quarkus binaries in the base images `ubi8/openjdk-11-runtime`, `ubi8/openjdk-17-runtime` and `ubi8/openjdk-21-runtime` (https://catalog.redhat.com/software/containers/ubi8/openjdk-17/618bdbf34ae3739687568813?container-tabs=dockerfile[Dockerfile for ubi8/openjdk-17-runtime, window="_blank"])
+NOTE: `/home/jboss` is the WORKDIR for all quarkus binaries in the base images `ubi9/openjdk-17-runtime` and `ubi9/openjdk-21-runtime` (https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f?container-tabs=dockerfile[Dockerfile for ubi9/openjdk-17-runtime, window="_blank"])
 
 ==== Multi-module projects and layering
 

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -518,13 +518,13 @@ Configuring the `quarkusBuild` task can be done as following:
 quarkusBuild {
     nativeArgs {
         containerBuild = true <1>
-        builderImage = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
+        builderImage = "quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
     }
 }
 ----
 
 <1> Set `quarkus.native.container-build` property to `true`
-<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
+<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}`
 ****
 
 [role="secondary asciidoc-tabs-sync-kotlin"]
@@ -535,13 +535,13 @@ quarkusBuild {
 tasks.quarkusBuild {
     nativeArgs {
         "container-build" to true <1>
-        "builder-image" to "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
+        "builder-image" to "quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
     }
 }
 ----
 
 <1> Set `quarkus.native.container-build` property to `true`
-<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
+<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}`
 ****
 
 [WARNING]
@@ -564,13 +564,15 @@ Note that in this case the build itself runs in a Docker container too, so you d
 
 [TIP]
 ====
-By default, the native executable will be generated using the `quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}` Docker image.
+By default, the native executable will be generated using the `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}` Docker image.
 
 If you want to build a native executable with a different Docker image (for instance to use a different GraalVM version),
 use the `-Dquarkus.native.builder-image=<image name>` build argument.
 
-The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[quay.io].
+The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[quay.io].
 Be aware that a given Quarkus version might not be compatible with all the images available.
+
+Note also that starting Quarkus 3.19, the default _builder_ images are based on UBI 9. To use the previous UBI 8 based images, you can use the pick an image from the https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[quay.io repository].
 ====
 
 == Running native tests

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -509,13 +509,18 @@ Note that in this case the build itself runs in a Docker container too, so you d
 
 [TIP]
 ====
-By default, the native executable will be generated using the `quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}` Docker image.
+By default, the native executable will be generated using the `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}` Docker image.
 
 If you want to build a native executable with a different Docker image (for instance to use a different GraalVM version),
 use the `-Dquarkus.native.builder-image=<image name>` build argument.
 
-The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[quay.io].
+The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[quay.io].
 Be aware that a given Quarkus version might not be compatible with all the images available.
+
+Starting from Quarkus 3.19, the _builder_ image is based on UBI 9, and thus requires an UBI 9 base image if you want to run the native executable in a container.
+You can switch back to UBI 8, by setting the `quarkus.native.builder-image` property to one of the available image from the https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[quay.io repository].
+For example ``quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}` is using UBI 8, and so the resulting native executable will be compatible with UBI 8 base images.
+
 ====
 
 You can follow the xref:building-native-image.adoc[Build a native executable guide] as well as xref:deploying-to-kubernetes.adoc[Deploying Application to Kubernetes and OpenShift] for more information.

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -608,7 +608,7 @@ $ ./mvnw verify -DskipITs=false -Dquarkus.test.integration-test-profile=test-wit
 [INFO]  T E S T S
 [INFO] -------------------------------------------------------
 [INFO] Running org.acme.GreetingResourceIT
-2024-05-14 16:29:53,941 INFO  [io.qua.tes.com.DefaultDockerContainerLauncher] (main) Executing "podman run --name quarkus-integration-test-PodgW -i --rm --user 501:20 -p 8081:8081 -p 8444:8444 --entrypoint java -v /tmp/new-project/target:/project --env QUARKUS_LOG_CATEGORY__IO_QUARKUS__LEVEL=INFO --env QUARKUS_HTTP_PORT=8081 --env QUARKUS_HTTP_SSL_PORT=8444 --env TEST_URL=http://localhost:8081 --env QUARKUS_PROFILE=test-with-native-agent --env QUARKUS_TEST_INTEGRATION_TEST_PROFILE=test-with-native-agent quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21 -agentlib:native-image-agent=access-filter-file=quarkus-access-filter.json,caller-filter-file=quarkus-caller-filter.json,config-output-dir=native-image-agent-base-config, -jar quarkus-app/quarkus-run.jar"
+2024-05-14 16:29:53,941 INFO  [io.qua.tes.com.DefaultDockerContainerLauncher] (main) Executing "podman run --name quarkus-integration-test-PodgW -i --rm --user 501:20 -p 8081:8081 -p 8444:8444 --entrypoint java -v /tmp/new-project/target:/project --env QUARKUS_LOG_CATEGORY__IO_QUARKUS__LEVEL=INFO --env QUARKUS_HTTP_PORT=8081 --env QUARKUS_HTTP_SSL_PORT=8444 --env TEST_URL=http://localhost:8081 --env QUARKUS_PROFILE=test-with-native-agent --env QUARKUS_TEST_INTEGRATION_TEST_PROFILE=test-with-native-agent quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21 -agentlib:native-image-agent=access-filter-file=quarkus-access-filter.json,caller-filter-file=quarkus-caller-filter.json,config-output-dir=native-image-agent-base-config, -jar quarkus-app/quarkus-run.jar"
 ...
 [INFO]
 [INFO] --- quarkus:{quarkus-version}:native-image-agent (default) @ new-project ---
@@ -862,7 +862,7 @@ So, go ahead and add the following options to that file:
 [source,properties,subs=attributes+]
 ----
 quarkus.native.container-build=true
-quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}
+quarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}
 quarkus.container-image.build=true
 quarkus.container-image.group=test
 ----
@@ -1282,7 +1282,7 @@ These are called expert options and you can learn more about them by running:
 
 [source,bash,subs=attributes+]
 ----
-docker run quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} --expert-options-all
+docker run quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} --expert-options-all
 ----
 
 [WARNING]
@@ -2478,7 +2478,7 @@ E.g.
 [source,bash,subs=attributes+]
 ----
 ./mvnw package -DskipTests -Dnative -Dquarkus.native.container-build=true \
-    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} \
+    -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} \
     -Dquarkus.native.monitoring=jfr
 ----
 

--- a/docs/src/main/asciidoc/platform.adoc
+++ b/docs/src/main/asciidoc/platform.adoc
@@ -129,8 +129,24 @@ A platform properties file for the example above would contain:
 
 [source,text,subs=attributes+]
 ----
-platform.quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}
+platform.quarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}
 ----
+
+[IMPORTANT]
+====
+Starting with Quarkus 3.19+, the _builder_ image used to build the native executable is based on UBI 9.
+It means that the native executable produced by the container build will be based on UBI 9 as well.
+So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 9.
+The native executable will not run on UBI 8 base images.
+
+For example to switch back to an UBI8 _builder image_ you can use:
+
+`platform.quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
+
+You can see the available tags for UBI8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here]
+and for UBI9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)])
+====
+
 
 There is also a Maven plugin goal that validates the platform properties content and its artifact coordinates and also checks whether the platform properties artifact is present in the platform's BOM. Here is a sample plugin configuration:
 

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -22,7 +22,7 @@ In your `Dockerfile`, just use:
 
 [source, dockerfile]
 ----
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 COPY --chmod=0755 target/*-runner /work/application
 EXPOSE 8080
@@ -38,11 +38,11 @@ In this case, you need to use a multi-stage `dockerfile` to copy the required li
 [source, dockerfile]
 ----
 # First stage - install the dependencies in an intermediate container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10 as BUILD
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 as BUILD
 RUN microdnf install freetype
 
 # Second stage - copy the dependencies
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 COPY --from=BUILD \
    /lib64/libfreetype.so.6 \
    /lib64/libbz2.so.1 \
@@ -60,11 +60,11 @@ If you need to have access to the full AWT support, you need more than just `lib
 [source, dockerfile]
 ----
 # First stage - install the dependencies in an intermediate container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10 as BUILD
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 as BUILD
 RUN microdnf install freetype fontconfig
 
 # Second stage - copy the dependencies
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 COPY --from=BUILD \
    /lib64/libfreetype.so.6 \
    /lib64/libgcc_s.so.1 \

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -101,7 +101,8 @@ CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
 
 == Alternative - Using ubi-minimal
 
-If the micro image does not suit your requirements, you can use https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8[ubi8/ubi-minimal].
+
+If the micro image does not suit your requirements, you can use https://catalog.redhat.com/software/containers/ubi9-minimal/61832888c0d15aff4912fe0d[ubi9-minimal].
 It's a bigger image, but contains more utilities and is closer to a full Linux distribution.
 Typically, it contains a package manager (`microdnf`), so you can install packages more easily.
 
@@ -109,7 +110,7 @@ To use this base image, use the following `Dockerfile`:
 
 [source, dockerfile]
 ----
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -349,7 +349,7 @@ To containerize your Quarkus application that use `@RunOnVirtualThread`, add the
 quarkus.container-image.build=true
 quarkus.container-image.group=<your-group-name>
 quarkus.container-image.name=<you-container-name>
-quarkus.jib.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-21-runtime <1>
+quarkus.jib.base-jvm-image=registry.access.redhat.com/ubi9/openjdk-21-runtime <1>
 quarkus.jib.platforms=linux/amd64,linux/arm64 <2>
 ----
 <1> Make sure you use a base image supporting virtual threads. Here we use an image providing Java 21. Quarkus picks an image providing Java 21+ automatically if you do not set one.

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi8-openjdk-17-runtime
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi8-openjdk-17-runtime
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.21
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi8-openjdk-21-runtime
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi8-openjdk-21-runtime
@@ -1,5 +1,5 @@
 # Use Java 21 base image
-FROM registry.access.redhat.com/ubi8/openjdk-21-runtime:1.20
+FROM registry.access.redhat.com/ubi8/openjdk-21-runtime:1.21
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-java17
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-java17
@@ -1,13 +1,13 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 
 ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script
 # Also set up permissions for user `1001`
-RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
+RUN microdnf -y install ca-certificates ${JAVA_PACKAGE} \
+    && microdnf -y update \
+    && microdnf -y clean all \
     && mkdir /deployments \
     && chown 1001 /deployments \
     && chmod "g+rwX" /deployments \

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-java21
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-java21
@@ -1,13 +1,13 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 
 ARG JAVA_PACKAGE=java-21-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script
 # Also set up permissions for user `1001`
-RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
+RUN microdnf -y install ca-certificates ${JAVA_PACKAGE} \
+    && microdnf -y update \
+    && microdnf -y clean all \
     && mkdir /deployments \
     && chown 1001 /deployments \
     && chmod "g+rwX" /deployments \

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-openjdk-17-runtime
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-openjdk-17-runtime
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.21
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-openjdk-21-runtime
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi9-openjdk-21-runtime
@@ -1,5 +1,5 @@
 # Use Java 21 base image
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
@@ -21,16 +21,16 @@ public interface ContainerImageJibConfig {
     /**
      * The base image to be used when a container image is being produced for the jar build.
      *
-     * When the application is built against Java 21 or higher, {@code registry.access.redhat.com/ubi8/openjdk-21-runtime:1.20}
+     * When the application is built against Java 21 or higher, {@code registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21}
      * is used as the default.
-     * Otherwise {@code registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20} is used as the default.
+     * Otherwise {@code registry.access.redhat.com/ubi9/openjdk-17-runtime:1.21} is used as the default.
      */
     Optional<String> baseJvmImage();
 
     /**
      * The base image to be used when a container image is being produced for the native binary build.
      * The default is "quay.io/quarkus/quarkus-micro-image". You can also use
-     * "registry.access.redhat.com/ubi8/ubi-minimal" which is a bigger base image, but provide more built-in utilities
+     * "registry.access.redhat.com/ubi9/ubi-minimal" which is a bigger base image, but provide more built-in utilities
      * such as the microdnf package manager.
      */
     @WithDefault(ContainerImages.QUARKUS_MICRO_IMAGE)

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
@@ -29,7 +29,7 @@ public interface ContainerImageJibConfig {
 
     /**
      * The base image to be used when a container image is being produced for the native binary build.
-     * The default is "quay.io/quarkus/quarkus-micro-image". You can also use
+     * The default is "quay.io/quarkus/ubi9-quarkus-micro-image:2.0". You can also use
      * "registry.access.redhat.com/ubi9/ubi-minimal" which is a bigger base image, but provide more built-in utilities
      * such as the microdnf package manager.
      */

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -94,8 +94,8 @@ public class JibProcessor {
     private static final IsClassPredicate IS_CLASS_PREDICATE = new IsClassPredicate();
     private static final String BINARY_NAME_IN_CONTAINER = "application";
 
-    // The source for this can be found at https://github.com/jboss-container-images/openjdk/blob/ubi8/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
-    // A list of env vars that affect this script can be found at https://jboss-container-images.github.io/openjdk/ubi8/ubi8-openjdk-17.html
+    // The source for this can be found at https://github.com/jboss-container-images/openjdk/blob/ubi9/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+    // A list of env vars that affect this script can be found at https://rh-openjdk.github.io/redhat-openjdk-containers/ubi9/ubi9-openjdk-17.html
     private static final String RUN_JAVA_PATH = "/opt/jboss/container/java/run/run-java.sh";
 
     private static final String DEFAULT_BASE_IMAGE_USER = "185";

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
@@ -46,9 +46,9 @@ public interface ContainerImageOpenshiftConfig {
      * The value of this property is used to create an ImageStream for the builder image used in the Openshift build.
      * When it references images already available in the internal Openshift registry, the corresponding streams are used
      * instead.
-     * When the application is built against Java 21 or higher, {@code registry.access.redhat.com/ubi8/openjdk-21:1.20}
+     * When the application is built against Java 21 or higher, {@code registry.access.redhat.com/ubi9/openjdk-21:1.21}
      * is used as the default.
-     * Otherwise {@code registry.access.redhat.com/ubi8/openjdk-17:1.20} is used as the default.
+     * Otherwise {@code registry.access.redhat.com/ubi9/openjdk-17:1.21} is used as the default.
      */
     Optional<String> baseJvmImage();
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -26,7 +26,8 @@
 # This scripts computes the command line to execute your Java application, and
 # includes memory/GC tuning.
 # You can configure the behavior using the following environment properties:
-# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class") - Be aware that this will override
+# the default JVM options, use `JAVA_OPTS_APPEND` to append options
 # - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
 #   in JAVA_OPTS (example: "-Dsome.property=foo")
 # - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -80,7 +80,7 @@
 {#if dockerfile.jvm.from}
 FROM {dockerfile.jvm.from}
 {#else}
-FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-{java.version}:1.21
 {/if}
 
 ENV LANGUAGE='en_US:en'

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native
@@ -13,6 +13,8 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}
 #
+# The ` {dockerfile.native.from}` base image is based on UBI 9.
+# To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
 FROM {dockerfile.native.from}
 WORKDIR /work/

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-micro
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-micro
@@ -16,6 +16,8 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}
 #
+# The `{dockerfile.native-micro.from}` base image is based on UBI 9.
+# To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.
 ###
 FROM {dockerfile.native-micro.from}
 WORKDIR /work/

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
@@ -7,4 +7,4 @@ language:
         native:
           from: registry.access.redhat.com/ubi9/ubi-minimal:9.5
         native-micro:
-          from: quay.io/quarkus/quarkus-micro-image:2.0
+          from: quay.io/quarkus/ubi9-quarkus-micro-image:2.0

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
@@ -5,6 +5,6 @@ language:
     data:
       dockerfile:
         native:
-          from: registry.access.redhat.com/ubi8/ubi-minimal:8.10
+          from: registry.access.redhat.com/ubi9/ubi-minimal:9.5
         native-micro:
           from: quay.io/quarkus/quarkus-micro-image:2.0

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -332,7 +332,7 @@ class QuarkusCodestartGenerationTest {
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native-micro")).exists()
                 .satisfies(checkContains("./mvnw package -Dnative"))
-                .satisfies(checkContains("quay.io/quarkus/quarkus-micro-image"))
+                .satisfies(checkContains("quay.io/quarkus/ubi9-quarkus-micro-image"))
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native")).exists()
                 .satisfies(checkContains("./mvnw package -Dnative"))
@@ -358,7 +358,7 @@ class QuarkusCodestartGenerationTest {
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native-micro")).exists()
                 .satisfies(checkContains("./gradlew build -Dquarkus.native.enabled=true"))
-                .satisfies(checkContains("quay.io/quarkus/quarkus-micro-image:2.0"))
+                .satisfies(checkContains("quay.io/quarkus/ubi9-quarkus-micro-image:2.0"))
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native")).exists()
                 .satisfies(checkContains("./gradlew build -Dquarkus.native.enabled=true"))

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -319,13 +319,13 @@ class QuarkusCodestartGenerationTest {
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.jvm")).exists()
                 .satisfies(checkContains("./mvnw package"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.jvm"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi9/openjdk-17:"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.legacy-jar")).exists()
                 .satisfies(checkContains("./mvnw package -Dquarkus.package.jar.type=legacy-jar"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.legacy-jar"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi9/openjdk-17:"))
                 .satisfies(checkContains("EXPOSE 8080"))
                 .satisfies(checkContains("USER 185"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
@@ -336,7 +336,7 @@ class QuarkusCodestartGenerationTest {
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native")).exists()
                 .satisfies(checkContains("./mvnw package -Dnative"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi8/ubi-minimal"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi9/ubi-minimal"))
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
     }
 
@@ -345,13 +345,13 @@ class QuarkusCodestartGenerationTest {
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.jvm")).exists()
                 .satisfies(checkContains("./gradlew build"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.jvm"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi9/openjdk-17:"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.legacy-jar")).exists()
                 .satisfies(checkContains("./gradlew build -Dquarkus.package.jar.type=legacy-jar"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.legacy-jar"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi9/openjdk-17:"))
                 .satisfies(checkContains("EXPOSE 8080"))
                 .satisfies(checkContains("USER 185"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
@@ -362,7 +362,7 @@ class QuarkusCodestartGenerationTest {
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native")).exists()
                 .satisfies(checkContains("./gradlew build -Dquarkus.native.enabled=true"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi8/ubi-minimal"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi9/ubi-minimal"))
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
     }
 

--- a/integration-tests/awt/src/main/docker/Dockerfile.native
+++ b/integration-tests/awt/src/main/docker/Dockerfile.native
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 # Dependencies for AWT
 RUN microdnf install freetype fontconfig \
     && microdnf clean all

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/src/main/docker/Dockerfile.jvm
@@ -21,16 +21,16 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/rest-client-quickstart-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 
 ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script
 # Also set up permissions for user `1001`
-RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
+RUN microdnf -y install ca-certificates ${JAVA_PACKAGE} \
+    && microdnf -y update \
+    && microdnf -y clean all \
     && mkdir /deployments \
     && chown 1001 /deployments \
     && chmod "g+rwX" /deployments \

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.native
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/integration-tests/gradle/src/main/resources/it-test-basic-project/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/gradle/src/main/resources/it-test-basic-project/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.18
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-deployment/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-deployment/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-statefulset/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-statefulset/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-jib-build-and-deploy/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-jib-build-and-deploy/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy-deploymentconfig/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy-deploymentconfig/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-s2i-build-and-deploy/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-s2i-build-and-deploy/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.legacy-jar
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.native-micro
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.native-micro
@@ -16,8 +16,11 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
 #
+# The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
+# To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.
+#
 ###
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
@@ -67,7 +67,7 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
                 Optional<String> entryPoint = Optional.of("java");
                 Map<String, String> volumeMounts = new HashMap<>(volumeMounts(config));
                 volumeMounts.put(context.buildOutputDirectory().toString(), "/project");
-                containerImage = ContainerImages.MANDREL_BUILDER;
+                containerImage = ContainerImages.UBI9_MANDREL_BUILDER;
 
                 List<String> programArgs = new ArrayList<>();
                 addNativeAgentProgramArgs(programArgs, context);


### PR DESCRIPTION
- Update UBI 8 and UBI 9 versions (including OpenJDK images)
- Switch the default to UBI 9

~~This commit does not cover the builder images and the quarkus-micro images, as they are not yet available using UBI9.~~


Fix https://github.com/quarkusio/quarkus/issues/45968.
