### PR TITLE
Make substitution of JMX#createProxy conditional on inclusion of jmxserver feature

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -967,6 +967,10 @@ public class NativeImageBuildStep {
                 if (nativeConfig.monitoring().isPresent()) {
                     monitoringOptions.addAll(nativeConfig.monitoring().get());
                 }
+
+                nativeImageArgs.add("-J-Dquarkus.native.jmxserver.included="
+                        + monitoringOptions.contains(NativeConfig.MonitoringOption.JMXSERVER));
+
                 if (!monitoringOptions.isEmpty()) {
                     nativeImageArgs.add("--enable-monitoring=" + monitoringOptions.stream()
                             .map(o -> o.name().toLowerCase(Locale.ROOT)).collect(Collectors.joining(",")));

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_management_JMX.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_management_JMX.java
@@ -1,5 +1,7 @@
 package io.quarkus.runtime.graal;
 
+import java.util.function.BooleanSupplier;
+
 import javax.management.JMX;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -7,7 +9,7 @@ import javax.management.ObjectName;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(JMX.class)
+@TargetClass(value = JMX.class, onlyWith = Target_javax_management_JMX.JmxServerNotIncluded.class)
 final class Target_javax_management_JMX {
 
     @Substitute
@@ -19,4 +21,11 @@ final class Target_javax_management_JMX {
         throw new IllegalStateException("Not Implemented in native mode");
     }
 
+    static final class JmxServerNotIncluded implements BooleanSupplier {
+
+        @Override
+        public boolean getAsBoolean() {
+            return !Boolean.getBoolean("quarkus.native.jmxserver.included");
+        }
+    }
 }


### PR DESCRIPTION
This is a fix for: https://github.com/quarkusio/quarkus/issues/46506

This change makes the substitution that prevents use of ` JMX#createProxy ` conditional. The substitution should only be enabled if the `jmxserver` feature is not included in the image build.

