### PR TITLE
Improve formatting for enum configuration values

### DIFF
--- a/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/generator/AbstractFormatter.java
+++ b/devtools/config-doc-maven-plugin/src/main/java/io/quarkus/maven/config/doc/generator/AbstractFormatter.java
@@ -79,11 +79,11 @@ abstract class AbstractFormatter implements Formatter {
                                     .transform(javadocElement.get().description(), javadocElement.get().format(),
                                             javadocFormat()));
                         })
-                        .collect(Collectors.joining(", "));
+                        .collect(Collectors.joining("\n- ", "- ", ""));
             } else {
                 typeContent = configProperty.getEnumAcceptedValues().values().values().stream()
                         .map(v -> v.configValue())
-                        .collect(Collectors.joining("`, `", "`", "`"));
+                        .collect(Collectors.joining("`\n- `", "- `", "`"));
             }
         } else {
             typeContent = configProperty.getTypeDescription();


### PR DESCRIPTION
- Improve readability of enum configuration value formatting by switching to a bullet list style in documentation generation.


Before:  
![image](https://github.com/user-attachments/assets/f129cee5-50c3-44b5-afed-0d993e3c6518)

After:
![image](https://github.com/user-attachments/assets/d024e2f0-20b4-48f0-8190-ae85e137eea2)

- Follow-up to https://github.com/quarkusio/quarkus/pull/43633/