### PR TITLE
Introduce inclusive authentication mode, improve documentation of inclusive authentication and make its config runtime

### DIFF
--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -591,6 +591,9 @@ For example, you can combine the built-in Basic and the Quarkus `quarkus-oidc` B
 
 The authentication process completes as soon as the first `SecurityIdentity` is produced by one of the authentication mechanisms.
 
+[[inclusive-authentication]]
+=== Inclusive Authentication
+
 In some cases it can be required that all registered authentication mechanisms create their `SecurityIdentity`.
 It can be required when the credentials such as tokens have to be passed over <<mutual-tls>>,
 for example, when users are authenticating via `Virtual Private Network`, or when the current token has to be bound
@@ -662,7 +665,10 @@ public class InclusiveAuthExampleBean {
 You cannot combine the Quarkus `quarkus-oidc` Bearer token and `smallrye-jwt` authentication mechanisms because both mechanisms attempt to verify the token extracted from the HTTP Bearer token authentication scheme.
 ====
 
-=== Use HTTP Security Policy to enable path-based authentication
+[[path-based-authentication]]
+=== Path-based authentication
+
+==== Use HTTP Security Policy to enable path-based authentication
 
 The following configuration example demonstrates how you can enforce a single selectable authentication mechanism for a given request path:
 
@@ -682,7 +688,7 @@ quarkus.http.auth.permission.bearer.auth-mechanism=bearer
 
 Ensure that the value of the `auth-mechanism` property matches the authentication scheme supported by `HttpAuthenticationMechanism`, for example, `basic`, `bearer`, or `form`.
 
-=== Use annotations to enable path-based authentication for Jakarta REST endpoints
+==== Use annotations to enable path-based authentication for Jakarta REST endpoints
 
 It is possible to use annotations to select an authentication mechanism specific to each Jakarta REST endpoint.
 This feature is only enabled when <<proactive-auth>> is disabled due to the fact that the annotations can only be used
@@ -761,6 +767,57 @@ It is also possible to use the `io.quarkus.vertx.http.runtime.security.annotatio
 Annotation-based analogy to the `quarkus.http.auth.permission.basic.auth-mechanism=custom` configuration property is the `@HttpAuthenticationMechanism("custom")` annotation.
 
 NOTE: For consistency with various Jakarta EE specifications, it is recommended to always repeat annotations instead of relying on annotation inheritance.
+
+==== Use inclusive authentication to enable path-based authentication
+
+By default, Quarkus only supports <<path-based-authentication>> for one authentication mechanism per path.
+If more than one authentication mechanism must be used for the path-based authentication, you can write a custom `HttpAuthenticationMechanism` as documented in the xref:security-customization.adoc#dealing-with-more-than-one-http-auth-mechanisms[Dealing with more than one HttpAuthenticationMechanism] section of the Security Tips and Tricks guide.
+Another option is to enable <<inclusive-authentication>> in the lax mode and write a custom `HttpSecurityPolicy` or `PermissionChecker` that verifies that all registered HTTP authentication mechanisms created their mechanism-specific `SecurityIdentity`.
+
+.Enable inclusive authentication in the lax mode
+[source,properties]
+----
+quarkus.http.auth.inclusive-mode=lax <1>
+quarkus.http.auth.inclusive=true
+----
+<1> By default, inclusive authentication requires that all registered HTTP authentication mechanisms must create the `SecurityIdentity`.
+However, in the lax mode, the authentication succeeds if at least one registered `HttpAuthenticationMechanism` created the `SecurityIdentity`.
+
+Let's assume that we have 3 registered mechanisms, mTLS, Basic and OIDC and you only require Basic and mTLS authentications to succeed to permit access to the `hello` method.
+In this case, enabling an inclusive authentication in a lax mode allows to check which mechanisms produced the identity as shown in the example below:
+
+.Example of the HTTP Authentication mechanisms check
+[source,java]
+----
+import io.quarkus.security.PermissionChecker;
+import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import java.util.Map;
+
+@Path("/hello")
+public class HelloResource {
+
+    @PermissionsAllowed("mtls-basic")
+    @GET
+    public String hello() {
+        return "Hello world";
+    }
+
+    @PermissionChecker("mtls-basic")
+    boolean isMtlsAndBasicAuthentication(SecurityIdentity identity) {
+        Map<String, SecurityIdentity> identities = HttpSecurityUtils.getSecurityIdentities(identity);
+        if (identities != null) {
+            return identities.containsKey("basic") && identities.containsKey("x509"); <1>
+        }
+        return false;
+    }
+}
+----
+<1> Permit access to the endpoint only if it is confirmed that both `mTLS` and `Basic` authentication mechanisms have authenticated the current request.
 
 ==== How to combine it with HTTP Security Policy
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -94,8 +94,8 @@ import io.quarkus.security.runtime.SecurityConfig;
 import io.quarkus.tls.TlsRegistryBuildItem;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.EagerSecurityInterceptorBindingBuildItem;
-import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.HttpAuthMechanismAnnotationBuildItem;
+import io.quarkus.vertx.http.deployment.PreRouterFinalizationBuildItem;
 import io.quarkus.vertx.http.deployment.SecurityInformationBuildItem;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
@@ -316,9 +316,7 @@ public class OidcBuildStep {
         recorder.setUserInfoInjectionPointDetected(detectUserInfoRequired(beanRegistration));
     }
 
-    // this ensures we initialize OIDC before HTTP router is finalized
-    // because we need TenantConfigBean in the BackChannelLogoutHandler
-    @Produce(FilterBuildItem.class)
+    @Produce(PreRouterFinalizationBuildItem.class)
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     @Consume(BeanContainerBuildItem.class)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -48,8 +48,8 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -276,13 +276,14 @@ public class HttpSecurityProcessor {
         }
     }
 
+    @Produce(PreRouterFinalizationBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    @Consume(BeanContainerBuildItem.class)
     void initializeAuthenticationHandler(Optional<HttpAuthenticationHandlerBuildItem> authenticationHandler,
-            HttpSecurityRecorder recorder, VertxHttpConfig httpConfig) {
+            HttpSecurityRecorder recorder, VertxHttpConfig httpConfig, BeanContainerBuildItem beanContainerBuildItem) {
         if (authenticationHandler.isPresent()) {
-            recorder.initializeHttpAuthenticatorHandler(authenticationHandler.get().handler, httpConfig);
+            recorder.initializeHttpAuthenticatorHandler(authenticationHandler.get().handler, httpConfig,
+                    beanContainerBuildItem.getValue());
         }
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ManagementInterfaceSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/ManagementInterfaceSecurityProcessor.java
@@ -12,8 +12,8 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.HttpSecurityProcessor.IsApplicationBasicAuthRequired;
@@ -81,13 +81,14 @@ public class ManagementInterfaceSecurityProcessor {
         }
     }
 
+    @Produce(PreRouterFinalizationBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    @Consume(BeanContainerBuildItem.class)
     void initializeAuthMechanismHandler(Optional<ManagementAuthenticationHandlerBuildItem> managementAuthenticationHandler,
-            ManagementSecurityRecorder recorder, ManagementConfig managementConfig) {
+            ManagementSecurityRecorder recorder, ManagementConfig managementConfig, BeanContainerBuildItem containerBuildItem) {
         if (managementAuthenticationHandler.isPresent()) {
-            recorder.initializeAuthenticationHandler(managementAuthenticationHandler.get().handler, managementConfig);
+            recorder.initializeAuthenticationHandler(managementAuthenticationHandler.get().handler, managementConfig,
+                    containerBuildItem.getValue());
         }
     }
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/PreRouterFinalizationBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/PreRouterFinalizationBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.vertx.http.deployment;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+
+/**
+ * Marker used by Build Steps that perform tasks which must run before the HTTP router has been finalized.
+ */
+public final class PreRouterFinalizationBuildItem extends EmptyBuildItem {
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -32,6 +32,7 @@ import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationStartBuildItem;
@@ -321,6 +322,7 @@ class VertxHttpProcessor {
         vertxDevUILogBuildItem.produce(new VertxDevUILogBuildItem(publisher));
     }
 
+    @Consume(PreRouterFinalizationBuildItem.class)
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     ServiceStartBuildItem finalizeRouter(Optional<LoggingDecorateBuildItem> decorateBuildItem,

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
@@ -31,29 +31,4 @@ public interface AuthConfig {
      */
     @WithDefault("true")
     boolean proactive();
-
-    /**
-     * Require that all registered HTTP authentication mechanisms must complete the authentication.
-     * <p>
-     * Typically, this property has to be true when the credentials are carried over mTLS, when both mTLS and another
-     * authentication, for example, OIDC bearer token authentication, must succeed.
-     * In such cases, `SecurityIdentity` created by the first mechanism, mTLS, can be injected, identities created
-     * by other mechanisms will be available on `SecurityIdentity`.
-     * The mTLS mechanism is always the first mechanism, because its priority is elevated when inclusive authentication
-     * is enabled.
-     * The identities can be retrieved using utility method as in the example below:
-     *
-     * <pre>
-     * {@code
-     * io.quarkus.vertx.http.runtime.security.HttpSecurityUtils.getSecurityIdentities(securityIdentity)
-     * }
-     * </pre>
-     * <p>
-     * This property is false by default which means that the authentication process is complete as soon as the first
-     * `SecurityIdentity` is created.
-     * <p>
-     * This property will be ignored if the path specific authentication is enabled.
-     */
-    @WithDefault("false")
-    boolean inclusive();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
@@ -76,4 +76,52 @@ public interface AuthRuntimeConfig {
      * Form Auth config
      */
     FormAuthRuntimeConfig form();
+
+    /**
+     * Require that all registered HTTP authentication mechanisms must attempt to verify the request credentials.
+     * <p>
+     * By default, when the {@link #inclusiveMode} is strict, every registered authentication mechanism must produce
+     * SecurityIdentity, otherwise, a number of mechanisms which produce the identity may be less than a total
+     * number of registered mechanisms.
+     * <p>
+     * All produced security identities can be retrieved using the following utility method:
+     *
+     * <pre>
+     * {@code
+     * io.quarkus.vertx.http.runtime.security.HttpSecurityUtils#getSecurityIdentities(io.quarkus.security.identity.SecurityIdentity)
+     * }
+     * </pre>
+     *
+     * An injected `SecurityIdentity` represents an identity produced by the first inclusive authentication mechanism.
+     * When the `mTLS` authentication is required, the `mTLS` mechanism is always the first mechanism,
+     * because its priority is elevated when inclusive authentication
+     * <p>
+     * This property is false by default which means that the authentication process is complete as soon as the first
+     * `SecurityIdentity` is created.
+     * <p>
+     * This property will be ignored if the path specific authentication is enabled.
+     */
+    @WithDefault("false")
+    boolean inclusive();
+
+    /**
+     * Inclusive authentication mode.
+     */
+    @WithDefault("strict")
+    InclusiveMode inclusiveMode();
+
+    enum InclusiveMode {
+        /**
+         * Authentication succeeds if at least one of the registered HTTP authentication mechanisms creates the identity.
+         */
+        LAX,
+        /**
+         * Authentication succeeds if all the registered HTTP authentication mechanisms create the identity.
+         * Typically, inclusive authentication should be in the strict mode when the credentials are carried over mTLS,
+         * when both mTLS and another authentication, for example, OIDC bearer token authentication, must succeed.
+         * In such cases, `SecurityIdentity` created by the first mechanism, mTLS, can be injected, identities created
+         * by other mechanisms will be available on `SecurityIdentity`.
+         */
+        STRICT
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementSecurityRecorder.java
@@ -4,6 +4,7 @@ import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.spi.CDI;
 
+import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.security.BasicAuthenticationMechanism;
@@ -26,8 +27,8 @@ public class ManagementSecurityRecorder {
     }
 
     public void initializeAuthenticationHandler(RuntimeValue<AuthenticationHandler> handler,
-            ManagementConfig managementConfig) {
-        handler.getValue().init(ManagementPathMatchingHttpSecurityPolicy.class,
+            ManagementConfig managementConfig, BeanContainer beanContainer) {
+        handler.getValue().init(beanContainer.beanInstance(ManagementPathMatchingHttpSecurityPolicy.class),
                 RolesMapping.of(managementConfig.auth().rolesMapping()));
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractHttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractHttpAuthorizer.java
@@ -36,18 +36,16 @@ abstract class AbstractHttpAuthorizer {
 
     private static final Logger log = Logger.getLogger(AbstractHttpAuthorizer.class);
 
-    private final HttpAuthenticator httpAuthenticator;
     private final IdentityProviderManager identityProviderManager;
     private final AuthorizationController controller;
     private final List<HttpSecurityPolicy> policies;
     private final SecurityEventHelper<AuthorizationSuccessEvent, AuthorizationFailureEvent> securityEventHelper;
     private final HttpSecurityPolicy.AuthorizationRequestContext context;
 
-    AbstractHttpAuthorizer(HttpAuthenticator httpAuthenticator, IdentityProviderManager identityProviderManager,
+    AbstractHttpAuthorizer(IdentityProviderManager identityProviderManager,
             AuthorizationController controller, List<HttpSecurityPolicy> policies, BeanManager beanManager,
             BlockingSecurityExecutor blockingExecutor, Event<AuthorizationFailureEvent> authZFailureEvent,
             Event<AuthorizationSuccessEvent> authZSuccessEvent, boolean securityEventsEnabled) {
-        this.httpAuthenticator = httpAuthenticator;
         this.identityProviderManager = identityProviderManager;
         this.controller = controller;
         this.policies = policies;
@@ -135,6 +133,7 @@ abstract class AbstractHttpAuthorizer {
     private void doDeny(SecurityIdentity identity, RoutingContext routingContext, HttpSecurityPolicy policy) {
         //if we were denied we send a challenge if we are not authenticated, otherwise we send a 403
         if (identity.isAnonymous()) {
+            HttpAuthenticator httpAuthenticator = routingContext.get(HttpAuthenticator.class.getName());
             httpAuthenticator.sendChallenge(routingContext).subscribe().withSubscriber(new UniSubscriber<Boolean>() {
                 @Override
                 public void onSubscribe(UniSubscription subscription) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
@@ -22,12 +22,12 @@ import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 @Singleton
 public final class HttpAuthorizer extends AbstractHttpAuthorizer {
 
-    HttpAuthorizer(HttpAuthenticator httpAuthenticator, IdentityProviderManager identityProviderManager,
+    HttpAuthorizer(IdentityProviderManager identityProviderManager,
             AuthorizationController controller, Instance<HttpSecurityPolicy> installedPolicies,
             BlockingSecurityExecutor blockingExecutor, BeanManager beanManager,
             Event<AuthorizationFailureEvent> authZFailureEvent, Event<AuthorizationSuccessEvent> authZSuccessEvent,
             @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled) {
-        super(httpAuthenticator, identityProviderManager, controller, toList(installedPolicies), beanManager, blockingExecutor,
+        super(identityProviderManager, controller, toList(installedPolicies), beanManager, blockingExecutor,
                 authZFailureEvent, authZSuccessEvent, securityEventsEnabled);
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementInterfaceHttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementInterfaceHttpAuthorizer.java
@@ -23,13 +23,12 @@ import io.vertx.ext.web.RoutingContext;
 @Singleton
 public class ManagementInterfaceHttpAuthorizer extends AbstractHttpAuthorizer {
 
-    public ManagementInterfaceHttpAuthorizer(HttpAuthenticator httpAuthenticator,
-            IdentityProviderManager identityProviderManager,
+    public ManagementInterfaceHttpAuthorizer(IdentityProviderManager identityProviderManager,
             AuthorizationController controller, ManagementPathMatchingHttpSecurityPolicy installedPolicy,
             BlockingSecurityExecutor blockingExecutor, Event<AuthorizationFailureEvent> authZFailureEvent,
             Event<AuthorizationSuccessEvent> authZSuccessEvent, BeanManager beanManager,
             @ConfigProperty(name = "quarkus.security.events.enabled") boolean securityEventsEnabled) {
-        super(httpAuthenticator, identityProviderManager, controller,
+        super(identityProviderManager, controller,
                 List.of(new HttpSecurityPolicy() {
 
                     @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
@@ -5,7 +5,6 @@ import static io.quarkus.vertx.http.runtime.PolicyMappingConfig.AppliesTo.ALL;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
 
-import io.quarkus.runtime.Startup;
 import io.quarkus.vertx.http.runtime.management.ManagementConfig;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
 
@@ -14,7 +13,6 @@ import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConf
  * <p>
  * This is used for the default path/method based RBAC.
  */
-@Startup // do not initialize path matcher during first HTTP request
 @Singleton
 public class ManagementPathMatchingHttpSecurityPolicy extends AbstractPathMatchingHttpSecurityPolicy {
     ManagementPathMatchingHttpSecurityPolicy(

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -5,7 +5,6 @@ import static io.quarkus.vertx.http.runtime.PolicyMappingConfig.AppliesTo.ALL;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
 
-import io.quarkus.runtime.Startup;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 
@@ -14,7 +13,6 @@ import io.quarkus.vertx.http.runtime.VertxHttpConfig;
  * <p>
  * This is used for the default path/method based RBAC.
  */
-@Startup // do not initialize path matcher during first HTTP request
 @Singleton
 public class PathMatchingHttpSecurityPolicy extends AbstractPathMatchingHttpSecurityPolicy implements HttpSecurityPolicy {
     PathMatchingHttpSecurityPolicy(

--- a/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/MtlsBasic.java
+++ b/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/MtlsBasic.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.oidc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.security.PermissionsAllowed;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@PermissionsAllowed(value = "mtls-basic")
+public @interface MtlsBasic {
+}

--- a/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/MtlsJwt.java
+++ b/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/MtlsJwt.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.oidc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.security.PermissionsAllowed;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@PermissionsAllowed(value = "mtls-jwt")
+public @interface MtlsJwt {
+}

--- a/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/MultipleAuthMechanismsEndpoint.java
+++ b/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/MultipleAuthMechanismsEndpoint.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.oidc;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/multiple-auth-mechanisms")
+@Authenticated
+public class MultipleAuthMechanismsEndpoint {
+
+    @GET
+    @Path("mtls-jwt-lax")
+    public String getMtlsJwtLax() {
+        return "ignored";
+    }
+
+    @MtlsJwt
+    @GET
+    @Path("mtls-jwt")
+    public String getMtlsJwt() {
+        return "ignored";
+    }
+
+    @MtlsBasic
+    @GET
+    @Path("mtls-basic")
+    public String getMtlsBasic() {
+        return "ignored";
+    }
+}

--- a/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/PathBasedAuthenticationCheckers.java
+++ b/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/PathBasedAuthenticationCheckers.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.oidc;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.security.PermissionChecker;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
+
+@ApplicationScoped
+public class PathBasedAuthenticationCheckers {
+
+    @PermissionChecker("mtls-jwt")
+    boolean isMtlsAndBearerAuthentication(SecurityIdentity identity) {
+        Map<String, SecurityIdentity> identities = HttpSecurityUtils.getSecurityIdentities(identity);
+        if (identities != null) {
+            return identities.containsKey("bearer") && identities.containsKey("x509");
+        }
+        return false;
+    }
+
+    @PermissionChecker("mtls-basic")
+    boolean isMtlsAndBasicAuthentication(SecurityIdentity identity) {
+        Map<String, SecurityIdentity> identities = HttpSecurityUtils.getSecurityIdentities(identity);
+        if (identities != null) {
+            return identities.containsKey("basic") && identities.containsKey("x509");
+        }
+        return false;
+    }
+
+}

--- a/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/SimpleBasicIdentityProvider.java
+++ b/integration-tests/oidc-mtls/src/main/java/io/quarkus/it/oidc/SimpleBasicIdentityProvider.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.oidc;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class SimpleBasicIdentityProvider implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+    @Override
+    public Class<UsernamePasswordAuthenticationRequest> getRequestType() {
+        return UsernamePasswordAuthenticationRequest.class;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(UsernamePasswordAuthenticationRequest request,
+            AuthenticationRequestContext authenticationRequestContext) {
+        if ("Gaston".equals(request.getUsername()) && "Gaston".equals(new String(request.getPassword().getPassword()))) {
+            return Uni.createFrom().item(QuarkusSecurityIdentity.builder()
+                    .setPrincipal(new QuarkusPrincipal("Gaston"))
+                    .setAnonymous(false)
+                    .build());
+        }
+        return null;
+    }
+}

--- a/integration-tests/oidc-mtls/src/test/java/io/quarkus/it/oidc/OidcMtlsBasicAuthTest.java
+++ b/integration-tests/oidc-mtls/src/test/java/io/quarkus/it/oidc/OidcMtlsBasicAuthTest.java
@@ -1,0 +1,156 @@
+package io.quarkus.it.oidc;
+
+import static io.quarkus.it.oidc.OidcMtlsTest.createWebClientOptions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URL;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
+import io.quarkus.test.keycloak.client.KeycloakTestClient.Tls;
+import io.restassured.RestAssured;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
+import io.vertx.mutiny.ext.web.client.WebClient;
+
+@TestProfile(OidcMtlsBasicAuthTest.LaxInclusiveModeProfile.class)
+@QuarkusTest
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class OidcMtlsBasicAuthTest {
+
+    KeycloakTestClient client = new KeycloakTestClient(
+            new Tls("target/certificates/oidc-client-keystore.p12",
+                    "target/certificates/oidc-client-truststore.p12"));
+
+    @TestHTTPResource(tls = true)
+    URL url;
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    public void testMtlsJwtLax() throws Exception {
+        // verifies that in LAX mode, it is permitted that not all the mechanisms need to create the identity
+        WebClientOptions options = createWebClientOptions(url);
+        WebClient webClient = WebClient.create(new io.vertx.mutiny.core.Vertx(vertx), options);
+
+        try {
+            // HTTP 200
+            HttpResponse<io.vertx.mutiny.core.buffer.Buffer> resp = webClient.get("/multiple-auth-mechanisms/mtls-jwt-lax")
+                    .putHeader("Authorization",
+                            OidcConstants.BEARER_SCHEME + " " + getAccessToken("backend-service", null, "alice"))
+                    .send().await()
+                    .indefinitely();
+            assertEquals(200, resp.statusCode());
+
+            // HTTP 401, invalid token
+            resp = webClient.get("/multiple-auth-mechanisms/mtls-jwt-lax")
+                    .putHeader("Authorization", OidcConstants.BEARER_SCHEME + " " + "123")
+                    .send().await()
+                    .indefinitely();
+            assertEquals(401, resp.statusCode());
+
+            // HTTP 200, no token and inclusive authentication in the lax mode, therefore 200
+            resp = webClient.get("/multiple-auth-mechanisms/mtls-jwt-lax").send().await().indefinitely();
+            assertEquals(200, resp.statusCode());
+        } finally {
+            webClient.close();
+        }
+    }
+
+    @Test
+    public void testMtlsJwt() throws Exception {
+        // verifies that in LAX mode, it is permitted that not all the mechanisms need to create the identity
+        WebClientOptions options = createWebClientOptions(url);
+        WebClient webClient = WebClient.create(new io.vertx.mutiny.core.Vertx(vertx), options);
+
+        try {
+            // HTTP 200
+            HttpResponse<io.vertx.mutiny.core.buffer.Buffer> resp = webClient.get("/multiple-auth-mechanisms/mtls-jwt")
+                    .putHeader("Authorization",
+                            OidcConstants.BEARER_SCHEME + " " + getAccessToken("backend-service", null, "alice"))
+                    .send().await()
+                    .indefinitely();
+            assertEquals(200, resp.statusCode());
+
+            // HTTP 401, invalid token
+            resp = webClient.get("/multiple-auth-mechanisms/mtls-jwt")
+                    .putHeader("Authorization", OidcConstants.BEARER_SCHEME + " " + "123")
+                    .send().await()
+                    .indefinitely();
+            assertEquals(401, resp.statusCode());
+
+            // HTTP 403, no token and inclusive authentication in the lax mode,
+            // but permission checker requires both JWT and mTLS
+            resp = webClient.get("/multiple-auth-mechanisms/mtls-jwt").send().await().indefinitely();
+            assertEquals(403, resp.statusCode());
+        } finally {
+            webClient.close();
+        }
+    }
+
+    @Test
+    public void testMtlsBasic() throws Exception {
+        WebClientOptions options = createWebClientOptions(url);
+        WebClient webClient = WebClient.create(new io.vertx.mutiny.core.Vertx(vertx), options);
+
+        try {
+            // HTTP 403, basic & mTLS are expected and basic is missing
+            HttpResponse<io.vertx.mutiny.core.buffer.Buffer> resp = webClient.get("/multiple-auth-mechanisms/mtls-basic")
+                    .putHeader("Authorization",
+                            OidcConstants.BEARER_SCHEME + " " + getAccessToken("backend-service", null, "alice"))
+                    .send().await()
+                    .indefinitely();
+            assertEquals(403, resp.statusCode());
+
+            // HTTP 200, basic & mTLS are expected
+            resp = webClient.get("/multiple-auth-mechanisms/mtls-basic")
+                    .putHeader("Authorization",
+                            new UsernamePasswordCredentials("Gaston", "Gaston").applyHttpChallenge(null).toHttpAuthorization())
+                    .send().await()
+                    .indefinitely();
+            assertEquals(200, resp.statusCode());
+
+            // HTTP 403, only basic but mTLS & basic are required
+            RestAssured
+                    .given()
+                    .auth().preemptive().basic("Gaston", "Gaston")
+                    .get("/multiple-auth-mechanisms/mtls-basic")
+                    .then()
+                    .statusCode(403);
+        } finally {
+            webClient.close();
+        }
+    }
+
+    private String getAccessToken(String clientName, String clientSecret, String userName) {
+        return client.getAccessToken(userName, userName, clientName, clientSecret);
+    }
+
+    public static class LaxInclusiveModeProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.http.auth.inclusive-mode", "lax",
+                    "quarkus.http.ssl.client-auth", "request",
+                    "quarkus.http.insecure-requests", "enabled",
+                    "quarkus.http.auth.basic", "true",
+                    "quarkus.oidc.mtls-jwt.tenant-paths", "/*/mtls-jwt-lax,/*/mtls-jwt,/*/mtls-basic");
+        }
+    }
+
+}

--- a/integration-tests/oidc-mtls/src/test/java/io/quarkus/it/oidc/OidcMtlsTest.java
+++ b/integration-tests/oidc-mtls/src/test/java/io/quarkus/it/oidc/OidcMtlsTest.java
@@ -76,6 +76,10 @@ public class OidcMtlsTest {
                 .send().await()
                 .indefinitely();
         assertEquals(401, resp.statusCode());
+
+        // HTTP 401, no token and inclusive authentication in the strict mode
+        resp = webClient.get("/service/mtls-jwt").send().await().indefinitely();
+        assertEquals(401, resp.statusCode());
     }
 
     @Test
@@ -134,6 +138,10 @@ public class OidcMtlsTest {
     }
 
     private WebClientOptions createWebClientOptions() throws Exception {
+        return createWebClientOptions(url);
+    }
+
+    static WebClientOptions createWebClientOptions(URL url) throws Exception {
         WebClientOptions webClientOptions = new WebClientOptions().setDefaultHost(url.getHost())
                 .setDefaultPort(url.getPort()).setSsl(true).setVerifyHost(false);
 


### PR DESCRIPTION
- documents how to handle user scenario described in https://github.com/quarkusio/quarkus/discussions/45619 until https://github.com/quarkusio/quarkus/issues/46167 is implemented
- introduces inclusive mode; by default the inclusive auth is strictly inclusive, all the mechanisms must create identity, while in lax all the mechanisms must perform authentication, but at least one must create identity
- moves "inclusive" flag to runtime. There is no win in keeping it build-time,we don't use it there. I made initially the build-time property because I was afraid about the moment when `HttpAuthenticator` is initialized, but:
  - I have inspected all injection points and can't see why would it make a difference even if we kept everything as is
  - I have reduced injection points to one (authentication handler), everyone else will take the authenticator from `RoutingContext`
  - I plan to work on programmatic security creation very soon and having this property at runtime will allow users to configure it programmatically
- introduces `PreRouterFinalizationBuildItem` because I realized that `FilterBuildItem` is sometimes consumed before runtime config are ready (e.g. in `UndertowBuildStep`) and it would cause a circular reference
