### PR TITLE
Add a way to override the artifact type to test for `@QuarkusIntegrationTest`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -261,6 +261,16 @@ public interface TestConfig {
     @WithDefault("false")
     boolean enableCallbacksForIntegrationTests();
 
+    /**
+     * Used to override the artifact type against which a {@code @QuarkusIntegrationTest} or {@code @QuarkusMainIntegrationTest}
+     * run.
+     * For example, if the application's artifact is a container build from a jar, this property could be used to test the jar
+     * instead of the container.
+     * <p>
+     * Allowed values are: jar, native
+     */
+    Optional<String> integrationTestArtifactType();
+
     interface Profile {
         /**
          * A comma separated list of profiles (dev, test, prod or custom profiles) to use when testing using @QuarkusTest

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -425,7 +425,16 @@ public final class IntegrationTestUtil {
         }
     }
 
+    static String getEffectiveArtifactType(Properties quarkusArtifactProperties, SmallRyeConfig config) {
+        Optional<String> maybeType = config.getOptionalValue("quarkus.test.integration-test-artifact-type", String.class);
+        if (maybeType.isPresent()) {
+            return maybeType.get();
+        }
+        return getArtifactType(quarkusArtifactProperties);
+    }
+
     static String getArtifactType(Properties quarkusArtifactProperties) {
+
         String artifactType = quarkusArtifactProperties.getProperty("type");
         if (artifactType == null) {
             throw new IllegalStateException("Unable to determine the type of artifact created by the Quarkus build");

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -8,7 +8,7 @@ import static io.quarkus.test.junit.IntegrationTestUtil.determineTestProfileAndP
 import static io.quarkus.test.junit.IntegrationTestUtil.doProcessTestInstance;
 import static io.quarkus.test.junit.IntegrationTestUtil.ensureNoInjectAnnotationIsUsed;
 import static io.quarkus.test.junit.IntegrationTestUtil.findProfile;
-import static io.quarkus.test.junit.IntegrationTestUtil.getArtifactType;
+import static io.quarkus.test.junit.IntegrationTestUtil.getEffectiveArtifactType;
 import static io.quarkus.test.junit.IntegrationTestUtil.getSysPropsToRestore;
 import static io.quarkus.test.junit.IntegrationTestUtil.handleDevServices;
 import static io.quarkus.test.junit.IntegrationTestUtil.readQuarkusArtifactProperties;
@@ -190,9 +190,9 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             throws Throwable {
         JBossVersion.disableVersionLogging();
 
-        String artifactType = getArtifactType(quarkusArtifactProperties);
-
         SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        String artifactType = getEffectiveArtifactType(quarkusArtifactProperties, config);
+
         TestConfig testConfig = config.getConfigMapping(TestConfig.class);
         boolean isDockerLaunch = isContainer(artifactType)
                 || (isJar(artifactType) && "test-with-native-agent".equals(testConfig.integrationTestProfile()));

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -6,6 +6,7 @@ import static io.quarkus.test.junit.IntegrationTestUtil.activateLogging;
 import static io.quarkus.test.junit.IntegrationTestUtil.determineBuildOutputDirectory;
 import static io.quarkus.test.junit.IntegrationTestUtil.determineTestProfileAndProperties;
 import static io.quarkus.test.junit.IntegrationTestUtil.ensureNoInjectAnnotationIsUsed;
+import static io.quarkus.test.junit.IntegrationTestUtil.getEffectiveArtifactType;
 import static io.quarkus.test.junit.IntegrationTestUtil.getSysPropsToRestore;
 import static io.quarkus.test.junit.IntegrationTestUtil.handleDevServices;
 import static io.quarkus.test.junit.IntegrationTestUtil.readQuarkusArtifactProperties;
@@ -101,11 +102,9 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
         ensureNoInjectAnnotationIsUsed(testClass, "@QuarkusMainIntegrationTest");
 
         quarkusArtifactProperties = readQuarkusArtifactProperties(extensionContext);
-        String artifactType = quarkusArtifactProperties.getProperty("type");
-        if (artifactType == null) {
-            throw new IllegalStateException("Unable to determine the type of artifact created by the Quarkus build");
-        }
         SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        String artifactType = getEffectiveArtifactType(quarkusArtifactProperties, config);
+
         TestConfig testConfig = config.getConfigMapping(TestConfig.class);
 
         boolean isDockerLaunch = isContainer(artifactType)


### PR DESCRIPTION
This can be useful when the application builds a
container image as it's final artifact,
but would like to use `@QuarkusIntegrationTest`
to test the jar or native image based on which
the container was built.

The way to achieve this is to set for example:

```
-Dquarkus.test.integration-test-artifact-type=jar
```

when testing the jar is necessary

- Closes: #46232