### PR TITLE
Fix Javadoc/MD syntax issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -427,7 +427,7 @@ productive. The following Maven tips can vastly speed up development when workin
 [mvnd](https://github.com/apache/maven-mvnd) is a daemon for Maven providing faster builds.
 It parallelizes your builds by default and makes sure the output is consistent even for a parallelized build.
 
-You can https://github.com/apache/maven-mvnd?tab=readme-ov-file#how-to-install-mvnd[install mvnd] with SDKMAN!, Homebrew...
+You can [install mvnd](https://github.com/apache/maven-mvnd?tab=readme-ov-file#how-to-install-mvnd) with SDKMAN!, Homebrew...
 
 mvnd is a good companion for your Quarkus builds.
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
@@ -55,7 +55,7 @@ public class DependencyTreeMojo extends AbstractMojo {
     String mode;
 
     /**
-     * INCUBATING option, enabled with @{code -Dquarkus.bootstrap.incubating-model-resolver} system or project property.
+     * INCUBATING option, enabled with {@code -Dquarkus.bootstrap.incubating-model-resolver} system or project property.
      * <p>
      * Whether to log dependency properties, such as on which classpath they belong, whether they are hot-reloadable in dev
      * mode, etc.
@@ -64,7 +64,7 @@ public class DependencyTreeMojo extends AbstractMojo {
     boolean verbose;
 
     /**
-     * INCUBATING option, enabled with @{code -Dquarkus.bootstrap.incubating-model-resolver} system or project property.
+     * INCUBATING option, enabled with {@code -Dquarkus.bootstrap.incubating-model-resolver} system or project property.
      * <p>
      * Whether to log all dependencies of each dependency node in a tree, adding {@code [+]} suffix
      * to those whose dependencies are not expanded.

--- a/extensions/caffeine/runtime/src/main/java/io/quarkus/caffeine/runtime/graal/CacheConstructorsFeature.java
+++ b/extensions/caffeine/runtime/src/main/java/io/quarkus/caffeine/runtime/graal/CacheConstructorsFeature.java
@@ -9,10 +9,10 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
 /**
  * This Automatic Feature for GraalVM will register for reflection
  * the most commonly used cache implementations from Caffeine.
- * It's implemented as an explicit @{@link Feature} rather than
+ * It's implemented as an explicit {@link Feature} rather than
  * using the Quarkus builditems because it doesn't need to be
  * dynamically tuned (the list is static), and to take advantage
- * of the reachability information we can infer from @{@link org.graalvm.nativeimage.hosted.Feature.DuringAnalysisAccess}.
+ * of the reachability information we can infer from {@link org.graalvm.nativeimage.hosted.Feature.DuringAnalysisAccess}.
  *
  * This allows us to register for reflection these resources only if
  * Caffeine is indeed being used: only if the cache builder is reachable

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeploy.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeploy.java
@@ -22,7 +22,7 @@ public class KubernetesDeploy {
     }
 
     /**
-     * @return {@code true} if @{code quarkus.kubernetes.deploy=true} AND the target Kubernetes API server is reachable,
+     * @return {@code true} if {@code quarkus.kubernetes.deploy=true} AND the target Kubernetes API server is reachable,
      *         {@code false} otherwise
      *
      * @throws RuntimeException if there was an error while communicating with the Kubernetes API server
@@ -38,7 +38,7 @@ public class KubernetesDeploy {
     }
 
     /**
-     * @return {@code true} if @{code quarkus.kubernetes.deploy=true} AND the target Kubernetes API server is reachable
+     * @return {@code true} if {@code quarkus.kubernetes.deploy=true} AND the target Kubernetes API server is reachable
      *         {@code false} otherwise or if there was an error while communicating with the Kubernetes API server
      */
     public boolean checkSilently(KubernetesClientBuildItem clientBuilder) {

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
@@ -160,7 +160,7 @@ public class MailerRuntimeConfig {
 
     /**
      * Sets the login mode for the connection.
-     * Either {@code NONE}, @{code DISABLED}, {@code OPTIONAL}, {@code REQUIRED} or {@code XOAUTH2}.
+     * Either {@code NONE}, {@code DISABLED}, {@code OPTIONAL}, {@code REQUIRED} or {@code XOAUTH2}.
      * <ul>
      * <li>DISABLED means no login will be attempted</li>
      * <li>NONE means a login will be attempted if the server supports in and login credentials are set</li>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/JsonCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/JsonCommands.java
@@ -272,7 +272,7 @@ public interface JsonCommands<K> extends RedisCommands {
      *
      * @param key the key, must not be {@code null}
      * @param path the path, {@code null} means {@code $}
-     * @return a list of integer containing for each path, the array's length, or @{code null} if the
+     * @return a list of integer containing for each path, the array's length, or {@code null} if the
      *         matching JSON value is not an array.
      **/
     List<Integer> jsonArrLen(K key, String path);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/ReactiveJsonCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/ReactiveJsonCommands.java
@@ -240,7 +240,7 @@ public interface ReactiveJsonCommands<K> extends ReactiveRedisCommands {
      *
      * @param key the key, must not be {@code null}
      * @param path the path, {@code null} means {@code $}
-     * @return a uni emitting a list of integer containing for each path, the array's length, or @{code null} if the
+     * @return a uni emitting a list of integer containing for each path, the array's length, or {@code null} if the
      *         matching JSON value is not an array.
      **/
     Uni<List<Integer>> jsonArrLen(K key, String path);
@@ -252,7 +252,7 @@ public interface ReactiveJsonCommands<K> extends ReactiveRedisCommands {
      * <p>
      *
      * @param key the key, must not be {@code null}
-     * @return a uni emitting the array's length, or @{code null} if the matching JSON value is not an array.
+     * @return a uni emitting the array's length, or {@code null} if the matching JSON value is not an array.
      **/
     default Uni<Integer> jsonArrLen(K key) {
         return jsonArrLen(key, null).map(l -> l.get(0));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZRangeArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZRangeArgs.java
@@ -24,7 +24,7 @@ public class ZRangeArgs implements RedisCommandExtraArguments {
 
     /**
      * The LIMIT argument can be used to obtain a sub-range from the matching elements.
-     * A negative @{code count} returns all elements from the {@code offset}.
+     * A negative {@code count} returns all elements from the {@code offset}.
      *
      * @param offset the offset value
      * @param count the count value

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/ReactiveStreamCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/ReactiveStreamCommands.java
@@ -108,7 +108,7 @@ public interface ReactiveStreamCommands<K, F, V> {
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream
@@ -134,7 +134,7 @@ public interface ReactiveStreamCommands<K, F, V> {
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream
@@ -162,7 +162,7 @@ public interface ReactiveStreamCommands<K, F, V> {
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/ReactiveTransactionalStreamCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/ReactiveTransactionalStreamCommands.java
@@ -110,7 +110,7 @@ public interface ReactiveTransactionalStreamCommands<K, F, V> extends ReactiveTr
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream
@@ -137,7 +137,7 @@ public interface ReactiveTransactionalStreamCommands<K, F, V> extends ReactiveTr
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream
@@ -165,7 +165,7 @@ public interface ReactiveTransactionalStreamCommands<K, F, V> extends ReactiveTr
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/StreamCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/StreamCommands.java
@@ -106,7 +106,7 @@ public interface StreamCommands<K, F, V> extends RedisCommands {
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream
@@ -132,7 +132,7 @@ public interface StreamCommands<K, F, V> extends RedisCommands {
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream
@@ -159,7 +159,7 @@ public interface StreamCommands<K, F, V> extends RedisCommands {
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/TransactionalStreamCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/TransactionalStreamCommands.java
@@ -103,7 +103,7 @@ public interface TransactionalStreamCommands<K, F, V> extends TransactionalRedis
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream
@@ -128,7 +128,7 @@ public interface TransactionalStreamCommands<K, F, V> extends TransactionalRedis
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream
@@ -154,7 +154,7 @@ public interface TransactionalStreamCommands<K, F, V> extends TransactionalRedis
      * straightforward way to deal with message delivery failures via {@code SCAN}-like semantics.
      * <p>
      * Like {@code XCLAIM}, the command operates on the stream entries at {@code key} and in the context of the provided
-     * {@code group}. It transfers ownership to @{code consumer} of messages pending for more than {@code min-idle-time}
+     * {@code group}. It transfers ownership to {@code consumer} of messages pending for more than {@code min-idle-time}
      * milliseconds and having an equal or greater ID than {@code start}.
      * <p>
      * Group: stream

--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnAuthenticationMechanism.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnAuthenticationMechanism.java
@@ -22,9 +22,9 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 /**
- * An AuthenticationMechanism for WebAuthn which mostly delegates to @{link PersistentLoginManager}
- * and @{TrustedAuthenticationRequest}, since authentication is handled by {@link WebAuthnController}
- * or @{link WebAuthnSecurity}.
+ * An AuthenticationMechanism for WebAuthn which mostly delegates to {@link PersistentLoginManager}
+ * and {@link TrustedAuthenticationRequest}, since authentication is handled by {@link WebAuthnController}
+ * or {@link WebAuthnSecurity}.
  */
 public class WebAuthnAuthenticationMechanism implements HttpAuthenticationMechanism {
 

--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnAuthenticatorStorage.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnAuthenticatorStorage.java
@@ -15,7 +15,7 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.Vertx;
 
 /**
- * WebAuthn authenticator storage which delegates to @{link WebAuthnUserProvider}.
+ * WebAuthn authenticator storage which delegates to {@link WebAuthnUserProvider}.
  */
 @ApplicationScoped
 public class WebAuthnAuthenticatorStorage {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -111,7 +111,7 @@ public class HttpConfiguration {
     /**
      * Enables or Disable the HTTP/2 Push feature.
      * This setting can be used to disable server push. The server will not send a {@code PUSH_PROMISE} frame if it
-     * receives this parameter set to @{code false}.
+     * receives this parameter set to {@code false}.
      */
     @ConfigItem(defaultValue = "true")
     public boolean http2PushEnabled;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/webjar/WebJarStaticHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/webjar/WebJarStaticHandler.java
@@ -12,8 +12,8 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.StaticHandler;
 
 /**
- * Static handler for webjars. Delegates to either Vert.x @{@link StaticHandler} if finalDestination starts with
- * META-INF, or otherwise to @{@link FileSystemStaticHandler}.
+ * Static handler for webjars. Delegates to either Vert.x {@link StaticHandler} if finalDestination starts with
+ * META-INF, or otherwise to {@link FileSystemStaticHandler}.
  */
 public class WebJarStaticHandler implements Handler<RoutingContext>, Closeable {
     private static final ReentrantLock HANDLER_CREATION_LOCK = new ReentrantLock();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuildExtension.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuildExtension.java
@@ -35,7 +35,7 @@ public interface BuildExtension {
      * Initialize self.
      *
      * @param buildContext
-     * @return {@code true} if the extension should be put into service, @{code false} otherwise
+     * @return {@code true} if the extension should be put into service, {@code false} otherwise
      */
     default boolean initialize(BuildContext buildContext) {
         return true;


### PR DESCRIPTION
This PR fixes a couple of small Javadoc/MD syntax issues. It might seem completely unimportant, but there are [cases where it shows up in the public documentation](https://quarkus.io/guides/mailer-reference#quarkus-mailer_quarkus-mailer-login) which is not nice.