### PR TITLE
Promote the incubating model resolver to the default one

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment;
 
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -47,13 +48,13 @@ public interface BootstrapConfig {
     boolean disableJarCache();
 
     /**
-     * A temporary option introduced to avoid a logging warning when {@code -Dquarkus.bootstrap.incubating-model-resolver}
+     * A temporary option introduced to avoid a logging warning when {@code -Dquarkus.bootstrap.legacy-model-resolver}
      * is added to the build command line.
-     * This option enables an incubating implementation of the Quarkus Application Model resolver.
-     * This option will be removed as soon as the incubating implementation becomes the default one.
+     * This option enables the legacy implementation of the Quarkus Application Model resolver.
+     * This option will be removed once the legacy {@link ApplicationModel} resolver implementation gets removed.
      */
     @WithDefault("false")
-    boolean incubatingModelResolver();
+    boolean legacyModelResolver();
 
     /**
      * Whether to throw an error, warn or silently ignore misaligned platform BOM imports

--- a/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/DependencyConditionMatchesConditionalDependencyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/DependencyConditionMatchesConditionalDependencyTest.java
@@ -8,19 +8,10 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.deployment.runnerjar.BootstrapFromOriginalJarTestBase;
 import io.quarkus.maven.dependency.ResolvedDependency;
 
 public class DependencyConditionMatchesConditionalDependencyTest extends BootstrapFromOriginalJarTestBase {
-
-    @Override
-    protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
-        var resolver = super.newAppModelResolver(currentProject);
-        //        resolver.setIncubatingModelResolver(true);
-        return resolver;
-    }
 
     @Override
     protected TsArtifact composeApplication() {
@@ -62,7 +53,7 @@ public class DependencyConditionMatchesConditionalDependencyTest extends Bootstr
         }
         assertThat(extensions).hasSize(8);
 
-        if (IncubatingApplicationModelResolver.isIncubatingEnabled(null)) {
+        if (!BootstrapAppModelResolver.isLegacyModelResolver(null)) {
             var extA = extensions.get("ext-a");
             assertThat(extA.getDependencies()).isEmpty();
             var extADeployment = extensions.get("ext-a-deployment");

--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencySbomMojo.java
@@ -20,7 +20,6 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.EffectiveModelResolver;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.cyclonedx.generator.CycloneDxSbomGenerator;
 import io.quarkus.maven.components.QuarkusWorkspaceProvider;
@@ -131,9 +130,7 @@ public class DependencySbomMojo extends AbstractMojo {
                             "Parameter 'mode' was set to '" + mode + "' while expected one of 'dev', 'test' or 'prod'");
                 }
             }
-            // enable the incubating model resolver impl by default for this mojo
-            modelResolver.setIncubatingModelResolver(
-                    !IncubatingApplicationModelResolver.isIncubatingModelResolverProperty(project.getProperties(), "false"));
+            modelResolver.setLegacyModelResolver(BootstrapAppModelResolver.isLegacyModelResolver(project.getProperties()));
             return modelResolver.resolveModel(appArtifact);
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to resolve application model " + appArtifact + " dependencies", e);

--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
@@ -24,7 +24,6 @@ import org.eclipse.aether.repository.RemoteRepository;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.DependencyLoggingConfig;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.maven.components.QuarkusWorkspaceProvider;
 import io.quarkus.maven.dependency.ArtifactCoords;
@@ -154,9 +153,7 @@ public class DependencyTreeMojo extends AbstractMojo {
                             "Parameter 'mode' was set to '" + mode + "' while expected one of 'dev', 'test' or 'prod'");
                 }
             }
-            // enable the incubating model resolver impl by default for this mojo
-            modelResolver.setIncubatingModelResolver(
-                    !IncubatingApplicationModelResolver.isIncubatingModelResolverProperty(project.getProperties(), "false"));
+            modelResolver.setLegacyModelResolver(BootstrapAppModelResolver.isLegacyModelResolver(project.getProperties()));
             modelResolver.setDepLogConfig(DependencyLoggingConfig.builder()
                     .setMessageConsumer(log)
                     .setVerbose(verbose)

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -97,7 +97,6 @@ import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContextConfig;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.util.BootstrapUtils;
 import io.quarkus.bootstrap.workspace.ArtifactSources;
@@ -1425,9 +1424,7 @@ public class DevMojo extends AbstractMojo {
                     .setDevMode(true)
                     .setTest(LaunchMode.TEST.equals(getLaunchModeClasspath()))
                     .setCollectReloadableDependencies(!noDeps)
-                    // enabled the incubating model resolver for in dev mode
-                    .setIncubatingModelResolver(!IncubatingApplicationModelResolver
-                            .isIncubatingModelResolverProperty(project.getProperties(), "false"))
+                    .setLegacyModelResolver(BootstrapAppModelResolver.isLegacyModelResolver(project.getProperties()))
                     .resolveModel(mvnCtx.getCurrentProject().getAppArtifact());
         }
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -43,7 +43,6 @@ import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContextConfig;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.resolver.maven.EffectiveModelResolver;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.maven.components.ManifestSection;
@@ -239,11 +238,8 @@ public class QuarkusBootstrapProvider implements Closeable {
                 Consumer<QuarkusBootstrap.Builder> builderCustomizer) throws MojoExecutionException {
 
             final BootstrapAppModelResolver modelResolver = new BootstrapAppModelResolver(artifactResolver(mojo, mode))
-                    .setIncubatingModelResolver(
-                            IncubatingApplicationModelResolver.isIncubatingEnabled(mojo.mavenProject().getProperties())
-                                    || mode == LaunchMode.DEVELOPMENT
-                                            && !IncubatingApplicationModelResolver.isIncubatingModelResolverProperty(
-                                                    mojo.mavenProject().getProperties(), "false"))
+                    .setLegacyModelResolver(
+                            BootstrapAppModelResolver.isLegacyModelResolver(mojo.mavenProject().getProperties()))
                     .setDevMode(mode == LaunchMode.DEVELOPMENT)
                     .setTest(mode == LaunchMode.TEST)
                     .setCollectReloadableDependencies(mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST);

--- a/devtools/maven/src/test/java/io/quarkus/maven/ConditionalDependencyGraphMojoTest.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/ConditionalDependencyGraphMojoTest.java
@@ -15,11 +15,6 @@ public class ConditionalDependencyGraphMojoTest extends DependencyTreeMojoTestBa
     }
 
     @Override
-    protected boolean isIncubatingModelResolver() {
-        return true;
-    }
-
-    @Override
     protected void initRepo() {
 
         final TsQuarkusExt coreExt = new TsQuarkusExt("test-core-ext");

--- a/devtools/maven/src/test/java/io/quarkus/maven/ConditionalDependencyTreeMojoRuntimeOnlyTest.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/ConditionalDependencyTreeMojoRuntimeOnlyTest.java
@@ -10,11 +10,6 @@ public class ConditionalDependencyTreeMojoRuntimeOnlyTest extends DependencyTree
     }
 
     @Override
-    protected boolean isIncubatingModelResolver() {
-        return true;
-    }
-
-    @Override
     protected boolean isRuntimeOnly() {
         return true;
     }

--- a/devtools/maven/src/test/java/io/quarkus/maven/ConditionalDependencyTreeMojoTest.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/ConditionalDependencyTreeMojoTest.java
@@ -10,11 +10,6 @@ public class ConditionalDependencyTreeMojoTest extends DependencyTreeMojoTestBas
     }
 
     @Override
-    protected boolean isIncubatingModelResolver() {
-        return true;
-    }
-
-    @Override
     protected void initRepo() {
 
         final TsQuarkusExt coreExt = new TsQuarkusExt("test-core-ext");

--- a/devtools/maven/src/test/java/io/quarkus/maven/DependencyTreeMojoTestBase.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/DependencyTreeMojoTestBase.java
@@ -61,10 +61,6 @@ abstract class DependencyTreeMojoTestBase {
         return false;
     }
 
-    protected boolean isIncubatingModelResolver() {
-        return false;
-    }
-
     protected boolean isRuntimeOnly() {
         return false;
     }
@@ -79,9 +75,6 @@ abstract class DependencyTreeMojoTestBase {
                 new DefaultArtifactHandler(ArtifactCoords.TYPE_JAR)));
         mojo.project.setModel(appModel);
         mojo.project.setOriginalModel(appModel);
-        if (isIncubatingModelResolver()) {
-            mojo.project.getProperties().setProperty("quarkus.bootstrap.incubating-model-resolver", "true");
-        }
         mojo.resolver = mvnResolver;
         mojo.mode = mode();
         mojo.graph = isGraph();

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -1057,6 +1057,9 @@ Here is a list of system properties the Quarkus bootstrap Maven resolver checks 
 | `false`
 | By default, the Quarkus Maven resolver is reading project's POMs directly when discovering the project's layout. While in most cases it works well enough and relatively fast, reading raw POMs has its limitation. E.g. if a POM includes modules in a profile, these modules will not be discovered. This system property enables project's layout discovery based on the effective POM models, that are properly interpolated, instead of the raw ones. The reason this option is not enabled by default is it may appear to be significantly more time-consuming that could increase, e.g. CI testing times. Until there is a better approach found that could be used by default, projects that require it should enable this option.
 
+| `quarkus.bootstrap.legacy-model-resolver`
+| `false`
+| This *system* or *POM* property can be used to enable the legacy `ApplicationModel` resolver implementation. The property was introduced in Quarkus 3.19.0 and will be removed once the legacy implementation is known to be not in demand.
 |===
 
 These system properties above could be added to, e.g., a `surefire` and/or `failsafe` plugin configuration as

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
@@ -25,7 +25,6 @@ import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContextConfig;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
@@ -175,9 +174,7 @@ public class BootstrapAppModelFactory {
             final Properties modelProps = project.getModelBuildingResult() == null
                     ? project.getRawModel().getProperties()
                     : project.getModelBuildingResult().getEffectiveModel().getProperties();
-            appModelResolver.setIncubatingModelResolver(IncubatingApplicationModelResolver.isIncubatingEnabled(modelProps)
-                    || devMode
-                            && !IncubatingApplicationModelResolver.isIncubatingModelResolverProperty(modelProps, "false"));
+            appModelResolver.setLegacyModelResolver(BootstrapAppModelResolver.isLegacyModelResolver(modelProps));
         }
         return appModelResolver;
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/ResolverSetupCleanup.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/ResolverSetupCleanup.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.util.IoUtils;
@@ -150,7 +149,7 @@ public class ResolverSetupCleanup {
 
     protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
         final BootstrapAppModelResolver appModelResolver = new BootstrapAppModelResolver(newArtifactResolver(currentProject));
-        appModelResolver.setIncubatingModelResolver(IncubatingApplicationModelResolver.isIncubatingEnabled(null));
+        appModelResolver.setLegacyModelResolver(BootstrapAppModelResolver.isLegacyModelResolver(null));
         switch (getBootstrapMode()) {
             case PROD:
                 break;

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesDevModelTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesDevModelTestCase.java
@@ -10,20 +10,11 @@ import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 
 public class ConditionalDependenciesDevModelTestCase extends CollectDependenciesBase {
-
-    @Override
-    protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
-        var resolver = super.newAppModelResolver(currentProject);
-        //resolver.setIncubatingModelResolver(true);
-        return resolver;
-    }
 
     @Override
     protected QuarkusBootstrap.Mode getBootstrapMode() {
@@ -113,7 +104,7 @@ public class ConditionalDependenciesDevModelTestCase extends CollectDependencies
 
     @Override
     protected void assertBuildDependencies(Collection<ResolvedDependency> buildDeps) {
-        if (!IncubatingApplicationModelResolver.isIncubatingEnabled(null)) {
+        if (BootstrapAppModelResolver.isLegacyModelResolver(null)) {
             return;
         }
         for (var d : buildDeps) {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesDirectDependencyOnTransitiveDeploymentArtifactTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesDirectDependencyOnTransitiveDeploymentArtifactTestCase.java
@@ -1,20 +1,11 @@
 package io.quarkus.bootstrap.resolver.test;
 
-import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.maven.dependency.DependencyFlags;
 
 public class ConditionalDependenciesDirectDependencyOnTransitiveDeploymentArtifactTestCase extends CollectDependenciesBase {
-
-    @Override
-    protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
-        var resolver = super.newAppModelResolver(currentProject);
-        //resolver.setIncubatingModelResolver(true);
-        return resolver;
-    }
 
     @Override
     protected void setupDependencies() {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesProdModelTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesProdModelTestCase.java
@@ -1,20 +1,11 @@
 package io.quarkus.bootstrap.resolver.test;
 
-import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.maven.dependency.DependencyFlags;
 
 public class ConditionalDependenciesProdModelTestCase extends CollectDependenciesBase {
-
-    @Override
-    protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
-        var resolver = super.newAppModelResolver(currentProject);
-        //resolver.setIncubatingModelResolver(false);
-        return resolver;
-    }
 
     @Override
     protected void setupDependencies() {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesRuntimeOnlyProdModelTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependenciesRuntimeOnlyProdModelTestCase.java
@@ -14,7 +14,6 @@ public class ConditionalDependenciesRuntimeOnlyProdModelTestCase extends Collect
     @Override
     protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
         var resolver = super.newAppModelResolver(currentProject);
-        //resolver.setIncubatingModelResolver(false);
         resolver.setRuntimeModelOnly(runtimeOnly);
         return resolver;
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/DevModeConditionalDependencyWithExtraConditionTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/DevModeConditionalDependencyWithExtraConditionTestCase.java
@@ -1,20 +1,11 @@
 package io.quarkus.bootstrap.resolver.test;
 
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
-import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.maven.dependency.DependencyFlags;
 
 public class DevModeConditionalDependencyWithExtraConditionTestCase extends CollectDependenciesBase {
-
-    @Override
-    protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
-        var resolver = super.newAppModelResolver(currentProject);
-        //resolver.setIncubatingModelResolver(false);
-        return resolver;
-    }
 
     @Override
     protected QuarkusBootstrap.Mode getBootstrapMode() {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/DevUiStyleConditionalDevModeDependenciesTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/DevUiStyleConditionalDevModeDependenciesTestCase.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collection;
 
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
@@ -40,7 +40,7 @@ public class DevUiStyleConditionalDevModeDependenciesTestCase extends CollectDep
 
     @Override
     protected void assertBuildDependencies(Collection<ResolvedDependency> buildDeps) {
-        if (!IncubatingApplicationModelResolver.isIncubatingEnabled(null)) {
+        if (BootstrapAppModelResolver.isLegacyModelResolver(null)) {
             return;
         }
         for (var d : buildDeps) {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/RequiredConditionalDependencyTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/RequiredConditionalDependencyTest.java
@@ -1,19 +1,10 @@
 package io.quarkus.bootstrap.resolver.test;
 
-import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.maven.dependency.DependencyFlags;
 
 public class RequiredConditionalDependencyTest extends CollectDependenciesBase {
-
-    @Override
-    protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
-        var resolver = super.newAppModelResolver(currentProject);
-        //resolver.setIncubatingModelResolver(false);
-        return resolver;
-    }
 
     @Override
     protected void setupDependencies() {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -34,10 +35,10 @@ import org.eclipse.aether.version.Version;
 import io.quarkus.bootstrap.BootstrapDependencyProcessingException;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.bootstrap.resolver.maven.ApplicationDependencyResolver;
 import io.quarkus.bootstrap.resolver.maven.ApplicationDependencyTreeResolver;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.resolver.maven.DependencyLoggingConfig;
-import io.quarkus.bootstrap.resolver.maven.IncubatingApplicationModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.util.DependencyUtils;
 import io.quarkus.bootstrap.workspace.ArtifactSources;
@@ -56,12 +57,43 @@ import io.quarkus.paths.PathList;
  */
 public class BootstrapAppModelResolver implements AppModelResolver {
 
+    private static final String LEGACY_MODEL_RESOLVER_PROP = "quarkus.bootstrap.legacy-model-resolver";
+
+    /**
+     * Temporary method that will be removed once the legacy {@link ApplicationModel} resolver implementation gets removed.
+     * <p>
+     * Returns {@code true} if the system or POM property {@code quarkus.bootstrap.legacy-model-resolver}
+     * is set to {@code true}.
+     *
+     * @return true if the legacy application model resolver should be used
+     */
+    public static boolean isLegacyModelResolver(Properties projectProperties) {
+        return Boolean.parseBoolean(getLegacyModelResolverProperty(projectProperties));
+    }
+
+    /**
+     * Temporary method that will be removed once the legacy {@link ApplicationModel} resolver implementation gets removed.
+     * <p>
+     * Returns value of the system or POM property {@code quarkus.bootstrap.legacy-model-resolver}.
+     * The system property is checked first and if its value is not {@code null}, the value is returned.
+     * Otherwise, the value of the POM property is returned as the result.
+     *
+     * @return value of the system or POM property {@code quarkus.bootstrap.legacy-model-resolver} or null if it's not set
+     */
+    private static String getLegacyModelResolverProperty(Properties projectProperties) {
+        var value = System.getProperty(LEGACY_MODEL_RESOLVER_PROP);
+        if (value != null || projectProperties == null) {
+            return value;
+        }
+        return String.valueOf(projectProperties.get(LEGACY_MODEL_RESOLVER_PROP));
+    }
+
     protected final MavenArtifactResolver mvn;
     private DependencyLoggingConfig depLogConfig;
     protected boolean devmode;
     protected boolean test;
     private boolean collectReloadableDeps = true;
-    private boolean incubatingModelResolver;
+    private boolean legacyModelResolver;
     private boolean runtimeModelOnly;
 
     public BootstrapAppModelResolver(MavenArtifactResolver mvn) {
@@ -69,12 +101,12 @@ public class BootstrapAppModelResolver implements AppModelResolver {
     }
 
     /**
-     * Temporary method that will be removed once the incubating implementation becomes the default.
+     * Temporary method that will be removed once the legacy {@link ApplicationModel} resolver implementation gets removed.
      *
      * @return this application model resolver
      */
-    public BootstrapAppModelResolver setIncubatingModelResolver(boolean incubatingModelResolver) {
-        this.incubatingModelResolver = incubatingModelResolver;
+    public BootstrapAppModelResolver setLegacyModelResolver(boolean legacyModelResolver) {
+        this.legacyModelResolver = legacyModelResolver;
         return this;
     }
 
@@ -370,17 +402,7 @@ public class BootstrapAppModelResolver implements AppModelResolver {
             if (logTime) {
                 start = System.currentTimeMillis();
             }
-            if (incubatingModelResolver) {
-                IncubatingApplicationModelResolver.newInstance()
-                        .setArtifactResolver(mvn)
-                        .setApplicationModelBuilder(appBuilder)
-                        .setCollectReloadableModules(collectReloadableDeps && reloadableModules.isEmpty())
-                        .setCollectCompileOnly(filteredProvidedDeps)
-                        .setDependencyLogging(depLogConfig)
-                        .setRuntimeModelOnly(runtimeModelOnly)
-                        .setDevMode(devmode)
-                        .resolve(collectRtDepsRequest);
-            } else {
+            if (legacyModelResolver) {
                 ApplicationDependencyTreeResolver.newInstance()
                         .setArtifactResolver(mvn)
                         .setApplicationModelBuilder(appBuilder)
@@ -390,11 +412,21 @@ public class BootstrapAppModelResolver implements AppModelResolver {
                         .setRuntimeModelOnly(runtimeModelOnly)
                         .setDevMode(devmode)
                         .resolve(collectRtDepsRequest);
+            } else {
+                ApplicationDependencyResolver.newInstance()
+                        .setArtifactResolver(mvn)
+                        .setApplicationModelBuilder(appBuilder)
+                        .setCollectReloadableModules(collectReloadableDeps && reloadableModules.isEmpty())
+                        .setCollectCompileOnly(filteredProvidedDeps)
+                        .setDependencyLogging(depLogConfig)
+                        .setRuntimeModelOnly(runtimeModelOnly)
+                        .setDevMode(devmode)
+                        .resolve(collectRtDepsRequest);
             }
             if (logTime) {
                 System.err.println(
-                        "Application model resolved in " + (System.currentTimeMillis() - start) + "ms, incubating="
-                                + incubatingModelResolver);
+                        "Application model resolved in " + (System.currentTimeMillis() - start) + "ms, legacy="
+                                + legacyModelResolver);
             }
         } catch (BootstrapDependencyProcessingException e) {
             throw new AppModelResolverException(

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -58,14 +57,12 @@ import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
 import io.quarkus.paths.PathTree;
 import io.quarkus.paths.PathVisit;
 
-public class IncubatingApplicationModelResolver {
+public class ApplicationDependencyResolver {
 
-    private static final Logger log = Logger.getLogger(IncubatingApplicationModelResolver.class);
+    private static final Logger log = Logger.getLogger(ApplicationDependencyResolver.class);
 
     private static final String QUARKUS_RUNTIME_ARTIFACT = "quarkus.runtime";
     private static final String QUARKUS_EXTENSION_DEPENDENCY = "quarkus.ext";
-
-    private static final String INCUBATING_MODEL_RESOLVER = "quarkus.bootstrap.incubating-model-resolver";
 
     /* @formatter:off */
     private static final byte COLLECT_TOP_EXTENSION_RUNTIME_NODES = 0b0001;
@@ -79,50 +76,8 @@ public class IncubatingApplicationModelResolver {
      */
     private static final boolean BLOCKING_TASK_RUNNER = Boolean.getBoolean("quarkus.bootstrap.blocking-task-runner");
 
-    /**
-     * Temporary method that will be removed once this implementation becomes the default.
-     * <p>
-     * Returns {@code true} if system or POM property {@code quarkus.bootstrap.incubating-model-resolver}
-     * is set to {@code true}.
-     *
-     * @return true if this implementation is enabled
-     */
-    public static boolean isIncubatingEnabled(Properties projectProperties) {
-        return Boolean.parseBoolean(getIncubatingModelResolverProperty(projectProperties));
-    }
-
-    /**
-     * Temporary method that will be removed once this implementation becomes the default.
-     * <p>
-     * Calls {@link #getIncubatingModelResolverProperty(Properties)} and checks whether the returned value
-     * equals the passed in {@code value}.
-     *
-     * @return true if value of quarkus.bootstrap.incubating-model-resolver property is equal to the passed in value
-     */
-    public static boolean isIncubatingModelResolverProperty(Properties projectProperties, String value) {
-        Objects.requireNonNull(value);
-        return value.equals(getIncubatingModelResolverProperty(projectProperties));
-    }
-
-    /**
-     * Temporary method that will be removed once this implementation becomes the default.
-     * <p>
-     * Returns value of system or POM property {@code quarkus.bootstrap.incubating-model-resolver}.
-     * The system property is checked first and if its value is not {@code null}, it's returned.
-     * Otherwise, the value of POM property is returned as the result.
-     *
-     * @return value of system or POM property quarkus.bootstrap.incubating-model-resolver or null if it's not set
-     */
-    public static String getIncubatingModelResolverProperty(Properties projectProperties) {
-        var value = System.getProperty(INCUBATING_MODEL_RESOLVER);
-        if (value != null || projectProperties == null) {
-            return value;
-        }
-        return String.valueOf(projectProperties.get(INCUBATING_MODEL_RESOLVER));
-    }
-
-    public static IncubatingApplicationModelResolver newInstance() {
-        return new IncubatingApplicationModelResolver();
+    public static ApplicationDependencyResolver newInstance() {
+        return new ApplicationDependencyResolver();
     }
 
     /**
@@ -156,7 +111,7 @@ public class IncubatingApplicationModelResolver {
      * @param resolver Maven artifact resolver
      * @return self
      */
-    public IncubatingApplicationModelResolver setArtifactResolver(MavenArtifactResolver resolver) {
+    public ApplicationDependencyResolver setArtifactResolver(MavenArtifactResolver resolver) {
         this.resolver = resolver;
         return this;
     }
@@ -167,7 +122,7 @@ public class IncubatingApplicationModelResolver {
      * @param appBuilder application model builder
      * @return self
      */
-    public IncubatingApplicationModelResolver setApplicationModelBuilder(ApplicationModelBuilder appBuilder) {
+    public ApplicationDependencyResolver setApplicationModelBuilder(ApplicationModelBuilder appBuilder) {
         this.appBuilder = appBuilder;
         return this;
     }
@@ -178,7 +133,7 @@ public class IncubatingApplicationModelResolver {
      * @param collectReloadableModules whether indicate which resolved dependencies are reloadable
      * @return self
      */
-    public IncubatingApplicationModelResolver setCollectReloadableModules(boolean collectReloadableModules) {
+    public ApplicationDependencyResolver setCollectReloadableModules(boolean collectReloadableModules) {
         this.collectReloadableModules = collectReloadableModules;
         return this;
     }
@@ -189,7 +144,7 @@ public class IncubatingApplicationModelResolver {
      * @param depLogging dependency logging configuration
      * @return self
      */
-    public IncubatingApplicationModelResolver setDependencyLogging(DependencyLoggingConfig depLogging) {
+    public ApplicationDependencyResolver setDependencyLogging(DependencyLoggingConfig depLogging) {
         this.depLogging = depLogging;
         return this;
     }
@@ -201,7 +156,7 @@ public class IncubatingApplicationModelResolver {
      * @param collectCompileOnly compile-only dependencies to add to the model
      * @return self
      */
-    public IncubatingApplicationModelResolver setCollectCompileOnly(List<Dependency> collectCompileOnly) {
+    public ApplicationDependencyResolver setCollectCompileOnly(List<Dependency> collectCompileOnly) {
         this.collectCompileOnly = collectCompileOnly;
         return this;
     }
@@ -212,7 +167,7 @@ public class IncubatingApplicationModelResolver {
      * @param runtimeModelOnly whether to limit the resulting application model to the runtime dependencies
      * @return self
      */
-    public IncubatingApplicationModelResolver setRuntimeModelOnly(boolean runtimeModelOnly) {
+    public ApplicationDependencyResolver setRuntimeModelOnly(boolean runtimeModelOnly) {
         this.runtimeModelOnly = runtimeModelOnly;
         return this;
     }
@@ -223,7 +178,7 @@ public class IncubatingApplicationModelResolver {
      * @param devMode whether an application model is resolved for dev mode
      * @return self
      */
-    public IncubatingApplicationModelResolver setDevMode(boolean devMode) {
+    public ApplicationDependencyResolver setDevMode(boolean devMode) {
         this.devMode = devMode;
         return this;
     }
@@ -840,7 +795,7 @@ public class IncubatingApplicationModelResolver {
         artifact = resolve(artifact, repos);
         final Path path = artifact.getFile().toPath();
         final Properties descriptor = PathTree.ofDirectoryOrArchive(path).apply(BootstrapConstants.DESCRIPTOR_PATH,
-                IncubatingApplicationModelResolver::readExtensionProperties);
+                ApplicationDependencyResolver::readExtensionProperties);
         if (descriptor == null) {
             allExtensions.put(extKey, EXT_INFO_NONE);
             return null;

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyTreeResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyTreeResolver.java
@@ -63,6 +63,16 @@ import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
 import io.quarkus.paths.PathTree;
 import io.quarkus.paths.PathVisit;
 
+/**
+ * The legacy {@link io.quarkus.bootstrap.model.ApplicationModel} resolver implementation.
+ * <p>
+ * This implementation is kept just in case an issue is found in the new default implementation, which is
+ * {@link ApplicationDependencyResolver},
+ * and can be enabled by setting {@code quarkus.bootstrap.legacy-model-resolver} system or POM property to {@code true}.
+ *
+ * @deprecated since 3.19.0
+ */
+@Deprecated(since = "3.19.0", forRemoval = true)
 public class ApplicationDependencyTreeResolver {
 
     private static final Logger log = Logger.getLogger(ApplicationDependencyTreeResolver.class);

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BuildDependencyGraphVisitor.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BuildDependencyGraphVisitor.java
@@ -18,6 +18,13 @@ import io.quarkus.bootstrap.model.ApplicationModelBuilder;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.DependencyFlags;
 
+/**
+ * This class is an implementation detail of {@link ApplicationDependencyTreeResolver},
+ * which at some point will be removed.
+ *
+ * @deprecated since 3.19.0
+ */
+@Deprecated(since = "3.19.0", forRemoval = true)
 public class BuildDependencyGraphVisitor {
 
     private final MavenArtifactResolver resolver;


### PR DESCRIPTION
The new implementation is generally more efficient. The more dependencies an application has, the bigger the benefits (i.e. the less time it will take to resolve and process all the dependencies). In addition to that, it collects and exposes more information about each particular dependency, such as its direct dependencies.

The legacy model resolver implementation can be enabled by setting `quarkus.bootstrap.legacy-model-resolver` system or POM property to `true`.

FYI @dmlloyd 