### PR TITLE
Text cannot be parsed to a Duration when assessing TlsConfigurationRegistry.get("javax.net.ssl")

### DIFF
--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/JavaNetSslTlsBucketConfig.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/JavaNetSslTlsBucketConfig.java
@@ -121,7 +121,7 @@ class JavaNetSslTlsBucketConfig implements TlsBucketConfig {
 
     @Override
     public Duration handshakeTimeout() {
-        return Duration.parse("10S");
+        return Duration.ofSeconds(10L);
     }
 
     @Override

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/keystores/ExpiryTrustOptions.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/keystores/ExpiryTrustOptions.java
@@ -7,6 +7,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
+import java.util.Objects;
 import java.util.function.Function;
 
 import javax.net.ssl.ManagerFactoryParameters;
@@ -147,5 +148,17 @@ public class ExpiryTrustOptions implements TrustOptions {
         public java.security.cert.X509Certificate[] getAcceptedIssuers() {
             return tm.getAcceptedIssuers();
         }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj != null && obj.getClass() == getClass()) {
+            ExpiryTrustOptions that = (ExpiryTrustOptions) obj;
+            return Objects.equals(delegate, that.delegate) &&
+                    Objects.equals(policy, that.policy);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
fix #46309

related to https://github.com/quarkiverse/quarkus-cxf/pull/1721#issuecomment-2660678352 cc @dcheng1248