### PR TITLE
Docs: Update Deploying on OpenShift guide to add RHBQ content 

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -4,142 +4,188 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="deploy-openshift"]
-= Deploying on OpenShift
+= Deploying {project-name} applications to {openshift}
 include::_attributes.adoc[]
 :categories: cloud, native
-:summary: This guide covers how to deploy a native application on OpenShift.
+:summary: This guide describes the deployment of {project-name} applications to {openshift}.
+:numbered:
+:sectnums:
+:sectnumlevels: 4
 :topics: devops,kubernetes,openshift,cloud,deployment
 :extensions: io.quarkus:quarkus-openshift
 
-This guide covers generating and deploying OpenShift resources based on sane default and user supplied configuration.
+{openshift-long} is a Kubernetes-based platform for developing and running containerized applications.
+Quarkus offers the ability to automatically generate {openshift} resources based on sane defaults and user-supplied configuration.
 
+As an application developer, you can deploy your {project-name} applications to {openshift-long}.
+This functionality is provided by the `quarkus-openshift` extension, which supports multiple deployment options:
 
-== Prerequisites
+* xref:deploying-to-openshift-howto.adoc[With a single step]
+* xref:deploying-to-openshift-docker-howto.adoc[By using a Docker build strategy]
+* xref:deploying-to-openshift-S2I-howto.adoc[By using a Source-to-Image (S2I) strategy]
+* xref:deploying-to-openshift-native-howto.adoc[Compiled to native executables]
 
-:prerequisites-no-graalvm:
-include::{includes}/prerequisites.adoc[]
-* Access to an OpenShift cluster (Minishift is a viable option)
-* OpenShift CLI (Optional, only required for manual deployment)
+== Overview of {openshift} build strategies
+
+Docker build:: This strategy builds the artifacts outside the {openshift} cluster, locally or in a CI environment, and provides them to the {openshift} build system together with a Dockerfile.
+The artifacts include JAR files or a native executable.
+The container gets built inside the {openshift} cluster and is provided as an image stream.
+
+[NOTE]
+====
+The {openshift} Docker build strategy is the preferred build strategy because it supports Quarkus applications targeted for JVM or compiled to native executables.
+However, for compatibility with earlier Quarkus versions, the default build strategy is S2I.
+To select the {openshift} Docker build strategy, use the `quarkus.openshift.build-strategy` property.
+====
+
+Source to Image (S2I):: The build process is performed inside the {openshift} cluster.
+{project-name} fully supports using S2I to deploy {project-name} as a JVM application.
+
+Binary S2I:: This strategy uses a JAR file as input to the S2I build process, which speeds up the building and deploying of your application.
+
+=== Build strategies supported by Quarkus
+
+The following table outlines the build strategies that {project-name} supports:
+
+[cols="15%,15%,15%,15%,15%,15%",options="header"]
+|====
+|Build strategy| Support for {project-name} tools|Support for JVM | Support for native | Support for JVM Serverless | Support for native Serverless
+|Docker build | YES | YES| YES| YES | YES
+|S2I Binary| YES | YES | NO| NO | NO
+|Source S2I | NO | YES| NO | NO | NO
+|====
 
 == Bootstrapping the project
 
-First, we need a new project that contains the OpenShift extension. This can be done using the following command:
+First, you need a new project that contains the OpenShift extension.
+Then, before you build and deploy our application, you must log into an OpenShift cluster.
 
-:create-app-artifact-id: openshift-quickstart
-:create-app-extensions: rest,openshift
-:create-app-code:
-include::{includes}/devtools/create-app.adoc[]
+=== Adding the OpenShift extension
 
-Quarkus offers the ability to automatically generate OpenShift resources based on sane defaults and user supplied configuration.
-The OpenShift extension is actually a wrapper extension that brings configures the xref:deploying-to-kubernetes.adoc[Kubernetes]
-extension with sensible defaults so that it's easier for the user to get started with Quarkus on OpenShift.
+To build and deploy your applications as a container image that runs inside your {openshift} cluster, you must add the {project-name} OpenShift extension `quarkus-openshift` as a dependency to your project.
 
-When we added the OpenShift extension to the command line invocation above, the following dependency was added to the `pom.xml`
+This extension also generates {openshift} resources such as image streams, build configuration, deployment, and service definitions.
+If your application includes the `quarkus-smallrye-health` extension, {openshift} can access the health endpoint and verify the startup, liveness, and readiness of your application.
 
-[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+[IMPORTANT]
+====
+From {project-name} 3.8, the `DeploymentConfig` object, deprecated in OpenShift, is also deprecated in {project-name}.
+`Deployment` is the default and preferred deployment kind for the `quarkus-openshift` extension.
+If you redeploy applications that you deployed before by using `DeploymentConfig`, by default, those applications use `Deployment` but do not remove the previous `DeploymentConfig`.
+This leads to a deployment of both new and old applications, so, you must remove the old `DeploymentConfig` manually.
+However, if you want to continue to use `DeploymentConfig`, it is still possible to do so by explicitly setting `quarkus.openshift.deployment-kind` to `DeploymentConfig`.
+====
+
+.Prerequisites
+
+* You have a Quarkus Maven project.
+
+.Procedure
+
+. To add the `quarkus-openshift` extension to your project, use one of the following methods:
+* Configure the `pom.xml` file:
++
 .pom.xml
+[source,xml,subs="+quotes,attributes+"]
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-openshift</artifactId>
 </dependency>
 ----
-
-[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
-.build.gradle
+* Enter the following command on the {openshift} CLI:
++
+[source,bash,subs="+quotes,attributes+"]
 ----
-implementation("io.quarkus:quarkus-openshift")
+./mvnw quarkus:add-extension -Dextensions="io.quarkus:quarkus-openshift"
+----
++
+* Enter the following command on the Quarkus CLI:
++
+[source,bash,subs="+quotes,attributes+"]
+----
+quarkus extension add 'quarkus-openshift'
 ----
 
-== Log Into the OpenShift Cluster
+== Logging in to an OpenShift cluster
 
-Before we build and deploy our application we need to log into an OpenShift cluster.
-You can log in via the https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]:
+You can log in to an OpenShift cluster by using the https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]:
 
-.Log In - OpenShift CLI Example
+.Example: Log in by using the OpenShift CLI
 [source,bash]
 ----
 oc login -u myUsername <1>
 ----
-<1> You'll be prompted for the required information such as server URL, password, etc.
+<1> You are prompted for the required information such as server URL, password, and so on.
 
-Alternatively, you may log in using the API token:
+Alternatively, you can log in by using the API token:
 
-.Log In - OpenShift CLI With API Token Example
+.Example: Log in by using the OpenShift command-line interface (CLI) with API token
 [source,bash]
 ----
 oc login --token=myToken --server=myServerUrl
 ----
 
-TIP: You can request the token via the _Copy Login Command_ link in the OpenShift web console.
+TIP: You can request the token by using the _Copy Login Command_ link in the OpenShift web console.
 
-Finally, you don't need to use the OpenShift CLI at all.
+Finally, you do not need to use the OpenShift CLI at all.
 Instead, set the `quarkus.kubernetes-client.api-server-url` config property and authenticate with the `quarkus.kubernetes-client.token`, or `quarkus.kubernetes-client.username` and `quarkus.kubernetes-client.password` respectively:
 
 :build-additional-parameters: -Dquarkus.kubernetes-client.api-server-url=myServerUrl -Dquarkus.kubernetes-client.token=myToken
 include::{includes}/devtools/build.adoc[]
 :!build-additional-parameters:
 
-== Build and Deployment
+=== Switching to the required {openshift} project
 
-You can trigger a build and deployment in a single step or build the container image first and then configure the OpenShift application manually if you need <<control_application_config,more control over the deployment configuration>>.
+You can use the {openshift-long} CLI to create applications and manage your {openshift} projects.
+Use the information provided to create an {openshift} project or to switch to an existing one.
 
-To trigger a build and deployment in a single step:
+.Prerequisites
 
-:build-additional-parameters: -Dquarkus.openshift.deploy=true
-include::{includes}/devtools/build.adoc[]
-:!build-additional-parameters:
+* You have access to an {openshift} cluster and the latest compatible version of the `oc` tool installed.
 
-TIP: If you want to test your application immediately then set the `quarkus.openshift.route.expose` config property to `true` to <<exposing_routes,expose the service automatically>>, e.g. add `-Dquarkus.openshift.route.expose=true` to the command above.
+.Procedure
 
-[[re-deploy-with-service-binding]]
-NOTE: When using `DeploymentConfig` and xref:deploying-to-kubernetes.adoc#service_binding[Service Binding], re-deploying might remove the configuration added by OpenShift to allow service discovery. A new container image build will trigger a refresh of the Quarkus app in OpenShift: `-Dquarkus.container-image.build=true` which might be enough in most situations. If you need to update the OpenShift resources, you need to delete the binding first to create it again after new deployment.
-
-This command will build your application locally, then trigger a container image build and finally apply the generated OpenShift resources automatically.
-The generated resources use a Kubernetes `Deployment`, but still make use of OpenShift specific resources like `Route`, `BuildConfig` etc.
-
-IMPORTANT: As of OpenShift 4.14, the https://access.redhat.com/articles/7041372[`DeploymentConfig` object has been deprecated].
-
-Since `Deployment` is a Kubernetes resource and not OpenShift specific, it can't possibly leverage `ImageStream` resources, as is the case with `DeploymentConfig`. This means that the image references need to include the container image registry that hosts the image.
-When the image is built, using OpenShift builds (s2i binary and docker strategy) the OpenShift internal image registry `image-registry.openshift-image-registry.svc:5000` will be used, unless another registry has been explicitly specified by the user. Please note, that in the internal registry the project/namespace name is added as part of the image repository: `image-registry.openshift-image-registry.svc:5000/<project name>/<name>:<tag>`, so users will need to make sure that the target project/namespace name is aligned with the `quarkus.container-image.group`.
-
-The https://access.redhat.com/articles/7041372[deprecation document] contains additional information about how to set up/use automatic rollbacks, triggers, lifecycle hooks, and custom strategies.
-
-[source,properties]
+. Log in to the `oc` tool:
++
+[source,shell]
 ----
-quarkus.container-image.group=<project/namespace name>
+oc login
+----
+. To show the current project space, enter the following command:
++
+[source,shell]
+----
+oc project -q
+----
+. Use one of the following steps to go to the required {openshift} project:
+.. If the project already exists, switch to the project:
++
+[source,shell]
+----
+oc project <project_name>
+----
++
+.. If the project does not exist, create a new project:
++
+[source,shell]
+----
+oc new-project <project_name>
 ----
 
-You can use the OpenShift web console to verify that the above command has created an image stream, a service resource and has deployed the application.
-Alternatively, you can run the following OpenShift CLI commands:
-[source,bash,subs=attributes+]
-----
-oc get is <1>
-oc get pods <2>
-oc get svc <3>
-----
-<1> Lists the image streams created.
-<2> Get the list of pods.
-<3> Get the list of Kubernetes services.
+== Building and deploying
 
-Note that the service is not exposed to the outside world by default.
-So unless you've used the `quarkus.openshift.route.expose` config property to expose the created service automatically you'll need to expose the service manually.
+You can build and deploy by using any of the following deployment options:
 
-.Expose The Service - OpenShift CLI Example
-[source,bash,subs=attributes+]
-----
-oc expose svc/openshift-quickstart <1>
-oc get routes <2>
-curl http://<route>/hello <3>
-----
-<1> Expose the service.
-<2> Get the list of exposed routes.
-<3> Access your application.
+* xref:deploying-to-openshift-howto.adoc[With a single step]
+* xref:deploying-to-openshift-docker-howto.adoc[By using a Docker build strategy]
+* xref:deploying-to-openshift-S2I-howto.adoc[By using a Source-to-Image (S2I) strategy]
+* xref:deploying-to-openshift-native-howto.adoc[Compiled to native executables]
 
-[[control_application_config]]
-=== Configure the OpenShift Application Manually
+ifndef::no-configuring-application-manually[]
+=== Configuring the OpenShift application manually
 
-If you need more control over the deployment configuration you can build the container image first and then configure the OpenShift application manually.
+If you need more control over the deployment configuration, you can build the container image first and then configure the OpenShift application manually.
 
 To trigger a container image build:
 
@@ -148,9 +194,11 @@ To trigger a container image build:
 ./mvnw clean package -Dquarkus.container-image.build=true
 ----
 
-The build that will be performed is a _s2i binary_ build.
-The input of the build is the jar that has been built locally and the output of the build is an `ImageStream` that is configured to automatically trigger a deployment.
-The base/builder image is specified using `base-jvm-image` and `base-native-image` for jvm and native mode respectively. An ImageStream for the image is automatically generated, unless these properties are used to reference an existing ImageStreamTag in the internal openshift registry. For example:
+The build that is performed is a _s2i binary_ build.
+The input of the build is the JAR file that has been built locally and the build output is an `ImageStream` that is configured to automatically trigger a deployment.
+The base or builder image is specified by using `base-jvm-image` and `base-native-image` for JVM and native mode respectively.
+An `ImageStream` for the image is automatically generated, unless these properties are used to reference an existing `ImageStreamTag` in the internal openshift registry.
+For example:
 
 [source,properties]
 ----
@@ -159,17 +207,16 @@ quarkus.openshift.base-jvm-image=image-registry.openshift-image-registry.svc:500
 
 [NOTE]
 ====
-During the build you may find the `Caused by: javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed` exception due to self-signed certificate. To solve this, just add the following line to your `application.properties`:
-
+During the build you might find the `Caused by: javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed` exception due to self-signed certificate.
+To solve this, add the following line to your `application.properties` file:
 [source,properties]
 ----
 quarkus.kubernetes-client.trust-certs=true
 ----
-
 For more information, see xref:deploying-to-kubernetes.adoc#client-connection-configuration[deploying to Kubernetes].
 ====
 
-Once the build is done we can create a new application from the relevant `ImageStream`.
+After the build is finished, you can create a new application from the relevant `ImageStream`.
 
 [source,bash,subs=attributes+]
 ----
@@ -180,18 +227,20 @@ oc expose svc/greeting <3>
 oc get routes <4>
 curl http://<route>/hello <5>
 ----
-<1> Lists the image streams created. The image stream of our application should be tagged as <project>/openshift-quickstart:1.0.0-SNAPSHOT.
+<1> Lists the image streams created.
+The image stream of our application should be tagged as <project>/openshift-quickstart:1.0.0-SNAPSHOT.
 <2> Create a new application from the image source.
 <3> Expose the service to the outside world.
 <4> Get the list of exposed routes.
 <5> Access your application.
 
 After this setup the next time the container image is built a deployment to OpenShift is triggered automatically.
-In other words, you don't need to repeat the above steps.
+In other words, you do not need to repeat the above steps.
+endif::no-configuring-application-manually[]
 
-=== Non-S2I Builds
+=== Non-S2I builds
 
-Out of the box the OpenShift extension is configured to use xref:container-image.adoc#s2i[container-image-s2i]. However, it's still possible to use other container image extensions like:
+The OpenShift extension is configured to use xref:container-image.adoc#s2i[container-image-s2i]. However, it is still possible to use other container image extensions, such as:
 
 - xref:container-image.adoc#docker[container-image-docker]
 - xref:container-image.adoc#jib[container-image-jib]
@@ -219,7 +268,7 @@ All available customization options are available in the xref:deploying-to-kuber
 Some examples are provided in the sections below:
 
 [[exposing_routes]]
-=== Exposing Routes
+=== Exposing routes
 
 To expose a `Route` for the Quarkus application:
 
@@ -230,21 +279,22 @@ quarkus.openshift.route.expose=true
 
 [TIP]
 ====
-You don't necessarily need to add this property in the `application.properties`. You can pass it as a command line argument:
-
+You do not need to add this property in the `application.properties` file.
+Instead, you can pass it as a command-line argument:
 [source,bash,subs=attributes+]
 ----
 ./mvnw clean package -Dquarkus.openshift.route.expose=true
 ----
-
 The same applies to all properties listed below.
 ====
 
 ==== Securing the Route resource
 
-To secure the incoming connections, OpenShift provides several types of TLS termination to serve certifications. You can read more information about how to secure routes in https://docs.openshift.com/container-platform/4.12/networking/routes/secured-routes.html[the official OpenShift guide].
+To secure the incoming connections, OpenShift provides several types of TLS termination to serve certifications.
 
-Let's see an example about how to configure a secured Route using passthrough termination by simply adding the "quarkus.openshift.route.tls" properties:
+For more information about how to secure routes, see https://docs.openshift.com/container-platform/4.18/networking/routes/secured-routes.html[OpenShift Container Platform] documentation.
+
+The following example shows how to configure a secured Route by using passthrough termination by adding the "quarkus.openshift.route.tls" properties:
 
 [source,properties]
 ----
@@ -292,20 +342,19 @@ To add a key/value pair as an environment variable in the generated resources:
 quarkus.openshift.env.vars.my-env-var=foobar
 ----
 
-The command above will add `MY_ENV_VAR=foobar` as an environment variable.
-Please note that the key `my-env-var` will be converted to uppercase and dashes will be replaced by underscores resulting in `MY_ENV_VAR`.
+The above command adds `MY_ENV_VAR=foobar` as an environment variable.
+The key `my-env-var` will convert to uppercase and dashes will be replaced by underscores resulting in `MY_ENV_VAR`.
 
 ==== Environment variables from Secret
 
-To add all key/value pairs of `Secret` as environment variables just apply the following configuration, separating each `Secret`
-to be used as source by a comma (`,`):
+To add all key/value pairs of `Secret` as environment variables, apply the following configuration, separating each `Secret` to be used as source by a comma (`,`):
 
 [source,properties]
 ----
 quarkus.openshift.env.secrets=my-secret,my-other-secret
 ----
 
-which would generate the following in the container definition:
+which generates the following in the container definition:
 
 [source,yaml]
 ----
@@ -318,7 +367,7 @@ envFrom:
       optional: false
 ----
 
-The following extracts a value identified by the `keyName` field from the `my-secret` Secret into a `foo` environment variable:
+The following code extracts a value identified by the `keyName` field from the `my-secret` Secret into a `foo` environment variable:
 
 [source,properties]
 ----
@@ -326,7 +375,7 @@ quarkus.openshift.env.mapping.foo.from-secret=my-secret
 quarkus.openshift.env.mapping.foo.with-key=keyName
 ----
 
-This would generate the following in the `env` section of your container:
+which generates the following in the `env` section of your container:
 
 [source,yaml]
 ----
@@ -341,15 +390,14 @@ This would generate the following in the `env` section of your container:
 
 ==== Environment variables from ConfigMap
 
-To add all key/value pairs from `ConfigMap` as environment variables just apply the following configuration, separating each
-`ConfigMap` to be used as source by a comma (`,`):
+To add all key/value pairs from `ConfigMap` as environment variables, apply the following configuration, separating each `ConfigMap` to be used as source by a comma (`,`):
 
 [source,properties]
 ----
 quarkus.openshift.env.configmaps=my-config-map,another-config-map
 ----
 
-which would generate the following in the container definition:
+which generates the following in the container definition:
 
 [source,yaml]
 ----
@@ -362,8 +410,7 @@ envFrom:
       optional: false
 ----
 
-The following extracts a value identified by the `keyName` field from the `my-config-map` ConfigMap into a `foo`
-environment variable:
+The following extracts a value identified by the `keyName` field from the `my-config-map` ConfigMap into a `foo` environment variable:
 
 [source,properties]
 ----
@@ -371,7 +418,7 @@ quarkus.openshift.env.mapping.foo.from-configmap=my-configmap
 quarkus.openshift.env.mapping.foo.with-key=keyName
 ----
 
-This would generate the following in the `env` section of your container:
+which generates the following in the `env` section of your container:
 
 [source,yaml]
 ----
@@ -386,7 +433,8 @@ This would generate the following in the `env` section of your container:
 
 ==== Environment variables from fields
 
-It's also possible to use the value from another field to add a new environment variable by specifying the path of the field to be used as a source, as follows:
+You can also use the value from another field to add a new environment variable by specifying the path of the field to be used as a source.
+For example:
 
 [source,properties]
 ----
@@ -395,7 +443,7 @@ quarkus.openshift.env.fields.foo=metadata.name
 
 ==== Changing the generated deployment resource
 
-Beside generating a `Deployment` resource, you can also choose to get either a `DeploymentConfig`, `StatefulSet`, `Job`, or a `CronJob` resource instead via `application.properties`:
+Beside generating a `Deployment` resource, you can also choose to get either a `DeploymentConfig`, `StatefulSet`, `Job`, or a `CronJob` resource instead by using `application.properties`:
 
 [source,properties]
 ----
@@ -404,7 +452,7 @@ quarkus.openshift.deployment-kind=StatefulSet
 
 ===== Generating Job resources
 
-If you want to generate a Job resource, you need to add the following property via the `application.properties`:
+If you want to generate a Job resource, you need to add the following property by using the `application.properties`:
 
 [source,properties]
 ----
@@ -413,15 +461,17 @@ quarkus.openshift.deployment-kind=Job
 
 IMPORTANT: If you are using the Picocli extension, by default the Job resource will be generated.
 
-You can provide the arguments that will be used by the Kubernetes Job via the property `quarkus.openshift.arguments`. For example, adding the property `quarkus.openshift.arguments=A,B`.
+You can provide the arguments that Kubernetes Job uses through the `quarkus.openshift.arguments` property.
+For example, adding the property `quarkus.openshift.arguments=A,B`.
 
-Finally, the Kubernetes job will be launched every time that is installed in OpenShift. You can know more about how to run Kubernetes jobs in this https://kubernetes.io/docs/concepts/workloads/controllers/job/#running-an-example-job[link].
+Finally, the Kubernetes job will be launched every time that it is installed in OpenShift.
+For more information about how to run Kubernetes jobs, see https://kubernetes.io/docs/concepts/workloads/controllers/job/#running-an-example-job[Running an example job].
 
-You can configure the rest of the Kubernetes Job configuration using the properties under `quarkus.openshift.job.xxx` (see xref:deploying-to-openshift.adoc#quarkus-kubernetes_quarkus-openshift-job-parallelism[link]).
+You can configure the rest of the Kubernetes Job configuration by using the properties under `quarkus.openshift.job.xxx` (for more information, see xref:deploying-to-openshift.adoc#quarkus-kubernetes_quarkus-openshift-job-parallelism[quarkus.openshift.job.parallelism).
 
 ===== Generating CronJob resources
 
-If you want to generate a CronJob resource, you need to add the following property via the `application.properties`:
+If you want to generate a CronJob resource, you need to add the following property by using the `application.properties` file:
 
 [source,properties]
 ----
@@ -430,22 +480,25 @@ quarkus.openshift.deployment-kind=CronJob
 quarkus.openshift.cron-job.schedule=0 * * * *
 ----
 
-IMPORTANT: CronJob resources require the https://en.wikipedia.org/wiki/Cron[Cron] expression to specify when to launch the job via the property `quarkus.openshift.cron-job.schedule`. If not provide, the build will fail.
+IMPORTANT: CronJob resources require the https://en.wikipedia.org/wiki/Cron[Cron] expression to specify when to launch the job through the `quarkus.openshift.cron-job.schedule` property.
+If thet are not provided, the build fails.
 
-You can configure the rest of the Kubernetes CronJob configuration using the properties under `quarkus.openshift.cron-job.xxx` (see xref:deploying-to-openshift.adoc#quarkus-kubernetes_quarkus-openshift-cron-job-parallelism[link]).
+You can configure the rest of the Kubernetes CronJob configuration by using the properties under `quarkus.openshift.cron-job.xxx` (for more information, see xref:deploying-to-openshift.adoc#quarkus-kubernetes_quarkus-openshift-cron-job-parallelism[quarkus.openshift.cron-job.parallelism]).
 
 ==== Validation
 
-A conflict between two definitions, e.g. mistakenly assigning both a value and specifying that a variable is derived from a field, will result in an error being thrown at build time so that you get the opportunity to fix the issue before you deploy your application to your cluster where it might be more difficult to diagnose the source of the issue.
+A conflict between two definitions, for example, mistakenly assigning both a value and specifying that a variable is derived from a field, results in an error being thrown at build time.
+You can fix the issue before you deploy your application to your cluster, where it might be more difficult to diagnose the source of the issue.
 
-Similarly, two redundant definitions, e.g. defining an injection from the same secret twice, will not cause an issue but will indeed report a warning to let you know that you might not have intended to duplicate that definition.
+Similarly, two redundant definitions, for example, defining an injection from the same secret twice, does not cause an issue but reports a warning to inform you that you might not have intended to duplicate that definition.
 
 [[env-vars-backwards]]
 ===== Backwards compatibility
 
-Previous versions of the OpenShift extension supported a different syntax to add environment variables. The older syntax is still supported but is deprecated, and it's advised that you migrate to the new syntax.
+Previous versions of the OpenShift extension supported a different syntax to add environment variables.
+The older syntax is still supported but is deprecated, and it is advised that you migrate to the new syntax.
 
-.Old vs. new syntax
+.Old syntax versus new syntax
 |====
 |                               |Old                                                    | New                                                 |
 | Plain variable                |`quarkus.openshift.env-vars.my-env-var.value=foobar`  | `quarkus.openshift.env.vars.my-env-var=foobar`     |
@@ -458,23 +511,24 @@ Previous versions of the OpenShift extension supported a different syntax to add
 |                               |`quarkus.openshift.env-vars.foo.value=field`          | `quarkus.openshift.env.mapping.foo.with-key=field` |
 |====
 
-NOTE: If you redefine the same variable using the new syntax while keeping the old syntax, **ONLY** the new version will be kept, and a warning will be issued to alert you of the problem. For example, if you define both
-`quarkus.openshift.env-vars.my-env-var.value=foobar` and `quarkus.openshift.env.vars.my-env-var=newValue`, the extension will only generate an environment variable `MY_ENV_VAR=newValue` and issue a warning.
+[NOTE]
+====
+ If you redefine the same variable using the new syntax while keeping the old syntax, **ONLY** the new version is kept, and a warning will be issued to alert you of the problem.
+ For example, if you define both `quarkus.openshift.env-vars.my-env-var.value=foobar` and `quarkus.openshift.env.vars.my-env-var=newValue`, the extension generates an environment variable `MY_ENV_VAR=newValue` and issues a warning.
+====
 
 === Mounting volumes
 
 The OpenShift extension allows the user to configure both volumes and mounts for the application.
-
-Any volume can be mounted with a simple configuration:
+You can mount any volume with a simple configuration:
 
 [source,properties]
 ----
 quarkus.openshift.mounts.my-volume.path=/where/to/mount
 ----
 
-This will add a mount to my pod for volume `my-volume` to path `/where/to/mount`
-
-The volumes themselves can be configured as shown in the sections below:
+This will add a mount to my pod for volume `my-volume` to path `/where/to/mount`.
+You can configure the volumes themselves as shown in the sections below:
 
 ==== Secret volumes
 
@@ -490,26 +544,26 @@ quarkus.openshift.secret-volumes.my-volume.secret-name=my-secret
 quarkus.openshift.config-map-volumes.my-volume.config-map-name=my-config-map
 ----
 
-==== Persistent Volume Claims
+==== Persistent volume claims
 
 [source,properties]
 ----
 quarkus.openshift.pvc-volumes.my-pvc.claim-name=my-pvc
 ----
 
+ifndef::no-knative-serverless-deployment[]
 == Knative - OpenShift Serverless
 
-OpenShift also provides the ability to use Knative via the link:https://www.openshift.com/learn/topics/serverless[OpenShift Serverless] functionality.
+OpenShift also provides the ability to use Knative by using the link:https://www.openshift.com/learn/topics/serverless[OpenShift Serverless] functionality.
 
-The first order of business is to instruct Quarkus to generate Knative resources by setting:
+First, you instruct Quarkus to generate Knative resources:
 
 [source,properties]
 ----
 quarkus.kubernetes.deployment-target=knative
 ----
 
-In order to leverage OpenShift S2I to build the container image on the cluster and use the resulting container image for the Knative application,
-we need to set a couple of configuration properties:
+To leverage OpenShift S2I to build the container image on the cluster and use the resulting container image for the Knative application, set the following configuration properties:
 
 [source,properties]
 ----
@@ -519,7 +573,8 @@ quarkus.container-image.group=geoand
 quarkus.container-image.registry=image-registry.openshift-image-registry.svc:5000
 ----
 
-The application can then be deployed to OpenShift Serverless by enabling the standard `quarkus.kubernetes.deploy=true` property.
+You can then deploy the application to OpenShift Serverless by enabling the standard `quarkus.kubernetes.deploy=true` property.
+endif::no-knative-serverless-deployment[]
 
 == Configuration Reference
 


### PR DESCRIPTION
This PR covers the following updates:

- Update the upstream Deploying on OpenShift guide to incorporate downstream content 
- Editing review
- Conditionalize content not relevant for downstream