### PR TITLE
Docs: Fix some more weaknesses

### DIFF
--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -52,7 +52,7 @@ Note that the Kafka advertised address is automatically configured with the chos
 [[configuring-the-image]]
 == Configuring the image
 
-Dev Services for Kafka supports https://redpanda.com[Redpanda], https://github/ozangunalp/kafka-native[kafka-native]
+Dev Services for Kafka supports https://redpanda.com[Redpanda], https://github.com/ozangunalp/kafka-native[kafka-native]
 and https://strimzi.io[Strimzi] (in https://github.com/apache/kafka/blob/trunk/config/kraft/README.md[Kraft] mode)  images.
 
 **Redpanda** is a Kafka compatible event streaming platform.

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1190,7 +1190,7 @@ In this case, just add `_isolated=false` or `_unisolated` argument to the call s
 ===== Arguments
 
 Named arguments can be accessed directly in the tag template.
-However, the first argument does not need to define a name and it can be accessed using the `it` alias.
+However, the first argument does not need to define a name, and it can be accessed using the `it` alias.
 Furthermore, if an argument does not have a name defined and the value is a single identifier, such as `foo`, then the name is defaulted to the value identifier, e.g. `{#myTag foo /}` becomes `{#myTag foo=foo /}`.
 In other words, the argument value `foo` is resolved and can be accessed using `{foo}` in the tag template.
 
@@ -2044,8 +2044,8 @@ public class ItemResource {
 You can also define a type-safe <<fragments,fragment>> in your Java code.
 A _native static_ method with the name that contains a dollar sign `$` denotes a method that represents a fragment of a type-safe template.
 The name of the fragment is derived from the annotated method name.
-The part before the last occurence of a dollar sign `$` is the method name of the related type-safe template.
-The part after the last occurence of a dollar sign is the fragment identifier.
+The part before the last occurrence of a dollar sign `$` is the method name of the related type-safe template.
+The part after the last occurrence of a dollar sign is the fragment identifier.
 The strategy defined by the relevant `CheckedTemplate#defaultName()` is honored when constructing the defaulted names.
 
 .Type-safe Fragment Example
@@ -2200,18 +2200,18 @@ static BigDecimal discountedPrice(Item item) {
 }
 ----
 
-A special constant - `TemplateExtension#ANY`/`*` - can be used to specify that the extension method matches any name.
+A special constant - `TemplateExtension#ANY` - can be used to specify that the extension method matches any name.
 
 .`TemplateExtension#ANY` Example
 [source,java]
 ----
-@TemplateExtension(matchName = "*")
+@TemplateExtension(matchName = TemplateExtension.ANY)
 static String itemProperty(Item item, String name) { <1>
    // this method matches {item.foo} if "item" resolves to an object assignable to "Item"
    // the value of the "name" argument is "foo"
 }
 ----
-<1> A additional string method parameter is used to pass the actual property name.
+<1> An additional string method parameter is used to pass the actual property name.
 
 It's also possible to match the name against a regular expression specified in `matchRegex()`.
 
@@ -2224,7 +2224,7 @@ static String itemProperty(Item item, String name) { <1>
    // the value of the "name" argument is "foo" or "bar"
 }
 ----
-<1> A additional string method parameter is used to pass the actual property name.
+<1> An additional string method parameter is used to pass the actual property name.
 
 Finally, `matchNames()` can be used to specify a collection of matching names.
 An additional string method parameter is mandatory as well.
@@ -2832,7 +2832,7 @@ In the development mode, all files located in `src/main/resources/templates` are
 By default, a template modification results in an application restart that also triggers build-time validations.
 
 However, it's possible to use the `quarkus.qute.dev-mode.no-restart-templates` configuration property to specify the templates for which the application is not restarted.
-The configration value is a regular expression that matches the template path relative from the `templates` directory and `/` is used as a path separator.
+The configuration value is a regular expression that matches the template path relative from the `templates` directory and `/` is used as a path separator.
 For example, `quarkus.qute.dev-mode.no-restart-templates=templates/foo.html` matches the template `src/main/resources/templates/foo.html`.
 The matching templates are reloaded and only runtime validations are performed.
 
@@ -2938,7 +2938,7 @@ However, the `io.quarkus.qute.i18n.MessageBundle#locale()` can be used to specif
 Additionally, there are two ways to define a localized bundle:
 
 1. Create an interface that extends the default interface that is annotated with `@Localized`
-2. Create an UTF-8 encoded file located in the `src/main/resources/messages` directory of an application archive; e.g. `msg_de.properties`.
+2. Create a UTF-8 encoded file located in the `src/main/resources/messages` directory of an application archive; e.g. `msg_de.properties`.
 
 TIP: While a localized interface enables easy refactoring, an external file might be more convenient in many situations.
 

--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -382,11 +382,11 @@ class Jobs {
 
 In some cases, it might be useful to choose a scheduler implementation used to execute a scheduled method.
 However, only one `Scheduler` implementation is used for all scheduled methods by default.
-For example, the `quarkus-quartz` extension provides an implementation that supports clustering but it also removes the simple in-memory implementation from the game.
+For example, the `quarkus-quartz` extension provides an implementation that supports clustering, but it also removes the simple in-memory implementation from the game.
 Now, if clustering is enabled then it's not possible to define a scheduled method that would be executed locally on a single node.
 Nevertheless, if you set the `quarkus.scheduler.use-composite-scheduler` config property to `true` then a composite `Scheduler` is used instead.
 This means that multiple scheduler implementations are kept running side by side.
-Furthermore, it's possible to chose a specific implementation used to execute a scheduled method using `@Scheduled#executeWith()`.
+Furthermore, it's possible to choose a specific implementation used to execute a scheduled method using `@Scheduled#executeWith()`.
 
 [source,java]
 ----


### PR DESCRIPTION
Just another handful of corrections for typos, grammar issues, missing commas etc. in the docs.

I found this mixing of the constant `TemplateExtension#ANY` with its value `*` in the current [Qute doc](https://quarkus.io/guides/qute-reference#matching-by-name) highly misleading (at first I thought it's a syntax issue), so I tried to improve that part, too.