### PR TITLE
Bump Gradle to 8.13 and adopt Quarkus Gradle plugin

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -61,7 +61,7 @@
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.9.9</proposed-maven-version>
         <maven-wrapper.version>3.3.2</maven-wrapper.version>
-        <gradle-wrapper.version>8.12</gradle-wrapper.version>
+        <gradle-wrapper.version>8.13</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>
         <quarkus-maven-plugin.version>${project.version}</quarkus-maven-plugin.version>
         <maven-plugin-plugin.version>3.8.1</maven-plugin-plugin.version>

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/dependency/DependencyUtils.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -377,7 +378,8 @@ public class DependencyUtils {
                     ped.getDeploymentModule().getName(),
                     ped.getDeploymentModule().getVersion().toString());
         } else if (ped.getDeploymentModule() instanceof ProjectInternal) {
-            return handler.create(new DefaultProjectDependency((ProjectInternal) ped.getDeploymentModule(), true));
+            return handler.create(new DefaultProjectDependency((ProjectInternal) ped.getDeploymentModule(), true,
+                    DefaultTaskDependencyFactory.withNoAssociatedProject()));
         } else {
             return handler.create(handler.project(Collections.singletonMap("path", ped.getDeploymentModule().getPath())));
         }

--- a/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # https://gradle.org/release-checksums/
-distributionSha256Sum=7ebdac923867a3cec0098302416d1e3c6c0c729fc4e2e05c10637a8af33a76c5
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionSha256Sum=fba8464465835e74f7270bbf43d6d8a8d7709ab0a43ce1aa3323f73e9aa0c612
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -72,7 +72,7 @@
         <plexus-utils.version>3.5.1</plexus-utils.version>
         <smallrye-common.version>2.10.0</smallrye-common.version>
         <smallrye-beanbag.version>1.5.2</smallrye-beanbag.version>
-        <gradle-tooling.version>8.12</gradle-tooling.version>
+        <gradle-tooling.version>8.13</gradle-tooling.version>
         <quarkus-fs-util.version>0.0.10</quarkus-fs-util.version>
         <org-crac.version>0.1.3</org-crac.version>
     </properties>

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -447,7 +447,7 @@
         "recommended-java-version": "17",
         "proposed-maven-version": "3.9.9",
         "maven-wrapper-version": "3.3.2",
-        "gradle-wrapper-version": "8.12"
+        "gradle-wrapper-version": "8.13"
       }
     },
     "codestarts-artifacts": [

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -39,7 +39,7 @@
         <!-- These properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.9.9</proposed-maven-version>
         <maven-wrapper.version>3.3.2</maven-wrapper.version>
-        <gradle-wrapper.version>8.12</gradle-wrapper.version>
+        <gradle-wrapper.version>8.13</gradle-wrapper.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <compiler-plugin.version>3.13.0</compiler-plugin.version>

--- a/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # https://gradle.org/release-checksums/
-distributionSha256Sum=7ebdac923867a3cec0098302416d1e3c6c0c729fc4e2e05c10637a8af33a76c5
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionSha256Sum=fba8464465835e74f7270bbf43d6d8a8d7709ab0a43ce1aa3323f73e9aa0c612
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The constructor of `org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency` [used in `io.quarkus.gradle.tooling.dependency.DependencyUtils`](https://github.com/gradle/gradle/blob/0b1ee1ff81d1f4a26574ff4a362ac9180852b140/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java#L60-L62) has been removed in [Gradle 8.13](https://github.com/gradle/gradle/blob/073314332697ba45c16c0a0ce1891fa6794179ff/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java#L52-L56), which means that certain dependencies render the Quarkus Gradle plugin(s) incompatible w/ Gradle 8.13.

This change bumps Gradle to 8.13 and updates `DependencyUtils` to do the same as the (removed) constructor.