### PR TITLE
Use UBI9 based Quarkus micro image

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
@@ -52,10 +52,20 @@ public class ContainerImages {
     public static final String UBI9_MINIMAL_VERSION = UBI9_VERSION;
     public static final String UBI9_MINIMAL = UBI9_MINIMAL_IMAGE_NAME + ":" + UBI9_MINIMAL_VERSION;
 
-    // Quarkus Micro image - https://quay.io/repository/quarkus/quarkus-micro-image?tab=tags
-    public static final String QUARKUS_MICRO_IMAGE_NAME = "quay.io/quarkus/quarkus-micro-image";
-    public static final String QUARKUS_MICRO_VERSION = "2.0";
-    public static final String QUARKUS_MICRO_IMAGE = QUARKUS_MICRO_IMAGE_NAME + ":" + QUARKUS_MICRO_VERSION;
+    // UBI 8 Quarkus Micro image - https://quay.io/repository/quarkus/quarkus-micro-image?tab=tags
+    public static final String UBI8_QUARKUS_MICRO_IMAGE_NAME = "quay.io/quarkus/quarkus-micro-image";
+    public static final String UBI8_QUARKUS_MICRO_VERSION = "2.0";
+    public static final String UBI8_QUARKUS_MICRO_IMAGE = UBI8_QUARKUS_MICRO_IMAGE_NAME + ":" + UBI8_QUARKUS_MICRO_VERSION;
+
+    // UBI 9 Quarkus Micro image - https://quay.io/repository/quarkus/ubi9-quarkus-micro-image?tab=tags
+    public static final String UBI9_QUARKUS_MICRO_IMAGE_NAME = "quay.io/quarkus/ubi9-quarkus-micro-image";
+    public static final String UBI9_QUARKUS_MICRO_VERSION = "2.0";
+    public static final String UBI9_QUARKUS_MICRO_IMAGE = UBI9_QUARKUS_MICRO_IMAGE_NAME + ":" + UBI9_QUARKUS_MICRO_VERSION;
+
+    // default Quarkus Micro image - https://quay.io/repository/quarkus/quarkus-micro-image?tab=tags
+    public static final String QUARKUS_MICRO_IMAGE_NAME = UBI9_QUARKUS_MICRO_IMAGE_NAME;
+    public static final String QUARKUS_MICRO_VERSION = UBI9_QUARKUS_MICRO_VERSION;
+    public static final String QUARKUS_MICRO_IMAGE = UBI9_QUARKUS_MICRO_IMAGE;
 
     // === Runtime images for containers (JVM)
 

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -9,9 +9,9 @@ include::_attributes.adoc[]
 :topics: docker,podman,images
 
 To ease the containerization of native executables, Quarkus provides a base image providing the requirements to run these executables.
-The `quarkus-micro-image:2.0` image is:
+The `ubi9-quarkus-micro-image:2.0` image is:
 
-* small (based on `ubi8-micro`)
+* small (based on `ubi9-micro`)
 * designed for containers
 * contains the right set of dependencies (glibc, libstdc++, zlib)
 * support upx-compressed executables (more details on the xref:upx.adoc[enabling compression documentation])


### PR DESCRIPTION
I have Kuberentes application that is failing over:

```
2025-02-11T23:37:09.2099788Z 23:37:09,153 INFO  [pingpong] [pingpong-5c5f8c5dd6-dkvr5] ./application: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by ./application)
2025-02-11T23:37:09.2101368Z 23:37:09,153 INFO  [pingpong] ./application: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ./application)
2025-02-11T23:37:09.2102362Z 23:37:09,153 INFO  [pingpong] ./application: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by ./application)
```

I believe the reason for this is combination of default `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21` and ubi8 based `quay.io/quarkus/quarkus-micro-image`.

This commit https://github.com/quarkusio/quarkus/commit/f95cf8cc0a269f90102c42b2aa3d6afb1f33b689 changed description of the `quarkus.jib.base-native-image` to say `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` is default, but didn't change default.

https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.19#ubi-9 says that UBI9 based micro image is default, I believe this will solve my issues. I experienced many similar issues when I combined UBI9 and UBI8. Thanks.

P.S. I have also mentioned that `ubi-quarkus-native-binary-s2i` didn't change to `ubi9-quarkus-native-binary-s2i`, but the difference is that it is not in the migration guide or in the configuration property javadoc `io.quarkus.container.image.openshift.deployment.ContainerImageOpenshiftConfig#baseNativeImage` and I always override it didn't hit issues yet. I wonder - is it intentional and why?