### PR TITLE
Ensure that the copied native executable has the executable permission when copied from the host to the container image.

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -495,10 +495,15 @@ The project generation has provided a `Dockerfile.native-micro` in the `src/main
 ----
 FROM quay.io/quarkus/quarkus-micro-image:2.0
 WORKDIR /work/
-COPY target/*-runner /work/application
-RUN chmod 775 /work
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root --chmod=755 target/*-runner /work/application
+
 EXPOSE 8080
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+USER 1001
+
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ----
 
 [NOTE]
@@ -543,7 +548,7 @@ WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -24,8 +24,7 @@ In your `Dockerfile`, just use:
 ----
 FROM quay.io/quarkus/quarkus-micro-image:2.0
 WORKDIR /work/
-COPY target/*-runner /work/application
-RUN chmod 775 /work
+COPY --chmod=0755 target/*-runner /work/application
 EXPOSE 8080
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ----
@@ -51,8 +50,7 @@ COPY --from=BUILD \
    /lib64/
 
 WORKDIR /work/
-COPY target/*-runner /work/application
-RUN chmod 775 /work
+COPY --chmod=0755 target/*-runner /work/application
 EXPOSE 8080
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ----
@@ -95,8 +93,7 @@ COPY --from=BUILD \
      /etc/fonts /etc/fonts
 
 WORKDIR /work/
-COPY target/*-runner /work/application
-RUN chmod 775 /work
+COPY --chmod=0755 target/*-runner /work/application
 EXPOSE 8080
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ----
@@ -117,7 +114,7 @@ WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native
@@ -19,7 +19,7 @@ WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root {buildtool.build-dir}/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 {buildtool.build-dir}/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-micro
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.native-micro
@@ -22,7 +22,7 @@ WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root {buildtool.build-dir}/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 {buildtool.build-dir}/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/integration-tests/awt/src/main/docker/Dockerfile.native
+++ b/integration-tests/awt/src/main/docker/Dockerfile.native
@@ -8,7 +8,7 @@ RUN chown 1001 /work \
     && chown 1001:root /work
 # Shared objects to be dynamically loaded at runtime as needed
 COPY --chown=1001:root target/*.so /work/
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 # Permissions fix for Windows
 RUN chmod "ugo+x" /work/application
 EXPOSE 8081

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.native
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/src/main/docker/Dockerfile.native
@@ -19,7 +19,7 @@ WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.native
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.native
@@ -19,7 +19,7 @@ WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.native-micro
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.native-micro
@@ -22,7 +22,7 @@ WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root target/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
 
 EXPOSE 8080
 USER 1001


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/46036
