### PR TITLE
Add ChannelBuilderCustomizer for custom gRPC Channel handling

### DIFF
--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -217,6 +217,50 @@ Don't forget to replace it with the name you used in the `@GrpcClient` annotatio
 
 IMPORTANT: When you enable `quarkus.grpc.clients."client-name".xds.enabled`, it's the xDS that should handle most of the configuration above.
 
+=== Custom Channel building
+
+When Quarkus builds a gRPC Channel instance (the way gRPC clients communicate with gRPC services on a lower network level), users can apply their own Channel(Builder) customizers. The customizers are applied by `priority`, the higher the number the later customizer is applied. The customizers are applied before Quarkus applies user's client configuration; e.g. ideal for some initial defaults per all clients.
+
+There are two `customize` methods, the first one uses gRPC's `ManagedChannelBuilder` as a parameter - to be used with Quarkus' legacy gRPC support, where the other uses `GrpcClientOptions` - to be used with the new Vert.x gRPC support. User should implement the right `customize` method per gRPC support type usage, or both if the customizer is gRPC type neutral.
+
+[source, java]
+----
+public interface ChannelBuilderCustomizer<T extends ManagedChannelBuilder<T>> {
+
+    /**
+     * Customize a ManagedChannelBuilder instance.
+     *
+     * @param name gRPC client name
+     * @param config client's configuration
+     * @param builder Channel builder instance
+     * @return map of config properties to be used as default service config against the builder
+     */
+    default Map<String, Object> customize(String name, GrpcClientConfiguration config, T builder) {
+        return Map.of();
+    }
+
+    /**
+     * Customize a GrpcClientOptions instance.
+     *
+     * @param name gRPC client name
+     * @param config client's configuration
+     * @param options GrpcClientOptions instance
+     */
+    default void customize(String name, GrpcClientConfiguration config, GrpcClientOptions options) {
+    }
+
+    /**
+     * Priority by which the customizers are applied.
+     * Higher priority is applied later.
+     *
+     * @return the priority
+     */
+    default int priority() {
+        return 0;
+    }
+}
+----
+
 === Enabling TLS
 
 To enable TLS, use the following configuration.

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -437,6 +437,11 @@ public class GrpcClientProcessor {
         return UnremovableBeanBuildItem.beanTypes(GrpcDotNames.CLIENT_INTERCEPTOR);
     }
 
+    @BuildStep
+    UnremovableBeanBuildItem unremovableChannelBuilderCustomizers() {
+        return UnremovableBeanBuildItem.beanTypes(GrpcDotNames.CHANNEL_BUILDER_CUSTOMIZER);
+    }
+
     Set<String> getRegisteredInterceptors(InjectionPointInfo injectionPoint) {
         Set<AnnotationInstance> qualifiers = injectionPoint.getRequiredQualifiers();
         if (qualifiers.size() <= 1) {

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcDotNames.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcDotNames.java
@@ -24,6 +24,7 @@ import io.quarkus.grpc.MutinyStub;
 import io.quarkus.grpc.RegisterClientInterceptor;
 import io.quarkus.grpc.RegisterInterceptor;
 import io.quarkus.grpc.RegisterInterceptors;
+import io.quarkus.grpc.api.ChannelBuilderCustomizer;
 import io.quarkus.grpc.runtime.supports.Channels;
 import io.quarkus.grpc.runtime.supports.GrpcClientConfigProvider;
 import io.smallrye.common.annotation.Blocking;
@@ -57,6 +58,8 @@ public class GrpcDotNames {
     public static final DotName REGISTER_CLIENT_INTERCEPTOR_LIST = DotName
             .createSimple(RegisterClientInterceptor.List.class.getName());
     public static final DotName CLIENT_INTERCEPTOR = DotName.createSimple(ClientInterceptor.class.getName());
+
+    public static final DotName CHANNEL_BUILDER_CUSTOMIZER = DotName.createSimple(ChannelBuilderCustomizer.class.getName());
 
     static final MethodDescriptor CREATE_CHANNEL_METHOD = MethodDescriptor.ofMethod(Channels.class, "createChannel",
             Channel.class, String.class, Set.class);

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/api/ChannelBuilderCustomizer.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/api/ChannelBuilderCustomizer.java
@@ -1,0 +1,48 @@
+package io.quarkus.grpc.api;
+
+import java.util.Map;
+
+import io.grpc.ManagedChannelBuilder;
+import io.quarkus.grpc.runtime.config.GrpcClientConfiguration;
+import io.vertx.grpc.client.GrpcClientOptions;
+
+/**
+ * Allow for customization of Channel building.
+ * Implement the customize method, depending on which Channel implementation you're going to use,
+ * e.g. Vert.x or Netty.
+ * This is an experimental API, subject to change.
+ */
+public interface ChannelBuilderCustomizer<T extends ManagedChannelBuilder<T>> {
+
+    /**
+     * Customize a ManagedChannelBuilder instance.
+     *
+     * @param name gRPC client name
+     * @param config client's configuration
+     * @param builder Channel builder instance
+     * @return map of config properties to be used as default service config against the builder
+     */
+    default Map<String, Object> customize(String name, GrpcClientConfiguration config, T builder) {
+        return Map.of();
+    }
+
+    /**
+     * Customize a GrpcClientOptions instance.
+     *
+     * @param name gRPC client name
+     * @param config client's configuration
+     * @param options GrpcClientOptions instance
+     */
+    default void customize(String name, GrpcClientConfiguration config, GrpcClientOptions options) {
+    }
+
+    /**
+     * Priority by which the customizers are applied.
+     * Higher priority is applied later.
+     *
+     * @return the priority
+     */
+    default int priority() {
+        return 0;
+    }
+}

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloWorldEndpoint.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloWorldEndpoint.java
@@ -32,6 +32,7 @@ public class HelloWorldEndpoint {
 
         return Response.ok(helloReply.getMessage())
                 .header("interceptors", String.join(",", invoked))
+                .header("used", MyCBC.USED.get() + "")
                 .build();
     }
 

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/MyCBC.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/MyCBC.java
@@ -1,0 +1,27 @@
+package io.quarkus.grpc.examples.interceptors;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.grpc.netty.NettyChannelBuilder;
+import io.quarkus.grpc.api.ChannelBuilderCustomizer;
+import io.quarkus.grpc.runtime.config.GrpcClientConfiguration;
+import io.vertx.grpc.client.GrpcClientOptions;
+
+@ApplicationScoped
+public class MyCBC implements ChannelBuilderCustomizer<NettyChannelBuilder> {
+    public static final AtomicBoolean USED = new AtomicBoolean(false);
+
+    @Override
+    public Map<String, Object> customize(String name, GrpcClientConfiguration config, NettyChannelBuilder builder) {
+        USED.set(true);
+        return Map.of();
+    }
+
+    @Override
+    public void customize(String name, GrpcClientConfiguration config, GrpcClientOptions options) {
+        USED.set(true);
+    }
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldEndpointTestBase.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldEndpointTestBase.java
@@ -26,6 +26,9 @@ class HelloWorldEndpointTestBase {
                 "io.quarkus.grpc.examples.interceptors.ServerInterceptors$MethodTarget");
 
         ensureThatMetricsAreProduced();
+
+        String used = response.getHeader("used");
+        assertThat(Boolean.parseBoolean(used)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
This add support for users to set initial defaults for gRPC Channel(Builders), as described in #16241.
Additional `customize` method had to be added, to support new Vert.x gRPC as well.