### PR TITLE
Add "basic" to client scopes for auto generated client in keycloak devservice

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -881,7 +881,7 @@ public class KeycloakDevServicesProcessor {
         client.setImplicitFlowEnabled(true);
         client.setEnabled(true);
         client.setRedirectUris(List.of("*"));
-        client.setDefaultClientScopes(List.of("microprofile-jwt"));
+        client.setDefaultClientScopes(List.of("microprofile-jwt", "basic"));
 
         return client;
     }


### PR DESCRIPTION
Following up on the discussion https://github.com/quarkusio/quarkus/discussions/44053, I have added the basic scope to the auto generated client.

I am unsure about testing, any suggestions?