### PR TITLE
DevUI: fix bean/build steps depenceny graphs

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevModeApiProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevModeApiProcessor.java
@@ -124,10 +124,12 @@ public class ArcDevModeApiProcessor {
             for (InjectionPointInfo injectionPoint : bean.getAllInjectionPoints()) {
                 BeanInfo resolved = injectionPoint.getResolvedBean();
                 if (resolved != null && !resolved.equals(bean)) {
-                    links.add(Link.dependency(bean.getIdentifier(), resolved.getIdentifier(), level));
+                    Link link = Link.dependency(bean.getIdentifier(), resolved.getIdentifier(), level);
+                    links.add(link);
                     // add transient dependencies
                     addNodesDependencies(level + 1, root, nodes, links, injectionPoint.getResolvedBean(), devBeanInfos);
                 }
+                // TODO built-in beans are skipped for now
             }
         }
     }
@@ -162,7 +164,7 @@ public class ArcDevModeApiProcessor {
             if (ip.getResolvedBean() == null) {
                 link = Link.lookup(dependent.getIdentifier(), bean.getIdentifier(), level);
             } else {
-                link = Link.dependent(dependent.getIdentifier(), bean.getIdentifier(), level);
+                link = Link.dependency(dependent.getIdentifier(), bean.getIdentifier(), level);
             }
             links.add(link);
             if (nodes.add(devBeanInfos.getBean(dependent.getIdentifier()))) {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/Link.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/Link.java
@@ -3,16 +3,17 @@ package io.quarkus.arc.deployment.devui;
 import java.util.Objects;
 
 public class Link {
-    static Link dependent(String source, String target, int level) {
-        return new Link(source, target, level == 0 ? "directDependent" : "dependency", level);
-    }
 
     static Link dependency(String source, String target, int level) {
-        return new Link(source, target, level == 0 ? "directDependency" : "dependency", level);
+        return new Link(source, target, "dependency", level);
     }
 
     static Link lookup(String source, String target, int level) {
         return new Link(source, target, "lookup", level);
+    }
+
+    static Link builtin(String source, String target, int level) {
+        return new Link(source, target, "builtin", level);
     }
 
     static Link producer(String source, String target, int level) {

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/echarts/echarts-force-graph.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/echarts/echarts-force-graph.js
@@ -8,6 +8,7 @@ class EchartsForceGraph extends EchartsAbstractCanvas {
     static get properties() {
         return {
             edgeLength: {type: Number},
+            repulsion: {type: Number},
             nodes: {type: String},
             links: {type: String},
             colors: {type: String},
@@ -21,6 +22,7 @@ class EchartsForceGraph extends EchartsAbstractCanvas {
     constructor() {
         super();
         this.edgeLength = 60;
+        this.repulsion = 300;
         this.nodes = null;
         this.links = null;
         this.colors = null;
@@ -69,7 +71,8 @@ class EchartsForceGraph extends EchartsAbstractCanvas {
         serie.type = 'graph';
         serie.layout = 'force';
         serie.animation = true;
-        serie.edgeSymbol = ['arrow', ''];
+        // source -> target
+        serie.edgeSymbol = ['', 'arrow'];
         serie.label = new Object();
         serie.label.position = 'right';
         serie.label.show = true;
@@ -85,11 +88,12 @@ class EchartsForceGraph extends EchartsAbstractCanvas {
         
         serie.force = new Object();
         serie.force.edgeLength = this.edgeLength;
-        serie.force.repulsion = 300;
+        serie.force.repulsion = this.repulsion;
         
         serie.edges = JSON.parse(this.links);
 
         serie.lineStyle = new Object();
+        // Use the color of the "source" by default
         serie.lineStyle.color = 'source';
         serie.lineStyle.curveness = 0.3;
         


### PR DESCRIPTION
- also simplify bean dependency graph and remove the direct dependency/dependent category

It seems that these graphs were broken in the new Dev UI from the beginning but no one complained so it's probably not frequently used :shrug:.