### PR TITLE
Allow mongo client to be configured by a tls registry

### DIFF
--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -676,19 +676,38 @@ If you want to use the legacy API, you need to add the following dependency to y
 implementation("org.mongodb:mongodb-driver-legacy")
 ----
 
-== Building a native executable
+== TLS configuration
 
-You can use the MongoDB client in a native executable.
-
-If you want to use SSL/TLS encryption, you need to add these properties in your `application.properties`:
+If you want to use SSL/TLS encryption, you need to add this property in your `application.properties`:
 
 [source,properties]
 ----
 quarkus.mongodb.tls=true
-quarkus.mongodb.tls-insecure=true # only if TLS certificate cannot be validated
 ----
 
-You can then build a native executable with the usual command:
+You can also configure the client to use a tls configuration from the TLS registry, this will enable tls:
+
+[source,properties]
+----
+quarkus.tls.mongo.trust-store.pem.certs=certa.pem,certb.pem
+quarkus.mongodb.tls-configuration-name=mongo
+----
+
+You can configure the client to trust servers with certificates with invalid hostnames:
+
+[source,properties]
+----
+quarkus.tls.mongo.hostname-verification-algorithm=NONE
+quarkus.mongodb.tls-configuration-name=mongo
+----
+
+
+== Building a native executable
+
+You can use the MongoDB client in a native executable.
+
+
+You can build a native executable with the usual command:
 
 include::{includes}/devtools/build-native.adoc[]
 

--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-tls-registry-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry-deployment</artifactId>
             <optional>true</optional>
         </dependency>
@@ -79,6 +83,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.certs</groupId>
+            <artifactId>smallrye-certificate-generator-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
@@ -1,24 +1,25 @@
 package io.quarkus.mongodb;
 
-import java.io.IOException;
-
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 
 import de.flapdoodle.embed.mongo.commands.MongodArguments;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.mongo.transitions.ImmutableMongod;
 import de.flapdoodle.embed.mongo.transitions.Mongod;
 import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess;
 import de.flapdoodle.embed.process.types.ProcessConfig;
 import de.flapdoodle.reverse.TransitionWalker;
 import de.flapdoodle.reverse.transitions.Start;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MongoTestBase {
 
     private static final Logger LOGGER = Logger.getLogger(MongoTestBase.class);
-    private static TransitionWalker.ReachedState<RunningMongodProcess> MONGO;
+    protected TransitionWalker.ReachedState<RunningMongodProcess> mongo;
 
     protected static String getConfiguredConnectionString() {
         return getProperty("connection_string");
@@ -37,7 +38,7 @@ public class MongoTestBase {
     }
 
     @BeforeAll
-    public static void startMongoDatabase() throws IOException {
+    public void startMongoDatabase() {
         forceExtendedSocketOptionsClassInit();
 
         String uri = getConfiguredConnectionString();
@@ -47,28 +48,36 @@ public class MongoTestBase {
             int port = 27018;
             LOGGER.infof("Starting Mongo %s on port %s", version, port);
 
-            MONGO = Mongod.instance()
+            ImmutableMongod config = Mongod.instance()
                     .withNet(Start.to(Net.class).initializedWith(Net.builder()
                             .from(Net.defaults())
                             .port(port)
                             .build()))
                     .withMongodArguments(Start.to(MongodArguments.class)
-                            .initializedWith(MongodArguments.defaults().withUseNoJournal(false)))
+                            .initializedWith(MongodArguments.defaults()
+                                    .withUseNoJournal(
+                                            false)))
                     .withProcessConfig(
                             Start.to(ProcessConfig.class)
-                                    .initializedWith(ProcessConfig.defaults().withStopTimeoutInMillis(15_000)))
-                    .start(version);
+                                    .initializedWith(ProcessConfig.defaults()
+                                            .withStopTimeoutInMillis(15_000)));
+            config = addExtraConfig(config);
+            mongo = config.start(version);
 
         } else {
             LOGGER.infof("Using existing Mongo %s", uri);
         }
     }
 
+    protected ImmutableMongod addExtraConfig(ImmutableMongod mongo) {
+        return mongo;
+    }
+
     @AfterAll
-    public static void stopMongoDatabase() {
-        if (MONGO != null) {
+    public void stopMongoDatabase() {
+        if (mongo != null) {
             try {
-                MONGO.close();
+                mongo.close();
             } catch (Exception e) {
                 LOGGER.error("Unable to stop MongoDB", e);
             }

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTlsRegistryTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTlsRegistryTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.client.MongoClient;
+
+import de.flapdoodle.embed.mongo.commands.MongodArguments;
+import de.flapdoodle.embed.mongo.transitions.ImmutableMongod;
+import de.flapdoodle.reverse.transitions.Start;
+import io.quarkus.mongodb.reactive.ReactiveMongoClient;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Tests don't pass on windows CI")
+@Certificates(baseDir = MongoTlsRegistryTest.BASEDIR, certificates = {
+        @Certificate(name = "mongo-cert", formats = Format.PEM, client = true)
+})
+public class MongoTlsRegistryTest extends MongoTestBase {
+    static final String BASEDIR = "target/certs";
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(MongoTestBase.class))
+            .withConfigurationResource("tls-mongoclient.properties");
+    private static final Path BASEPATH = Path.of(BASEDIR);
+    private final Path serverCertPath = Path.of(BASEDIR, "mongo-cert.crt");
+    private final Path serverKeyPath = Path.of(BASEDIR, "mongo-cert.key");
+    private final Path serverCaPath = Path.of(BASEDIR, "mongo-cert-server-ca.crt");
+    private final Path serverCertKeyPath = Path.of(BASEDIR, "mongo-certkey.pem");
+    @Inject
+    MongoClient client;
+    @Inject
+    ReactiveMongoClient reactiveClient;
+
+    @AfterEach
+    void cleanup() {
+        if (reactiveClient != null) {
+            reactiveClient.close();
+        }
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Override
+    protected ImmutableMongod addExtraConfig(ImmutableMongod mongo) {
+        try (var fos = Files.newOutputStream(serverCertKeyPath)) {
+            Files.copy(serverCertPath, fos);
+            Files.copy(serverKeyPath, fos);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return mongo.withMongodArguments(Start.to(mongo.mongodArguments().destination())
+                .initializedWith(MongodArguments.builder()
+                        .putArgs("--tlsCertificateKeyFile", serverCertKeyPath.toAbsolutePath().toString())
+                        .putArgs("--tlsMode", "requireTLS")
+                        .putArgs("--tlsCAFile", serverCaPath.toAbsolutePath().toString())
+                        .build()));
+
+    }
+
+    @Test
+    public void testClientWorksWithTls() {
+        assertThat(client.listDatabaseNames().first()).isNotEmpty();
+        assertThat(reactiveClient.listDatabases().collect().first().await().indefinitely()).isNotEmpty();
+    }
+}

--- a/extensions/mongodb-client/deployment/src/test/resources/tls-mongoclient.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/tls-mongoclient.properties
@@ -1,0 +1,5 @@
+quarkus.mongodb.connection-string=mongodb://127.0.0.1:27018
+quarkus.mongodb.tls-configuration-name=mongo
+quarkus.tls.mongo.key-store.pem.0.cert=target/certs/mongo-cert-client.crt
+quarkus.tls.mongo.key-store.pem.0.key=target/certs/mongo-cert-client.key
+quarkus.tls.mongo.trust-store.pem.certs=target/certs/mongo-cert-client-ca.crt

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>quarkus-mutiny</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-tls-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny-zero-flow-adapters</artifactId>
         </dependency>

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
@@ -122,8 +122,13 @@ public interface MongoClientConfig {
 
     /**
      * If connecting with TLS, this option enables insecure TLS connections.
+     *
+     * @deprecated in favor of configuration at the tls registry level. See {@link #tlsConfigurationName()}
+     *             and quarkus tls registry hostname verification configuration
+     *             {@code quarkus.tls.hostname-verification-algorithm=NONE}.
      */
     @WithDefault("false")
+    @Deprecated(forRemoval = true, since = "3.21")
     boolean tlsInsecure();
 
     /**
@@ -131,6 +136,16 @@ public interface MongoClientConfig {
      */
     @WithDefault("false")
     boolean tls();
+
+    /**
+     * The name of the TLS configuration to use.
+     * <p>
+     * If a name is configured, it uses the configuration from {@code quarkus.tls.<name>.*}
+     * If a name is configured, but no TLS configuration is found with that name then an error will be thrown.
+     * <p>
+     * The default TLS configuration is <strong>not</strong> used by default.
+     */
+    Optional<String> tlsConfigurationName();
 
     /**
      * Implies that the hosts given are a seed list, and the driver will attempt to find all members of the set.

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/TlsConfiguration.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/TlsConfiguration.java
@@ -19,7 +19,7 @@ public interface TlsConfiguration {
         if (name.isPresent()) {
             Optional<TlsConfiguration> maybeConfiguration = registry.get(name.get());
             if (maybeConfiguration.isEmpty()) {
-                throw new IllegalStateException("Unable to find the TLS configuration for name " + name + ".");
+                throw new IllegalStateException("Unable to find the TLS configuration for name " + name.get() + ".");
             }
             return maybeConfiguration;
         }


### PR DESCRIPTION
This PR allows the mongodb client to be configured using a tls registry configuration. This allows simpler ways to configure the trustores, and mtls connections.

By default the mongodb client dost not use the default tls registry.