### PR TITLE
Do not index rest-client interfaces using the server endpoint indexer

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -776,6 +776,11 @@ public class ResteasyReactiveProcessor {
                         // to share method and annotations between Resource classes
                         continue;
                     }
+
+                    if (resourceClassImplCount == 0 && index.getKnownDirectImplementors(classInfo.name()).isEmpty()
+                            && result.getClientInterfaces().containsKey(classInfo.name())) {
+                        continue;
+                    }
                 }
 
                 Optional<ResourceClass> endpoints = serverEndpointIndexer.createEndpoints(classInfo, false);


### PR DESCRIPTION
Rest Client interfaces that looked like sub resources where before this change where handled as if they where server sub resources. only later in the process where they then filtered out (afaiu).


improves hot reload times by about 50ms
related to #45631