### PR TITLE
Add docs for maximum values of MemorySize based config items

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java
@@ -224,7 +224,7 @@ public interface LogRuntimeConfig {
 
         interface RotationConfig {
             /**
-             * The maximum log file size, after which a rotation is executed.
+             * The maximum log file size, after which a rotation is executed, up to {@code Long.MAX_VALUE} bytes.
              * Note that the file is rotated <em>after</em> the log record is written.
              * Thus, this isn't a hard maximum on the file size; rather, it's a hard <em>minimum</em>
              * on the size of the file before it is rotated.
@@ -401,7 +401,8 @@ public interface LogRuntimeConfig {
         Optional<String> filter();
 
         /**
-         * The maximum length, in bytes, of the message allowed to be sent. The length includes the header and the message.
+         * The maximum length, in bytes, of the message allowed to be sent, up to {@code Integer.MAX_VALUE} bytes. The length
+         * includes the header and the message.
          * <p>
          * If not set, the default value is {@code 2048} when {@code sys-log-type} is {@code rfc5424} (which is the default)
          * and {@code 1024} when {@code sys-log-type} is {@code rfc3164}

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
@@ -204,7 +204,7 @@ public interface KeycloakDevServicesConfig {
     Map<String, String> containerEnv();
 
     /**
-     * Memory limit for Keycloak container
+     * Memory limit for Keycloak container, up to {@code Long.MAX_VALUE} bytes.
      * </p>
      * If not specified, 750MiB is the default memory limit.
      */

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -279,7 +279,7 @@ public interface RestClientsConfig {
     /**
      * Configures two different things:
      * <ul>
-     * <li>The max HTTP chunk size</li>
+     * <li>The max HTTP chunk size, up to {@code Integer.MAX_VALUE} bytes.</li>
      * <li>The size of the chunk to be read when an {@link InputStream} is being used as an input</li>
      * </ul>
      * <p>
@@ -616,7 +616,7 @@ public interface RestClientsConfig {
         /**
          * Configures two different things:
          * <ul>
-         * <li>The max HTTP chunk size</li>
+         * <li>The max HTTP chunk size, up to {@code Integer.MAX_VALUE} bytes.</li>
          * <li>The size of the chunk to be read when an {@link InputStream} is being read and sent to the server</li>
          * </ul>
          * <p>

--- a/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/ResteasyCommonConfig.java
+++ b/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/ResteasyCommonConfig.java
@@ -24,7 +24,7 @@ public interface ResteasyCommonConfig {
         boolean enabled();
 
         /**
-         * Maximum deflated file bytes size
+         * Maximum deflated file bytes size, up to {@code Long.MAX_VALUE} bytes.
          * <p>
          * If the limit is exceeded, Resteasy will return Response
          * with status 413("Request Entity Too Large")

--- a/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
+++ b/extensions/resteasy-reactive/rest-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
@@ -13,7 +13,7 @@ public interface ResteasyReactiveConfig {
 
     /**
      * The amount of memory that can be used to buffer input before switching to
-     * blocking IO.
+     * blocking IO, up to {@code Long.MAX_VALUE} bytes.
      */
     @WithDefault("10k")
     MemorySize inputBufferSize();

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
@@ -13,7 +13,8 @@ import io.smallrye.config.WithDefault;
 public interface ServletRuntimeConfig {
 
     /**
-     * The buffer size to use for Servlet. If this is not specified the default will depend on the amount
+     * The buffer size to use for Servlet, up to {@code Integer.MAX_VALUE} bytes. If this is not specified the default will
+     * depend on the amount
      * of available memory. If there is less than 64mb it will default to 512b heap buffer, less that 128mb
      * 1k direct buffer and otherwise 16k direct buffers.
      *

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrafficShapingConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrafficShapingConfig.java
@@ -31,13 +31,13 @@ public interface TrafficShapingConfig {
     boolean enabled();
 
     /**
-     * Set bandwidth limit in bytes per second for inbound connections.
+     * Set bandwidth limit in bytes per second for inbound connections, up to {@code Long.MAX_VALUE} bytes.
      * If not set, no limits are applied.
      */
     Optional<MemorySize> inboundGlobalBandwidth();
 
     /**
-     * Set bandwidth limit in bytes per second for outbound connections.
+     * Set bandwidth limit in bytes per second for outbound connections, up to {@code Long.MAX_VALUE} bytes.
      * If not set, no limits are applied.
      */
     Optional<MemorySize> outboundGlobalBandwidth();
@@ -61,7 +61,7 @@ public interface TrafficShapingConfig {
 
     /**
      * Set the maximum global write size in bytes per second allowed in the buffer globally for all channels before write
-     * are suspended.
+     * are suspended, up to {@code Long.MAX_VALUE} bytes.
      * The default value is 400 MB.
      */
     Optional<MemorySize> peakOutboundGlobalBandwidth();


### PR DESCRIPTION
As a follow-up to #46428, this PR adds docs to state maximum values to all not yet documented `io.quarkus.runtime.configuration.MemorySize` based config items.