### PR TITLE
Use source file mapping for all compilation providers

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
@@ -2,11 +2,7 @@ package io.quarkus.deployment.dev;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -20,14 +16,10 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
 import org.jboss.logging.Logger;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
 
 import io.quarkus.deployment.dev.filesystem.QuarkusFileManager;
 import io.quarkus.deployment.dev.filesystem.ReloadableFileManager;
 import io.quarkus.deployment.dev.filesystem.StaticFileManager;
-import io.quarkus.gizmo.Gizmo;
-import io.quarkus.paths.PathCollection;
 
 public class JavaCompilationProvider implements CompilationProvider {
 
@@ -116,20 +108,6 @@ public class JavaCompilationProvider implements CompilationProvider {
     }
 
     @Override
-    public Path getSourcePath(Path classFilePath, PathCollection sourcePaths, String classesPath) {
-        Path sourceFilePath;
-        final RuntimeUpdatesClassVisitor visitor = new RuntimeUpdatesClassVisitor(sourcePaths, classesPath);
-        try (final InputStream inputStream = Files.newInputStream(classFilePath)) {
-            final ClassReader reader = new ClassReader(inputStream);
-            reader.accept(visitor, 0);
-            sourceFilePath = visitor.getSourceFileForClass(classFilePath);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return sourceFilePath;
-    }
-
-    @Override
     public void close() throws IOException {
         if (this.fileManager != null) {
             this.fileManager.close();
@@ -153,37 +131,5 @@ public class JavaCompilationProvider implements CompilationProvider {
         StringBuilder builder = new StringBuilder();
         diagnosticsCollector.getDiagnostics().forEach(diagnostic -> builder.append("\n").append(diagnostic));
         return String.format("\u001B[91mCompilation Failed:%s\u001b[0m", builder);
-    }
-
-    private static class RuntimeUpdatesClassVisitor extends ClassVisitor {
-        private final PathCollection sourcePaths;
-        private final String classesPath;
-        private String sourceFile;
-
-        public RuntimeUpdatesClassVisitor(PathCollection sourcePaths, String classesPath) {
-            super(Gizmo.ASM_API_VERSION);
-            this.sourcePaths = sourcePaths;
-            this.classesPath = classesPath;
-        }
-
-        @Override
-        public void visitSource(String source, String debug) {
-            this.sourceFile = source;
-        }
-
-        public Path getSourceFileForClass(final Path classFilePath) {
-            for (Path sourcesDir : sourcePaths) {
-                final Path classesDir = Paths.get(classesPath);
-                final StringBuilder sourceRelativeDir = new StringBuilder();
-                sourceRelativeDir.append(classesDir.relativize(classFilePath.getParent()));
-                sourceRelativeDir.append(File.separator);
-                sourceRelativeDir.append(sourceFile);
-                final Path sourceFilePath = sourcesDir.resolve(Path.of(sourceRelativeDir.toString()));
-                if (Files.exists(sourceFilePath)) {
-                    return sourceFilePath;
-                }
-            }
-            return null;
-        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesClassVisitor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesClassVisitor.java
@@ -1,0 +1,43 @@
+package io.quarkus.deployment.dev;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.objectweb.asm.ClassVisitor;
+
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.paths.PathCollection;
+
+public class RuntimeUpdatesClassVisitor extends ClassVisitor {
+    private final PathCollection sourcePaths;
+    private final String classesPath;
+    private String sourceFile;
+
+    public RuntimeUpdatesClassVisitor(PathCollection sourcePaths, String classesPath) {
+        super(Gizmo.ASM_API_VERSION);
+        this.sourcePaths = sourcePaths;
+        this.classesPath = classesPath;
+    }
+
+    @Override
+    public void visitSource(String source, String debug) {
+        this.sourceFile = source;
+    }
+
+    public Path getSourceFileForClass(final Path classFilePath) {
+        for (Path sourcesDir : sourcePaths) {
+            final Path classesDir = Paths.get(classesPath);
+            final StringBuilder sourceRelativeDir = new StringBuilder();
+            sourceRelativeDir.append(classesDir.relativize(classFilePath.getParent()));
+            sourceRelativeDir.append(File.separator);
+            sourceRelativeDir.append(sourceFile);
+            final Path sourceFilePath = sourcesDir.resolve(Path.of(sourceRelativeDir.toString()));
+            if (Files.exists(sourceFilePath)) {
+                return sourceFilePath;
+            }
+        }
+        return null;
+    }
+}

--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinCompilationProvider.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinCompilationProvider.java
@@ -1,7 +1,6 @@
 package io.quarkus.kotlin.deployment;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -22,7 +21,6 @@ import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler;
 import org.jetbrains.kotlin.config.Services;
 
 import io.quarkus.deployment.dev.CompilationProvider;
-import io.quarkus.paths.PathCollection;
 
 public class KotlinCompilationProvider implements CompilationProvider {
 
@@ -101,12 +99,6 @@ public class KotlinCompilationProvider implements CompilationProvider {
                 throw new RuntimeException("Compilation failed. " + errors);
             }
         }
-    }
-
-    @Override
-    public Path getSourcePath(Path classFilePath, PathCollection sourcePaths, String classesPath) {
-        // return same class so it is not removed
-        return classFilePath;
     }
 
     private static class SimpleKotlinCompilerMessageCollector implements MessageCollector {

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicKotlinApplicationModuleDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicKotlinApplicationModuleDevModeTest.java
@@ -23,5 +23,10 @@ public class BasicKotlinApplicationModuleDevModeTest extends QuarkusDevGradleTes
                 ImmutableMap.of("return \"hello\"", "return \"" + uuid + "\""));
 
         assertUpdatedResponseContains("/hello", uuid);
+
+        delete("src/main/kotlin/org/acme/GreetingResource.kt");
+
+        assertStatusCode("/hello", 404);
+
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
+import org.wildfly.common.Assert;
 
 import io.quarkus.gradle.BuildResult;
 import io.quarkus.gradle.QuarkusGradleWrapperTestBase;
@@ -180,6 +181,12 @@ public abstract class QuarkusDevGradleTestBase extends QuarkusGradleWrapperTestB
         }
     }
 
+    protected void delete(String srcFile) {
+        final File source = new File(getProjectDir(), srcFile);
+        assertThat(source).exists();
+        Assert.assertTrue(source.delete());
+    }
+
     protected void assertUpdatedResponseContains(String path, String value) {
         assertUpdatedResponseContains(path, value, devModeTimeoutSeconds(), TimeUnit.SECONDS);
     }
@@ -197,5 +204,12 @@ public abstract class QuarkusDevGradleTestBase extends QuarkusGradleWrapperTestB
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
                 .atMost(waitAtMost, timeUnit).until(() -> getHttpResponse(path, waitAtMost, timeUnit).contains(value));
+    }
+
+    protected void assertStatusCode(String path, int code) {
+        await()
+                .pollDelay(100, TimeUnit.MILLISECONDS)
+                .atMost(devModeTimeoutSeconds(), TimeUnit.SECONDS)
+                .until(() -> Assert.assertTrue(devModeClient.getStrictHttpResponse(path, code)));
     }
 }


### PR DESCRIPTION
All compilation providers should be setting the source file attribute for use in debugging, there is no need to limit this to Java. This should allow for deletions of Kotlin classes to be handled correctly.