### PR TITLE
Switch to supported com.tisonkun.os:os-detector-maven-plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -19,4 +19,9 @@
         <artifactId>quarkus-project-develocity-extension</artifactId>
         <version>1.1.9</version>
     </extension>
+     <extension>
+         <groupId>com.tisonkun.os</groupId>
+         <artifactId>os-detector-maven-plugin</artifactId>
+         <version>0.6.0</version>
+     </extension>
 </extensions>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -146,7 +146,6 @@
 
         <surefire.argLine.additional></surefire.argLine.additional>
         <failsafe.argLine.additional>${surefire.argLine.additional}</failsafe.argLine.additional>
-        <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
 
         <!-- google cloud functions invoker-->
         <gcf-invoker.version>1.3.0</gcf-invoker.version>

--- a/docs/src/main/asciidoc/grpc-generation-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-generation-reference.adoc
@@ -188,16 +188,16 @@ To do this, define the following properties in the `<properties>` section:
 
 These properties configure the gRPC version and the `protoc` version.
 
-Then, add the `os-maven-plugin` extension and the `protobuf-maven-plugin` configuration to the `build` section:
+Then, add the `os-detector-maven-plugin` extension and the `protobuf-maven-plugin` configuration to the `build` section:
 
 [source,xml]
 ----
 <build>
     <extensions>
         <extension>
-            <groupId>kr.motd.maven</groupId>
-            <artifactId>os-maven-plugin</artifactId>
-            <version>${os-maven-plugin-version}</version>
+            <groupId>com.tisonkun.os</groupId>
+            <artifactId>os-detector-maven-plugin</artifactId>
+            <version>${os-detector-maven-plugin.version}</version>
         </extension>
     </extensions>
 
@@ -244,7 +244,7 @@ Then, add the `os-maven-plugin` extension and the `protobuf-maven-plugin` config
 ----
 
 <1> The `protobuf-maven-plugin` generates stub classes from your gRPC service definition (`proto` files).
-<2> Class generation uses the tool `protoc`, which is OS-specific. This is why we use the `os-maven-plugin` to target the executable compatible with the operating system.
+<2> Class generation uses the tool `protoc`, which is OS-specific. This is why we use the `os-detector-maven-plugin` to target the executable compatible with the operating system.
 
 Note: This configuration instructs the `protobuf-maven-plugin` to generate default gRPC classes and classes using Mutiny to fit with the Quarkus development experience.
 

--- a/docs/src/main/asciidoc/jreleaser.adoc
+++ b/docs/src/main/asciidoc/jreleaser.adoc
@@ -107,10 +107,10 @@ shell completion scripts, man pages, license, readme, and more.
 == Creating the distribution
 
 We can leverage the link:http://maven.apache.org/plugins/maven-assembly-plugin/[maven-assembly-plugin] to create such
-a distribution. We'll also make use of the link:https://github.com/trustin/os-maven-plugin[os-maven-plugin] to properly
+a distribution. We'll also make use of the link:https://github.com/tikonsun/os-detector-maven-plugin[os-detector-maven-plugin] to properly
 identify the platform on which this executable can run, adding said platform to the distribution's filename.
 
-First, let's add the os-maven-plugin to the `pom.xml`. This plugin works as a Maven extension and as such must be added
+First, let's add the os-detector-maven-plugin to the `pom.xml`. This plugin works as a Maven extension and as such must be added
 to the `<build>` section of the file:
 
 [source,xml]
@@ -118,9 +118,9 @@ to the `<build>` section of the file:
   <build>
     <extensions>
       <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.1</version>
+        <groupId>com.tisonkun.os</groupId>
+        <artifactId>os-detector-maven-plugin</artifactId>
+        <version>0.6.0</version>
       </extension>
     </extensions>
     <!-- ... -->
@@ -139,7 +139,7 @@ their own directory to avoid cluttering the `target` directory. Thus, let's add 
 
 Now we configure the maven-assembly-plugin to create a Zip and a Tar file containing the executable and any supporting files
 it may need to perform its job. Take special note on the name of the distribution, this is where we make use of the platform
-properties detected by the os-maven-plugin. This plugin is configured in its own profile with the `single` goal bound to
+properties detected by the os-detector-maven-plugin. This plugin is configured in its own profile with the `single` goal bound to
 the `package` phase. It's done this way to avoid rebuilding the distribution every single time the build is invoked, as we
 only needed when we're ready for a release.
 
@@ -659,9 +659,9 @@ As a reference, these are the full contents of the `pom.xml`:
   <build>
     <extensions>
       <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.1</version>
+        <groupId>com.tisonkun.os</groupId>
+        <artifactId>os-detector-maven-plugin</artifactId>
+        <version>0.6.0/version>
       </extension>
     </extensions>
     <plugins>

--- a/extensions/grpc/deployment/pom.xml
+++ b/extensions/grpc/deployment/pom.xml
@@ -109,14 +109,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
-
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>

--- a/extensions/grpc/stubs/pom.xml
+++ b/extensions/grpc/stubs/pom.xml
@@ -72,14 +72,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
-
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>

--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -168,14 +168,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
-
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>

--- a/integration-tests/devmode/pom.xml
+++ b/integration-tests/devmode/pom.xml
@@ -92,13 +92,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>


### PR DESCRIPTION
The `os-maven-plugin` is not maintained anymore.
A fork has been created a while ago with Maven 4 support.
It makes sense to use it instead.