### PR TITLE
Remove invalid timer from Client SSE handling

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/SseEventSourceImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/SseEventSourceImpl.java
@@ -209,10 +209,6 @@ public class SseEventSourceImpl implements SseEventSource, Handler<Long> {
             vertx.cancelTimer(timerId);
             timerId = -1;
         }
-        // schedule a new reconnect if the client closed us
-        if (clientClosed) {
-            timerId = vertx.setTimer(TimeUnit.MILLISECONDS.convert(reconnectDelay, reconnectUnit), this);
-        }
     }
 
     private synchronized void notifyCompletion() {


### PR DESCRIPTION
This timer apart from serving no functional purpose, can also lead to OOME as the timers are accumulated by Vert.x

- Fixes: #46237