### PR TITLE
Spring DI - Fix behavior with named beans

### DIFF
--- a/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java
+++ b/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java
@@ -526,7 +526,7 @@ public class SpringDIProcessor {
         }
         if (beanName == null || beanName.isEmpty()) {
             final AnnotationValue beanValueAnnotationValue = annotationInstance.value();
-            if (beanNameAnnotationValue != null) {
+            if (beanValueAnnotationValue != null) {
                 beanName = determineName(beanValueAnnotationValue);
             }
         }

--- a/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/MyConfigurationWithNamedBean.java
+++ b/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/MyConfigurationWithNamedBean.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MyConfigurationWithNamedBean {
+
+    @Bean("mySpecialName")
+    public String foo() {
+        return "foo";
+    }
+}

--- a/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/UseNamedBeanService.java
+++ b/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/UseNamedBeanService.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.spring;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UseNamedBeanService {
+
+    String name;
+
+    public UseNamedBeanService(@Qualifier("mySpecialName") String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
Fixes #45961

This pull request aims to solve an issue when using `@Named` annotation. 

Having the following code below:

```java
@Configuration
public class MyConfiguration {
    @Bean("mySpecialName")
    public String foo() {
        return "foo";
    }
}
```

> The Quarkus SpringDIProcessor will add `@Named("foo")` (the method name) instead of `@Named("mySpecialName") `(the bean name), and we will get an UnsatisfiedResolutionException.

> This should work properly, `getBeanNameFromBeanInstance` in SpringDIProcessor [does check](https://github.com/quarkusio/quarkus/blob/55c7c15a633433a6e810b1875b7c1a31fd932c84/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java#L528-L531) the value of the @Bean annotation to place the correct `@Named` annotation on the method, but it has a small error: [this if statement](https://github.com/quarkusio/quarkus/blob/55c7c15a633433a6e810b1875b7c1a31fd932c84/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java#L529) checks if beanNameAnnotationValue != null instead of if beanValueAnnotationValue != null (beanName vs beanValue).

This change uses the value instead the name, removing the `UnsatisfiedResolutionException`.

