### PR TITLE
Add configuration options to configure limits for Multipart Payloads in Rest Clients

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -375,6 +375,19 @@ public interface RestClientsConfig {
          */
         @Deprecated
         OptionalInt maxChunkSize();
+
+        /**
+         * The threshold to use for the amount of data to store in memory for entities, up to {@code Long.MAX_VALUE}. See
+         * {@code dev.resteasy.entity.memory.threshold} in RESTEasy documentation.
+         */
+        Optional<MemorySize> memoryThreshold();
+
+        /**
+         * The threshold to use for the amount of data that can be stored in a file for entities. If the threshold is reached an
+         * IllegalStateException will be thrown. A value of -1 means no limit, up to {@code Long.MAX_VALUE}. See
+         * {@code dev.resteasy.entity.file.threshold	} in RESTEasy documentation.
+         */
+        Optional<MemorySize> fileThreshold();
     }
 
     interface RestClientConfig {

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
@@ -16,6 +16,7 @@ import io.quarkus.restclient.config.key.SharedOneConfigKeyRestClient;
 import io.quarkus.restclient.config.key.SharedThreeConfigKeyRestClient;
 import io.quarkus.restclient.config.key.SharedTwoConfigKeyRestClient;
 import io.quarkus.runtime.configuration.ConfigUtils;
+import io.quarkus.runtime.configuration.MemorySizeConverter;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
@@ -357,5 +358,9 @@ class RestClientConfigTest {
         assertThat(config.connectionPoolSize().getAsInt()).isEqualTo(10);
         assertTrue(config.maxChunkSize().isPresent());
         assertThat(config.maxChunkSize().get().asBigInteger()).isEqualTo(BigInteger.valueOf(1024));
+        assertThat(config.multipart().fileThreshold().get().asBigInteger())
+                .isEqualTo(new MemorySizeConverter().convert("5M").asBigInteger());
+        assertThat(config.multipart().memoryThreshold().get().asBigInteger())
+                .isEqualTo(new MemorySizeConverter().convert("10M").asBigInteger());
     }
 }

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/resources/application.properties
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/resources/application.properties
@@ -14,6 +14,8 @@ quarkus.rest-client."io.quarkus.restclient.config.FullNameRestClient".hostname-v
 quarkus.rest-client."io.quarkus.restclient.config.FullNameRestClient".connection-ttl=30000
 quarkus.rest-client."io.quarkus.restclient.config.FullNameRestClient".connection-pool-size=10
 quarkus.rest-client."io.quarkus.restclient.config.FullNameRestClient".max-chunk-size=1024
+quarkus.rest-client."io.quarkus.restclient.config.FullNameRestClient".multipart.file-threshold=5M
+quarkus.rest-client."io.quarkus.restclient.config.FullNameRestClient".multipart.memory-threshold=10M
 
 quarkus.rest-client.key.removes-trailing-slash=false
 quarkus.rest-client.key.url=http://localhost:8080
@@ -29,6 +31,8 @@ quarkus.rest-client.key.hostname-verifier=io.quarkus.restclient.configuration.My
 quarkus.rest-client.key.connection-ttl=30000
 quarkus.rest-client.key.connection-pool-size=10
 quarkus.rest-client.key.max-chunk-size=1024
+quarkus.rest-client.key.multipart.file-threshold=5M
+quarkus.rest-client.key.multipart.memory-threshold=10M
 
 quarkus.rest-client."io.quarkus.restclient.config.MPRestClient".url=http://localhost:8080
 io.quarkus.restclient.config.MPRestClient/mp-rest/url=http://localhost:8081

--- a/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/GlobalConfigurationTest.java
+++ b/extensions/resteasy-classic/resteasy-client/deployment/src/test/java/io/quarkus/restclient/configuration/GlobalConfigurationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.restclient.config.RestClientsConfig;
+import io.quarkus.runtime.configuration.MemorySizeConverter;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class GlobalConfigurationTest {
@@ -78,5 +79,9 @@ public class GlobalConfigurationTest {
         assertThat(configRoot.keyStore().get()).isEqualTo("/path");
         assertThat(configRoot.keyStorePassword().get()).isEqualTo("password");
         assertThat(configRoot.keyStoreType().get()).isEqualTo("JKS");
+        assertThat(configRoot.multipart().fileThreshold().get().asBigInteger())
+                .isEqualTo(new MemorySizeConverter().convert("5M").asBigInteger());
+        assertThat(configRoot.multipart().memoryThreshold().get().asBigInteger())
+                .isEqualTo(new MemorySizeConverter().convert("10M").asBigInteger());
     }
 }

--- a/extensions/resteasy-classic/resteasy-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
+++ b/extensions/resteasy-classic/resteasy-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
@@ -29,6 +29,7 @@ import io.quarkus.arc.InstanceHandle;
 import io.quarkus.restclient.NoopHostnameVerifier;
 import io.quarkus.restclient.config.RestClientsConfig;
 import io.quarkus.restclient.config.RestClientsConfig.RestClientConfig;
+import io.quarkus.runtime.configuration.MemorySize;
 import io.smallrye.config.SmallRyeConfig;
 
 public class RestClientBase {
@@ -92,6 +93,20 @@ public class RestClientBase {
         if (connectionTTL.isPresent()) {
             builder.property("resteasy.connectionTTL",
                     Arrays.asList(connectionTTL.getAsInt(), TimeUnit.MILLISECONDS));
+        }
+
+        Optional<MemorySize> fileThreshold = oneOf(restClientConfig.multipart().fileThreshold(),
+                configRoot.multipart().fileThreshold());
+        if (fileThreshold.isPresent()) {
+            builder.property("dev.resteasy.entity.file.threshold",
+                    fileThreshold.get().asLongValue());
+        }
+
+        Optional<MemorySize> memoryThreshold = oneOf(restClientConfig.multipart().memoryThreshold(),
+                configRoot.multipart().memoryThreshold());
+        if (memoryThreshold.isPresent()) {
+            builder.property("dev.resteasy.entity.memory.threshold",
+                    memoryThreshold.get().asLongValue());
         }
     }
 

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.arc.Arc;
 import io.quarkus.rest.client.reactive.configuration.EchoResource;
 import io.quarkus.restclient.config.RestClientsConfig;
+import io.quarkus.runtime.configuration.MemorySizeConverter;
 import io.quarkus.test.QuarkusUnitTest;
 
 class ConfigurationTest {
@@ -91,6 +92,10 @@ class ConfigurationTest {
         assertThat(clientConfig.followRedirects().get()).isEqualTo(true);
         assertTrue(clientConfig.queryParamStyle().isPresent());
         assertThat(clientConfig.queryParamStyle().get()).isEqualTo(QueryParamStyle.COMMA_SEPARATED);
+        assertThat(clientConfig.multipart().fileThreshold().get().asBigInteger())
+                .isEqualTo(new MemorySizeConverter().convert("5M").asBigInteger());
+        assertThat(clientConfig.multipart().memoryThreshold().get().asBigInteger())
+                .isEqualTo(new MemorySizeConverter().convert("10M").asBigInteger());
 
         if (checkExtraProperties) {
             assertTrue(clientConfig.connectionTTL().isPresent());

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/GlobalConfigurationTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/GlobalConfigurationTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.arc.Arc;
 import io.quarkus.rest.client.reactive.configuration.EchoResource;
 import io.quarkus.restclient.config.RestClientsConfig;
+import io.quarkus.runtime.configuration.MemorySizeConverter;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class GlobalConfigurationTest {
@@ -77,5 +78,9 @@ public class GlobalConfigurationTest {
         assertThat(configRoot.keyStore().get()).isEqualTo("/path");
         assertThat(configRoot.keyStorePassword().get()).isEqualTo("password");
         assertThat(configRoot.keyStoreType().get()).isEqualTo("JKS");
+        assertThat(configRoot.multipart().fileThreshold().get().asBigInteger())
+                .isEqualTo(new MemorySizeConverter().convert("5M").asBigInteger());
+        assertThat(configRoot.multipart().memoryThreshold().get().asBigInteger())
+                .isEqualTo(new MemorySizeConverter().convert("10M").asBigInteger());
     }
 }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -50,6 +50,7 @@ import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.rest.client.reactive.runtime.ProxyAddressUtil.HostAndPort;
 import io.quarkus.restclient.config.RestClientsConfig;
+import io.quarkus.runtime.configuration.MemorySize;
 import io.quarkus.tls.TlsConfiguration;
 import io.smallrye.config.SmallRyeConfig;
 import io.vertx.core.net.KeyCertOptions;
@@ -537,6 +538,24 @@ public class RestClientBuilderImpl implements RestClientBuilder {
             clientBuilder.maxChunkSize(restClients.multipart().maxChunkSize().getAsInt());
         } else {
             clientBuilder.maxChunkSize(DEFAULT_MAX_CHUNK_SIZE);
+        }
+
+        MemorySize fileThreshold = (MemorySize) getConfiguration()
+                .getProperty(QuarkusRestClientProperties.MULTIPART_FILE_THRESHOLD);
+        if (fileThreshold != null) {
+            property("dev.resteasy.entity.file.threshold", fileThreshold.asLongValue());
+        } else if (restClients.multipart().fileThreshold().isPresent()) {
+            property("dev.resteasy.entity.file.threshold",
+                    restClients.multipart().fileThreshold().get().asLongValue());
+        }
+
+        MemorySize memoryThreshold = (MemorySize) getConfiguration()
+                .getProperty(QuarkusRestClientProperties.MULTIPART_MEMORY_THRESHOLD);
+        if (memoryThreshold != null) {
+            property("dev.resteasy.entity.memory.threshold", memoryThreshold.asLongValue());
+        } else if (restClients.multipart().memoryThreshold().isPresent()) {
+            property("dev.resteasy.entity.memory.threshold",
+                    restClients.multipart().memoryThreshold().get().asLongValue());
         }
 
         if (getConfiguration().hasProperty(QuarkusRestClientProperties.HTTP2)) {

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -148,6 +148,20 @@ public class RestClientCDIDelegateBuilder<T> {
                         : Optional.empty());
         builder.property(QuarkusRestClientProperties.MAX_CHUNK_SIZE, maxChunkSize.orElse(DEFAULT_MAX_CHUNK_SIZE));
 
+        Optional<MemorySize> fileThreshold = oneOf(restClientConfig.multipart().fileThreshold(),
+                configRoot.multipart().fileThreshold());
+        if (fileThreshold.isPresent()) {
+            builder.property("dev.resteasy.entity.file.threshold",
+                    fileThreshold.get().asLongValue());
+        }
+
+        Optional<MemorySize> memoryThreshold = oneOf(restClientConfig.multipart().memoryThreshold(),
+                configRoot.multipart().memoryThreshold());
+        if (memoryThreshold.isPresent()) {
+            builder.property("dev.resteasy.entity.memory.threshold",
+                    memoryThreshold.get().asLongValue());
+        }
+
         Optional<Boolean> enableCompressions = oneOf(restClientConfig.enableCompression(), configRoot.enableCompression());
         if (enableCompressions.isPresent()) {
             builder.enableCompression(enableCompressions.get());

--- a/extensions/resteasy-reactive/rest-client/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
@@ -45,6 +45,7 @@ import io.quarkus.restclient.config.AbstractRestClientConfigBuilder;
 import io.quarkus.restclient.config.RegisteredRestClient;
 import io.quarkus.restclient.config.RestClientsConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
+import io.quarkus.runtime.configuration.MemorySizeConverter;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
 
@@ -145,6 +146,10 @@ class RestClientCDIDelegateBuilderTest {
         verify(restClientBuilderMock).property(KEEP_ALIVE_ENABLED, false);
         verify(restClientBuilderMock).property(MAX_REDIRECTS, 104);
         verify(restClientBuilderMock).property(MAX_CHUNK_SIZE, 1024);
+        verify(restClientBuilderMock).property("dev.resteasy.entity.file.threshold",
+                new MemorySizeConverter().convert("50M").asLongValue());
+        verify(restClientBuilderMock).property("dev.resteasy.entity.memory.threshold",
+                new MemorySizeConverter().convert("100M").asLongValue());
         verify(restClientBuilderMock).followRedirects(true);
         verify(restClientBuilderMock).register(MyResponseFilter1.class);
         verify(restClientBuilderMock).queryParamStyle(COMMA_SEPARATED);
@@ -200,6 +205,10 @@ class RestClientCDIDelegateBuilderTest {
         verify(restClientBuilderMock).property(KEEP_ALIVE_ENABLED, true);
         verify(restClientBuilderMock).property(MAX_REDIRECTS, 204);
         verify(restClientBuilderMock).property(MAX_CHUNK_SIZE, 1024);
+        verify(restClientBuilderMock).property("dev.resteasy.entity.file.threshold",
+                new MemorySizeConverter().convert("5M").asLongValue());
+        verify(restClientBuilderMock).property("dev.resteasy.entity.memory.threshold",
+                new MemorySizeConverter().convert("10M").asLongValue());
         verify(restClientBuilderMock).followRedirects(true);
         verify(restClientBuilderMock).register(MyResponseFilter2.class);
         verify(restClientBuilderMock).queryParamStyle(MULTI_PAIRS);
@@ -228,6 +237,8 @@ class RestClientCDIDelegateBuilderTest {
         rootConfig.put("quarkus.rest-client.keep-alive-enabled", "true");
         rootConfig.put("quarkus.rest-client.max-redirects", "204");
         rootConfig.put("quarkus.rest-client.multipart-max-chunk-size", "1024");
+        rootConfig.put("quarkus.rest-client.multipart.file-threshold", "5M");
+        rootConfig.put("quarkus.rest-client.multipart.memory-threshold", "10M");
         rootConfig.put("quarkus.rest-client.follow-redirects", "true");
         rootConfig.put("quarkus.rest-client.max-chunk-size", "1024");
         rootConfig.put("quarkus.rest-client.providers",
@@ -265,6 +276,8 @@ class RestClientCDIDelegateBuilderTest {
         clientConfig.put("quarkus.rest-client." + restClientName + ".max-redirects", "104");
         clientConfig.put("quarkus.rest-client." + restClientName + ".follow-redirects", "true");
         clientConfig.put("quarkus.rest-client." + restClientName + ".max-chunk-size", "1024");
+        clientConfig.put("quarkus.rest-client." + restClientName + ".multipart.file-threshold", "50M");
+        clientConfig.put("quarkus.rest-client." + restClientName + ".multipart.memory-threshold", "100M");
         clientConfig.put("quarkus.rest-client." + restClientName + ".providers",
                 "io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyResponseFilter1");
         clientConfig.put("quarkus.rest-client." + restClientName + ".query-param-style", "comma-separated");

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
@@ -10,6 +10,15 @@ public class QuarkusRestClientProperties {
     public static final String MAX_CHUNK_SIZE = "io.quarkus.rest.client.max-chunk-size";
 
     /**
+     * Configure the threshold to use for the amount of data to store in memory for entities.
+     */
+    public static final String MULTIPART_FILE_THRESHOLD = "io.quarkus.rest.client.multipart.file-threshold";
+    /**
+     * Configure the threshold to use for the amount of data that can be stored in a file for entities.
+     */
+    public static final String MULTIPART_MEMORY_THRESHOLD = "io.quarkus.rest.client.multipart.memory-threshold";
+
+    /**
      * Configure the connect timeout in ms.
      */
     public static final String CONNECT_TIMEOUT = "io.quarkus.rest.client.connect-timeout";

--- a/integration-tests/rest-client-reactive-multipart/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive-multipart/src/main/resources/application.properties
@@ -2,5 +2,7 @@ multipart-client/mp-rest/url=${test.url}
 multipart-chunks-client/mp-rest/url=${test.url}
 
 quarkus.rest-client.multipart-chunks-client.max-chunk-size=1000
+quarkus.rest-client.multipart-chunks-client.multipart.file-threshold=5M
+quarkus.rest-client.multipart-chunks-client.multipart.memory-threshold=10M
 
 quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true


### PR DESCRIPTION
The [RESTEasy Documentation](https://docs.resteasy.dev/6.2/userguide/#_entity_part) states that the limits for the content of `jakarta.ws.rs.core.EntityPart` in Multipart requests can be configured using the configuration properties `dev.resteasy.entity.memory.threshold` (defaulting to 5 MB) and `dev.resteasy.entity.file.threshold` (defaulting to 50 MB) and that it is possible to define these properties as system properties, servlet context properties or a MicroProfile Config compatible value.

This PR introduces two new properties to `io.quarkus.restclient.config.RestClientsConfig.RestClientMultipartConfig`, allowing the user to specify these two limits as `io.quarkus.runtime.configuration.MemorySize` values via the Quarkus configuration, e.g.:

```properties
quarkus.rest-client.multipart.file-threshold=10M
quarkus.rest-client.multipart.memory-threshold=100M

quarkus.rest-client.foo.multipart.file-threshold=25M
quarkus.rest-client.foo.multipart.memory-threshold=250M

quarkus.rest-client.bar.multipart.file-threshold=50M
quarkus.rest-client.bar.multipart.memory-threshold=500M
```