### PR TITLE
Change how JPAConfig cleans up its resources

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -92,6 +92,7 @@ import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.LogCategoryBuildItem;
 import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
@@ -678,9 +679,10 @@ public final class HibernateOrmProcessor {
     @Consume(PersistenceProviderSetUpBuildItem.class)
     @Record(RUNTIME_INIT)
     public ServiceStartBuildItem startPersistenceUnits(HibernateOrmRecorder recorder, BeanContainerBuildItem beanContainer,
-            JpaModelBuildItem jpaModel) {
+            JpaModelBuildItem jpaModel,
+            ShutdownContextBuildItem shutdownContextBuildItem) {
         if (hasEntities(jpaModel)) {
-            recorder.startAllPersistenceUnits(beanContainer.getValue());
+            recorder.startAllPersistenceUnits(beanContainer.getValue(), shutdownContextBuildItem);
         }
 
         return new ServiceStartBuildItem("Hibernate ORM");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
@@ -10,14 +10,12 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
 
 public class JPAConfig {
@@ -129,18 +127,22 @@ public class JPAConfig {
         return this.requestScopedSessionEnabled;
     }
 
-    public static class Destroyer implements BeanDestroyer<JPAConfig> {
-        @Override
-        public void destroy(JPAConfig instance, CreationalContext<JPAConfig> creationalContext, Map<String, Object> params) {
-            for (LazyPersistenceUnit factory : instance.persistenceUnits.values()) {
+    void shutdown() {
+        LOGGER.trace("Starting to shut down Hibernate ORM persistence units.");
+        for (LazyPersistenceUnit factory : this.persistenceUnits.values()) {
+            if (factory.isStarted()) {
                 try {
+                    LOGGER.tracef("Closing Hibernate ORM persistence unit: %s.", factory.name);
                     factory.close();
                 } catch (Exception e) {
                     LOGGER.warn("Unable to close the EntityManagerFactory: " + factory, e);
                 }
+            } else {
+                LOGGER.tracef("Skipping Hibernate ORM persistence unit, that failed to start: %s.", factory.name);
             }
-            instance.persistenceUnits.clear();
         }
+        this.persistenceUnits.clear();
+        LOGGER.trace("Finished shutting down Hibernate ORM persistence units.");
     }
 
     static final class LazyPersistenceUnit {
@@ -174,6 +176,10 @@ public class JPAConfig {
             if (emf != null) {
                 emf.close();
             }
+        }
+
+        boolean isStarted() {
+            return !closed && value != null;
         }
     }
 

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/pom.xml
@@ -33,6 +33,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
@@ -49,6 +54,11 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -77,6 +87,32 @@
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- These tests seem to leak metaspace memory
+                                 so we run them in a separate, short-lived JVM -->
+                            <excludedGroups>devmode</excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>devmode-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- These tests seem to leak metaspace memory
+                                 so we run them in a separate, short-lived JVM -->
+                            <groups>devmode</groups>
+                            <!-- We could consider setting reuseForks=false if we
+                                 really need to run every single test in its own JVM -->
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchDevModeFailingOrmTest.java
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchDevModeFailingOrmTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.hibernate.search.orm.outboxpolling.test.configuration.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+@Tag("devmode")
+public class HibernateSearchDevModeFailingOrmTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HibernateSearchOutboxPollingTestResource.class,
+                            HibernateSearchOutboxPollingTestResource.Person.class,
+                            HibernateSearchOutboxPollingTestResource.OutboxPollingTestUtils.class)
+                    .addAsResource("application-dev-mode.properties", "application.properties"))
+            .setLogRecordPredicate(r -> true);
+
+    static String APPLICATION_PROPERTIES;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        APPLICATION_PROPERTIES = Files
+                .readString(
+                        Paths.get(HibernateSearchDevModeFailingOrmTest.class.getResource("/application-dev-mode.properties")
+                                .toURI()));
+    }
+
+    @Test
+    public void smoke() {
+        RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                .statusCode(200);
+
+        // now add a property that will fail the datasource:
+        config.modifyResourceFile(
+                "application.properties",
+                s -> APPLICATION_PROPERTIES + """
+                        quarkus.datasource.jdbc.min-size=20
+                        """);
+        RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                .statusCode(500);
+
+        // add any change to get the shutdown of a failed app completed:
+        config.modifyResourceFile("application.properties", s -> APPLICATION_PROPERTIES);
+
+        RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                .statusCode(200);
+
+        // At this point we've tried starting the app 3 times: one initial, one failing, one successful live-reloads
+        // Hence we expect the following things logged:
+        // initial run:
+        //  - profile activated (after a successful startup)
+        //  - ORM message after a successful shutdown caused by a following live-reload (closing a PU)
+        // first reload:
+        //  - ORM message telling us that the PU closing won't happen as the PU failed to start
+        // second reload:
+        //  - profile activated (after a successful startup)
+        //  - no ORM shutdown message, as that will happen after the test body finishes.
+        assertThat(config.getLogRecords()).satisfiesOnlyOnce(
+                r -> {
+                    assertThat(r.getMessage()).contains("Closing Hibernate ORM persistence unit");
+                    assertThat(r.getParameters()).containsExactly("<default>");
+                });
+        assertThat(config.getLogRecords()).satisfiesOnlyOnce(
+                r -> {
+                    assertThat(r.getMessage()).contains("Skipping Hibernate ORM persistence unit, that failed to start");
+                    assertThat(r.getParameters()).containsExactly("<default>");
+                });
+        assertThat(config.getLogRecords().stream()
+                .filter(r -> r.getMessage().contains("Profile%s %s activated. %s")))
+                .hasSize(2);
+    }
+}

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchDevModeFailingSearchTest.java
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchDevModeFailingSearchTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.hibernate.search.orm.outboxpolling.test.configuration.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+@Tag("devmode")
+public class HibernateSearchDevModeFailingSearchTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HibernateSearchOutboxPollingTestResource.class,
+                            HibernateSearchOutboxPollingTestResource.Person.class,
+                            HibernateSearchOutboxPollingTestResource.OutboxPollingTestUtils.class)
+                    .addAsResource("application-dev-mode.properties", "application.properties"))
+            .setLogRecordPredicate(r -> true);
+
+    static String APPLICATION_PROPERTIES;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        APPLICATION_PROPERTIES = Files
+                .readString(Paths
+                        .get(HibernateSearchDevModeFailingSearchTest.class.getResource("/application-dev-mode.properties")
+                                .toURI()));
+    }
+
+    @Test
+    public void smoke() {
+        RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                .statusCode(200);
+
+        // now add a property that will fail the search, but since search is started through ORM integrator.. we are actually failing ORM startup:
+        config.modifyResourceFile(
+                "application.properties",
+                s -> APPLICATION_PROPERTIES.replace(
+                        "quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}",
+                        "quarkus.hibernate-search-orm.elasticsearch.hosts=not-a-localhost:9211"));
+        RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                .statusCode(500);
+
+        // and any change to get the shutdown of a failed app completed:
+        config.modifyResourceFile("application.properties", s -> APPLICATION_PROPERTIES);
+
+        RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                .statusCode(200);
+
+        // At this point we've tried starting the app 3 times: one initial, one failing, one successful live-reloads
+        // Hence we expect the following things logged:
+        // initial run:
+        //  - profile activated (after a successful startup)
+        //  - ORM message after a successful shutdown caused by a following live-reload (closing a PU)
+        // first reload:
+        //  - ORM message telling us that the PU closing won't happen as the PU failed to start
+        // second reload:
+        //  - profile activated (after a successful startup)
+        //  - no ORM shutdown message, as that will happen after the test body finishes.
+        assertThat(config.getLogRecords()).satisfiesOnlyOnce(
+                r -> {
+                    assertThat(r.getMessage()).contains("Closing Hibernate ORM persistence unit");
+                    assertThat(r.getParameters()).containsExactly("<default>");
+                });
+        assertThat(config.getLogRecords()).satisfiesOnlyOnce(
+                r -> {
+                    assertThat(r.getMessage()).contains("Skipping Hibernate ORM persistence unit, that failed to start");
+                    assertThat(r.getParameters()).containsExactly("<default>");
+                });
+        assertThat(config.getLogRecords().stream()
+                .filter(r -> r.getMessage().contains("Profile%s %s activated. %s")))
+                .hasSize(2);
+    }
+}

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchDevModeTest.java
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchDevModeTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.hibernate.search.orm.outboxpolling.test.configuration.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+@Tag("devmode")
+public class HibernateSearchDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HibernateSearchOutboxPollingTestResource.class)
+                    .addAsResource("application.properties", "application.properties"))
+            .setLogRecordPredicate(r -> true);
+
+    @Test
+    public void smoke() {
+        String[] schemaManagementStrategies = { "drop-and-create-and-drop", "drop-and-create" };
+
+        RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        for (int i = 0; i < 3; i++) {
+            int current = i;
+            config.modifyResourceFile(
+                    "application.properties",
+                    s -> s.replace(
+                            "quarkus.hibernate-search-orm.schema-management.strategy="
+                                    + schemaManagementStrategies[current % 2],
+                            "quarkus.hibernate-search-orm.schema-management.strategy="
+                                    + schemaManagementStrategies[(current + 1) % 2]));
+
+            RestAssured.when().put("/test/hibernate-search-outbox-polling/check-agents-running").then()
+                    .statusCode(200)
+                    .body(is("OK"));
+        }
+
+        assertThat(config.getLogRecords()).noneSatisfy(
+                r -> assertThat(r.getMessage()).contains("Unable to shut down Hibernate Search"));
+    }
+}

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchOutboxPollingTestResource.java
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/outboxpolling/test/configuration/devmode/HibernateSearchOutboxPollingTestResource.java
@@ -1,0 +1,249 @@
+package io.quarkus.hibernate.search.orm.outboxpolling.test.configuration.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.UserTransaction;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.outboxpolling.cluster.impl.Agent;
+import org.hibernate.search.mapper.orm.outboxpolling.cluster.impl.AgentState;
+import org.hibernate.search.mapper.orm.outboxpolling.cluster.impl.OutboxPollingAgentAdditionalMappingProducer;
+import org.hibernate.search.mapper.orm.outboxpolling.event.impl.OutboxEvent;
+import org.hibernate.search.mapper.orm.outboxpolling.event.impl.OutboxPollingOutboxEventAdditionalMappingProducer;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+
+@Path("/test/hibernate-search-outbox-polling")
+public class HibernateSearchOutboxPollingTestResource {
+
+    @Inject
+    EntityManager entityManager;
+
+    @Inject
+    UserTransaction userTransaction;
+
+    @PUT
+    @Path("/check-agents-running")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String checkAgentsRunning() {
+        OutboxPollingTestUtils.awaitAgentsRunning(entityManager, userTransaction, 1);
+        return "OK";
+    }
+
+    @PUT
+    @Path("/init-data")
+    @Transactional
+    public void initData() {
+        createPerson("John Irving");
+        createPerson("David Lodge");
+        createPerson("Paul Auster");
+        createPerson("John Grisham");
+
+        // Add many other entities, so that mass indexing has something to do.
+        // DO NOT REMOVE, it's important to have many entities to fully test mass indexing.
+        for (int i = 0; i < 1000; i++) {
+            createPerson("Other entity #" + i);
+        }
+    }
+
+    @PUT
+    @Path("/await-event-processing")
+    public void awaitEventProcessing() {
+        OutboxPollingTestUtils.awaitNoMoreOutboxEvents(entityManager, userTransaction);
+    }
+
+    @GET
+    @Path("/search")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public String testSearch() {
+        SearchSession searchSession = Search.session(entityManager);
+
+        List<Person> person = searchSession.search(Person.class)
+                .where(f -> f.match().field("name").matching("john"))
+                .sort(f -> f.field("name_sort"))
+                .fetchHits(20);
+
+        assertEquals(2, person.size());
+        assertEquals("John Grisham", person.get(0).getName());
+        assertEquals("John Irving", person.get(1).getName());
+
+        assertEquals(4 + 1000, searchSession.search(Person.class)
+                .where(f -> f.matchAll())
+                .fetchTotalHitCount());
+
+        return "OK";
+    }
+
+    @PUT
+    @Path("/purge")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testPurge() {
+        SearchSession searchSession = Search.session(entityManager);
+
+        searchSession.workspace().purge();
+
+        return "OK";
+    }
+
+    @PUT
+    @Path("/refresh")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testRefresh() {
+        SearchSession searchSession = Search.session(entityManager);
+
+        searchSession.workspace().refresh();
+
+        return "OK";
+    }
+
+    @GET
+    @Path("/search-empty")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public String testSearchEmpty() {
+        SearchSession searchSession = Search.session(entityManager);
+
+        List<Person> person = searchSession.search(Person.class)
+                .where(f -> f.matchAll())
+                .fetchHits(20);
+
+        assertEquals(0, person.size());
+
+        return "OK";
+    }
+
+    @PUT
+    @Path("/mass-indexer")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testMassIndexer() throws InterruptedException {
+        SearchSession searchSession = Search.session(entityManager);
+
+        searchSession.massIndexer().startAndWait();
+
+        return "OK";
+    }
+
+    private void createPerson(String name) {
+        Person entity = new Person(name);
+        entityManager.persist(entity);
+    }
+
+    @Entity
+    @Indexed
+    public static class Person {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @FullTextField
+        @KeywordField(name = "name_sort", sortable = Sortable.YES)
+        private String name;
+
+        Person() {
+        }
+
+        public Person(String name) {
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class OutboxPollingTestUtils {
+
+        public static void inTransaction(UserTransaction transaction, Runnable runnable) {
+            try {
+                transaction.begin();
+                try {
+                    runnable.run();
+                    transaction.commit();
+                } catch (Throwable t) {
+                    try {
+                        transaction.rollback();
+                    } catch (Throwable t2) {
+                        t.addSuppressed(t2);
+                    }
+                    throw t;
+                }
+            } catch (SystemException | NotSupportedException | RollbackException | HeuristicMixedException
+                    | HeuristicRollbackException e) {
+                throw new IllegalStateException("Transaction exception", e);
+            }
+        }
+
+        public static void awaitAgentsRunning(EntityManager entityManager, UserTransaction userTransaction,
+                int expectedAgentCount) {
+            await("Waiting for the formation of a cluster of " + expectedAgentCount + " agents")
+                    .pollDelay(Duration.ZERO)
+                    .pollInterval(Duration.ofMillis(5))
+                    .atMost(Duration.ofSeconds(10)) // CI can be rather slow...
+                    .untilAsserted(() -> inTransaction(userTransaction, () -> {
+                        List<Agent> agents = entityManager
+                                .createQuery("select a from " + OutboxPollingAgentAdditionalMappingProducer.ENTITY_NAME
+                                        + " a order by a.id", Agent.class)
+                                .getResultList();
+                        assertThat(agents)
+                                .hasSize(expectedAgentCount)
+                                .allSatisfy(agent -> {
+                                    assertThat(agent.getState()).isEqualTo(AgentState.RUNNING);
+                                    assertThat(agent.getTotalShardCount()).isEqualTo(expectedAgentCount);
+                                });
+                    }));
+        }
+
+        public static void awaitNoMoreOutboxEvents(EntityManager entityManager, UserTransaction userTransaction) {
+            await("Waiting for all outbox events to be processed")
+                    .pollDelay(Duration.ZERO)
+                    .pollInterval(Duration.ofMillis(5))
+                    .atMost(Duration.ofSeconds(20)) // CI can be rather slow...
+                    .untilAsserted(() -> inTransaction(userTransaction, () -> {
+                        List<OutboxEvent> events = entityManager
+                                .createQuery("select e from " + OutboxPollingOutboxEventAdditionalMappingProducer.ENTITY_NAME
+                                        + " e order by e.id", OutboxEvent.class)
+                                .getResultList();
+                        assertThat(events).isEmpty();
+                    }));
+        }
+
+    }
+}

--- a/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/hibernate-search-orm-outbox-polling/deployment/src/test/resources/application-dev-mode.properties
@@ -1,0 +1,16 @@
+quarkus.ssl.native = false
+
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
+quarkus.datasource.jdbc.max-size=8
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+
+quarkus.hibernate-search-orm.elasticsearch.version=9
+quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
+quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:http}
+quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
+quarkus.hibernate-search-orm.coordination.strategy=outbox-polling
+
+quarkus.log.category."io.quarkus.hibernate.orm.runtime".min-level=TRACE
+quarkus.log.category."io.quarkus.hibernate.orm.runtime".level=TRACE


### PR DESCRIPTION
this is an alternative to https://github.com/quarkusio/quarkus/pull/45451.

Adding a priority to shutdown tasks allows us to have a better understanding of how those will be executed. Having the task firing the shutdown event as the first one in that queue seemed reasonable; that way, those handling this event will not be in a situation where something gets shut down before the event handler can use it.

Then, for the ORM-specific part, we add a shutdown task when we create a JPA config, and the cleanup of PUs will only close those that actually correctly started.

I thought about removing the `lastShutdownTasks` queue and just handling that through priority, but then ... I didn't want to change too much 😄 so I've kept it for now.

- Closes: https://github.com/quarkusio/quarkus/issues/34547