### PR TITLE
Switch to Nisse to get OS specific properties

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,4 +1,4 @@
- <extensions>
+<extensions>
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
@@ -18,5 +18,10 @@
         <groupId>io.quarkus.develocity</groupId>
         <artifactId>quarkus-project-develocity-extension</artifactId>
         <version>1.1.9</version>
+    </extension>
+    <extension>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>extension</artifactId>
+        <version>0.4.0</version>
     </extension>
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dnisse.compat.osDetector=true

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -146,7 +146,6 @@
 
         <surefire.argLine.additional></surefire.argLine.additional>
         <failsafe.argLine.additional>${surefire.argLine.additional}</failsafe.argLine.additional>
-        <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
 
         <!-- google cloud functions invoker-->
         <gcf-invoker.version>1.3.0</gcf-invoker.version>

--- a/docs/src/main/asciidoc/grpc-generation-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-generation-reference.adoc
@@ -199,20 +199,26 @@ To do this, define the following properties in the `<properties>` section:
 
 These properties configure the gRPC version and the `protoc` version.
 
-Then, add the `os-maven-plugin` extension and the `protobuf-maven-plugin` configuration to the `build` section:
+Then, add the `eu.maveniverse.maven.nisse:plugin3` and the `protobuf-maven-plugin` configuration to the `build` section:
 
 [source,xml]
 ----
 <build>
-    <extensions>
-        <extension>
-            <groupId>kr.motd.maven</groupId>
-            <artifactId>os-maven-plugin</artifactId>
-            <version>${os-maven-plugin-version}</version>
-        </extension>
-    </extensions>
-
     <plugins>
+        <plugin>
+            <groupId>eu.maveniverse.maven.nisse</groupId>
+            <artifactId>plugin3</artifactId>
+            <version>0.4.0</version>
+            <executions>
+                <execution>
+                    <id>inject-properties</id>
+                    <goals>
+                        <goal>inject-properties</goal>
+                    </goals>
+                    <phase>validate</phase>
+                </execution>
+            </executions>
+        </plugin>
         <plugin>
             <groupId>org.xolstice.maven.plugins</groupId>
             <artifactId>protobuf-maven-plugin</artifactId>   <!--1-->
@@ -255,11 +261,19 @@ Then, add the `os-maven-plugin` extension and the `protobuf-maven-plugin` config
 ----
 
 <1> The `protobuf-maven-plugin` generates stub classes from your gRPC service definition (`proto` files).
-<2> Class generation uses the tool `protoc`, which is OS-specific. This is why we use the `os-maven-plugin` to target the executable compatible with the operating system.
+<2> Class generation uses the tool `protoc`, which is OS-specific. This is why we use the Nisse Maven plugin to target the executable compatible with the operating system.
 
 Note: This configuration instructs the `protobuf-maven-plugin` to generate default gRPC classes and classes using Mutiny to fit with the Quarkus development experience.
 
 IMPORTANT: When using `protobuf-maven-plugin`, instead of the `quarkus-maven-plugin`, you need to re-generate classes (using `mvn compile`) every time you update the `proto` files.
+
+In order for the Nisse Maven plugin to generate the correct properties, we need to make sure the `nisse.compat.osDetector` system
+property is set. This can be done by adding the following `.mvn/maven.config` file:
+
+[source]
+----
+-Dnisse.compat.osDetector=true
+----
 
 == Using generated gRPC classes from dependencies
 

--- a/docs/src/main/asciidoc/jreleaser.adoc
+++ b/docs/src/main/asciidoc/jreleaser.adoc
@@ -107,23 +107,39 @@ shell completion scripts, man pages, license, readme, and more.
 == Creating the distribution
 
 We can leverage the link:http://maven.apache.org/plugins/maven-assembly-plugin/[maven-assembly-plugin] to create such
-a distribution. We'll also make use of the link:https://github.com/trustin/os-maven-plugin[os-maven-plugin] to properly
+a distribution. We'll also make use of the link:https://github.com/maveniverse/nisse[Nisse Maven plugin] to properly
 identify the platform on which this executable can run, adding said platform to the distribution's filename.
 
-First, let's add the os-maven-plugin to the `pom.xml`. This plugin works as a Maven extension and as such must be added
+First, let's add the Nisse Maven plugin to the `pom.xml`. This plugin must be added
 to the `<build>` section of the file:
 
 [source,xml]
 ----
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.1</version>
-      </extension>
-    </extensions>
+    <plugins>
+      <plugin>
+        <groupId>eu.maveniverse.maven.plugins</groupId>
+        <artifactId>nisse-plugin3</artifactId>
+        <version>0.4.0</version>
+        <executions>
+          <execution>
+            <id>inject-properties</id>
+              <goals>
+                <goal>inject-properties</goal>
+              </goals>
+              <phase>validate</phase>
+            </execution>
+          </executions>
+        </plugin>
     <!-- ... -->
+----
+
+In order for this plugin to generate the correct properties, we need to make sure the `nisse.compat.osDetector` system
+property is set. This can be done by adding the following `.mvn/maven.config` file:
+
+[source]
+----
+-Dnisse.compat.osDetector=true
 ----
 
 Next, native executables on Linux and macOS platforms typically do not have a file extension but Windows executables do,
@@ -139,7 +155,7 @@ their own directory to avoid cluttering the `target` directory. Thus, let's add 
 
 Now we configure the maven-assembly-plugin to create a Zip and a Tar file containing the executable and any supporting files
 it may need to perform its job. Take special note on the name of the distribution, this is where we make use of the platform
-properties detected by the os-maven-plugin. This plugin is configured in its own profile with the `single` goal bound to
+properties detected by the os-detector-maven-plugin. This plugin is configured in its own profile with the `single` goal bound to
 the `package` phase. It's done this way to avoid rebuilding the distribution every single time the build is invoked, as we
 only needed when we're ready for a release.
 
@@ -657,14 +673,21 @@ As a reference, these are the full contents of the `pom.xml`:
     </dependency>
   </dependencies>
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.1</version>
-      </extension>
-    </extensions>
     <plugins>
+      <plugin>
+        <groupId>eu.maveniverse.maven.nisse</groupId>
+        <artifactId>plugin3</artifactId>
+        <version>0.3.4</version>
+        <executions>
+          <execution>
+            <id>inject-properties</id>
+            <goals>
+              <goal>inject-properties</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/extensions/grpc/deployment/pom.xml
+++ b/extensions/grpc/deployment/pom.xml
@@ -109,14 +109,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
-
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>

--- a/extensions/grpc/stubs/pom.xml
+++ b/extensions/grpc/stubs/pom.xml
@@ -72,14 +72,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
-
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>

--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -168,14 +168,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
-
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>

--- a/integration-tests/devmode/pom.xml
+++ b/integration-tests/devmode/pom.xml
@@ -92,13 +92,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>


### PR DESCRIPTION
New try for https://github.com/quarkusio/quarkus/pull/46513

We've enhanced the Nisse plugin to provide a simple compatibility flag to generate the exact same properties than the defunct `os-maven-plugin`.  

The [`dependency:go-offline` problem](https://github.com/quarkusio/quarkus/pull/46569#issuecomment-2692129838) does work locally.