### PR TITLE
Qute message bundles: add Message#defaultValue()

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -3082,8 +3082,10 @@ TIP: There is also <<convenient-annotation-for-enums,`@TemplateEnum`>> - a conve
 
 ==== Message Templates
 
-Every method of a message bundle interface must define a message template. The value is normally defined by `io.quarkus.qute.i18n.Message#value()`,
-but for convenience, there is also an option to define the value in a localized file.
+Every method of a message bundle interface must define a message template. 
+The value is normally defined by `io.quarkus.qute.i18n.Message#value()`, but for convenience, there is also an option to define the value in a localized file.
+Message templates are validated during the build. 
+If a missing message template is detected, an exception is thrown and the build fails.
 
 .Example of the Message Bundle Interface without the value
 [source,java]
@@ -3114,8 +3116,23 @@ goodbye=Best regards, {name} <1>
 ----
 <1> The value is ignored as `io.quarkus.qute.i18n.Message#value()` is always prioritized.
 
-Message templates are validated during the build. If a missing message template is detected, an exception is thrown and build fails.
+It is also possible to define a _default message template_.
+The default template is only used if the `Message#value()` is not specified and no relevant message template is defined in a localized file.
 
+.Example of the Message Bundle Interface with a default value
+[source,java]
+----
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle
+public interface AppMessages {
+
+    @Message(defaultValue = "Goodbye {name}!") <1>
+    String goodbye(String name);
+}
+----
+<1> The annotation value is only used if no message template is defined in a localized file.
 
 === Configuration Reference
 

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -812,7 +812,7 @@ public class MessageBundleProcessor {
                                 messageAnnotation = AnnotationInstance.builder(Names.MESSAGE).value(Message.DEFAULT_VALUE)
                                         .add("name", Message.DEFAULT_NAME).build();
                             }
-                            return getMessageAnnotationValue(messageAnnotation) != null;
+                            return getMessageAnnotationValue(messageAnnotation, false) != null;
                         })
                         .map(MethodInfo::name)
                         .forEach(keyToTemplate::remove);
@@ -1013,13 +1013,13 @@ public class MessageBundleProcessor {
             boolean generatedTemplate = false;
             String messageTemplate = messageTemplates.get(method.name());
             if (messageTemplate == null) {
-                messageTemplate = getMessageAnnotationValue(messageAnnotation);
+                messageTemplate = getMessageAnnotationValue(messageAnnotation, true);
             }
 
             if (messageTemplate == null && defaultBundleInterface != null) {
                 // method is annotated with @Message without value() -> fallback to default locale
                 messageTemplate = getMessageAnnotationValue((defaultBundleInterface.method(method.name(),
-                        method.parameterTypes().toArray(new Type[] {}))).annotation(Names.MESSAGE));
+                        method.parameterTypes().toArray(new Type[] {}))).annotation(Names.MESSAGE), true);
             }
 
             // We need some special handling for enum message bundle methods
@@ -1215,11 +1215,19 @@ public class MessageBundleProcessor {
     /**
      * @return {@link Message#value()} if value was provided
      */
-    private String getMessageAnnotationValue(AnnotationInstance messageAnnotation) {
+    private String getMessageAnnotationValue(AnnotationInstance messageAnnotation, boolean useDefault) {
         var messageValue = messageAnnotation.value();
         if (messageValue == null || messageValue.asString().equals(Message.DEFAULT_VALUE)) {
             // no value was provided in annotation
-            return null;
+            if (useDefault) {
+                var defaultMessageValue = messageAnnotation.value("defaultValue");
+                if (defaultMessageValue == null || defaultMessageValue.asString().equals(Message.DEFAULT_VALUE)) {
+                    return null;
+                }
+                return defaultMessageValue.asString();
+            } else {
+                return null;
+            }
         }
         return messageValue.asString();
     }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageDefaultValueTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageDefaultValueTest.java
@@ -1,0 +1,91 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MessageDefaultValueTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Messages.class)
+                    .addAsResource(new StringAsset("""
+                            alpha=Hi {foo}!
+                            delta=Hey {foo}!
+                            """), "messages/msg_en.properties")
+                    .addAsResource(new StringAsset("""
+                            alpha=Ahoj {foo}!
+                            delta=Hej {foo}!
+                            """), "messages/msg_cs.properties")
+
+                    .addAsResource(new StringAsset(
+                            "{msg:alpha('baz')}::{msg:bravo('baz')}::{msg:charlie('baz')}"),
+                            "templates/foo.html")
+                    .addAsResource(new StringAsset(
+                            "{msg:delta('baz')}::{msg:echo('baz')}"),
+                            "templates/bar.html"))
+            .overrideConfigKey("quarkus.default-locale", "en");
+
+    @Inject
+    Template foo;
+
+    @Inject
+    Template bar;
+
+    @Test
+    public void testMessages() {
+        assertEquals("Hi baz!::Bravo baz!::Hey baz!", foo.instance().setLocale("en").render());
+        assertEquals("Hej baz!::Echo cs baz!", bar.instance().setLocale("cs").render());
+    }
+
+    @MessageBundle("msg")
+    public interface Messages {
+
+        // localized file wins
+        @Message(defaultValue = "Alpha {foo}!")
+        String alpha(String foo);
+
+        // defaultValue is used
+        @Message(defaultValue = "Bravo {foo}!")
+        String bravo(String foo);
+
+        // value() wins
+        @Message(value = "Hey {foo}!", defaultValue = "Charlie {foo}!")
+        String charlie(String foo);
+
+        // msg_cs.properties wins
+        @Message(defaultValue = "Delta {foo}!")
+        String delta(String foo);
+
+        // CsMessages#echo() wins
+        @Message(defaultValue = "Echo {foo}!")
+        String echo(String foo);
+
+    }
+
+    @Localized("cs")
+    public interface CsMessages extends Messages {
+
+        // msg_cs.properties wins
+        @Message(defaultValue = "Delta cs {foo}!")
+        @Override
+        String delta(String foo);
+
+        @Message(defaultValue = "Echo cs {foo}!")
+        @Override
+        String echo(String foo);
+
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/Message.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/Message.java
@@ -97,13 +97,21 @@ public @interface Message {
 
     /**
      * This value has higher priority over a message template specified in a localized file, and it's
-     * considered a good practice to specify it. In case the value is not provided and there is no
-     * match in the localized file too, the build fails.
+     * considered a good practice to specify it. In case the value is not provided, there is no
+     * match in the localized file and the {@link #defaultValue()} is not specified, the build fails.
      * <p>
      * There is a convenient way to localize enums. See the javadoc of {@link Message}.
      *
      * @return the message template
      */
     String value() default DEFAULT_VALUE;
+
+    /**
+     * The default template is only used if {@link #value()} is not specified and a message template is not defined in a
+     * localized file.
+     *
+     * @return the default message template
+     */
+    String defaultValue() default DEFAULT_VALUE;
 
 }


### PR DESCRIPTION
- this message template is only used if Message#value() is not specified and a relevant message template is not defined in a localized file
- resolves #46259