### PR TITLE
Fix compatibility issue introduced by new OS detection extension

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -16,7 +16,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!-- Maven plugin versions -->
+        <!-- OS detection, compatibility layer for Netty dependencies -->
+        <os.detected.classifier>${nisse.os.classifier}</os.detected.classifier>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <compiler-plugin.version>${version.compiler.plugin}</compiler-plugin.version>


### PR DESCRIPTION
The new extension is using other properties and it causes issues when trying to download the Netty dependencies with the go-offline plugin.

```
2025-02-28T16:34:13.2182940Z Caused by: org.apache.maven.plugin.MojoExecutionException: org.eclipse.aether.resolution.DependencyResolutionException: The following artifacts could not be resolved: io.netty:netty-tcnative:jar:${os.detected.classifier}:2.0.70.Final (absent): Could not find artifact io.netty:netty-tcnative:jar:${os.detected.classifier}:2.0.70.Final in google-maven-central (https://maven-central.storage-download.googleapis.com/maven2/)
```

Follow-up of https://github.com/quarkusio/quarkus/pull/46513 .