### PR TITLE
Create a KubernetesDevServiceInfoBuildItem

### DIFF
--- a/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesDevServiceInfoBuildItem.java
+++ b/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesDevServiceInfoBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.kubernetes.client.spi;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class KubernetesDevServiceInfoBuildItem extends SimpleBuildItem {
+    private final String kubeConfig;
+    private final String containerId;
+
+    public KubernetesDevServiceInfoBuildItem(String kubeConfig, String containerId) {
+        this.kubeConfig = kubeConfig;
+        this.containerId = containerId;
+    }
+
+    public String getKubeConfig() {
+        return kubeConfig;
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+}


### PR DESCRIPTION
- Produce a `KubernetesDevServiceInfoBuildItem` when a kubernetes testContainer is created to allow to get cluster information (id, kubeConfig in YAML string format) and use use such information part of a DevService consuming it (example: quarkus-argocd, quarkus-tekton, etc)
```
// We produce it
...
            container.start();

            KubeConfig kubeConfig = KubeConfigUtils.parseKubeConfig(container.getKubeconfig());

            devServicesKube
                    .produce(new KubernetesDevServiceInfoBuildItem(container.getKubeconfig(), container.getContainerId()));

// DevService consuming it
    @BuildStep
    public DevServicesResultBuildItem deployArgocd(
            ArgocdBuildTimeConfig config,
            Optional<KubernetesDevServiceInfoBuildItem> kubeServiceInfo) {
...
        // Create the Kubernetes client using the Kube YAML Config
        KubernetesClient client = new KubernetesClientBuilder()
                .withConfig(io.fabric8.kubernetes.client.Config.fromKubeconfig(kubeServiceInfo.get().getKubeConfig()))
                .build();

```
- Fix: #46330