### PR TITLE
Qute: fix namespace build-time validation

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -1386,12 +1386,8 @@ public class QuteProcessor {
                         ignoring = true;
                     }
                 } else {
-                    // No global and no namespace extension method found - incorrect expression
-                    incorrectExpressions.produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),
-                            String.format("No matching namespace [%s] extension method found", namespace.namespace),
-                            expression.getOrigin()));
+                    // No global and no namespace extension method found - just ignore the expression
                     match.clearValues();
-                    putResult(match, results, expression);
                     ignoring = true;
                 }
             }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/NamespaceTemplateExtensionValidationFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/NamespaceTemplateExtensionValidationFailureTest.java
@@ -33,8 +33,7 @@ public class NamespaceTemplateExtensionValidationFailureTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found incorrect expressions (2)"), te.getMessage());
-                assertTrue(te.getMessage().contains("No matching namespace [bro] extension method found"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (1)"), te.getMessage());
                 assertTrue(te.getMessage().contains("Property/method [bubu] not found on class [java.lang.String]"),
                         te.getMessage());
             });

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/StringTemplateExtensionsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/StringTemplateExtensionsTest.java
@@ -7,20 +7,27 @@ import java.util.Locale;
 
 import jakarta.inject.Inject;
 
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.qute.Engine;
+import io.quarkus.qute.Template;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class StringTemplateExtensionsTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withEmptyApplication();
+            .withApplicationRoot(root -> root.addAsResource(
+                    new StringAsset("{str:eval('Hello {name}!')}"),
+                    "templates/hello.txt"));
 
     @Inject
     Engine engine;
+
+    @Inject
+    Template hello;
 
     @Test
     public void testTemplateExtensions() {
@@ -82,6 +89,9 @@ public class StringTemplateExtensionsTest {
         assertEquals("Hello fool!",
                 engine.parse("{str:eval('Hello {name}!')}")
                         .data("name", "fool")
+                        .render());
+        assertEquals("Hello fool!",
+                hello.data("name", "fool")
                         .render());
     }
 


### PR DESCRIPTION
- when a matching template extension method exists
- this is a follow-up of #46258