### PR TITLE
ArC: consider built-in session context during client proxy optimization

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -591,6 +591,7 @@ public class BeanProcessor {
         Map<DotName, Integer> contextsForScope = new HashMap<>();
         // built-in contexts
         contextsForScope.put(BuiltinScope.REQUEST.getName(), 1);
+        contextsForScope.put(BuiltinScope.SESSION.getName(), 1);
         // custom contexts
         for (Map.Entry<ScopeInfo, List<Function<MethodCreator, ResultHandle>>> entry : beanDeployment
                 .getCustomContexts()

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Contexts.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Contexts.java
@@ -176,6 +176,10 @@ class Contexts {
                 // If a custom request context is registered then add the built-in context as well
                 putContext(requestContext);
             }
+            if (contexts.containsKey(SessionScoped.class)) {
+                // If a custom session context is registered then add the built-in context as well
+                putContext(sessionContext);
+            }
             return new Contexts(requestContext, sessionContext, applicationContext, singletonContext, dependentContext,
                     contexts);
         }


### PR DESCRIPTION
- the problem occurs when quarkus-websockets-next and quarkus-undertow extensions are used at the same time
- fixes #46548