### PR TITLE
Drop telemetry.metrics exclusion from tcks/microprofile-opentelemetry module

### DIFF
--- a/tcks/microprofile-opentelemetry/src/test/resources/exclusions.txt
+++ b/tcks/microprofile-opentelemetry/src/test/resources/exclusions.txt
@@ -2,4 +2,3 @@
 org.eclipse.microprofile.telemetry.tracing.tck.rest.JaegerPropagationTest
 org.eclipse.microprofile.telemetry.tracing.tck.rest.B3MultiPropagationTest
 org.eclipse.microprofile.telemetry.tracing.tck.rest.B3PropagationTest
-org.eclipse.microprofile.telemetry.metrics.tck.jvm.JvmThreadTest


### PR DESCRIPTION
Drop telemetry.metrics exclusion from tcks/microprofile-opentelemetry module

https://github.com/microprofile/microprofile-telemetry/commit/e53a41f5de3cc62db53e020465399d78dca574b9 was merged for 2.0.1 release and we are using 2.0.1 TCK since https://github.com/quarkusio/quarkus/pull/44699

