### PR TITLE
Drop gRPC messages to debug

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -204,7 +204,7 @@ public class GrpcServerRecorder {
         boolean reflectionServiceEnabled = configuration.enableReflectionService() || launchMode == LaunchMode.DEVELOPMENT;
 
         if (reflectionServiceEnabled) {
-            LOGGER.info("Registering gRPC reflection service");
+            LOGGER.debug("Registering gRPC reflection service");
             ReflectionServiceV1 reflectionServiceV1 = new ReflectionServiceV1(definitions);
             ReflectionServiceV1alpha reflectionServiceV1alpha = new ReflectionServiceV1alpha(definitions);
             ServerServiceDefinition serviceDefinition = ServerInterceptors.intercept(reflectionServiceV1, globalInterceptors);
@@ -256,7 +256,7 @@ public class GrpcServerRecorder {
             }
         }
 
-        LOGGER.info("Starting new Quarkus gRPC server (using Vert.x transport)...");
+        LOGGER.debug("Starting new Quarkus gRPC server (using Vert.x transport)...");
         Route route = router.route().handler(ctx -> {
             if (!isGrpc(ctx)) {
                 ctx.next();


### PR DESCRIPTION
There is no real reason to print them out on every start