### PR TITLE
Fix config converter loading issue when arrays are used

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
@@ -25,7 +25,7 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
     protected static <T> void withConverter(SmallRyeConfigBuilder builder, String type, int priority, Converter<T> converter) {
         try {
             // To support converters that are not public
-            builder.withConverter((Class<T>) builder.getClassLoader().loadClass(type), priority, converter);
+            builder.withConverter((Class<T>) Class.forName(type, false, builder.getClassLoader()), priority, converter);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/ByteArrayConverterTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/ByteArrayConverterTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ByteArrayConverterTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("someapp.bytearray", "XyZ*123");
+
+    @ConfigProperty(name = "someapp.bytearray")
+    protected byte[] bytearray;
+
+    @Test
+    void buildTimeConfigBuilder() {
+        assertEquals("XyZ*123", new String(bytearray, StandardCharsets.UTF_8));
+    }
+}

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/ByteArrayConfigConverter.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/ByteArrayConfigConverter.java
@@ -1,0 +1,13 @@
+package io.quarkus.extest.runtime.config;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+public class ByteArrayConfigConverter implements Converter<byte[]> {
+
+    @Override
+    public byte[] convert(final String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/integration-tests/test-extension/extension/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
+++ b/integration-tests/test-extension/extension/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
@@ -1,0 +1,1 @@
+io.quarkus.extest.runtime.config.ByteArrayConfigConverter


### PR DESCRIPTION
We essentially use `Class.forName` to load the class instead of the ClassLoader directly, as the former knows how to deal with arrays

- Fixes: #46170