### PR TITLE
Various bits of formatting and trivial tidying

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -248,7 +248,7 @@
                 <scope>import</scope>
             </dependency>
 
-             <!-- Dev UI -->
+            <!-- Dev UI -->
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bom-dev-ui</artifactId>

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -356,7 +356,7 @@ public class StartupActionImpl implements StartupAction {
     }
 
     @Override
-    public ClassLoader getClassLoader() {
+    public QuarkusClassLoader getClassLoader() {
         return runtimeClassLoader;
     }
 

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -2,8 +2,6 @@ package io.quarkus.kubernetes.client.deployment;
 
 import static com.dajudge.kindcontainer.KubernetesVersionEnum.latest;
 import static io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig.Flavor.api_only;
-import static io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig.Flavor.k3s;
-import static io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig.Flavor.kind;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -1,5 +1,7 @@
 package io.quarkus.bootstrap.app;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+
 import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -13,7 +15,7 @@ public interface StartupAction {
 
     RunningQuarkusApplication run(String... args) throws Exception;
 
-    ClassLoader getClassLoader();
+    QuarkusClassLoader getClassLoader();
 
     Map<String, String> getDevServicesProperties();
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -1,10 +1,10 @@
 package io.quarkus.bootstrap.app;
 
-import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
-
 import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Consumer;
+
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 
 public interface StartupAction {
 

--- a/integration-tests/flyway/pom.xml
+++ b/integration-tests/flyway/pom.xml
@@ -25,12 +25,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm</artifactId>
         </dependency>
-         <dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
-       
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-postgresql</artifactId>
@@ -150,6 +150,5 @@
             </plugin>
         </plugins>
     </build>
-
 
 </project>

--- a/integration-tests/oidc/pom.xml
+++ b/integration-tests/oidc/pom.xml
@@ -138,32 +138,32 @@
                 </executions>
             </plugin>
             <plugin>
-	        <groupId>io.smallrye.certs</groupId>
-	        <artifactId>smallrye-certificate-generator-maven-plugin</artifactId>
-	        <executions>
-		    <execution>
-		        <phase>generate-test-resources</phase>
-		        <goals>
-		            <goal>generate</goal>
-		        </goals>
-		    </execution>
-	        </executions>
-	        <configuration>
-		    <certificates>
-		        <certificate>
-		            <name>oidc</name> <!-- the name of the certificate -->
-		            <formats>  <!-- List of formats to generate, are supported PEM, JKS and PKCS12 -->
-		                <format>PEM</format>
-		                <format>PKCS12</format>
-		            </formats>
-		            <password>password</password> <!-- Password for the key store if supported -->
-		            <cn>backend-service</cn> <!-- Common Name -->
-		            <duration>2</duration> <!-- in days -->
-		            <client>true</client> <!-- Generate a client certificate -->
-		        </certificate>
-		    </certificates>
-	        </configuration>
-	    </plugin>
+                <groupId>io.smallrye.certs</groupId>
+                <artifactId>smallrye-certificate-generator-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <certificates>
+                        <certificate>
+                            <name>oidc</name> <!-- the name of the certificate -->
+                            <formats>  <!-- List of formats to generate, are supported PEM, JKS and PKCS12 -->
+                                <format>PEM</format>
+                                <format>PKCS12</format>
+                            </formats>
+                            <password>password</password> <!-- Password for the key store if supported -->
+                            <cn>backend-service</cn> <!-- Common Name -->
+                            <duration>2</duration> <!-- in days -->
+                            <client>true</client> <!-- Generate a client certificate -->
+                        </certificate>
+                    </certificates>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
In my test classloading branch, I have a bunch of trivial little changes that I don't want to delete, because they're good, but they're not related to classloading. Moving them to their own trivial PR to make The Big One easier to review. 

I have 

- Corrected the formatting of some poms
- Removed unsed imports in a class 
- Been a bit more specific about return types in `StartupApplication`. This one _is_ related to classloading, but it's so innocuous it can go in on its own.