### PR TITLE
Redis Client: Refactored Exception Throwing in Uni Functions

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBloomCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBloomCommands.java
@@ -43,7 +43,7 @@ class AbstractBloomCommands<K, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         doesNotContainNull(values, "values");
         if (values.length == 0) {
-            throw new IllegalArgumentException("`values` must contain at least one item");
+            return Uni.createFrom().failure(new IllegalArgumentException("`values` must contain at least one item"));
         }
 
         RedisCommand command = RedisCommand.of(Command.BF_MADD)
@@ -60,7 +60,7 @@ class AbstractBloomCommands<K, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         doesNotContainNull(values, "values");
         if (values.length == 0) {
-            throw new IllegalArgumentException("`values` must contain at least one item");
+            return Uni.createFrom().failure(new IllegalArgumentException("`values` must contain at least one item"));
         }
 
         RedisCommand command = RedisCommand.of(Command.BF_MEXISTS)
@@ -91,7 +91,7 @@ class AbstractBloomCommands<K, V> extends AbstractRedisCommands {
         nonNull(args, "args");
         doesNotContainNull(values, "values");
         if (values.length == 0) {
-            throw new IllegalArgumentException("`values` must contain at least one item");
+            return Uni.createFrom().failure(new IllegalArgumentException("`values` must contain at least one item"));
         }
 
         RedisCommand command = RedisCommand.of(Command.BF_INSERT)

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
@@ -35,7 +35,7 @@ public class AbstractCountMinCommands<K, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         nonNull(couples, "couples");
         if (couples.isEmpty()) {
-            throw new IllegalArgumentException("`couples` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`couples` must not be empty"));
         }
         // Create command
         RedisCommand cmd = RedisCommand.of(Command.CMS_INCRBY)
@@ -86,7 +86,7 @@ public class AbstractCountMinCommands<K, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         doesNotContainNull(items, "items");
         if (items.length == 0) {
-            throw new IllegalArgumentException("`items` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`items` must not be empty"));
         }
         // Create command
         RedisCommand cmd = RedisCommand.of(Command.CMS_QUERY)

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCuckooCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCuckooCommands.java
@@ -78,7 +78,7 @@ public class AbstractCuckooCommands<K, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         doesNotContainNull(values, "values");
         if (values.length == 0) {
-            throw new IllegalArgumentException("`values` must contain at least one item");
+            return Uni.createFrom().failure(new IllegalArgumentException("`values` must contain at least one item"));
         }
 
         // Create command
@@ -96,7 +96,7 @@ public class AbstractCuckooCommands<K, V> extends AbstractRedisCommands {
         nonNull(args, "args");
         doesNotContainNull(values, "values");
         if (values.length == 0) {
-            throw new IllegalArgumentException("`values` must contain at least one item");
+            return Uni.createFrom().failure(new IllegalArgumentException("`values` must contain at least one item"));
         }
         // Create command
         RedisCommand cmd = RedisCommand.of(Command.CF_INSERT)
@@ -114,7 +114,7 @@ public class AbstractCuckooCommands<K, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         doesNotContainNull(values, "values");
         if (values.length == 0) {
-            throw new IllegalArgumentException("`values` must contain at least one item");
+            return Uni.createFrom().failure(new IllegalArgumentException("`values` must contain at least one item"));
         }
         // Create command
         RedisCommand cmd = RedisCommand.of(Command.CF_INSERTNX)
@@ -132,7 +132,7 @@ public class AbstractCuckooCommands<K, V> extends AbstractRedisCommands {
         doesNotContainNull(values, "values");
         nonNull(args, "args");
         if (values.length == 0) {
-            throw new IllegalArgumentException("`values` must contain at least one item");
+            return Uni.createFrom().failure(new IllegalArgumentException("`values` must contain at least one item"));
         }
         // Create command
         RedisCommand cmd = RedisCommand.of(Command.CF_INSERTNX)
@@ -150,7 +150,7 @@ public class AbstractCuckooCommands<K, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         doesNotContainNull(values, "values");
         if (values.length == 0) {
-            throw new IllegalArgumentException("`values` must contain at least one item");
+            return Uni.createFrom().failure(new IllegalArgumentException("`values` must contain at least one item"));
         }
         // Create command
         RedisCommand cmd = RedisCommand.of(Command.CF_MEXISTS)

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHashCommands.java
@@ -85,7 +85,7 @@ class AbstractHashCommands<K, F, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         doesNotContainNull(fields, "fields");
         if (fields.length == 0) {
-            throw new IllegalArgumentException("`fields` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`fields` must not be empty"));
         }
         RedisCommand cmd = RedisCommand.of(Command.HMGET);
         cmd.put(marshaller.encode(key));
@@ -101,7 +101,7 @@ class AbstractHashCommands<K, F, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         nonNull(map, "map");
         if (map.isEmpty()) {
-            throw new IllegalArgumentException("`map` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`map` must not be empty"));
         }
         RedisCommand cmd = RedisCommand.of(Command.HMSET);
         cmd.put(marshaller.encode(key));
@@ -142,7 +142,7 @@ class AbstractHashCommands<K, F, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         nonNull(map, "map");
         if (map.isEmpty()) {
-            throw new IllegalArgumentException("`map` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`map` must not be empty"));
         }
         RedisCommand cmd = RedisCommand.of(Command.HSET);
         cmd.put(marshaller.encode(key));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractKeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractKeyCommands.java
@@ -145,7 +145,7 @@ class AbstractKeyCommands<K> extends AbstractRedisCommands {
     Uni<Response> _keys(String pattern) {
         nonNull(pattern, "pattern");
         if (pattern.isBlank()) {
-            throw new IllegalArgumentException("`pattern` must not be blank");
+            return Uni.createFrom().failure(new IllegalArgumentException("`pattern` must not be blank"));
         }
 
         return execute(RedisCommand.of(Command.KEYS).put(pattern));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSetCommands.java
@@ -40,7 +40,7 @@ class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length <= 1) {
-            throw new IllegalArgumentException("`keys` must contain at least 2 keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("`keys` must contain at least 2 keys"));
         }
         return execute(RedisCommand.of(Command.SDIFF).put(marshaller.encode(keys)));
     }
@@ -54,7 +54,7 @@ class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length <= 1) {
-            throw new IllegalArgumentException("`keys` must contain at least 2 keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("`keys` must contain at least 2 keys"));
         }
         RedisCommand cmd = RedisCommand.of(Command.SDIFFSTORE)
                 .put(marshaller.encode(destination))
@@ -66,7 +66,7 @@ class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length <= 1) {
-            throw new IllegalArgumentException("`keys` must contain at least 2 keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("`keys` must contain at least 2 keys"));
         }
         return execute(RedisCommand.of(Command.SINTER).put(marshaller.encode(keys)));
     }
@@ -75,7 +75,7 @@ class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length <= 1) {
-            throw new IllegalArgumentException("`keys` must contain at least 2 keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("`keys` must contain at least 2 keys"));
         }
 
         RedisCommand cmd = RedisCommand.of(Command.SINTERCARD).put(keys.length).putAll(marshaller.encode(keys));
@@ -89,7 +89,7 @@ class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
         positive(limit, "limit");
 
         if (keys.length <= 1) {
-            throw new IllegalArgumentException("`keys` must contain at least 2 keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("`keys` must contain at least 2 keys"));
         }
 
         RedisCommand cmd = RedisCommand.of(Command.SINTERCARD).put(keys.length).putAll(marshaller.encode(keys))
@@ -101,7 +101,7 @@ class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
         nonNull(destination, "destination");
         notNullOrEmpty(keys, "keys");
         if (keys.length <= 1) {
-            throw new IllegalArgumentException("`keys` must contain at least 2 keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("`keys` must contain at least 2 keys"));
         }
         RedisCommand cmd = RedisCommand.of(Command.SINTERSTORE)
                 .put(marshaller.encode(destination))
@@ -186,7 +186,7 @@ class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length <= 1) {
-            throw new IllegalArgumentException("`keys` must contain at least 2 keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("`keys` must contain at least 2 keys"));
         }
         return execute(RedisCommand.of(Command.SUNION).put(marshaller.encode(keys)));
     }
@@ -196,7 +196,7 @@ class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length <= 1) {
-            throw new IllegalArgumentException("`keys` must contain at least 2 keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("`keys` must contain at least 2 keys"));
         }
         RedisCommand cmd = RedisCommand.of(Command.SUNIONSTORE)
                 .put(marshaller.encode(destination))

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSortedSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSortedSetCommands.java
@@ -130,7 +130,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length < 2) {
-            throw new IllegalArgumentException("Need at least two keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("Need at least two keys"));
         }
         RedisCommand cmd = RedisCommand.of(Command.ZDIFF)
                 .put(keys.length)
@@ -142,7 +142,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length < 2) {
-            throw new IllegalArgumentException("Need at least two keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("Need at least two keys"));
         }
 
         RedisCommand cmd = RedisCommand.of(Command.ZDIFF)
@@ -162,7 +162,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length < 2) {
-            throw new IllegalArgumentException("Need at least two keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("Need at least two keys"));
         }
         RedisCommand cmd = RedisCommand.of(Command.ZDIFFSTORE)
                 .put(marshaller.encode(destination))
@@ -189,7 +189,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length < 2) {
-            throw new IllegalArgumentException("Need at least two keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("Need at least two keys"));
         }
         RedisCommand cmd = RedisCommand.of(Command.ZINTER)
                 .put(keys.length);
@@ -210,7 +210,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length < 2) {
-            throw new IllegalArgumentException("Need at least two keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("Need at least two keys"));
         }
         RedisCommand cmd = RedisCommand.of(Command.ZINTER)
                 .put(keys.length);
@@ -231,7 +231,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length < 2) {
-            throw new IllegalArgumentException("Need at least two keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("Need at least two keys"));
         }
         RedisCommand cmd = RedisCommand.of(Command.ZINTERCARD)
                 .put(keys.length);
@@ -247,7 +247,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length < 2) {
-            throw new IllegalArgumentException("Need at least two keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("Need at least two keys"));
         }
         positive(limit, "limit");
         RedisCommand cmd = RedisCommand.of(Command.ZINTERCARD)
@@ -267,7 +267,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
         notNullOrEmpty(keys, "keys");
         doesNotContainNull(keys, "keys");
         if (keys.length < 2) {
-            throw new IllegalArgumentException("Need at least two keys");
+            return Uni.createFrom().failure(new IllegalArgumentException("Need at least two keys"));
         }
         nonNull(arguments, "arguments");
         nonNull(destination, "destination");

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTimeSeriesCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTimeSeriesCommands.java
@@ -176,7 +176,7 @@ public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
     Uni<Response> _tsMAdd(SeriesSample<K>... samples) {
         doesNotContainNull(samples, "samples");
         if (samples.length == 0) {
-            throw new IllegalArgumentException("`samples` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`samples` must not be empty"));
         }
 
         RedisCommand cmd = RedisCommand.of(Command.TS_MADD);
@@ -196,7 +196,7 @@ public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
         nonNull(args, "args");
         doesNotContainNull(filters, "filters");
         if (filters.length == 0) {
-            throw new IllegalArgumentException("`filters` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`filters` must not be empty"));
         }
         RedisCommand cmd = RedisCommand.of(Command.TS_MGET).putArgs(args);
         cmd.put("FILTER");
@@ -210,7 +210,7 @@ public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
     Uni<Response> _tsMGet(Filter... filters) {
         doesNotContainNull(filters, "filters");
         if (filters.length == 0) {
-            throw new IllegalArgumentException("`filters` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`filters` must not be empty"));
         }
         RedisCommand cmd = RedisCommand.of(Command.TS_MGET);
         cmd.put("FILTER");
@@ -226,7 +226,7 @@ public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
         nonNull(range, "range");
         doesNotContainNull(filters, "filters");
         if (filters.length == 0) {
-            throw new IllegalArgumentException("`filters` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`filters` must not be empty"));
         }
 
         RedisCommand cmd = RedisCommand.of(Command.TS_MRANGE).putAll(range.toArgs());
@@ -244,7 +244,7 @@ public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
         nonNull(args, "args");
         doesNotContainNull(filters, "filters");
         if (filters.length == 0) {
-            throw new IllegalArgumentException("`filters` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`filters` must not be empty"));
         }
 
         RedisCommand cmd = RedisCommand.of(Command.TS_MRANGE).putAll(range.toArgs()).putArgs(args);
@@ -277,7 +277,7 @@ public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
         nonNull(range, "range");
         doesNotContainNull(filters, "filters");
         if (filters.length == 0) {
-            throw new IllegalArgumentException("`filters` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`filters` must not be empty"));
         }
 
         RedisCommand cmd = RedisCommand.of(Command.TS_MREVRANGE).putAll(range.toArgs()).putArgs(args);
@@ -293,7 +293,7 @@ public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
 
         doesNotContainNull(filters, "filters");
         if (filters.length == 0) {
-            throw new IllegalArgumentException("`filters` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`filters` must not be empty"));
         }
 
         RedisCommand cmd = RedisCommand.of(Command.TS_QUERYINDEX);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTopKCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTopKCommands.java
@@ -34,7 +34,7 @@ public class AbstractTopKCommands<K, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         doesNotContainNull(items, "items");
         if (items.length == 0) {
-            throw new IllegalArgumentException("`items` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`items` must not be empty"));
         }
         // Create command
         RedisCommand cmd = RedisCommand.of(Command.TOPK_ADD)
@@ -106,7 +106,7 @@ public class AbstractTopKCommands<K, V> extends AbstractRedisCommands {
         nonNull(key, "key");
         doesNotContainNull(items, "items");
         if (items.length == 0) {
-            throw new IllegalArgumentException("`items` must not be empty");
+            return Uni.createFrom().failure(new IllegalArgumentException("`items` must not be empty"));
         }
         // Create command
         RedisCommand cmd = RedisCommand.of(Command.TOPK_QUERY)

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactivePubSubCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactivePubSubCommandsImpl.java
@@ -194,10 +194,10 @@ public class ReactivePubSubCommandsImpl<V> extends AbstractRedisCommands impleme
 
         for (String channel : channels) {
             if (channel == null) {
-                throw new IllegalArgumentException("Channels must not be null");
+                return Uni.createFrom().failure(new IllegalArgumentException("Channels must not be null"));
             }
             if (channel.isBlank()) {
-                throw new IllegalArgumentException("Channels cannot be blank");
+                return Uni.createFrom().failure(new IllegalArgumentException("Channels cannot be blank"));
             }
         }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
@@ -192,7 +192,8 @@ public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransac
                 .map(r -> {
                     if (r == null || !r.toString().equals("QUEUED")) {
                         this.tx.discard();
-                        throw new IllegalStateException("Unable to enqueue command into the current transaction");
+                        return Uni.createFrom()
+                                .failure(new IllegalStateException("Unable to enqueue command into the current transaction"));
                     }
                     return r;
                 })


### PR DESCRIPTION
Some of the Redis Client methods that returned Unis were throwing Exceptions rather than returning Unis created from the exceptions. 

This was causing issues where the exceptions weren't being caught in .onFailure() blocks and required the classic try catch approach, especially hindersome in Multi pipelines.