### PR TITLE
Make URL inherit TestHTTPEndpoint from class level

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestHTTPResourceClassTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestHTTPResourceClassTestCase.java
@@ -1,0 +1,57 @@
+package io.quarkus.it.main;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.rest.GreetingEndpoint;
+import io.quarkus.it.rest.TestResource;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@TestHTTPEndpoint(TestResource.class)
+public class TestHTTPResourceClassTestCase {
+
+    URL testRootEndpoint;
+
+    @TestHTTPResource("int/10")
+    URL testPathEndpoint;
+
+    @TestHTTPEndpoint(GreetingEndpoint.class)
+    URL externalGreetingEndpoint;
+
+    @TestHTTPEndpoint(GreetingEndpoint.class)
+    @TestHTTPResource("name")
+    URL externalGreetingNameEndpoint;
+
+    @Test
+    public void shouldConfigURLWithTestHTTPEndpointOnClass() {
+        given()
+                .when().get(testRootEndpoint).then()
+                .body(is("TEST"));
+    }
+
+    @Test
+    public void shouldConfigURLWithTestHTTPEndpointOnClassAndTestHTTPResourceOnField() {
+        given()
+                .when().get(testPathEndpoint).then()
+                .body(is("11"));
+    }
+
+    @Test
+    public void shouldConfigURLAndOverrideTestHTTPEndpointOnClass() {
+        given()
+                .when().get(externalGreetingEndpoint.toString() + "/anotherName").then()
+                .body(is("Hello anotherName"));
+
+        given()
+                .when().get(externalGreetingNameEndpoint).then()
+                .body(is("Hello name"));
+    }
+
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestHTTPResourceFieldTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestHTTPResourceFieldTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.main;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.rest.TestResource;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class TestHTTPResourceFieldTestCase {
+
+    @TestHTTPEndpoint(TestResource.class)
+    URL testRootEndpoint;
+
+    @TestHTTPEndpoint(TestResource.class)
+    @TestHTTPResource("int/10")
+    URL testPathEndpoint;
+
+    @Test
+    public void shouldConfigURLWithTestHTTPEndpointOnField() {
+        given()
+                .when().get(testRootEndpoint).then()
+                .body(is("TEST"));
+    }
+
+    @Test
+    public void shouldConfigURLWithTestHTTPEndpointAndTestHTTPResourceOnField() {
+        given()
+                .when().get(testPathEndpoint).then()
+                .body(is("11"));
+    }
+
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPResourceManager.java
@@ -19,8 +19,8 @@ public class TestHTTPResourceManager {
         try {
             return ConfigProvider.getConfig().getValue("test.url", String.class);
         } catch (IllegalStateException e) {
-            //massive hack for dev mode tests, dev mode has not started yet
-            //so we don't have any way to load this correctly from config
+            // massive hack for dev mode tests, dev mode has not started yet
+            // so we don't have any way to load this correctly from config
             return "http://localhost:8080";
         }
     }
@@ -29,8 +29,8 @@ public class TestHTTPResourceManager {
         try {
             return ConfigProvider.getConfig().getValue("test.management.url", String.class);
         } catch (IllegalStateException e) {
-            //massive hack for dev mode tests, dev mode has not started yet
-            //so we don't have any way to load this correctly from config
+            // massive hack for dev mode tests, dev mode has not started yet
+            // so we don't have any way to load this correctly from config
             return "http://localhost:9000";
         }
     }
@@ -59,30 +59,23 @@ public class TestHTTPResourceManager {
         Map<Class<?>, TestHTTPResourceProvider<?>> providers = getProviders();
         Class<?> c = testCase.getClass();
         while (c != Object.class) {
+            TestHTTPEndpoint classEndpointAnnotation = c.getAnnotation(TestHTTPEndpoint.class);
             for (Field f : c.getDeclaredFields()) {
                 TestHTTPResource resource = f.getAnnotation(TestHTTPResource.class);
-                if (resource != null) {
+                TestHTTPEndpoint fieldEndpointAnnotation = f.getAnnotation(TestHTTPEndpoint.class);
+                if (resource != null || classEndpointAnnotation != null || fieldEndpointAnnotation != null) {
                     TestHTTPResourceProvider<?> provider = providers.get(f.getType());
                     if (provider == null) {
                         throw new RuntimeException(
                                 "Unable to inject TestHTTPResource field " + f + " as no provider exists for the type");
                     }
-                    String path = resource.value();
+                    String path = resource != null ? resource.value() : "";
                     String endpointPath = null;
-                    boolean management = resource.management();
-                    TestHTTPEndpoint endpointAnnotation = f.getAnnotation(TestHTTPEndpoint.class);
-                    if (endpointAnnotation != null) {
-                        for (Function<Class<?>, String> func : endpointProviders) {
-                            endpointPath = func.apply(endpointAnnotation.value());
-                            if (endpointPath != null) {
-                                break;
-                            }
-                        }
-                        if (endpointPath == null) {
-                            throw new RuntimeException(
-                                    "Could not determine the endpoint path for " + endpointAnnotation.value() + " to inject "
-                                            + f);
-                        }
+                    boolean management = resource != null && resource.management();
+                    if (fieldEndpointAnnotation != null) {
+                        endpointPath = getEndpointPath(endpointProviders, f, fieldEndpointAnnotation);
+                    } else if (classEndpointAnnotation != null) {
+                        endpointPath = getEndpointPath(endpointProviders, f, classEndpointAnnotation);
                     }
                     if (!path.isEmpty() && endpointPath != null) {
                         if (!endpointPath.endsWith("/")) {
@@ -94,7 +87,7 @@ public class TestHTTPResourceManager {
                         path = endpointPath;
                     }
                     String val;
-                    if (resource.ssl() || resource.tls()) {
+                    if (resource != null && (resource.ssl() || resource.tls())) {
                         if (management) {
                             if (path.startsWith("/")) {
                                 val = getManagementSslUri() + path;
@@ -143,4 +136,18 @@ public class TestHTTPResourceManager {
         }
         return Collections.unmodifiableMap(map);
     }
+
+    private static String getEndpointPath(List<Function<Class<?>, String>> endpointProviders, Field field,
+            TestHTTPEndpoint endpointAnnotation) {
+        for (Function<Class<?>, String> func : endpointProviders) {
+            String endpointPath = func.apply(endpointAnnotation.value());
+            if (endpointPath != null) {
+                return endpointPath;
+            }
+        }
+        throw new RuntimeException(
+                "Could not determine the endpoint path for " + endpointAnnotation.value()
+                        + " to inject " + field);
+    }
+
 }


### PR DESCRIPTION
Closes #34935 
Continuation of #35095

### Functionality:

If a Test Class is annotated with `@TestHTTPEndpoint` then all URL fields inherit it's configuration.
If URL is also annotated, URL's annotation takes precedence.

### Local tests (Windows):

- `./mvnw "-Dquickly"` passed successfully.
- `./mvnw test -f integration-tests/main/` passed successfully
- `Quarkus CI` GitHub action, on local repo, passed successfully (https://github.com/gian1200/quarkus/actions/runs/13360530930)

### Additional notes:

I couldn't find the tests for original functionality, so I included both (new and original). 
I reused some resources/endpoints. Not sure if that's acceptable/expected or not (hopefully it doesn't make other tests fail)
