### PR TITLE
Improve type safety of method signature

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -168,25 +168,27 @@ public final class PathTestHelper {
      * @return directory or JAR containing the application being tested by the test class
      */
     public static Path getAppClassLocation(Class<?> testClass) {
-        return getAppClassLocationForTestLocation(getTestClassesLocation(testClass).toString());
+        return getAppClassLocationForTestLocation(getTestClassesLocation(testClass));
     }
 
     /**
      * Resolves the directory or the JAR file containing the application being tested by a test from the given location.
      *
-     * @param testClassLocation the test class location
+     * @param testClassLocationPath the test class location
      * @return directory or JAR containing the application being tested by a test from the given location
      */
-    public static Path getAppClassLocationForTestLocation(String testClassLocation) {
-        if (testClassLocation.endsWith(".jar")) {
-            if (testClassLocation.endsWith("-tests.jar")) {
+    public static Path getAppClassLocationForTestLocation(Path testClassLocationPath) {
+        if (testClassLocationPath.endsWith(".jar")) {
+            if (testClassLocationPath.endsWith("-tests.jar")) {
+                String testClassLocation = testClassLocationPath.toString();
                 return Paths.get(new StringBuilder()
                         .append(testClassLocation, 0, testClassLocation.length() - "-tests.jar".length())
                         .append(".jar")
                         .toString());
             }
-            return Path.of(testClassLocation);
+            return testClassLocationPath;
         }
+        String testClassLocation = testClassLocationPath.toString();
         Optional<Path> mainClassesDir = TEST_TO_MAIN_DIR_FRAGMENTS.entrySet().stream()
                 .filter(e -> testClassLocation.contains(e.getKey()))
                 .map(e -> {

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -409,7 +409,7 @@ public class QuarkusProdModeTest
             // sources nor resources, we need to create an empty classes dir to satisfy the resolver
             // as this project will appear as the root application artifact during the bootstrap
             if (Files.isDirectory(testLocation)) {
-                final Path projectClassesDir = PathTestHelper.getAppClassLocationForTestLocation(testLocation.toString());
+                final Path projectClassesDir = PathTestHelper.getAppClassLocationForTestLocation(testLocation);
                 if (!Files.exists(projectClassesDir)) {
                     Files.createDirectories(projectClassesDir);
                 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -134,7 +134,7 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
             }
 
             testClassLocation = getTestClassesLocation(requiredTestClass);
-            appClassLocation = getAppClassLocationForTestLocation(testClassLocation.toString());
+            appClassLocation = getAppClassLocationForTestLocation(testClassLocation);
             if (!appClassLocation.equals(testClassLocation)) {
                 addToBuilderIfConditionMet.accept(testClassLocation);
                 // if test classes is a dir, we should also check whether test resources dir exists as a separate dir (gradle)

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -176,7 +176,7 @@ public final class IntegrationTestUtil {
             boolean isDockerAppLaunch) throws Exception {
         Class<?> requiredTestClass = context.getRequiredTestClass();
         Path testClassLocation = getTestClassesLocation(requiredTestClass);
-        final Path appClassLocation = getAppClassLocationForTestLocation(testClassLocation.toString());
+        final Path appClassLocation = getAppClassLocationForTestLocation(testClassLocation);
 
         final PathList.Builder rootBuilder = PathList.builder();
 


### PR DESCRIPTION
More minor adjustments, peeling unrelated changes out from #34681. 

We convert the parameter for this method to a string before passing it in, but we can improve the expressiveness of the signature by passing in the Path. 