### PR TITLE
Only check filters once for calls to getResourceMethod

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -563,6 +563,8 @@ public class ResteasyReactiveProcessor {
                             classLevelExceptionMappers.isPresent() ? classLevelExceptionMappers.get().getMappers()
                                     : Collections.emptyMap())
                     .setResourceMethodCallback(new Consumer<>() {
+                        Boolean filtersAccessResourceMethod;
+
                         @Override
                         public void accept(EndpointIndexer.ResourceMethodCallbackEntry entry) {
                             MethodInfo method = entry.getMethodInfo();
@@ -589,6 +591,11 @@ public class ResteasyReactiveProcessor {
                                         .build());
                             }
 
+                            if (filtersAccessResourceMethod == null) {
+                                filtersAccessResourceMethod = filtersAccessResourceMethod(
+                                        resourceInterceptorsBuildItem.getResourceInterceptors());
+                            }
+
                             boolean paramsRequireReflection = false;
                             for (short i = 0; i < method.parametersCount(); i++) {
                                 Type parameterType = method.parameterType(i);
@@ -612,12 +619,12 @@ public class ResteasyReactiveProcessor {
                                 }
                             }
 
-                            if (paramsRequireReflection ||
+                            if (filtersAccessResourceMethod ||
+                                    paramsRequireReflection ||
                                     MULTI.toString().equals(entry.getResourceMethod().getSimpleReturnType()) ||
                                     REST_MULTI.toString().equals(entry.getResourceMethod().getSimpleReturnType()) ||
                                     PUBLISHER.toString().equals(entry.getResourceMethod().getSimpleReturnType()) ||
                                     LEGACY_PUBLISHER.toString().equals(entry.getResourceMethod().getSimpleReturnType()) ||
-                                    filtersAccessResourceMethod(resourceInterceptorsBuildItem.getResourceInterceptors()) ||
                                     entry.additionalRegisterClassForReflectionCheck()) {
                                 minimallyRegisterResourceClassForReflection(entry, reflectiveClassBuildItemBuildProducer);
                             }


### PR DESCRIPTION
Reproducer: 

I had a bit of time today, and decided to check the hot reload time of a real world application. While sampling, I noticed a lot of calls to the `usesGetResourceMethod` method. This method is used to check, if any filter needs to reflectivly access the resource method (ResourceInfo#getResourceMethod calls), and if true, leads to every resource class being marked for reflection. (see #28378).
An quick debugging session showed that this method is called once for each filter and for each resource method, and twice if the filter is prematching (`2*n*m`).


I created a simple reproducer, with keycloak-admin-rest-client, and one server filter.
```
    @ServerRequestFilter(preMatching = true)
    void filter(ResourceInfo resourceMethod) {
        Method resourceMethod1 = resourceInfo.getResourceMethod();
        System.out.println(resourceMethod1);
    }
```

The full reproducer: 
[kc-sub-slow-filter.zip](https://github.com/user-attachments/files/18803436/kc-sub-slow-filter.zip)

The reproducer showed, that a lot of time can be saved, by caching the result of `usesGetResourceMethod`.

The following hot reload times are for quarkus 046dc99a53a208dba5a8c6e64f432f4d05f76de7:

without the filter:
```
565ms
509ms
532ms
505ms
506ms
547ms
avg 527,3333333ms
```

with the filter:
```
616ms
573ms
612ms
544ms
535ms
536ms
avg 569,3333333ms
```

(About +40ms, just by adding a Filter..)

I decided to implement a simple fix. This is more so intended to showcase the potential savings, as it is intended as a real solution.
The result of `usesGetResourceMethod` is now cached, which should be ok since I believe the list of filters can not change anymore at this point in time (?).


```
571ms
507ms
524ms
511ms
514ms
482ms
avg 518,1666667ms
```

so after my quick fix, about the same numbers as without the filter.
Somewhat related to #45631