### PR TITLE
Use the quarkus MongoClients in the liquibase-mongodb extension

### DIFF
--- a/docs/src/main/asciidoc/liquibase-mongodb.adoc
+++ b/docs/src/main/asciidoc/liquibase-mongodb.adoc
@@ -66,7 +66,7 @@ The following is an example for the `{config-file}` file:
 [source,properties]
 ----
 # configure MongoDB
-quarkus.mongodb.connection-string = mongodb://localhost:27017
+quarkus.mongodb.connection-string = mongodb://localhost:27017/mydatabase
 
 # Liquibase MongoDB minimal config properties
 quarkus.liquibase-mongodb.migrate-at-start=true
@@ -80,8 +80,9 @@ quarkus.liquibase-mongodb.migrate-at-start=true
 # quarkus.liquibase-mongodb.default-catalog-name=DefaultCatalog
 # quarkus.liquibase-mongodb.default-schema-name=DefaultSchema
 ----
+NOTE: Liquibase needs a database either in the connection string or with the `quarkus.mongodb.database` property.
 
-NOTE: Liquibase MongoDB is configured using a connection string, we do our best to craft a connection string that matches the MongoDB client configuration but if some configuration properties are not working you may consider adding them directly into the `quarkus.mongodb.connection-string` config property.
+NOTE: By default, Liquibase MongoDB is configured to use the default MongoDB client Quarkus creates, but you can configure the extension to use a named client by setting `quarkus.liquibase-mongodb.mongo-client-name`.
 
 Add a changeLog file to the default folder following the Liquibase naming conventions: `{change-log}`
 YAML, JSON and XML formats are supported for the changeLog.

--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbConfig.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbConfig.java
@@ -24,6 +24,11 @@ public interface LiquibaseMongodbConfig {
     boolean enabled();
 
     /**
+     * Mongodb client name to use to connect to database, defaults to the default mongodb client.
+     */
+    Optional<String> mongoClientName();
+
+    /**
      * The migrate at start flag
      */
     @WithDefault("false")

--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbRecorder.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbRecorder.java
@@ -28,7 +28,7 @@ public class LiquibaseMongodbRecorder {
         return new Supplier<LiquibaseMongodbFactory>() {
             @Override
             public LiquibaseMongodbFactory get() {
-                return new LiquibaseMongodbFactory(config, buildTimeConfig, mongodbConfig.defaultMongoClientConfig());
+                return new LiquibaseMongodbFactory(config, buildTimeConfig, mongodbConfig);
             }
         };
     }

--- a/integration-tests/liquibase-mongodb/src/main/java/io/quarkus/it/liquibase/mongodb/Fruit.java
+++ b/integration-tests/liquibase-mongodb/src/main/java/io/quarkus/it/liquibase/mongodb/Fruit.java
@@ -1,7 +1,9 @@
 package io.quarkus.it.liquibase.mongodb;
 
 import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
 
+@MongoEntity(clientName = "fruit-client")
 public class Fruit extends PanacheMongoEntity {
     public String name;
     public String color;

--- a/integration-tests/liquibase-mongodb/src/main/resources/application.properties
+++ b/integration-tests/liquibase-mongodb/src/main/resources/application.properties
@@ -1,4 +1,8 @@
-quarkus.mongodb.connection-string=mongodb://localhost:27017
-quarkus.mongodb.database=fruits
+# The tests use flapdoodle no need for devservices
+quarkus.mongodb.devservices.enabled=false
+
 quarkus.liquibase-mongodb.change-log=liquibase/changelog.xml
 quarkus.liquibase-mongodb.migrate-at-start=true
+quarkus.liquibase-mongodb.mongo-client-name=fruit-client
+quarkus.mongodb.fruit-client.database=fruits
+quarkus.mongodb.fruit-client.hosts=localhost:27018

--- a/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/FruitResourceTest.java
+++ b/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/FruitResourceTest.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import org.bson.Document;
 import org.junit.jupiter.api.Assertions;
@@ -19,22 +20,24 @@ import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoClient;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.mongodb.MongoTestResource;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@QuarkusTestResource(MongoTestResource.class)
+@QuarkusTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = "port", value = "27018"))
 @DisabledOnOs(OS.WINDOWS)
 class FruitResourceTest {
 
     @Inject
+    @Named("fruit-client")
     MongoClient mongoClient;
 
     @Test
     public void testTheEndpoint() {
         // assert that a fruit exist as one has been created in the changelog
-        List<Fruit> list = get("/fruits").as(new TypeRef<List<Fruit>>() {
+        List<Fruit> list = get("/fruits").as(new TypeRef<>() {
         });
         Assertions.assertEquals(1, list.size());
     }

--- a/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/NativeFruitResourceTestIT.java
+++ b/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/NativeFruitResourceTestIT.java
@@ -10,12 +10,13 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.mongodb.MongoTestResource;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(MongoTestResource.class)
+@QuarkusTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = "port", value = "27018"))
 @DisabledOnOs(OS.WINDOWS)
 class NativeFruitResourceTestIT {
     @Test


### PR DESCRIPTION
This PR makes the liquibase-mongodb extension use the quarkus `MongoClients` to create mongo clients instead of relying on the liquibase logic.

This allows the following:
* remove all the problems linked to the need of rebuilding `connection-string`
* apply the MongoClientCustomizer on the clients
* Reuse all the mongo clients configuration

- Closes: #46312