### PR TITLE
Docs: Updated link to "MicroProfile Rest Client Spec"

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -2130,7 +2130,7 @@ To change this behavior, set the `quarkus.rest-client.scope` property to the ful
 
 == Further reading
 
- * link:https://download.eclipse.org/microprofile/microprofile-rest-client-2.0/microprofile-rest-client-spec-2.0.html[MicroProfile Rest Client specification]
+ * link:https://download.eclipse.org/microprofile/microprofile-rest-client-4.0/microprofile-rest-client-spec-4.0.html[MicroProfile Rest Client specification]
 
 == Configuration Reference
 


### PR DESCRIPTION
The link to the _REST Client for the MicroProfile Specification_ in the guide [Using the REST Client](https://quarkus.io/guides/rest-client#further-reading) did not point to the version currently used by Quarkus.