### PR TITLE
Use `quarkus-security-test-utils` and `quarkus-arc-test-supplement` dependencies within a test scope

### DIFF
--- a/extensions/arc/deployment/pom.xml
+++ b/extensions/arc/deployment/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-test-supplement</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- Used to test wrong @Singleton detection -->
         <dependency>

--- a/extensions/resteasy-classic/resteasy/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy/deployment/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-test-utils</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/extensions/security/deployment/pom.xml
+++ b/extensions/security/deployment/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-test-utils</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
I mentioned scope of these dependencies isn't what I expected when I analyzed Quarkus core dependencies that are not managed by Quarkus BOM. I expected they will have a test scope but nope.

- `quarkus-security-test-utils` here I am pretty sure that compile scope doesn't make sense because we don't expect other deployment modules of extensions will use this  internal tool; if they need it, they should include it explicitly
- `quarkus-arc-test-supplement` seems like purely test scope dependency, but there can be a reason why it must be in a compile scope I don't know about

