### PR TITLE
Runtime values from mapping without expansion

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -651,7 +651,7 @@ public final class BuildTimeConfigurationReader {
                 }
                 if (runTimeNames.contains(name)) {
                     unknownBuildProperties.remove(property);
-                    ConfigValue value = runtimeConfig.getConfigValue(property);
+                    ConfigValue value = withoutExpansion(() -> runtimeConfig.getConfigValue(property));
                     if (value.getRawValue() != null) {
                         runTimeValues.put(value.getNameProfiled(), value.noProblems().withValue(value.getRawValue()));
                     }

--- a/integration-tests/test-extension/extension/deployment/src/main/resources/application.properties
+++ b/integration-tests/test-extension/extension/deployment/src/main/resources/application.properties
@@ -170,6 +170,7 @@ quarkus.mapping.btrt.group.value=value
 
 quarkus.mapping.rt.value=value
 quarkus.mapping.rt.group.value=value
+quarkus.mapping.rt.record-secret=${handler::secret}
 
 ### prefix
 my.prefix.prop=1234

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/RunTimeConfigBuilder.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/RunTimeConfigBuilder.java
@@ -1,6 +1,7 @@
 package io.quarkus.extest.runtime.config;
 
 import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.SecretKeysHandler;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
 public class RunTimeConfigBuilder implements ConfigBuilder {
@@ -8,6 +9,17 @@ public class RunTimeConfigBuilder implements ConfigBuilder {
     public SmallRyeConfigBuilder configBuilder(final SmallRyeConfigBuilder builder) {
         builder.withDefaultValue("skip.build.sources", "true");
         builder.withDefaultValue("additional.builder.property", "1234");
+        builder.withSecretKeysHandlers(new SecretKeysHandler() {
+            @Override
+            public String decode(final String secret) {
+                return "secret";
+            }
+
+            @Override
+            public String getName() {
+                return "handler";
+            }
+        });
         return builder;
     }
 }

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestMappingRunTime.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/TestMappingRunTime.java
@@ -32,6 +32,8 @@ public interface TestMappingRunTime {
     @WithDefault("from-default")
     String recordDefault();
 
+    String recordSecret();
+
     interface Group {
         /**
          * A Group value.


### PR DESCRIPTION
When recording runtime properties, we need to do it without expansion. Using `ConfigValue` is usually fine because it doesn't give an error if the expansion is unavailable, and we can only record the expression. 

In this case, even if the secret is not expanded, the interceptor initializes the handler (and any configuration required for the handler). We must disable the expression's expansion entirely when recording runtime properties from mappings.

- Fixes #45996