### PR TITLE
GIB experiment: Deliberate failure in pl job

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
@@ -151,7 +151,7 @@ public class JarRunnerIT extends MojoTestBase {
         Process process = doLaunch(new File(testDir, "app/target/quarkus-app"), Paths.get("quarkus-run.jar"), output,
                 List.of()).start();
         try {
-            Assertions.assertEquals("builder-image is customized", devModeClient.getHttpResponse("/hello"));
+            Assertions.assertEquals("deliberate failure builder-image is customized", devModeClient.getHttpResponse("/hello"));
         } finally {
             process.destroy();
         }


### PR DESCRIPTION
Experiment to validate whether GIB is operating correctly when `-pl` is used. See https://github.com/quarkusio/quarkus/issues/46367. 