### PR TITLE
Fix typo remove extra bracket

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -2269,7 +2269,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
          * For this option be effective the `authentication.session-age-extension` property should also be set to a nonzero
          * value since the refresh token is currently kept in the user session.
          *
-         * This option is valid only when the application is of type {@link ApplicationType#WEB_APP}}.
+         * This option is valid only when the application is of type {@link ApplicationType#WEB_APP}.
          *
          * This property is enabled if `quarkus.oidc.token.refresh-token-time-skew` is configured,
          * you do not need to enable this property manually in this case.
@@ -2292,7 +2292,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
 
         /**
          * Custom HTTP header that contains a bearer token.
-         * This option is valid only when the application is of type {@link ApplicationType#SERVICE}}.
+         * This option is valid only when the application is of type {@link ApplicationType#SERVICE}.
          */
         public Optional<String> header = Optional.empty();
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -1020,7 +1020,7 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
          * For this option be effective the `authentication.session-age-extension` property should also be set to a nonzero
          * value since the refresh token is currently kept in the user session.
          *
-         * This option is valid only when the application is of type {@link ApplicationType#WEB_APP}}.
+         * This option is valid only when the application is of type {@link ApplicationType#WEB_APP}.
          *
          * This property is enabled if `quarkus.oidc.token.refresh-token-time-skew` is configured,
          * you do not need to enable this property manually in this case.
@@ -1045,7 +1045,7 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
 
         /**
          * Custom HTTP header that contains a bearer token.
-         * This option is valid only when the application is of type {@link ApplicationType#SERVICE}}.
+         * This option is valid only when the application is of type {@link ApplicationType#SERVICE}.
          */
         Optional<String> header();
 

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/config/SmallRyeFaultToleranceConfig.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/config/SmallRyeFaultToleranceConfig.java
@@ -352,7 +352,7 @@ public interface SmallRyeFaultToleranceConfig {
 
             /**
              * The exception types that are not considered failures and hence should not trigger fallback.
-             * Takes priority over {@link #applyOn()}}.
+             * Takes priority over {@link #applyOn()}.
              *
              * @see Fallback#skipOn()
              */


### PR DESCRIPTION
Removes a typo, an extra bracket that appears in several of the generated config docs.
FYI @sberyozkin and thanks @gtroitsk for spotting this issue.
