### PR TITLE
Quarkus REST: prevent NPE for EagerSecurityContext

### DIFF
--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityCheckWithMethodArgsHandler.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityCheckWithMethodArgsHandler.java
@@ -24,7 +24,7 @@ final class SecurityCheckWithMethodArgsHandler implements ServerRestHandler {
 
     @Override
     public void handle(ResteasyReactiveRequestContext requestContext) {
-        if (!EagerSecurityContext.instance.authorizationController.isAuthorizationEnabled()) {
+        if (!EagerSecurityContext.isAuthorizationEnabled()) {
             return;
         }
 
@@ -32,8 +32,8 @@ final class SecurityCheckWithMethodArgsHandler implements ServerRestHandler {
         requestContext.suspend();
 
         // no need to use deferred identity as we require request to be authenticated on pre-match and set identity
-        SecurityIdentity securityIdentity = EagerSecurityContext.instance.identityAssociation.get().getIdentity();
-        EagerSecurityContext.instance
+        SecurityIdentity securityIdentity = EagerSecurityContext.getCurrentIdentityAssociation().getIdentity();
+        EagerSecurityContext.getInstance()
                 .runSecurityCheck(securityCheck, invokedMethodDesc, requestContext, securityIdentity)
                 .subscribe().withSubscriber(new UniSubscriber<Object>() {
                     @Override

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/SecurityContextOverrideHandler.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.runtime.security;
 
+import static io.quarkus.resteasy.reactive.server.runtime.security.EagerSecurityContext.getCurrentIdentityAssociation;
+
 import java.security.Permission;
 import java.security.Principal;
 import java.util.Collections;
@@ -121,8 +123,9 @@ public class SecurityContextOverrideHandler implements ServerRestHandler {
     }
 
     private static CurrentIdentityAssociation getIdentityAssociation() {
-        if (EagerSecurityContext.instance != null) {
-            return EagerSecurityContext.instance.identityAssociation.orElse(null);
+        CurrentIdentityAssociation currentIdentityAssociation = getCurrentIdentityAssociation();
+        if (currentIdentityAssociation != null) {
+            return currentIdentityAssociation;
         }
         // this should only happen when Quarkus Security extension is not present
         // but user implements security themselves, like in their own JAX-RS filter


### PR DESCRIPTION
- closes: https://github.com/quarkusio/quarkus/issues/46435
- no test because conditions under which this can be reproduced are unclear; my best guess is that it's related to shutdown where I set this field to `null`, that's not confirmed