### PR TITLE
Clarify expected behavior of SmallRye Config disambiguation

### DIFF
--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -97,31 +97,9 @@ property names together.
 
 [source,properties]
 ----
-# value cannot be left empty
-quarkus.datasource."datasource-name".jdbc.url=value
+# value can be left empty but must be supplied by another source at runtime (or be an optional)
+quarkus.datasource."datasource-name".jdbc.url=
 ----
-
-If the value is not known until runtime, the key name can still be provided using the `io.smallrye.config.WithKeys` annotation.
-
-[source,java]
-----
-@ConfigMapping(prefix = "com.example")
-public interface ExampleConfig {
-
-    @WithKeys(KeySupplier.class)
-    Map<String, String> deployments();
-
-
-    class KeySupplier implements Supplier<Iterable<String>> {
-        @Override
-        public Iterable<String> get() {
-            return List.of("fake-deployment-name-2", "fake-deployment-name-1");
-        }
-    }
-}
-----
-
-However, a values for these keys **must** then be provided at runtime. Configuration key disambiguation is not supported for optional properties.
 
 [source,bash]
 ----

--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -91,15 +91,37 @@ configuration name to its most likely dotted format. This works fine for fixed c
 names that contain dynamic segments. In this case, Quarkus is unable to determine if `DATASOURCE_NAME` should be
 converted to `datasource.name` or `datasource-name` (or any other special character separator).
 
-For this reason, such properties always require their dotted version name in another source (the value can be left
-empty) to disambiguate the Environment Variable name. It will provide additional information to perform a two-way
-conversion and match the property names together.
+For this reason, such properties always require their dotted version name in another source to disambiguate the
+Environment Variable name. It will provide additional information to perform a two-way conversion and match the
+property names together.
 
 [source,properties]
 ----
-# value can be left empty
-quarkus.datasource."datasource-name".jdbc.url=
+# value cannot be left empty
+quarkus.datasource."datasource-name".jdbc.url=value
 ----
+
+If the value is not known until runtime, the key name can still be provided using the `io.smallrye.config.WithKeys` annotation.
+
+[source,java]
+----
+@ConfigMapping(prefix = "com.example")
+public interface ExampleConfig {
+
+    @WithKeys(KeySupplier.class)
+    Map<String, String> deployments();
+
+
+    class KeySupplier implements Supplier<Iterable<String>> {
+        @Override
+        public Iterable<String> get() {
+            return List.of("fake-deployment-name-2", "fake-deployment-name-1");
+        }
+    }
+}
+----
+
+However, a values for these keys **must** then be provided at runtime. Configuration key disambiguation is not supported for optional properties.
 
 [source,bash]
 ----


### PR DESCRIPTION
Fixes #46245

Per discussion in #46245, previous versions of SmallRye Config supported configuration disambiguation for optional config keys with dynamic values. This was fixed in smallrye 3.10.0 and shipped to Quarkus users in 3.17.0.Final. These documentation changes help clarify expected behavior of Quarkus, how to disambiguate configuration, and the limitations of the existing support.

See https://quarkus-pr-main-46347-preview.surge.sh/version/main/guides/config-reference#environment-variables

Thanks to @radcortez for the clarification