### PR TITLE
Add OIDC client access token expires in skew

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -26,6 +26,7 @@ public class OidcClientConfig extends OidcClientCommonConfig implements io.quark
         scopes = mapping.scopes();
         refreshTokenTimeSkew = mapping.refreshTokenTimeSkew();
         accessTokenExpiresIn = mapping.accessTokenExpiresIn();
+        accessTokenExpirySkew = mapping.accessTokenExpirySkew();
         absoluteExpiresIn = mapping.absoluteExpiresIn();
         grant.addConfigMappingValues(mapping.grant());
         grantOptions = mapping.grantOptions();
@@ -65,6 +66,11 @@ public class OidcClientConfig extends OidcClientCommonConfig implements io.quark
     public Optional<Duration> accessTokenExpiresIn = Optional.empty();
 
     /**
+     * Access token expiry time skew that can be added to the calculated token expiry time.
+     */
+    public Optional<Duration> accessTokenExpirySkew = Optional.empty();
+
+    /**
      * If the access token 'expires_in' property should be checked as an absolute time value
      * as opposed to a duration relative to the current time.
      */
@@ -95,6 +101,11 @@ public class OidcClientConfig extends OidcClientCommonConfig implements io.quark
     @Override
     public Optional<Duration> accessTokenExpiresIn() {
         return accessTokenExpiresIn;
+    }
+
+    @Override
+    public Optional<Duration> accessTokenExpirySkew() {
+        return accessTokenExpirySkew;
     }
 
     @Override

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfigBuilder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfigBuilder.java
@@ -26,6 +26,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
         private final Grant grant;
         private final boolean absoluteExpiresIn;
         private final Optional<Duration> accessTokenExpiresIn;
+        private final Optional<Duration> accessTokenExpirySkew;
         private final Optional<Duration> refreshTokenTimeSkew;
         private final Optional<List<String>> scopes;
         private final boolean clientEnabled;
@@ -39,6 +40,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
             this.grant = builder.grant;
             this.absoluteExpiresIn = builder.absoluteExpiresIn;
             this.accessTokenExpiresIn = builder.accessTokenExpiresIn;
+            this.accessTokenExpirySkew = builder.accessTokenExpirySkew;
             this.refreshTokenTimeSkew = builder.refreshTokenTimeSkew;
             this.scopes = builder.scopes.isEmpty() ? Optional.empty() : Optional.of(List.copyOf(builder.scopes));
             this.clientEnabled = builder.clientEnabled;
@@ -68,6 +70,11 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
         @Override
         public Optional<Duration> accessTokenExpiresIn() {
             return accessTokenExpiresIn;
+        }
+
+        @Override
+        public Optional<Duration> accessTokenExpirySkew() {
+            return accessTokenExpirySkew;
         }
 
         @Override
@@ -103,6 +110,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
     private Grant grant;
     private boolean absoluteExpiresIn;
     private Optional<Duration> accessTokenExpiresIn;
+    private Optional<Duration> accessTokenExpirySkew;
     private Optional<Duration> refreshTokenTimeSkew;
     private boolean clientEnabled;
     private Optional<String> id;
@@ -118,6 +126,7 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
         this.grant = config.grant();
         this.absoluteExpiresIn = config.absoluteExpiresIn();
         this.accessTokenExpiresIn = config.accessTokenExpiresIn();
+        this.accessTokenExpirySkew = config.accessTokenExpirySkew();
         this.refreshTokenTimeSkew = config.refreshTokenTimeSkew();
         this.clientEnabled = config.clientEnabled();
         this.id = config.id();
@@ -216,6 +225,15 @@ public final class OidcClientConfigBuilder extends OidcClientCommonConfigBuilder
      */
     public OidcClientConfigBuilder accessTokenExpiresIn(Duration accessTokenExpiresIn) {
         this.accessTokenExpiresIn = Optional.ofNullable(accessTokenExpiresIn);
+        return this;
+    }
+
+    /**
+     * @param accessTokenExpirySkew {@link OidcClientConfig#accessTokenExpirySkew()}
+     * @return this builder
+     */
+    public OidcClientConfigBuilder accessTokenExpirySkew(Duration accessTokenExpirySkew) {
+        this.accessTokenExpirySkew = Optional.ofNullable(accessTokenExpirySkew);
         return this;
     }
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
@@ -48,6 +48,11 @@ public interface OidcClientConfig extends OidcClientCommonConfig {
     Optional<Duration> accessTokenExpiresIn();
 
     /**
+     * Access token expiry time skew that can be added to the calculated token expiry time.
+     */
+    Optional<Duration> accessTokenExpirySkew();
+
+    /**
      * If the access token 'expires_in' property should be checked as an absolute time value
      * as opposed to a duration relative to the current time.
      */

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -287,6 +287,9 @@ public class OidcClientImpl implements OidcClient {
             final long now = System.currentTimeMillis() / 1000;
             expiresAt = now + oidcConfig.accessTokenExpiresIn().get().toSeconds();
         }
+        if (expiresAt != null && oidcConfig.accessTokenExpirySkew().isPresent()) {
+            expiresAt += oidcConfig.accessTokenExpirySkew().get().getSeconds();
+        }
         return expiresAt;
     }
 

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigImpl.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigImpl.java
@@ -49,6 +49,7 @@ final class OidcClientConfigImpl implements OidcClientConfig {
         SCOPES,
         REFRESH_TOKEN_TIME_SKEW,
         ACCESS_TOKEN_EXPIRES_IN,
+        ACCESS_TOKEN_EXPIRY_SKEW,
         ABSOLUTE_EXPIRES_IN,
         GRANT,
         GRANT_TYPE,
@@ -335,6 +336,12 @@ final class OidcClientConfigImpl implements OidcClientConfig {
     @Override
     public Optional<Duration> accessTokenExpiresIn() {
         invocationsRecorder.put(ConfigMappingMethods.ACCESS_TOKEN_EXPIRES_IN, true);
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> accessTokenExpirySkew() {
+        invocationsRecorder.put(ConfigMappingMethods.ACCESS_TOKEN_EXPIRY_SKEW, true);
         return Optional.empty();
     }
 

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -12,6 +12,7 @@ quarkus.oidc-client.configured-expires-in.client-id=quarkus-app
 quarkus.oidc-client.configured-expires-in.credentials.client-secret.value=secret
 quarkus.oidc-client.configured-expires-in.credentials.client-secret.method=post
 quarkus.oidc-client.configured-expires-in.access-token-expires-in=5S
+quarkus.oidc-client.configured-expires-in.access-token-expiry-skew=2S
 
 quarkus.oidc-client.jwtbearer.auth-server-url=${keycloak.url}
 quarkus.oidc-client.jwtbearer.discovery-enabled=false

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -63,7 +63,7 @@ public class OidcClientTest {
         assertEquals("access_token_without_expires_in", data[0]);
 
         long now = System.currentTimeMillis() / 1000;
-        long expectedExpiresAt = now + 5;
+        long expectedExpiresAt = now + 7;
         long accessTokenExpiresAt = Long.valueOf(data[1]);
         assertTrue(accessTokenExpiresAt >= expectedExpiresAt
                 && accessTokenExpiresAt <= expectedExpiresAt + 4);


### PR DESCRIPTION
Fixes #46142.

This simple PR adds an OIDC client access token expires in property to let users get the correct token expiry time.

By default, the current time is added to the relative expires_in response property - however, due to the clock skew or the IDP specific configuration (as explained in the recent Zulip dev thread), the actual token issued at time can be earlier (or even later) than the current time. For example, a 1 min difference can be quite significant.

Adding an option to sync it with by configuring this new skew property (Duration can also be negative if needed) will let OIDC client calculate a more precise token expiry time. 

I've confirmed that updated test is failing without adding a skew property.

If this PR does not make it to 3.18 right now then we might Guillaume to consider it for the backport to 3.18 later, we don't have to rush  it if there are some concerns