### PR TITLE
Allow offloading Linux CI load to RunsOn

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -96,26 +96,123 @@ jobs:
     steps:
       - name: Build
         run: sleep 30
-  build-jdk17:
-    name: "Initial JDK 17 Build"
+  configure:
+    name: "Configure jobs"
     runs-on: ubuntu-latest
-    # Skip main in forks
-    # Skip draft PRs, rerun as soon as its removed
-    if: "(github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')) && ( \
-           github.event_name != 'pull_request' || ( \
-             github.event.pull_request.draft == false && \
-             github.event.pull_request.state != 'closed' && \
-             github.event.action != 'edited' \
-           ) \
-         )"
     outputs:
-      gib_args: ${{ steps.get-gib-args.outputs.gib_args }}
-      gib_impacted: ${{ steps.get-gib-impacted.outputs.impacted_modules }}
+      config: ${{ steps.configure.outputs.config }}
       m2-monthly-branch-cache-key: ${{ steps.cache-key.outputs.m2-monthly-branch-cache-key }}
       m2-monthly-cache-key: ${{ steps.cache-key.outputs.m2-monthly-cache-key }}
       m2-cache-key: ${{ steps.cache-key.outputs.m2-cache-key }}
       quarkus-metadata-cache-key: ${{ steps.cache-key.outputs.quarkus-metadata-cache-key }}
       quarkus-metadata-cache-key-default: ${{ steps.cache-key.outputs.quarkus-metadata-cache-key-default }}
+    steps:
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Generate cache key
+        id: cache-key
+        run: |
+          CURRENT_BRANCH="${{ github.repository != 'quarkusio/quarkus' && 'fork' || github.base_ref || github.ref_name }}"
+          CURRENT_MONTH=$(/bin/date -u "+%Y-%m")
+          CURRENT_DAY=$(/bin/date -u "+%d")
+          ROOT_CACHE_KEY="m2-cache"
+          echo "m2-monthly-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}" >> $GITHUB_OUTPUT
+          echo "m2-monthly-branch-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}" >> $GITHUB_OUTPUT
+          echo "m2-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}-${CURRENT_DAY}" >> $GITHUB_OUTPUT
+          CURRENT_WEEK=$(/bin/date -u "+%Y-%U")
+          echo "quarkus-metadata-cache-key=quarkus-metadata-cache-${CURRENT_WEEK}-${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "quarkus-metadata-cache-key-default=quarkus-metadata-cache-${CURRENT_WEEK}-${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
+      - name: Configure Runs-On
+        id: configure
+        uses: quarkusio/runs-on-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          main-repository: quarkusio/quarkus
+          runs-on: true
+
+  populate-cache:
+    name: "Populate cache"
+    needs: [ configure ]
+    runs-on: ubuntu-latest
+    if: github.repository == 'quarkusio/quarkus' && github.event_name == 'push'
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Cache Maven Repository
+        id: cache-maven
+        uses: quarkusio/cache-action@v4
+        with:
+          path: ~/.m2/repository
+          # A new cache will be stored daily. After that first store of the day, cache save actions will fail because the cache is immutable but it's not a problem.
+          # The whole cache is dropped monthly to prevent unlimited growth.
+          # The cache is per branch but in case we don't find a branch for a given branch, we will get a cache from another branch.
+          key: ${{ needs.configure.outputs.m2-cache-key }}
+          restore-keys: |
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: false
+      - name: Populate the cache
+        run: |
+          ./mvnw -T2C $COMMON_MAVEN_ARGS dependency:go-offline
+
+  populate-cache-runs-on:
+    name: "Populate cache on RunsOn"
+    needs: [ configure ]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn || 'ubuntu-latest' }}
+    if: fromJson(needs.configure.outputs.config).runners['ubuntu-latest'] && github.repository == 'quarkusio/quarkus' && github.event_name == 'push'
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Cache Maven Repository
+        id: cache-maven
+        uses: quarkusio/cache-action@v4
+        with:
+          path: ~/.m2/repository
+          # A new cache will be stored daily. After that first store of the day, cache save actions will fail because the cache is immutable but it's not a problem.
+          # The whole cache is dropped monthly to prevent unlimited growth.
+          # The cache is per branch but in case we don't find a branch for a given branch, we will get a cache from another branch.
+          key: ${{ needs.configure.outputs.m2-cache-key }}
+          restore-keys: |
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: true
+      - name: Populate the cache
+        run: |
+          ./mvnw -T2C $COMMON_MAVEN_ARGS dependency:go-offline
+
+  build-jdk17:
+    name: "Initial JDK 17 Build"
+    needs: [ configure, populate-cache, populate-cache-runs-on ]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn || 'ubuntu-latest' }}
+    # Skip main in forks
+    # Skip draft PRs, rerun as soon as its removed
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')) && (
+           github.event_name != 'pull_request' || (
+             github.event.pull_request.draft == false &&
+             github.event.pull_request.state != 'closed' &&
+             github.event.action != 'edited'
+           )
+         )
+    env:
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn && 'true' || 'false' }}
+    outputs:
+      gib_args: ${{ steps.get-gib-args.outputs.gib_args }}
+      gib_impacted: ${{ steps.get-gib-impacted.outputs.impacted_modules }}
     steps:
       - name: Gradle Enterprise environment
         run: |
@@ -134,56 +231,24 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - name: Generate cache key
-        id: cache-key
-        run: |
-          CURRENT_BRANCH="${{ github.repository != 'quarkusio/quarkus' && 'fork' || github.base_ref || github.ref_name }}"
-          CURRENT_MONTH=$(/bin/date -u "+%Y-%m")
-          CURRENT_DAY=$(/bin/date -u "+%d")
-          ROOT_CACHE_KEY="m2-cache"
-          echo "m2-monthly-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}" >> $GITHUB_OUTPUT
-          echo "m2-monthly-branch-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}" >> $GITHUB_OUTPUT
-          echo "m2-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}-${CURRENT_DAY}" >> $GITHUB_OUTPUT
-          CURRENT_WEEK=$(/bin/date -u "+%Y-%U")
-          echo "quarkus-metadata-cache-key=quarkus-metadata-cache-${CURRENT_WEEK}-${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          echo "quarkus-metadata-cache-key-default=quarkus-metadata-cache-${CURRENT_WEEK}-${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
-      - name: Cache Maven Repository
-        id: cache-maven
-        uses: actions/cache@v4
-        # if it's not a pull request, we restore and save the cache
-        if: github.event_name != 'pull_request'
-        with:
-          path: ~/.m2/repository
-          # A new cache will be stored daily. After that first store of the day, cache save actions will fail because the cache is immutable but it's not a problem.
-          # The whole cache is dropped monthly to prevent unlimited growth.
-          # The cache is per branch but in case we don't find a branch for a given branch, we will get a cache from another branch.
-          key: ${{ steps.cache-key.outputs.m2-cache-key }}
-          restore-keys: |
-            ${{ steps.cache-key.outputs.m2-monthly-branch-cache-key }}-
-            ${{ steps.cache-key.outputs.m2-monthly-cache-key }}-
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
-        # if it a pull request, we restore the cache but we don't save it
-        if: github.event_name == 'pull_request'
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ steps.cache-key.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ steps.cache-key.outputs.m2-monthly-branch-cache-key }}-
-            ${{ steps.cache-key.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Cache Develocity local cache
-        uses: actions/cache@v4
+        uses: quarkusio/cache-action@v4
         if: github.event_name == 'pull_request'
         with:
           path: ~/.m2/.develocity/build-cache
           key: develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           restore-keys: |
             develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number }}-
-      - name: Populate the cache
-        # only populate the cache if it's not a pull request as we only store the cache in this case
-        if: github.event_name != 'pull_request'
-        run: |
-          ./mvnw -T2C $COMMON_MAVEN_ARGS dependency:go-offline
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Verify native-tests.json
         run: ./.github/verify-tests-json.sh native-tests.json integration-tests/
       - name: Verify virtual-threads-tests.json
@@ -341,14 +406,15 @@ jobs:
 
   jvm-tests:
     name: ${{ matrix.java.name }}
-    runs-on: ${{ matrix.java.os-name }}
-    needs: [build-jdk17, calculate-test-jobs]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
+    needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_jvm == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     timeout-minutes: 400
     env:
       MAVEN_OPTS: ${{ matrix.java.maven_opts }}
       JAVA_VERSION_GRADLE: ${{ matrix.java.java-version-gradle || matrix.java.java-version }}
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.jvm_matrix) }}
@@ -404,13 +470,14 @@ jobs:
           architecture: ${{ matrix.java.architecture || 'x64' }}
 
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
@@ -419,13 +486,14 @@ jobs:
       - name: Extract previously uploaded .m2 content
         run: tar -xzf m2-content.tgz -C ~
       - name: Cache Develocity local cache
-        uses: actions/cache@v4
+        uses: quarkusio/cache-action@v4
         if: github.event_name == 'pull_request'
         with:
           path: ~/.m2/.develocity/build-cache
           key: develocity-cache-${{matrix.java.name}}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           restore-keys: |
             develocity-cache-${{matrix.java.name}}-${{ github.event.pull_request.number }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Setup Develocity Build Scan capture
         uses: gradle/develocity-actions/setup-maven@v1.3
         with:
@@ -500,10 +568,11 @@ jobs:
 
   maven-tests:
     name: Maven Tests - JDK ${{matrix.java.name}}
-    runs-on: ${{ matrix.java.os-name }}
-    needs: [build-jdk17, calculate-test-jobs]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
+    needs: [configure, build-jdk17, calculate-test-jobs]
     env:
       MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_maven == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     timeout-minutes: 130
@@ -536,13 +605,14 @@ jobs:
       - name: Add quarkusio remote for GIB
         run: git remote show quarkusio &> /dev/null || git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
@@ -606,11 +676,12 @@ jobs:
 
   gradle-tests:
     name: Gradle Tests - JDK ${{matrix.java.name}}
-    runs-on: ${{matrix.java.os-name}}
-    needs: [build-jdk17, calculate-test-jobs]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
+    needs: [configure, build-jdk17, calculate-test-jobs]
     env:
       # leave more space for the actual gradle execution (which is just wrapped by maven)
       MAVEN_OPTS: -Xmx1g
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_gradle == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     timeout-minutes: 120
@@ -638,13 +709,14 @@ jobs:
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
@@ -696,10 +768,12 @@ jobs:
 
   devtools-tests:
     name: Devtools Tests - JDK ${{matrix.java.name}}
-    runs-on: ${{matrix.java.os-name}}
-    needs: [build-jdk17, calculate-test-jobs]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
+    needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_devtools == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    env:
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -730,13 +804,14 @@ jobs:
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
@@ -792,10 +867,12 @@ jobs:
 
   kubernetes-tests:
     name: Kubernetes Tests - JDK ${{matrix.java.name}}
-    runs-on: ${{matrix.java.os-name}}
-    needs: [build-jdk17, calculate-test-jobs]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
+    needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_kubernetes == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    env:
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -826,13 +903,14 @@ jobs:
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
@@ -888,10 +966,12 @@ jobs:
 
   quickstarts-tests:
     name: Quickstarts Compilation - JDK ${{matrix.java.name}}
-    runs-on: ${{matrix.java.os-name}}
-    needs: [build-jdk17, calculate-test-jobs]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
+    needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_quickstarts == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    env:
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -909,13 +989,14 @@ jobs:
           echo "GE_CUSTOM_VALUES=gh-job-name=Quickstarts Compilation - JDK ${{matrix.java.name}}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
@@ -981,13 +1062,15 @@ jobs:
 
   virtual-thread-native-tests:
     name: Native Tests - Virtual Thread - ${{matrix.category}}
-    runs-on: ${{matrix.os-name}}
-    needs: [build-jdk17, calculate-test-jobs]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn || matrix.os-name }}
+    needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.virtual_threads_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    env:
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: ${{matrix.timeout}}
     strategy:
-      max-parallel: 12
+      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
       fail-fast: false
       matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.virtual_threads_matrix) }}
     steps:
@@ -998,13 +1081,14 @@ jobs:
           echo "GE_CUSTOM_VALUES=gh-job-name=Native Tests - Virtual Thread - ${{matrix.category}}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
@@ -1058,10 +1142,12 @@ jobs:
 
   tcks-test:
     name: MicroProfile TCKs Tests
-    needs: [build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_tcks == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn || 'ubuntu-latest' }}
+    env:
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn && 'true' || 'false' }}
     timeout-minutes: 150
     steps:
       - name: Gradle Enterprise environment
@@ -1082,13 +1168,14 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
@@ -1143,17 +1230,18 @@ jobs:
 
   native-tests:
     name: Native Tests - ${{matrix.category}}
-    needs: [build-jdk17, calculate-test-jobs]
-    runs-on: ${{matrix.os-name}}
+    needs: [configure, build-jdk17, calculate-test-jobs]
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn || matrix.os-name }}
     env:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn && 'true' || 'false' }}
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.native_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:
-      max-parallel: 12
+      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
       fail-fast: false
       matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.native_matrix) }}
     steps:
@@ -1195,13 +1283,14 @@ jobs:
             cat <<< $(jq '.HttpHeaders += {"User-Agent": "Quarkus-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
           fi
       - name: Restore Maven Repository
-        uses: actions/cache/restore@v4
+        uses: quarkusio/cache-action/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.configure.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Download previously uploaded .m2 content
         uses: actions/download-artifact@v4
         with:
@@ -1219,12 +1308,13 @@ jobs:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           develocity-token-expiry: 6
       - name: Cache Quarkus metadata
-        uses: actions/cache@v4
+        uses: quarkusio/cache-action@v4
         with:
           path: '**/.quarkus/quarkus-prod-config-dump'
-          key: ${{ needs.build-jdk17.outputs.quarkus-metadata-cache-key }}
+          key: ${{ needs.configure.outputs.quarkus-metadata-cache-key }}
           # The key is restored from default branch if not found, but still branch specific to override the default after first run
-          restore-keys: ${{ needs.build-jdk17.outputs.quarkus-metadata-cache-key-default }}
+          restore-keys: ${{ needs.configure.outputs.quarkus-metadata-cache-key-default }}
+          runs-on: ${{ env.RUNS_ON_ENABLED }}
       - name: Build
         env:
           TEST_MODULES: ${{matrix.test-modules}}

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -92,7 +92,7 @@ jobs:
     name: "CI Sanity Check"
     runs-on: ubuntu-latest
     # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
+    if: github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')
     steps:
       - name: Build
         run: sleep 30
@@ -339,7 +339,7 @@ jobs:
     name: Calculate Test Jobs
     runs-on: ubuntu-latest
     # Skip main in forks
-    if: "github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')"
+    if: github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')
     needs: build-jdk17
     env:
       GIB_IMPACTED_MODULES: ${{ needs.build-jdk17.outputs.gib_impacted }}
@@ -409,7 +409,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: "needs.calculate-test-jobs.outputs.run_jvm == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    if: needs.calculate-test-jobs.outputs.run_jvm == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
     timeout-minutes: 400
     env:
       MAVEN_OPTS: ${{ matrix.java.maven_opts }}
@@ -425,12 +425,12 @@ jobs:
           echo "GE_TAGS=jdk-${{matrix.java.java-version}}" >> "$GITHUB_ENV"
           echo "GE_CUSTOM_VALUES=gh-job-name=${{ matrix.java.name }}" >> "$GITHUB_ENV"
       - name: Stop mysql
-        if: "!startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos')"
+        if: ${{ !startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos') }}
         run: |
           ss -ln
           sudo service mysql stop || true
       - name: Support longpaths on Windows
-        if: "startsWith(matrix.java.os-name, 'windows')"
+        if: startsWith(matrix.java.os-name, 'windows')
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
         with:
@@ -440,15 +440,15 @@ jobs:
         run: git remote show quarkusio &> /dev/null || git remote add quarkusio https://github.com/quarkusio/quarkus.git
 
       - name: apt clean
-        if: "!startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos')"
+        if: ${{ !startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos') }}
         run: sudo apt-get clean
 
       - name: Reclaim Disk Space
-        if: "!startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos')"
+        if: ${{ !startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos') }}
         run: .github/ci-prerequisites.sh
 
       - name: Set up JDK ${{ env.JAVA_VERSION_GRADLE }} for Gradle (if needed)
-        if: ${{ env.JAVA_VERSION_GRADLE != matrix.java.java-version }}
+        if: env.JAVA_VERSION_GRADLE != matrix.java.java-version
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -574,7 +574,7 @@ jobs:
       MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     # Skip main in forks
-    if: "needs.calculate-test-jobs.outputs.run_maven == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    if: needs.calculate-test-jobs.outputs.run_maven == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
     timeout-minutes: 130
     strategy:
       fail-fast: false
@@ -596,7 +596,7 @@ jobs:
           echo "GE_TAGS=jdk-${{matrix.java.name}}" >> "$GITHUB_ENV"
           echo "GE_CUSTOM_VALUES=gh-job-name=Maven Tests - JDK ${{matrix.java.name}}" >> "$GITHUB_ENV"
       - name: Support longpaths on Windows
-        if: "startsWith(matrix.java.os-name, 'windows')"
+        if: startsWith(matrix.java.os-name, 'windows')
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
         with:
@@ -683,7 +683,7 @@ jobs:
       MAVEN_OPTS: -Xmx1g
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     # Skip main in forks
-    if: "needs.calculate-test-jobs.outputs.run_gradle == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    if: needs.calculate-test-jobs.outputs.run_gradle == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -705,7 +705,7 @@ jobs:
           echo "GE_TAGS=jdk-${{matrix.java.name}}" >> "$GITHUB_ENV"
           echo "GE_CUSTOM_VALUES=gh-job-name=Gradle Tests - JDK ${{matrix.java.name}}" >> "$GITHUB_ENV"
       - name: Support longpaths on Windows
-        if: "startsWith(matrix.java.os-name, 'windows')"
+        if: startsWith(matrix.java.os-name, 'windows')
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
       - name: Restore Maven Repository
@@ -732,7 +732,7 @@ jobs:
           cache: 'gradle'
       - name: Verify dependencies
         # runs on Windows as well but would require newline conversion, not worth it
-        if: "!startsWith(matrix.java.os-name, 'windows')"
+        if: ${{ !startsWith(matrix.java.os-name, 'windows') }}
         run: ./integration-tests/gradle/update-dependencies.sh $COMMON_MAVEN_ARGS -Dscan=false
       - name: Setup Develocity Build Scan capture
         uses: gradle/develocity-actions/setup-maven@v1.3
@@ -771,7 +771,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: "needs.calculate-test-jobs.outputs.run_devtools == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    if: needs.calculate-test-jobs.outputs.run_devtools == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: 60
@@ -800,7 +800,7 @@ jobs:
           echo "GE_TAGS=jdk-${{matrix.java.name}}" >> "$GITHUB_ENV"
           echo "GE_CUSTOM_VALUES=gh-job-name=Devtools Tests - JDK ${{matrix.java.name}}" >> "$GITHUB_ENV"
       - name: Support longpaths on Windows
-        if: "startsWith(matrix.java.os-name, 'windows')"
+        if: startsWith(matrix.java.os-name, 'windows')
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
       - name: Restore Maven Repository
@@ -870,7 +870,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: "needs.calculate-test-jobs.outputs.run_kubernetes == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    if: needs.calculate-test-jobs.outputs.run_kubernetes == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: 40
@@ -899,7 +899,7 @@ jobs:
           echo "GE_TAGS=jdk-${{matrix.java.name}}" >> "$GITHUB_ENV"
           echo "GE_CUSTOM_VALUES=gh-job-name=Kubernetes Tests - JDK ${{matrix.java.name}}" >> "$GITHUB_ENV"
       - name: Support longpaths on Windows
-        if: "startsWith(matrix.java.os-name, 'windows')"
+        if: startsWith(matrix.java.os-name, 'windows')
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
       - name: Restore Maven Repository
@@ -969,7 +969,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: "needs.calculate-test-jobs.outputs.run_quickstarts == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    if: needs.calculate-test-jobs.outputs.run_quickstarts == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: 90
@@ -1065,7 +1065,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn || matrix.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: "needs.calculate-test-jobs.outputs.virtual_threads_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    if: needs.calculate-test-jobs.outputs.virtual_threads_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: ${{matrix.timeout}}
@@ -1144,7 +1144,7 @@ jobs:
     name: MicroProfile TCKs Tests
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: "needs.calculate-test-jobs.outputs.run_tcks == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    if: needs.calculate-test-jobs.outputs.run_tcks == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn || 'ubuntu-latest' }}
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn && 'true' || 'false' }}
@@ -1237,7 +1237,7 @@ jobs:
       MAVEN_OPTS: -Xmx1g
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn && 'true' || 'false' }}
     # Skip main in forks
-    if: "needs.calculate-test-jobs.outputs.native_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
+    if: needs.calculate-test-jobs.outputs.native_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:
@@ -1251,7 +1251,7 @@ jobs:
           echo "GE_TAGS=native-${category}" >> "$GITHUB_ENV"
           echo "GE_CUSTOM_VALUES=gh-job-name=Native Tests - ${{matrix.category}}" >> "$GITHUB_ENV"
       - name: Support longpaths on Windows
-        if: "startsWith(matrix.os-name, 'windows')"
+        if: startsWith(matrix.os-name, 'windows')
         run: git config --global core.longpaths true
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -201,13 +201,13 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn || 'ubuntu-latest' }}
     # Skip main in forks
     # Skip draft PRs, rerun as soon as its removed
-    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')) && (
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')) && (
            github.event_name != 'pull_request' || (
              github.event.pull_request.draft == false &&
              github.event.pull_request.state != 'closed' &&
              github.event.action != 'edited'
            )
-         )
+        ) }}
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn && 'true' || 'false' }}
     outputs:
@@ -339,7 +339,7 @@ jobs:
     name: Calculate Test Jobs
     runs-on: ubuntu-latest
     # Skip main in forks
-    if: github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')) }}
     needs: build-jdk17
     env:
       GIB_IMPACTED_MODULES: ${{ needs.build-jdk17.outputs.gib_impacted }}
@@ -409,7 +409,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: needs.calculate-test-jobs.outputs.run_jvm == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (needs.calculate-test-jobs.outputs.run_jvm == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))) }}
     timeout-minutes: 400
     env:
       MAVEN_OPTS: ${{ matrix.java.maven_opts }}
@@ -574,7 +574,7 @@ jobs:
       MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     # Skip main in forks
-    if: needs.calculate-test-jobs.outputs.run_maven == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (needs.calculate-test-jobs.outputs.run_maven == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))) }}
     timeout-minutes: 130
     strategy:
       fail-fast: false
@@ -683,7 +683,7 @@ jobs:
       MAVEN_OPTS: -Xmx1g
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     # Skip main in forks
-    if: needs.calculate-test-jobs.outputs.run_gradle == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (needs.calculate-test-jobs.outputs.run_gradle == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))) }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -771,7 +771,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: needs.calculate-test-jobs.outputs.run_devtools == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (needs.calculate-test-jobs.outputs.run_devtools == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))) }}
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: 60
@@ -870,7 +870,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: needs.calculate-test-jobs.outputs.run_kubernetes == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (needs.calculate-test-jobs.outputs.run_kubernetes == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))) }}
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: 40
@@ -969,7 +969,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn || matrix.java.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: needs.calculate-test-jobs.outputs.run_quickstarts == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (needs.calculate-test-jobs.outputs.run_quickstarts == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))) }}
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: 90
@@ -1065,7 +1065,7 @@ jobs:
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn || matrix.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: needs.calculate-test-jobs.outputs.virtual_threads_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (needs.calculate-test-jobs.outputs.virtual_threads_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))) }}
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn && 'true' || 'false' }}
     timeout-minutes: ${{matrix.timeout}}
@@ -1144,7 +1144,7 @@ jobs:
     name: MicroProfile TCKs Tests
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
-    if: needs.calculate-test-jobs.outputs.run_tcks == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (needs.calculate-test-jobs.outputs.run_tcks == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))) }}
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn || 'ubuntu-latest' }}
     env:
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn && 'true' || 'false' }}
@@ -1237,7 +1237,7 @@ jobs:
       MAVEN_OPTS: -Xmx1g
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.os-name].runsOn && 'true' || 'false' }}
     # Skip main in forks
-    if: needs.calculate-test-jobs.outputs.native_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (needs.calculate-test-jobs.outputs.native_matrix != '{}' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))) }}
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:


### PR DESCRIPTION
This is now ready.

It only targets Linux CI runs as Windows images on RunsOn don't offer Git Bash for now and thus are not usable for us.

Also it doesn't offload the small technical jobs, only the ones that need massive resources.

It makes use of:
- https://github.com/quarkusio/runs-on-action - to configure things
- https://github.com/quarkusio/cache-action - to switch between standard GitHub Actions cache and RunsOn cache (you cannot use a variable for the action coordinates so I use a composite action)