### PR TITLE
Context propagation for Messaging (take 2)

### DIFF
--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -317,6 +317,7 @@ If you also need to customize your instance, you can do so using `@ManagedExecut
     ThreadContext sameContext;
 ----
 
+[[context-propagation-for-cdi]]
 == Context Propagation for CDI
 
 In terms of CDI, `@RequestScoped`, `@ApplicationScoped` and `@Singleton` beans get propagated and are available in other threads.

--- a/docs/src/main/asciidoc/messaging.adoc
+++ b/docs/src/main/asciidoc/messaging.adoc
@@ -179,8 +179,9 @@ For more control, using link:{mutiny}[Mutiny] APIs, you can use the `MutinyEmitt
 [source, java]
 ----
 import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+
 import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.MutinyEmitter;
 
 @ApplicationScoped
 @Path("/")
@@ -316,6 +317,7 @@ Some messaging technologies allow consumers to subscribe to a set of topics or q
 If you are sure you need to configure and create clients dynamically at runtime, you should consider using the low-level clients directly.
 ====
 
+[[internal-channels]]
 ==== Internal Channels
 
 In some use cases, it is convenient to use messaging patterns to transfer messages inside the same application.
@@ -562,6 +564,7 @@ public class StreamProcessor {
 }
 ----
 
+[[execution_model]]
 == Execution Model
 
 Quarkus Messaging sits on top of the xref:quarkus-reactive-architecture.adoc#engine[reactive engine] of Quarkus and leverages link:{eclipse-vertx}[Eclipse Vert.x] to dispatch messages for processing.
@@ -633,6 +636,163 @@ This creates four copies of the incoming channel under the hood, wiring them to 
 Depending on the broker technology, this can be useful to increase the application's throughput by processing multiple messages concurrently
 while still preserving the partial order of messages received in different copies.
 This is the case, for example, for Kafka, where multiple consumers can consume different topic partitions.
+
+== Context Propagation
+
+In Quarkus Messaging, the default mechanism for propagating context between different processing stages is the
+link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/message-context[message context].
+This provides a consistent way to pass context information along with the message as it flows through different stages.
+
+When integrating with other extensions, notably using Emitters, it relies on the Mutiny context propagation:
+
+=== Interaction with Mutiny and MicroProfile Context Propagation
+
+Mutiny, which is the foundation of reactive programming in Quarkus, is integrated with the MicroProfile Context Propagation.
+This integration enables automatic capturing and restoring of context across asynchronous boundaries.
+To learn more about context propagation in Quarkus and Mutiny, refer to the xref:context-propagation.adoc[Context Propagation] guide.
+
+To ensure consistent behavior, Quarkus Messaging disables the propagation of any context during message dispatching through inbound or outbound connectors.
+This means that context captured through Emitters won't be propagated to the outgoing channel, and incoming channels won't dispatch messages by activating a context (e.g. the request context).
+This behaviour can be configured using `quarkus.messaging.connector-context-propagation` configuration property, by listing the context types to propagate.
+For example `quarkus.messaging.connector-context-propagation=CDI` will only propagate the CDI context.
+
+<<internal-channels>> however do propagate the context, as they are part of the same application and the context is not lost.
+
+For example, you might want to propagate the caller context from an incoming HTTP request to the message processing stage.
+For emitters, it is recommended to use the `MutinyEmitter`, as it exposes methods such as `sendAndAwait` that makes sure to wait until a message processing is terminated.
+
+[WARNING]
+====
+The execution context to which the RequestScoped context is bound, in the previous example the REST call, controls the lifecycle of the context.
+This means that when the REST call is completed the RequestScoped context is destroyed.
+Therefore, you need to make sure that your processing or message dispatch is completed before the REST call completes.
+
+For more information check the xref:context-propagation.adoc#context-propagation-for-cdi[Context Propagation] guide.
+====
+
+For example, let `RequestScopedBean` a request-scoped bean, `MutinyEmitter` can be used to dispatch messages locally through the internal channel `app`:
+
+[source, java]
+----
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+
+import io.quarkus.logging.Log;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/")
+public class Resource {
+
+    @Channel("app")
+    MutinyEmitter<String> emitter;
+
+    @Inject
+    RequestScopedBean requestScopedBean;
+
+    @POST
+    @Path("/send")
+    public void send(String message) {
+        requestScopedBean.setValue("Hello");
+        emitter.sendAndAwait(message);
+    }
+
+}
+----
+
+Then the request-scoped bean can be accessed in the message processing stage, regardless of the <<execution_model>>:
+
+[source, java]
+----
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.quarkus.logging.Log;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+
+
+@ApplicationScoped
+public class Processor {
+
+    @Inject
+    RequestScopedBean requestScopedBean;
+
+    @Incoming("app")
+    @Blocking
+    public void process(String message) {
+        Log.infof("Message %s from request %s", message, requestScopedBean.getValue());
+    }
+
+}
+----
+
+[TIP]
+====
+You can use the context propagation annotation `@CurrentThreadContext` to configure the contexts that will be propagated from an _emitter_ method.
+The annotation configures the contexts that will be captured and propagated from that method,
+and needs to be present on the propagator method, i.e. the caller of the emitter, not the processing method.
+
+Because Quarkus Messaging dispatches messages on link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/message-context[message context],
+propagation plans with cleared or not propagated contexts can lead to race conditions using emitters in <<internal-channels,internal channels>>.
+It is recommended to use `ContextualEmitter` to ensure the context propagation plan is applied correctly.
+
+The following example shows how to avoid propagating any context to the message processing stage:
+
+[source, java]
+----
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.quarkus.logging.Log;
+import io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitter;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/")
+public class Resource {
+
+    @Channel("app")
+    ContextualEmitter<String> emitter;
+
+    @Inject
+    RequestScopedBean requestScopedBean;
+
+    @POST
+    @Path("/send")
+    @CurrentThreadContext(propagated = {})
+    public void send(String message) {
+        requestScopedBean.setValue("Hello");
+        emitter.sendAndAwait(message);
+    }
+
+}
+----
+
+====
+
+=== Request Context Activation
+
+In some cases, you might need to activate the request context while processing messages consumed from a broker.
+While using `@ActivateRequestContext` on the `@Incoming` method is an option, its lifecycle does not follow that of a Quarkus Messaging message.
+For incoming channels, you can enable the request scope activation with the build time property `quarkus.messaging.request-scoped.enabled=true`.
+This will activate the request context for each message processed by incoming channels, and close the context once the message is processed.
 
 == Health Checks
 
@@ -868,8 +1028,38 @@ The `quarkus-test-vertx` dependency provides the `@io.quarkus.test.vertx.RunOnVe
 
 If your tests are dependent on context propagation, you can configure the in-memory connector channels with `run-on-vertx-context` attribute to dispatch events, including messages and acknowledgements, on a Vert.x context.
 Alternatively you can switch this behaviour using the `InMemorySource#runOnVertxContext` method.
-
 ====
+
+=== Channel Decorators
+
+https://smallrye.io/smallrye-reactive-messaging/latest/concepts/decorators/[Channel decorators] is a way to intercept and decorate the reactive streams corresponding to messaging channels.
+This can be useful for adding custom behavior to the channels, such as logging, metrics, or error handling.
+
+It is therefore possible to implement a bean implementing `PublisherDecorator` for incoming channels, and `SubscriberDecorator` for outgoing channels.
+Since two APIs are symmetric, you can implement both interfaces in the same bean.
+These beans are automatically discovered by Quarkus and applied by priority (from the least value to the greatest).
+
+Some decorators are included by default by Quarkus extensions.
+
+Incoming channels (PublisherDecorator) in the order of priority:
+
+- `io.quarkus.smallrye.reactivemessaging.runtime.ConnectorContextPropagationDecorator` (-100): Clears the context propagation for incoming channels
+- `io.smallrye.reactive.messaging.providers.locals.ContextDecorator` (0): Ensures messages are dispatched on the message context
+- `io.quarkus.smallrye.reactivemessaging.runtime.RequestScopedDecorator` (100): Handles pausable channels
+- `io.smallrye.reactive.messaging.providers.IncomingInterceptorDecorator` (500): Handles `IncomingInterceptor` beans
+- `io.smallrye.reactive.messaging.providers.metrics.MetricDecorator` (1000): MicroProfile Metrics support, enabled with `quarkus-smallrye-metrics` extension
+- `io.smallrye.reactive.messaging.providers.metrics.MicrometerDecorator` (1000): Micrometer Metrics support, enabled with `quarkus-micrometer` extension
+- `io.smallrye.reactive.messaging.providers.extension.ObservationDecorator` (1000): Message observation support for incoming channels
+- `io.smallrye.reactive.messaging.providers.extension.PausableChannelDecorator` (1000): Handles pausable channels
+- `io.quarkus.opentelemetry.runtime.tracing.intrumentation.reactivemessaging.ReactiveMessagingTracingIncomingDecorator` (1000): Included with `quarkus-opentelemetry` extension, propagates tracing information
+
+Outgoing channels (SubscriberDecorator):
+
+- `io.quarkus.smallrye.reactivemessaging.runtime.ConnectorContextPropagationDecorator` (-100): Clears the context propagation for outgoing channels
+- `io.smallrye.reactive.messaging.providers.extension.OutgoingObservationDecorator` (1000): Message observation support for outgoing channels
+- `io.smallrye.reactive.messaging.providers.extension.PausableChannelDecorator` (1000): Handles pausable channels
+- `io.quarkus.opentelemetry.runtime.tracing.intrumentation.reactivemessaging.ReactiveMessagingTracingOutgoingDecorator` (1000): Included with `quarkus-opentelemetry` extension, propagates tracing information
+- `io.smallrye.reactive.messaging.providers.OutgoingInterceptorDecorator` (2000): Handles `OutgoingInterceptor` beans
 
 == Going further
 

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DotNames.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DotNames.java
@@ -15,6 +15,7 @@ final class DotNames {
 
     static final DotName EMITTER = DotName.createSimple(org.eclipse.microprofile.reactive.messaging.Emitter.class.getName());
     static final DotName MUTINY_EMITTER = DotName.createSimple(io.smallrye.reactive.messaging.MutinyEmitter.class.getName());
+    static final DotName CONTEXTUAL_EMITTER = DotName.createSimple(io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitter.class.getName());
     static final DotName KAFKA_TRANSACTIONS_EMITTER = DotName.createSimple(io.smallrye.reactive.messaging.kafka.transactions.KafkaTransactions.class.getName());
     static final DotName KAFKA_REQUEST_REPLY_EMITTER = DotName.createSimple(io.smallrye.reactive.messaging.kafka.reply.KafkaRequestReply.class.getName());
 

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -538,7 +538,7 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             return null;
         }
 
-        if (isEmitter(injectionPointType) || isMutinyEmitter(injectionPointType)
+        if (isEmitter(injectionPointType) || isMutinyEmitter(injectionPointType) || isContextualEmitter(injectionPointType)
                 || isKafkaTransactionsEmitter(injectionPointType)) {
             return injectionPointType.asParameterizedType().arguments().get(0);
         } else {
@@ -691,6 +691,13 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
     private static boolean isMutinyEmitter(Type type) {
         // raw type MutinyEmitter is wrong, must be MutinyEmitter<Something>
         return DotNames.MUTINY_EMITTER.equals(type.name())
+                && type.kind() == Type.Kind.PARAMETERIZED_TYPE
+                && type.asParameterizedType().arguments().size() == 1;
+    }
+
+    private static boolean isContextualEmitter(Type type) {
+        // raw type ContextualEmitter is wrong, must be ContextualEmitter<Something>
+        return DotNames.CONTEXTUAL_EMITTER.equals(type.name())
                 && type.kind() == Type.Kind.PARAMETERIZED_TYPE
                 && type.asParameterizedType().arguments().size() == 1;
     }

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/DotNames.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/DotNames.java
@@ -15,6 +15,7 @@ final class DotNames {
 
     static final DotName EMITTER = DotName.createSimple(org.eclipse.microprofile.reactive.messaging.Emitter.class.getName());
     static final DotName MUTINY_EMITTER = DotName.createSimple(io.smallrye.reactive.messaging.MutinyEmitter.class.getName());
+    static final DotName CONTEXTUAL_EMITTER = DotName.createSimple(io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitter.class.getName());
     static final DotName PULSAR_EMITTER = DotName.createSimple(io.smallrye.reactive.messaging.pulsar.transactions.PulsarTransactions.class.getName());
 
     static final DotName TARGETED = DotName.createSimple(io.smallrye.reactive.messaging.Targeted.class.getName());

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarSchemaDiscoveryProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarSchemaDiscoveryProcessor.java
@@ -300,7 +300,8 @@ public class PulsarSchemaDiscoveryProcessor {
             return null;
         }
 
-        if (isEmitter(injectionPointType) || isMutinyEmitter(injectionPointType) || isPulsarEmitter(injectionPointType)) {
+        if (isEmitter(injectionPointType) || isMutinyEmitter(injectionPointType)
+                || isContextualEmitter(injectionPointType) || isPulsarEmitter(injectionPointType)) {
             return injectionPointType.asParameterizedType().arguments().get(0);
         } else {
             return null;
@@ -463,6 +464,13 @@ public class PulsarSchemaDiscoveryProcessor {
     private static boolean isMutinyEmitter(Type type) {
         // raw type MutinyEmitter is wrong, must be MutinyEmitter<Something>
         return DotNames.MUTINY_EMITTER.equals(type.name())
+                && type.kind() == Type.Kind.PARAMETERIZED_TYPE
+                && type.asParameterizedType().arguments().size() == 1;
+    }
+
+    private static boolean isContextualEmitter(Type type) {
+        // raw type MutinyEmitter is wrong, must be MutinyEmitter<Something>
+        return DotNames.CONTEXTUAL_EMITTER.equals(type.name())
                 && type.kind() == Type.Kind.PARAMETERIZED_TYPE
                 && type.asParameterizedType().arguments().size() == 1;
     }

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingBuildTimeConfig.java
@@ -27,4 +27,11 @@ public interface ReactiveMessagingBuildTimeConfig {
     @WithName("auto-connector-attachment")
     @WithDefault("true")
     boolean autoConnectorAttachment();
+
+    /**
+     * Whether to enable the RequestScope context on a message context
+     */
+    @WithName("request-scoped.enabled")
+    @WithDefault("false")
+    boolean activateRequestScopeEnabled();
 }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ConnectorContextPropagationDecorator.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ConnectorContextPropagationDecorator.java
@@ -1,0 +1,45 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.PublisherDecorator;
+import io.smallrye.reactive.messaging.SubscriberDecorator;
+
+@ApplicationScoped
+public class ConnectorContextPropagationDecorator implements PublisherDecorator, SubscriberDecorator {
+
+    private final ThreadContext tc;
+
+    @Inject
+    public ConnectorContextPropagationDecorator(
+            @ConfigProperty(name = "quarkus.messaging.connector-context-propagation") Optional<List<String>> propagation) {
+        tc = ThreadContext.builder()
+                .propagated(propagation.map(l -> l.toArray(String[]::new)).orElse(ThreadContext.NONE))
+                .cleared(ThreadContext.ALL_REMAINING)
+                .build();
+    }
+
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, List<String> channelName,
+            boolean isConnector) {
+        if (isConnector) {
+            return publisher.emitOn(tc.currentContextExecutor());
+        }
+        return publisher;
+    }
+
+    @Override
+    public int getPriority() {
+        // Before the io.smallrye.reactive.messaging.providers.locals.ContextDecorator which has the priority 0
+        return -100;
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitter.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitter.java
@@ -1,0 +1,138 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow;
+
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.reactive.messaging.EmitterType;
+
+/**
+ * Emitter implementation that plays better with context propagation, especially with the request scoped context.
+ * The message emit of this emitter makes sure that
+ * <p>
+ * <ul>
+ * <li>the message context is captured when active thread context plan is applied</li>
+ * <li>the message is emitted only after the context propagation ends the context switch, destroying the intermediate state for
+ * cleared contexts.</li>
+ * </ul>
+ *
+ * @param <T> the payload type
+ */
+public interface ContextualEmitter<T> extends EmitterType {
+
+    /**
+     * Sends a payload to the channel.
+     * <p>
+     * A {@link Message} object will be created to hold the payload and the returned {@code Uni}
+     * can be subscribed to for triggering the send.
+     * When subscribed, a {@code null} item will be passed to the {@code Uni} when the
+     * {@code Message} is acknowledged. If the {@code Message} is never acknowledged, then the {@code Uni} will
+     * never be completed.
+     * <p>
+     * The {@code Message} will not be sent to the channel until the {@code Uni} has been subscribed to:
+     *
+     * <pre>
+     * emitter.send("a").subscribe().with(x -> {
+     * });
+     * </pre>
+     *
+     * @param payload the <em>thing</em> to send, must not be {@code null}
+     * @return the {@code Uni}, that requires subscription to send the {@link Message}.
+     * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
+     *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
+     *         configured and the emitter overflows.
+     */
+    @CheckReturnValue
+    Uni<Void> send(T payload);
+
+    /**
+     * Sends a payload to the channel.
+     * <p>
+     * A {@link Message} object will be created to hold the payload.
+     * <p>
+     * Execution will block waiting for the resulting {@code Message} to be acknowledged before returning.
+     *
+     * @param payload the <em>thing</em> to send, must not be {@code null}
+     * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
+     *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
+     *         configured and the emitter overflows.
+     */
+    void sendAndAwait(T payload);
+
+    /**
+     * Sends a payload to the channel without waiting for acknowledgement.
+     * <p>
+     * A {@link Message} object will be created to hold the payload.
+     *
+     * @param payload the <em>thing</em> to send, must not be {@code null}
+     * @return the {@code Cancellable} from the subscribed {@code Uni}.
+     * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
+     *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
+     *         configured and the emitter overflows.
+     */
+    Cancellable sendAndForget(T payload);
+
+    /**
+     * Sends a message to the channel.
+     *
+     * @param <M> the <em>Message</em> type
+     * @param msg the <em>Message</em> to send, must not be {@code null}
+     * @return the {@code Uni}, that requires subscription to send the {@link Message}.
+     * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
+     *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
+     *         configured and the emitter overflows.
+     */
+    @CheckReturnValue
+    <M extends Message<? extends T>> Uni<Void> sendMessage(M msg);
+
+    /**
+     * Sends a message to the channel.
+     *
+     * Execution will block waiting for the resulting {@code Message} to be acknowledged before returning.
+     *
+     * @param <M> the <em>Message</em> type
+     * @param msg the <em>Message</em> to send, must not be {@code null}
+     * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
+     *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
+     *         configured and the emitter overflows.
+     */
+    <M extends Message<? extends T>> void sendMessageAndAwait(M msg);
+
+    /**
+     * Sends a message to the channel without waiting for acknowledgement.
+     *
+     * @param <M> the <em>Message</em> type
+     * @param msg the <em>Message</em> to send, must not be {@code null}
+     * @return the {@code Cancellable} from the subscribed {@code Uni}.
+     * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
+     *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
+     *         configured and the emitter overflows.
+     */
+    <M extends Message<? extends T>> Cancellable sendMessageAndForget(M msg);
+
+    /**
+     * Sends the completion event to the channel indicating that no other events will be sent afterward.
+     */
+    void complete();
+
+    /**
+     * Sends a failure event to the channel. No more events will be sent afterward.
+     *
+     * @param e the exception, must not be {@code null}
+     */
+    void error(Exception e);
+
+    /**
+     * @return {@code true} if the emitter has been terminated or the subscription cancelled.
+     */
+    boolean isCancelled();
+
+    /**
+     * @return {@code true} if one or more subscribers request messages from the corresponding channel where the emitter
+     *         connects to,
+     *         return {@code false} otherwise.
+     */
+    boolean hasRequests();
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterFactory.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterFactory.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Typed;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.EmitterConfiguration;
+import io.smallrye.reactive.messaging.EmitterFactory;
+import io.smallrye.reactive.messaging.annotations.EmitterFactoryFor;
+import io.smallrye.reactive.messaging.providers.extension.ChannelProducer;
+
+@EmitterFactoryFor(ContextualEmitter.class)
+@ApplicationScoped
+public class ContextualEmitterFactory implements EmitterFactory<ContextualEmitterImpl<Object>> {
+
+    @Inject
+    ChannelRegistry channelRegistry;
+
+    @Override
+    public ContextualEmitterImpl<Object> createEmitter(EmitterConfiguration emitterConfiguration, long l) {
+        return new ContextualEmitterImpl<>(emitterConfiguration, l);
+    }
+
+    @Produces
+    @Typed(ContextualEmitter.class)
+    @Channel("") // Stream name is ignored during type-safe resolution
+    <T> ContextualEmitter<T> produceEmitter(InjectionPoint injectionPoint) {
+        String channelName = ChannelProducer.getChannelName(injectionPoint);
+        return channelRegistry.getEmitter(channelName, ContextualEmitter.class);
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterImpl.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterImpl.java
@@ -1,0 +1,108 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import static io.smallrye.reactive.messaging.providers.i18n.ProviderExceptions.ex;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni;
+import io.smallrye.mutiny.operators.uni.builders.UniCreateWithEmitter;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.subscription.UniEmitter;
+import io.smallrye.reactive.messaging.EmitterConfiguration;
+import io.smallrye.reactive.messaging.providers.extension.AbstractEmitter;
+import io.smallrye.reactive.messaging.providers.i18n.ProviderLogging;
+import io.smallrye.reactive.messaging.providers.locals.ContextAwareMessage;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+public class ContextualEmitterImpl<T> extends AbstractEmitter<T> implements ContextualEmitter<T> {
+
+    public ContextualEmitterImpl(EmitterConfiguration configuration, long defaultBufferSize) {
+        super(configuration, defaultBufferSize);
+    }
+
+    @Override
+    public void sendAndAwait(T payload) {
+        sendMessage(Message.of(payload)).await().indefinitely();
+    }
+
+    @Override
+    public Cancellable sendAndForget(T payload) {
+        return send(payload).subscribe().with(x -> {
+            // Do nothing.
+        }, ProviderLogging.log::failureEmittingMessage);
+    }
+
+    @Override
+    public Uni<Void> send(T payload) {
+        return sendMessage(Message.of(payload));
+    }
+
+    @Override
+    public <M extends Message<? extends T>> void sendMessageAndAwait(M msg) {
+        sendMessage(msg).await().indefinitely();
+    }
+
+    @Override
+    public <M extends Message<? extends T>> Cancellable sendMessageAndForget(M msg) {
+        return sendMessage(msg).subscribe().with(x -> {
+            // Do nothing.
+        }, ProviderLogging.log::failureEmittingMessage);
+    }
+
+    @Override
+    @CheckReturnValue
+    public <M extends Message<? extends T>> Uni<Void> sendMessage(M msg) {
+        if (msg == null) {
+            throw ex.illegalArgumentForNullValue();
+        }
+
+        // If we are running on a Vert.x context, we need to capture the context to switch back
+        // during the emission.
+        Context context = Vertx.currentContext();
+        // context propagation capture and duplicate the context
+        var msgUni = Uni.createFrom().item(() -> ContextAwareMessage.withContextMetadata((Message<? extends T>) msg));
+        if (context != null) {
+            msgUni = msgUni.emitOn(r -> context.runOnContext(x -> r.run()));
+        }
+        // emit the message, skip context propagation as it is unnecessary here
+        Uni<Void> uni = transformToUni(msgUni, message -> ContextualEmitterImpl.emitter(e -> {
+            try {
+                emit(message
+                        .withAck(() -> {
+                            e.complete(null);
+                            return msg.ack();
+                        })
+                        .withNack(t -> {
+                            e.fail(t);
+                            return msg.nack(t);
+                        }));
+            } catch (Exception t) {
+                // Capture synchronous exception and nack the message.
+                msg.nack(t);
+                throw t;
+            }
+        }));
+        // switch back to the caller context
+        if (context != null) {
+            return uni.emitOn(r -> context.runOnContext(x -> r.run()));
+        } else {
+            return uni;
+        }
+    }
+
+    public static <T> Uni<T> emitter(Consumer<UniEmitter<? super T>> emitter) {
+        return Infrastructure.onUniCreation(new UniCreateWithEmitter<>(emitter));
+    }
+
+    public static <T, R> Uni<R> transformToUni(Uni<T> upstream, Function<? super T, Uni<? extends R>> mapper) {
+        return Infrastructure.onUniCreation(new UniOnItemTransformToUni<>(upstream, mapper));
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -25,7 +26,9 @@ import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.providers.helpers.Validation;
 import io.vertx.core.impl.ConcurrentHashSet;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.WorkerExecutor;
 
 @Alternative
@@ -62,42 +65,53 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
         }
     }
 
-    public <T> Uni<T> executeWork(Context currentContext, Uni<T> uni, String workerName, boolean ordered) {
+    public <T> Uni<T> executeWork(Context msgContext, Uni<T> uni, String workerName, boolean ordered) {
         Objects.requireNonNull(uni, "Action to execute not provided");
-
         if (workerName == null) {
-            if (currentContext != null) {
-                return currentContext.executeBlocking(Uni.createFrom().deferred(() -> uni), ordered);
+            if (msgContext != null) {
+                return msgContext.executeBlocking(uni, ordered);
             }
             return executionHolder.vertx().executeBlocking(uni, ordered);
         } else if (virtualThreadWorkers.contains(workerName)) {
-            return runOnVirtualThread(currentContext, uni);
+            return runOnVirtualThread(msgContext, uni);
         } else {
-            if (currentContext != null) {
-                return getWorker(workerName).executeBlocking(uni, ordered)
-                        .onItemOrFailure().transformToUni((item, failure) -> {
-                            return Uni.createFrom().emitter(emitter -> {
-                                if (failure != null) {
-                                    currentContext.runOnContext(() -> emitter.fail(failure));
-                                } else {
-                                    currentContext.runOnContext(() -> emitter.complete(item));
-                                }
-                            });
-                        });
-            }
-            return getWorker(workerName).executeBlocking(uni, ordered);
+            return runOnWorkerThread(msgContext, uni, workerName, ordered);
         }
     }
 
-    private <T> Uni<T> runOnVirtualThread(Context currentContext, Uni<T> uni) {
-        return uni.runSubscriptionOn(VirtualThreadsRecorder.getCurrent())
+    private <T> Uni<T> runOnWorkerThread(Context msgContext, Uni<T> uni, String workerName, boolean ordered) {
+        WorkerExecutor worker = getWorker(workerName);
+        if (msgContext != null) {
+            return worker.executeBlocking(uniOnMessageContext(uni, msgContext), ordered)
+                    .onItemOrFailure().transformToUni((item, failure) -> {
+                        return Uni.createFrom().emitter(emitter -> {
+                            if (failure != null) {
+                                msgContext.runOnContext(() -> emitter.fail(failure));
+                            } else {
+                                msgContext.runOnContext(() -> emitter.complete(item));
+                            }
+                        });
+                    });
+        }
+        return worker.executeBlocking(uni, ordered);
+    }
+
+    private static <T> Uni<T> uniOnMessageContext(Uni<T> uni, Context msgContext) {
+        return msgContext != Vertx.currentContext() ? uni
+                .runSubscriptionOn(r -> new ContextPreservingRunnable(r, msgContext).run())
+                : uni;
+    }
+
+    private <T> Uni<T> runOnVirtualThread(Context msgContext, Uni<T> uni) {
+        ExecutorService vtExecutor = VirtualThreadsRecorder.getCurrent();
+        return uniOnMessageContext(uni, msgContext, vtExecutor)
                 .onItemOrFailure().transformToUni((item, failure) -> {
                     return Uni.createFrom().emitter(emitter -> {
-                        if (currentContext != null) {
+                        if (msgContext != null) {
                             if (failure != null) {
-                                currentContext.runOnContext(() -> emitter.fail(failure));
+                                msgContext.runOnContext(() -> emitter.fail(failure));
                             } else {
-                                currentContext.runOnContext(() -> emitter.complete(item));
+                                msgContext.runOnContext(() -> emitter.complete(item));
                             }
                         } else {
                             // Some method do not have a context (generator methods)
@@ -109,6 +123,38 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
                         }
                     });
                 });
+    }
+
+    private static <T> Uni<T> uniOnMessageContext(Uni<T> uni, Context msgContext, ExecutorService vtExecutor) {
+        return msgContext != Vertx.currentContext()
+                ? uni.runSubscriptionOn(r -> vtExecutor.execute(new ContextPreservingRunnable(r, msgContext)))
+                : uni.runSubscriptionOn(vtExecutor);
+    }
+
+    private static final class ContextPreservingRunnable implements Runnable {
+
+        private final Runnable task;
+        private final io.vertx.core.Context context;
+
+        public ContextPreservingRunnable(Runnable task, Context context) {
+            this.task = task;
+            this.context = context.getDelegate();
+        }
+
+        @Override
+        public void run() {
+            if (context instanceof ContextInternal) {
+                ContextInternal contextInternal = (ContextInternal) context;
+                final var previousContext = contextInternal.beginDispatch();
+                try {
+                    task.run();
+                } finally {
+                    contextInternal.endDispatch(previousContext);
+                }
+            } else {
+                task.run();
+            }
+        }
     }
 
     public WorkerExecutor getWorker(String workerName) {

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingRuntimeConfig.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ReactiveMessagingRuntimeConfig.java
@@ -1,0 +1,20 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.messaging")
+public interface ReactiveMessagingRuntimeConfig {
+
+    /**
+     * Whether to enable the context propagation for connector channels
+     */
+    @WithName("connector-context-propagation")
+    Optional<List<String>> connectorContextPropagation();
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/RequestScopedDecorator.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/RequestScopedDecorator.java
@@ -1,0 +1,55 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.ManagedContext;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.PublisherDecorator;
+import io.smallrye.reactive.messaging.providers.locals.LocalContextMetadata;
+
+@ApplicationScoped
+public class RequestScopedDecorator implements PublisherDecorator {
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, List<String> channelName,
+            boolean isConnector) {
+        if (isConnector) {
+            return publisher.map(message -> {
+                Optional<LocalContextMetadata> localContextMetadata = message.getMetadata(LocalContextMetadata.class);
+                if (localContextMetadata.isPresent() && VertxContext.isOnDuplicatedContext()) {
+                    ManagedContext requestContext = Arc.container().requestContext();
+                    if (!requestContext.isActive()) {
+                        requestContext.activate();
+                        InjectableContext.ContextState state = requestContext.getState();
+                        Message<?> withAck = message.withAckWithMetadata(m -> message.ack(m)
+                                .thenAccept(x -> {
+                                    requestContext.destroy(state);
+                                    requestContext.deactivate();
+                                }));
+                        return withAck.withNackWithMetadata((m, t) -> withAck.nack(m, t)
+                                .thenAccept(x -> {
+                                    requestContext.destroy(state);
+                                    requestContext.deactivate();
+                                }));
+                    }
+                    return message;
+                } else {
+                    return message;
+                }
+            });
+        }
+        return publisher;
+    }
+
+    @Override
+    public int getPriority() {
+        return 100;
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -342,6 +342,7 @@
                 <module>reactive-messaging-rabbitmq-dyn</module>
                 <module>reactive-messaging-hibernate-reactive</module>
                 <module>reactive-messaging-hibernate-orm</module>
+                <module>reactive-messaging-context-propagation</module>
                 <module>rest-client</module>
                 <module>resteasy-reactive-kotlin</module>
                 <module>rest-client-reactive</module>

--- a/integration-tests/reactive-messaging-context-propagation/pom.xml
+++ b/integration-tests/reactive-messaging-context-propagation/pom.xml
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-reactive-messaging-context-propagation</artifactId>
+    <name>Quarkus - Integration Tests - Reactive Messaging - Context Propagation</name>
+    <description>The Reactive Messaging Context Propagation integration tests module</description>
+
+    <properties>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-shared-library</artifactId>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+        </dependency>
+
+        <!-- Health -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+
+        <!-- Micrometer -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+
+        <!-- Kafka -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-kafka</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-kafka-companion</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-client-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-kafka-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-kafka</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerConsumers.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerConsumers.java
@@ -1,0 +1,60 @@
+package io.quarkus.it.kafka;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.quarkus.logging.Log;
+import io.quarkus.test.vertx.VirtualThreadsAssertions;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@ApplicationScoped
+public class FlowerConsumers {
+
+    @Inject
+    RequestBean reqBean;
+
+    @Inject
+    FlowerProducer producer;
+
+    @Incoming("flowers-in")
+    @NonBlocking
+    void receive(String flower) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnEventLoopThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        System.out.println("Received io: " + flower);
+        producer.addReceived(flower);
+    }
+
+    @Incoming("flowers-in")
+    @Blocking
+    void receiveBlocking(String flower) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        System.out.println("Received blocking: " + flower);
+        producer.addReceived(flower);
+    }
+
+    @Incoming("flowers-in")
+    @RunOnVirtualThread
+    void receiveVT(String flower) {
+        Context ctx = Vertx.currentContext();
+        if (Runtime.version().feature() >= 21) {
+            VirtualThreadsAssertions.assertThatItRunsOnVirtualThread();
+            VirtualThreadsAssertions.assertThatItRunsOnADuplicatedContext();
+        }
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        System.out.println("Received vt: " + flower);
+        producer.addReceived(flower);
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerProducer.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerProducer.java
@@ -1,0 +1,53 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.quarkus.logging.Log;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+
+@Path("/flowers")
+public class FlowerProducer {
+
+    List<String> received = new CopyOnWriteArrayList<>();
+
+    @Channel("flowers-out")
+    MutinyEmitter<String> emitter;
+
+    @Inject
+    RequestBean reqBean;
+
+    @POST
+    @Path("/produce")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void produce(String flower) {
+        reqBean.setName(flower);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        emitter.sendAndAwait(flower);
+    }
+
+    void addReceived(String flower) {
+        received.add(flower);
+    }
+
+    public List<String> getReceived() {
+        return received;
+    }
+
+    @GET
+    @Path("/received")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> received() {
+        return received;
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerReceivers.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerReceivers.java
@@ -1,0 +1,79 @@
+package io.quarkus.it.kafka;
+
+import java.util.Objects;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.jboss.logging.Logger;
+
+import io.quarkus.logging.Log;
+import io.quarkus.test.vertx.VirtualThreadsAssertions;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@ApplicationScoped
+public class FlowerReceivers {
+
+    @Inject
+    RequestBean reqBean;
+
+    @Inject
+    Logger logger;
+
+    @Incoming("flower")
+    void process(String id) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnEventLoopThread();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Greeting, %s", reqBean.getName());
+        if (!Objects.equals(id, reqBean.getId())) {
+            throw new IllegalStateException("RequestScoped context not propagated");
+        }
+    }
+
+    @Blocking
+    @Incoming("flower-blocking")
+    void processBlocking(String id) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Greeting, %s", reqBean.getName());
+        if (!Objects.equals(id, reqBean.getId())) {
+            throw new IllegalStateException("RequestScoped context not propagated");
+        }
+    }
+
+    @Blocking("named-pool")
+    @Incoming("flower-blocking-named")
+    void processBlockingNamed(String id) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Greeting, %s", reqBean.getName());
+        if (!Objects.equals(id, reqBean.getId())) {
+            throw new IllegalStateException("RequestScoped context not propagated");
+        }
+    }
+
+    @RunOnVirtualThread
+    @Incoming("flower-virtual-thread")
+    void processVT(String id) {
+        Context ctx = Vertx.currentContext();
+        VirtualThreadsAssertions.assertThatItRunsOnVirtualThread();
+        VirtualThreadsAssertions.assertThatItRunsOnADuplicatedContext();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Greeting, %s", reqBean.getName());
+        if (!Objects.equals(id, reqBean.getId())) {
+            throw new IllegalStateException("RequestScoped context not propagated");
+        }
+    }
+
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerResource.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/FlowerResource.java
@@ -1,0 +1,132 @@
+package io.quarkus.it.kafka;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.quarkus.logging.Log;
+import io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitter;
+import io.smallrye.context.api.CurrentThreadContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/flowers")
+public class FlowerResource {
+
+    @Channel("flower")
+    ContextualEmitter<String> emitter;
+
+    @Channel("flower-blocking")
+    ContextualEmitter<String> emitterBlocking;
+
+    @Channel("flower-blocking-named")
+    ContextualEmitter<String> emitterBlockingNamed;
+
+    @Channel("flower-virtual-thread")
+    ContextualEmitter<String> emitterVT;
+
+    @Inject
+    RequestBean reqBean;
+
+    @POST
+    @Path("/uni")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @CurrentThreadContext(propagated = {})
+    public Uni<Void> uniEventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitter.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/uni/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @CurrentThreadContext(propagated = {})
+    public Uni<Void> uniBlocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterBlocking.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/uni/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @CurrentThreadContext(propagated = {})
+    public Uni<Void> uniBlockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterBlockingNamed.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/uni/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @CurrentThreadContext(propagated = {})
+    public Uni<Void> uniVT(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterVT.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @CurrentThreadContext(propagated = {})
+    public void eventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitter.sendAndAwait(reqBean.getId());
+    }
+
+    @POST
+    @Path("/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @CurrentThreadContext(propagated = {})
+    public void blocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterBlocking.sendAndAwait(reqBean.getId());
+    }
+
+    @POST
+    @Path("/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @CurrentThreadContext(propagated = {})
+    public void blockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterBlockingNamed.sendAndAwait(reqBean.getId());
+    }
+
+    @POST
+    @Path("/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @CurrentThreadContext(propagated = {})
+    public void vt(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx.hashCode() + " " + ctx);
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterVT.sendAndAwait(reqBean.getId());
+    }
+
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/OutgoingInterceptor.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/OutgoingInterceptor.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.kafka;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.quarkus.logging.Log;
+import io.smallrye.common.annotation.Identifier;
+
+@ApplicationScoped
+@Identifier("flowers-out")
+public class OutgoingInterceptor implements io.smallrye.reactive.messaging.OutgoingInterceptor {
+
+    @Inject
+    RequestBean reqBean;
+
+    @Override
+    public Message<?> beforeMessageSend(Message<?> message) {
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        return message;
+    }
+
+    @Override
+    public void onMessageAck(Message<?> message) {
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+    }
+
+    @Override
+    public void onMessageNack(Message<?> message, Throwable failure) {
+
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/RequestBean.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/RequestBean.java
@@ -1,0 +1,34 @@
+package io.quarkus.it.kafka;
+
+import java.util.UUID;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class RequestBean {
+
+    private final String id;
+    private String name;
+
+    public RequestBean() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    @PostConstruct
+    void construct() {
+        System.out.println("ReqBean constructed " + this.id);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/contextual/FlowerContextualResource.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/contextual/FlowerContextualResource.java
@@ -1,0 +1,123 @@
+package io.quarkus.it.kafka.contextual;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.quarkus.it.kafka.RequestBean;
+import io.quarkus.logging.Log;
+import io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitter;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/flowers/contextual")
+public class FlowerContextualResource {
+
+    @Channel("contextual-flower")
+    ContextualEmitter<String> emitter;
+
+    @Channel("contextual-flower-blocking")
+    ContextualEmitter<String> emitterBlocking;
+
+    @Channel("contextual-flower-blocking-named")
+    ContextualEmitter<String> emitterBlockingNamed;
+
+    @Channel("contextual-flower-virtual-thread")
+    ContextualEmitter<String> emitterVT;
+
+    @Inject
+    RequestBean reqBean;
+
+    @POST
+    @Path("/uni")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniEventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitter.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/uni/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniBlocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterBlocking.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/uni/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniBlockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterBlockingNamed.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/uni/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniVT(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterVT.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void eventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitter.sendAndAwait(reqBean.getId());
+    }
+
+    @POST
+    @Path("/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void blocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterBlocking.sendAndAwait(reqBean.getId());
+    }
+
+    @POST
+    @Path("/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void blockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterBlockingNamed.sendAndAwait(reqBean.getId());
+    }
+
+    @POST
+    @Path("/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void vt(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterVT.sendAndAwait(reqBean.getId());
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/contextual/FlowerMutinyResource.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/contextual/FlowerMutinyResource.java
@@ -1,0 +1,123 @@
+package io.quarkus.it.kafka.contextual;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.quarkus.it.kafka.RequestBean;
+import io.quarkus.logging.Log;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/flowers/mutiny")
+public class FlowerMutinyResource {
+
+    @Channel("mutiny-flower")
+    MutinyEmitter<String> emitter;
+
+    @Channel("mutiny-flower-blocking")
+    MutinyEmitter<String> emitterBlocking;
+
+    @Channel("mutiny-flower-blocking-named")
+    MutinyEmitter<String> emitterBlockingNamed;
+
+    @Channel("mutiny-flower-virtual-thread")
+    MutinyEmitter<String> emitterVT;
+
+    @Inject
+    RequestBean reqBean;
+
+    @POST
+    @Path("/uni")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniEventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitter.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/uni/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniBlocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterBlocking.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/uni/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniBlockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterBlockingNamed.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/uni/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Uni<Void> uniVT(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        return emitterVT.send(reqBean.getId());
+    }
+
+    @POST
+    @Path("/")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void eventLoop(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitter.sendAndAwait(reqBean.getId());
+    }
+
+    @POST
+    @Path("/blocking")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void blocking(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterBlocking.sendAndAwait(reqBean.getId());
+    }
+
+    @POST
+    @Path("/blocking-named")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void blockingNamed(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterBlockingNamed.sendAndAwait(reqBean.getId());
+    }
+
+    @POST
+    @Path("/virtual-thread")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void vt(String body) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        reqBean.setName(body != null ? body.toUpperCase() : body);
+        emitterVT.sendAndAwait(reqBean.getId());
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/contextual/FlowersContextualReceivers.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/contextual/FlowersContextualReceivers.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.kafka.contextual;
+
+import java.util.Objects;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.kafka.RequestBean;
+import io.quarkus.logging.Log;
+import io.quarkus.test.vertx.VirtualThreadsAssertions;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@ApplicationScoped
+public class FlowersContextualReceivers {
+
+    @Inject
+    RequestBean reqBean;
+
+    @Inject
+    Logger logger;
+
+    @Incoming("contextual-flower")
+    void processContextual(String id) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+        assert Objects.equals(id, reqBean.getId());
+    }
+
+    @Blocking
+    @Incoming("contextual-flower-blocking")
+    void processContextualBlocking(String id) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+        assert Objects.equals(id, reqBean.getId());
+    }
+
+    @Blocking("named-pool")
+    @Incoming("contextual-flower-blocking-named")
+    void processContextualBlockingNamed(String id) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+        assert Objects.equals(id, reqBean.getId());
+    }
+
+    @RunOnVirtualThread
+    @Incoming("contextual-flower-virtual-thread")
+    void processContextualVT(String id) {
+        Context ctx = Vertx.currentContext();
+        VirtualThreadsAssertions.assertThatItRunsOnVirtualThread();
+        VirtualThreadsAssertions.assertThatItRunsOnADuplicatedContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+        assert Objects.equals(id, reqBean.getId());
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/contextual/FlowersMutinyReceivers.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/java/io/quarkus/it/kafka/contextual/FlowersMutinyReceivers.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.kafka.contextual;
+
+import java.util.Objects;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.jboss.logging.Logger;
+
+import io.quarkus.it.kafka.RequestBean;
+import io.quarkus.logging.Log;
+import io.quarkus.test.vertx.VirtualThreadsAssertions;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@ApplicationScoped
+public class FlowersMutinyReceivers {
+
+    @Inject
+    RequestBean reqBean;
+
+    @Inject
+    Logger logger;
+
+    @Incoming("mutiny-flower")
+    void processContextual(String id) {
+        Context ctx = Vertx.currentContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+        assert Objects.equals(id, reqBean.getId());
+    }
+
+    @Blocking
+    @Incoming("mutiny-flower-blocking")
+    void processContextualBlocking(String id) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+        assert Objects.equals(id, reqBean.getId());
+    }
+
+    @Blocking("named-pool")
+    @Incoming("mutiny-flower-blocking-named")
+    void processContextualBlockingNamed(String id) {
+        Context ctx = Vertx.currentContext();
+        assert Context.isOnWorkerThread();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+        assert Objects.equals(id, reqBean.getId());
+    }
+
+    @RunOnVirtualThread
+    @Incoming("mutiny-flower-virtual-thread")
+    void processContextualVT(String id) {
+        Context ctx = Vertx.currentContext();
+        VirtualThreadsAssertions.assertThatItRunsOnVirtualThread();
+        VirtualThreadsAssertions.assertThatItRunsOnADuplicatedContext();
+        Log.info(ctx + "[" + ctx.getClass() + "]");
+        Log.infof("bean: %s, id: %s", reqBean, reqBean.getId());
+        logger.infof("Hello, %s", reqBean.getName());
+        assert Objects.equals(id, reqBean.getId());
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-context-propagation/src/main/resources/application.properties
@@ -1,0 +1,22 @@
+quarkus.log.category.kafka.level=WARN
+quarkus.log.category.\"org.apache.kafka\".level=WARN
+quarkus.log.category.\"org.apache.zookeeper\".level=WARN
+
+# enable health check
+quarkus.kafka.health.enabled=true
+
+kafka.auto.offset.reset=earliest
+
+quarkus.micrometer.binder.messaging.enabled=true
+smallrye.messaging.observation.enabled=true
+
+
+smallrye.messaging.worker.named-pool.max-concurrency=2
+
+mp.messaging.incoming.flowers-in.topic=flowers
+# Broadcast to 3 different consume methods
+mp.messaging.incoming.flowers-in.broadcast=true
+mp.messaging.outgoing.flowers-out.topic=flowers
+# Uncomment the following line to enable request-scoped messaging, disabled by default:
+#quarkus.messaging.request-scoped.enabled=true
+quarkus.messaging.connector-context-propagation=CDI

--- a/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationIT.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationIT.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.kafka;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class KafkaContextPropagationIT extends KafkaContextPropagationTest {
+
+    @Override
+    protected Matcher<String> assertBodyRequestScopedContextWasNotActive() {
+        return Matchers.not(Matchers.blankOrNullString());
+    }
+}

--- a/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationTest.java
+++ b/integration-tests/reactive-messaging-context-propagation/src/test/java/io/quarkus/it/kafka/KafkaContextPropagationTest.java
@@ -1,0 +1,274 @@
+package io.quarkus.it.kafka;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+
+@QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
+public class KafkaContextPropagationTest {
+
+    @Nested
+    class ContextNotPropagated {
+        @Test
+        void testNonBlocking() {
+            given().body("rose").post("/flowers").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+        }
+
+        @Test
+        void testNonBlockingUni() {
+            given().body("rose").post("/flowers/uni").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/uni").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/uni").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+        }
+
+        @Test
+        void testBlocking() {
+            given().body("rose").post("/flowers/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+        }
+
+        @Test
+        void testBlockingUni() {
+            given().body("rose").post("/flowers/uni/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/uni/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/uni/blocking").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+        }
+
+        @Test
+        void testBlockingNamed() {
+            given().body("rose").post("/flowers/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+        }
+
+        @Test
+        void testBlockingNamedUni() {
+            given().body("rose").post("/flowers/uni/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/uni/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/uni/blocking-named").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+        }
+
+        @Test
+        @EnabledForJreRange(min = JRE.JAVA_21)
+        void testVirtualThread() {
+            given().body("rose").post("/flowers/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+        }
+
+        @Test
+        @EnabledForJreRange(min = JRE.JAVA_21)
+        void testVirtualThreadUni() {
+            given().body("rose").post("/flowers/uni/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("peony").post("/flowers/uni/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+            given().body("daisy").post("/flowers/uni/virtual-thread").then()
+                    .statusCode(500)
+                    .body(assertBodyRequestScopedContextWasNotActive());
+        }
+    }
+
+    @Nested
+    class ContextPropagated {
+        @Test
+        void testNonBlocking() {
+            given().body("rose").post("/flowers/contextual").then().statusCode(204);
+            given().body("peony").post("/flowers/contextual").then().statusCode(204);
+            given().body("daisy").post("/flowers/contextual").then().statusCode(204);
+        }
+
+        @Test
+        void testNonBlockingUni() {
+            given().body("rose").post("/flowers/contextual/uni").then().statusCode(204);
+            given().body("peony").post("/flowers/contextual/uni").then().statusCode(204);
+            given().body("daisy").post("/flowers/contextual/uni").then().statusCode(204);
+        }
+
+        @Test
+        void testBlocking() {
+            given().body("rose").post("/flowers/contextual/blocking").then().statusCode(204);
+            given().body("peony").post("/flowers/contextual/blocking").then().statusCode(204);
+            given().body("daisy").post("/flowers/contextual/blocking").then().statusCode(204);
+        }
+
+        @Test
+        void testBlockingUni() {
+            given().body("rose").post("/flowers/contextual/uni/blocking").then().statusCode(204);
+            given().body("peony").post("/flowers/contextual/uni/blocking").then().statusCode(204);
+            given().body("daisy").post("/flowers/contextual/uni/blocking").then().statusCode(204);
+        }
+
+        @Test
+        void testBlockingNamed() {
+            given().body("rose").post("/flowers/contextual/blocking-named").then().statusCode(204);
+            given().body("peony").post("/flowers/contextual/blocking-named").then().statusCode(204);
+            given().body("daisy").post("/flowers/contextual/blocking-named").then().statusCode(204);
+        }
+
+        @Test
+        void testBlockingNamedUni() {
+            given().body("rose").post("/flowers/contextual/uni/blocking-named").then().statusCode(204);
+            given().body("peony").post("/flowers/contextual/uni/blocking-named").then().statusCode(204);
+            given().body("daisy").post("/flowers/contextual/uni/blocking-named").then().statusCode(204);
+        }
+
+        @Test
+        @EnabledForJreRange(min = JRE.JAVA_21)
+        void testVirtualThread() {
+            given().body("rose").post("/flowers/contextual/virtual-thread").then().statusCode(204);
+            given().body("peony").post("/flowers/contextual/virtual-thread").then().statusCode(204);
+            given().body("daisy").post("/flowers/contextual/virtual-thread").then().statusCode(204);
+        }
+
+        @Test
+        @EnabledForJreRange(min = JRE.JAVA_21)
+        void testVirtualThreadUni() {
+            given().body("rose").post("/flowers/contextual/uni/virtual-thread").then().statusCode(204);
+            given().body("peony").post("/flowers/contextual/uni/virtual-thread").then().statusCode(204);
+            given().body("daisy").post("/flowers/contextual/uni/virtual-thread").then().statusCode(204);
+        }
+    }
+
+    @Nested
+    class MutinyContextPropagated {
+        @Test
+        void testNonBlocking() {
+            given().body("rose").post("/flowers/mutiny").then().statusCode(204);
+            given().body("peony").post("/flowers/mutiny").then().statusCode(204);
+            given().body("daisy").post("/flowers/mutiny").then().statusCode(204);
+        }
+
+        @Test
+        void testNonBlockingUni() {
+            given().body("rose").post("/flowers/mutiny/uni").then().statusCode(204);
+            given().body("peony").post("/flowers/mutiny/uni").then().statusCode(204);
+            given().body("daisy").post("/flowers/mutiny/uni").then().statusCode(204);
+        }
+
+        @Test
+        void testBlocking() {
+            given().body("rose").post("/flowers/mutiny/blocking").then().statusCode(204);
+            given().body("peony").post("/flowers/mutiny/blocking").then().statusCode(204);
+            given().body("daisy").post("/flowers/mutiny/blocking").then().statusCode(204);
+        }
+
+        @Test
+        void testBlockingUni() {
+            given().body("rose").post("/flowers/mutiny/uni/blocking").then().statusCode(204);
+            given().body("peony").post("/flowers/mutiny/uni/blocking").then().statusCode(204);
+            given().body("daisy").post("/flowers/mutiny/uni/blocking").then().statusCode(204);
+        }
+
+        @Test
+        void testBlockingNamed() {
+            given().body("rose").post("/flowers/mutiny/blocking-named").then().statusCode(204);
+            given().body("peony").post("/flowers/mutiny/blocking-named").then().statusCode(204);
+            given().body("daisy").post("/flowers/mutiny/blocking-named").then().statusCode(204);
+        }
+
+        @Test
+        void testBlockingNamedUni() {
+            given().body("rose").post("/flowers/mutiny/uni/blocking-named").then().statusCode(204);
+            given().body("peony").post("/flowers/mutiny/uni/blocking-named").then().statusCode(204);
+            given().body("daisy").post("/flowers/mutiny/uni/blocking-named").then().statusCode(204);
+        }
+
+        @Test
+        @EnabledForJreRange(min = JRE.JAVA_21)
+        void testVirtualThread() {
+            given().body("rose").post("/flowers/mutiny/virtual-thread").then().statusCode(204);
+            given().body("peony").post("/flowers/mutiny/virtual-thread").then().statusCode(204);
+            given().body("daisy").post("/flowers/mutiny/virtual-thread").then().statusCode(204);
+        }
+
+        @Test
+        @EnabledForJreRange(min = JRE.JAVA_21)
+        void testVirtualThreadUni() {
+            given().body("rose").post("/flowers/mutiny/uni/virtual-thread").then().statusCode(204);
+            given().body("peony").post("/flowers/mutiny/uni/virtual-thread").then().statusCode(204);
+            given().body("daisy").post("/flowers/mutiny/uni/virtual-thread").then().statusCode(204);
+        }
+    }
+
+    protected Matcher<String> assertBodyRequestScopedContextWasNotActive() {
+        return containsString("RequestScoped context was not active");
+    }
+
+    @Test
+    void testIncomingFromConnector() {
+        given().body("rose").post("/flowers/produce").then()
+                .statusCode(204);
+        given().body("daisy").post("/flowers/produce").then()
+                .statusCode(204);
+        given().body("peony").post("/flowers/produce").then()
+                .statusCode(204);
+
+        await().pollDelay(5, TimeUnit.SECONDS).untilAsserted(() -> given().get("/flowers/received")
+                .then().body(not(containsString("rose")),
+                        not(containsString("daisy")),
+                        not(containsString("peony"))));
+    }
+
+}


### PR DESCRIPTION
Take 2 after #45827 has been reverted for flaky tests.

- Changes to WorkerPoolRegistry implementation to make sure messages are dispatched on the correct context (duplicated context created as message context), this makes sure the regular emitters, when _used correctly_ work with context propagation.
- `quarkus.messaging.connector-context-propagation` runtime property to configure propagated context to connector channels, defaults to NONE.
- `quarkus.messaging.request-scoped.enabled` build time property to enable request scoped context for consumed incoming messages, destroys state/deactivates the context once the message is (n)acked, defaults to false
- `ContextualEmitter`, a Quarkus-specific emitter type for better handling the request-scoped context propagation.
- Added messaging doc section on context propagation and channel decorators

----

Note on previous PR flaky tests and `ContextualEmitter`:

When context propagation is configured to clear (not propagate) the request-scoped (CDI) context, the currently active contexts are still available to the contextualized call, with their state erased. https://github.com/microprofile/microprofile-context-propagation/blob/aed4d96d81675a0502185e340ec42d88b8bf2339/api/src/main/java/org/eclipse/microprofile/context/ThreadContext.java#L326
Once the contextualized call returns, the intermediate state is destroyed.

When using internal channels with emitters to dispatch messages locally, the message is emitted asynchronously and dispatched on the duplicated message context. This duplicated context references a fresh CDI state. 
The race condition is,
- most of the times the contextualized call returns before the message is dispatched to the processor method, so the state is destroyed, and the request-scope is not active when the message is processed.
- sometimes (rarely) the message is dispatched before the state is destroyed, so the message consumer method has an active albeit fresh request-scope context.

Tricks like `@ActivateRequestScope` create more confusion because sometimes there already is an active context, other times it creates a new one.

The `ContextualEmitter` makes sure the duplicated context is captured on the contextualized call, and it returns (destroying the state) before the message emit happens. 
It ensures that, if the caller method doesn't propagate CDI context (ex. is annotated with `@CurrentThreadContext(propagated = {})`) the processing of the messaged dispatched by the emitter won't have an active CDI context.

WARNING: All this doesn't resolve issues like calls that propagate a request-scoped context to an emitter, that doesn't wait until the end of processing, destroying the context state before or during the locally dispatched message processing.

----
Fix #46256