### PR TITLE
Avoid creating a timer when reconnectDelay is set to Max

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/SseEventSourceImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/SseEventSourceImpl.java
@@ -210,7 +210,7 @@ public class SseEventSourceImpl implements SseEventSource, Handler<Long> {
             timerId = -1;
         }
         // schedule a new reconnect if the client closed us
-        if (clientClosed) {
+        if (clientClosed && reconnectDelay != Integer.MAX_VALUE) {
             timerId = vertx.setTimer(TimeUnit.MILLISECONDS.convert(reconnectDelay, reconnectUnit), this);
         }
     }


### PR DESCRIPTION
When dealing with SSE using a Multi in the REST Client, the `reconnectDelay` is [set](https://github.com/quarkusio/quarkus/blob/bd77018404ed7151c9b58fa88fa1dbb5d014630e/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/MultiInvoker.java#L177) to `Integer.MAX_VALUE` in order to essentially turn off reconnecting.
In this case we need to avoid creating a timer that will linger around forever and potentially create a OOME

- Fixes: #46237