### PR TITLE
Add logging to LGTM container

### DIFF
--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/GrafanaConfig.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/GrafanaConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.observability.common.config;
 
 import java.time.Duration;
 
+import io.quarkus.observability.common.ContainerConstants;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -23,7 +24,7 @@ public interface GrafanaConfig extends ContainerConfig {
     /**
      * The port of the Grafana container.
      */
-    @WithDefault("3000")
+    @WithDefault("" + ContainerConstants.GRAFANA_PORT)
     int grafanaPort();
 
     /**

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmComponent.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmComponent.java
@@ -1,0 +1,10 @@
+package io.quarkus.observability.common.config;
+
+public enum LgtmComponent {
+    GRAFANA,
+    LOKI,
+    PROMETHEUS,
+    TEMPO,
+    OTELCOL,
+    ALL
+}

--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/config/LgtmConfig.java
@@ -34,6 +34,14 @@ public interface LgtmConfig extends GrafanaConfig {
     // where we want http as a default with LGTM
 
     /**
+     * Set of components to log.
+     * Comma separated set of components whose container log we want to output.
+     *
+     * @return set of components to log
+     */
+    Optional<Set<LgtmComponent>> logging();
+
+    /**
      * The LGTM's OTLP protocol.
      */
     @WithDefault(ContainerConstants.OTEL_HTTP_PROTOCOL)

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
@@ -14,6 +14,7 @@ import org.testcontainers.utility.MountableFile;
 
 import io.quarkus.observability.common.ContainerConstants;
 import io.quarkus.observability.common.config.AbstractGrafanaConfig;
+import io.quarkus.observability.common.config.LgtmComponent;
 import io.quarkus.observability.common.config.LgtmConfig;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.utilities.OS;
@@ -101,6 +102,9 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
         this.scrapingRequired = scrapingRequired;
         // always expose both -- since the LGTM image already does that as well
         addExposedPorts(ContainerConstants.OTEL_GRPC_EXPORTER_PORT, ContainerConstants.OTEL_HTTP_EXPORTER_PORT);
+
+        Optional<Set<LgtmComponent>> logging = config.logging();
+        logging.ifPresent(set -> set.forEach(l -> withEnv("ENABLE_LOGS_" + l.name(), "true")));
 
         // Replacing bundled dashboards with our own
         addFileToContainer(DASHBOARDS_CONFIG.getBytes(),
@@ -200,6 +204,11 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
         @Override
         public Optional<Set<String>> networkAliases() {
             return Optional.of(Set.of("lgtm", LGTM_NETWORK_ALIAS));
+        }
+
+        @Override
+        public Optional<Set<LgtmComponent>> logging() {
+            return Optional.empty();
         }
 
         @Override

--- a/integration-tests/observability-lgtm/src/main/resources/application.properties
+++ b/integration-tests/observability-lgtm/src/main/resources/application.properties
@@ -12,3 +12,4 @@ quarkus.micrometer.export.otlp.default-registry=true
 %prod.quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4318
 
 #quarkus.observability.lgtm.image-name=grafana/otel-lgtm
+#quarkus.observability.lgtm.logging=ALL


### PR DESCRIPTION
This allows for users to check LGTM (sub)containers for their logging, as per
* https://github.com/grafana/docker-otel-lgtm?tab=readme-ov-file#enable-logging