### PR TITLE
Start the function only once in test

### DIFF
--- a/integration-tests/google-cloud-functions/src/test/java/io/quarkus/gcp/function/test/HttpFunctionTestCase.java
+++ b/integration-tests/google-cloud-functions/src/test/java/io/quarkus/gcp/function/test/HttpFunctionTestCase.java
@@ -21,4 +21,15 @@ class HttpFunctionTestCase {
                 .statusCode(200)
                 .body(is("Hello World!"));
     }
+
+    // we do twice the test to be sure we can call multiple time the same function
+    @Test
+    public void test2() {
+        // test the function using RestAssured
+        when()
+                .get()
+                .then()
+                .statusCode(200)
+                .body(is("Hello World!"));
+    }
 }


### PR DESCRIPTION
If a test using `WithFunction` contains multiple test method, the function will be started multiple time, wich will fail the test.

Using an atomic boolean to be sure that the function is only started once fixes the issue.

Fixes #44661