### PR TITLE
For synthetic injection points, target can be null

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -410,15 +410,19 @@ public class ConfigBuildStep {
             if (configClass != null) {
                 AnnotationTarget target = injectionPoint.getAnnotationTarget();
                 AnnotationInstance mapping = null;
-                if (target.kind().equals(FIELD)) {
-                    mapping = target.asField().annotation(CONFIG_MAPPING_NAME);
-                } else if (target.kind().equals(METHOD_PARAMETER)) {
-                    MethodParameterInfo methodParameterInfo = target.asMethodParameter();
-                    if (methodParameterInfo.type().name().equals(type.name())) {
-                        Set<AnnotationInstance> parameterAnnotations = getParameterAnnotations(
-                                validationPhase.getBeanProcessor().getBeanDeployment(),
-                                target.asMethodParameter().method(), methodParameterInfo.position());
-                        mapping = Annotations.find(parameterAnnotations, CONFIG_MAPPING_NAME);
+
+                // target can be null for synthetic injection point
+                if (target != null) {
+                    if (target.kind().equals(FIELD)) {
+                        mapping = target.asField().annotation(CONFIG_MAPPING_NAME);
+                    } else if (target.kind().equals(METHOD_PARAMETER)) {
+                        MethodParameterInfo methodParameterInfo = target.asMethodParameter();
+                        if (methodParameterInfo.type().name().equals(type.name())) {
+                            Set<AnnotationInstance> parameterAnnotations = getParameterAnnotations(
+                                    validationPhase.getBeanProcessor().getBeanDeployment(),
+                                    target.asMethodParameter().method(), methodParameterInfo.position());
+                            mapping = Annotations.find(parameterAnnotations, CONFIG_MAPPING_NAME);
+                        }
                     }
                 }
 


### PR DESCRIPTION
So we need to handle it properly.

Spotted in: https://github.com/quarkiverse/quarkus-artemis/actions/runs/13150585162/job/36697206471

With stacktrace:
```
Error: ]: Build step io.quarkus.arc.deployment.ConfigBuildStep#validateConfigMappingsInjectionPoints threw an exception: java.lang.NullPointerException: Cannot invoke "org.jboss.jandex.AnnotationTarget.kind()" because "target" is null
	at io.quarkus.arc.deployment.ConfigBuildStep.validateConfigMappingsInjectionPoints(ConfigBuildStep.java:413)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	at org.jboss.threads.JBossThread.run(JBossThread.java:499)

	at io.quarkus.builder.Execution.run(Execution.java:122)
	at io.quarkus.builder.BuildExecutionBuilder.execute(BuildExecutionBuilder.java:78)
	at io.quarkus.deployment.QuarkusAugmentor.run(QuarkusAugmentor.java:161)
	at io.quarkus.runner.bootstrap.AugmentActionImpl.runAugment(AugmentActionImpl.java:350)
```