### PR TITLE
Make URL inherit TestHTTPEndpoint from class level

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestHTTPResourceClassTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestHTTPResourceClassTestCase.java
@@ -1,0 +1,69 @@
+package io.quarkus.it.main;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.rest.GreetingEndpoint;
+import io.quarkus.it.rest.TestResource;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@TestHTTPEndpoint(TestResource.class)
+public class TestHTTPResourceClassTestCase {
+
+    @TestHTTPResource("")
+    URL testRootEndpoint;
+
+    @TestHTTPResource("/")
+    URL testRootEndpoint2;
+
+    String testRootExpectedResponse = "TEST";
+
+    @TestHTTPResource("int/10")
+    URL testPathEndpoint;
+
+    int testPathExpectedResponse = 11;
+
+    @TestHTTPEndpoint(GreetingEndpoint.class)
+    @TestHTTPResource("")
+    URL overridenGreetingEndpoint;
+
+    @TestHTTPEndpoint(GreetingEndpoint.class)
+    @TestHTTPResource("name")
+    URL overridenGreetingNameEndpoint;
+
+    String overridenGreetingNameExpectedResponse = "Hello name";
+
+    @Test
+    public void shouldConfigURLWithTestHTTPEndpointFromClass() {
+        given()
+                .when().get(testRootEndpoint).then()
+                .body(is(testRootExpectedResponse));
+
+        given()
+                .when().get(testRootEndpoint2).then()
+                .body(is(testRootExpectedResponse));
+
+        given()
+                .when().get(testPathEndpoint).then()
+                .body(is(String.valueOf(testPathExpectedResponse)));
+    }
+
+    @Test
+    public void shouldConfigURLWithTestHTTPEndpointFromField() {
+        given()
+                .when().get(overridenGreetingEndpoint.toString() + "/anotherName").then()
+                .body(is("Hello anotherName"));
+
+        given()
+                .when().get(overridenGreetingNameEndpoint).then()
+                .body(is(overridenGreetingNameExpectedResponse));
+    }
+
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestHTTPResourceFieldTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestHTTPResourceFieldTestCase.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.main;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.rest.TestResource;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class TestHTTPResourceFieldTestCase {
+
+    @TestHTTPEndpoint(TestResource.class)
+    @TestHTTPResource("")
+    URL testRootEndpoint;
+
+    @TestHTTPEndpoint(TestResource.class)
+    @TestHTTPResource("/")
+    URL testRootEndpoint2;
+
+    String testRootExpectedResponse = "TEST";
+
+    @TestHTTPEndpoint(TestResource.class)
+    @TestHTTPResource("int/10")
+    URL testPathEndpoint;
+
+    int testPathExpectedResponse = 11;
+
+    @Test
+    public void shouldConfigURLWithTestHTTPEndpointFromField() {
+        given()
+                .when().get(testRootEndpoint).then()
+                .body(is(testRootExpectedResponse));
+
+        given()
+                .when().get(testRootEndpoint2).then()
+                .body(is(testRootExpectedResponse));
+    }
+
+    @Test
+    public void shouldConfigURLWithTestHTTPEndpointAndTestHTTPResourceFromField() {
+        given()
+                .when().get(testPathEndpoint).then()
+                .body(is(String.valueOf(testPathExpectedResponse)));
+    }
+
+}


### PR DESCRIPTION
### Functionality:

- If a Test Class is annotated with `@TestHTTPEndpoint` then all fields annotated with `@TestHTTPResource` inherit it's configuration.
- If field is also annotated with `@TestHTTPEndpoint`, field's annotation takes precedence.
- Will only work if `@TestHTTPResource` annotation is used on field (AS-IS)

### Tests

- Local (Windows) `./mvnw "-Dquickly"` passed successfully.
- Local (Windows) `./mvnw test -f integration-tests/main/` passed successfully
- `Quarkus CI` GitHub action on local repo (https://github.com/gian1200/quarkus/actions/runs/13448988736) ~~in progress~~ passed successfully.

### Additional notes:

- I couldn't find the tests for original functionality, so I included both (new and original). 
- I reused some resources/endpoints. Not sure if that's acceptable/expected or not (hopefully it doesn't make other tests fail)
- Added more tests to cover https://github.com/quarkusio/quarkus/issues/46336

### References

- Closes:  #34935 
- Continuation of: #46157