### PR TITLE
Workaround classloading issue in Quarkus internal tests by making `io.quarkus.security.test.utils.AuthData#applyAugmentors` public

### DIFF
--- a/extensions/security/test-utils/src/main/java/io/quarkus/security/test/utils/AuthData.java
+++ b/extensions/security/test-utils/src/main/java/io/quarkus/security/test/utils/AuthData.java
@@ -13,7 +13,7 @@ public class AuthData {
     public final boolean anonymous;
     public final String name;
     public final Set<Permission> permissions;
-    final boolean applyAugmentors;
+    public final boolean applyAugmentors;
 
     public AuthData(Set<String> roles, boolean anonymous, String name) {
         this.roles = roles;


### PR DESCRIPTION
I wrote plugin that allows me to run all the tests in this project (both in extension deployment modules and IT modules) against delivered Quarkus artifacts placed in local Maven repository (like if I download RHBQ Maven repo zip and unwrap it) and tests that use `quarkus-security-test-utils` fails over some classloader issue even though Quarkus artifact versions seem to match, for example:

```
[ERROR]   CDIAccessDenyUnannotatedTest.shouldAllowClassLevelPermitAll:97 » IllegalAccess class io.quarkus.security.test.utils.IdentityMock tried to access field io.quarkus.security.test.utils.AuthData.applyAugmentors (io.quarkus.security.test.utils.IdentityMock is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @25291901; io.quarkus.security.test.utils.AuthData is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @7aa5292d)
```

No idea why, the only difference is that sources are not built locally, but instead artifacts are used from local repository. And also I made all dependencies a test scope ones (in extension modules). Now, `io.quarkus.security.test.utils.AuthData#applyAugmentors` field is only non-public field in the class and it was me who added it (and made it package-private), so maybe it would be acceptable to make it `public`?

It works around my issues, thanks. (P.S. I need this fix for 3.20, so adding a backport label)