### PR TITLE
Introduce validation mode instead of a boolean flag for BV integration in ORM

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -664,9 +664,38 @@ public interface HibernateOrmConfigPersistenceUnit {
 
         /**
          * Enables the Bean Validation integration.
+         *
+         * @deprecated Use {@link #mode()} instead.
          */
+        @Deprecated(since = "3.19", forRemoval = true)
         @WithDefault("true")
         boolean enabled();
+
+        /**
+         * Defines how the Bean Validation integration behaves.
+         */
+        @WithDefault("auto")
+        Set<ValidationMode> mode();
+
+        enum ValidationMode {
+            /**
+             * If a Bean Validation provider is present then behaves as if both {@link ValidationMode#CALLBACK} and
+             * {@link ValidationMode#DDL} modes are configured. Otherwise, same as {@link ValidationMode#NONE}.
+             */
+            AUTO,
+            /**
+             * Bean Validation will perform the lifecycle event validation.
+             */
+            CALLBACK,
+            /**
+             * Bean Validation constraints will be considered for the DDL operations.
+             */
+            DDL,
+            /**
+             * Bean Validation integration will be disabled.
+             */
+            NONE
+        }
     }
 
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -1103,15 +1103,15 @@ public final class HibernateOrmProcessor {
             p.put(JAKARTA_SHARED_CACHE_MODE, SharedCacheMode.NONE);
         }
 
-        // Hibernate Validator integration: we force the callback mode to have bootstrap errors reported rather than validation ignored
-        // if there is any issue when bootstrapping Hibernate Validator.
-        if (capabilities.isPresent(Capability.HIBERNATE_VALIDATOR)) {
-            if (persistenceUnitConfig.validation().enabled()) {
-                descriptor.getProperties().setProperty(AvailableSettings.JAKARTA_VALIDATION_MODE,
-                        ValidationMode.CALLBACK.name());
-            } else {
-                descriptor.getProperties().setProperty(AvailableSettings.JAKARTA_VALIDATION_MODE, ValidationMode.NONE.name());
-            }
+        if (!persistenceUnitConfig.validation().enabled()) {
+            descriptor.getProperties().setProperty(AvailableSettings.JAKARTA_VALIDATION_MODE, ValidationMode.NONE.name());
+        } else {
+            descriptor.getProperties().setProperty(
+                    AvailableSettings.JAKARTA_VALIDATION_MODE,
+                    persistenceUnitConfig.validation().mode()
+                            .stream()
+                            .map(Enum::name)
+                            .collect(Collectors.joining(",")));
         }
 
         // Discriminator Column

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPATestValidationResource.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPATestValidationResource.java
@@ -7,8 +7,11 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 
 import io.quarkus.hibernate.orm.MyEntity;
 
@@ -34,5 +37,17 @@ public class JPATestValidationResource {
                     .map(s -> s.getMessage())
                     .collect(Collectors.joining());
         }
+    }
+
+    @GET
+    public String ddl() {
+        return "nullable: " + em.getEntityManagerFactory()
+                .unwrap(SessionFactoryImplementor.class)
+                .getMappingMetamodel()
+                .getEntityDescriptor(MyEntity.class)
+                .getEntityMappingType()
+                .getAttributeMapping(0)
+                .getAttributeMetadata()
+                .isNullable();
     }
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPAValidationModeAutoTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPAValidationModeAutoTestCase.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.validation;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class JPAValidationModeAutoTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class, JPATestValidationResource.class)
+                    .addAsResource("application-validation-mode-auto.properties", "application.properties"));
+
+    @Test
+    public void testInValidEntity() {
+        String entityName = "Post method should not persist an entity having a Size constraint of 50 on the name column if validation was enabled.";
+        RestAssured.given().body(entityName).when().post("/validation").then()
+                .body(is("entity name too long"));
+    }
+
+    @Test
+    public void testDDL() {
+        RestAssured.when().get("/validation").then()
+                .body(is("nullable: false"));
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPAValidationModeMultipleTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPAValidationModeMultipleTestCase.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.validation;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class JPAValidationModeMultipleTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class, JPATestValidationResource.class)
+                    .addAsResource("application-validation-mode-multiple.properties", "application.properties"));
+
+    @Test
+    public void testValidEntity() {
+        String entityName = "Post method should not persist an entity having a Size constraint of 50 on the name column if validation was enabled.";
+        RestAssured.given().body(entityName).when().post("/validation").then()
+                .body(is("entity name too long"));
+    }
+
+    @Test
+    public void testDDL() {
+        RestAssured.when().get("/validation").then()
+                .body(is("nullable: false"));
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPAValidationModeNoneTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/validation/JPAValidationModeNoneTestCase.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.validation;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class JPAValidationModeNoneTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class, JPATestValidationResource.class)
+                    .addAsResource("application-validation-mode-none.properties", "application.properties"));
+
+    @Test
+    public void testValidEntity() {
+        String entityName = "Post method should not persist an entity having a Size constraint of 50 on the name column if validation was enabled.";
+        RestAssured.given().body(entityName).when().post("/validation").then()
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testDDL() {
+        RestAssured.when().get("/validation").then()
+                .body(is("nullable: true"));
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-auto.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-auto.properties
@@ -1,0 +1,7 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+#quarkus.hibernate-orm.log.sql=true
+# we don't set it explicitly as it is a default:
+#quarkus.hibernate-orm.validation.mode=AUTO
+quarkus.hibernate-orm.database.generation=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-multiple.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-multiple.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+#quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.validation.mode=callback,ddl
+quarkus.hibernate-orm.database.generation=drop-and-create

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-none.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-validation-mode-none.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+#quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.validation.mode=none
+quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/46034

I'm not sure about the property name itself ... I went with plural `quarkus.hibernate-orm.validation.modes` since we can accept multiple values there... but maybe it should be singular instead `quarkus.hibernate-orm.validation.mode`?

As for the migration guide, I'd add something along the lines:

```
Bean Validation integration changes its default behaviour and now considers validation constraints while generating DDL. 
To preserve the previous behaviour, use `quarkus.hibernate-orm.validation.mode=CALLBACK`. 

`quarkus.hibernate-orm.validation.enabled` is deprecated. To disable the Bean Validation integration, set `quarkus.hibernate-orm.validation.mode=NONE` instead.
```

as to:

> Also we'd need to see what's different in Hibernate Reactive...

.... we do not set the property in the reactive processor so it is defaulted to `null` which in turn behaves as `AUTO` so both `CALLBACK` and `DDL` work:
https://github.com/quarkusio/quarkus/blob/1bdd69f6f9fe2ae7ea7c166e293500146f983e45/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java#L251-L428