### PR TITLE
Introduce support for JEP 483's new AOT cache

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -202,6 +202,13 @@ public interface PackageConfig {
              */
             @WithDefault("true")
             boolean useContainer();
+
+            /**
+             * Whether to use <a href="https://openjdk.org/jeps/483">Ahead-of-Time Class Loading & Linking</a> introduced in JDK
+             * 24.
+             */
+            @WithDefault("false")
+            boolean useAot();
         }
 
         /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AppCDSRequestedBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AppCDSRequestedBuildItem.java
@@ -13,13 +13,23 @@ public final class AppCDSRequestedBuildItem extends SimpleBuildItem {
     /**
      * Directory where various files needed for AppCDS generation will reside
      */
-    private final Path appCDSDir;
+    private final Path dir;
+    private final JvmStartupOptimizerArchiveType type;
 
-    public AppCDSRequestedBuildItem(Path appCDSDir) {
-        this.appCDSDir = appCDSDir;
+    public AppCDSRequestedBuildItem(Path dir) {
+        this(dir, JvmStartupOptimizerArchiveType.AppCDS);
+    }
+
+    public AppCDSRequestedBuildItem(Path dir, JvmStartupOptimizerArchiveType type) {
+        this.dir = dir;
+        this.type = type;
     }
 
     public Path getAppCDSDir() {
-        return appCDSDir;
+        return dir;
+    }
+
+    public JvmStartupOptimizerArchiveType getType() {
+        return type;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AppCDSResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AppCDSResultBuildItem.java
@@ -13,12 +13,25 @@ public final class AppCDSResultBuildItem extends SimpleBuildItem {
      * The file containing the generated AppCDS
      */
     private final Path appCDS;
+    /**
+     * The type of file generated
+     */
+    private final JvmStartupOptimizerArchiveType type;
 
     public AppCDSResultBuildItem(Path appCDS) {
+        this(appCDS, JvmStartupOptimizerArchiveType.AppCDS);
+    }
+
+    public AppCDSResultBuildItem(Path appCDS, JvmStartupOptimizerArchiveType type) {
         this.appCDS = appCDS;
+        this.type = type;
     }
 
     public Path getAppCDS() {
         return appCDS;
+    }
+
+    public JvmStartupOptimizerArchiveType getType() {
+        return type;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JvmStartupOptimizerArchiveType.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/JvmStartupOptimizerArchiveType.java
@@ -1,0 +1,19 @@
+package io.quarkus.deployment.pkg.builditem;
+
+/**
+ * Represents the type of JVM startup archive to be produced
+ */
+public enum JvmStartupOptimizerArchiveType {
+    AppCDS("-XX:SharedArchiveFile"),
+    AOT("-XX:AOTCache");
+
+    private final String jvmFlag;
+
+    JvmStartupOptimizerArchiveType(String jvmFlag) {
+        this.jvmFlag = jvmFlag;
+    }
+
+    public String getJvmFlag() {
+        return jvmFlag;
+    }
+}

--- a/docs/src/main/asciidoc/appcds.adoc
+++ b/docs/src/main/asciidoc/appcds.adoc
@@ -95,6 +95,28 @@ As a result, users are expected to get a slightly more effective archive if they
 AppCDS has improved significantly in the latest JDK releases. This means that to ensure the best possible improvements from it, make sure your projects targets the highest possible Java version (ideally 17 or 21).
 ====
 
+[TIP]
+====
+Starting with JDK 24, the JVM provides an evolution of the class-data sharing in the form of the AOT cache.
+If you are building an application that will target JDK 24+ you can take advantage of this feature by adding the following system property when packaging your application:
+
+[source,bash]
+----
+-Dquarkus.package.jar.appcds.use-aot=true
+----
+
+The result of this flag (plus the `-Dquarkus.package.jar.appcds.use-aot=true` original one) is the creation of an AOT cache file
+named `app.aot`.
+
+You can use this AOT cache when launching the application like so:
+
+[source,bash]
+----
+cd target/quarkus-app
+java -XX:AOTCache=app.aot -jar quarkus-run.jar
+----
+====
+
 === Usage in containers
 
 When building container images using the `quarkus-container-image-jib` extension, Quarkus automatically takes care of all the steps needed to generate the archive and make it usable at runtime in the container.

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -680,20 +680,22 @@ public class JibProcessor {
     }
 
     private List<String> determineEffectiveJvmArguments(ContainerImageJibConfig jibConfig,
-            Optional<AppCDSResultBuildItem> appCDSResult,
+            Optional<AppCDSResultBuildItem> maybeAppCDSResult,
             boolean isMutableJar) {
         List<String> effectiveJvmArguments = new ArrayList<>(jibConfig.jvmArguments());
         jibConfig.jvmAdditionalArguments().ifPresent(effectiveJvmArguments::addAll);
-        if (appCDSResult.isPresent()) {
+        if (maybeAppCDSResult.isPresent()) {
+            AppCDSResultBuildItem appCDSResult = maybeAppCDSResult.get();
             boolean containsAppCDSOptions = false;
             for (String effectiveJvmArgument : effectiveJvmArguments) {
-                if (effectiveJvmArgument.startsWith("-XX:SharedArchiveFile")) {
+                if (effectiveJvmArgument.startsWith(appCDSResult.getType().getJvmFlag())) {
                     containsAppCDSOptions = true;
                     break;
                 }
             }
             if (!containsAppCDSOptions) {
-                effectiveJvmArguments.add("-XX:SharedArchiveFile=" + appCDSResult.get().getAppCDS().getFileName().toString());
+                effectiveJvmArguments
+                        .add(appCDSResult.getType().getJvmFlag() + "=" + appCDSResult.getAppCDS().getFileName().toString());
             }
         }
         if (isMutableJar) {


### PR DESCRIPTION
This works in much the same way as AppCDS does -
it allows us to create an archive at build time
without the training run.
This is done by launching the application up to
a known point where no connections are made,
therefore capturing a good portion of the classes
that will be needed for the entire startup without
the hassle of introducing a proper training run.

This obviously only work on JDK 24+