### PR TITLE
Update SmallRye Config to 3.12.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -47,7 +47,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
         <smallrye-common.version>2.10.0</smallrye-common.version>
-        <smallrye-config.version>3.12.0</smallrye-config.version>
+        <smallrye-config.version>3.12.2</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.8</smallrye-open-api.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ plugin-publish = "1.3.1"
 
 # updating Kotlin here makes QuarkusPluginTest > shouldNotFailOnProjectDependenciesWithoutMain(Path) fail
 kotlin = "2.0.21"
-smallrye-config = "3.12.0"
+smallrye-config = "3.12.2"
 
 junit5 = "5.10.5"
 assertj = "3.27.3"


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.12.2</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1324">#1324</a> Revert skip profile optimization because Quarkus mutates the source</li>
    </ul>
</blockquote>
<br>
<blockquote>
    <h2>3.12.1</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1324">#1324</a> Correct check of ConfigValue having a value with indexed APIs</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1318">#1318</a> check duplicate keys for yaml (snakeyaml.version update to 2.4)</li>
    </ul>
</blockquote>

Quarkus:
- Fixes #46341
- Fixes failing `io.quarkus.it.vertx.RandomTestPortTestCase#testLegacyProperties` test, because it mutates the System config source. SmallRye Config 3.12.0 added an optimization to skip profile lookups (https://github.com/smallrye/smallrye-config/pull/1303) if they don't exist, but it doesn't work if the source can be mutated. Reverted in https://github.com/smallrye/smallrye-config/pull/1324.