### PR TITLE
Update SmallRye Config to 3.12.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -47,7 +47,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
         <smallrye-common.version>2.10.0</smallrye-common.version>
-        <smallrye-config.version>3.11.2</smallrye-config.version>
+        <smallrye-config.version>3.12.0</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.8</smallrye-open-api.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ConfigMappingBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ConfigMappingBuildItem.java
@@ -28,7 +28,7 @@ public final class ConfigMappingBuildItem extends MultiBuildItem {
     }
 
     public ConfigClass toConfigClass() {
-        return new ConfigClass(configClass, prefix);
+        return ConfigClass.configClass(configClass, prefix);
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -193,7 +193,8 @@ public class ConfigMappingUtils {
 
     public static Object newInstance(Class<?> configClass) {
         if (configClass.isAnnotationPresent(ConfigMapping.class)) {
-            return ReflectUtil.newInstance(ConfigMappingLoader.getImplementationClass(configClass));
+            // TODO - radcortez - mapping classes cannot be initialized like this.
+            return ReflectUtil.newInstance(ConfigMappingLoader.ensureLoaded(configClass).implementation());
         } else {
             return ReflectUtil.newInstance(configClass);
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -3,6 +3,7 @@ package io.quarkus.deployment.configuration;
 import static io.quarkus.deployment.util.ReflectUtil.reportError;
 import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_AND_RUN_TIME_FIXED;
 import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
+import static io.smallrye.config.common.utils.StringUtil.skewer;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -1231,7 +1232,8 @@ public final class RunTimeConfigurationGenerator {
                     BranchResult nextEquals = hasNextTrue
                             .ifTrue(hasNextTrue.invokeStaticMethod(PU_IS_MAPPED, nameIterator, hasNextTrue.load(childName)));
                     try (BytecodeCreator nextEqualsTrue = nextEquals.trueBranch()) {
-                        String childMethodName = methodName + "$" + childName.replace("[*]", "-collection");
+                        childName = childName.replace("[*]", "-collection");
+                        String childMethodName = methodName + "$" + skewer(childName, '_');
                         if (child.getMatched() == null) {
                             generateIsMapped(childMethodName, child);
                             nextEqualsTrue.invokeVirtualMethod(NI_NEXT, nameIterator);

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
@@ -1,14 +1,20 @@
 package io.quarkus.runtime.configuration;
 
+import java.util.Map;
+
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.eclipse.microprofile.config.spi.Converter;
 
+import io.smallrye.config.ConfigMappingLoader;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.ConfigSourceFactory;
 import io.smallrye.config.ConfigSourceInterceptor;
 import io.smallrye.config.ConfigSourceInterceptorFactory;
 import io.smallrye.config.SecretKeysHandler;
 import io.smallrye.config.SecretKeysHandlerFactory;
+import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
 
@@ -17,8 +23,9 @@ import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
  * require varargs or collections as parameters.
  */
 public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCustomizer {
-    protected static void withDefaultValue(SmallRyeConfigBuilder builder, String name, String value) {
-        builder.withDefaultValue(name, value);
+
+    protected static void withDefaultValues(SmallRyeConfigBuilder builder, Map<String, String> values) {
+        builder.withDefaultValues(values);
     }
 
     @SuppressWarnings("unchecked")
@@ -62,6 +69,10 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
         builder.withSecretKeyHandlerFactories(secretKeysHandlerFactory);
     }
 
+    protected static void withMapping(SmallRyeConfigBuilder builder, ConfigClass mapping) {
+        builder.withMapping(mapping);
+    }
+
     protected static void withMapping(SmallRyeConfigBuilder builder, String mappingClass, String prefix) {
         try {
             // To support mappings that are not public
@@ -69,6 +80,11 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    protected static void withMappingInstance(SmallRyeConfigBuilder builder, ConfigClass mapping) {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        builder.getMappingsBuilder().mappingInstance(mapping, config.getConfigMapping(mapping.getType()));
     }
 
     protected static void withBuilder(SmallRyeConfigBuilder builder, ConfigBuilder configBuilder) {
@@ -96,6 +112,24 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
                     .getClassLoader().loadClass(customizer);
             customizerClass.getDeclaredConstructor().newInstance().configBuilder(builder);
         } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static ConfigClass configClass(final String mappingClass, final String prefix) {
+        try {
+            // To support mappings that are not public
+            return ConfigClass.configClass(Thread.currentThread().getContextClassLoader().loadClass(mappingClass), prefix);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void ensureLoaded(final String mappingClass) {
+        try {
+            // To support mappings that are not public
+            ConfigMappingLoader.ensureLoaded(Thread.currentThread().getContextClassLoader().loadClass(mappingClass));
+        } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/init/InitRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/init/InitRuntimeConfig.java
@@ -1,7 +1,5 @@
 package io.quarkus.runtime.init;
 
-import static io.smallrye.config.Converters.newEmptyValueConverter;
-
 import org.eclipse.microprofile.config.spi.Converter;
 
 import io.quarkus.runtime.annotations.ConfigDocPrefix;
@@ -19,7 +17,6 @@ import io.smallrye.config.WithDefault;
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 @ConfigDocPrefix("quarkus.init")
 public interface InitRuntimeConfig {
-
     /**
      * true to quit exit right after the initialization.
      * The option is not meant be used directly by users.
@@ -30,26 +27,9 @@ public interface InitRuntimeConfig {
     boolean initAndExit();
 
     // Because of https://github.com/eclipse/microprofile-config/issues/708
-    // TODO - radcortez - Make SR Config built-in converters public to be used directly
-    class BooleanConverter implements Converter<Boolean> {
-        static final Converter<Boolean> BOOLEAN_CONVERTER = Converters
-                .newTrimmingConverter(newEmptyValueConverter(new Converter<Boolean>() {
-                    @Override
-                    public Boolean convert(final String value) throws IllegalArgumentException, NullPointerException {
-                        return Boolean.valueOf(
-                                "TRUE".equalsIgnoreCase(value)
-                                        || "1".equalsIgnoreCase(value)
-                                        || "YES".equalsIgnoreCase(value)
-                                        || "Y".equalsIgnoreCase(value)
-                                        || "ON".equalsIgnoreCase(value)
-                                        || "JA".equalsIgnoreCase(value)
-                                        || "J".equalsIgnoreCase(value)
-                                        || "SI".equalsIgnoreCase(value)
-                                        || "SIM".equalsIgnoreCase(value)
-                                        || "OUI".equalsIgnoreCase(value));
-                    }
-                }));
+    Converter<Boolean> BOOLEAN_CONVERTER = Converters.getImplicitConverter(Boolean.class);
 
+    class BooleanConverter implements Converter<Boolean> {
         @Override
         public Boolean convert(final String value) throws IllegalArgumentException, NullPointerException {
             return BOOLEAN_CONVERTER.convert(value);

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ plugin-publish = "1.3.1"
 
 # updating Kotlin here makes QuarkusPluginTest > shouldNotFailOnProjectDependenciesWithoutMain(Path) fail
 kotlin = "2.0.21"
-smallrye-config = "3.11.2"
+smallrye-config = "3.11.3-SNAPSHOT"
 
 junit5 = "5.10.5"
 assertj = "3.27.3"

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -502,7 +502,7 @@ public class ConfigBuildStep {
         // TODO - Register ConfigProperties during build time
         context.registerNonDefaultConstructor(
                 ConfigClass.class.getDeclaredConstructor(Class.class, String.class),
-                configClass -> Stream.of(configClass.getKlass(), configClass.getPrefix())
+                configClass -> Stream.of(configClass.getType(), configClass.getPrefix())
                         .collect(toList()));
 
         recorder.registerConfigProperties(


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.12.0</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1316">#1316</a> Revert "Add new method isEnabled to ConfigSourceInterceptor (#1311)"</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1315">#1315</a> Try indexed names on injection when non indexed value is null</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1314">#1314</a> Compute indexed properties when building the list of PropertyNames</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1313">#1313</a> Keep properties from ConfigMapping implementation</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1312">#1312</a> Bump io.smallrye.common:smallrye-common-bom from 2.9.0 to 2.10.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1311">#1311</a> Add new method isEnabled to ConfigSourceInterceptor</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1310">#1310</a> Add API in the builder to register a mapping instance</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1309">#1309</a> Cache MethodHandles to construct and get defaults from the mapping implementation</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1308">#1308</a> Slight optimization when populating the DefaultValuesConfigSource</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1306">#1306</a> Add a way for ConfigClass to also carry and load defaults from a config mapping class</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1304">#1304</a> Ignore default methods inherited from super classes in mappings</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1303">#1303</a> Skip profile lookup if System, Env, Properties and Default sources do not contain a profile property name</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1297">#1297</a> Bump io.smallrye:smallrye-parent from 46 to 47</li>
    </ul>
</blockquote>

Quarkus:
- Fixes #46172

This PR also makes some improvements in the startup time and RSS by:

- Caching the `MethodHandle` used to construct the mappings (and all inner elements). In the native image, because `ClassValue` is substituted by `ConcurrentHashMap`, it is considerably slower due to the locking mechanism. Check the full explanation here:
  - https://github.com/smallrye/smallrye-config/pull/1311#issuecomment-2654438883 
  - https://github.com/smallrye/smallrye-config/pull/1311#issuecomment-2654444874
  - https://github.com/smallrye/smallrye-config/pull/1311#issuecomment-2654457272
- Reusing the instance of mappings build in the `STATIC_INIT` phase. Until now, mappings shared between `STATIC_INIT` and `RUNTIME` would be initialized twice.
- Skip the configuration profile shorthand lookup `%profile.*` if the source does not contain profile property names.

Used `config-quickstart` to measure improvements with Java 21 Temurin and Graal 21:

<google-sheets-html-origin style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">

  | JVM RSS | Native RSS | JVM Start | Native Start
-- | -- | -- | -- | --
3.19.0 | 132542 | 20441 | 0.632 | 0.020
#46249 | 132599 | 19705 | 0.606 | 0.015
Diff to 3.19.0 | 0.04% | -4.36% | -3.74% | -28.95%

</google-sheets-html-origin>
