### PR TITLE
Minor test corrections

### DIFF
--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/CallbackDevModeIT.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/CallbackDevModeIT.java
@@ -14,13 +14,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import io.quarkus.maven.it.RunAndCheckMojoTestBase;
 import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
 
-/**
- * Be aware! This test will not run if the name does not start with 'Test'.
- * <p>
- * NOTE to anyone diagnosing failures in this test, to run a single method use:
- * <p>
- * mvn install -Dit.test=TestTemplateDevModeIT#methodName
- */
 @DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
 @Disabled // Tracked by #22611
 public class CallbackDevModeIT extends RunAndCheckMojoTestBase {

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/ParameterDevModeIT.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/ParameterDevModeIT.java
@@ -16,6 +16,7 @@ import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
 @DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
 public class ParameterDevModeIT extends RunAndCheckMojoTestBase {
 
+    @Override
     protected int getPort() {
         return 8098;
     }

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/TemplateDevModeIT.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/it/TemplateDevModeIT.java
@@ -19,6 +19,7 @@ public class TemplateDevModeIT extends RunAndCheckMojoTestBase {
     /*
      * We have a few tests that will run in parallel, so set a unique port
      */
+    @Override
     protected int getPort() {
         return 8092;
     }

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/src/test/java/org/acme/QuarkusTestAccessingBeanInCallback.java
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/src/test/java/org/acme/QuarkusTestAccessingBeanInCallback.java
@@ -22,6 +22,7 @@ public class QuarkusTestAccessingBeanInCallback {
 
     @Callback
     public void callback() {
+        callbackHappened = true;
         // Callbacks invoked by test frameworks should be able to see injected beans
         assertNotNull(bean, "A method invoked by a test interceptor should have access to CDI beans");
 


### PR DESCRIPTION
- Add missing `@Override`
- Correct a method so that instance variable which is supposed to be updated is updated. The reason this omission isn't currently causing a test failure is that the test is disabled.
- Remove stale comment