### PR TITLE
Avoid repeatedly creating same DotNames in ResteasyReactiveProcessor

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/DotNames.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/DotNames.java
@@ -13,6 +13,7 @@ import io.quarkus.arc.NoClassInterceptors;
 final class DotNames {
 
     static final String POPULATE_METHOD_NAME = "populate";
+    static final DotName CLASS_NAME = DotName.createSimple(Class.class.getName());
     static final DotName OBJECT_NAME = DotName.createSimple(Object.class.getName());
     static final DotName STRING_NAME = DotName.createSimple(String.class.getName());
     static final DotName BYTE_NAME = DotName.createSimple(byte.class.getName());

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -737,7 +737,7 @@ public class ResteasyReactiveProcessor {
                     if (type.kind() == Type.Kind.CLASS) {
                         return typeName;
                     } else if (type.kind() == Type.Kind.PARAMETERIZED_TYPE
-                            && typeName.equals(DotName.createSimple(Class.class))) {
+                            && DotNames.CLASS_NAME.equals(typeName)) {
                         // spec allows for Class<SubResource> to be returned that the container should instantiate
                         return type.asParameterizedType().arguments().get(0).name();
                     }
@@ -833,7 +833,7 @@ public class ResteasyReactiveProcessor {
                         }
 
                         Set<DotName> all = new HashSet<>();
-                        if (dotName.equals(DotName.createSimple(Object.class.getName()))) {
+                        if (DotNames.OBJECT_NAME.equals(dotName)) {
                             all.addAll(returnsBySubResources.keySet());
                             for (DotName name : returnsBySubResources.keySet()) {
                                 //we need to also look for all subclasses and interfaces


### PR DESCRIPTION
This is a follow-up of https://github.com/quarkusio/quarkus/pull/46464.

Given the purpose of the PR was to improve dev mode reload performance, I think it's worth avoiding the extra allocations.