### PR TITLE
Add critical IDs

### DIFF
--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -3,6 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
+[id="security-jwt-build"]
 = Build, sign, and encrypt JSON Web Tokens
 include::_attributes.adoc[]
 :categories: security

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -3,6 +3,7 @@ This guide is maintained in the main Quarkus repository.
 To contribute, submit a pull request here:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
+[id="security-keycloak-authorization"]
 = Using OpenID Connect (OIDC) and Keycloak to centralize authorization
 include::_attributes.adoc[]
 :diataxis-type: howto


### PR DESCRIPTION
Add missing IDs, which are critical for downstream links to work.