### PR TITLE
[3.8] Move from vectorized/redpanda images to redpandadata/redpanda

### DIFF
--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -56,8 +56,8 @@ Dev Services for Kafka supports https://redpanda.com[Redpanda], https://github/o
 and https://strimzi.io[Strimzi] (in https://github.com/apache/kafka/blob/trunk/config/kraft/README.md[Kraft] mode)  images.
 
 **Redpanda** is a Kafka compatible event streaming platform.
-Because it provides a fast startup times, dev services defaults to Redpanda images from `vectorized/redpanda`.
-You can select any version from https://hub.docker.com/r/vectorized/redpanda.
+Because it provides a fast startup times, Dev Services defaults to Redpanda images from `redpandadata/redpanda`.
+You can select any version from https://hub.docker.com/r/redpandadata/redpanda.
 
 **kafka-native** provides images of standard Apache Kafka distribution compiled to native binary using Quarkus and GraalVM.
 While still being _experimental_, it provides very fast startup times with small footprint.

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -228,7 +228,7 @@ public class DevServicesKafkaProcessor {
             switch (config.provider) {
                 case REDPANDA:
                     RedpandaKafkaContainer redpanda = new RedpandaKafkaContainer(
-                            DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("vectorized/redpanda"),
+                            DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("redpandadata/redpanda"),
                             config.fixedExposedPort,
                             launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
                             useSharedNetwork, config.redpanda);

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -33,7 +33,7 @@ public class KafkaDevServicesBuildTimeConfig {
      * Redpanda, Strimzi and kafka-native container providers are supported. Default is redpanda.
      * <p>
      * For Redpanda:
-     * See https://docs.redpanda.com/current/get-started/quick-start/ and https://hub.docker.com/r/vectorized/redpanda
+     * See https://docs.redpanda.com/current/get-started/quick-start/ and https://hub.docker.com/r/redpandadata/redpanda
      * <p>
      * For Strimzi:
      * See https://github.com/strimzi/test-container and https://quay.io/repository/strimzi-test-container/test-container
@@ -47,7 +47,7 @@ public class KafkaDevServicesBuildTimeConfig {
     public Provider provider = Provider.REDPANDA;
 
     public enum Provider {
-        REDPANDA("docker.io/vectorized/redpanda:v22.3.4"),
+        REDPANDA("docker.io/redpandadata/redpanda:v22.3.4"),
         STRIMZI("quay.io/strimzi-test-container/test-container:latest-kafka-3.2.1"),
         KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest");
 


### PR DESCRIPTION
Apparently, Docker dropped the redirections and we now have hard failures on CI.

See https://github.com/quarkusio/quarkus/pull/46425

This is a backport of https://github.com/quarkusio/quarkus/pull/45028.