### PR TITLE
Implement isValidAuthority() in ForwardedServerRequestWrapper

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
@@ -198,6 +198,11 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     }
 
     @Override
+    public boolean isValidAuthority() {
+        return forwardedParser.authority() != null;
+    }
+
+    @Override
     public SocketAddress localAddress() {
         return delegate.localAddress();
     }


### PR DESCRIPTION
Following https://github.com/vert-x3/vertx-web/pull/2647/files, the fact this method is not implemented is creating issues when proxying is used.

I would also be in favor of changing the default implementation of the method in Vert.x as the current one is quite error prone.