### PR TITLE
Use same `smallrye-common` dependencies across independent subprojects

### DIFF
--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -49,6 +49,7 @@
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
         <version.mutiny>2.8.0</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
+        <version.smallrye-common>2.10.0</version.smallrye-common>
         <!-- test versions -->
         <version.assertj>3.27.3</version.assertj>
         <version.junit5>5.10.5</version.junit5>
@@ -77,6 +78,13 @@
     <dependencyManagement>
 
         <dependencies>
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-bom</artifactId>
+                <version>${version.smallrye-common}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
             <dependency>
                 <groupId>io.quarkus.arc</groupId>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -43,6 +43,7 @@
         <version.jandex>3.2.6</version.jandex>
         <version.gizmo>1.8.0</version.gizmo>
         <version.jboss-logging>3.6.1.Final</version.jboss-logging>
+        <version.smallrye-common>2.10.0</version.smallrye-common>
         <version.smallrye-mutiny>2.8.0</version.smallrye-mutiny>
     </properties>
 
@@ -53,6 +54,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-bom</artifactId>
+                <version>${version.smallrye-common}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- JUnit 5 dependencies, imported as a BOM -->
             <dependency>
                 <groupId>org.junit</groupId>


### PR DESCRIPTION
This makes sure the projects do not use an older `smallrye-commons-annotation` dependency resolved transitively from `smallrye-mutiny`