### PR TITLE
Move JAX-RS security configuration to build-time as we don't use it during the runtime

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/JaxRsSecurityConfig.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/JaxRsSecurityConfig.java
@@ -1,30 +1,31 @@
-package io.quarkus.resteasy.reactive.common.runtime;
+package io.quarkus.resteasy.deployment;
 
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
-import io.smallrye.config.WithName;
 
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+@ConfigRoot
 @ConfigMapping(prefix = "quarkus.security.jaxrs")
 public interface JaxRsSecurityConfig {
     /**
      * if set to true, access to all JAX-RS resources will be denied by default
      */
-    @WithName("deny-unannotated-endpoints")
     @WithDefault("false")
-    boolean denyJaxRs();
+    boolean denyUnannotatedEndpoints();
 
     /**
      * If no security annotations are affecting a method then they will default to requiring these roles,
      * (equivalent to adding an @RolesAllowed annotation with the roles to every endpoint class).
      *
-     * The role of '**' means any authenticated user, which is equivalent to the {@code io.quarkus.security.Authenticated}
+     * The role of '**' means any authenticated user, which is equivalent to the {@link io.quarkus.security.Authenticated}
      * annotation.
      */
     Optional<List<String>> defaultRolesAllowed();
+
 }

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
@@ -23,7 +23,6 @@ import io.quarkus.resteasy.runtime.CompositeExceptionMapper;
 import io.quarkus.resteasy.runtime.EagerSecurityFilter;
 import io.quarkus.resteasy.runtime.ForbiddenExceptionMapper;
 import io.quarkus.resteasy.runtime.JaxRsPermissionChecker;
-import io.quarkus.resteasy.runtime.JaxRsSecurityConfig;
 import io.quarkus.resteasy.runtime.SecurityContextFilter;
 import io.quarkus.resteasy.runtime.StandardSecurityCheckInterceptor;
 import io.quarkus.resteasy.runtime.UnauthorizedExceptionMapper;

--- a/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/JaxRsSecurityConfig.java
+++ b/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/JaxRsSecurityConfig.java
@@ -1,32 +1,29 @@
-package io.quarkus.resteasy.runtime;
+package io.quarkus.resteasy.reactive.common.deployment;
 
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
-/**
- * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
- */
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot
 @ConfigMapping(prefix = "quarkus.security.jaxrs")
 public interface JaxRsSecurityConfig {
     /**
      * if set to true, access to all JAX-RS resources will be denied by default
      */
+    @WithName("deny-unannotated-endpoints")
     @WithDefault("false")
-    boolean denyUnannotatedEndpoints();
+    boolean denyJaxRs();
 
     /**
      * If no security annotations are affecting a method then they will default to requiring these roles,
      * (equivalent to adding an @RolesAllowed annotation with the roles to every endpoint class).
      *
-     * The role of '**' means any authenticated user, which is equivalent to the {@link io.quarkus.security.Authenticated}
+     * The role of '**' means any authenticated user, which is equivalent to the {@code io.quarkus.security.Authenticated}
      * annotation.
      */
     Optional<List<String>> defaultRolesAllowed();
-
 }

--- a/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
+++ b/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
@@ -57,7 +57,6 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.maven.dependency.ResolvedDependency;
-import io.quarkus.resteasy.reactive.common.runtime.JaxRsSecurityConfig;
 import io.quarkus.resteasy.reactive.common.runtime.ResteasyReactiveConfig;
 import io.quarkus.resteasy.reactive.spi.AbstractInterceptorBuildItem;
 import io.quarkus.resteasy.reactive.spi.AdditionalResourceClassBuildItem;

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -163,6 +163,7 @@ import io.quarkus.netty.deployment.MinNettyAllocatorMaxOrderBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.AggregatedParameterContainersBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.ApplicationResultBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.FactoryUtils;
+import io.quarkus.resteasy.reactive.common.deployment.JaxRsSecurityConfig;
 import io.quarkus.resteasy.reactive.common.deployment.ParameterContainersBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.QuarkusFactoryCreator;
 import io.quarkus.resteasy.reactive.common.deployment.QuarkusResteasyReactiveDotNames;
@@ -170,7 +171,6 @@ import io.quarkus.resteasy.reactive.common.deployment.ResourceInterceptorsBuildI
 import io.quarkus.resteasy.reactive.common.deployment.ResourceScanningResultBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.SerializersUtil;
 import io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem;
-import io.quarkus.resteasy.reactive.common.runtime.JaxRsSecurityConfig;
 import io.quarkus.resteasy.reactive.common.runtime.ResteasyReactiveConfig;
 import io.quarkus.resteasy.reactive.server.EndpointDisabled;
 import io.quarkus.resteasy.reactive.server.runtime.QuarkusServerFileBodyHandler;


### PR DESCRIPTION
I think we are the only consumer of this configuration (because it doesn't make too much of a sense for anyone else) and runtime is too late to do anything about default security as we need to detect this during the build-time. So let's avoid having extra `@ConfigMapping`s during the runtime.