### PR TITLE
[3.8] Always close OutputStream in RESTEasy Classic

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
@@ -138,8 +138,18 @@ public class VertxHttpResponse implements HttpResponse {
 
     public void finish() throws IOException {
         checkException();
-        if (finished || response.ended() || response.closed())
+
+        if (finished || response.ended() || response.closed()) {
+            if (os != null) {
+                try {
+                    os.close();
+                    os = null;
+                } catch (Exception ignored) {
+
+                }
+            }
             return;
+        }
         try {
             if (os != null) {
                 os.close(); // this will end() vertx response


### PR DESCRIPTION
Fixes: #46412