### PR TITLE
WebSockets Next: make it possible to configure max frame size

### DIFF
--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/maxframesize/MaxFrameSizeTest.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/maxframesize/MaxFrameSizeTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.websockets.next.test.maxframesize;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.netty.handler.codec.http.websocketx.CorruptedWebSocketFrameException;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.test.utils.WSClient;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocketFrame;
+
+public class MaxFrameSizeTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(Echo.class, WSClient.class);
+            })
+            .overrideConfigKey("quarkus.websockets-next.server.max-frame-size", "10");
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource("/echo")
+    URI echoUri;
+
+    @Test
+    void testMaxFrameSize() throws InterruptedException, ExecutionException, TimeoutException {
+        WSClient client = WSClient.create(vertx).connect(echoUri);
+        client.socket().writeFrame(WebSocketFrame.textFrame("foo".repeat(10), false));
+        assertTrue(Echo.CORRUPTED_LATCH.await(5, TimeUnit.SECONDS));
+    }
+
+    @WebSocket(path = "/echo")
+    public static class Echo {
+
+        static final CountDownLatch CORRUPTED_LATCH = new CountDownLatch(1);
+
+        @OnTextMessage
+        String process(String message) {
+            return message;
+        }
+
+        @OnError
+        void onError(CorruptedWebSocketFrameException e) {
+            // Note that connection is automatically closed when CorruptedWebSocketFrameException is thrown
+            CORRUPTED_LATCH.countDown();
+        }
+
+    }
+
+}

--- a/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/utils/WSClient.java
+++ b/extensions/websockets-next/deployment/src/test/java/io/quarkus/websockets/next/test/utils/WSClient.java
@@ -164,6 +164,10 @@ public class WSClient implements AutoCloseable {
         disconnect();
     }
 
+    public WebSocket socket() {
+        return socket.get();
+    }
+
     public enum ReceiverMode {
         BINARY,
         TEXT,

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectorBase.java
@@ -153,6 +153,9 @@ abstract class WebSocketConnectorBase<THIS extends WebSocketConnectorBase<THIS>>
         if (config.maxMessageSize().isPresent()) {
             clientOptions.setMaxMessageSize(config.maxMessageSize().getAsInt());
         }
+        if (config.maxFrameSize().isPresent()) {
+            clientOptions.setMaxFrameSize(config.maxFrameSize().getAsInt());
+        }
 
         Optional<TlsConfiguration> maybeTlsConfiguration = TlsConfiguration.from(tlsConfigurationRegistry,
                 config.tlsConfigurationName());

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketHttpServerOptionsCustomizer.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketHttpServerOptionsCustomizer.java
@@ -34,6 +34,9 @@ public class WebSocketHttpServerOptionsCustomizer implements HttpServerOptionsCu
         if (config.maxMessageSize().isPresent()) {
             options.setMaxWebSocketMessageSize(config.maxMessageSize().getAsInt());
         }
+        if (config.maxFrameSize().isPresent()) {
+            options.setMaxWebSocketFrameSize(config.maxFrameSize().getAsInt());
+        }
     }
 
 }

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/config/WebSocketsClientRuntimeConfig.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/config/WebSocketsClientRuntimeConfig.java
@@ -35,6 +35,12 @@ public interface WebSocketsClientRuntimeConfig {
     OptionalInt maxMessageSize();
 
     /**
+     * The maximum size of a frame in bytes. The default values is
+     * {@value io.vertx.core.http.HttpClientOptions#DEFAULT_MAX_WEBSOCKET_FRAME_SIZEX}.
+     */
+    OptionalInt maxFrameSize();
+
+    /**
      * The interval after which, when set, the client sends a ping message to a connected server automatically.
      * <p>
      * Ping messages are not sent automatically by default.

--- a/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/config/WebSocketsServerRuntimeConfig.java
+++ b/extensions/websockets-next/runtime/src/main/java/io/quarkus/websockets/next/runtime/config/WebSocketsServerRuntimeConfig.java
@@ -41,6 +41,12 @@ public interface WebSocketsServerRuntimeConfig {
     OptionalInt maxMessageSize();
 
     /**
+     * The maximum size of a frame in bytes. The default values is
+     * {@value io.vertx.core.http.HttpServerOptions#DEFAULT_MAX_WEBSOCKET_FRAME_SIZE}.
+     */
+    OptionalInt maxFrameSize();
+
+    /**
      * The interval after which, when set, the server sends a ping message to a connected client automatically.
      * <p>
      * Ping messages are not sent automatically by default.


### PR DESCRIPTION
- add quarkus.websockets-next.server.max-frame-size and quarkus.websockets-next.client.max-frame-size config properties
- related to https://github.com/quarkusio/quarkus/issues/43381#issuecomment-2653470445