### PR TITLE
Recalculate config property names during tests

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestExtensionState.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestExtensionState.java
@@ -4,7 +4,10 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.test.common.TestResourceManager;
+import io.smallrye.config.SmallRyeConfig;
 
 public class IntegrationTestExtensionState extends QuarkusTestExtensionState {
 
@@ -28,5 +31,7 @@ public class IntegrationTestExtensionState extends QuarkusTestExtensionState {
                 System.setProperty(entry.getKey(), val);
             }
         }
+        // recalculate the property names that may have changed with the restore
+        ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getLatestPropertyNames();
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -53,6 +53,7 @@ import io.quarkus.test.common.PathTestHelper;
 import io.quarkus.test.common.TestClassIndexer;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
+import io.smallrye.config.SmallRyeConfig;
 
 public final class IntegrationTestUtil {
 
@@ -147,6 +148,8 @@ public final class IntegrationTestUtil {
                 System.setProperty(i.getKey(), i.getValue());
             }
         }
+        // recalculate the property names that may have changed
+        ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getLatestPropertyNames();
         return new TestProfileAndProperties(testProfile, properties);
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -263,10 +263,14 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
                                 } else {
                                     System.setProperty(i.getKey(), i.getValue());
                                 }
+                                // recalculate the property names that may have changed with the restore
+                                ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getLatestPropertyNames();
                             }
                         }
                     });
             additionalProperties.putAll(resourceManagerProps);
+            // recalculate the property names that may have changed with testProfileAndProperties.properties
+            ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getLatestPropertyNames();
 
             ArtifactLauncher<?> launcher;
             String testHost = System.getProperty("quarkus.http.test-host");

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -164,6 +164,8 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
                     }
                 }
                 additionalProperties.putAll(resourceManagerProps);
+                // recalculate the property names that may have changed with testProfileAndProperties.properties
+                ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getLatestPropertyNames();
 
                 testResourceManager.inject(context.getRequiredTestInstance());
 
@@ -197,6 +199,8 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
                         System.setProperty(i.getKey(), i.getValue());
                     }
                 }
+                // recalculate the property names that may have changed with the restore
+                ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getLatestPropertyNames();
                 try {
                     if (testResourceManager != null) {
                         testResourceManager.close();


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/42715, the Config is initialized way earlier, which means that if the System source is mutated, the list of property names is not updated because it is cached.

Our assumption is that the Config is immutable, but we have these workarounds to pass the configuration around. Ideally, we shouldn't be mutating the configuration, which causes issues like:
- https://github.com/quarkusio/quarkus/issues/27996
- https://github.com/quarkusio/quarkus/issues/45868
- https://github.com/quarkusio/quarkus/issues/42986

Obviously, it is tricky to make that change now, and we are still trying to figure out how to handle the case of the port, but the goal is to completely remove the mutability of sources. 

For now, I added a way to refresh the list of property names. Probably, a better way is to add some way to not cache the list of names for specific profiles, but that requires changes in SR Config, while this one can be done directly in Quarkus. I'll keep this in mind.

- Fixes #46008