### PR TITLE
Add class and method to WithSpan attributes

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/AddingSpanAttributesInterceptorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/AddingSpanAttributesInterceptorTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.opentelemetry.deployment.interceptor;
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_NAMESPACE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -104,9 +106,11 @@ public class AddingSpanAttributesInterceptorTest {
         SpanData spanDataOut = spanItems.get(0);
         assertEquals("HelloRouter.withSpanTakesPrecedence", spanDataOut.getName());
         assertEquals(INTERNAL, spanDataOut.getKind());
-        assertEquals(2, spanDataOut.getAttributes().size());
+        assertEquals(4, spanDataOut.getAttributes().size());
         assertEquals("implicit", getAttribute(spanDataOut, "implicitName"));
         assertEquals("explicit", getAttribute(spanDataOut, "explicitName"));
+        assertEquals("withSpanTakesPrecedence", spanDataOut.getAttributes().get((CODE_FUNCTION)));
+        assertEquals(HelloRouter.class.getName(), spanDataOut.getAttributes().get((CODE_NAMESPACE)));
     }
 
     @Test

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/WithSpanInterceptorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/interceptor/WithSpanInterceptorTest.java
@@ -4,6 +4,8 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.api.trace.StatusCode.ERROR;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_NAMESPACE;
 import static io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporter.getSpanByKindAndParentId;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -87,17 +89,21 @@ public class WithSpanInterceptorTest {
     void spanKind() {
         spanBean.spanKind();
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
-        assertEquals("SpanBean.spanKind", spanItems.get(0).getName());
-        assertEquals(SERVER, spanItems.get(0).getKind());
+        SpanData span = spanItems.get(0);
+        assertEquals("SpanBean.spanKind", span.getName());
+        assertEquals(SERVER, span.getKind());
+        assertClassMethodNames(span, SpanBean.class, "spanKind");
     }
 
     @Test
     void spanArgs() {
         spanBean.spanArgs("argument");
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
-        assertEquals("SpanBean.spanArgs", spanItems.get(0).getName());
-        assertEquals(INTERNAL, spanItems.get(0).getKind());
-        assertEquals("argument", spanItems.get(0).getAttributes().get(AttributeKey.stringKey("arg")));
+        SpanData span = spanItems.get(0);
+        assertEquals("SpanBean.spanArgs", span.getName());
+        assertEquals(INTERNAL, span.getKind());
+        assertEquals("argument", span.getAttributes().get(AttributeKey.stringKey("arg")));
+        assertClassMethodNames(span, SpanBean.class, "spanArgs");
     }
 
     @Test
@@ -107,9 +113,12 @@ public class WithSpanInterceptorTest {
 
         final SpanData parent = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
         assertEquals("SpanBean.spanChild", parent.getName());
+        assertClassMethodNames(parent, SpanBean.class, "spanChild");
 
         final SpanData child = getSpanByKindAndParentId(spans, INTERNAL, parent.getSpanId());
         assertEquals("SpanChildBean.spanChild", child.getName());
+        assertClassMethodNames(child, SpanChildBean.class, "spanChild");
+
     }
 
     @Test
@@ -120,7 +129,7 @@ public class WithSpanInterceptorTest {
         final SpanData parent = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
         final SpanData child = getSpanByKindAndParentId(spans, INTERNAL, parent.getSpanId());
         final SpanData client = getSpanByKindAndParentId(spans, CLIENT, child.getSpanId());
-        final SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
+        getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
     }
 
     @Test
@@ -134,12 +143,14 @@ public class WithSpanInterceptorTest {
             });
         }
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
-        assertEquals("SpanBean.spanWithException", spanItems.get(0).getName());
-        assertEquals(INTERNAL, spanItems.get(0).getKind());
-        assertEquals(ERROR, spanItems.get(0).getStatus().getStatusCode());
-        assertEquals(1, spanItems.get(0).getEvents().size());
+        SpanData span = spanItems.get(0);
+        assertEquals("SpanBean.spanWithException", span.getName());
+        assertEquals(INTERNAL, span.getKind());
+        assertEquals(ERROR, span.getStatus().getStatusCode());
+        assertEquals(1, span.getEvents().size());
         assertEquals("spanWithException for tests",
-                ((ExceptionEventData) spanItems.get(0).getEvents().get(0)).getException().getMessage());
+                ((ExceptionEventData) span.getEvents().get(0)).getException().getMessage());
+        assertClassMethodNames(span, SpanBean.class, "spanWithException");
     }
 
     @Test
@@ -150,6 +161,7 @@ public class WithSpanInterceptorTest {
         final SpanData parent = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
         assertEquals("withSpanAndUni", parent.getName());
         assertEquals(StatusCode.UNSET, parent.getStatus().getStatusCode());
+        assertClassMethodNames(parent, SpanBean.class, "spanUni");
     }
 
     @Test
@@ -163,12 +175,14 @@ public class WithSpanInterceptorTest {
             });
         }
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
-        assertEquals("withSpanAndUni", spanItems.get(0).getName());
-        assertEquals(INTERNAL, spanItems.get(0).getKind());
-        assertEquals(ERROR, spanItems.get(0).getStatus().getStatusCode());
-        assertEquals(1, spanItems.get(0).getEvents().size());
+        SpanData span = spanItems.get(0);
+        assertEquals("withSpanAndUni", span.getName());
+        assertEquals(INTERNAL, span.getKind());
+        assertEquals(ERROR, span.getStatus().getStatusCode());
+        assertEquals(1, span.getEvents().size());
         assertEquals("hello Uni",
-                ((ExceptionEventData) spanItems.get(0).getEvents().get(0)).getException().getMessage());
+                ((ExceptionEventData) span.getEvents().get(0)).getException().getMessage());
+        assertClassMethodNames(span, SpanBean.class, "spanUniWithException");
     }
 
     @Test
@@ -179,6 +193,7 @@ public class WithSpanInterceptorTest {
         final SpanData parent = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
         assertEquals("withSpanAndMulti", parent.getName());
         assertEquals(StatusCode.UNSET, parent.getStatus().getStatusCode());
+        assertClassMethodNames(parent, SpanBean.class, "spanMulti");
     }
 
     @Test
@@ -198,6 +213,12 @@ public class WithSpanInterceptorTest {
         assertEquals(1, spanItems.get(0).getEvents().size());
         assertEquals("hello Multi",
                 ((ExceptionEventData) spanItems.get(0).getEvents().get(0)).getException().getMessage());
+        assertClassMethodNames(spanItems.get(0), SpanBean.class, "spanMultiWithException");
+    }
+
+    private void assertClassMethodNames(SpanData span, Class<?> clazz, String method) {
+        assertEquals(method, span.getAttributes().get((CODE_FUNCTION)));
+        assertEquals(clazz.getName(), span.getAttributes().get((CODE_NAMESPACE)));
     }
 
     @ApplicationScoped

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryHttpCDITest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetryHttpCDITest.java
@@ -89,6 +89,7 @@ public class OpenTelemetryHttpCDITest {
 
         final SpanData withSpan = getSpanByKindAndParentId(spans, INTERNAL, server.getSpanId());
         assertEquals("withSpan", withSpan.getName());
+        assertEquals(2, withSpan.getAttributes().size());
 
         final SpanData bean = getSpanByKindAndParentId(spans, INTERNAL, withSpan.getSpanId());
         assertEquals("HelloBean.hello", bean.getName());

--- a/integration-tests/rest-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive/src/main/resources/application.properties
@@ -7,4 +7,4 @@ io.quarkus.it.rest.client.main.ParamClient/mp-rest/url=${test.url}
 quarkus.rest-client.logging.scope=request-response
 
 # speed up build
-quarkus.otel.bsp.schedule.delay=100
+quarkus.otel.bsp.schedule.delay=10


### PR DESCRIPTION
This was @ozangunalp idea, when discussing https://github.com/quarkusio/quarkus/issues/45375
Not having attributes on the span is strange and now we will publish method and class attributes when the `@WithSpan` interceptor is used.