### PR TITLE
[3.15] Correctly handle REST field injection

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -627,7 +627,8 @@ public class ResteasyReactiveProcessor {
                             boolean disableIfMissing = disableIfMissingValue != null && disableIfMissingValue.asBoolean();
                             return recorder.disableIfPropertyMatches(propertyName, propertyValue, disableIfMissing);
                         }
-                    });
+                    })
+                    .alreadyHandledRequestScopedResources(result.getRequestScopedResources());
 
             serverEndpointIndexerBuilder.skipNotRestParameters(allowNotRestParametersBuildItem.isPresent());
 

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/FormFieldSingletonScopeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/FormFieldSingletonScopeTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.resteasy.reactive.server.test.injection;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FormFieldSingletonScopeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class))
+            .assertException(t -> {
+                org.junit.jupiter.api.Assertions.assertEquals(DeploymentException.class, t.getClass());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail("should never have run");
+    }
+
+    @Path("/test")
+    @Singleton
+    public static class Resource {
+
+        @FormParam("foo")
+        String foo;
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello() {
+            return "foo: " + foo;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/HeaderFieldInSuperClassDependentScopeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/HeaderFieldInSuperClassDependentScopeTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.resteasy.reactive.server.test.injection;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.resteasy.reactive.RestHeader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class HeaderFieldInSuperClassDependentScopeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(AbstractResource.class, Resource.class))
+            .assertException(t -> {
+                org.junit.jupiter.api.Assertions.assertEquals(DeploymentException.class, t.getClass());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail("should never have run");
+    }
+
+    @Path("/test")
+    @Dependent
+    public static class Resource extends AbstractResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello() {
+            return "foo: " + foo + ", bar: " + bar;
+        }
+    }
+
+    public static class AbstractResource {
+        @HeaderParam("foo")
+        String foo;
+
+        @RestHeader
+        String bar;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/HeaderFieldInSuperClassNoScopeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/HeaderFieldInSuperClassNoScopeTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.resteasy.reactive.server.test.injection;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestHeader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class HeaderFieldInSuperClassNoScopeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(AbstractResource.class, AbstractAbstractResource.class, Resource.class));
+
+    @Test
+    public void test() {
+        given()
+                .header("foo", "f")
+                .header("bar", "b")
+                .when()
+                .get("/test")
+                .then()
+                .statusCode(200)
+                .body(is("foo: f, bar: b"));
+
+        when()
+                .get("/test")
+                .then()
+                .statusCode(200)
+                .body(is("foo: null, bar: null"));
+    }
+
+    @Path("/test")
+    @RequestScoped
+    public static class Resource extends AbstractAbstractResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello() {
+            return "foo: " + foo + ", bar: " + bar;
+        }
+    }
+
+    public static class AbstractResource {
+        @HeaderParam("foo")
+        String foo;
+
+        @RestHeader
+        String bar;
+    }
+
+    public static class AbstractAbstractResource extends AbstractResource {
+
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/HeaderFieldInSuperClassRequestScopeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/HeaderFieldInSuperClassRequestScopeTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.resteasy.reactive.server.test.injection;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestHeader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class HeaderFieldInSuperClassRequestScopeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(AbstractResource.class, Resource.class));
+
+    @Test
+    public void test() {
+        given()
+                .header("foo", "f")
+                .header("bar", "b")
+                .when()
+                .get("/test")
+                .then()
+                .statusCode(200)
+                .body(is("foo: f, bar: b"));
+
+        when()
+                .get("/test")
+                .then()
+                .statusCode(200)
+                .body(is("foo: null, bar: null"));
+    }
+
+    @Path("/test")
+    @RequestScoped
+    public static class Resource extends AbstractResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello() {
+            return "foo: " + foo + ", bar: " + bar;
+        }
+    }
+
+    public static class AbstractResource {
+        @HeaderParam("foo")
+        String foo;
+
+        @RestHeader
+        String bar;
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/HeaderFieldNoScopeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/HeaderFieldNoScopeTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.resteasy.reactive.server.test.injection;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestHeader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class HeaderFieldNoScopeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class));
+
+    @Test
+    public void test() {
+        given()
+                .header("foo", "f")
+                .header("bar", "b")
+                .when()
+                .get("/test")
+                .then()
+                .statusCode(200)
+                .body(is("foo: f, bar: b"));
+
+        when()
+                .get("/test")
+                .then()
+                .statusCode(200)
+                .body(is("foo: null, bar: null"));
+    }
+
+    @Path("/test")
+    public static class Resource {
+
+        @HeaderParam("foo")
+        String foo;
+
+        @RestHeader
+        String bar;
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello() {
+            return "foo: " + foo + ", bar: " + bar;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/PathFieldApplicationScopeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/PathFieldApplicationScopeTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.resteasy.reactive.server.test.injection;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.resteasy.reactive.RestPath;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PathFieldApplicationScopeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class))
+            .assertException(t -> {
+                org.junit.jupiter.api.Assertions.assertEquals(DeploymentException.class, t.getClass());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail("should never have run");
+    }
+
+    @Path("/test")
+    @Singleton
+    public static class Resource {
+
+        @RestPath
+        String id;
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        @Path("/{id}")
+        public String hello() {
+            return "id: " + id;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/QueryFieldRequestScopeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/injection/QueryFieldRequestScopeTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.resteasy.reactive.server.test.injection;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestQuery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QueryFieldRequestScopeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class));
+
+    @Test
+    public void test() {
+        when()
+                .get("/test?foo=f&bar=b")
+                .then()
+                .statusCode(200)
+                .body(is("foo: f, bar: b"));
+
+        when()
+                .get("/test")
+                .then()
+                .statusCode(200)
+                .body(is("foo: null, bar: null"));
+    }
+
+    @Path("/test")
+    @RequestScoped
+    public static class Resource {
+
+        @QueryParam("foo")
+        String foo;
+
+        @RestQuery
+        String bar;
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello() {
+            return "foo: " + foo + ", bar: " + bar;
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Flow.Publisher;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Typed;
 import jakarta.enterprise.inject.Vetoed;
@@ -175,6 +176,7 @@ public final class ResteasyReactiveDotNames {
     public static final DotName APPLICATION_SCOPED = DotName.createSimple(ApplicationScoped.class.getName());
     public static final DotName SINGLETON = DotName.createSimple(Singleton.class.getName());
     public static final DotName REQUEST_SCOPED = DotName.createSimple(RequestScoped.class.getName());
+    public static final DotName DEPENDENT = DotName.createSimple(Dependent.class.getName());
     public static final DotName WEB_APPLICATION_EXCEPTION = DotName.createSimple(WebApplicationException.class.getName());
 
     public static final DotName INVOCATION_CALLBACK = DotName.createSimple(InvocationCallback.class.getName());

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResourceScanningResult.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResourceScanningResult.java
@@ -21,13 +21,15 @@ public final class ResourceScanningResult {
     final Set<String> beanParams;
     final Map<DotName, String> httpAnnotationToMethod;
     final List<MethodInfo> classLevelExceptionMappers;
+    final Set<DotName> requestScopedResources;
 
     public ResourceScanningResult(IndexView index, Map<DotName, ClassInfo> scannedResources,
             Map<DotName, String> scannedResourcePaths,
             Map<DotName, ClassInfo> possibleSubResources, Map<DotName, String> pathInterfaces,
             Map<DotName, String> clientInterfaces,
             Map<DotName, MethodInfo> resourcesThatNeedCustomProducer,
-            Set<String> beanParams, Map<DotName, String> httpAnnotationToMethod, List<MethodInfo> classLevelExceptionMappers) {
+            Set<String> beanParams, Map<DotName, String> httpAnnotationToMethod, List<MethodInfo> classLevelExceptionMappers,
+            Set<DotName> requestScopedResources) {
         this.index = index;
         this.scannedResources = scannedResources;
         this.scannedResourcePaths = scannedResourcePaths;
@@ -38,6 +40,7 @@ public final class ResourceScanningResult {
         this.beanParams = beanParams;
         this.httpAnnotationToMethod = httpAnnotationToMethod;
         this.classLevelExceptionMappers = classLevelExceptionMappers;
+        this.requestScopedResources = requestScopedResources;
     }
 
     public IndexView getIndex() {
@@ -78,5 +81,9 @@ public final class ResourceScanningResult {
 
     public List<MethodInfo> getClassLevelExceptionMappers() {
         return classLevelExceptionMappers;
+    }
+
+    public Set<DotName> getRequestScopedResources() {
+        return requestScopedResources;
     }
 }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -1,12 +1,25 @@
 package org.jboss.resteasy.reactive.common.processor.scanning;
 
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.BEAN_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.COOKIE_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.DELETE;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.FORM_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.GET;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.HEAD;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.HEADER_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MATRIX_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.OPTIONS;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.PATCH;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.PATH_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.POST;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.PUT;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.QUERY_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_COOKIE_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_FORM_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_HEADER_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_MATRIX_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_PATH_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_QUERY_PARAM;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
@@ -219,6 +232,7 @@ public class ResteasyReactiveScanner {
         Map<DotName, String> pathInterfaces = new HashMap<>();
         Map<DotName, MethodInfo> resourcesThatNeedCustomProducer = new HashMap<>();
         List<MethodInfo> methodExceptionMappers = new ArrayList<>();
+        Set<DotName> requestScopedResources = new HashSet<>();
 
         Set<DotName> interfacesWithPathOnMethods = new HashSet<>();
 
@@ -234,6 +248,9 @@ public class ResteasyReactiveScanner {
                 MethodInfo ctor = hasJaxRsCtorParams(clazz);
                 if (ctor != null) {
                     resourcesThatNeedCustomProducer.put(clazz.name(), ctor);
+                }
+                if (hasJaxRsFieldInjection(clazz, index)) {
+                    requestScopedResources.add(clazz.name());
                 }
                 List<AnnotationInstance> exceptionMapperAnnotationInstances = clazz.annotationsMap()
                         .get(ResteasyReactiveDotNames.SERVER_EXCEPTION_MAPPER);
@@ -421,7 +438,7 @@ public class ResteasyReactiveScanner {
         return new ResourceScanningResult(index, scannedResources,
                 scannedResourcePaths, possibleSubResources, pathInterfaces, clientInterfaces, resourcesThatNeedCustomProducer,
                 beanParams,
-                httpAnnotationToMethod, methodExceptionMappers);
+                httpAnnotationToMethod, methodExceptionMappers, requestScopedResources);
     }
 
     private static void addClientSubInterfaces(DotName interfaceName, IndexView index,
@@ -461,6 +478,32 @@ public class ResteasyReactiveScanner {
             }
         }
         return needsHandling ? ctor : null;
+    }
+
+    public static final Set<DotName> ANNOTATIONS_REQUIRING_FIELD_INJECTION = new HashSet<>(
+            Arrays.asList(PATH_PARAM, QUERY_PARAM, HEADER_PARAM, FORM_PARAM, MATRIX_PARAM,
+                    COOKIE_PARAM, REST_PATH_PARAM, REST_QUERY_PARAM, REST_HEADER_PARAM, REST_FORM_PARAM, REST_MATRIX_PARAM,
+                    REST_COOKIE_PARAM, BEAN_PARAM));
+
+    private static boolean hasJaxRsFieldInjection(ClassInfo classInfo, IndexView index) {
+        while (true) {
+            for (FieldInfo field : classInfo.fields()) {
+                List<AnnotationInstance> annotations = field.annotations();
+                if (annotations.stream()
+                        .anyMatch(an -> ANNOTATIONS_REQUIRING_FIELD_INJECTION.contains(an.name()))) {
+                    return true;
+                }
+            }
+            DotName parentDotName = classInfo.superName();
+            if (parentDotName.equals(ResteasyReactiveDotNames.OBJECT)) {
+                return false;
+            }
+            classInfo = index.getClassByName(parentDotName);
+            if (classInfo == null) {
+                return false;
+            }
+        }
+
     }
 
 }


### PR DESCRIPTION
This is done by converting the Resource class to
@RequestScoped when possible and failing the build when it's not

(cherry picked from commit 9eb48b4a35d1a1e4d8f8900f485a06119221079c)