### PR TITLE
Ensure that QuarkusUnitTest plays nicely with `@TestFactory`

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/SimpleBeanTestFactoryTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/SimpleBeanTestFactoryTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SimpleBeanTestFactoryTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(SimpleBean.class)
+                    .addAsResource(new StringAsset("simpleBean.baz=1"), "application.properties"));
+
+    @Inject
+    SimpleBean simpleBean;
+
+    @TestFactory
+    public List<DynamicTest> testBeanInsideFactory() {
+        return List.of(
+                DynamicTest.dynamicTest("test 1", () -> {
+                    assertNotNull(simpleBean);
+                }),
+                DynamicTest.dynamicTest("test 2", () -> {
+                    assertEquals(1, 1);
+                }));
+    }
+}

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -401,6 +401,14 @@ public class QuarkusUnitTest
     }
 
     @Override
+    public <T> T interceptTestFactoryMethod(Invocation<T> invocation,
+            ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        T result = (T) runExtensionMethod(invocationContext, extensionContext, false);
+        invocation.skip();
+        return result;
+    }
+
+    @Override
     public void interceptAfterEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext,
             ExtensionContext extensionContext) throws Throwable {
         if (assertException == null) {
@@ -438,7 +446,7 @@ public class QuarkusUnitTest
         invocation.skip();
     }
 
-    private void runExtensionMethod(ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext,
+    private Object runExtensionMethod(ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext,
             boolean testMethodInvokersAllowed) throws Throwable {
         Method newMethod = null;
         Class<?> c = actualTestClass;
@@ -505,12 +513,12 @@ public class QuarkusUnitTest
                         effectiveArguments.add(originalValue);
                     }
                 }
-                testMethodInvokerToUse.getClass()
+                return testMethodInvokerToUse.getClass()
                         .getMethod("invoke", Object.class, Method.class, List.class, String.class)
                         .invoke(testMethodInvokerToUse, actualTestInstance, newMethod, effectiveArguments,
                                 extensionContext.getRequiredTestClass().getName());
             } else {
-                newMethod.invoke(actualTestInstance, invocationContext.getArguments().toArray());
+                return newMethod.invoke(actualTestInstance, invocationContext.getArguments().toArray());
             }
         } catch (InvocationTargetException e) {
             throw e.getCause();


### PR DESCRIPTION
These are the exact same fixes as provided in #8066, but simply ported to QuarkusUnitTest. They fix the problem as the tests do not pass without the changes. 

That being said, I'm not entirely sure where I should have put the tests. It looked like to me Arc tests were the only place to put them in, however I'm more than happy to move them if needed. 

- Closes: #46473