### PR TITLE
Add docs for maximum values in quarkus.http.limits

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -10,19 +10,19 @@ import io.smallrye.config.WithDefault;
 
 public interface ServerLimitsConfig {
     /**
-     * The maximum length of all headers.
+     * The maximum length of all headers, up to {@code Integer.MAX_VALUE} bytes.
      */
     @WithDefault("20K")
     MemorySize maxHeaderSize();
 
     /**
-     * The maximum size of a request body.
+     * The maximum size of a request body, up to {@code Long.MAX_VALUE} bytes.
      */
     @WithDefault("10240K")
     Optional<MemorySize> maxBodySize();
 
     /**
-     * The max HTTP chunk size
+     * The max HTTP chunk size, up to {@code Integer.MAX_VALUE} bytes.
      */
     @WithDefault("8192")
     MemorySize maxChunkSize();
@@ -34,7 +34,7 @@ public interface ServerLimitsConfig {
     int maxInitialLineLength();
 
     /**
-     * The maximum length of a form attribute.
+     * The maximum length of a form attribute, up to {@code Integer.MAX_VALUE} bytes.
      */
     @WithDefault("2048")
     MemorySize maxFormAttributeSize();
@@ -47,7 +47,7 @@ public interface ServerLimitsConfig {
 
     /**
      * Set the maximum number of bytes a server can buffer when decoding a form.
-     * Set to {@code -1} to allow unlimited length
+     * Set to {@code -1} to allow unlimited length, up to {@code Integer.MAX_VALUE} bytes.
      **/
     @WithDefault("1K")
     MemorySize maxFormBufferedBytes();


### PR DESCRIPTION
This PR adds some small enhancements to the docs in `io.quarkus.vertx.http.runtime.ServerLimitsConfig`, stating the respective maximum values for
```
quarkus.http.limits.max-header-size
quarkus.http.limits.max-body-size
quarkus.http.limits.max-chunk-size
quarkus.http.limits.max-form-attribute-size
quarkus.http.limits.max-form-buffered-bytes
```

`io.quarkus.vertx.http.runtime.options.HttpServerOptionsUtils#applyCommonOptions` does many things, amongst others it forwards these settings to Vert.x APIs that expect an `int` or a `long`, e.g. `httpServerOptions.setMaxHeaderSize(httpConfig.limits().maxHeaderSize().asBigInteger().intValueExact());`.

Sticking to that call, if `quarkus.http.limits.max-header-size` is set to `2g`, that would lead to an `java.lang.ArithmeticException: BigInteger out of int range` (quite unlucky, but still: `2g` or 2147483648 > `Integer.MAX_VALUE` or 2147483647).

BTW: I could imagine that this would cause an error elsewhere, but at least these Vert.x APIs would also accept `-1` to allow unlimited length, which is not possible to specify with `io.quarkus.runtime.configuration.MemorySize` as per `MEMORY_SIZE_PATTERN`. Also, we cannot not-define them due to `@WithDefault` values in `io.quarkus.vertx.http.runtime.ServerLimitsConfig` (which I think are great in there).