### PR TITLE
KeycloakDevServicesProcessor - Avoid all work if disabled

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -144,6 +144,11 @@ public class KeycloakDevServicesProcessor {
             LoggingSetupBuildItem loggingSetupBuildItem,
             DevServicesConfig devServicesConfig, DockerStatusBuildItem dockerStatusBuildItem) {
 
+        if (!devServicesConfig.enabled() || !config.enabled()) {
+            LOG.debug("Not starting Dev Services for Keycloak as it has been disabled in the configuration");
+            return null;
+        }
+
         if (devSvcRequiredMarkerItems.isEmpty()
                 || linuxContainersNotAvailable(dockerStatusBuildItem, devSvcRequiredMarkerItems)
                 || oidcDevServicesEnabled()) {


### PR DESCRIPTION
Even if the Dev Services for Keycloak were disabled, we were actually doing a lot of things, including some Docker work, which should be avoided.

Noticed while having a look at https://github.com/quarkusio/quarkus/issues/45631 .