### PR TITLE
Bump kubernetes-client-bom from 7.0.1 to 7.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Properties below are set in this file because they are used
              in the BOM as well as other POMs (build-parent/pom.xml, docs/pom.xml, ...) -->
         <jacoco.version>0.8.12</jacoco.version>
-        <kubernetes-client.version>7.0.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>7.1.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.0</rest-assured.version>
         <hibernate-orm.version>6.6.5.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <antlr.version>4.13.0</antlr.version> <!-- version controlled by Hibernate ORM's needs -->


### PR DESCRIPTION
Kubernetes Client 7.1.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v7.1.0

Note that this does include the fix in https://github.com/fabric8io/kubernetes-client/issues/6781 that will be needed by keycloak in 3.20 (transitive from quarkus-operator-sdk) 

/cc @metacosm @vmuzikar