### PR TITLE
Produce a KubernetesDevServiceInfoBuildItem

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -43,6 +43,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import io.fabric8.kubernetes.client.Config;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
@@ -62,6 +63,7 @@ import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig.Flavor;
+import io.quarkus.kubernetes.client.spi.KubernetesDevServiceInfoBuildItem;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
 @BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { DevServicesConfig.Enabled.class, NoQuarkusTestKubernetesClient.class })
@@ -89,7 +91,8 @@ public class DevServicesKubernetesProcessor {
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             CuratedApplicationShutdownBuildItem closeBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
-            DevServicesConfig devServicesConfig) {
+            DevServicesConfig devServicesConfig,
+            BuildProducer<KubernetesDevServiceInfoBuildItem> devServicesKube) {
 
         KubernetesDevServiceCfg configuration = getConfiguration(kubernetesClientBuildTimeConfig);
 
@@ -108,7 +111,8 @@ public class DevServicesKubernetesProcessor {
         try {
             devService = startKubernetes(dockerStatusBuildItem, configuration, launchMode,
                     !devServicesSharedNetworkBuildItem.isEmpty(),
-                    devServicesConfig.timeout());
+                    devServicesConfig.timeout(),
+                    devServicesKube);
             if (devService == null) {
                 compressor.closeAndDumpCaptured();
             } else {
@@ -143,7 +147,6 @@ public class DevServicesKubernetesProcessor {
                     "Dev Services for Kubernetes started. Other Quarkus applications in dev mode will find the "
                             + "cluster automatically.");
         }
-
         return devService.toBuildItem();
     }
 
@@ -161,7 +164,8 @@ public class DevServicesKubernetesProcessor {
 
     @SuppressWarnings("unchecked")
     private RunningDevService startKubernetes(DockerStatusBuildItem dockerStatusBuildItem, KubernetesDevServiceCfg config,
-            LaunchModeBuildItem launchMode, boolean useSharedNetwork, Optional<Duration> timeout) {
+            LaunchModeBuildItem launchMode, boolean useSharedNetwork, Optional<Duration> timeout,
+            BuildProducer<KubernetesDevServiceInfoBuildItem> devServicesKube) {
         if (!config.devServicesEnabled) {
             // explicitly disabled
             log.debug("Not starting Dev Services for Kubernetes, as it has been disabled in the config.");
@@ -232,6 +236,8 @@ public class DevServicesKubernetesProcessor {
             container.start();
 
             KubeConfig kubeConfig = KubeConfigUtils.parseKubeConfig(container.getKubeconfig());
+
+            devServicesKube.produce(new KubernetesDevServiceInfoBuildItem(container.getKubeconfig(), container));
 
             return new RunningDevService(Feature.KUBERNETES_CLIENT.getName(), container.getContainerId(),
                     new ContainerShutdownCloseable(container, Feature.KUBERNETES_CLIENT.getName()),

--- a/extensions/kubernetes-client/spi/pom.xml
+++ b/extensions/kubernetes-client/spi/pom.xml
@@ -44,6 +44,10 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-httpclient-vertx</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.dajudge.kindcontainer</groupId>
+            <artifactId>kindcontainer</artifactId>
+        </dependency>
 
     </dependencies>
     <build>

--- a/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesDevServiceInfoBuildItem.java
+++ b/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesDevServiceInfoBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkus.kubernetes.client.spi;
+
+import org.testcontainers.containers.GenericContainer;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class KubernetesDevServiceInfoBuildItem extends SimpleBuildItem {
+    private final String kubeConfig;
+    private final GenericContainer container;
+
+    public KubernetesDevServiceInfoBuildItem(String kubeConfig, GenericContainer container) {
+        this.kubeConfig = kubeConfig;
+        this.container = container;
+    }
+
+    public String getKubeConfig() {
+        return kubeConfig;
+    }
+
+    public GenericContainer getContainer() {
+        return container;
+    }
+
+}


### PR DESCRIPTION
- Produce a `KubernetesDevServiceInfoBuildItem` when the kubernetes container is created to allow to sync the cluster to be used with a DevService consuming (example quarkus-argocd) in order to access the container's kubeconfig
- Fix: #46330