### PR TITLE
Update WildFly Common to 2.0.1 and adjust substitutions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,7 @@ updates:
       - dependency-name: com.google.cloud.tools:jib-core
       - dependency-name: org.jboss.threads:jboss-threads
       - dependency-name: org.jboss.marshalling:*
+      - dependency-name: org.wildfly.common:*
       # Quarkus
       - dependency-name: io.quarkus.*:*
       - dependency-name: io.quarkus:*

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -105,7 +105,7 @@
         <wildfly.openssl-linux.version>2.2.2.SP01</wildfly.openssl-linux.version>
         <jboss-logging-annotations.version>3.0.3.Final</jboss-logging-annotations.version>
         <slf4j-jboss-logmanager.version>2.0.0.Final</slf4j-jboss-logmanager.version>
-        <wildfly-common.version>1.7.0.Final</wildfly-common.version>
+        <wildfly-common.version>2.0.1</wildfly-common.version>
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.6.0.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.2.Final</jboss-marshalling.version>

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_org_wildfly_common_net_CidrAddress.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_org_wildfly_common_net_CidrAddress.java
@@ -17,7 +17,8 @@ import com.oracle.svm.core.annotate.TargetClass;
 final class Target_org_wildfly_common_net_CidrAddress {
 
     @Alias
-    private Target_org_wildfly_common_net_CidrAddress(InetAddress networkAddress, int netmaskBits) {
+    public static Target_org_wildfly_common_net_CidrAddress create(InetAddress networkAddress, int netmaskBits) {
+        return null;
     }
 
     @Alias
@@ -30,7 +31,7 @@ final class Target_org_wildfly_common_net_CidrAddress {
 
     static class CidrAddressUtil {
         static Target_org_wildfly_common_net_CidrAddress newInstance(InetAddress networkAddress, int netmaskBits) {
-            return new Target_org_wildfly_common_net_CidrAddress(networkAddress, netmaskBits);
+            return Target_org_wildfly_common_net_CidrAddress.create(networkAddress, netmaskBits);
         }
     }
 }


### PR DESCRIPTION
@dmlloyd adjusted WildFly Common to rely on SmallRye Common in 2.0.x but we never updated to this version which was a mistake.

Also adjusted the substitutions.