### PR TITLE
Drop deprecated synchronous 'getCredentialTransport' declared on HttpAuthenticationMechanism

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticationMechanism.java
@@ -41,23 +41,11 @@ public interface HttpAuthenticationMechanism {
     /**
      * The credential transport, used for finding the best candidate for authenticating and challenging when more than one
      * mechanism is installed.
-     * and finding the best candidate for issuing a challenge when more than one mechanism is installed.
      *
-     * May be null if this mechanism cannot interfere with other mechanisms
-     */
-    @Deprecated(since = "2.8", forRemoval = true)
-    default HttpCredentialTransport getCredentialTransport() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * The credential transport, used for finding the best candidate for authenticating and challenging when more than one
-     * mechanism is installed.
-     *
-     * May be null if this mechanism cannot interfere with other mechanisms
+     * May be {@link Uni} with null item if this mechanism cannot interfere with other mechanisms.
      */
     default Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context) {
-        throw new UnsupportedOperationException();
+        return Uni.createFrom().nullItem();
     }
 
     class ChallengeSender implements Function<ChallengeData, Boolean> {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
@@ -370,7 +370,7 @@ public final class HttpAuthenticator {
 
     private Uni<SecurityIdentity> authenticateWithAllMechanisms(SecurityIdentity identity, int i,
             RoutingContext routingContext) {
-        return getCredentialTransport(mechanisms[i], routingContext)
+        return mechanisms[i].getCredentialTransport(routingContext)
                 .onItem().transformToUni(new Function<HttpCredentialTransport, Uni<? extends SecurityIdentity>>() {
                     @Override
                     public Uni<SecurityIdentity> apply(HttpCredentialTransport httpCredentialTransport) {
@@ -425,7 +425,7 @@ public final class HttpAuthenticator {
 
     private Uni<HttpAuthenticationMechanism> getPathSpecificMechanism(int index, RoutingContext routingContext,
             String pathSpecificMechanism) {
-        return getCredentialTransport(mechanisms[index], routingContext).onItem()
+        return mechanisms[index].getCredentialTransport(routingContext).onItem()
                 .transform(new Function<HttpCredentialTransport, HttpAuthenticationMechanism>() {
                     @Override
                     public HttpAuthenticationMechanism apply(HttpCredentialTransport t) {
@@ -458,15 +458,6 @@ public final class HttpAuthenticator {
         routingContext.put(AUTH_MECHANISM, authMechanism);
     }
 
-    private static Uni<HttpCredentialTransport> getCredentialTransport(HttpAuthenticationMechanism mechanism,
-            RoutingContext routingContext) {
-        try {
-            return mechanism.getCredentialTransport(routingContext);
-        } catch (UnsupportedOperationException ex) {
-            return Uni.createFrom().item(mechanism.getCredentialTransport());
-        }
-    }
-
     private static void rememberAuthAttempted(RoutingContext routingContext) {
         routingContext.put(ATTEMPT_AUTH_INVOKED, TRUE);
     }
@@ -489,7 +480,7 @@ public final class HttpAuthenticator {
      * when the selected mechanism is same as the one already used.
      */
     private static Uni<HttpCredentialTransport> rememberAuthMechScheme(HttpAuthenticationMechanism mech, RoutingContext event) {
-        return getCredentialTransport(mech, event)
+        return mech.getCredentialTransport(event)
                 .onItem().ifNotNull().invoke(new Consumer<HttpCredentialTransport>() {
                     @Override
                     public void accept(HttpCredentialTransport t) {


### PR DESCRIPTION
This method has been deprecated and marked for removal since 2.8. Users should use `Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context)` that allows to determine credential transport dynamically based on the `RoutingContext`. We can wait with this removal much longer, but personally I think it was sufficient time for migration.