### PR TITLE
Prioritize test model cache over the dev one in BootstrapAppModelFactory

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
@@ -364,11 +364,11 @@ public class BootstrapAppModelFactory {
     }
 
     private Path resolveCachedCpPath(LocalProject project) {
-        if (devMode) {
-            return BootstrapUtils.resolveSerializedAppModelPath(project.getOutputDir());
-        }
         if (test) {
             return BootstrapUtils.getSerializedTestAppModelPath(project.getOutputDir());
+        }
+        if (devMode) {
+            return BootstrapUtils.resolveSerializedAppModelPath(project.getOutputDir());
         }
         return project.getOutputDir().resolve(QUARKUS).resolve(BOOTSTRAP).resolve(APP_MODEL_DAT);
     }


### PR DESCRIPTION
When both `test` and `dev` options are enabled in the app model factory, a wider dependency scope (the test one) should be picked when looking for a cached model. If the cached model is not found then the resolver will resolve the `test` scope anyway.

- Fixes: https://github.com/quarkusio/quarkus/issues/46333