### PR TITLE
[3.19] Update SmallRye Config to 3.11.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -47,7 +47,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
         <smallrye-common.version>2.10.0</smallrye-common.version>
-        <smallrye-config.version>3.11.2</smallrye-config.version>
+        <smallrye-config.version>3.11.3</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.8</smallrye-open-api.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ plugin-publish = "1.3.1"
 
 # updating Kotlin here makes QuarkusPluginTest > shouldNotFailOnProjectDependenciesWithoutMain(Path) fail
 kotlin = "2.0.21"
-smallrye-config = "3.11.2"
+smallrye-config = "3.11.3"
 
 junit5 = "5.10.5"
 assertj = "3.27.3"


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.11.3</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1320">#1320</a> Correct check of ConfigValue having a value with indexed APIs</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1315">#1315</a> Try indexed names on injection when non indexed value is null</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1314">#1314</a> Compute indexed properties when building the list of PropertyNames</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1312">#1312</a> Bump io.smallrye.common:smallrye-common-bom from 2.9.0 to 2.10.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1304">#1304</a> Ignore default methods inherited from super classes in mappings</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1297">#1297</a> Bump io.smallrye:smallrye-parent from 46 to 47</li>
    </ul>
</blockquote>

Quarkus:
- Fixes #46172
- Fixes #46341