### PR TITLE
Simplify and fix building the list of framework endpoints

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriHealthRootPathTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetrySuppressNonAppUriHealthRootPathTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporterProvider;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class OpenTelemetrySuppressNonAppUriHealthRootPathTest {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloResource.class, TestSpanExporter.class, TestSpanExporterProvider.class)
+                    .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                    .add(new StringAsset(
+                            """
+                                    quarkus.otel.traces.exporter=test-span-exporter
+                                    quarkus.otel.metrics.exporter=none
+                                    quarkus.otel.bsp.export.timeout=1s
+                                    quarkus.otel.bsp.schedule.delay=50
+                                    quarkus.smallrye-health.root-path=/observe/health
+                                    """),
+                            "application.properties"));
+
+    @Test
+    void test() {
+
+        // Must not be traced
+        RestAssured.get("/observe/health").then().statusCode(200);
+        RestAssured.get("/observe/health/ready").then().statusCode(200);
+        RestAssured.get("/observe/health/live").then().statusCode(200);
+
+        // Valid trace
+        RestAssured.given()
+                .get("/hello")
+                .then()
+                .statusCode(200);
+        // Get span names
+        List<String> spans = Arrays.asList(
+                RestAssured.given()
+                        .get("/hello/spans")
+                        .then()
+                        .statusCode(200)
+                        .extract().body()
+                        .asString()
+                        .split(";"));
+
+        assertThat(spans).containsExactly("GET /hello");
+    }
+
+    @Path("/hello")
+    public static class HelloResource {
+
+        @Inject
+        TestSpanExporter spanExporter;
+
+        @GET
+        public String greetings() {
+            return "Hello test";
+        }
+
+        /**
+         * Gets a string with the received spans names concatenated by ;
+         *
+         * @return
+         */
+        @GET
+        @Path("/spans")
+        public String greetingsInsertAtLeast() {
+            String spanNames = spanExporter.getFinishedSpanItemsAtLeast(1).stream()
+                    .map(SpanData::getName)
+                    .reduce((s1, s2) -> s1 + ";" + s2).orElse("");
+            System.out.println(spanNames);
+            return spanNames;
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -32,6 +32,7 @@ public final class RouteBuildItem extends MultiBuildItem {
     private final RouteType routeType;
     private final RouteType routerType;
     private final NotFoundPageDisplayableEndpointBuildItem notFoundPageDisplayableEndpoint;
+    private final String absolutePath;
     private final ConfiguredPathInfo configuredPathInfo;
 
     RouteBuildItem(Builder builder, RouteType routeType, RouteType routerType, boolean management) {
@@ -43,6 +44,7 @@ public final class RouteBuildItem extends MultiBuildItem {
         this.routerType = routerType;
         this.notFoundPageDisplayableEndpoint = builder.getNotFoundEndpoint();
         this.configuredPathInfo = builder.getRouteConfigInfo();
+        this.absolutePath = builder.absolutePath;
     }
 
     public Handler<RoutingContext> getHandler() {
@@ -79,6 +81,10 @@ public final class RouteBuildItem extends MultiBuildItem {
 
     public NotFoundPageDisplayableEndpointBuildItem getNotFoundPageDisplayableEndpoint() {
         return notFoundPageDisplayableEndpoint;
+    }
+
+    public String getAbsolutePath() {
+        return absolutePath;
     }
 
     public ConfiguredPathInfo getConfiguredPathInfo() {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -1,6 +1,5 @@
 package io.quarkus.vertx.http.deployment;
 
-import static io.quarkus.runtime.TemplateHtmlBuilder.adjustRoot;
 import static io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem.getBodyHandlerRequiredConditions;
 import static io.quarkus.vertx.http.deployment.RouteBuildItem.RouteType.FRAMEWORK_ROUTE;
 
@@ -65,7 +64,6 @@ import io.quarkus.vertx.http.HttpServerOptionsCustomizer;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.deployment.spi.FrameworkEndpointsBuildItem;
 import io.quarkus.vertx.http.deployment.spi.UseManagementInterfaceBuildItem;
-import io.quarkus.vertx.http.runtime.BasicRoute;
 import io.quarkus.vertx.http.runtime.CurrentRequestProducer;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.HttpCertificateUpdateEventListener;
@@ -137,27 +135,11 @@ class VertxHttpProcessor {
         Set<String> frameworkEndpoints = new HashSet<>();
         for (RouteBuildItem route : routes) {
             if (FRAMEWORK_ROUTE.equals(route.getRouteType())) {
-                if (route.getConfiguredPathInfo() != null) {
-                    String endpointPath = route.getConfiguredPathInfo().getEndpointPath(nonApplicationRootPath,
-                            managementBuildTimeConfig, launchModeBuildItem);
-                    frameworkEndpoints.add(endpointPath);
+                if (route.getAbsolutePath() == null) {
                     continue;
                 }
-                if (route.getRouteFunction() != null && route.getRouteFunction() instanceof BasicRoute) {
-                    BasicRoute basicRoute = (BasicRoute) route.getRouteFunction();
-                    if (basicRoute.getPath() != null) {
-                        if (basicRoute.getPath().startsWith(nonApplicationRootPath.getNonApplicationRootPath())) {
-                            // Do not repeat the non application root path.
-                            frameworkEndpoints.add(basicRoute.getPath());
-                        } else {
-                            // Calling TemplateHtmlBuilder does not see very correct here, but it is the underlying API for ConfiguredPathInfo
-                            String adjustRoot = adjustRoot(nonApplicationRootPath.getNonApplicationRootPath(),
-                                    basicRoute.getPath());
-                            frameworkEndpoints.add(adjustRoot);
-                        }
 
-                    }
-                }
+                frameworkEndpoints.add(route.getAbsolutePath());
             }
         }
         return new FrameworkEndpointsBuildItem(frameworkEndpoints);


### PR DESCRIPTION
We already have the full path at some point so there's really no need to rebuild it once again, especially since the code was incorrect as it was adding the /q/ prefix always if it wasn't there in the path.

It's perfectly valid to not have /q in the path, for instance if you set quarkus.smallrye-health.root-path to /something/else.

I added a new test based on the report in addition to the ones we added recently for related fixes.

Fixes #46040