### PR TITLE
Undertow - Session context lifecycle events should be observable from session scoped beans 

### DIFF
--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/sessioncontext/SessionScopedObserver.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/sessioncontext/SessionScopedObserver.java
@@ -1,0 +1,26 @@
+package io.quarkus.undertow.test.sessioncontext;
+
+import jakarta.enterprise.context.BeforeDestroyed;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.enterprise.event.Observes;
+
+@SessionScoped
+public class SessionScopedObserver {
+
+    static int timesInitObserved = 0;
+    static int timesBeforeDestroyedObserved = 0;
+
+    public void observeInit(@Observes @Initialized(SessionScoped.class) Object event) {
+        timesInitObserved++;
+    }
+
+    public void observeBeforeDestroyed(@Observes @BeforeDestroyed(SessionScoped.class) Object event) {
+        timesBeforeDestroyedObserved++;
+    }
+
+    public static void resetState() {
+        timesInitObserved = 0;
+        timesBeforeDestroyedObserved = 0;
+    }
+}


### PR DESCRIPTION
Fixes #46363 

Contains a test with a reproducer and a draft of a fix.

I don't really like having to store the session like so but that's the only working solution I have found so far...