### PR TITLE
Old exec plugin does not work with Maven4

### DIFF
--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -26,7 +26,7 @@
         <version.plugin.plugin>3.11.0</version.plugin.plugin>
         <version.dependency.plugin>3.6.1</version.dependency.plugin>
         <version.enforcer.plugin>3.3.0</version.enforcer.plugin>
-        <version.exec.plugin>3.1.0</version.exec.plugin>
+        <version.exec.plugin>3.5.0</version.exec.plugin>
         <version.formatter.plugin>2.24.1</version.formatter.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.impsort.plugin>1.12.0</version.impsort.plugin>


### PR DESCRIPTION
This old version of the exec plugin used does not work with Maven 4, so an upgrade would be nice.

