### PR TITLE
Fix docker templates and platform to support ubi8 and ubi9

### DIFF
--- a/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
+++ b/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
@@ -91,7 +91,6 @@
       "name": "Artificial Intelligence (AI)",
       "id": "ai",
       "description": "Help making Artificial Intgelligence (AI)-infused applications using Large Language Models and more"
-      
     },
     {
       "name": "Cloud",
@@ -146,6 +145,12 @@
   "metadata":{
     "project": {
       "default-codestart": "rest",
+      "codestart-data": {
+        "dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.21",
+        "dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.21",
+        "dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.5",
+        "dockerfile.native-micro": "quay.io/quarkus/ubi9-quarkus-micro-image:2.0"
+      },
       "properties": {
         "doc-root": "https://quarkus.io",
         "rest-assured-version": "${rest-assured.version}",

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -78,10 +78,12 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-{#if dockerfile.jvm.from}
+{#if dockerfile.jvm.from-template}
+FROM {#eval dockerfile.jvm.from-template /}
+{#else if dockerfile.jvm.from}
 FROM {dockerfile.jvm.from}
 {#else}
-FROM registry.access.redhat.com/ubi9/openjdk-{java.version}:1.21
+FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.21
 {/if}
 
 ENV LANGUAGE='en_US:en'

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
@@ -5,6 +5,6 @@ language:
     data:
       dockerfile:
         native:
-          from: registry.access.redhat.com/ubi9/ubi-minimal:9.5
+          from: registry.access.redhat.com/ubi8/ubi-minimal:8.10
         native-micro:
-          from: quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+          from: quay.io/quarkus/quarkus-micro-image:2.0

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -428,6 +428,12 @@
   "metadata": {
     "project": {
       "default-codestart": "resteasy-reactive",
+      "codestart-data": {
+        "dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.21",
+        "dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.21",
+        "dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.5",
+        "dockerfile.native-micro": "quay.io/quarkus/ubi9-quarkus-micro-image:2.0"
+      },
       "properties": {
         "doc-root": "https://quarkus.io",
         "rest-assured-version": "4.3.2",

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -319,24 +319,24 @@ class QuarkusCodestartGenerationTest {
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.jvm")).exists()
                 .satisfies(checkContains("./mvnw package"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.jvm"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi9/openjdk-17:"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.legacy-jar")).exists()
                 .satisfies(checkContains("./mvnw package -Dquarkus.package.jar.type=legacy-jar"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.legacy-jar"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi9/openjdk-17:"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
                 .satisfies(checkContains("EXPOSE 8080"))
                 .satisfies(checkContains("USER 185"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native-micro")).exists()
                 .satisfies(checkContains("./mvnw package -Dnative"))
-                .satisfies(checkContains("quay.io/quarkus/ubi9-quarkus-micro-image"))
+                .satisfies(checkContains("quay.io/quarkus/quarkus-micro-image"))
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native")).exists()
                 .satisfies(checkContains("./mvnw package -Dnative"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi9/ubi-minimal"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi8/ubi-minimal"))
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
     }
 
@@ -345,24 +345,24 @@ class QuarkusCodestartGenerationTest {
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.jvm")).exists()
                 .satisfies(checkContains("./gradlew build"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.jvm"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi9/openjdk-17:"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.legacy-jar")).exists()
                 .satisfies(checkContains("./gradlew build -Dquarkus.package.jar.type=legacy-jar"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.legacy-jar"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi9/openjdk-17:"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
                 .satisfies(checkContains("EXPOSE 8080"))
                 .satisfies(checkContains("USER 185"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native-micro")).exists()
                 .satisfies(checkContains("./gradlew build -Dquarkus.native.enabled=true"))
-                .satisfies(checkContains("quay.io/quarkus/ubi9-quarkus-micro-image:2.0"))
+                .satisfies(checkContains("quay.io/quarkus/quarkus-micro-image:2.0"))
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native")).exists()
                 .satisfies(checkContains("./gradlew build -Dquarkus.native.enabled=true"))
-                .satisfies(checkContains("registry.access.redhat.com/ubi9/ubi-minimal"))
+                .satisfies(checkContains("registry.access.redhat.com/ubi8/ubi-minimal"))
                 .satisfies(checkContains("ENTRYPOINT [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
     }
 


### PR DESCRIPTION
Supersed #46538 

### Current Challenges

| CLI Version | Target Version | Base Image | Builder Image | Status |
|------------|---------------|------------|---------------|--------|
| Old CLI (<3.19) | <3.19 | UBI8 | UBI8 | ✅ OK |
| Old CLI (<3.19) | 3.19+ | UBI8 | UBI9 | ❌ BAD (incompatible) |
| New CLI (3.19+) | <3.19 | UBI9 | UBI8 | ✅ OK (support issue) |
| New CLI (3.19+) | 3.19+ | UBI9 | UBI9 | ✅ OK |

### Solution
- Set `platform.codestart.metadata.dockerfile.from.XX` to UBI9.
- Keep UBI8 as the default in the template.
- Modify the template to introduce a new eval-based variable (only available in 3.19+).

### New Behavior

| CLI Version | Target Version | Base Image | Builder Image | Status |
|------------|---------------|------------|---------------|--------|
| Old CLI (<3.19) | <3.19 | UBI8 | UBI8 | ✅ OK |
| Old CLI (<3.19) | 3.19+ | UBI8 | UBI9 | ✅ ~OK (java version is not dynamic) |
| New CLI (3.19+) | <3.19 | UBI8 | UBI8 | ✅ OK |
| New CLI (3.19.2+) | 3.19.2+ | UBI9 | UBI9 | ✅ OK |
| Old CLI | 3.19.1 | ❌ | ❌ | ❌ Broken |
