### PR TITLE
Greatly improve Quarkus update

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Update.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Update.java
@@ -9,23 +9,20 @@ import io.quarkus.cli.update.RewriteGroup;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "update", aliases = { "up",
-        "upgrade" }, sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Suggest recommended project updates with the possibility to apply them.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+        "upgrade" }, sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Suggest project updates and create a recipe with the possibility to apply it.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
 public class Update extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.ArgGroup(order = 0, heading = "%nTarget Quarkus version:%n", multiplicity = "0..1")
     TargetQuarkusVersionGroup targetQuarkusVersion = new TargetQuarkusVersionGroup();
 
-    @CommandLine.ArgGroup(order = 1, heading = "%nRewrite:%n", exclusive = false)
+    @CommandLine.ArgGroup(order = 1, heading = "%nRewrite (interactive by default):%n", exclusive = false)
     RewriteGroup rewrite = new RewriteGroup();
-
-    @CommandLine.Option(order = 2, names = { "--per-module" }, description = "Display information per project module.")
-    public boolean perModule = false;
 
     @Override
     public Integer call() throws Exception {
         try {
             final BuildSystemRunner runner = getRunner();
-            return runner.updateProject(targetQuarkusVersion, rewrite, perModule);
+            return runner.updateProject(targetQuarkusVersion, rewrite);
         } catch (Exception e) {
             return output.handleCommandException(e, "Unable to run Quarkus project update : " + e.getMessage());
         }

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -110,7 +110,7 @@ public interface BuildSystemRunner {
 
     Integer projectInfo(boolean perModule) throws Exception;
 
-    Integer updateProject(TargetQuarkusVersionGroup targetQuarkusVersion, RewriteGroup rewrite, boolean perModule)
+    Integer updateProject(TargetQuarkusVersionGroup targetQuarkusVersion, RewriteGroup rewrite)
             throws Exception;
 
     BuildCommandArgs prepareAction(String action, BuildOptions buildOptions, RunModeOption runMode, List<String> params);

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -145,7 +145,7 @@ public class GradleRunner implements BuildSystemRunner {
     }
 
     @Override
-    public Integer updateProject(TargetQuarkusVersionGroup targetQuarkusVersion, RewriteGroup rewrite, boolean perModule)
+    public Integer updateProject(TargetQuarkusVersionGroup targetQuarkusVersion, RewriteGroup rewrite)
             throws Exception {
         final ExtensionCatalog extensionCatalog = ToolsUtils.resolvePlatformDescriptorDirectly(
                 ToolsConstants.QUARKUS_CORE_GROUP_ID, null,
@@ -176,14 +176,16 @@ public class GradleRunner implements BuildSystemRunner {
         if (rewrite.additionalUpdateRecipes != null) {
             args.add("--additionalUpdateRecipes=" + rewrite.additionalUpdateRecipes);
         }
-        if (rewrite.noRewrite) {
-            args.add("--noRewrite");
-        }
-        if (perModule) {
-            args.add("--perModule");
-        }
-        if (rewrite.dryRun) {
-            args.add("--rewriteDryRun");
+        if (rewrite.run != null) {
+            if (rewrite.run.yes) {
+                args.add("--rewrite");
+            }
+            if (rewrite.run.no) {
+                args.add("--rewrite=false");
+            }
+            if (rewrite.run.dryRun) {
+                args.add("--rewriteDryRun");
+            }
         }
         return run(prependExecutable(args));
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -77,7 +77,7 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
-    public Integer updateProject(TargetQuarkusVersionGroup targetQuarkusVersion, RewriteGroup rewrite, boolean perModule)
+    public Integer updateProject(TargetQuarkusVersionGroup targetQuarkusVersion, RewriteGroup rewrite)
             throws Exception {
         throw new UnsupportedOperationException("Not there yet. ;)");
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -149,7 +149,7 @@ public class MavenRunner implements BuildSystemRunner {
     }
 
     @Override
-    public Integer updateProject(TargetQuarkusVersionGroup targetQuarkusVersion, RewriteGroup rewrite, boolean perModule)
+    public Integer updateProject(TargetQuarkusVersionGroup targetQuarkusVersion, RewriteGroup rewrite)
             throws Exception {
         ArrayDeque<String> args = new ArrayDeque<>();
         setMavenProperties(args, true);
@@ -167,9 +167,6 @@ public class MavenRunner implements BuildSystemRunner {
         if (targetQuarkusVersion.streamId != null) {
             args.add("-Dstream=" + targetQuarkusVersion.streamId);
         }
-        if (rewrite.noRewrite) {
-            args.add("-DnoRewrite");
-        }
         if (rewrite.pluginVersion != null) {
             args.add("-DrewritePluginVersion=" + rewrite.pluginVersion);
         }
@@ -179,11 +176,16 @@ public class MavenRunner implements BuildSystemRunner {
         if (rewrite.additionalUpdateRecipes != null) {
             args.add("-DadditionalUpdateRecipes=" + rewrite.additionalUpdateRecipes);
         }
-        if (rewrite.dryRun) {
-            args.add("-DrewriteDryRun");
-        }
-        if (perModule) {
-            args.add("-DperModule");
+        if (rewrite.run != null) {
+            if (rewrite.run.yes) {
+                args.add("-Drewrite");
+            }
+            if (rewrite.run.no) {
+                args.add("-Drewrite=false");
+            }
+            if (rewrite.run.dryRun) {
+                args.add("-DrewriteDryRun");
+            }
         }
         args.add("-ntp");
         return run(prependExecutable(args));

--- a/devtools/cli/src/main/java/io/quarkus/cli/update/RewriteGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/update/RewriteGroup.java
@@ -4,24 +4,39 @@ import picocli.CommandLine;
 
 public class RewriteGroup {
 
+    @CommandLine.ArgGroup(exclusive = true)
+    public RewriteRun run;
+
     @CommandLine.Option(order = 0, names = {
-            "--no-rewrite" }, description = "Disable the rewrite feature.", defaultValue = "false")
-    public boolean noRewrite = false;
-
-    @CommandLine.Option(order = 1, names = {
-            "--dry-run" }, description = "Rewrite in dry-mode.", defaultValue = "false")
-    public boolean dryRun = false;
-
-    @CommandLine.Option(order = 2, names = {
             "--quarkus-update-recipes" }, description = "Use custom io.quarkus:quarkus-update-recipes:LATEST artifact (GAV) or just provide the version. This artifact should contain the base Quarkus update recipes to update a project.")
     public String quarkusUpdateRecipes;
 
-    @CommandLine.Option(order = 3, names = {
+    @CommandLine.Option(order = 1, names = {
             "--rewrite-plugin-version" }, description = "Use a custom OpenRewrite plugin version.")
     public String pluginVersion;
 
-    @CommandLine.Option(order = 4, names = {
+    @CommandLine.Option(order = 2, names = {
             "--additional-update-recipes" }, description = "Specify a list of additional artifacts (GAV) containing rewrite recipes.")
     public String additionalUpdateRecipes;
+
+    public static class RewriteRun {
+        @CommandLine.Option(order = 3, names = {
+                "--yes",
+                "-y" }, description = "Run the suggested update recipe for this project.", defaultValue = "false")
+        public boolean yes = false;
+
+        @CommandLine.Option(order = 5, names = {
+                "--dry-run",
+                "-n"
+        }, description = "Do a dry run of the suggested update recipe for this project and create a patch file.", defaultValue = "false")
+        public boolean dryRun = false;
+
+        @CommandLine.Option(order = 4, names = {
+                "--no",
+                "--no-rewrite",
+                "-N" }, description = "Do NOT run the update.", defaultValue = "false")
+        public boolean no = false;
+
+    }
 
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusInfo.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusInfo.java
@@ -7,7 +7,6 @@ import org.gradle.api.tasks.options.Option;
 
 import io.quarkus.devtools.commands.ProjectInfo;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
-import io.quarkus.devtools.commands.handlers.ProjectInfoCommandHandler;
 import io.quarkus.devtools.project.QuarkusProject;
 
 public abstract class QuarkusInfo extends QuarkusPlatformTask {
@@ -41,10 +40,6 @@ public abstract class QuarkusInfo extends QuarkusPlatformTask {
             outcome = invoker.execute();
         } catch (Exception e) {
             throw new GradleException("Failed to collect Quarkus project information", e);
-        }
-        if (outcome.getValue(ProjectInfoCommandHandler.RECOMMENDATIONS_AVAILABLE, false)) {
-            getLogger().warn(
-                    "Non-recommended Quarkus platform BOM and/or extension versions were found. For more details, please, execute 'gradle quarkusUpdate --rectify'");
         }
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -17,9 +17,8 @@ import io.quarkus.registry.catalog.PlatformStreamCoords;
 
 public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
-    private boolean perModule = false;
-
-    private boolean noRewrite;
+    private Boolean noRewrite;
+    private Boolean rewrite;
 
     private boolean rewriteDryRun;
 
@@ -33,13 +32,27 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
     @Input
     @Optional
+    @Deprecated
     public Boolean getNoRewrite() {
         return noRewrite;
     }
 
-    @Option(description = "Disable the rewrite feature.", option = "noRewrite")
+    @Option(description = "Disable the rewrite feature (deprecated use --rewrite=false instead).", option = "noRewrite")
+    @Deprecated
     public QuarkusUpdate setNoRewrite(Boolean noRewrite) {
         this.noRewrite = noRewrite;
+        return this;
+    }
+
+    @Input
+    @Optional
+    public Boolean getRewrite() {
+        return rewrite;
+    }
+
+    @Option(description = "Run the suggested update recipe for this project.", option = "rewrite")
+    public QuarkusUpdate setRewrite(Boolean rewrite) {
+        this.rewrite = rewrite;
         return this;
     }
 
@@ -49,7 +62,7 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
         return rewriteDryRun;
     }
 
-    @Option(description = "Rewrite in dry-mode.", option = "rewriteDryRun")
+    @Option(description = "Do a dry run of the suggested update recipe for this project.", option = "rewriteDryRun")
     public QuarkusUpdate setRewriteDryRun(Boolean rewriteDryRun) {
         this.rewriteDryRun = rewriteDryRun;
         return this;
@@ -57,12 +70,12 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
     @Input
     public boolean getPerModule() {
-        return perModule;
+        return false;
     }
 
-    @Option(description = "Log project's state per module.", option = "perModule")
+    @Option(description = "This option was not used", option = "perModule")
+    @Deprecated
     public void setPerModule(boolean perModule) {
-        this.perModule = perModule;
     }
 
     @Input
@@ -164,8 +177,15 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
         }
         invoker.targetPlatformVersion(targetPlatformVersion);
         invoker.rewriteDryRun(rewriteDryRun);
-        invoker.noRewrite(noRewrite);
-        invoker.perModule(perModule);
+
+        // backward compat
+        if (noRewrite != null && noRewrite) {
+            rewrite = false;
+        }
+
+        if (rewrite != null) {
+            invoker.rewrite(rewrite);
+        }
         invoker.appModel(extension().getApplicationModel());
         try {
             invoker.execute();

--- a/devtools/maven/src/main/java/io/quarkus/maven/InfoMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/InfoMojo.java
@@ -6,7 +6,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import io.quarkus.devtools.commands.ProjectInfo;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
-import io.quarkus.devtools.commands.handlers.ProjectInfoCommandHandler;
 import io.quarkus.devtools.project.QuarkusProject;
 
 /**
@@ -34,11 +33,6 @@ public class InfoMojo extends QuarkusProjectStateMojoBase {
             outcome = invoker.execute();
         } catch (QuarkusCommandException e) {
             throw new MojoExecutionException("Failed to resolve the available updates", e);
-        }
-
-        if (outcome.getValue(ProjectInfoCommandHandler.RECOMMENDATIONS_AVAILABLE, false)) {
-            getLog().warn(
-                    "Non-recommended Quarkus platform BOM and/or extension versions were found. For more details, please, execute 'mvn quarkus:update -Drectify'");
         }
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectStateMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectStateMojoBase.java
@@ -102,7 +102,8 @@ public abstract class QuarkusProjectStateMojoBase extends QuarkusProjectMojoBase
                     }
                     try {
                         Files.createDirectories(classesDir);
-                        createdDirs.add(topDirToCreate);
+                        // We keep the root target dir because it is used to store the update recipes
+                        //createdDirs.add(topDirToCreate);
                     } catch (IOException e) {
                         throw new MojoExecutionException("Failed to create " + classesDir, e);
                     }

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -21,16 +21,16 @@ import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.PlatformStreamCoords;
 
 /**
- * Log Quarkus-related recommended updates, such as new Quarkus platform BOM versions and
- * Quarkus extensions versions that aren't managed by the Quarkus platform BOMs.
+ * Suggest project updates and create a recipe with the possibility to apply it.
  */
 @Mojo(name = "update", requiresProject = true)
 public class UpdateMojo extends QuarkusProjectStateMojoBase {
 
     /**
-     * Display information per project module.
+     * Deprecated: this option was unused
      */
     @Parameter(property = "perModule")
+    @Deprecated
     boolean perModule;
 
     /**
@@ -47,13 +47,22 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
     private String rewritePluginVersion;
 
     /**
-     * Disable the rewrite feature.
+     * Run the suggested update recipe for this project.
      */
+    @Parameter(property = "rewrite", required = false)
+    private Boolean rewrite;
+
+    /**
+     * Disable the rewrite feature.
+     *
+     * Deprecated: use -Drewrite=false instead
+     */
+    @Deprecated
     @Parameter(property = "noRewrite", required = false, defaultValue = "false")
     private Boolean noRewrite;
 
     /**
-     * Rewrite in dry-mode.
+     * Do a dry run the suggested update recipe for this project.
      */
     @Parameter(property = "rewriteDryRun", required = false, defaultValue = "false")
     private Boolean rewriteDryRun;
@@ -115,7 +124,6 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
         final UpdateProject invoker = new UpdateProject(quarkusProject);
         invoker.targetCatalog(targetCatalog);
         invoker.targetPlatformVersion(platformVersion);
-        invoker.perModule(perModule);
         invoker.appModel(resolveApplicationModel());
         if (rewritePluginVersion != null) {
             invoker.rewritePluginVersion(rewritePluginVersion);
@@ -127,7 +135,15 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
             invoker.rewriteAdditionalUpdateRecipes(rewriteAdditionalUpdateRecipes);
         }
         invoker.rewriteDryRun(rewriteDryRun);
-        invoker.noRewrite(noRewrite);
+
+        // backward compat
+        if (noRewrite != null && noRewrite) {
+            rewrite = false;
+        }
+
+        if (rewrite != null) {
+            invoker.rewrite(rewrite);
+        }
 
         try {
             final QuarkusCommandOutcome result = invoker.execute();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/UpdateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/UpdateProject.java
@@ -20,8 +20,7 @@ public class UpdateProject {
 
     public static final String APP_MODEL = "quarkus.update-project.app-model";
     public static final String TARGET_CATALOG = "quarkus.update-project.target-catalog";
-    public static final String PER_MODULE = "quarkus.update-project.per-module";
-    public static final String NO_REWRITE = "quarkus.update-project.rewrite.disabled";
+    public static final String REWRITE = "quarkus.update-project.rewrite.yes";
     public static final String TARGET_PLATFORM_VERSION = "quarkus.update-project.target-platform-version";
     public static final String REWRITE_PLUGIN_VERSION = "quarkus.update-project.rewrite.plugin-version";
     public static final String REWRITE_QUARKUS_UPDATE_RECIPES = "quarkus.update-project.rewrite.quarkus-update-recipes";
@@ -49,8 +48,8 @@ public class UpdateProject {
         return this;
     }
 
-    public UpdateProject noRewrite(boolean noRewrite) {
-        invocation.setValue(NO_REWRITE, noRewrite);
+    public UpdateProject rewrite(boolean rewrite) {
+        invocation.setValue(REWRITE, rewrite);
         return this;
     }
 
@@ -72,11 +71,6 @@ public class UpdateProject {
 
     public UpdateProject rewriteDryRun(boolean rewriteDryRun) {
         invocation.setValue(REWRITE_DRY_RUN, rewriteDryRun);
-        return this;
-    }
-
-    public UpdateProject perModule(boolean perModule) {
-        invocation.setValue(PER_MODULE, perModule);
         return this;
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/TopExtensionDependency.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/TopExtensionDependency.java
@@ -2,6 +2,7 @@ package io.quarkus.devtools.project.state;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Objects;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.maven.dependency.ArtifactCoords;
@@ -161,5 +162,19 @@ public class TopExtensionDependency {
 
     public String getProviderKey() {
         return providerKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        TopExtensionDependency that = (TopExtensionDependency) o;
+        return transitive == that.transitive && Objects.equals(coords, that.coords)
+                && Objects.equals(catalogMetadata, that.catalogMetadata) && Objects.equals(providerKey, that.providerKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(coords, catalogMetadata, transitive, providerKey);
     }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ExtensionUpdateInfo.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ExtensionUpdateInfo.java
@@ -3,6 +3,8 @@ package io.quarkus.devtools.project.update;
 import static io.quarkus.devtools.project.update.ExtensionUpdateInfo.VersionUpdateType.PLATFORM_MANAGED;
 import static io.quarkus.devtools.project.update.ExtensionUpdateInfo.VersionUpdateType.computeVersionUpdateType;
 
+import java.util.Objects;
+
 import io.quarkus.devtools.project.state.TopExtensionDependency;
 import io.quarkus.registry.catalog.Extension;
 
@@ -78,7 +80,7 @@ public final class ExtensionUpdateInfo {
     }
 
     public boolean isUpdateRecommended() {
-        return recommendedDep != currentDep;
+        return !Objects.equals(recommendedDep, currentDep);
     }
 
     public boolean shouldUpdateExtension() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectExtensionsUpdateInfo.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectExtensionsUpdateInfo.java
@@ -39,7 +39,8 @@ public class ProjectExtensionsUpdateInfo {
     }
 
     public List<ExtensionUpdateInfo> getSimpleVersionUpdates() {
-        return streamExtensions().filter(ExtensionUpdateInfo::isSimpleVersionUpdate).collect(Collectors.toList());
+        return streamExtensions().filter(ExtensionUpdateInfo::isSimpleVersionUpdate)
+                .filter(ExtensionUpdateInfo::isUpdateRecommended).collect(Collectors.toList());
     }
 
     public List<ExtensionUpdateInfo> getVersionUpdates() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateCommand.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateCommand.java
@@ -45,13 +45,13 @@ public class QuarkusUpdateCommand {
     }
 
     public static void handle(MessageWriter log, BuildTool buildTool, Path baseDir,
-            String rewritePluginVersion, String recipesGAV, Path recipe, boolean dryRun) {
+            String rewritePluginVersion, String recipesGAV, Path recipe, Path logFile, boolean dryRun) {
         switch (buildTool) {
             case MAVEN:
-                runMavenUpdate(log, baseDir, rewritePluginVersion, recipesGAV, recipe, dryRun);
+                runMavenUpdate(log, baseDir, rewritePluginVersion, recipesGAV, recipe, logFile, dryRun);
                 break;
             case GRADLE:
-                runGradleUpdate(log, baseDir, rewritePluginVersion, recipesGAV, recipe, dryRun);
+                runGradleUpdate(log, baseDir, rewritePluginVersion, recipesGAV, recipe, logFile, dryRun);
                 break;
             default:
                 throw new QuarkusUpdateException(buildTool.getKey() + " is not supported yet");
@@ -60,18 +60,19 @@ public class QuarkusUpdateCommand {
 
     private static void runMavenUpdate(MessageWriter log, Path baseDir, String rewritePluginVersion, String recipesGAV,
             Path recipe,
-            boolean dryRun) {
+            Path logFile, boolean dryRun) {
         final String mvnBinary = findMvnBinary(baseDir);
-        executeCommand(baseDir, getMavenUpdateCommand(mvnBinary, rewritePluginVersion, recipesGAV, recipe, dryRun), log);
+        executeCommand(baseDir, getMavenUpdateCommand(mvnBinary, rewritePluginVersion, recipesGAV, recipe, dryRun), log,
+                logFile);
 
         // format the sources
         if (!dryRun) {
-            executeCommand(baseDir, getMavenProcessSourcesCommand(mvnBinary), log);
+            executeCommand(baseDir, getMavenProcessSourcesCommand(mvnBinary), log, logFile);
         }
     }
 
     private static void runGradleUpdate(MessageWriter log, Path baseDir, String rewritePluginVersion, String recipesGAV,
-            Path recipe, boolean dryRun) {
+            Path recipe, Path logFile, boolean dryRun) {
         Path tempInit = null;
         try {
             tempInit = Files.createTempFile("openrewrite-init", "gradle");
@@ -100,7 +101,7 @@ public class QuarkusUpdateCommand {
             List<String> command = List.of(gradleBinary.toString(), "--console", "plain", "--stacktrace",
                     "--init-script",
                     tempInit.toAbsolutePath().toString(), dryRun ? "rewriteDryRun" : "rewriteRun");
-            executeCommand(baseDir, command, log);
+            executeCommand(baseDir, command, log, logFile);
         } catch (QuarkusUpdateException e) {
             throw e;
         } catch (Exception e) {
@@ -175,7 +176,7 @@ public class QuarkusUpdateCommand {
         return command;
     }
 
-    private static void executeCommand(Path baseDir, List<String> command, MessageWriter log) {
+    private static void executeCommand(Path baseDir, List<String> command, MessageWriter log, Path logFile) {
         final List<String> effectiveCommand = new ArrayList<>(command);
         propagateSystemPropertyIfSet("maven.repo.local", effectiveCommand);
         ProcessBuilder processBuilder = new ProcessBuilder();
@@ -183,54 +184,63 @@ public class QuarkusUpdateCommand {
         log.info("");
         log.info("");
         log.info(" ------------------------------------------------------------------------");
-        log.info("Executing:\n" + String.join(" ", effectiveCommand));
+        log.info("Executing (this may take a while):\n" + String.join(" ", effectiveCommand));
+
         log.info("");
         processBuilder.command(effectiveCommand);
 
         try {
-            Process process = processBuilder.redirectOutput(ProcessBuilder.Redirect.PIPE)
-                    .redirectError(ProcessBuilder.Redirect.PIPE).start();
+            ProcessBuilder.Redirect redirect = logFile != null ? ProcessBuilder.Redirect.to(logFile.toFile())
+                    : ProcessBuilder.Redirect.PIPE;
+            Process process = processBuilder.redirectOutput(redirect)
+                    .redirectError(redirect).start();
 
-            BufferedReader inputReader = new BufferedReader(new java.io.InputStreamReader(process.getInputStream()));
-            BufferedReader errorReader = new BufferedReader(new java.io.InputStreamReader(process.getErrorStream()));
+            if (logFile == null) {
+                BufferedReader inputReader = new BufferedReader(new java.io.InputStreamReader(process.getInputStream()));
+                BufferedReader errorReader = new BufferedReader(new java.io.InputStreamReader(process.getErrorStream()));
 
-            String line;
-            LogLevel currentLogLevel = LogLevel.UNKNOWN;
+                String line;
+                LogLevel currentLogLevel = LogLevel.UNKNOWN;
 
-            while ((line = inputReader.readLine()) != null) {
-                Optional<LogLevel> detectedLogLevel = LogLevel.of(line);
-                if (detectedLogLevel.isPresent()) {
-                    currentLogLevel = detectedLogLevel.get();
+                while ((line = inputReader.readLine()) != null) {
+                    Optional<LogLevel> detectedLogLevel = LogLevel.of(line);
+                    if (detectedLogLevel.isPresent()) {
+                        currentLogLevel = detectedLogLevel.get();
+                    }
+                    switch (currentLogLevel) {
+                        case ERROR:
+                            log.error(currentLogLevel.clean(line));
+                            break;
+                        case WARNING:
+                            log.warn(currentLogLevel.clean(line));
+                            break;
+                        case INFO:
+                            log.info(currentLogLevel.clean(line));
+                            break;
+                        case UNKNOWN:
+                        default:
+                            log.info(line);
+                            break;
+                    }
                 }
-                switch (currentLogLevel) {
-                    case ERROR:
-                        log.error(currentLogLevel.clean(line));
-                        break;
-                    case WARNING:
-                        log.warn(currentLogLevel.clean(line));
-                        break;
-                    case INFO:
-                        log.info(currentLogLevel.clean(line));
-                        break;
-                    case UNKNOWN:
-                    default:
-                        log.info(line);
-                        break;
+                while ((line = errorReader.readLine()) != null) {
+                    log.error(line);
                 }
-            }
-            while ((line = errorReader.readLine()) != null) {
-                log.error(line);
-            }
 
-            log.info("");
-            log.info("");
-            log.info("");
+                log.info("");
+
+            }
+            String logInfo = logFile != null ? "Logs can be found at: %s".formatted(baseDir.relativize(logFile).toString())
+                    : "See the execution logs above for more details";
 
             int exitCode = process.waitFor();
             if (exitCode != 0) {
                 throw new QuarkusUpdateExitErrorException(
-                        "The command to update the project exited with an error, see the execution logs above for more details");
+                        "The command to update the project exited with an error" + logInfo);
             }
+
+            log.info("Rewrite process completed. " + logInfo);
+            log.info("");
         } catch (QuarkusUpdateException e) {
             throw e;
         } catch (Exception e) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/operations/DropDependencyVersionOperation.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/operations/DropDependencyVersionOperation.java
@@ -23,7 +23,7 @@ public class DropDependencyVersionOperation implements RewriteOperation {
                 return Map.of("org.openrewrite.maven.RemoveRedundantDependencyVersions",
                         Map.of(
                                 "groupId", groupId,
-                                "artifactId", artifactId));
+                                "artifactId", artifactId, "onlyIfManagedVersionIs", "ANY"));
             default:
                 return Map.of();
         }

--- a/independent-projects/tools/message-writer/src/main/java/io/quarkus/devtools/messagewriter/MessageFormatter.java
+++ b/independent-projects/tools/message-writer/src/main/java/io/quarkus/devtools/messagewriter/MessageFormatter.java
@@ -1,0 +1,31 @@
+package io.quarkus.devtools.messagewriter;
+
+public class MessageFormatter {
+
+    public enum Format {
+        RED("\u001B[91m"),
+        GREEN("\u001b[32m"),
+        BLUE("\u001b[94m"),
+        RESET("\u001b[39m"),
+        UNDERLINE("\u001b[4m"),
+        NO_UNDERLINE("\u001b[24m"),
+        BOLD("\u001b[1m"),
+        NO_BOLD("\u001b[22m");
+
+        private final String code;
+
+        Format(String code) {
+            this.code = code;
+        }
+
+        @Override
+        public String toString() {
+            return code;
+        }
+    }
+
+    public static String format(Format format, String text) {
+        return format + text + Format.RESET;
+    }
+
+}

--- a/independent-projects/tools/message-writer/src/main/java/io/quarkus/devtools/messagewriter/MessageIcons.java
+++ b/independent-projects/tools/message-writer/src/main/java/io/quarkus/devtools/messagewriter/MessageIcons.java
@@ -4,8 +4,8 @@ import io.smallrye.common.os.OS;
 
 public enum MessageIcons {
 
-    UP_TO_DATE_ICON(toEmoji("U+2714"), "[UP-TO-DATE]"),
-    OUT_OF_DATE_ICON(toEmoji("U+26A0"), "[OUT-OF-DATE]"),
+    UP_TO_DATE_ICON(toEmoji("U+2714"), "v"),
+    OUT_OF_DATE_ICON(toEmoji("U+26A0"), "x"),
     SUCCESS_ICON(toEmoji("U+2705"), "[SUCCESS]"),
     FAILURE_ICON(toEmoji("U+274C"), "[FAILURE]"),
     NOOP_ICON(toEmoji("U+1F44D"), ""),


### PR DESCRIPTION
- Allow to run update even if only Quarkiverse extensions needs updates.
- Improve and fix info and update logs
- Add colors
- Fix recipe resolver algorithm 
- Make update interactive by default (but add options `-y/-n/-N`)
- Fix issue when drop version specific version with Maven (to managed)
- Move rewrite logs in a log file (`target/rewrite/rewrite.log`) to have a clean update logging output
- Print patch file location in dry-run

update
![image](https://github.com/user-attachments/assets/5f634097-7106-489a-ad98-74b3bba63edf)

info:
![image](https://github.com/user-attachments/assets/85bf84de-d0f8-4ff8-9a02-13e256a849b2)

help:
```shell
Rewrite (interactive by default):
      --quarkus-update-recipes=<quarkusUpdateRecipes>
                           Use custom io.quarkus:quarkus-update-recipes:LATEST
                             artifact (GAV) or just provide the version. This
                             artifact should contain the base Quarkus update
                             recipes to update a project.
      --rewrite-plugin-version=<pluginVersion>
                           Use a custom OpenRewrite plugin version.
      --additional-update-recipes=<additionalUpdateRecipes>
                           Specify a list of additional artifacts (GAV)
                             containing rewrite recipes.
  -y, --yes                Run the suggested update recipe for this project.
  -N, --no, --no-rewrite   Do NOT run the update.
  -n, --dry-run            Do a dry run of the suggested update recipe for this
                             project.
```



Created https://github.com/quarkusio/quarkus/issues/46460 for follow up work


