### PR TITLE
Force closing of HTTP Client on tests

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/WithSpanInterceptorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/WithSpanInterceptorTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
@@ -278,10 +279,13 @@ public class WithSpanInterceptorTest {
 
         @WithSpan
         public void spanRestClient() {
-            WebTarget target = ClientBuilder.newClient()
-                    .target(UriBuilder.fromUri(config.getRawValue("test.url")).path("hello"));
-            Response response = target.request().get();
-            assertEquals(HTTP_OK, response.getStatus());
+            try (Client client = ClientBuilder.newClient()) {
+                WebTarget target = client.target(UriBuilder
+                        .fromUri(config.getRawValue("test.url"))
+                        .path("hello"));
+                Response response = target.request().get();
+                assertEquals(HTTP_OK, response.getStatus());
+            }
         }
     }
 


### PR DESCRIPTION
This tries to fix the CI error in this PR:
https://github.com/quarkusio/quarkus/pull/46192

The error:
```
org.opentest4j.AssertionFailedError: Expected log to have severity <ERROR> but was <WARN>
	at io.quarkus.opentelemetry.deployment.logs.OtelLoggingTest.testException(OtelLoggingTest.java:160)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.quarkus.test.QuarkusUnitTest.runExtensionMethod(QuarkusUnitTest.java:513)
	at io.quarkus.test.QuarkusUnitTest.interceptTestMethod(QuarkusUnitTest.java:427)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```
Inspecting the CI log:
```
2025-02-11T11:28:36.0131109Z 2025-02-11 11:28:35,984 WARN  [org.jbo.res.cli.jax.i18n] (Cleaner-1) RESTEASY004687: Closing a class org.jboss.resteasy.client.jaxrs.engines.ManualClosingApacheHttpClient43Engine$CleanupAction instance for you. Please close clients yourself.
...
2025-02-11T11:28:43.0974346Z [ERROR] Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 9.480 s <<< FAILURE! -- in io.quarkus.opentelemetry.deployment.logs.OtelLoggingTest
2025-02-11T11:28:43.0986027Z [ERROR] io.quarkus.opentelemetry.deployment.logs.OtelLoggingTest.testException -- Time elapsed: 0.913 s <<< FAILURE!
2025-02-11T11:28:43.0987576Z org.opentest4j.AssertionFailedError: Expected log to have severity <ERROR> but was <WARN>
```
We can see that after the ERROR log message we were expecting, we get an unexpected WARN from an http client.

The PR tries to force the closing of the existing clients, even if they are from different tests... Something weird is going on there.