### PR TITLE
Avoid using generated Jackson serializers for subclasses

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -25,6 +25,7 @@ import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.TypeVariable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
@@ -337,9 +338,13 @@ public abstract class JacksonCodeGenerator {
             return annotations.keySet().stream().anyMatch(FieldSpecs::isUnknownAnnotation);
         }
 
+        boolean isIgnoredField() {
+            return annotations.get(JsonIgnore.class.getName()) != null;
+        }
+
         private static boolean isUnknownAnnotation(String ann) {
             if (ann.startsWith("com.fasterxml.jackson.")) {
-                return !ann.equals(JsonProperty.class.getName());
+                return !ann.equals(JsonProperty.class.getName()) && !ann.equals(JsonIgnore.class.getName());
             }
             return false;
         }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -342,6 +342,9 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
             ResultHandle objHandle, ResultHandle fieldValue, Set<String> deserializedFields, Switch.StringSwitch strSwitch,
             FieldSpecs fieldSpecs, AtomicBoolean valid) {
         if (fieldSpecs != null && deserializedFields.add(fieldSpecs.jsonName)) {
+            if (fieldSpecs.isIgnoredField()) {
+                return true;
+            }
             if (fieldSpecs.hasUnknownAnnotation()) {
                 return false;
             }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -223,6 +223,9 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         for (FieldInfo fieldInfo : classFields(classInfo)) {
             FieldSpecs fieldSpecs = fieldSpecsFromField(classInfo, fieldInfo);
             if (fieldSpecs != null && serializedFields.add(fieldSpecs.jsonName)) {
+                if (fieldSpecs.isIgnoredField()) {
+                    continue;
+                }
                 if (fieldSpecs.hasUnknownAnnotation()) {
                     return false;
                 }
@@ -237,6 +240,9 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         for (MethodInfo methodInfo : classMethods(classInfo)) {
             FieldSpecs fieldSpecs = fieldSpecsFromMethod(methodInfo);
             if (fieldSpecs != null && serializedFields.add(fieldSpecs.jsonName)) {
+                if (fieldSpecs.isIgnoredField()) {
+                    continue;
+                }
                 if (fieldSpecs.hasUnknownAnnotation()) {
                     return false;
                 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemExtended.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ItemExtended.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class ItemExtended extends Item {
+
+    private String nameExtended;
+
+    @JsonIgnore
+    private String emailExtended;
+
+    public String getNameExtended() {
+        return nameExtended;
+    }
+
+    public void setNameExtended(String nameExtended) {
+        this.nameExtended = nameExtended;
+    }
+
+    public String getEmailExtended() {
+        return emailExtended;
+    }
+
+    public void setEmailExtended(String emailExtended) {
+        this.emailExtended = emailExtended;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -467,6 +467,26 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return new ContainerDTO(NestedInterface.INSTANCE);
     }
 
+    @GET
+    @Path("/item")
+    public Item getItem() {
+        Item item = new Item();
+        item.setName("Name");
+        item.setEmail("E-mail");
+        return item;
+    }
+
+    @GET
+    @Path("/item-extended")
+    public ItemExtended getItemExtended() {
+        ItemExtended item = new ItemExtended();
+        item.setName("Name");
+        item.setEmail("E-mail");
+        item.setNameExtended("Name-Extended");
+        item.setEmailExtended("E-mail-Extended");
+        return item;
+    }
+
     public static class UnquotedFieldsPersonSerialization implements BiFunction<ObjectMapper, Type, ObjectWriter> {
 
         public static final AtomicInteger count = new AtomicInteger();

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.resteasy.reactive.jackson.deployment.test;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -37,7 +38,7 @@ public class SimpleJsonTest {
                                     AbstractUnsecuredPet.class, UnsecuredPet.class, SecuredPersonInterface.class, Frog.class,
                                     Pond.class, FrogBodyParts.class, FrogBodyParts.BodyPart.class, ContainerDTO.class,
                                     NestedInterface.class, StateRecord.class, MapWrapper.class, GenericWrapper.class,
-                                    Fruit.class, Price.class, DogRecord.class)
+                                    Fruit.class, Price.class, DogRecord.class, ItemExtended.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n"), "application.properties");
@@ -781,5 +782,29 @@ public class SimpleJsonTest {
                 .contentType("application/json")
                 .body("name", Matchers.is("test"))
                 .body("properties", Matchers.nullValue());
+    }
+
+    @Test
+    public void testItem() {
+        RestAssured
+                .with()
+                .get("/simple/item")
+                .then()
+                .statusCode(200)
+                .body("name", Matchers.is("Name"))
+                .body("email", Matchers.is("E-mail"));
+    }
+
+    @Test
+    public void testItemExtended() {
+        RestAssured
+                .with()
+                .get("/simple/item-extended")
+                .then()
+                .statusCode(200)
+                .body("name", Matchers.is("Name"))
+                .body("email", Matchers.is("E-mail"))
+                .body("nameExtended", Matchers.is("Name-Extended"))
+                .body("emailExtended", Matchers.is(emptyOrNullString()));
     }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -28,7 +28,7 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends SimpleJsonTest 
                                     AbstractUnsecuredPet.class, UnsecuredPet.class, SecuredPersonInterface.class, Frog.class,
                                     Pond.class, FrogBodyParts.class, FrogBodyParts.BodyPart.class, ContainerDTO.class,
                                     NestedInterface.class, StateRecord.class, MapWrapper.class, GenericWrapper.class,
-                                    Fruit.class, Price.class, DogRecord.class)
+                                    Fruit.class, Price.class, DogRecord.class, ItemExtended.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/GeneratedSerializersRegister.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/GeneratedSerializersRegister.java
@@ -1,12 +1,20 @@
 package io.quarkus.resteasy.reactive.jackson.runtime.serialisers;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
 
 import jakarta.inject.Singleton;
 
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import io.quarkus.jackson.ObjectMapperCustomizer;
@@ -21,20 +29,25 @@ public class GeneratedSerializersRegister implements ObjectMapperCustomizer {
     }
 
     static class MappingModuleHolder {
-        static final SimpleModule mappingModule = createMappingModule();
+        static final Module mappingModule = createMappingModule();
 
-        private static SimpleModule createMappingModule() {
+        private static Module createMappingModule() {
             SimpleModule module = new SimpleModule();
+            // Use a custom SimpleSerializers to use a json serializer only if it has been generated for that
+            // exact class and not one of its sublclasses. This is already the default behaviour for deserializers.
+            ExactSerializers serializers = new ExactSerializers();
 
             for (Class<? extends StdSerializer> serClass : ResteasyReactiveServerJacksonRecorder.getGeneratedSerializers()) {
                 try {
                     StdSerializer serializer = serClass.getConstructor().newInstance();
-                    module.addSerializer(serializer.handledType(), serializer);
+                    serializers.addExactSerializer(serializer.handledType(), serializer);
                 } catch (InstantiationException | IllegalAccessException | InvocationTargetException
                         | NoSuchMethodException e) {
                     throw new RuntimeException(e);
                 }
             }
+
+            module.setSerializers(serializers);
 
             for (Class<? extends StdDeserializer> deserClass : ResteasyReactiveServerJacksonRecorder
                     .getGeneratedDeserializers()) {
@@ -48,6 +61,22 @@ public class GeneratedSerializersRegister implements ObjectMapperCustomizer {
             }
 
             return module;
+        }
+
+    }
+
+    public static class ExactSerializers extends SimpleSerializers {
+
+        private final Map<Class<?>, JsonSerializer<?>> exactSerializers = new HashMap<>();
+
+        public <T> void addExactSerializer(Class<? extends T> type, JsonSerializer<T> ser) {
+            exactSerializers.put(type, ser);
+        }
+
+        @Override
+        public JsonSerializer<?> findSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+            JsonSerializer<?> exactSerializer = exactSerializers.get(type.getRawClass());
+            return exactSerializer != null ? exactSerializer : super.findSerializer(config, type, beanDesc);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/46156

The reason why it requires 2 different endpoints to reproduce the problem is the following: in the reproducer one endpoint returned objects of class A and the second of class B extending A. The serializer for A is correctly generated and registered. Conversely the serializer for B cannot be generated because the class contains an unknown annotation (`JsonIgnore` in this case, but this pull request also adds support for it), so Jackson should use the default, reflection based, serializer. However, as discussed [here](https://github.com/FasterXML/jackson-databind/issues/1784#issuecomment-2648813043) since there's a registered serializer for A and B is also an instance of A, Jackson decides to use the serializer generated for A, thus leaving out the properties of B during serialization. Without the endpoint returning instances of A, no serializers is generated for that class, so the problem doesn't happen. Note that this problem also doesn't happen for deserializers because (for some reason) in that case Jackson use a generated deserializer only if there is one registered exactly for it.