### PR TITLE
Remove non-existing value "OPTIONAL", fix typo

### DIFF
--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
@@ -149,10 +149,10 @@ public interface MailerRuntimeConfig {
 
     /**
      * Sets the login mode for the connection.
-     * Either {@code NONE}, {@code DISABLED}, {@code OPTIONAL}, {@code REQUIRED} or {@code XOAUTH2}.
+     * Either {@code NONE}, {@code DISABLED}, {@code REQUIRED} or {@code XOAUTH2}.
      * <ul>
+     * <li>NONE means a login will be attempted if the server supports it and login credentials are set</li>
      * <li>DISABLED means no login will be attempted</li>
-     * <li>NONE means a login will be attempted if the server supports in and login credentials are set</li>
      * <li>REQUIRED means that a login will be attempted if the server supports it and the send operation will fail
      * otherwise</li>
      * <li>XOAUTH2 means that a login will be attempted using Google Gmail Oauth2 tokens</li>


### PR DESCRIPTION
Sorry, should have fixed this with the last PR at the very same location but I only realized it now. Now the whole CI has to run again. :-/

This value `OPTIONAL` does not exist in the underlying Vertx Mail Client. It's almost funny that it's also incorrectly documented in `io.vertx.ext.mail.LoginOption` (where the docs were copied from) and in `io.vertx.ext.mail.MailConfig`.

Additionally, I wonder why they called the other option `NONE` considering its meaning, but that's probably their secret.

Fixed a tiny typo that was also copied over from Vertx Mail Client, but then it is correct at least here in Quarkus.