### PR TITLE
Remove quarkus-mutiny dependency from container-image extensions

### DIFF
--- a/extensions/container-image/deployment/pom.xml
+++ b/extensions/container-image/deployment/pom.xml
@@ -19,10 +19,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-mutiny-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-container-image-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/container-image/deployment/src/main/resources/dev-ui/qwc-container-image-build.js
+++ b/extensions/container-image/deployment/src/main/resources/dev-ui/qwc-container-image-build.js
@@ -121,13 +121,9 @@ export class QwcContainerImageBuild extends LitElement {
         this.build_error = false;
         this.result = "";
         this.jsonRpc.build({'type': this.selected_type, 'builder': this.selected_builder})
-            .onNext(jsonRpcResponse => {
+            .then(jsonRpcResponse => {
                 const msg = jsonRpcResponse.result;
-                if (msg === "started") {
-                    this.build_complete = false;
-                    this.build_in_progress = true;
-                    this.build_error = false;
-                } else if (msg.includes("created.")) {
+                if (msg.includes("created.")) {
                     this.result = msg;
                     this.build_complete = true;
                     this.build_in_progress = false;

--- a/extensions/container-image/runtime/pom.xml
+++ b/extensions/container-image/runtime/pom.xml
@@ -25,10 +25,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-mutiny</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/container-image/runtime/src/main/java/io/quarkus/container/image/runtime/devui/ContainerBuilderJsonRpcService.java
+++ b/extensions/container-image/runtime/src/main/java/io/quarkus/container/image/runtime/devui/ContainerBuilderJsonRpcService.java
@@ -3,27 +3,15 @@ package io.quarkus.container.image.runtime.devui;
 import java.util.Map;
 
 import io.quarkus.dev.console.DevConsoleManager;
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 public class ContainerBuilderJsonRpcService {
 
-    public Multi<String> build(String type, String builder) {
+    public String build(String type, String builder) {
         Map<String, String> params = Map.of(
                 "quarkus.container-image.builder", builder,
                 "quarkus.build.package-type", type);
 
-        // For now, the JSON RPC are called on the event loop, but the action is blocking,
-        // So, work around this by invoking the action on a worker thread.
-        Multi<String> build = Uni.createFrom().item(() -> DevConsoleManager
-                .<String> invoke("container-image-build-action", params))
-                .runSubscriptionOn(Infrastructure.getDefaultExecutor()) // It's a blocking action.
-                .toMulti();
-
-        return Multi.createBy().concatenating()
-                .streams(Multi.createFrom().item("started"), build);
-
+        return DevConsoleManager.invoke("container-image-build-action", params);
     }
 
 }

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/pom.xml
@@ -31,6 +31,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
DevUI JsonRPC services are called on worker threads if the signature is blocking.

Removes the unnecessary dependency. `quarkus-mutiny` pulls the context-propagation extensions when adding container-image extensions.

@phillip-kruger I can't open the new Dev UI (even without this change), I don't know if it is related to #46527
