### PR TITLE
Improve security failure handling in gRPC

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -719,6 +719,9 @@ public class GrpcServerProcessor {
                             .filter(filter -> filter.getPriority() == FilterBuildItem.AUTHENTICATION
                                     || filter.getPriority() == FilterBuildItem.AUTHORIZATION)
                             .collect(Collectors.toMap(f -> f.getPriority() * -1, FilterBuildItem::getHandler));
+                    // for the moment being, the main router doesn't have QuarkusErrorHandler, but we need to make
+                    // sure that exceptions raised during proactive authentication or HTTP authorization are handled
+                    recorder.addMainRouterErrorHandlerIfSameServer(routerRuntimeValue, config);
                 }
             } else {
                 routerRuntimeValue = routerBuildItem.getHttpRouter();

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/auth/BasicGrpcSecurityMechanism.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/auth/BasicGrpcSecurityMechanism.java
@@ -31,6 +31,10 @@ public class BasicGrpcSecurityMechanism implements GrpcSecurityMechanism {
             String userName = plainChallenge.substring(0, colonPos);
             char[] password = plainChallenge.substring(colonPos + 1).toCharArray();
             return new UsernamePasswordAuthenticationRequest(userName, new PasswordCredential(password));
+        } else if (!plainChallenge.isEmpty()) {
+            // this is illegal argument exception because ATM when Basic HTTP Auth mechanism doesn't throw auth exception
+            // for the same credentials, so let's simulate the same situation in this test
+            throw new IllegalArgumentException("Empty authentication request");
         } else {
             return null;
         }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/auth/GrpcEagerAuthCustomRootPathTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/auth/GrpcEagerAuthCustomRootPathTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class GrpcAuthCustomRootPathTest extends GrpcAuthTestBase {
+public class GrpcEagerAuthCustomRootPathTest extends GrpcAuthTestBase {
 
     @RegisterExtension
     static final QuarkusUnitTest config = createQuarkusUnitTest("""

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/auth/GrpcLazyAuthCustomRootPathTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/auth/GrpcLazyAuthCustomRootPathTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.grpc.auth;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GrpcLazyAuthCustomRootPathTest extends GrpcAuthTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createQuarkusUnitTest("""
+            quarkus.grpc.server.use-separate-server=false
+            quarkus.grpc.clients.securityClient.host=localhost
+            quarkus.grpc.clients.securityClient.port=8081
+            quarkus.http.root-path=/api
+            quarkus.http.auth.proactive=false
+            """, true);
+
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/auth/AuthExceptionHandlerProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/auth/AuthExceptionHandlerProvider.java
@@ -5,6 +5,7 @@ import jakarta.enterprise.inject.spi.Prioritized;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
+import io.grpc.StatusException;
 
 /**
  * Provider for AuthExceptionHandler.
@@ -17,4 +18,22 @@ public interface AuthExceptionHandlerProvider extends Prioritized {
 
     <ReqT, RespT> AuthExceptionHandler<ReqT, RespT> createHandler(Listener<ReqT> listener,
             ServerCall<ReqT, RespT> serverCall, Metadata metadata);
+
+    /**
+     * @param failure security exception this provider can handle according to the {@link #handlesException(Throwable)}
+     * @return status exception
+     */
+    default StatusException transformToStatusException(Throwable failure) {
+        // because by default we don't handle any exception
+        // the original behavior (before introduction of this method) is kept because 'handlesException' return false
+        throw new IllegalStateException("Cannot transform exception " + failure + " to a status exception");
+    }
+
+    /**
+     * @param failure any gRPC request failure
+     * @return whether this provider should create response status for given failure
+     */
+    default boolean handlesException(Throwable failure) {
+        return false;
+    }
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/auth/DefaultAuthExceptionHandlerProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/auth/DefaultAuthExceptionHandlerProvider.java
@@ -4,9 +4,19 @@ import jakarta.inject.Singleton;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.security.AuthenticationException;
 
 @Singleton
 public class DefaultAuthExceptionHandlerProvider implements AuthExceptionHandlerProvider {
+
+    private final boolean addStatusDescription;
+
+    public DefaultAuthExceptionHandlerProvider() {
+        this.addStatusDescription = LaunchMode.current().isDevOrTest();
+    }
 
     @Override
     public int getPriority() {
@@ -16,6 +26,34 @@ public class DefaultAuthExceptionHandlerProvider implements AuthExceptionHandler
     @Override
     public <ReqT, RespT> AuthExceptionHandler<ReqT, RespT> createHandler(ServerCall.Listener<ReqT> listener,
             ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
-        return new AuthExceptionHandler<>(listener, serverCall, metadata);
+        return new AuthExceptionHandler<>(listener, serverCall, metadata, addStatusDescription);
+    }
+
+    @Override
+    public StatusException transformToStatusException(Throwable t) {
+        return new StatusException(transformToStatusException(addStatusDescription, t));
+    }
+
+    @Override
+    public boolean handlesException(Throwable failure) {
+        return failure instanceof AuthenticationException || failure instanceof SecurityException;
+    }
+
+    static Status transformToStatusException(boolean addExceptionMessage, Throwable exception) {
+        if (exception instanceof AuthenticationException) {
+            if (addExceptionMessage) {
+                return Status.UNAUTHENTICATED.withDescription(exception.getMessage());
+            } else {
+                return Status.UNAUTHENTICATED;
+            }
+        } else if (exception instanceof SecurityException) {
+            if (addExceptionMessage) {
+                return Status.PERMISSION_DENIED.withDescription(exception.getMessage());
+            } else {
+                return Status.PERMISSION_DENIED;
+            }
+        } else {
+            throw new IllegalStateException("Cannot transform exception " + exception, exception);
+        }
     }
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/DefaultExceptionHandlerProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/DefaultExceptionHandlerProvider.java
@@ -1,6 +1,7 @@
 package io.quarkus.grpc.runtime.supports.exc;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -8,25 +9,54 @@ import io.grpc.StatusException;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.grpc.ExceptionHandler;
 import io.quarkus.grpc.ExceptionHandlerProvider;
+import io.quarkus.grpc.auth.AuthExceptionHandlerProvider;
 
 @ApplicationScoped
 @DefaultBean
 public class DefaultExceptionHandlerProvider implements ExceptionHandlerProvider {
+
+    private final AuthExceptionHandlerProvider authExceptionHandlerProvider;
+
+    public DefaultExceptionHandlerProvider(Instance<AuthExceptionHandlerProvider> authExceptionHandlerProviderInstance) {
+        if (authExceptionHandlerProviderInstance.isResolvable()) {
+            this.authExceptionHandlerProvider = authExceptionHandlerProviderInstance.get();
+        } else {
+            this.authExceptionHandlerProvider = null;
+        }
+    }
+
     @Override
     public <ReqT, RespT> ExceptionHandler<ReqT, RespT> createHandler(ServerCall.Listener<ReqT> listener,
             ServerCall<ReqT, RespT> call, Metadata metadata) {
-        return new DefaultExceptionHandler<>(listener, call, metadata);
+        return new DefaultExceptionHandler<>(listener, call, metadata, authExceptionHandlerProvider);
+    }
+
+    @Override
+    public Throwable transform(Throwable t) {
+        return toStatusException(authExceptionHandlerProvider, t);
+    }
+
+    private static Throwable toStatusException(AuthExceptionHandlerProvider authExceptionHandlerProvider, Throwable t) {
+        if (authExceptionHandlerProvider != null && authExceptionHandlerProvider.handlesException(t)) {
+            return authExceptionHandlerProvider.transformToStatusException(t);
+        } else {
+            return ExceptionHandlerProvider.toStatusException(t, false);
+        }
     }
 
     private static class DefaultExceptionHandler<ReqT, RespT> extends ExceptionHandler<ReqT, RespT> {
+
+        private final AuthExceptionHandlerProvider authExceptionHandlerProvider;
+
         public DefaultExceptionHandler(ServerCall.Listener<ReqT> listener, ServerCall<ReqT, RespT> call,
-                Metadata metadata) {
+                Metadata metadata, AuthExceptionHandlerProvider authExceptionHandlerProvider) {
             super(listener, call, metadata);
+            this.authExceptionHandlerProvider = authExceptionHandlerProvider;
         }
 
         @Override
         protected void handleException(Throwable exception, ServerCall<ReqT, RespT> call, Metadata metadata) {
-            StatusException se = (StatusException) ExceptionHandlerProvider.toStatusException(exception, false);
+            StatusException se = (StatusException) toStatusException(authExceptionHandlerProvider, exception);
             Metadata trailers = se.getTrailers() != null ? se.getTrailers() : metadata;
             call.close(se.getStatus(), trailers);
         }


### PR DESCRIPTION
- fixes the issue reported here https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Unhandled.20exception.20in.20router.20quarkus.20security.20and.20grpc.2E - which is main router not having an error handler means that when proactive authentication fails it resulted in unhandled exception (500 instead of 4xx)
- and the test I added uncovered couple of more things in gRPC security exception handling, this PR:
  - makes sure that security  and authentication exceptions are not added as description to status unless in DEV / TEST. it's not good idea to give away details about failure like exception message in production and https://grpc.io/docs/guides/error/#protocol-errors says that description is optional; users have a choice to define their own exception handler or even authentication exception handler and add them
  - when using separate gRPC server and no gRPC security mechanism provides identity, an anonymous identity is set as we don't work with null identity in Quarkus Security
  - when gRPC is combined with other REST stack like Quarkus REST and lazy authentication failed, I have mentioned that there was a race in the exception handling as authentication failure handler needs to be removed, otherwise Ver.tx failure handler chain takes over; when gRPC starts processing, it can handle authentication failures on it's own (in logs there was _response already written_)
  - fixes response status for authentication and security failures that happens when authorization using standard security annotations triggers authentication it ended in the `io.quarkus.grpc.runtime.supports.exc.DefaultExceptionHandlerProvider` and the `io.quarkus.grpc.auth.AuthExceptionHandlerProvider` was never invoked for that failure; I corrected the response status to UNAUTHENTICATION/PERMISSION_DENIED, before this change it was UNKNOWN for authorization and authentication exceptions as well
- making sure that authorization handler is not skipped even though we don't support that according to the docs, it was either that or dropping the handler, context here https://github.com/quarkusio/quarkus/pull/45861#discussion_r1930317867