### PR TITLE
Fix quotes and missing parentheses in `security-testing.adoc`

### DIFF
--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -101,8 +101,10 @@ Additionally, you can specify attributes for the identity, perhaps custom items 
 SecurityIdentity identity;
 
 @Test
-@TestSecurity(user = "testUser", "roles = {"admin, "user"}, attributes = {
-            @SecurityAttribute(key = "answer", value = "42", type = AttributeType.LONG) }
+@TestSecurity(
+    user = "testUser",
+    roles = {"admin", "user"},
+    attributes = { @SecurityAttribute(key = "answer", value = "42", type = AttributeType.LONG) })
 void someTestMethod() {
     Long answer = identity.<Long>getAttribute("answer");
 ...


### PR DESCRIPTION
I also put some parameters on new lines so it's easier to read.