### PR TITLE
Simplify pattern used introduced in #46284

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -521,6 +521,9 @@ public class ResteasyReactiveProcessor {
                 return false;
             };
 
+            final boolean filtersAccessResourceMethod = filtersAccessResourceMethod(
+                    resourceInterceptorsBuildItem.getResourceInterceptors());
+
             BiConsumer<String, BiFunction<String, ClassVisitor, ClassVisitor>> transformationConsumer = (name,
                     function) -> bytecodeTransformerBuildItemBuildProducer
                             .produce(new BytecodeTransformerBuildItem(name, function));
@@ -563,8 +566,6 @@ public class ResteasyReactiveProcessor {
                             classLevelExceptionMappers.isPresent() ? classLevelExceptionMappers.get().getMappers()
                                     : Collections.emptyMap())
                     .setResourceMethodCallback(new Consumer<>() {
-                        Boolean filtersAccessResourceMethod;
-
                         @Override
                         public void accept(EndpointIndexer.ResourceMethodCallbackEntry entry) {
                             MethodInfo method = entry.getMethodInfo();
@@ -589,11 +590,6 @@ public class ResteasyReactiveProcessor {
                                                 QuarkusResteasyReactiveDotNames.IGNORE_METHOD_FOR_REFLECTION_PREDICATE)
                                         .source(source + " > " + method.returnType().name().toString())
                                         .build());
-                            }
-
-                            if (filtersAccessResourceMethod == null) {
-                                filtersAccessResourceMethod = filtersAccessResourceMethod(
-                                        resourceInterceptorsBuildItem.getResourceInterceptors());
                             }
 
                             boolean paramsRequireReflection = false;


### PR DESCRIPTION
There is one reason for doing that: this way, we are sure the value of the boolean is not dependent of anything contextual to the Consumer invocation.
I think it's a lot safer this way.

Related to #46284