### PR TITLE
Add time zone property for kubernetes and openshift cron jobs

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddCronJobResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddCronJobResourceDecorator.java
@@ -83,6 +83,7 @@ public class AddCronJobResourceDecorator extends ResourceProvidingDecorator<Kube
         config.successfulJobsHistoryLimit().ifPresent(spec::withSuccessfulJobsHistoryLimit);
         config.failedJobsHistoryLimit().ifPresent(spec::withFailedJobsHistoryLimit);
         config.startingDeadlineSeconds().ifPresent(spec::withStartingDeadlineSeconds);
+        config.timeZone().ifPresent(spec::withTimeZone);
 
         jobTemplateSpec.withCompletionMode(config.completionMode().name());
         jobTemplateSpec.editTemplate().editSpec().withRestartPolicy(config.restartPolicy().name()).endSpec().endTemplate();

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/CronJobConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/CronJobConfig.java
@@ -14,6 +14,11 @@ public interface CronJobConfig {
     Optional<String> schedule();
 
     /**
+     * The time zone for the job schedule. The default value is the local time of the kube-controller-manager.
+     */
+    Optional<String> timeZone();
+
+    /**
      * ConcurrencyPolicy describes how the job will be handled.
      */
     @WithDefault("Allow")

--- a/extensions/kubernetes/vanilla/deployment/src/test/resources/application-kubernetes.properties
+++ b/extensions/kubernetes/vanilla/deployment/src/test/resources/application-kubernetes.properties
@@ -201,6 +201,7 @@ quarkus.kubernetes.job.restart-policy=Never
 
 # quarkus.kubernetes.deployment-kind=CronJob
 quarkus.kubernetes.cron-job.schedule=-
+quarkus.kubernetes.cron-job.time-zone=Etc/UTC
 quarkus.kubernetes.cron-job.concurrency-policy=Forbid
 quarkus.kubernetes.cron-job.starting-deadline-seconds=7
 quarkus.kubernetes.cron-job.failed-jobs-history-limit=7

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithCronJobResourceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithCronJobResourceTest.java
@@ -50,6 +50,7 @@ public class KubernetesWithCronJobResourceTest {
                 });
 
                 assertThat(s.getSpec().getSchedule()).isEqualTo("0 0 0 0 *");
+                assertThat(s.getSpec().getTimeZone()).isEqualTo("Etc/UTC");
 
                 assertThat(s.getSpec().getJobTemplate().getSpec()).satisfies(jobSpec -> {
                     assertThat(jobSpec.getParallelism()).isEqualTo(10);

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithCronJobResourceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithCronJobResourceTest.java
@@ -50,6 +50,7 @@ public class OpenshiftWithCronJobResourceTest {
                 });
 
                 assertThat(s.getSpec().getSchedule()).isEqualTo("0 0 0 0 *");
+                assertThat(s.getSpec().getTimeZone()).isEqualTo("Etc/UTC");
 
                 assertThat(s.getSpec().getJobTemplate().getSpec()).satisfies(jobSpec -> {
                     assertThat(jobSpec.getParallelism()).isEqualTo(10);

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-cronjob-resource.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-cronjob-resource.properties
@@ -1,5 +1,6 @@
 quarkus.kubernetes.deployment-kind=CronJob
 quarkus.kubernetes.arguments=A,B
 quarkus.kubernetes.cron-job.schedule=0 0 0 0 *
+quarkus.kubernetes.cron-job.time-zone=Etc/UTC
 quarkus.kubernetes.cron-job.parallelism=10
 quarkus.kubernetes.cron-job.restart-policy=Never

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-cronjob-resource.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-cronjob-resource.properties
@@ -1,5 +1,6 @@
 quarkus.openshift.deployment-kind=CronJob
 quarkus.openshift.arguments=A,B
 quarkus.openshift.cron-job.schedule=0 0 0 0 *
+quarkus.openshift.cron-job.time-zone=Etc/UTC
 quarkus.openshift.cron-job.parallelism=10
 quarkus.openshift.cron-job.restart-policy=Never


### PR DESCRIPTION
Implements the `quarkus.kubernetes.cron-job.time-zone` and `quarkus.openshift.cron-job.time-zone` properties to set the time zone for the cron job schedule. 

- Closes: #45285