### PR TITLE
Fix and restore hibernate-reactive-mssql tests

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -44,8 +44,8 @@
         },
         {
             "category": "Data7",
-            "timeout": 85,
-            "test-modules": "reactive-oracle-client, reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mariadb, hibernate-reactive-mysql, hibernate-reactive-mysql-agroal-flyway, hibernate-reactive-panache, hibernate-reactive-panache-kotlin",
+            "timeout": 90,
+            "test-modules": "reactive-oracle-client, reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mariadb, hibernate-reactive-mssql, hibernate-reactive-mysql, hibernate-reactive-mysql-agroal-flyway, hibernate-reactive-panache, hibernate-reactive-panache-kotlin",
             "os-name": "ubuntu-latest"
         },
         {

--- a/integration-tests/hibernate-reactive-mssql/pom.xml
+++ b/integration-tests/hibernate-reactive-mssql/pom.xml
@@ -14,7 +14,7 @@
     <description>Hibernate Reactive related tests running with the MS SQL Server database</description>
 
     <properties>
-        <reactive-mssql.url>vertx-reactive:mssql://localhost:3306/hibernate_orm_test</reactive-mssql.url>
+        <reactive-mssql.url>vertx-reactive:sqlserver://localhost:1435</reactive-mssql.url>
     </properties>
 
     <dependencies>
@@ -30,15 +30,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jsonb</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow</artifactId>
-        </dependency>
 
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -201,7 +202,7 @@
                                     <alias>quarkus-test-mssqldb</alias>
                                     <run>
                                         <ports>
-                                            <port>1433:1433</port>
+                                            <port>1435:1433</port>
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>

--- a/integration-tests/hibernate-reactive-mssql/src/main/java/io/quarkus/it/hibernate/reactive/mssql/DialectEndpoint.java
+++ b/integration-tests/hibernate-reactive-mssql/src/main/java/io/quarkus/it/hibernate/reactive/mssql/DialectEndpoint.java
@@ -1,44 +1,28 @@
 package io.quarkus.it.hibernate.reactive.mssql;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 
 import jakarta.inject.Inject;
-import jakarta.servlet.annotation.WebServlet;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 
 import io.quarkus.hibernate.orm.runtime.config.DialectVersions;
 
-@WebServlet(name = "DialectEndpoint", urlPatterns = "/dialect/version")
-public class DialectEndpoint extends HttpServlet {
+@Path("/dialect/version")
+@Produces(MediaType.TEXT_PLAIN)
+public class DialectEndpoint {
     @Inject
     SessionFactory sessionFactory;
 
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        try {
-            var version = sessionFactory.unwrap(SessionFactoryImplementor.class).getJdbcServices().getDialect().getVersion();
-            resp.getWriter().write(DialectVersions.toString(version));
-        } catch (Exception e) {
-            reportException("Failed to retrieve dialect version", e, resp);
-        }
-    }
-
-    private void reportException(String errorMessage, final Exception e, final HttpServletResponse resp) throws IOException {
-        final PrintWriter writer = resp.getWriter();
-        if (errorMessage != null) {
-            writer.write(errorMessage);
-            writer.write(" ");
-        }
-        writer.write(e.toString());
-        writer.append("\n\t");
-        e.printStackTrace(writer);
-        writer.append("\n\t");
+    @GET
+    public String test() throws IOException {
+        var version = sessionFactory.unwrap(SessionFactoryImplementor.class).getJdbcServices().getDialect().getVersion();
+        return DialectVersions.toString(version);
     }
 
 }

--- a/integration-tests/hibernate-reactive-mssql/src/main/java/io/quarkus/it/hibernate/reactive/mssql/HibernateReactiveMSSQLTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-mssql/src/main/java/io/quarkus/it/hibernate/reactive/mssql/HibernateReactiveMSSQLTestEndpoint.java
@@ -87,7 +87,7 @@ public class HibernateReactiveMSSQLTestEndpoint {
     }
 
     private Uni<String> selectNameFromId(Integer id) {
-        return mssqlPool.preparedQuery("SELECT name FROM Pig WHERE id = ?").execute(Tuple.of(id)).map(rowSet -> {
+        return mssqlPool.preparedQuery("SELECT name FROM Pig WHERE id = @p1").execute(Tuple.of(id)).map(rowSet -> {
             if (rowSet.size() == 1) {
                 return rowSet.iterator().next().getString(0);
             } else if (rowSet.size() > 1) {

--- a/integration-tests/hibernate-reactive-mssql/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-mssql/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-quarkus.datasource.db-kind=mysql
-quarkus.datasource.username=hibernate_orm_test
-quarkus.datasource.password=hibernate_orm_test
+quarkus.datasource.db-kind=mssql
+quarkus.datasource.username=sa
+quarkus.datasource.password=yourStrong(!)Password
 
 # Hibernate config
 #quarkus.hibernate-orm.log.sql=true
@@ -8,4 +8,4 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # Reactive config
 quarkus.datasource.reactive=true
-quarkus.datasource.reactive.url=${reactive-mysql.url}
+quarkus.datasource.reactive.url=${reactive-mssql.url}

--- a/integration-tests/hibernate-reactive-mssql/src/test/java/io/quarkus/it/hibernate/reactive/mssql/DialectInGraalITCase.java
+++ b/integration-tests/hibernate-reactive-mssql/src/test/java/io/quarkus/it/hibernate/reactive/mssql/DialectInGraalITCase.java
@@ -6,6 +6,6 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
  * DialectTest, but in native mode.
  */
 @QuarkusIntegrationTest
-public class DialectInGraalITCase extends DefaultDialectVersionTest {
+public class DialectInGraalITCase extends DialectTest {
 
 }

--- a/integration-tests/hibernate-reactive-mssql/src/test/java/io/quarkus/it/hibernate/reactive/mssql/DialectTest.java
+++ b/integration-tests/hibernate-reactive-mssql/src/test/java/io/quarkus/it/hibernate/reactive/mssql/DialectTest.java
@@ -12,7 +12,7 @@ import io.restassured.RestAssured;
  * Test the dialect used by default in Quarkus.
  */
 @QuarkusTest
-public class DefaultDialectVersionTest {
+public class DialectTest {
 
     /**
      * This is important for backwards compatibility reasons:

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -213,6 +213,7 @@
                 <module>hibernate-orm-panache-kotlin</module>
                 <module>hibernate-reactive-db2</module>
                 <module>hibernate-reactive-mariadb</module>
+                <module>hibernate-reactive-mssql</module>
                 <module>hibernate-reactive-mysql</module>
                 <module>hibernate-reactive-mysql-agroal-flyway</module>
                 <module>hibernate-reactive-postgresql</module>


### PR DESCRIPTION
Fixes #46018

(thanks again @holly-cummins for spotting this...)

I had to make a few changes to the tests, which were quite thoroughly broken. Not even compiling.

Even though we went (quite) some time without running these tests, it looks like we got lucky: tests still pass, and (critically) native compilation works fine.

I'd recommend trying to backport to (at least) 3.15 to make sure things are alright there too...