### PR TITLE
Remove a repeated check from the ServiceInitiatorsTest in the Hibernate Reactive extension

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/services/ServiceInitiatorsTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/services/ServiceInitiatorsTest.java
@@ -3,7 +3,6 @@ package io.quarkus.hibernate.reactive.services;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import org.hibernate.boot.registry.StandardServiceInitiator;
@@ -16,16 +15,10 @@ public class ServiceInitiatorsTest {
 
     private static final Map<String, String> HR_SERVICES = toServicesMap(ReactiveServiceInitiators.LIST);
     private static final Map<String, String> ORM_SERVICES = toServicesMap(StandardServiceInitiators.LIST);
-    private static final Map<String, String> QUARKUS_HR_SERVICES = toServicesMap(ReactiveServiceInitiators.LIST);
-
-    // These services are NOT provided by the Hibernate Reactive default initiators, and that should be fine:
-    private static final Set<String> HR_INTENTIONALLY_OMITTED = Set
-            .of("org.hibernate.engine.transaction.jta.platform.spi.JtaPlatformResolver");
 
     @Test
     public void serviceInitiatorsAreUnique() {
         Assertions.assertEquals(HR_SERVICES.size(), ReactiveServiceInitiators.LIST.size());
-        Assertions.assertEquals(ORM_SERVICES.size(), StandardServiceInitiators.LIST.size());
         Assertions.assertEquals(ORM_SERVICES.size(), StandardServiceInitiators.LIST.size());
     }
 


### PR DESCRIPTION
I stumbled upon this when looking at some other test in the module, and it felt like we've missed something here, and the test is incomplete... but I'm not as familiar with the HR extension ... so I'm not sure 😃 
(The `QUARKUS_HR_SERVICES`  map wasn't used, and currently, it's also the same as `HR_SERVICES`.)

@Sanne, maybe you have an idea, as it looks like you've authored the test initially? 🙈 