### PR TITLE
Change timing of @Initialized and @BeforeDestroyed events so that they can be observed from a bean within given context

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ManagedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ManagedContext.java
@@ -10,6 +10,8 @@ public interface ManagedContext extends InjectableContext {
 
     /**
      * Activate the context with no initial state.
+     * <p>
+     * If needed, activating a context will fire {@code @Initialized} event for the given context.
      *
      * @return the context state
      */
@@ -39,7 +41,7 @@ public interface ManagedContext extends InjectableContext {
     }
 
     /**
-     * Deactivate the context - do not destoy existing contextual instances.
+     * Deactivate the context - do not destroy existing contextual instances.
      */
     void deactivate();
 
@@ -52,6 +54,9 @@ public interface ManagedContext extends InjectableContext {
     }
 
     /**
+     * Creates a new {@link io.quarkus.arc.InjectableContext.ContextState}.
+     * <p>
+     * Creating a context state does not fire {@code @Initialized} event for given context.
      *
      * @return a new initialized context state
      */

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/RequestContextTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/RequestContextTest.java
@@ -25,7 +25,7 @@ public class RequestContextTest {
 
     @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Controller.class, ControllerClient.class,
-            ContextObserver.class, Boom.class);
+            ContextObserver.class, Boom.class, RequestScopedObserver.class);
 
     @Test
     public void testRequestContext() {
@@ -125,6 +125,7 @@ public class RequestContextTest {
     public void testRequestContextEvents() {
         // reset counters since other tests might have triggered it already
         ContextObserver.reset();
+        RequestScopedObserver.reset();
 
         // firstly test manual activation
         ArcContainer arc = Arc.container();
@@ -140,6 +141,8 @@ public class RequestContextTest {
         assertEquals(1, ContextObserver.initializedObserved);
         assertEquals(0, ContextObserver.beforeDestroyedObserved);
         assertEquals(0, ContextObserver.destroyedObserved);
+        assertEquals(1, RequestScopedObserver.initializedObserved);
+        assertEquals(0, RequestScopedObserver.beforeDestroyedObserved);
 
         // dummy check that bean is available
         arc.instance(Controller.class).get().getId();
@@ -148,6 +151,8 @@ public class RequestContextTest {
         assertEquals(1, ContextObserver.initializedObserved);
         assertEquals(1, ContextObserver.beforeDestroyedObserved);
         assertEquals(1, ContextObserver.destroyedObserved);
+        assertEquals(1, RequestScopedObserver.initializedObserved);
+        assertEquals(1, RequestScopedObserver.beforeDestroyedObserved);
 
         try {
             arc.instance(Controller.class).get().getId();
@@ -160,6 +165,8 @@ public class RequestContextTest {
         assertEquals(2, ContextObserver.initializedObserved);
         assertEquals(2, ContextObserver.beforeDestroyedObserved);
         assertEquals(2, ContextObserver.destroyedObserved);
+        assertEquals(2, RequestScopedObserver.initializedObserved);
+        assertEquals(2, RequestScopedObserver.beforeDestroyedObserved);
 
         // lastly, use RequestContextController bean to handle the context
         try {
@@ -173,6 +180,8 @@ public class RequestContextTest {
         assertEquals(3, ContextObserver.initializedObserved);
         assertEquals(2, ContextObserver.beforeDestroyedObserved);
         assertEquals(2, ContextObserver.destroyedObserved);
+        assertEquals(3, RequestScopedObserver.initializedObserved);
+        assertEquals(2, RequestScopedObserver.beforeDestroyedObserved);
 
         // dummy check that bean is available
         arc.instance(Controller.class).get().getId();
@@ -181,6 +190,8 @@ public class RequestContextTest {
         assertEquals(3, ContextObserver.initializedObserved);
         assertEquals(3, ContextObserver.beforeDestroyedObserved);
         assertEquals(3, ContextObserver.destroyedObserved);
+        assertEquals(3, RequestScopedObserver.initializedObserved);
+        assertEquals(3, RequestScopedObserver.beforeDestroyedObserved);
 
         try {
             arc.instance(Controller.class).get().getId();

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/RequestScopedObserver.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/RequestScopedObserver.java
@@ -1,0 +1,26 @@
+package io.quarkus.arc.test.contexts.request;
+
+import jakarta.enterprise.context.BeforeDestroyed;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.event.Observes;
+
+@RequestScoped
+public class RequestScopedObserver {
+
+    public static int initializedObserved = 0;
+    public static int beforeDestroyedObserved = 0;
+
+    public static void reset() {
+        initializedObserved = 0;
+        beforeDestroyedObserved = 0;
+    }
+
+    public void observeContextInit(@Observes @Initialized(RequestScoped.class) Object event) {
+        initializedObserved++;
+    }
+
+    public void observeContextBeforeDestroyed(@Observes @BeforeDestroyed(RequestScoped.class) Object event) {
+        beforeDestroyedObserved++;
+    }
+}


### PR DESCRIPTION
Fixes #46108

The idea is to be able to observe `@Initialized` and `@BeforeDestroyed` from within a bean in a context that's being initialized/destroyed - see the test in this PR.

Since we can be handing over context states that may or may not have been initialized/destroyed yet, I placed that information into the `CurrentContextState` implementation.