### PR TITLE
SqlClient pool migration

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -535,7 +535,7 @@ Navigate to http://localhost:8080/fruits.html and read/create/delete some fruits
 
 |MariaDB/MySQL
 |`quarkus-reactive-mysql-client`
-|`io.vertx.mutiny.mysqlclient.MySQLPool`
+|`io.vertx.mutiny.sqlclient.Pool`
 |`?`
 
 |Microsoft SQL Server

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -545,7 +545,7 @@ Navigate to http://localhost:8080/fruits.html and read/create/delete some fruits
 
 |Oracle
 |`quarkus-reactive-oracle-client`
-|`io.vertx.mutiny.oracleclient.OraclePool`
+|`io.vertx.mutiny.sqlclient.Pool`
 |`?`
 
 |PostgreSQL

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -540,7 +540,7 @@ Navigate to http://localhost:8080/fruits.html and read/create/delete some fruits
 
 |Microsoft SQL Server
 |`quarkus-reactive-mssql-client`
-|`io.vertx.mutiny.mssqlclient.MSSQLPool`
+|`io.vertx.mutiny.sqlclient.Pool`
 |`@p1`, `@p2`, etc.
 
 |Oracle

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -524,33 +524,28 @@ Navigate to http://localhost:8080/fruits.html and read/create/delete some fruits
 [[reactive-sql-clients-details]]
 == Database Clients details
 
-[cols="10,40,40,10"]
+[cols="15,70,15"]
 |===
-|Database |Extension name |Pool class name |Placeholders
+|Database |Extension name |Placeholders
 
 |IBM Db2
 |`quarkus-reactive-db2-client`
-|`io.vertx.mutiny.db2client.DB2Pool`
 |`?`
 
 |MariaDB/MySQL
 |`quarkus-reactive-mysql-client`
-|`io.vertx.mutiny.sqlclient.Pool`
 |`?`
 
 |Microsoft SQL Server
 |`quarkus-reactive-mssql-client`
-|`io.vertx.mutiny.sqlclient.Pool`
 |`@p1`, `@p2`, etc.
 
 |Oracle
 |`quarkus-reactive-oracle-client`
-|`io.vertx.mutiny.sqlclient.Pool`
 |`?`
 
 |PostgreSQL
 |`quarkus-reactive-pg-client`
-|`io.vertx.mutiny.sqlclient.Pool`
 |`$1`, `$2`, etc.
 |===
 

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -44,7 +44,7 @@ package org.acme.reactive.crud;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -179,7 +179,7 @@ quarkus.datasource.password=quarkus_test
 quarkus.datasource.reactive.url=postgresql://localhost:5432/quarkus_test
 ----
 
-With that you can create your `FruitResource` skeleton and inject a `io.vertx.mutiny.pgclient.PgPool` instance:
+With that you can create your `FruitResource` skeleton and inject a `io.vertx.mutiny.sqlclient.Pool` instance:
 
 [source,java]
 .src/main/java/org/acme/vertx/FruitResource.java
@@ -199,14 +199,14 @@ import jakarta.ws.rs.core.Response.Status;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("fruits")
 public class FruitResource {
 
-    private final PgPool client;
+    private final Pool client;
 
-    public FruitResource(PgPool client) {
+    public FruitResource(Pool client) {
         this.client = client;
     }
 }
@@ -226,7 +226,7 @@ But for development we can simply drop and create the tables on startup, and the
 package org.acme.reactive.crud;
 
 import io.quarkus.runtime.StartupEvent;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -235,10 +235,10 @@ import jakarta.enterprise.event.Observes;
 @ApplicationScoped
 public class DBInit {
 
-    private final PgPool client;
+    private final Pool client;
     private final boolean schemaCreate;
 
-    public DBInit(PgPool client, @ConfigProperty(name = "myapp.schema.create", defaultValue = "true") boolean schemaCreate) {
+    public DBInit(Pool client, @ConfigProperty(name = "myapp.schema.create", defaultValue = "true") boolean schemaCreate) {
         this.client = client;
         this.schemaCreate = schemaCreate;
     }
@@ -293,7 +293,7 @@ To retrieve all the data, we will use the `query` method again:
 [source,java]
 ./src/main/java/org/acme/reactive/crud/Fruit.java
 ----
-    public static Multi<Fruit> findAll(PgPool client) {
+    public static Multi<Fruit> findAll(Pool client) {
         return client.query("SELECT id, name FROM fruits ORDER BY name ASC").execute()
                 .onItem().transformToMulti(set -> Multi.createFrom().iterable(set)) // <1>
                 .onItem().transform(Fruit::from); // <2>
@@ -350,7 +350,7 @@ Equipped with this tooling, we are able to safely use an `id` provided by the us
 [source,java]
 .src/main/java/org/acme/vertx/Fruit.java
 ----
-public static Uni<Fruit> findById(PgPool client, Long id) {
+public static Uni<Fruit> findById(Pool client, Long id) {
     return client.preparedQuery("SELECT id, name FROM fruits WHERE id = $1").execute(Tuple.of(id)) // <1>
             .onItem().transform(RowSet::iterator) // <2>
             .onItem().transform(iterator -> iterator.hasNext() ? from(iterator.next()) : null); // <3>
@@ -381,7 +381,7 @@ The same logic applies when saving a `Fruit`:
 [source,java]
 .src/main/java/org/acme/vertx/Fruit.java
 ----
-public Uni<Long> save(PgPool client) {
+public Uni<Long> save(Pool client) {
     return client.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING id").execute(Tuple.of(name))
             .onItem().transform(pgRowSet -> pgRowSet.iterator().next().getLong("id"));
 }
@@ -412,7 +412,7 @@ Let's use this to support removal of fruits in the database:
 [source,java]
 .src/main/java/org/acme/vertx/Fruit.java
 ----
-public static Uni<Boolean> delete(PgPool client, Long id) {
+public static Uni<Boolean> delete(Pool client, Long id) {
     return client.preparedQuery("DELETE FROM fruits WHERE id = $1").execute(Tuple.of(id))
             .onItem().transform(pgRowSet -> pgRowSet.rowCount() == 1); // <1>
 }
@@ -550,7 +550,7 @@ Navigate to http://localhost:8080/fruits.html and read/create/delete some fruits
 
 |PostgreSQL
 |`quarkus-reactive-pg-client`
-|`io.vertx.mutiny.pgclient.PgPool`
+|`io.vertx.mutiny.sqlclient.Pool`
 |`$1`, `$2`, etc.
 |===
 
@@ -570,7 +570,7 @@ The following snippet shows how to run 2 insertions in the same transaction:
 
 [source, java]
 ----
-public static Uni<Void> insertTwoFruits(PgPool client, Fruit fruit1, Fruit fruit2) {
+public static Uni<Void> insertTwoFruits(Pool client, Fruit fruit1, Fruit fruit2) {
     return client.withTransaction(conn -> {
         Uni<RowSet<Row>> insertOne = conn.preparedQuery("INSERT INTO fruits (name) VALUES ($1) RETURNING id")
                 .execute(Tuple.of(fruit1.name));
@@ -691,11 +691,11 @@ You can then inject the clients as follows:
 [source,java]
 ----
 @Inject <1>
-PgPool defaultClient;
+Pool defaultClient;
 
 @Inject
 @ReactiveDataSource("additional1") <2>
-PgPool additional1Client;
+Pool additional1Client;
 
 @Inject
 @ReactiveDataSource("additional2")
@@ -830,18 +830,18 @@ import jakarta.inject.Singleton;
 
 import io.quarkus.reactive.pg.client.PgPoolCreator;
 import io.vertx.pgclient.PgConnectOptions;
-import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 
 @Singleton
 public class CustomPgPoolCreator implements PgPoolCreator {
 
     @Override
-    public PgPool create(Input input) {
+    public Pool create(Input input) {
         PgConnectOptions connectOptions = input.pgConnectOptions();
         PoolOptions poolOptions = input.poolOptions();
         // Customize connectOptions, poolOptions or both, as required
-        return PgPool.pool(input.vertx(), connectOptions, poolOptions);
+        return Pool.pool(input.vertx(), connectOptions, poolOptions);
     }
 }
 ----
@@ -860,12 +860,12 @@ Here's an example for PostgreSQL:
 import jakarta.inject.Inject;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 public class PipeliningExample {
 
     @Inject
-    PgPool client;
+    Pool client;
 
     public Uni<String> favoriteFruitAndVegetable() {
         // Explicitly acquire a connection

--- a/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/ReactiveDataSourceBuildUtil.java
+++ b/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/ReactiveDataSourceBuildUtil.java
@@ -3,12 +3,17 @@ package io.quarkus.reactive.datasource.deployment;
 import jakarta.enterprise.inject.Default;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.Type;
 
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 
 public final class ReactiveDataSourceBuildUtil {
+
+    public static final Type VERTX_POOL_TYPE = ClassType.create(ReactiveDataSourceDotNames.VERTX_POOL);
+
     private ReactiveDataSourceBuildUtil() {
     }
 

--- a/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/ReactiveDataSourceDotNames.java
+++ b/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/ReactiveDataSourceDotNames.java
@@ -1,0 +1,17 @@
+package io.quarkus.reactive.datasource.deployment;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.jboss.jandex.DotName;
+
+import io.vertx.sqlclient.Pool;
+
+public class ReactiveDataSourceDotNames {
+
+    public static final DotName VERTX_POOL = DotName.createSimple(Pool.class);
+    public static final DotName INJECT_INSTANCE = DotName.createSimple(Instance.class);
+
+    private ReactiveDataSourceDotNames() {
+        //Utility
+    }
+}

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ReactiveDatasourceHealthCheck.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ReactiveDatasourceHealthCheck.java
@@ -46,16 +46,16 @@ public abstract class ReactiveDatasourceHealthCheck implements HealthCheck {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named(healthCheckResponseName);
         builder.up();
 
-        for (Map.Entry<String, Pool> pgPoolEntry : pools.entrySet()) {
-            final String dataSourceName = pgPoolEntry.getKey();
-            final Pool pgPool = pgPoolEntry.getValue();
+        for (Map.Entry<String, Pool> poolEntry : pools.entrySet()) {
+            final String dataSourceName = poolEntry.getKey();
+            final Pool pool = poolEntry.getValue();
             try {
                 CompletableFuture<Void> databaseConnectionAttempt = new CompletableFuture<>();
                 Context context = Vertx.currentContext();
                 if (context != null) {
                     log.debug("Run health check on the current Vert.x context");
                     context.runOnContext(v -> {
-                        pgPool.query(healthCheckSQL)
+                        pool.query(healthCheckSQL)
                                 .execute(ar -> {
                                     checkFailure(ar, builder, dataSourceName);
                                     databaseConnectionAttempt.complete(null);
@@ -64,7 +64,7 @@ public abstract class ReactiveDatasourceHealthCheck implements HealthCheck {
                 } else {
                     log.warn("Vert.x context unavailable to perform health check of reactive datasource `" + dataSourceName
                             + "`. This is unlikely to work correctly.");
-                    pgPool.query(healthCheckSQL)
+                    pool.query(healthCheckSQL)
                             .execute(ar -> {
                                 checkFailure(ar, builder, dataSourceName);
                                 databaseConnectionAttempt.complete(null);

--- a/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/DB2PoolBuildItem.java
+++ b/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/DB2PoolBuildItem.java
@@ -7,6 +7,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.vertx.db2client.DB2Pool;
 
+@Deprecated(forRemoval = true)
 public final class DB2PoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/DB2PoolCreator.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/DB2PoolCreator.java
@@ -3,21 +3,21 @@ package io.quarkus.reactive.db2.client;
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.vertx.core.Vertx;
 import io.vertx.db2client.DB2ConnectOptions;
-import io.vertx.db2client.DB2Pool;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 
 /**
  * This interface is an integration point that allows users to use the {@link Vertx}, {@link PoolOptions} and
  * {@link DB2ConnectOptions} objects configured automatically by Quarkus, in addition to a custom strategy
- * for creating the final {@link DB2Pool}.
- *
+ * for creating the final {@link Pool}.
+ * <p>
  * Implementations of this class are meant to be used as CDI beans.
  * If a bean of this type is used without a {@link ReactiveDataSource} qualifier, then it's applied to the default datasource,
  * otherwise it applies to the datasource matching the name of the annotation.
  */
 public interface DB2PoolCreator {
 
-    DB2Pool create(Input input);
+    Pool create(Input input);
 
     interface Input {
 

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolSupport.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolSupport.java
@@ -1,0 +1,16 @@
+package io.quarkus.reactive.db2.client.runtime;
+
+import java.util.Set;
+
+public class DB2PoolSupport {
+
+    private final Set<String> db2PoolNames;
+
+    public DB2PoolSupport(Set<String> db2PoolNames) {
+        this.db2PoolNames = Set.copyOf(db2PoolNames);
+    }
+
+    public Set<String> getDB2PoolNames() {
+        return db2PoolNames;
+    }
+}

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/health/ReactiveDB2DataSourcesHealthCheck.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/health/ReactiveDB2DataSourcesHealthCheck.java
@@ -1,84 +1,47 @@
 package io.quarkus.reactive.db2.client.runtime.health;
 
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
-import jakarta.enterprise.inject.spi.Bean;
 
-import org.eclipse.microprofile.health.HealthCheck;
-import org.eclipse.microprofile.health.HealthCheckResponse;
-import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
-import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.runtime.DataSourceSupport;
-import io.quarkus.reactive.datasource.ReactiveDataSource;
-import io.vertx.mutiny.db2client.DB2Pool;
+import io.quarkus.reactive.datasource.runtime.ReactiveDataSourceUtil;
+import io.quarkus.reactive.datasource.runtime.ReactiveDatasourceHealthCheck;
+import io.quarkus.reactive.db2.client.runtime.DB2PoolSupport;
+import io.vertx.sqlclient.Pool;
 
 @Readiness
 @ApplicationScoped
-/**
- * Implementation note: this health check doesn't extend ReactiveDatasourceHealthCheck
- * as a DB2Pool is based on Mutiny: does not extend io.vertx.sqlclient.Pool
- */
-class ReactiveDB2DataSourcesHealthCheck implements HealthCheck {
+class ReactiveDB2DataSourcesHealthCheck extends ReactiveDatasourceHealthCheck {
 
-    private Map<String, DB2Pool> db2Pools = new HashMap<>();
+    public ReactiveDB2DataSourcesHealthCheck() {
+        super("Reactive DB2 connections health check", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+    }
 
     @PostConstruct
     protected void init() {
         ArcContainer container = Arc.container();
-        DataSourceSupport support = container.instance(DataSourceSupport.class).get();
-        Set<String> excludedNames = support.getHealthCheckExcludedNames();
-        for (InstanceHandle<DB2Pool> handle : container.select(DB2Pool.class, Any.Literal.INSTANCE).handles()) {
+        DataSourceSupport dataSourceSupport = container.instance(DataSourceSupport.class).get();
+        Set<String> excludedNames = dataSourceSupport.getHealthCheckExcludedNames();
+        DB2PoolSupport db2PoolSupport = container.instance(DB2PoolSupport.class).get();
+        Set<String> db2PoolNames = db2PoolSupport.getDB2PoolNames();
+        for (InstanceHandle<Pool> handle : container.select(Pool.class, Any.Literal.INSTANCE).handles()) {
             if (!handle.getBean().isActive()) {
                 continue;
             }
-            String poolName = getDB2PoolName(handle.getBean());
-            if (excludedNames.contains(poolName)) {
+            String poolName = ReactiveDataSourceUtil.dataSourceName(handle.getBean());
+            if (!db2PoolNames.contains(poolName) || excludedNames.contains(poolName)) {
                 continue;
             }
-            db2Pools.put(poolName, handle.get());
+            addPool(poolName, handle.get());
         }
     }
 
-    @Override
-    public HealthCheckResponse call() {
-        HealthCheckResponseBuilder builder = HealthCheckResponse.named("Reactive DB2 connections health check");
-        builder.up();
-
-        for (Entry<String, DB2Pool> db2PoolEntry : db2Pools.entrySet()) {
-            String dataSourceName = db2PoolEntry.getKey();
-            DB2Pool db2Pool = db2PoolEntry.getValue();
-            try {
-                db2Pool.query("SELECT 1 FROM SYSIBM.SYSDUMMY1")
-                        .execute()
-                        .await().atMost(Duration.ofSeconds(10));
-                builder.withData(dataSourceName, "up");
-            } catch (Exception exception) {
-                builder.down();
-                builder.withData(dataSourceName, "down - connection failed: " + exception.getMessage());
-            }
-        }
-
-        return builder.build();
-    }
-
-    private String getDB2PoolName(Bean<?> bean) {
-        for (Object qualifier : bean.getQualifiers()) {
-            if (qualifier instanceof ReactiveDataSource) {
-                return ((ReactiveDataSource) qualifier).value();
-            }
-        }
-        return DataSourceUtil.DEFAULT_DATASOURCE_NAME;
-    }
 }

--- a/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/MSSQLPoolBuildItem.java
+++ b/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/MSSQLPoolBuildItem.java
@@ -7,6 +7,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.vertx.mssqlclient.MSSQLPool;
 
+@Deprecated(forRemoval = true)
 public final class MSSQLPoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
@@ -12,13 +12,13 @@ import jakarta.ws.rs.core.Response;
 
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.mssqlclient.MSSQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/test")
 public class ChangingCredentialsTestResource {
 
     @Inject
-    MSSQLPool client;
+    Pool client;
 
     @Inject
     ChangingCredentialsProvider credentialsProvider;

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/CredentialsTestResource.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/CredentialsTestResource.java
@@ -10,13 +10,13 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import io.vertx.mutiny.mssqlclient.MSSQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/test")
 public class CredentialsTestResource {
 
     @Inject
-    MSSQLPool client;
+    Pool client;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DevModeResource.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DevModeResource.java
@@ -12,13 +12,13 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.sqlclient.Pool;
 
 @Path("/dev")
 public class DevModeResource {
 
     @Inject
-    MSSQLPool client;
+    Pool client;
 
     @GET
     @Path("/error")

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DevServicesMsSQLDatasourceTestCase.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DevServicesMsSQLDatasourceTestCase.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mutiny.mssqlclient.MSSQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 public class DevServicesMsSQLDatasourceTestCase {
 
@@ -30,7 +30,7 @@ public class DevServicesMsSQLDatasourceTestCase {
                     .isEmpty());
 
     @Inject
-    MSSQLPool pool;
+    Pool pool;
 
     @Test
     public void testDatasource() throws Exception {

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/LocalhostMSSQLPoolCreator.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/LocalhostMSSQLPoolCreator.java
@@ -2,14 +2,14 @@ package io.quarkus.reactive.mssql.client;
 
 import jakarta.inject.Singleton;
 
-import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.sqlclient.Pool;
 
 @Singleton
 public class LocalhostMSSQLPoolCreator implements MSSQLPoolCreator {
 
     @Override
-    public MSSQLPool create(Input input) {
-        return MSSQLPool.pool(input.vertx(), input.msSQLConnectOptions().setHost("localhost").setPort(1435),
+    public Pool create(Input input) {
+        return Pool.pool(input.vertx(), input.msSQLConnectOptions().setHost("localhost").setPort(1435),
                 input.poolOptions());
     }
 }

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MSSQLPoolProducerTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MSSQLPoolProducerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.sqlclient.Pool;
 
 public class MSSQLPoolProducerTest {
 
@@ -38,7 +38,7 @@ public class MSSQLPoolProducerTest {
     static class BeanUsingBareMSSQLClient {
 
         @Inject
-        MSSQLPool mssqlClient;
+        Pool mssqlClient;
 
         public CompletionStage<?> verify() {
             return mssqlClient.query("SELECT 1").execute().toCompletionStage();
@@ -49,7 +49,7 @@ public class MSSQLPoolProducerTest {
     static class BeanUsingMutinyMSSQLClient {
 
         @Inject
-        io.vertx.mutiny.mssqlclient.MSSQLPool mssqlClient;
+        io.vertx.mutiny.sqlclient.Pool mssqlClient;
 
         public CompletionStage<Void> verify() {
             return mssqlClient.query("SELECT 1").execute()

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MultipleDataSourcesAndMSSQLPoolCreatorsTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MultipleDataSourcesAndMSSQLPoolCreatorsTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleDataSourcesAndMSSQLPoolCreatorsTest {
 
@@ -45,7 +45,7 @@ public class MultipleDataSourcesAndMSSQLPoolCreatorsTest {
     static class BeanUsingDefaultDataSource {
 
         @Inject
-        MSSQLPool mSSQLClient;
+        Pool mSSQLClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -65,7 +65,7 @@ public class MultipleDataSourcesAndMSSQLPoolCreatorsTest {
 
         @Inject
         @ReactiveDataSource("hibernate")
-        MSSQLPool mSSQLClient;
+        Pool mSSQLClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -84,9 +84,9 @@ public class MultipleDataSourcesAndMSSQLPoolCreatorsTest {
     public static class DefaultMSSQLPoolCreator implements MSSQLPoolCreator {
 
         @Override
-        public MSSQLPool create(Input input) {
+        public Pool create(Input input) {
             assertEquals(12345, input.msSQLConnectOptions().getPort()); // validate that the bean has been called for the proper datasource
-            return MSSQLPool.pool(input.vertx(), input.msSQLConnectOptions().setHost("localhost").setPort(1435),
+            return Pool.pool(input.vertx(), input.msSQLConnectOptions().setHost("localhost").setPort(1435),
                     input.poolOptions());
         }
     }
@@ -96,9 +96,9 @@ public class MultipleDataSourcesAndMSSQLPoolCreatorsTest {
     public static class HibernateMSSQLPoolCreator implements MSSQLPoolCreator {
 
         @Override
-        public MSSQLPool create(Input input) {
+        public Pool create(Input input) {
             assertEquals(55555, input.msSQLConnectOptions().getPort()); // validate that the bean has been called for the proper datasource
-            return MSSQLPool.pool(input.vertx(), input.msSQLConnectOptions().setHost("localhost").setPort(1435),
+            return Pool.pool(input.vertx(), input.msSQLConnectOptions().setHost("localhost").setPort(1435),
                     input.poolOptions());
         }
     }

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MultipleDataSourcesTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MultipleDataSourcesTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleDataSourcesTest {
 
@@ -40,7 +40,7 @@ public class MultipleDataSourcesTest {
     static class BeanUsingDefaultDataSource {
 
         @Inject
-        MSSQLPool msSQLClient;
+        Pool msSQLClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -60,7 +60,7 @@ public class MultipleDataSourcesTest {
 
         @Inject
         @ReactiveDataSource("hibernate")
-        MSSQLPool msSQLClient;
+        Pool msSQLClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MultipleMSSQLPoolCreatorsForSameDatasourceTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MultipleMSSQLPoolCreatorsForSameDatasourceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleMSSQLPoolCreatorsForSameDatasourceTest {
 
@@ -32,8 +32,8 @@ public class MultipleMSSQLPoolCreatorsForSameDatasourceTest {
     public static class AnotherMSSQLPoolCreator implements MSSQLPoolCreator {
 
         @Override
-        public MSSQLPool create(Input input) {
-            return MSSQLPool.pool(input.vertx(), input.msSQLConnectOptions(), input.poolOptions());
+        public Pool create(Input input) {
+            return Pool.pool(input.vertx(), input.msSQLConnectOptions(), input.poolOptions());
         }
     }
 

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/SamePoolInstanceTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/SamePoolInstanceTest.java
@@ -17,9 +17,9 @@ public class SamePoolInstanceTest {
             .overrideConfigKey("quarkus.devservices.enabled", "false");
 
     @Inject
-    io.vertx.mutiny.mssqlclient.MSSQLPool mutinyPool;
+    io.vertx.mutiny.sqlclient.Pool mutinyPool;
     @Inject
-    io.vertx.mssqlclient.MSSQLPool pool;
+    io.vertx.sqlclient.Pool pool;
 
     @Test
     public void test() {

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/MSSQLPoolCreator.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/MSSQLPoolCreator.java
@@ -3,21 +3,21 @@ package io.quarkus.reactive.mssql.client;
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.vertx.core.Vertx;
 import io.vertx.mssqlclient.MSSQLConnectOptions;
-import io.vertx.mssqlclient.MSSQLPool;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 
 /**
  * This interface is an integration point that allows users to use the {@link Vertx}, {@link PoolOptions} and
  * {@link MSSQLConnectOptions} objects configured automatically by Quarkus, in addition to a custom strategy
- * for creating the final {@link MSSQLPool}.
- *
+ * for creating the final {@link Pool}.
+ * <p>
  * Implementations of this class are meant to be used as CDI beans.
  * If a bean of this type is used without a {@link ReactiveDataSource} qualifier, then it's applied to the default datasource,
  * otherwise it applies to the datasource matching the name of the annotation.
  */
 public interface MSSQLPoolCreator {
 
-    MSSQLPool create(Input input);
+    Pool create(Input input);
 
     interface Input {
 

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolSupport.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolSupport.java
@@ -1,0 +1,16 @@
+package io.quarkus.reactive.mssql.client.runtime;
+
+import java.util.Set;
+
+public class MSSQLPoolSupport {
+
+    private final Set<String> msSQLPoolNames;
+
+    public MSSQLPoolSupport(Set<String> msSQLPoolNames) {
+        this.msSQLPoolNames = Set.copyOf(msSQLPoolNames);
+    }
+
+    public Set<String> getMSSQLPoolNames() {
+        return msSQLPoolNames;
+    }
+}

--- a/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/MySQLPoolBuildItem.java
+++ b/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/MySQLPoolBuildItem.java
@@ -7,6 +7,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.vertx.mysqlclient.MySQLPool;
 
+@Deprecated(forRemoval = true)
 public final class MySQLPoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;

--- a/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
+++ b/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
@@ -2,6 +2,8 @@ package io.quarkus.reactive.mysql.client.deployment;
 
 import static io.quarkus.reactive.datasource.deployment.ReactiveDataSourceBuildUtil.qualifier;
 import static io.quarkus.reactive.datasource.deployment.ReactiveDataSourceBuildUtil.qualifiers;
+import static io.quarkus.reactive.datasource.deployment.ReactiveDataSourceDotNames.INJECT_INSTANCE;
+import static java.util.stream.Collectors.toSet;
 
 import java.util.HashMap;
 import java.util.List;
@@ -12,9 +14,10 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Singleton;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
@@ -56,6 +59,7 @@ import io.quarkus.reactive.datasource.runtime.DataSourcesReactiveRuntimeConfig;
 import io.quarkus.reactive.mysql.client.MySQLPoolCreator;
 import io.quarkus.reactive.mysql.client.runtime.DataSourcesReactiveMySQLConfig;
 import io.quarkus.reactive.mysql.client.runtime.MySQLPoolRecorder;
+import io.quarkus.reactive.mysql.client.runtime.MySQLPoolSupport;
 import io.quarkus.reactive.mysql.client.runtime.MySQLServiceBindingConverter;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.core.deployment.EventLoopCountBuildItem;
@@ -65,11 +69,12 @@ import io.vertx.sqlclient.Pool;
 
 class ReactiveMySQLClientProcessor {
 
-    private static final ParameterizedType POOL_CREATOR_INJECTION_TYPE = ParameterizedType.create(
-            DotName.createSimple(Instance.class),
-            new Type[] { ClassType.create(DotName.createSimple(MySQLPoolCreator.class.getName())) }, null);
+    private static final Type MYSQL_POOL_CREATOR = ClassType.create(DotName.createSimple(MySQLPoolCreator.class.getName()));
+    private static final ParameterizedType POOL_CREATOR_INJECTION_TYPE = ParameterizedType.create(INJECT_INSTANCE,
+            new Type[] { MYSQL_POOL_CREATOR }, null);
+
     private static final DotName VERTX_MYSQL_POOL = DotName.createSimple(MySQLPool.class);
-    private static final Type VERTX_MYSQL_POOL_TYPE = Type.create(VERTX_MYSQL_POOL, Type.Kind.CLASS);
+    private static final Type VERTX_MYSQL_POOL_TYPE = ClassType.create(VERTX_MYSQL_POOL);
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -91,11 +96,28 @@ class ReactiveMySQLClientProcessor {
 
         feature.produce(new FeatureBuildItem(Feature.REACTIVE_MYSQL_CLIENT));
 
+        Stream.Builder<String> mySQLPoolNamesBuilder = Stream.builder();
         for (String dataSourceName : dataSourcesBuildTimeConfig.dataSources().keySet()) {
-            createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, mySQLPool, syntheticBeans, dataSourceName,
-                    dataSourcesBuildTimeConfig, dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig,
-                    dataSourcesReactiveRuntimeConfig, dataSourcesReactiveMySQLConfig, defaultDataSourceDbKindBuildItems,
-                    curateOutcomeBuildItem);
+
+            if (!isReactiveMySQLPoolDefined(dataSourcesBuildTimeConfig, dataSourcesReactiveBuildTimeConfig, dataSourceName,
+                    defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem)) {
+                continue;
+            }
+
+            createPool(recorder, vertx, eventLoopCount, shutdown, mySQLPool, syntheticBeans, dataSourceName,
+                    dataSourcesRuntimeConfig, dataSourcesReactiveRuntimeConfig, dataSourcesReactiveMySQLConfig);
+
+            mySQLPoolNamesBuilder.add(dataSourceName);
+        }
+
+        Set<String> mySQLPoolNames = mySQLPoolNamesBuilder.build().collect(toSet());
+        if (!mySQLPoolNames.isEmpty()) {
+            syntheticBeans.produce(SyntheticBeanBuildItem.configure(MySQLPoolSupport.class)
+                    .scope(Singleton.class)
+                    .unremovable()
+                    .runtimeValue(recorder.createMySQLPoolSupport(mySQLPoolNames))
+                    .setRuntimeInit()
+                    .done());
         }
 
         // Enable SSL support by default
@@ -176,25 +198,16 @@ class ReactiveMySQLClientProcessor {
                         dataSourcesBuildTimeConfig.healthEnabled()));
     }
 
-    private void createPoolIfDefined(MySQLPoolRecorder recorder,
+    private void createPool(MySQLPoolRecorder recorder,
             VertxBuildItem vertx,
             EventLoopCountBuildItem eventLoopCount,
             ShutdownContextBuildItem shutdown,
             BuildProducer<MySQLPoolBuildItem> mySQLPool,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             String dataSourceName,
-            DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
-            DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
             DataSourcesReactiveRuntimeConfig dataSourcesReactiveRuntimeConfig,
-            DataSourcesReactiveMySQLConfig dataSourcesReactiveMySQLConfig,
-            List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
-            CurateOutcomeBuildItem curateOutcomeBuildItem) {
-
-        if (!isReactiveMySQLPoolDefined(dataSourcesBuildTimeConfig, dataSourcesReactiveBuildTimeConfig, dataSourceName,
-                defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem)) {
-            return;
-        }
+            DataSourcesReactiveMySQLConfig dataSourcesReactiveMySQLConfig) {
 
         Function<SyntheticCreationalContext<MySQLPool>, MySQLPool> poolFunction = recorder.configureMySQLPool(vertx.getVertx(),
                 eventLoopCount.getEventLoopCount(),
@@ -282,8 +295,6 @@ class ReactiveMySQLClientProcessor {
     }
 
     private static class MySQLPoolCreatorBeanClassPredicate implements Predicate<Set<Type>> {
-        private static final Type MYSQL_POOL_CREATOR = Type.create(DotName.createSimple(MySQLPoolCreator.class.getName()),
-                Type.Kind.CLASS);
 
         @Override
         public boolean test(Set<Type> types) {

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsTestResource.java
@@ -10,13 +10,13 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.mysqlclient.MySQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/test")
 public class ChangingCredentialsTestResource {
 
     @Inject
-    MySQLPool client;
+    Pool client;
 
     @Inject
     ChangingCredentialsProvider credentialsProvider;

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CredentialsTestResource.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CredentialsTestResource.java
@@ -10,13 +10,13 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import io.vertx.mutiny.mysqlclient.MySQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/test")
 public class CredentialsTestResource {
 
     @Inject
-    MySQLPool client;
+    Pool client;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DevModeResource.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DevModeResource.java
@@ -12,13 +12,13 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.sqlclient.Pool;
 
 @Path("/dev")
 public class DevModeResource {
 
     @Inject
-    MySQLPool client;
+    Pool client;
 
     @GET
     @Path("/error")

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DevServicesMySQLDatasourceTestCase.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DevServicesMySQLDatasourceTestCase.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mutiny.mysqlclient.MySQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 public class DevServicesMySQLDatasourceTestCase {
 
@@ -29,7 +29,7 @@ public class DevServicesMySQLDatasourceTestCase {
                     .isEmpty());
 
     @Inject
-    MySQLPool pool;
+    Pool pool;
 
     @Test
     public void testDatasource() throws Exception {

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/LocalhostMySQLPoolCreator.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/LocalhostMySQLPoolCreator.java
@@ -2,14 +2,14 @@ package io.quarkus.reactive.mysql.client;
 
 import jakarta.inject.Singleton;
 
-import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.sqlclient.Pool;
 
 @Singleton
 public class LocalhostMySQLPoolCreator implements MySQLPoolCreator {
 
     @Override
-    public MySQLPool create(Input input) {
-        return MySQLPool.pool(input.vertx(), input.mySQLConnectOptionsList().get(0).setHost("localhost").setPort(3308),
+    public Pool create(Input input) {
+        return Pool.pool(input.vertx(), input.mySQLConnectOptionsList().get(0).setHost("localhost").setPort(3308),
                 input.poolOptions());
     }
 }

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleDataSourcesAndMySQLPoolCreatorsTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleDataSourcesAndMySQLPoolCreatorsTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleDataSourcesAndMySQLPoolCreatorsTest {
 
@@ -45,7 +45,7 @@ public class MultipleDataSourcesAndMySQLPoolCreatorsTest {
     static class BeanUsingDefaultDataSource {
 
         @Inject
-        MySQLPool mySQLClient;
+        Pool mySQLClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -65,7 +65,7 @@ public class MultipleDataSourcesAndMySQLPoolCreatorsTest {
 
         @Inject
         @ReactiveDataSource("hibernate")
-        MySQLPool mySQLClient;
+        Pool mySQLClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -84,9 +84,9 @@ public class MultipleDataSourcesAndMySQLPoolCreatorsTest {
     public static class DefaultMySQLPoolCreator implements MySQLPoolCreator {
 
         @Override
-        public MySQLPool create(Input input) {
+        public Pool create(Input input) {
             assertEquals(12345, input.mySQLConnectOptionsList().get(0).getPort()); // validate that the bean has been called for the proper datasource
-            return MySQLPool.pool(input.vertx(), input.mySQLConnectOptionsList().get(0).setHost("localhost").setPort(3308),
+            return Pool.pool(input.vertx(), input.mySQLConnectOptionsList().get(0).setHost("localhost").setPort(3308),
                     input.poolOptions());
         }
     }
@@ -96,9 +96,9 @@ public class MultipleDataSourcesAndMySQLPoolCreatorsTest {
     public static class HibernateMySQLPoolCreator implements MySQLPoolCreator {
 
         @Override
-        public MySQLPool create(Input input) {
+        public Pool create(Input input) {
             assertEquals(55555, input.mySQLConnectOptionsList().get(0).getPort()); // validate that the bean has been called for the proper datasource
-            return MySQLPool.pool(input.vertx(), input.mySQLConnectOptionsList().get(0).setHost("localhost").setPort(3308),
+            return Pool.pool(input.vertx(), input.mySQLConnectOptionsList().get(0).setHost("localhost").setPort(3308),
                     input.poolOptions());
         }
     }

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleDataSourcesTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleDataSourcesTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleDataSourcesTest {
 
@@ -40,7 +40,7 @@ public class MultipleDataSourcesTest {
     static class BeanUsingDefaultDataSource {
 
         @Inject
-        MySQLPool mySQLClient;
+        Pool mySQLClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -60,7 +60,7 @@ public class MultipleDataSourcesTest {
 
         @Inject
         @ReactiveDataSource("hibernate")
-        MySQLPool mySQLClient;
+        Pool mySQLClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleMySQLPoolCreatorsForSameDatasourceTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleMySQLPoolCreatorsForSameDatasourceTest.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.mysqlclient.spi.MySQLDriver;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleMySQLPoolCreatorsForSameDatasourceTest {
 
@@ -32,8 +33,8 @@ public class MultipleMySQLPoolCreatorsForSameDatasourceTest {
     public static class AnotherMySQLPoolCreator implements MySQLPoolCreator {
 
         @Override
-        public MySQLPool create(Input input) {
-            return MySQLPool.pool(input.vertx(), input.mySQLConnectOptionsList(), input.poolOptions());
+        public Pool create(Input input) {
+            return MySQLDriver.INSTANCE.createPool(input.vertx(), input.mySQLConnectOptionsList(), input.poolOptions());
         }
     }
 

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MySQLPoolProducerTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MySQLPoolProducerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.sqlclient.Pool;
 
 public class MySQLPoolProducerTest {
 
@@ -37,7 +37,7 @@ public class MySQLPoolProducerTest {
     static class BeanUsingBareMySQLClient {
 
         @Inject
-        MySQLPool mysqlClient;
+        Pool mysqlClient;
 
         public CompletionStage<?> verify() {
             return mysqlClient.query("SELECT 1").execute().toCompletionStage();
@@ -48,7 +48,7 @@ public class MySQLPoolProducerTest {
     static class BeanUsingMutinyMySQLClient {
 
         @Inject
-        io.vertx.mutiny.mysqlclient.MySQLPool mysqlClient;
+        io.vertx.mutiny.sqlclient.Pool mysqlClient;
 
         public CompletionStage<Void> verify() {
             return mysqlClient.query("SELECT 1").execute()

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/SamePoolInstanceTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/SamePoolInstanceTest.java
@@ -15,9 +15,9 @@ public class SamePoolInstanceTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest();
 
     @Inject
-    io.vertx.mutiny.mysqlclient.MySQLPool mutinyPool;
+    io.vertx.mutiny.sqlclient.Pool mutinyPool;
     @Inject
-    io.vertx.mysqlclient.MySQLPool pool;
+    io.vertx.sqlclient.Pool pool;
 
     @Test
     public void test() {

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/MySQLPoolCreator.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/MySQLPoolCreator.java
@@ -5,21 +5,21 @@ import java.util.List;
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.vertx.core.Vertx;
 import io.vertx.mysqlclient.MySQLConnectOptions;
-import io.vertx.mysqlclient.MySQLPool;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 
 /**
  * This interface is an integration point that allows users to use the {@link Vertx}, {@link PoolOptions} and
  * {@link MySQLConnectOptions} objects configured automatically by Quarkus, in addition to a custom strategy
- * for creating the final {@link MySQLPool}.
- *
+ * for creating the final {@link Pool}.
+ * <p>
  * Implementations of this class are meant to be used as CDI beans.
  * If a bean of this type is used without a {@link ReactiveDataSource} qualifier, then it's applied to the default datasource,
  * otherwise it applies to the datasource matching the name of the annotation.
  */
 public interface MySQLPoolCreator {
 
-    MySQLPool create(Input input);
+    Pool create(Input input);
 
     interface Input {
 

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolSupport.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolSupport.java
@@ -1,0 +1,16 @@
+package io.quarkus.reactive.mysql.client.runtime;
+
+import java.util.Set;
+
+public class MySQLPoolSupport {
+
+    private final Set<String> mySQLPoolNames;
+
+    public MySQLPoolSupport(Set<String> mySQLPoolNames) {
+        this.mySQLPoolNames = Set.copyOf(mySQLPoolNames);
+    }
+
+    public Set<String> getMySQLPoolNames() {
+        return mySQLPoolNames;
+    }
+}

--- a/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/OraclePoolBuildItem.java
+++ b/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/OraclePoolBuildItem.java
@@ -7,6 +7,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.vertx.oracleclient.OraclePool;
 
+@Deprecated(forRemoval = true)
 public final class OraclePoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsTestResource.java
@@ -12,13 +12,13 @@ import jakarta.ws.rs.core.Response;
 
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.oracleclient.OraclePool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/test")
 public class ChangingCredentialsTestResource {
 
     @Inject
-    OraclePool client;
+    Pool client;
 
     @Inject
     ChangingCredentialsProvider credentialsProvider;

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/CredentialsTestResource.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/CredentialsTestResource.java
@@ -10,13 +10,13 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import io.vertx.mutiny.oracleclient.OraclePool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/test")
 public class CredentialsTestResource {
 
     @Inject
-    OraclePool client;
+    Pool client;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/DevModeResource.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/DevModeResource.java
@@ -12,13 +12,13 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import io.vertx.oracleclient.OracleException;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.sqlclient.Pool;
 
 @Path("/dev")
 public class DevModeResource {
 
     @Inject
-    OraclePool client;
+    Pool client;
 
     @GET
     @Path("/error")

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/DevServicesOracleDatasourceTestCase.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/DevServicesOracleDatasourceTestCase.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mutiny.oracleclient.OraclePool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 public class DevServicesOracleDatasourceTestCase {
 
@@ -29,7 +29,7 @@ public class DevServicesOracleDatasourceTestCase {
                     .isEmpty());
 
     @Inject
-    OraclePool pool;
+    Pool pool;
 
     @Test
     public void testDatasource() throws Exception {

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/LocalhostOraclePoolCreator.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/LocalhostOraclePoolCreator.java
@@ -2,14 +2,14 @@ package io.quarkus.reactive.oracle.client;
 
 import jakarta.inject.Singleton;
 
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.sqlclient.Pool;
 
 @Singleton
 public class LocalhostOraclePoolCreator implements OraclePoolCreator {
 
     @Override
-    public OraclePool create(Input input) {
-        return OraclePool.pool(input.vertx(), input.oracleConnectOptions().setHost("localhost").setPort(1521),
+    public Pool create(Input input) {
+        return Pool.pool(input.vertx(), input.oracleConnectOptions().setHost("localhost").setPort(1521),
                 input.poolOptions());
     }
 }

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/MultipleDataSourcesAndOraclePoolCreatorsTest.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/MultipleDataSourcesAndOraclePoolCreatorsTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleDataSourcesAndOraclePoolCreatorsTest {
 
@@ -45,7 +45,7 @@ public class MultipleDataSourcesAndOraclePoolCreatorsTest {
     static class BeanUsingDefaultDataSource {
 
         @Inject
-        OraclePool oracleClient;
+        Pool oracleClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -65,7 +65,7 @@ public class MultipleDataSourcesAndOraclePoolCreatorsTest {
 
         @Inject
         @ReactiveDataSource("hibernate")
-        OraclePool oracleClient;
+        Pool oracleClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -84,9 +84,9 @@ public class MultipleDataSourcesAndOraclePoolCreatorsTest {
     public static class DefaultOraclePoolCreator implements OraclePoolCreator {
 
         @Override
-        public OraclePool create(Input input) {
+        public Pool create(Input input) {
             assertEquals(12345, input.oracleConnectOptions().getPort()); // validate that the bean has been called for the proper datasource
-            return OraclePool.pool(input.vertx(), input.oracleConnectOptions().setHost("localhost").setPort(1521),
+            return Pool.pool(input.vertx(), input.oracleConnectOptions().setHost("localhost").setPort(1521),
                     input.poolOptions());
         }
     }
@@ -96,9 +96,9 @@ public class MultipleDataSourcesAndOraclePoolCreatorsTest {
     public static class HibernateOraclePoolCreator implements OraclePoolCreator {
 
         @Override
-        public OraclePool create(Input input) {
+        public Pool create(Input input) {
             assertEquals(55555, input.oracleConnectOptions().getPort()); // validate that the bean has been called for the proper datasource
-            return OraclePool.pool(input.vertx(), input.oracleConnectOptions().setHost("localhost").setPort(1521),
+            return Pool.pool(input.vertx(), input.oracleConnectOptions().setHost("localhost").setPort(1521),
                     input.poolOptions());
         }
     }

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/MultipleDataSourcesTest.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/MultipleDataSourcesTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleDataSourcesTest {
 
@@ -40,7 +40,7 @@ public class MultipleDataSourcesTest {
     static class BeanUsingDefaultDataSource {
 
         @Inject
-        OraclePool oracleClient;
+        Pool oracleClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -60,7 +60,7 @@ public class MultipleDataSourcesTest {
 
         @Inject
         @ReactiveDataSource("hibernate")
-        OraclePool oracleClient;
+        Pool oracleClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/MultipleOraclePoolCreatorsForSameDatasourceTest.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/MultipleOraclePoolCreatorsForSameDatasourceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleOraclePoolCreatorsForSameDatasourceTest {
 
@@ -32,8 +32,8 @@ public class MultipleOraclePoolCreatorsForSameDatasourceTest {
     public static class AnotherOraclePoolCreator implements OraclePoolCreator {
 
         @Override
-        public OraclePool create(Input input) {
-            return OraclePool.pool(input.vertx(), input.oracleConnectOptions(), input.poolOptions());
+        public Pool create(Input input) {
+            return Pool.pool(input.vertx(), input.oracleConnectOptions(), input.poolOptions());
         }
     }
 

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/OraclePoolProducerTest.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/OraclePoolProducerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.sqlclient.Pool;
 
 public class OraclePoolProducerTest {
 
@@ -38,7 +38,7 @@ public class OraclePoolProducerTest {
     static class BeanUsingBareOracleClient {
 
         @Inject
-        OraclePool oracleClient;
+        Pool oracleClient;
 
         public CompletionStage<?> verify() {
             return oracleClient.query("SELECT 1 FROM DUAL").execute().toCompletionStage();
@@ -49,7 +49,7 @@ public class OraclePoolProducerTest {
     static class BeanUsingMutinyOracleClient {
 
         @Inject
-        io.vertx.mutiny.oracleclient.OraclePool oracleClient;
+        io.vertx.mutiny.sqlclient.Pool oracleClient;
 
         public CompletionStage<Void> verify() {
             return oracleClient.query("SELECT 1 FROM DUAL").execute()

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/SamePoolInstanceTest.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/SamePoolInstanceTest.java
@@ -15,9 +15,9 @@ public class SamePoolInstanceTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest();
 
     @Inject
-    io.vertx.mutiny.oracleclient.OraclePool mutinyPool;
+    io.vertx.mutiny.sqlclient.Pool mutinyPool;
     @Inject
-    io.vertx.oracleclient.OraclePool pool;
+    io.vertx.sqlclient.Pool pool;
 
     @Test
     public void test() {

--- a/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/OraclePoolCreator.java
+++ b/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/OraclePoolCreator.java
@@ -3,21 +3,21 @@ package io.quarkus.reactive.oracle.client;
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.vertx.core.Vertx;
 import io.vertx.oracleclient.OracleConnectOptions;
-import io.vertx.oracleclient.OraclePool;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 
 /**
  * This interface is an integration point that allows users to use the {@link Vertx}, {@link PoolOptions} and
  * {@link OracleConnectOptions} objects configured automatically by Quarkus, in addition to a custom strategy
- * for creating the final {@link OraclePool}.
- *
+ * for creating the final {@link Pool}.
+ * <p>
  * Implementations of this class are meant to be used as CDI beans.
  * If a bean of this type is used without a {@link ReactiveDataSource} qualifier, then it's applied to the default datasource,
  * otherwise it applies to the datasource matching the name of the annotation.
  */
 public interface OraclePoolCreator {
 
-    OraclePool create(Input input);
+    Pool create(Input input);
 
     interface Input {
 

--- a/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolSupport.java
+++ b/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolSupport.java
@@ -1,0 +1,16 @@
+package io.quarkus.reactive.oracle.client.runtime;
+
+import java.util.Set;
+
+public class OraclePoolSupport {
+
+    private final Set<String> oraclePoolNames;
+
+    public OraclePoolSupport(Set<String> oraclePoolNames) {
+        this.oraclePoolNames = Set.copyOf(oraclePoolNames);
+    }
+
+    public Set<String> getOraclePoolNames() {
+        return oraclePoolNames;
+    }
+}

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/PgPoolBuildItem.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/PgPoolBuildItem.java
@@ -7,6 +7,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.vertx.pgclient.PgPool;
 
+@Deprecated(forRemoval = true)
 public final class PgPoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsTestResource.java
@@ -12,13 +12,13 @@ import jakarta.ws.rs.core.Response;
 
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/test")
 public class ChangingCredentialsTestResource {
 
     @Inject
-    PgPool client;
+    Pool client;
 
     @Inject
     ChangingCredentialsProvider credentialsProvider;

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CredentialsTestResource.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CredentialsTestResource.java
@@ -10,13 +10,13 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/test")
 public class CredentialsTestResource {
 
     @Inject
-    PgPool client;
+    Pool client;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DevModeResource.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DevModeResource.java
@@ -11,13 +11,13 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.Pool;
 
 @Path("/dev")
 public class DevModeResource {
 
     @Inject
-    PgPool client;
+    Pool client;
 
     @GET
     @Path("/error")

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DevServicesPostgresqlDatasourceTestCase.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DevServicesPostgresqlDatasourceTestCase.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 public class DevServicesPostgresqlDatasourceTestCase {
 
@@ -29,7 +29,7 @@ public class DevServicesPostgresqlDatasourceTestCase {
                     .isEmpty());
 
     @Inject
-    PgPool pool;
+    Pool pool;
 
     @Test
     public void testDatasource() throws Exception {

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/LocalhostPgPoolCreator.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/LocalhostPgPoolCreator.java
@@ -2,14 +2,14 @@ package io.quarkus.reactive.pg.client;
 
 import jakarta.inject.Singleton;
 
-import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.Pool;
 
 @Singleton
 public class LocalhostPgPoolCreator implements PgPoolCreator {
 
     @Override
-    public PgPool create(Input input) {
-        return PgPool.pool(input.vertx(), input.pgConnectOptionsList().get(0).setHost("localhost").setPort(5431),
+    public Pool create(Input input) {
+        return Pool.pool(input.vertx(), input.pgConnectOptionsList().get(0).setHost("localhost").setPort(5431),
                 input.poolOptions());
     }
 }

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultipleDataSourcesAndPgPoolCreatorsTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultipleDataSourcesAndPgPoolCreatorsTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleDataSourcesAndPgPoolCreatorsTest {
 
@@ -45,7 +45,7 @@ public class MultipleDataSourcesAndPgPoolCreatorsTest {
     static class BeanUsingDefaultDataSource {
 
         @Inject
-        PgPool pgClient;
+        Pool pgClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -65,7 +65,7 @@ public class MultipleDataSourcesAndPgPoolCreatorsTest {
 
         @Inject
         @ReactiveDataSource("hibernate")
-        PgPool pgClient;
+        Pool pgClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -84,9 +84,9 @@ public class MultipleDataSourcesAndPgPoolCreatorsTest {
     public static class DefaultPgPoolCreator implements PgPoolCreator {
 
         @Override
-        public PgPool create(Input input) {
+        public Pool create(Input input) {
             assertEquals(10, input.pgConnectOptionsList().get(0).getPipeliningLimit()); // validate that the bean has been called for the proper datasource
-            return PgPool.pool(input.vertx(), input.pgConnectOptionsList().get(0).setHost("localhost").setPort(5431),
+            return Pool.pool(input.vertx(), input.pgConnectOptionsList().get(0).setHost("localhost").setPort(5431),
                     input.poolOptions());
         }
     }
@@ -96,9 +96,9 @@ public class MultipleDataSourcesAndPgPoolCreatorsTest {
     public static class HibernatePgPoolCreator implements PgPoolCreator {
 
         @Override
-        public PgPool create(Input input) {
+        public Pool create(Input input) {
             assertEquals(7, input.pgConnectOptionsList().get(0).getPipeliningLimit()); // validate that the bean has been called for the proper datasource
-            return PgPool.pool(input.vertx(), input.pgConnectOptionsList().get(0).setHost("localhost").setPort(5431),
+            return Pool.pool(input.vertx(), input.pgConnectOptionsList().get(0).setHost("localhost").setPort(5431),
                     input.poolOptions());
         }
     }

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultipleDataSourcesTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultipleDataSourcesTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.Pool;
 
 public class MultipleDataSourcesTest {
 
@@ -40,7 +40,7 @@ public class MultipleDataSourcesTest {
     static class BeanUsingDefaultDataSource {
 
         @Inject
-        PgPool pgClient;
+        Pool pgClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();
@@ -60,7 +60,7 @@ public class MultipleDataSourcesTest {
 
         @Inject
         @ReactiveDataSource("hibernate")
-        PgPool pgClient;
+        Pool pgClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultiplePgPoolCreatorsForSameDatasourceTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultiplePgPoolCreatorsForSameDatasourceTest.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.pgclient.PgPool;
+import io.vertx.pgclient.spi.PgDriver;
+import io.vertx.sqlclient.Pool;
 
 public class MultiplePgPoolCreatorsForSameDatasourceTest {
 
@@ -32,8 +33,8 @@ public class MultiplePgPoolCreatorsForSameDatasourceTest {
     public static class AnotherPgPoolCreator implements PgPoolCreator {
 
         @Override
-        public PgPool create(Input input) {
-            return PgPool.pool(input.vertx(), input.pgConnectOptionsList(), input.poolOptions());
+        public Pool create(Input input) {
+            return PgDriver.INSTANCE.createPool(input.vertx(), input.pgConnectOptionsList(), input.poolOptions());
         }
     }
 

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/PgPoolProducerTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/PgPoolProducerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.Pool;
 
 public class PgPoolProducerTest {
 
@@ -38,7 +38,7 @@ public class PgPoolProducerTest {
     static class BeanUsingBarePgClient {
 
         @Inject
-        PgPool pgClient;
+        Pool pgClient;
 
         public CompletionStage<?> verify() {
             return pgClient.query("SELECT 1").execute().toCompletionStage();
@@ -49,7 +49,7 @@ public class PgPoolProducerTest {
     static class BeanUsingMutinyPgClient {
 
         @Inject
-        io.vertx.mutiny.pgclient.PgPool pgClient;
+        io.vertx.mutiny.sqlclient.Pool pgClient;
 
         public CompletionStage<Void> verify() {
             return pgClient.query("SELECT 1").execute()

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/SamePoolInstanceTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/SamePoolInstanceTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.reactive.pg.client;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.inject.Inject;
 
@@ -16,9 +16,9 @@ public class SamePoolInstanceTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest();
 
     @Inject
-    io.vertx.mutiny.pgclient.PgPool mutinyPool;
+    io.vertx.mutiny.sqlclient.Pool mutinyPool;
     @Inject
-    io.vertx.pgclient.PgPool pool;
+    io.vertx.sqlclient.Pool pool;
 
     @Test
     public void test() {

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/PgPoolCreator.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/PgPoolCreator.java
@@ -5,21 +5,21 @@ import java.util.List;
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
-import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 
 /**
  * This interface is an integration point that allows users to use the {@link Vertx}, {@link PoolOptions} and
  * {@link PgConnectOptions} objects configured automatically by Quarkus, in addition to a custom strategy
- * for creating the final {@link PgPool}.
- *
+ * for creating the final {@link Pool}.
+ * <p>
  * Implementations of this class are meant to be used as CDI beans.
  * If a bean of this type is used without a {@link ReactiveDataSource} qualifier, then it's applied to the default datasource,
  * otherwise it applies to the datasource matching the name of the annotation.
  */
 public interface PgPoolCreator {
 
-    PgPool create(Input input);
+    Pool create(Input input);
 
     interface Input {
 

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolSupport.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolSupport.java
@@ -1,0 +1,16 @@
+package io.quarkus.reactive.pg.client.runtime;
+
+import java.util.Set;
+
+public class PgPoolSupport {
+
+    private final Set<String> pgPoolNames;
+
+    public PgPoolSupport(Set<String> pgPoolNames) {
+        this.pgPoolNames = Set.copyOf(pgPoolNames);
+    }
+
+    public Set<String> getPgPoolNames() {
+        return pgPoolNames;
+    }
+}

--- a/integration-tests/hibernate-reactive-db2/src/main/java/io/quarkus/it/hibernate/reactive/db2/HibernateReactiveDB2TestEndpoint.java
+++ b/integration-tests/hibernate-reactive-db2/src/main/java/io/quarkus/it/hibernate/reactive/db2/HibernateReactiveDB2TestEndpoint.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Path;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.db2client.DB2Pool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -21,7 +21,7 @@ public class HibernateReactiveDB2TestEndpoint {
     // Injecting a Vert.x Pool is not required, it us only used to
     // independently validate the contents of the database for the test
     @Inject
-    DB2Pool db2Pool;
+    Pool db2Pool;
 
     @GET
     @Path("/reactiveFindMutiny")

--- a/integration-tests/hibernate-reactive-mariadb/src/main/java/io/quarkus/it/hibernate/reactive/mariadb/HibernateReactiveMariaDBTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-mariadb/src/main/java/io/quarkus/it/hibernate/reactive/mariadb/HibernateReactiveMariaDBTestEndpoint.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Path;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.mysqlclient.MySQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -21,7 +21,7 @@ public class HibernateReactiveMariaDBTestEndpoint {
     // Injecting a Vert.x Pool is not required, it us only used to
     // independently validate the contents of the database for the test
     @Inject
-    MySQLPool mysqlPool;
+    Pool mysqlPool;
 
     @GET
     @Path("/reactiveFindMutiny")

--- a/integration-tests/hibernate-reactive-mssql/src/main/java/io/quarkus/it/hibernate/reactive/mssql/HibernateReactiveMSSQLTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-mssql/src/main/java/io/quarkus/it/hibernate/reactive/mssql/HibernateReactiveMSSQLTestEndpoint.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Path;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.mssqlclient.MSSQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -21,7 +21,7 @@ public class HibernateReactiveMSSQLTestEndpoint {
     // Injecting a Vert.x Pool is not required, it us only used to
     // independently validate the contents of the database for the test
     @Inject
-    MSSQLPool mssqlPool;
+    Pool mssqlPool;
 
     @GET
     @Path("/reactiveFindMutiny")

--- a/integration-tests/hibernate-reactive-mysql-agroal-flyway/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-mysql-agroal-flyway/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLTestEndpoint.java
@@ -1,6 +1,9 @@
 package io.quarkus.it.hibernate.reactive.mysql;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -10,7 +13,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.agroal.api.AgroalDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.mysqlclient.MySQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -24,7 +27,7 @@ public class HibernateReactiveMySQLTestEndpoint {
     // Injecting a Vert.x Pool is not required, it us only used to
     // independently validate the contents of the database for the test
     @Inject
-    MySQLPool mysqlPool;
+    Pool mysqlPool;
 
     @Inject
     AgroalDataSource jdbcDataSource;

--- a/integration-tests/hibernate-reactive-mysql/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-mysql/src/main/java/io/quarkus/it/hibernate/reactive/mysql/HibernateReactiveMySQLTestEndpoint.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Path;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.mysqlclient.MySQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -21,7 +21,7 @@ public class HibernateReactiveMySQLTestEndpoint {
     // Injecting a Vert.x Pool is not required, it us only used to
     // independently validate the contents of the database for the test
     @Inject
-    MySQLPool mysqlPool;
+    Pool mysqlPool;
 
     @GET
     @Path("/reactiveFindMutiny")

--- a/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpoint.java
@@ -10,7 +10,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.security.Authenticated;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -25,7 +25,7 @@ public class HibernateReactiveTestEndpoint {
     // Injecting a Vert.x Pool is not required, it's only used to
     // independently validate the contents of the database for the test
     @Inject
-    PgPool pgPool;
+    Pool pgPool;
 
     @GET
     @Path("/reactiveFindNativeQuery")

--- a/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpointFetchLazy.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTestEndpointFetchLazy.java
@@ -13,7 +13,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import io.quarkus.it.hibernate.reactive.postgresql.lazy.Author;
 import io.quarkus.it.hibernate.reactive.postgresql.lazy.Book;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Tuple;
 
 @Path("/hr-fetch")
@@ -25,7 +25,7 @@ public class HibernateReactiveTestEndpointFetchLazy {
     // Injecting a Vert.x Pool is not required, It's used to
     // independently validate the contents of the database for the test
     @Inject
-    PgPool pgPool;
+    Pool pgPool;
 
     @GET
     @Path("/findBooksWithMutiny/{authorId}")

--- a/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/SqlClientTest.java
+++ b/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/SqlClientTest.java
@@ -26,7 +26,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.ext.web.Router;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @QuarkusTest
 public class SqlClientTest {
@@ -34,7 +34,7 @@ public class SqlClientTest {
     Router router;
 
     @Inject
-    PgPool pool;
+    Pool pool;
 
     @Inject
     InMemorySpanExporter inMemorySpanExporter;

--- a/integration-tests/reactive-db2-client/src/main/java/io/quarkus/it/reactive/db2/client/PlantResource.java
+++ b/integration-tests/reactive-db2-client/src/main/java/io/quarkus/it/reactive/db2/client/PlantResource.java
@@ -10,18 +10,18 @@ import jakarta.ws.rs.Path;
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.db2client.DB2Pool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 
 @Path("/plants")
 public class PlantResource {
 
     @Inject
-    DB2Pool client;
+    Pool client;
 
     @Inject
     @ReactiveDataSource("additional")
-    DB2Pool additionalClient;
+    Pool additionalClient;
 
     @PostConstruct
     void setupDb() {

--- a/integration-tests/reactive-mssql-client/src/main/java/io/quarkus/it/reactive/mssql/client/FruitResource.java
+++ b/integration-tests/reactive-mssql-client/src/main/java/io/quarkus/it/reactive/mssql/client/FruitResource.java
@@ -9,14 +9,14 @@ import jakarta.ws.rs.Path;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.mssqlclient.MSSQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 
 @Path("/fruits")
 public class FruitResource {
 
     @Inject
-    MSSQLPool client;
+    Pool client;
 
     @PostConstruct
     void setupDb() {

--- a/integration-tests/reactive-mssql-client/src/test/java/io/quarkus/it/reactive/mssql/client/HotReloadFruitResource.java
+++ b/integration-tests/reactive-mssql-client/src/test/java/io/quarkus/it/reactive/mssql/client/HotReloadFruitResource.java
@@ -9,14 +9,14 @@ import jakarta.ws.rs.Path;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.mssqlclient.MSSQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 
 @Path("/hot-fruits")
 public class HotReloadFruitResource {
 
     @Inject
-    MSSQLPool client;
+    Pool client;
 
     @PostConstruct
     void setupDb() {

--- a/integration-tests/reactive-mysql-client/src/main/java/io/quarkus/it/reactive/mysql/client/FruitResource.java
+++ b/integration-tests/reactive-mysql-client/src/main/java/io/quarkus/it/reactive/mysql/client/FruitResource.java
@@ -9,14 +9,14 @@ import jakarta.ws.rs.Path;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.mysqlclient.MySQLPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 
 @Path("/fruits")
 public class FruitResource {
 
     @Inject
-    MySQLPool client;
+    Pool client;
 
     @PostConstruct
     void setupDb() {

--- a/integration-tests/reactive-oracle-client/src/main/java/io/quarkus/it/reactive/oracle/client/FruitResource.java
+++ b/integration-tests/reactive-oracle-client/src/main/java/io/quarkus/it/reactive/oracle/client/FruitResource.java
@@ -9,14 +9,14 @@ import jakarta.ws.rs.Path;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.oracleclient.OraclePool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 
 @Path("/fruits")
 public class FruitResource {
 
     @Inject
-    OraclePool client;
+    Pool client;
 
     @PostConstruct
     void setupDb() {

--- a/integration-tests/reactive-oracle-client/src/test/java/io/quarkus/it/reactive/oracle/client/HotReloadFruitResource.java
+++ b/integration-tests/reactive-oracle-client/src/test/java/io/quarkus/it/reactive/oracle/client/HotReloadFruitResource.java
@@ -9,14 +9,14 @@ import jakarta.ws.rs.Path;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.oracleclient.OraclePool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 
 @Path("/hot-fruits")
 public class HotReloadFruitResource {
 
     @Inject
-    OraclePool client;
+    Pool client;
 
     @PostConstruct
     void setupDb() {

--- a/integration-tests/reactive-pg-client/src/main/java/io/quarkus/it/reactive/pg/client/FruitResource.java
+++ b/integration-tests/reactive-pg-client/src/main/java/io/quarkus/it/reactive/pg/client/FruitResource.java
@@ -9,14 +9,14 @@ import jakarta.ws.rs.Path;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 
 @Path("/fruits")
 public class FruitResource {
 
     @Inject
-    PgPool client;
+    Pool client;
 
     @PostConstruct
     void setupDb() {

--- a/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HotReloadFruitResource.java
+++ b/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HotReloadFruitResource.java
@@ -9,14 +9,14 @@ import jakarta.ws.rs.Path;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 
 @Path("/hot-fruits")
 public class HotReloadFruitResource {
 
     @Inject
-    PgPool client;
+    Pool client;
 
     @PostConstruct
     void setupDb() {

--- a/integration-tests/smallrye-jwt-oidc-webapp/src/main/java/io/quarkus/it/keycloak/PublicResource.java
+++ b/integration-tests/smallrye-jwt-oidc-webapp/src/main/java/io/quarkus/it/keycloak/PublicResource.java
@@ -4,13 +4,13 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
-import io.vertx.mutiny.oracleclient.OraclePool;
+import io.vertx.mutiny.sqlclient.Pool;
 
 @Path("/public")
 public class PublicResource {
 
     @Inject
-    OraclePool pool;
+    Pool pool;
 
     @Path("/token-state-count")
     @GET


### PR DESCRIPTION
`PgPool` and other vendor pool types are deprecated in Vert.x 4. In Vert.x 5, these types are going away.

This PR is an attempt to make the transition incremental. Instead of using `PgPool` and other vendor pool types as the basis for bean creation, we can use the `Pool` parent type.

In the recorder, the pool configurator now returns the parent `Pool` type.
Then, in the processor, new bean configurators are set up to support injection of the different pools:

- bare pool
- vendor pool
- mutiny pool
- mutiny vendor pool

Each commit can be reviewed individually.

Updated extensions:

- [x] Reactive Pg Client
- [x] Reactive MySQL Client
- [x] Reactive SqlServer Client
- [x] Reactive Oracle Client
- [x] Reactive DB2 Client