### PR TITLE
introduce `AvoidStarImport` rule via `maven-checkstyle-plugin`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = false
+max_line_length = 128
+[*.java]
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_class_count_to_use_import_on_demand = 999

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="AvoidStarImport"/>
+<!--        <module name="ImportOrder"/>-->
+    </module>
+<!--    <module name="LineLength">-->
+<!--        <property name="fileExtensions" value="java"/>-->
+<!--        <property name="max" value="128"/>-->
+<!--    </module>-->
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -177,8 +177,29 @@
                         <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.6.0</version>
+                    <configuration>
+                        <configLocation>checkstyle.xml</configLocation>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
         <extensions>
             <extension>
                 <groupId>io.quarkus.bot</groupId>


### PR DESCRIPTION
prerequisite: https://github.com/quarkusio/quarkus/pull/46149

resolve: https://github.com/quarkusio/quarkus/issues/45898

apply: https://checkstyle.sourceforge.io/checks/imports/avoidstarimport.html#Example1-config


This change would address the issue of wildcard imports and reduce the effort for new developers, as well as for those (like myself) who need to reference the documentation before committing. It would help reduce noise and friction, making things work out of the box and more self-explanatory.

@rhusar @gastaldi