### PR TITLE
[3.19] Update SmallRye Config to 3.12.0 for Quarkus 3.19

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -47,7 +47,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
         <smallrye-common.version>2.10.0</smallrye-common.version>
-        <smallrye-config.version>3.11.2</smallrye-config.version>
+        <smallrye-config.version>3.12.0</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.8</smallrye-open-api.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ConfigMappingBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ConfigMappingBuildItem.java
@@ -28,7 +28,7 @@ public final class ConfigMappingBuildItem extends MultiBuildItem {
     }
 
     public ConfigClass toConfigClass() {
-        return new ConfigClass(configClass, prefix);
+        return ConfigClass.configClass(configClass, prefix);
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -193,7 +193,8 @@ public class ConfigMappingUtils {
 
     public static Object newInstance(Class<?> configClass) {
         if (configClass.isAnnotationPresent(ConfigMapping.class)) {
-            return ReflectUtil.newInstance(ConfigMappingLoader.getImplementationClass(configClass));
+            // TODO - radcortez - mapping classes cannot be initialized like this.
+            return ReflectUtil.newInstance(ConfigMappingLoader.ensureLoaded(configClass).implementation());
         } else {
             return ReflectUtil.newInstance(configClass);
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -3,6 +3,7 @@ package io.quarkus.deployment.configuration;
 import static io.quarkus.deployment.util.ReflectUtil.reportError;
 import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_AND_RUN_TIME_FIXED;
 import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
+import static io.smallrye.config.common.utils.StringUtil.skewer;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -1231,7 +1232,8 @@ public final class RunTimeConfigurationGenerator {
                     BranchResult nextEquals = hasNextTrue
                             .ifTrue(hasNextTrue.invokeStaticMethod(PU_IS_MAPPED, nameIterator, hasNextTrue.load(childName)));
                     try (BytecodeCreator nextEqualsTrue = nextEquals.trueBranch()) {
-                        String childMethodName = methodName + "$" + childName.replace("[*]", "-collection");
+                        childName = childName.replace("[*]", "-collection");
+                        String childMethodName = methodName + "$" + skewer(childName, '_');
                         if (child.getMatched() == null) {
                             generateIsMapped(childMethodName, child);
                             nextEqualsTrue.invokeVirtualMethod(NI_NEXT, nameIterator);

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -750,12 +750,6 @@ public class ConfigGenerationBuildStep {
                         method.newInstance(MethodDescriptor.ofConstructor(secretKeyHandlerFactory)));
             }
 
-            for (ConfigClass mappingInstance : mappingsInstances) {
-                method.invokeStaticMethod(WITH_MAPPING_INSTANCE, configBuilder,
-                        method.readStaticField(sharedFields.get(mappingInstance)));
-            }
-
-            mappings.removeAll(mappingsInstances);
             for (ConfigClass mapping : mappings) {
                 method.invokeStaticMethod(WITH_MAPPING, configBuilder, method.readStaticField(sharedFields.get(mapping)));
             }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
@@ -1,14 +1,20 @@
 package io.quarkus.runtime.configuration;
 
+import java.util.Map;
+
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.eclipse.microprofile.config.spi.Converter;
 
+import io.smallrye.config.ConfigMappingLoader;
+import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.ConfigSourceFactory;
 import io.smallrye.config.ConfigSourceInterceptor;
 import io.smallrye.config.ConfigSourceInterceptorFactory;
 import io.smallrye.config.SecretKeysHandler;
 import io.smallrye.config.SecretKeysHandlerFactory;
+import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
 
@@ -17,8 +23,9 @@ import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
  * require varargs or collections as parameters.
  */
 public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCustomizer {
-    protected static void withDefaultValue(SmallRyeConfigBuilder builder, String name, String value) {
-        builder.withDefaultValue(name, value);
+
+    protected static void withDefaultValues(SmallRyeConfigBuilder builder, Map<String, String> values) {
+        builder.withDefaultValues(values);
     }
 
     @SuppressWarnings("unchecked")
@@ -62,6 +69,10 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
         builder.withSecretKeyHandlerFactories(secretKeysHandlerFactory);
     }
 
+    protected static void withMapping(SmallRyeConfigBuilder builder, ConfigClass mapping) {
+        builder.withMapping(mapping);
+    }
+
     protected static void withMapping(SmallRyeConfigBuilder builder, String mappingClass, String prefix) {
         try {
             // To support mappings that are not public
@@ -69,6 +80,11 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    protected static void withMappingInstance(SmallRyeConfigBuilder builder, ConfigClass mapping) {
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        builder.getMappingsBuilder().mappingInstance(mapping, config.getConfigMapping(mapping.getType()));
     }
 
     protected static void withBuilder(SmallRyeConfigBuilder builder, ConfigBuilder configBuilder) {
@@ -96,6 +112,24 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
                     .getClassLoader().loadClass(customizer);
             customizerClass.getDeclaredConstructor().newInstance().configBuilder(builder);
         } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static ConfigClass configClass(final String mappingClass, final String prefix) {
+        try {
+            // To support mappings that are not public
+            return ConfigClass.configClass(Thread.currentThread().getContextClassLoader().loadClass(mappingClass), prefix);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void ensureLoaded(final String mappingClass) {
+        try {
+            // To support mappings that are not public
+            ConfigMappingLoader.ensureLoaded(Thread.currentThread().getContextClassLoader().loadClass(mappingClass));
+        } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/init/InitRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/init/InitRuntimeConfig.java
@@ -1,7 +1,5 @@
 package io.quarkus.runtime.init;
 
-import static io.smallrye.config.Converters.newEmptyValueConverter;
-
 import org.eclipse.microprofile.config.spi.Converter;
 
 import io.quarkus.runtime.annotations.ConfigDocPrefix;
@@ -19,7 +17,6 @@ import io.smallrye.config.WithDefault;
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 @ConfigDocPrefix("quarkus.init")
 public interface InitRuntimeConfig {
-
     /**
      * true to quit exit right after the initialization.
      * The option is not meant be used directly by users.
@@ -30,26 +27,9 @@ public interface InitRuntimeConfig {
     boolean initAndExit();
 
     // Because of https://github.com/eclipse/microprofile-config/issues/708
-    // TODO - radcortez - Make SR Config built-in converters public to be used directly
-    class BooleanConverter implements Converter<Boolean> {
-        static final Converter<Boolean> BOOLEAN_CONVERTER = Converters
-                .newTrimmingConverter(newEmptyValueConverter(new Converter<Boolean>() {
-                    @Override
-                    public Boolean convert(final String value) throws IllegalArgumentException, NullPointerException {
-                        return Boolean.valueOf(
-                                "TRUE".equalsIgnoreCase(value)
-                                        || "1".equalsIgnoreCase(value)
-                                        || "YES".equalsIgnoreCase(value)
-                                        || "Y".equalsIgnoreCase(value)
-                                        || "ON".equalsIgnoreCase(value)
-                                        || "JA".equalsIgnoreCase(value)
-                                        || "J".equalsIgnoreCase(value)
-                                        || "SI".equalsIgnoreCase(value)
-                                        || "SIM".equalsIgnoreCase(value)
-                                        || "OUI".equalsIgnoreCase(value));
-                    }
-                }));
+    Converter<Boolean> BOOLEAN_CONVERTER = Converters.getImplicitConverter(Boolean.class);
 
+    class BooleanConverter implements Converter<Boolean> {
         @Override
         public Boolean convert(final String value) throws IllegalArgumentException, NullPointerException {
             return BOOLEAN_CONVERTER.convert(value);

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ plugin-publish = "1.3.1"
 
 # updating Kotlin here makes QuarkusPluginTest > shouldNotFailOnProjectDependenciesWithoutMain(Path) fail
 kotlin = "2.0.21"
-smallrye-config = "3.11.3-SNAPSHOT"
+smallrye-config = "3.12.0"
 
 junit5 = "5.10.5"
 assertj = "3.27.3"

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ plugin-publish = "1.3.1"
 
 # updating Kotlin here makes QuarkusPluginTest > shouldNotFailOnProjectDependenciesWithoutMain(Path) fail
 kotlin = "2.0.21"
-smallrye-config = "3.11.2"
+smallrye-config = "3.11.3-SNAPSHOT"
 
 junit5 = "5.10.5"
 assertj = "3.27.3"

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -502,7 +502,7 @@ public class ConfigBuildStep {
         // TODO - Register ConfigProperties during build time
         context.registerNonDefaultConstructor(
                 ConfigClass.class.getDeclaredConstructor(Class.class, String.class),
-                configClass -> Stream.of(configClass.getKlass(), configClass.getPrefix())
+                configClass -> Stream.of(configClass.getType(), configClass.getPrefix())
                         .collect(toList()));
 
         recorder.registerConfigProperties(


### PR DESCRIPTION
Same as https://github.com/quarkusio/quarkus/pull/46249, but without:

- Reusing the instance of mappings build in the STATIC_INIT phase. Until now, mappings shared between STATIC_INIT and RUNTIME would be initialized twice, due to https://github.com/quarkusio/quarkus/pull/46323#issuecomment-2664947344, still under investigation