### PR TITLE
Fix loading of Maven workspaces that use revision properties using effective model building

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
@@ -209,14 +209,23 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
             return;
         }
 
+        final String rawVersion = ModelUtils.getRawVersion(rawModule.model);
+        final String version = ModelUtils.isUnresolvedVersion(rawVersion)
+                ? ModelUtils.resolveVersion(rawVersion, rawModule.model)
+                : rawVersion;
         var added = loadedModules.putIfAbsent(
-                new GAV(ModelUtils.getGroupId(rawModule.model), rawModule.model.getArtifactId(),
-                        ModelUtils.getVersion(rawModule.model)),
+                new GAV(ModelUtils.getGroupId(rawModule.model), rawModule.model.getArtifactId(), version),
                 rawModule.model);
         if (added != null) {
             return;
         }
         newModules.add(rawModule);
+
+        if (!rawVersion.equals(version)) {
+            loadedModules.putIfAbsent(
+                    new GAV(ModelUtils.getGroupId(rawModule.model), rawModule.model.getArtifactId(), rawVersion),
+                    rawModule.model);
+        }
 
         for (var module : rawModule.model.getModules()) {
             queueModule(rawModule.model.getProjectDirectory().toPath().resolve(module));

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
@@ -616,6 +616,27 @@ public class LocalWorkspaceDiscoveryTest {
     }
 
     @Test
+    public void testVersionRevisionPropertyEffectiveModel() throws Exception {
+        final URL projectUrl = Thread.currentThread().getContextClassLoader().getResource("workspace-revision/root/module1");
+        assertNotNull(projectUrl);
+        final Path projectDir = Paths.get(projectUrl.toURI());
+        assertTrue(Files.exists(projectDir));
+
+        final LocalProject module1 = new BootstrapMavenContext(BootstrapMavenContext.config()
+                .setEffectiveModelBuilder(true)
+                .setCurrentProject(projectDir.toString()))
+                .getCurrentProject();
+        final LocalWorkspace ws = module1.getWorkspace();
+        var project = ws.getProject("org.acme", "root-module1");
+        assertNotNull(project);
+        assertEquals("1.2.3", project.getVersion());
+
+        project = ws.getProject("org.acme", "root");
+        assertNotNull(project);
+        assertEquals("1.2.3", project.getVersion());
+    }
+
+    @Test
     public void testVersionRevisionProperty() throws Exception {
         testMavenCiFriendlyVersion("${revision}", "workspace-revision", "1.2.3", true);
     }


### PR DESCRIPTION
Partial fix for https://github.com/quarkusio/quarkus/issues/41420
Fixes #46819

It fixes the model loading part and the error reported in the issue. But the update still fails complaining it can't find the Maven wrapper in the application module.