### PR TITLE
Bump version of kindcontainer from 1.4.7 to 1.4.8

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -199,7 +199,7 @@
         <docker-java.version>3.4.0</docker-java.version> <!-- must be the version Testcontainers use: https://central.sonatype.com/artifact/org.testcontainers/testcontainers -->
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.0.2</opensearch-testcontainers.version>
-        <com.dajudge.kindcontainer>1.4.7</com.dajudge.kindcontainer>
+        <com.dajudge.kindcontainer>1.4.8</com.dajudge.kindcontainer>
         <aesh.version>2.8.2</aesh.version>
         <aesh-readline.version>2.6</aesh-readline.version>
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with aesh-readline and dekorate -->


### PR DESCRIPTION
Bump version of kindcontainer from 1.4.7 to 1.4.8 to support to use `podman rootless` with kind

- Closes: #46190