### PR TITLE
Mark former OIDC config class fields for removal

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -12,7 +12,7 @@ import io.quarkus.oidc.common.runtime.OidcConstants;
  * @deprecated create {@link io.quarkus.oidc.client.runtime.OidcClientConfig} with the {@link OidcClientConfigBuilder}
  *             for example, you can use the {@link io.quarkus.oidc.client.runtime.OidcClientConfig#builder()} method.
  */
-@Deprecated(since = "3.18")
+@Deprecated(since = "3.18", forRemoval = true)
 public class OidcClientConfig extends OidcClientCommonConfig implements io.quarkus.oidc.client.runtime.OidcClientConfig {
 
     public OidcClientConfig() {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
@@ -28,7 +28,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
      *
      * @deprecated use the {@link #tokenPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> tokenPath = Optional.empty();
 
     /**
@@ -36,7 +36,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
      *
      * @deprecated use the {@link #revokePath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> revokePath = Optional.empty();
 
     /**
@@ -45,7 +45,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
      *
      * @deprecated use the {@link #clientId()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> clientId = Optional.empty();
 
     /**
@@ -56,7 +56,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
      *
      * @deprecated use the {@link #clientName()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> clientName = Optional.empty();
 
     /**
@@ -64,7 +64,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
      *
      * @deprecated use the {@link #credentials()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Credentials credentials = new Credentials();
 
     @Override
@@ -95,7 +95,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder.CredentialsBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Credentials implements io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials {
 
         /**
@@ -663,7 +663,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use the {@link #tokenPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getTokenPath() {
         return tokenPath;
     }
@@ -671,7 +671,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setTokenPath(String tokenPath) {
         this.tokenPath = Optional.of(tokenPath);
     }
@@ -679,7 +679,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use the {@link #revokePath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getRevokePath() {
         return revokePath;
     }
@@ -687,7 +687,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setRevokePath(String revokePath) {
         this.revokePath = Optional.of(revokePath);
     }
@@ -695,7 +695,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use the {@link #clientId()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getClientId() {
         return clientId;
     }
@@ -703,7 +703,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setClientId(String clientId) {
         this.clientId = Optional.of(clientId);
     }
@@ -711,7 +711,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use the {@link #clientName()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getClientName() {
         return clientName;
     }
@@ -719,7 +719,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setClientName(String clientName) {
         this.clientName = Optional.of(clientName);
     }
@@ -727,7 +727,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use the {@link #credentials()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Credentials getCredentials() {
         return credentials;
     }
@@ -735,7 +735,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcClientCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setCredentials(Credentials credentials) {
         this.credentials = credentials;
     }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -34,7 +34,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #authServerUrl()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> authServerUrl = Optional.empty();
 
     /**
@@ -43,7 +43,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #discoveryEnabled()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Boolean> discoveryEnabled = Optional.empty();
 
     /**
@@ -52,7 +52,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #registrationPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> registrationPath = Optional.empty();
 
     /**
@@ -63,7 +63,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #connectionDelay()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Duration> connectionDelay = Optional.empty();
 
     /**
@@ -74,7 +74,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #connectionRetryCount()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public int connectionRetryCount = 3;
 
     /**
@@ -82,7 +82,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #connectionTimeout()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Duration connectionTimeout = Duration.ofSeconds(10);
 
     /**
@@ -91,7 +91,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #useBlockingDnsLookup()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public boolean useBlockingDnsLookup;
 
     /**
@@ -99,7 +99,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #maxPoolSize()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public OptionalInt maxPoolSize = OptionalInt.empty();
 
     /**
@@ -109,7 +109,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #followRedirects()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public boolean followRedirects = true;
 
     /**
@@ -117,7 +117,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #proxy()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Proxy proxy = new Proxy();
 
     /**
@@ -125,7 +125,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
      *
      * @deprecated use {@link #tls()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Tls tls = new Tls();
 
     @Override
@@ -186,7 +186,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder} to create the TLS config
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Tls implements io.quarkus.oidc.common.runtime.config.OidcCommonConfig.Tls {
 
         /**
@@ -444,7 +444,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder} to create the Proxy config
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Proxy implements io.quarkus.oidc.common.runtime.config.OidcCommonConfig.Proxy {
 
         /**
@@ -500,7 +500,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use the {@link #connectionDelay()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Duration> getConnectionDelay() {
         return connectionDelay;
     }
@@ -508,7 +508,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setConnectionDelay(Duration connectionDelay) {
         this.connectionDelay = Optional.of(connectionDelay);
     }
@@ -516,7 +516,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use the {@link #authServerUrl()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getAuthServerUrl() {
         return authServerUrl;
     }
@@ -524,7 +524,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setAuthServerUrl(String authServerUrl) {
         this.authServerUrl = Optional.of(authServerUrl);
     }
@@ -532,7 +532,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use the {@link #registrationPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getRegistrationPath() {
         return registrationPath;
     }
@@ -540,7 +540,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setRegistrationPath(String registrationPath) {
         this.registrationPath = Optional.of(registrationPath);
     }
@@ -548,7 +548,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use the {@link #discoveryEnabled()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Boolean> isDiscoveryEnabled() {
         return discoveryEnabled;
     }
@@ -556,7 +556,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setDiscoveryEnabled(boolean enabled) {
         this.discoveryEnabled = Optional.of(enabled);
     }
@@ -564,7 +564,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use the {@link #proxy()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Proxy getProxy() {
         return proxy;
     }
@@ -572,7 +572,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setProxy(Proxy proxy) {
         this.proxy = proxy;
     }
@@ -580,7 +580,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use the {@link #connectionTimeout()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Duration getConnectionTimeout() {
         return connectionTimeout;
     }
@@ -588,7 +588,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setConnectionTimeout(Duration connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
     }
@@ -596,7 +596,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use the {@link #maxPoolSize()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public OptionalInt getMaxPoolSize() {
         return maxPoolSize;
     }
@@ -604,7 +604,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setMaxPoolSize(int maxPoolSize) {
         this.maxPoolSize = OptionalInt.of(maxPoolSize);
     }
@@ -612,7 +612,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use the {@link #discoveryEnabled()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Boolean> getDiscoveryEnabled() {
         return discoveryEnabled;
     }
@@ -620,7 +620,7 @@ public abstract class OidcCommonConfig implements io.quarkus.oidc.common.runtime
     /**
      * @deprecated use {@link io.quarkus.oidc.common.runtime.config.OidcCommonConfigBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setDiscoveryEnabled(Boolean discoveryEnabled) {
         this.discoveryEnabled = Optional.of(discoveryEnabled);
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -23,7 +23,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated Use {@link #builder()} to create this config
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public OidcTenantConfig() {
 
     }
@@ -61,7 +61,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #tenantId()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> tenantId = Optional.empty();
 
     /**
@@ -74,7 +74,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #tenantEnabled()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public boolean tenantEnabled = true;
 
     /**
@@ -82,7 +82,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #applicationType()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<ApplicationType> applicationType = Optional.empty();
 
     /**
@@ -93,7 +93,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #authorizationPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> authorizationPath = Optional.empty();
 
     /**
@@ -104,7 +104,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #userInfoPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> userInfoPath = Optional.empty();
 
     /**
@@ -116,7 +116,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #introspectionPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> introspectionPath = Optional.empty();
 
     /**
@@ -127,7 +127,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #jwksPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> jwksPath = Optional.empty();
 
     /**
@@ -138,7 +138,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #endSessionPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> endSessionPath = Optional.empty();
 
     /**
@@ -148,7 +148,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #tenantPaths()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<List<String>> tenantPaths = Optional.empty();
 
     /**
@@ -157,7 +157,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #publicKey()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> publicKey = Optional.empty();
 
     /**
@@ -167,7 +167,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #introspectionCredentials()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public IntrospectionCredentials introspectionCredentials = new IntrospectionCredentials();
 
     /**
@@ -175,7 +175,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link OidcTenantConfigBuilder.IntrospectionCredentialsBuilder}
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class IntrospectionCredentials implements io.quarkus.oidc.runtime.OidcTenantConfig.IntrospectionCredentials {
         /**
          * Name
@@ -243,7 +243,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #roles()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Roles roles = new Roles();
 
     /**
@@ -251,7 +251,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #token()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Token token = new Token();
 
     /**
@@ -259,7 +259,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #logout()} method
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Logout logout = new Logout();
 
     /**
@@ -279,13 +279,13 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use {@link #certificateChain()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public CertificateChain certificateChain = new CertificateChain();
 
     /**
      * @deprecated use the {@link OidcTenantConfigBuilder.CertificateChainBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class CertificateChain implements io.quarkus.oidc.runtime.OidcTenantConfig.CertificateChain {
         /**
          * Common name of the leaf certificate. It must be set if the {@link #trustStoreFile} does not have
@@ -395,7 +395,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #authentication()} method
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Authentication authentication = new Authentication();
 
     /**
@@ -403,7 +403,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #codeGrant()} method
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public CodeGrant codeGrant = new CodeGrant();
 
     /**
@@ -411,7 +411,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #tokenStateManager()} method
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public TokenStateManager tokenStateManager = new TokenStateManager();
 
     /**
@@ -422,7 +422,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #allowTokenIntrospectionCache()} method
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public boolean allowTokenIntrospectionCache = true;
 
     /**
@@ -433,7 +433,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #allowUserInfoCache()} method
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public boolean allowUserInfoCache = true;
 
     /**
@@ -448,13 +448,13 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #cacheUserInfoInIdtoken()} method
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Boolean> cacheUserInfoInIdtoken = Optional.empty();
 
     /**
      * @deprecated use the {@link LogoutConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Logout implements io.quarkus.oidc.runtime.OidcTenantConfig.Logout {
 
         /**
@@ -583,7 +583,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link OidcTenantConfigBuilder.BackchannelBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Backchannel implements io.quarkus.oidc.runtime.OidcTenantConfig.Backchannel {
         /**
          * The relative path of the Back-Channel Logout endpoint at the application.
@@ -695,13 +695,13 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #jwks()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Jwks jwks = new Jwks();
 
     /**
      * @deprecated use the {@link OidcTenantConfigBuilder.JwksBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Jwks implements io.quarkus.oidc.runtime.OidcTenantConfig.Jwks {
         /**
          * If JWK verification keys should be fetched at the moment a connection to the OIDC provider
@@ -815,7 +815,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link LogoutConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Frontchannel implements io.quarkus.oidc.runtime.OidcTenantConfig.Frontchannel {
         /**
          * The relative path of the Front-Channel Logout endpoint at the application.
@@ -845,7 +845,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link OidcTenantConfigBuilder.TokenStateManagerBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class TokenStateManager implements io.quarkus.oidc.runtime.OidcTenantConfig.TokenStateManager {
 
         @Override
@@ -1007,7 +1007,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #authorizationPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getAuthorizationPath() {
         return authorizationPath();
     }
@@ -1015,7 +1015,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setAuthorizationPath(String authorizationPath) {
         this.authorizationPath = Optional.of(authorizationPath);
     }
@@ -1023,7 +1023,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #userInfoPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getUserInfoPath() {
         return userInfoPath();
     }
@@ -1031,7 +1031,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setUserInfoPath(String userInfoPath) {
         this.userInfoPath = Optional.of(userInfoPath);
     }
@@ -1039,7 +1039,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #introspectionPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getIntrospectionPath() {
         return introspectionPath();
     }
@@ -1047,7 +1047,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setIntrospectionPath(String introspectionPath) {
         this.introspectionPath = Optional.of(introspectionPath);
     }
@@ -1055,7 +1055,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #jwksPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getJwksPath() {
         return jwksPath();
     }
@@ -1063,7 +1063,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setJwksPath(String jwksPath) {
         this.jwksPath = Optional.of(jwksPath);
     }
@@ -1071,7 +1071,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #endSessionPath()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getEndSessionPath() {
         return endSessionPath();
     }
@@ -1079,7 +1079,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setEndSessionPath(String endSessionPath) {
         this.endSessionPath = Optional.of(endSessionPath);
     }
@@ -1087,7 +1087,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #publicKey()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getPublicKey() {
         return publicKey();
     }
@@ -1095,7 +1095,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setPublicKey(String publicKey) {
         this.publicKey = Optional.of(publicKey);
     }
@@ -1103,7 +1103,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #roles()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Roles getRoles() {
         return roles;
     }
@@ -1111,7 +1111,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setRoles(Roles roles) {
         this.roles = roles;
     }
@@ -1119,7 +1119,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #token()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Token getToken() {
         return token;
     }
@@ -1127,7 +1127,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setToken(Token token) {
         this.token = token;
     }
@@ -1135,7 +1135,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #authentication()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Authentication getAuthentication() {
         return authentication;
     }
@@ -1143,7 +1143,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setAuthentication(Authentication authentication) {
         this.authentication = authentication;
     }
@@ -1151,7 +1151,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #tenantId()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<String> getTenantId() {
         return tenantId();
     }
@@ -1159,7 +1159,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setTenantId(String tenantId) {
         this.tenantId = Optional.of(tenantId);
     }
@@ -1167,7 +1167,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #tenantEnabled()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public boolean isTenantEnabled() {
         return tenantEnabled();
     }
@@ -1175,7 +1175,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setTenantEnabled(boolean enabled) {
         this.tenantEnabled = enabled;
     }
@@ -1183,7 +1183,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setLogout(Logout logout) {
         this.logout = logout;
     }
@@ -1191,7 +1191,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #logout()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Logout getLogout() {
         return logout;
     }
@@ -1199,7 +1199,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link OidcTenantConfigBuilder.RolesBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Roles implements io.quarkus.oidc.runtime.OidcTenantConfig.Roles {
 
         public static Roles fromClaimPath(List<String> path) {
@@ -1305,7 +1305,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link AuthenticationConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Authentication implements io.quarkus.oidc.runtime.OidcTenantConfig.Authentication {
 
         @Override
@@ -2081,7 +2081,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link OidcTenantConfigBuilder.CodeGrantBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class CodeGrant implements io.quarkus.oidc.runtime.OidcTenantConfig.CodeGrant {
 
         /**
@@ -2154,7 +2154,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link TokenConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Token implements io.quarkus.oidc.runtime.OidcTenantConfig.Token {
 
         public static Token fromIssuer(String issuer) {
@@ -2678,7 +2678,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link TokenConfigBuilder.BindingConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public static class Binding implements io.quarkus.oidc.runtime.OidcTenantConfig.Binding {
 
         /**
@@ -2727,7 +2727,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
      *
      * @deprecated use the {@link #provider()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Provider> provider = Optional.empty();
 
     public static enum Provider {
@@ -2751,7 +2751,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #provider()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Provider> getProvider() {
         return provider;
     }
@@ -2759,7 +2759,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setProvider(Provider provider) {
         this.provider = Optional.of(provider);
     }
@@ -2767,7 +2767,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #applicationType()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<ApplicationType> getApplicationType() {
         return applicationType;
     }
@@ -2775,7 +2775,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setApplicationType(ApplicationType type) {
         this.applicationType = Optional.of(type);
     }
@@ -2783,7 +2783,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #allowTokenIntrospectionCache()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public boolean isAllowTokenIntrospectionCache() {
         return allowTokenIntrospectionCache();
     }
@@ -2791,7 +2791,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setAllowTokenIntrospectionCache(boolean allowTokenIntrospectionCache) {
         this.allowTokenIntrospectionCache = allowTokenIntrospectionCache;
     }
@@ -2799,7 +2799,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #allowUserInfoCache()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public boolean isAllowUserInfoCache() {
         return allowUserInfoCache();
     }
@@ -2807,7 +2807,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setAllowUserInfoCache(boolean allowUserInfoCache) {
         this.allowUserInfoCache = allowUserInfoCache;
     }
@@ -2815,7 +2815,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #cacheUserInfoInIdtoken()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public Optional<Boolean> isCacheUserInfoInIdtoken() {
         return cacheUserInfoInIdtoken();
     }
@@ -2823,7 +2823,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setCacheUserInfoInIdtoken(boolean cacheUserInfoInIdtoken) {
         this.cacheUserInfoInIdtoken = Optional.of(cacheUserInfoInIdtoken);
     }
@@ -2831,7 +2831,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #introspectionCredentials()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public IntrospectionCredentials getIntrospectionCredentials() {
         return introspectionCredentials;
     }
@@ -2839,7 +2839,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setIntrospectionCredentials(IntrospectionCredentials introspectionCredentials) {
         this.introspectionCredentials = introspectionCredentials;
     }
@@ -2847,7 +2847,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #codeGrant()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public CodeGrant getCodeGrant() {
         return codeGrant;
     }
@@ -2855,7 +2855,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setCodeGrant(CodeGrant codeGrant) {
         this.codeGrant = codeGrant;
     }
@@ -2863,7 +2863,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated use the {@link #certificateChain()} method instead
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public CertificateChain getCertificateChain() {
         return certificateChain;
     }
@@ -2871,7 +2871,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
     /**
      * @deprecated build this config with the {@link OidcTenantConfigBuilder} builder
      */
-    @Deprecated(since = "3.18")
+    @Deprecated(since = "3.18", forRemoval = true)
     public void setCertificateChain(CertificateChain certificateChain) {
         this.certificateChain = certificateChain;
     }


### PR DESCRIPTION
This should give users impulse to migrate as we will eventually remove them, though not anytime soon.