### PR TITLE
Fix return type for MariaDB PAM substitution

### DIFF
--- a/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/graal/SendPamAuthPacketFactory_Substitutions.java
+++ b/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/graal/SendPamAuthPacketFactory_Substitutions.java
@@ -2,6 +2,7 @@ package io.quarkus.jdbc.mariadb.runtime.graal;
 
 import org.mariadb.jdbc.Configuration;
 import org.mariadb.jdbc.HostAddress;
+import org.mariadb.jdbc.plugin.AuthenticationPlugin;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
@@ -10,7 +11,8 @@ import com.oracle.svm.core.annotate.TargetClass;
 public final class SendPamAuthPacketFactory_Substitutions {
 
     @Substitute
-    public void initialize(String authenticationData, byte[] seed, Configuration conf, HostAddress hostAddress) {
+    public AuthenticationPlugin initialize(String authenticationData, byte[] seed, Configuration conf,
+            HostAddress hostAddress) {
         throw new UnsupportedOperationException("Authentication strategy 'dialog' is not supported in GraalVM");
     }
 


### PR DESCRIPTION
Closes #46274

Tested with 25+8.1 GraalVM Community:
```
[INFO] --- quarkus:999-SNAPSHOT:build (default) @ quarkus-integration-test-jpa-mariadb ---
[INFO] [quarkus-build-caching-extension] Quarkus previous configuration not found
[INFO] [quarkus-build-caching-extension] Quarkus build goal marked as not cacheable
[INFO] [quarkus-build-caching-extension] Quarkus previous configuration not found
[INFO] [quarkus-build-caching-extension] Quarkus build goal marked as not cacheable
[INFO] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Building native image source jar: /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Building native image from /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on GRAALVM 25.0-dev JDK 25+8-jvmci-b01
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] /disk/graal/builds/graalvm-community-openjdk-25+8.1/bin/native-image -J-DCoordinatorEnvironmentBean.transactionStatusManagerEnable=false -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Duser.language=en -J-Duser.country=US -J-Dlogging.initial-configurator.min-level=500 -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -H:+UnlockExperimentalVMOptions -H:IncludeLocales=en-US -H:-UnlockExperimentalVMOptions -J-Dfile.encoding=UTF-8 -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED --features=org.hibernate.graalvm.internal.GraalVMStaticFeature,io.quarkus.hibernate.orm.runtime.graal.RegisterServicesForReflectionFeature,io.quarkus.runner.Feature,io.quarkus.hibernate.orm.runtime.graal.DisableLoggingFeature,io.quarkus.runtime.graal.DisableLoggingFeature,io.quarkus.caffeine.runtime.graal.CacheConstructorsFeature,io.quarkus.runtime.graal.SkipConsoleServiceProvidersFeature -J--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED -J--add-exports=java.security.jgss/sun.security.jgss=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -J--add-opens=java.base/java.io=ALL-UNNAMED -J--add-opens=java.base/java.lang.invoke=ALL-UNNAMED -J--add-opens=java.base/java.util=ALL-UNNAMED -H:+UnlockExperimentalVMOptions -H:PrintAnalysisCallTreeType=CSV -H:-UnlockExperimentalVMOptions -H:+UnlockExperimentalVMOptions -H:BuildOutputJSONFile=quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner-build-output-stats.json -H:-UnlockExperimentalVMOptions -H:+UnlockExperimentalVMOptions -H:+GenerateBuildArtifactsFile -H:-UnlockExperimentalVMOptions -H:+UnlockExperimentalVMOptions -H:+AllowFoldMethods -H:-UnlockExperimentalVMOptions -H:+UnlockExperimentalVMOptions -H:+ForeignAPISupport -H:-UnlockExperimentalVMOptions -J-Djava.awt.headless=true --no-fallback --link-at-build-time -H:+UnlockExperimentalVMOptions -H:+ReportExceptionStackTraces -H:-UnlockExperimentalVMOptions -H:-AddAllCharsets --enable-url-protocols=http,https -H:NativeLinkerOption=-no-pie --enable-monitoring=heapdump -H:+UnlockExperimentalVMOptions -H:-UseServiceLoaderFeature -H:-UnlockExperimentalVMOptions -J--add-exports=org.graalvm.nativeimage/org.graalvm.nativeimage.impl=ALL-UNNAMED --exclude-config io\.netty\.netty-codec /META-INF/native-image/io\.netty/netty-codec/generated/handlers/reflect-config\.json --exclude-config io\.netty\.netty-handler /META-INF/native-image/io\.netty/netty-handler/generated/handlers/reflect-config\.json quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner -jar quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner.jar
Warning: Option 'DynamicProxyConfigurationResources' is deprecated and might be removed in a future release: This can be caused by a proxy-config.json file in your META-INF directory. Consider including proxy configuration in the reflection section of reachability-metadata.md instead.. Please refer to the GraalVM release notes.
12:59:12.000 MariaDB:2025-02-14 11:59:12 4 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
========================================================================================================================
GraalVM Native Image: Generating 'quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner' (executable)...
========================================================================================================================
[1/8] Initializing...                                                                                    (5.9s @ 0.33GB)
 Java version: 25+8, vendor version: GraalVM CE 25-dev+8.1
 Graal compiler: optimization level: 2, target machine: x86-64-v3
 C compiler: gcc (redhat, x86_64, 14.2.1)
 Garbage collector: Serial GC (max heap size: 80% of RAM)
 9 user-specific feature(s):
 - com.oracle.svm.thirdparty.gson.GsonFeature
 - io.quarkus.caffeine.runtime.graal.CacheConstructorsFeature
 - io.quarkus.hibernate.orm.runtime.graal.DisableLoggingFeature: Disables INFO logging during the analysis phase
 - io.quarkus.hibernate.orm.runtime.graal.RegisterServicesForReflectionFeature: Makes methods of reachable hibernate services accessible through getMethods()`
 - io.quarkus.runner.Feature: Auto-generated class by Quarkus from the existing extensions
 - io.quarkus.runtime.graal.DisableLoggingFeature: Adapts logging during the analysis phase
 - io.quarkus.runtime.graal.SkipConsoleServiceProvidersFeature: Skip unsupported console service providers when quarkus.native.auto-service-loader-registration is false
 - org.eclipse.angus.activation.nativeimage.AngusActivationFeature
 - org.hibernate.graalvm.internal.GraalVMStaticFeature: Hibernate ORM's static reflection registrations for GraalVM
------------------------------------------------------------------------------------------------------------------------
 6 experimental option(s) unlocked:
 - '-H:+AllowFoldMethods' (origin(s): command line)
 - '-H:+ForeignAPISupport' (origin(s): command line)
 - '-H:BuildOutputJSONFile' (origin(s): command line)
 - '-H:-UseServiceLoaderFeature' (origin(s): command line)
 - '-H:+GenerateBuildArtifactsFile' (origin(s): command line)
 - '-H:PrintAnalysisCallTreeType' (origin(s): command line)
------------------------------------------------------------------------------------------------------------------------
Build resources:
 - 28.45GB of memory (42.4% of system memory, using available memory)
 - 12 thread(s) (100.0% of 12 available processor(s), determined at start)
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess (file:/home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/lib/io.netty.netty-common-4.1.118.Final.jar)
WARNING: Please consider reporting this to the maintainers of class io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release
[2/8] Performing analysis...  [12:59:19.000 MariaDB:2025-02-14 11:59:19 5 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
12:59:24.000 MariaDB:2025-02-14 11:59:24 6 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
12:59:30.000 MariaDB:2025-02-14 11:59:30 7 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
***12:59:36.000 MariaDB:2025-02-14 11:59:36 8 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by com.aayushatharva.brotli4j.Brotli4jLoader in an unnamed module (file:/home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/lib/com.aayushatharva.brotli4j.brotli4j-1.16.0.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

12:59:42.000 MariaDB:2025-02-14 11:59:42 9 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
***]                                                                  (29.8s @ 2.04GB)
   17,867 reachable types   (86.1% of   20,746 total)
   23,729 reachable fields  (52.1% of   45,574 total)
   85,765 reachable methods (50.6% of  169,359 total)
    6,018 types,    32 fields, and 1,486 methods registered for reflection
       62 types,    68 fields, and    55 methods registered for JNI access
        0 downcalls and 0 upcalls registered for foreign access
        4 native libraries: dl, pthread, rt, z
12:59:48.000 MariaDB:2025-02-14 11:59:48 10 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
# Printing call tree csv file for methods to: /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/reports/call_tree_methods_quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner_20250214_125951.csv
# Printing call tree csv file for invokes to: /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/reports/call_tree_invokes_quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner_20250214_125951.csv
# Printing call tree csv file for targets to: /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/reports/call_tree_targets_quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner_20250214_125951.csv
# Printing list of used methods to: /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/reports/used_methods_quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner_20250214_125952.txt
# Printing list of used classes to: /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/reports/used_classes_quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner_20250214_125952.txt
# Printing list of used packages to: /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/reports/used_packages_quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner_20250214_125952.txt
[3/8] Building universe...12:59:54.000 MariaDB:2025-02-14 11:59:54 11 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
                                                                               (6.4s @ 1.98GB)
[4/8] Parsing methods...      [**13:00:00.000 MariaDB:2025-02-14 12:00:00 12 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
]                                                                       (3.3s @ 2.19GB)
[5/8] Inlining methods...     [***]                                                                      (2.1s @ 2.36GB)
[6/8] Compiling methods...    [**13:00:06.000 MariaDB:2025-02-14 12:00:06 13 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
*13:00:12.000 MariaDB:2025-02-14 12:00:12 14 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
*13:00:19.000 MariaDB:2025-02-14 12:00:19 15 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
13:00:25.000 MariaDB:2025-02-14 12:00:25 16 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
*13:00:31.000 MariaDB:2025-02-14 12:00:31 17 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
*13:00:37.000 MariaDB:2025-02-14 12:00:37 18 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
]                                                                  (36.4s @ 1.87GB)
[7/8] Laying out methods...   [**13:00:42.000 MariaDB:2025-02-14 12:00:42 19 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
*]                                                                      (7.7s @ 2.41GB)
13:00:48.000 MariaDB:2025-02-14 12:00:48 20 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
[8/8] Creating image...       [***13:00:54.000 MariaDB:2025-02-14 12:00:54 21 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
]                                                                      (5.5s @ 2.71GB)
  35.62MB (46.24%) for code area:    56,779 compilation units
  36.11MB (46.88%) for image heap:  397,230 objects and 76 resources
   5.31MB ( 6.89%) for other data
  77.03MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 origins of code area:                                Top 10 object types in image heap:
  13.36MB java.base                                           10.01MB byte[] for code metadata
   7.55MB org.hibernate.orm.hibernate-core-6.6.7.Final.jar     5.18MB byte[] for java.lang.String
   2.13MB svm.jar (Native Image)                               3.57MB com.oracle.svm.core.hub.DynamicHubCompanion
   1.41MB org.mariadb.jdbc.mariadb-java-client-3.5.2.jar       3.38MB java.lang.String
   1.40MB q.jar                                                2.77MB java.lang.Class
 860.87kB modified-io.vertx.vertx-core-4.5.13.jar              1.11MB byte[] for general heap data
 655.52kB o.jboss.narayana.jta.narayana-jta-7.2.1.Final.jar  830.68kB java.lang.Object[]
 630.57kB io.netty.netty-buffer-4.1.118.Final.jar            655.30kB java.util.HashMap$Node
 470.10kB io.netty.netty-common-4.1.118.Final.jar            632.16kB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
 405.63kB io.netty.netty-codec-http-4.1.118.Final.jar        605.20kB java.lang.String[]
   6.31MB for 102 more packages                                7.35MB for 4218 more object types
------------------------------------------------------------------------------------------------------------------------
Recommendations:
 HEAP: Set max heap for improved and more predictable memory usage.
 CPU:  Enable more CPU features with '-march=native' for improved performance.
------------------------------------------------------------------------------------------------------------------------
                       7.7s (7.4% of total time) in 1506 GCs | Peak RSS: 3.67GB | CPU load: 8.70
------------------------------------------------------------------------------------------------------------------------
Build artifacts:
 /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/build-artifacts.json (build_info)
 /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner (executable)
 /home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-native-image-source-jar/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner-build-output-stats.json (build_info)
========================================================================================================================
Finished generating 'quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner' in 1m 44s.
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] objcopy --strip-debug quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 107657ms
[INFO] 
[INFO] --- failsafe:3.5.2:integration-test (default) @ quarkus-integration-test-jpa-mariadb ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.quarkus.it.jpa.mariadb.DialectInGraalITCase
Executing "/home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus-integration-test-jpa-mariadb-999-SNAPSHOT-runner -Dquarkus.http.port=8081 -Dquarkus.http.ssl-port=8444 -Dtest.url=http://localhost:8081 -Dquarkus.log.file.path=/home/sgehwolf/Documents/openjdk/quarkus/quarkus-source/integration-tests/jpa-mariadb/target/quarkus.log -Dquarkus.log.file.enable=true -Dquarkus.log.category."io.quarkus".level=INFO -Dquarkus.profile=prod -Dquarkus.native.enable-reports=true"
13:01:00.000 MariaDB:2025-02-14 12:01:00 22 [Warning] Access denied for user 'root'@'localhost' (using password: YES)
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2025-02-14 13:01:01,292 WARN  [org.mar.jdb.mes.ser.ErrorPacket] (JPA Startup Thread) Error: 4091-42S02: Unknown SEQUENCE: 'hibernate_orm_test.Address_SEQ'
2025-02-14 13:01:01,292 WARN  [org.hib.too.sch.int.ExceptionHandlerLoggedImpl] (JPA Startup Thread) GenerationTarget encountered exception accepting command : Error executing DDL "drop sequence Address_SEQ" via JDBC [(conn=23) Unknown SEQUENCE: 'hibernate_orm_test.Address_SEQ']: org.hibernate.tool.schema.spi.CommandAcceptanceException: Error executing DDL "drop sequence Address_SEQ" via JDBC [(conn=23) Unknown SEQUENCE: 'hibernate_orm_test.Address_SEQ']
	at org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:94)
	at org.hibernate.tool.schema.internal.Helper.applySqlString(Helper.java:233)
	at org.hibernate.tool.schema.internal.Helper.applySqlStrings(Helper.java:217)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.dropSequences(SchemaDropperImpl.java:343)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.dropConstraintsTablesSequences(SchemaDropperImpl.java:269)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.dropFromMetadata(SchemaDropperImpl.java:218)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.performDrop(SchemaDropperImpl.java:186)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.doDrop(SchemaDropperImpl.java:156)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.doDrop(SchemaDropperImpl.java:116)
	at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.performDatabaseAction(SchemaManagementToolCoordinator.java:238)
	at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.lambda$process$5(SchemaManagementToolCoordinator.java:144)
	at java.base@25/java.util.HashMap.forEach(HashMap.java:1430)
	at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.process(SchemaManagementToolCoordinator.java:141)
	at io.quarkus.hibernate.orm.runtime.observers.SessionFactoryObserverForSchemaExport.sessionFactoryCreated(SessionFactoryObserverForSchemaExport.java:21)
	at org.hibernate.internal.SessionFactoryObserverChain.sessionFactoryCreated(SessionFactoryObserverChain.java:35)
	at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:324)
	at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:87)
	at io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.createEntityManagerFactory(FastBootHibernatePersistenceProvider.java:72)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:80)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:55)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$LazyPersistenceUnit.get(JPAConfig.java:163)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$1.run(JPAConfig.java:63)
	at java.base@25/java.lang.Thread.runWith(Thread.java:1460)
	at java.base@25/java.lang.Thread.run(Thread.java:1447)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
Caused by: java.sql.SQLSyntaxErrorException: (conn=23) Unknown SEQUENCE: 'hibernate_orm_test.Address_SEQ'
	at org.mariadb.jdbc.export.ExceptionFactory.createException(ExceptionFactory.java:289)
	at org.mariadb.jdbc.export.ExceptionFactory.create(ExceptionFactory.java:378)
	at org.mariadb.jdbc.message.ClientMessage.readPacket(ClientMessage.java:187)
	at org.mariadb.jdbc.client.impl.StandardClient.readPacket(StandardClient.java:1347)
	at org.mariadb.jdbc.client.impl.StandardClient.readResults(StandardClient.java:1286)
	at org.mariadb.jdbc.client.impl.StandardClient.readResponse(StandardClient.java:1205)
	at org.mariadb.jdbc.client.impl.StandardClient.execute(StandardClient.java:1129)
	at org.mariadb.jdbc.Statement.executeInternal(Statement.java:1003)
	at org.mariadb.jdbc.Statement.execute(Statement.java:1132)
	at org.mariadb.jdbc.Statement.execute(Statement.java:471)
	at io.agroal.pool.wrapper.StatementWrapper.execute(StatementWrapper.java:220)
	at org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:80)
	... 25 more

2025-02-14 13:01:01,292 WARN  [org.mar.jdb.mes.ser.ErrorPacket] (JPA Startup Thread) Error: 4091-42S02: Unknown SEQUENCE: 'hibernate_orm_test.Person_SEQ'
2025-02-14 13:01:01,292 WARN  [org.hib.too.sch.int.ExceptionHandlerLoggedImpl] (JPA Startup Thread) GenerationTarget encountered exception accepting command : Error executing DDL "drop sequence Person_SEQ" via JDBC [(conn=23) Unknown SEQUENCE: 'hibernate_orm_test.Person_SEQ']: org.hibernate.tool.schema.spi.CommandAcceptanceException: Error executing DDL "drop sequence Person_SEQ" via JDBC [(conn=23) Unknown SEQUENCE: 'hibernate_orm_test.Person_SEQ']
	at org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:94)
	at org.hibernate.tool.schema.internal.Helper.applySqlString(Helper.java:233)
	at org.hibernate.tool.schema.internal.Helper.applySqlStrings(Helper.java:217)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.dropSequences(SchemaDropperImpl.java:343)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.dropConstraintsTablesSequences(SchemaDropperImpl.java:269)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.dropFromMetadata(SchemaDropperImpl.java:218)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.performDrop(SchemaDropperImpl.java:186)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.doDrop(SchemaDropperImpl.java:156)
	at org.hibernate.tool.schema.internal.SchemaDropperImpl.doDrop(SchemaDropperImpl.java:116)
	at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.performDatabaseAction(SchemaManagementToolCoordinator.java:238)
	at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.lambda$process$5(SchemaManagementToolCoordinator.java:144)
	at java.base@25/java.util.HashMap.forEach(HashMap.java:1430)
	at org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.process(SchemaManagementToolCoordinator.java:141)
	at io.quarkus.hibernate.orm.runtime.observers.SessionFactoryObserverForSchemaExport.sessionFactoryCreated(SessionFactoryObserverForSchemaExport.java:21)
	at org.hibernate.internal.SessionFactoryObserverChain.sessionFactoryCreated(SessionFactoryObserverChain.java:35)
	at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:324)
	at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:87)
	at io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.createEntityManagerFactory(FastBootHibernatePersistenceProvider.java:72)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:80)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:55)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$LazyPersistenceUnit.get(JPAConfig.java:163)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$1.run(JPAConfig.java:63)
	at java.base@25/java.lang.Thread.runWith(Thread.java:1460)
	at java.base@25/java.lang.Thread.run(Thread.java:1447)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
Caused by: java.sql.SQLSyntaxErrorException: (conn=23) Unknown SEQUENCE: 'hibernate_orm_test.Person_SEQ'
	at org.mariadb.jdbc.export.ExceptionFactory.createException(ExceptionFactory.java:289)
	at org.mariadb.jdbc.export.ExceptionFactory.create(ExceptionFactory.java:378)
	at org.mariadb.jdbc.message.ClientMessage.readPacket(ClientMessage.java:187)
	at org.mariadb.jdbc.client.impl.StandardClient.readPacket(StandardClient.java:1347)
	at org.mariadb.jdbc.client.impl.StandardClient.readResults(StandardClient.java:1286)
	at org.mariadb.jdbc.client.impl.StandardClient.readResponse(StandardClient.java:1205)
	at org.mariadb.jdbc.client.impl.StandardClient.execute(StandardClient.java:1129)
	at org.mariadb.jdbc.Statement.executeInternal(Statement.java:1003)
	at org.mariadb.jdbc.Statement.execute(Statement.java:1132)
	at org.mariadb.jdbc.Statement.execute(Statement.java:471)
	at io.agroal.pool.wrapper.StatementWrapper.execute(StatementWrapper.java:220)
	at org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:80)
	... 25 more

2025-02-14 13:01:01,296 INFO  [io.quarkus] (main) quarkus-integration-test-jpa-mariadb 999-SNAPSHOT native (powered by Quarkus 999-SNAPSHOT) started in 0.064s. Listening on: http://0.0.0.0:8081
2025-02-14 13:01:01,297 INFO  [io.quarkus] (main) Profile prod activated. 
2025-02-14 13:01:01,297 INFO  [io.quarkus] (main) Installed features: [agroal, cdi, hibernate-orm, jdbc-mariadb, narayana-jta, rest, smallrye-context-propagation, vertx]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.315 s -- in io.quarkus.it.jpa.mariadb.DialectInGraalITCase
[INFO] Running io.quarkus.it.jpa.mariadb.JPAFunctionalityInGraalITCase
list of stored Person names:
	Person with id=1, name='Gizmo', address { Address with id=1, street='Street 9daecddf-d08d-4e41-aef9-36558a718f63' }Person with id=3, name='Hibernate ORM', address { Address with id=3, street='Street 24a8dc50-37f8-42ac-ba7e-cd22a3fe7692' }Person with id=2, name='Quarkus', address { Address with id=2, street='Street 4caded84-7a16-4be2-9bd4-cd4b66d61ee7' }
List complete.
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s -- in io.quarkus.it.jpa.mariadb.JPAFunctionalityInGraalITCase
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- docker:0.45.1:stop (docker-stop) @ quarkus-integration-test-jpa-mariadb ---
13:01:02.000 MariaDB:2025-02-14 12:01:02 0 [Note] mariadbd (initiated by: unknown): Normal shutdown
13:01:02.000 MariaDB:2025-02-14 12:01:02 0 [Note] InnoDB: FTS optimize thread exiting.
13:01:02.000 MariaDB:2025-02-14 12:01:02 0 [Note] InnoDB: Starting shutdown...
13:01:02.000 MariaDB:2025-02-14 12:01:02 0 [Note] InnoDB: Dumping buffer pool(s) to /var/lib/mysql/ib_buffer_pool
13:01:02.000 MariaDB:2025-02-14 12:01:02 0 [Note] InnoDB: Restricted to 78 pages due to innodb_buf_pool_dump_pct=25
13:01:02.000 MariaDB:2025-02-14 12:01:02 0 [Note] InnoDB: Buffer pool(s) dump completed at 250214 12:01:02
13:01:02.000 MariaDB:2025-02-14 12:01:02 0 [Note] InnoDB: Removed temporary tablespace data file: "./ibtmp1"
13:01:02.000 MariaDB:2025-02-14 12:01:02 0 [Note] InnoDB: Shutdown completed; log sequence number 68383; transaction id 54
13:01:02.000 MariaDB:2025-02-14 12:01:02 0 [Note] mariadbd: Shutdown complete
[INFO] DOCKER> [healthcheck-docker.io/mariadb:10.11] "quarkus-test-mariadb": Stop and removed container 7ae0aa5c4b05 after 0 ms
[INFO] 
[INFO] --- failsafe:3.5.2:verify (default) @ quarkus-integration-test-jpa-mariadb ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:11 min
[INFO] Finished at: 2025-02-14T13:01:03+01:00
[INFO] ------------------------------------------------------------------------
[WARNING] The requested profile "test-kafka" could not be activated because it does not exist.
[INFO] 21 goals, 18 executed, 3 from cache
```

Also with a 23.1 (JDK 21) mandrel build. Works fine.


@zakkak @gsmet PTAL. Thanks!