### PR TITLE
[3.15] Bump io.smallrye.common:smallrye-common-bom from 2.6.0 to 2.6.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -52,7 +52,7 @@
         <microprofile-jwt.version>2.1</microprofile-jwt.version>
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>3.1.1</microprofile-openapi.version>
-        <smallrye-common.version>2.6.0</smallrye-common.version>
+        <smallrye-common.version>2.6.1</smallrye-common.version>
         <smallrye-config.version>3.9.1</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -49,6 +49,7 @@
         <version.jboss-logging>3.6.0.Final</version.jboss-logging>
         <version.mutiny>2.6.2</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
+        <version.smallrye-common>2.6.1</version.smallrye-common>
         <!-- test versions -->
         <version.assertj>3.26.3</version.assertj>
         <version.junit5>5.10.3</version.junit5>
@@ -77,6 +78,13 @@
     <dependencyManagement>
 
         <dependencies>
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-bom</artifactId>
+                <version>${version.smallrye-common}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
             <dependency>
                 <groupId>io.quarkus.arc</groupId>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -71,7 +71,7 @@
         <plexus-interpolation.version>1.26</plexus-interpolation.version>
         <plexus-sec-dispatcher.version>2.0</plexus-sec-dispatcher.version>
         <plexus-utils.version>3.5.1</plexus-utils.version>
-        <smallrye-common.version>2.6.0</smallrye-common.version>
+        <smallrye-common.version>2.6.1</smallrye-common.version>
         <smallrye-beanbag.version>1.5.2</smallrye-beanbag.version>
         <gradle-tooling.version>8.9</gradle-tooling.version>
         <quarkus-fs-util.version>0.0.10</quarkus-fs-util.version>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -43,6 +43,7 @@
         <version.jandex>3.2.3</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>
         <version.jboss-logging>3.6.0.Final</version.jboss-logging>
+        <version.smallrye-common>2.6.1</version.smallrye-common>
         <version.smallrye-mutiny>2.6.2</version.smallrye-mutiny>
     </properties>
 
@@ -53,6 +54,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-bom</artifactId>
+                <version>${version.smallrye-common}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- JUnit 5 dependencies, imported as a BOM -->
             <dependency>
                 <groupId>org.junit</groupId>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -57,7 +57,7 @@
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
         <mutiny.version>2.6.2</mutiny.version>
-        <smallrye-common.version>2.6.0</smallrye-common.version>
+        <smallrye-common.version>2.6.1</smallrye-common.version>
         <vertx.version>4.5.11</vertx.version>
         <rest-assured.version>5.5.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>


### PR DESCRIPTION
- This is necessary Because https://github.com/quarkusio/quarkus/pull/44954 didn't make it to 3.15 and still prevents bumping the registry as seen in https://github.com/quarkusio/registry.quarkus.io/pull/273