### PR TITLE
Continuous Testing: add support for build system like test selection

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/ModuleTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/ModuleTestRunner.java
@@ -56,6 +56,7 @@ public class ModuleTestRunner {
                         .setExcludeTags(testSupport.excludeTags)
                         .setInclude(testSupport.include)
                         .setExclude(testSupport.exclude)
+                        .setSpecificSelection(testSupport.specificSelection)
                         .setIncludeEngines(testSupport.includeEngines)
                         .setExcludeEngines(testSupport.excludeEngines)
                         .setTestType(testSupport.testType)

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -62,6 +62,7 @@ public class TestSupport implements TestController {
     volatile List<String> excludeTags = Collections.emptyList();
     volatile Pattern include = null;
     volatile Pattern exclude = null;
+    volatile String specificSelection = null;
     volatile List<String> includeEngines = Collections.emptyList();
     volatile List<String> excludeEngines = Collections.emptyList();
     volatile boolean displayTestOutput;
@@ -603,6 +604,10 @@ public class TestSupport implements TestController {
     public void setPatterns(String include, String exclude) {
         this.include = include == null ? null : Pattern.compile(include);
         this.exclude = exclude == null ? null : Pattern.compile(exclude);
+    }
+
+    public void setSpecificSelection(String specificSelection) {
+        this.specificSelection = specificSelection;
     }
 
     public void setEngines(List<String> includeEngines, List<String> excludeEngines) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -95,6 +95,10 @@ public class TestTracingProcessor {
                 config.excludeTags().orElse(Collections.emptyList()));
         testSupport.setPatterns(config.includePattern().orElse(null),
                 config.excludePattern().orElse(null));
+        String specificSelection = System.getProperty("quarkus-internal.test.specific-selection");
+        if (specificSelection != null) {
+            testSupport.setSpecificSelection(specificSelection);
+        }
         testSupport.setEngines(config.includeEngines().orElse(Collections.emptyList()),
                 config.excludeEngines().orElse(Collections.emptyList()));
         testSupport.setConfiguredDisplayTestOutput(config.displayTestOutput());

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -103,6 +103,7 @@ public abstract class QuarkusDev extends QuarkusTask {
     private final Property<Boolean> openJavaLang;
     private final ListProperty<String> modules;
     private final ListProperty<String> compilerArgs;
+    private final ListProperty<String> tests;
 
     private final Set<File> filesIncludedInClasspath = new HashSet<>();
 
@@ -139,6 +140,7 @@ public abstract class QuarkusDev extends QuarkusTask {
         openJavaLang = objectFactory.property(Boolean.class);
         openJavaLang.convention(false);
         modules = objectFactory.listProperty(String.class);
+        tests = objectFactory.listProperty(String.class);
     }
 
     /**
@@ -311,6 +313,17 @@ public abstract class QuarkusDev extends QuarkusTask {
         return this;
     }
 
+    @Input
+    public ListProperty<String> getTests() {
+        return tests;
+    }
+
+    @SuppressWarnings("unused")
+    @Option(description = "Sets test class or method name to be included (for continuous testing), '*' is supported.", option = "tests")
+    public void setTests(List<String> tests) {
+        getTests().set(tests);
+    }
+
     @TaskAction
     public void startDev() {
         if (!sourcesExist()) {
@@ -418,6 +431,10 @@ public abstract class QuarkusDev extends QuarkusTask {
         if (System.getProperty(IO_QUARKUS_DEVMODE_ARGS) == null) {
             builder.jvmArgs("-Dquarkus.console.basic=true")
                     .jvmArgs("-Dio.quarkus.force-color-support=true");
+        }
+        if (!getTests().get().isEmpty()) {
+            builder.jvmArgs("-Dquarkus-internal.test.specific-selection=gradle:"
+                    + String.join(",", getTests().get()));
         }
 
         if (getJvmArguments().isPresent() && !getJvmArguments().get().isEmpty()) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -430,6 +430,37 @@ public class DevMojo extends AbstractMojo {
     ExtensionDevModeJvmOptionFilter extensionJvmOptions;
 
     /**
+     * Selects given test(s) for continuous testing. This is an alternative to {@code quarkus.test.include-pattern}
+     * and {@code quarkus.test.exclude-pattern}; if set, the {@code quarkus.test.[include|exclude]-pattern} configuration
+     * is ignored.
+     * <p>
+     * The format of this configuration property is the same as the Maven Surefire {@code -Dtest=...}
+     * <a href="https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#test">format</a>.
+     * Specifically: it is a comma ({@code ,}) separated list of globs of class file paths and/or
+     * method names. Each glob can potentially be prefixed with an exclamation mark ({@code !}), which makes
+     * it an exclusion filter instead of an inclusion filter. Exclusions have higher priority than inclusions.
+     * The class file path glob is separated from the method name glob by the hash sign ({@code #}) and multiple
+     * method name globs may be present, separated by the plus sign ({@code +}).
+     * <p>
+     * For example:
+     * <ul>
+     * <li>{@code Basic*}: all classes starting with {@code Basic}</li>
+     * <li>{@code ???Test}: all classes named with 3 arbitrary characters followed by {@code Test}</li>
+     * <li>{@code !Unstable*}: all classes except classes starting with {@code Unstable}</li>
+     * <li>{@code pkg/**}{@code /Ci*leTest}: all classes in the package {@code pkg} and subpackages, starting
+     * with {@code Ci} and ending with {@code leTest}</li>
+     * <li>{@code *Test#test*One+testTwo?????}: all classes ending with {@code Test}, and in them, only methods
+     * starting with {@code test} and ending with {@code One}, or starting with {@code testTwo} and followed
+     * by 5 arbitrary characters</li>
+     * <li>{@code #fast*+slowTest}: all classes, and in them, only methods starting with {@code fast} or methods
+     * named {@code slowTest}</li>
+     * </ul>
+     * Note that the syntax {@code %regex[...]} and {@code %ant[...]} is <em>NOT</em> supported.
+     */
+    @Parameter(property = "test")
+    String test;
+
+    /**
      * console attributes, used to restore the console state
      */
     private Attributes attributes;
@@ -1312,6 +1343,9 @@ public class DevMojo extends AbstractMojo {
         setJvmArgs(builder);
         if (windowsColorSupport) {
             builder.jvmArgs("-Dio.quarkus.force-color-support=true");
+        }
+        if (test != null) {
+            builder.jvmArgs("-Dquarkus-internal.test.specific-selection=maven:" + test);
         }
 
         if (openJavaLang) {

--- a/docs/src/main/asciidoc/continuous-testing.adoc
+++ b/docs/src/main/asciidoc/continuous-testing.adoc
@@ -139,9 +139,58 @@ changes the application will still restart. This will still work even if live re
 
 It is possible to run continuous testing without starting dev mode. This can be useful if dev mode will interfere with
 your tests (e.g. running wiremock on the same port), or if you only want to develop using tests. To start continuous testing
-mode run `mvn quarkus:test`.
+mode, run `mvn quarkus:test` or `gradle quarkusTest`.
 
 NOTE: The Dev UI is not available when running in continuous testing mode, as this is provided by dev mode.
+
+== Selecting Tests to Run
+
+The configuration properties `quarkus.test.include-pattern` and `quarkus.test.exclude-pattern` can be used to select which tests to run.
+They are regular expressions matched against the fully qualified class name of the test class.
+If `include-patterns` is configured, `exclude-patterns` is ignored.
+
+Alternatively, an approach native to the build system may be used.
+In Maven, that is the `-Dtest=\...` system property, while in Gradle, it is the `--tests \...` command line option.
+These options, when used with `maven quarkus:[dev|test]` or `gradle quarkus[Dev|Test]`, work just like they work with `mvn test` or `gradle test`, except that they filter the set of tests executed during continuous testing.
+When these options are used, the `quarkus.test.[include|exclude]-pattern` configuration is ignored.
+
+=== Maven
+
+The `-Dtest=\...` system property selects given test(s) for continuous testing.
+The format of this configuration property is the same as the Maven Surefire `-Dtest=\...` https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#test[format].
+Specifically: it is a comma (`,`) separated list of globs of class file paths and/or method names.
+Each glob can potentially be prefixed with an exclamation mark (`!`), which makes it an exclusion filter instead of an inclusion filter.
+Exclusions have higher priority than inclusions.
+The class file path glob is separated from the method name glob by the hash sign (`#`) and multiple method name globs may be present, separated by the plus sign (`+`).
+
+For example:
+
+* `Basic*`: all classes starting with `Basic`
+* `???Test`: all classes named with 3 arbitrary characters followed by `Test`
+* `!Unstable*`: all classes except classes starting with `Unstable`
+* `pkg/**/Ci*leTest`: all classes in the package `pkg` and subpackages, starting with `Ci` and ending with `leTest`
+* `*Test#test*One+testTwo?????`: all classes ending with `Test`, and in them, only methods starting with `test` and ending with `One`, or starting with `testTwo` and followed by 5 arbitrary characters
+* `#fast*+slowTest`: all classes, and in them, only methods starting with `fast` or methods named `slowTest`
+
+Note that the syntax `%regex[\...]` and `%ant[\...]` is _NOT_ supported.
+
+=== Gradle
+
+The `--tests \...` command line option selects given test(s) for continuous testing.
+The format is the same as the `gradle test --tests \...` https://docs.gradle.org/current/userguide/java_testing.html#test_filtering[format].
+Specifically: the option can be passed multiple times, and each item is a simple pattern for the test class name and optionally a method name.
+When the pattern starts with an upper case letter, it matches a simple name of the class; otherwise, it matches a fully qualified name of the class.
+After the class name, separated by a period (`.`), a method name pattern may be included.
+The only wildcard character supported is `\*`, which matches an arbitrary number of characters.
+Note that `*` is based purely on text, it doesn't pay extra attention to package delimiters.
+
+For example:
+
+* `com.example.Basic*`: all classes in package `com.example` starting with `Basic`
+* `MyTest*`: all classes whose simple name starts with `MyTest`
+* `\*.pkg.Test*`: all classes in package `pkg` (regardless of the parent packages) starting with `Test`
+* `MyTest.test*`: all classes whose simple name is `MyTest`, and in them, only methods starting with `test`
+* `com.example.IntegTest.fast*`: the class `com.example.IntegTest`, and in it, only methods starting with `fast`
 
 == Multi-module Projects
 

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -71,6 +71,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-dev-ui-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-tooling-api</artifactId>
             <scope>test</scope>
@@ -174,6 +179,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -425,6 +434,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/gradle/src/main/resources/test-selection/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/test-selection/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    java
+    id("io.quarkus")
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex("io.quarkus.*")
+            includeGroup("org.hibernate.orm")
+        }
+    }
+    mavenCentral()
+}
+
+val quarkusPlatformGroupId: String by project
+val quarkusPlatformArtifactId: String by project
+val quarkusPlatformVersion: String by project
+
+dependencies {
+    implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
+    implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-vertx-http")
+
+    testImplementation("io.quarkus:quarkus-junit5")
+}
+
+group = "com.example"
+version = "1.0.0-SNAPSHOT"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+    options.compilerArgs.add("-parameters")
+}
+
+tasks.withType<Test> {
+    systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+}

--- a/integration-tests/gradle/src/main/resources/test-selection/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/test-selection/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+    val quarkusPluginVersion: String by settings
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+                includeGroup("org.hibernate.orm")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id("io.quarkus") version quarkusPluginVersion
+    }
+}
+rootProject.name="test-selection"

--- a/integration-tests/gradle/src/main/resources/test-selection/src/main/java/com/example/MyBean.java
+++ b/integration-tests/gradle/src/main/resources/test-selection/src/main/java/com/example/MyBean.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MyBean {
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-selection/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/test-selection/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.test.continuous-testing=enabled
+quarkus.console.basic=true

--- a/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/Ano.java
+++ b/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/Ano.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class Ano {
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", bean.hello());
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/Another.java
+++ b/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/Another.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class Another {
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", bean.hello());
+    }
+
+    @Test
+    public void foobar() {
+        assertEquals("hello", bean.hello());
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/Ignored.java
+++ b/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/Ignored.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class Ignored {
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", bean.hello());
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/MyBeanFirstTest.java
+++ b/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/MyBeanFirstTest.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class MyBeanFirstTest {
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", bean.hello());
+    }
+
+    @Test
+    public void foobar() {
+        assertEquals("hello", bean.hello());
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/MyBeanSecondTest.java
+++ b/integration-tests/gradle/src/main/resources/test-selection/src/test/java/com/example/MyBeanSecondTest.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class MyBeanSecondTest {
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", bean.hello());
+    }
+
+    @Test
+    public void foobar() {
+        assertEquals("hello", bean.hello());
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/continuoustesting/ContinuousTestingClient.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/continuoustesting/ContinuousTestingClient.java
@@ -1,0 +1,204 @@
+package io.quarkus.gradle.continuoustesting;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+
+/**
+ * Utilities for testing the test runner itself
+ */
+// copy of `ContinuousTestingMavenTestUtils`, perhaps we should unify them somewhere?
+public class ContinuousTestingClient {
+    private static final int DEFAULT_PORT = 8080;
+
+    long runtToWaitFor = 1;
+    final String host;
+
+    protected static String getDefaultHost(int port) {
+        return "http://localhost:" + port;
+    }
+
+    public ContinuousTestingClient() {
+        this(getDefaultHost(DEFAULT_PORT));
+    }
+
+    public ContinuousTestingClient(int port) {
+        this(getDefaultHost(port));
+    }
+
+    public ContinuousTestingClient(String host) {
+        this.host = host;
+    }
+
+    public TestStatus waitForNextCompletion() {
+        try {
+            Awaitility.waitAtMost(2, TimeUnit.MINUTES).pollInterval(200, TimeUnit.MILLISECONDS).until(() -> {
+                TestStatus ts = getTestStatus();
+                if (ts.getLastRun() > runtToWaitFor) {
+                    throw new RuntimeException(
+                            "Waiting for run " + runtToWaitFor + " but run " + ts.getLastRun() + " has already occurred");
+                }
+                boolean runComplete = ts.getLastRun() == runtToWaitFor;
+                if (runComplete && ts.getRunning() > 0) {
+                    //there is a small chance of a race, where changes are picked up twice, due to how filesystems work
+                    //this works around it by waiting for the next run
+                    runtToWaitFor = ts.getRunning();
+                    return false;
+                } else if (runComplete) {
+                    runtToWaitFor++;
+                }
+                return runComplete;
+            });
+            return getTestStatus();
+        } catch (Exception e) {
+            TestStatus ts;
+            try {
+                ts = getTestStatus();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+            throw new ConditionTimeoutException("Failed to wait for test run " + runtToWaitFor + " " + ts, e);
+        }
+    }
+
+    private TestStatus getTestStatus() {
+        DevUIJsonRPCTest devUIJsonRPCTest = new DevUIJsonRPCTest("devui-continuous-testing", this.host);
+        try {
+
+            TypeReference<Map<String, Long>> typeRef = new TypeReference<Map<String, Long>>() {
+            };
+            Map<String, Long> testStatus = devUIJsonRPCTest.executeJsonRPCMethod(typeRef, "getStatus");
+
+            long lastRun = testStatus.getOrDefault("lastRun", -1L);
+            long running = testStatus.getOrDefault("running", -1L);
+            long testsRun = testStatus.getOrDefault("testsRun", -1L);
+            long testsPassed = testStatus.getOrDefault("testsPassed", -1L);
+            long testsFailed = testStatus.getOrDefault("testsFailed", -1L);
+            long testsSkipped = testStatus.getOrDefault("testsSkipped", -1L);
+            long totalTestsPassed = testStatus.getOrDefault("totalTestsPassed", -1L);
+            long totalTestsFailed = testStatus.getOrDefault("totalTestsFailed", -1L);
+            long totalTestsSkipped = testStatus.getOrDefault("totalTestsSkipped", -1L);
+
+            return new TestStatus(lastRun, running, testsRun, testsPassed, testsFailed, testsSkipped, totalTestsPassed,
+                    totalTestsFailed, totalTestsSkipped);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class TestStatus {
+
+        private long lastRun;
+        private long running;
+        private long testsRun = -1;
+        private long testsPassed = -1;
+        private long testsFailed = -1;
+        private long testsSkipped = -1;
+        private long totalTestsPassed = -1;
+        private long totalTestsFailed = -1;
+        private long totalTestsSkipped = -1;
+
+        public TestStatus() {
+            super();
+        }
+
+        public TestStatus(long lastRun, long running, long testsRun, long testsPassed, long testsFailed, long testsSkipped,
+                long totalTestsPassed, long totalTestsFailed, long totalTestsSkipped) {
+            this.lastRun = lastRun;
+            this.running = running;
+            this.testsRun = testsRun;
+            this.testsPassed = testsPassed;
+            this.testsFailed = testsFailed;
+            this.testsSkipped = testsSkipped;
+            this.totalTestsPassed = totalTestsPassed;
+            this.totalTestsFailed = totalTestsFailed;
+            this.totalTestsSkipped = totalTestsSkipped;
+        }
+
+        public long getLastRun() {
+            return lastRun;
+        }
+
+        public void setLastRun(long lastRun) {
+            this.lastRun = lastRun;
+        }
+
+        public long getRunning() {
+            return running;
+        }
+
+        public void setRunning(long running) {
+            this.running = running;
+        }
+
+        public long getTestsRun() {
+            return testsRun;
+        }
+
+        public void setTestsRun(long testsRun) {
+            this.testsRun = testsRun;
+        }
+
+        public long getTestsPassed() {
+            return testsPassed;
+        }
+
+        public void setTestsPassed(long testsPassed) {
+            this.testsPassed = testsPassed;
+        }
+
+        public long getTestsFailed() {
+            return testsFailed;
+        }
+
+        public void setTestsFailed(long testsFailed) {
+            this.testsFailed = testsFailed;
+        }
+
+        public long getTestsSkipped() {
+            return testsSkipped;
+        }
+
+        public void setTestsSkipped(long testsSkipped) {
+            this.testsSkipped = testsSkipped;
+        }
+
+        public long getTotalTestsPassed() {
+            return totalTestsPassed;
+        }
+
+        public void setTotalTestsPassed(long totalTestsPassed) {
+            this.totalTestsPassed = totalTestsPassed;
+        }
+
+        public long getTotalTestsFailed() {
+            return totalTestsFailed;
+        }
+
+        public void setTotalTestsFailed(long totalTestsFailed) {
+            this.totalTestsFailed = totalTestsFailed;
+        }
+
+        public long getTotalTestsSkipped() {
+            return totalTestsSkipped;
+        }
+
+        public void setTotalTestsSkipped(long totalTestsSkipped) {
+            this.totalTestsSkipped = totalTestsSkipped;
+        }
+
+        @Override
+        public String toString() {
+            return "TestStatus{" + "lastRun=" + lastRun + ", running=" + running + ", testsRun=" + testsRun + ", testsPassed="
+                    + testsPassed + ", testsFailed=" + testsFailed + ", testsSkipped=" + testsSkipped + ", totalTestsPassed="
+                    + totalTestsPassed + ", totalTestsFailed=" + totalTestsFailed + ", totalTestsSkipped=" + totalTestsSkipped
+                    + '}';
+        }
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/TestSelectionTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/TestSelectionTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.gradle.devmode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.gradle.continuoustesting.ContinuousTestingClient;
+
+public class TestSelectionTest extends QuarkusDevGradleTestBase {
+    @Override
+    protected String projectDirectoryName() {
+        return "test-selection";
+    }
+
+    @Override
+    protected String[] buildArguments() {
+        return new String[] { "clean", "quarkusDev", "--tests", "MyBean*Test.test", "--tests", "com.example.Ano*" };
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        // ignore outcome, just wait for the application to start
+        devModeClient.getHttpResponse();
+
+        ContinuousTestingClient.TestStatus tests = new ContinuousTestingClient().waitForNextCompletion();
+        assertEquals(5, tests.getTestsPassed());
+
+    }
+}

--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -108,6 +108,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <!-- copy of the default `<includes>` with removed `**/Test*.java`,
+                             because it matches `TestMojoIT`, which is NOT a Surefire test -->
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                        <include>**/*TestCase.java</include>
+                    </includes>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/LaunchMojoTestBase.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/LaunchMojoTestBase.java
@@ -14,6 +14,7 @@ import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
+import io.quarkus.runtime.LaunchMode;
 
 /**
  * Contains tests that we expect to pass with both quarkus:dev and quarkus:test
@@ -70,4 +71,17 @@ public abstract class LaunchMojoTestBase extends RunAndCheckMojoTestBase {
 
     }
 
+    @Test
+    public void testSelection() throws MavenInvocationException, IOException {
+        testDir = initProject("projects/test-selection");
+        run(true, "-Dtest=Ba*ic,Enabled?Test,NotEnabled*#executeAnyway*,!NotEnabledHardDisabled,#alwaysExecute,!#neverExecute");
+
+        if (getDefaultLaunchMode() == LaunchMode.DEVELOPMENT) {
+            // ignore outcome, just wait for the application to start
+            devModeClient.getHttpResponse();
+        }
+
+        ContinuousTestingMavenTestUtils.TestStatus tests = getTestingTestUtils().waitForNextCompletion();
+        assertEquals(7, tests.getTestsPassed());
+    }
 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>test-selection</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>@project.version@</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/main/java/com/example/MyBean.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/main/java/com/example/MyBean.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MyBean {
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.test.continuous-testing=enabled
+quarkus.console.basic=true

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/Basic.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/Basic.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class Basic {
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void neverExecute() {
+        assertEquals("hello", myBean.hello());
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/Enabled1Test.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/Enabled1Test.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class Enabled1Test {
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void neverExecute() {
+        assertEquals("hello", myBean.hello());
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/Enabled2Test.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/Enabled2Test.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class Enabled2Test {
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void neverExecute() {
+        assertEquals("hello", myBean.hello());
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/Enabled30Test.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/Enabled30Test.java
@@ -1,0 +1,28 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class Enabled30Test {
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void alwaysExecute() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void neverExecute() {
+        assertEquals("hello", myBean.hello());
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/NotEnabledHardDisabled.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/NotEnabledHardDisabled.java
@@ -1,0 +1,38 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class NotEnabledHardDisabled {
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void executeAnyway() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void executeAnywayAgain() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void alwaysExecute() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void neverExecute() {
+        assertEquals("hello", myBean.hello());
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/NotEnabledTest.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/src/test/java/com/example/NotEnabledTest.java
@@ -1,0 +1,43 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class NotEnabledTest {
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void test() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void executeAnyway() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void executeAnywayAgain() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void alwaysExecute() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void alwaysExecuteButNotThis() {
+        assertEquals("hello", myBean.hello());
+    }
+
+    @Test
+    public void neverExecute() {
+        assertEquals("hello", myBean.hello());
+    }
+}


### PR DESCRIPTION
This commit adds support for selecting tests to run during continuous testing that is very close to the native test filtering capability of the given build system. That is, in Maven, there's support for the `-Dtest=...` system property, while in Gradle, there's support for the `--tests` command line option. Format of these options follows the format used by the build system.

Fixes #20231