### PR TITLE
Raise default pool size to 500 for Quarkus REST Client to improve performance

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -151,7 +151,7 @@ public interface RestClientsConfig {
      * <p>
      * Can be overwritten by client-specific settings.
      */
-    @ConfigDocDefault("50")
+    @ConfigDocDefault("500")
     OptionalInt connectionPoolSize();
 
     /**
@@ -555,7 +555,7 @@ public interface RestClientsConfig {
         /**
          * The size of the connection pool for this client.
          */
-        @ConfigDocDefault("50")
+        @ConfigDocDefault("500")
         OptionalInt connectionPoolSize();
 
         /**

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
@@ -89,7 +89,7 @@ public class ClientImpl implements Client {
     private static final Logger log = Logger.getLogger(ClientImpl.class);
 
     private static final int DEFAULT_CONNECT_TIMEOUT = 15000;
-    private static final int DEFAULT_CONNECTION_POOL_SIZE = 50;
+    private static final int DEFAULT_CONNECTION_POOL_SIZE = 500;
 
     final ClientContext clientContext;
     final boolean closeVertx;


### PR DESCRIPTION
I created this PR to adapt the Quarkus Rest Client Pool Size to match the one used by [Spring Boot Webflux](https://projectreactor.io/docs/netty/release/reference/http-client.html#_connection_pool) . We have benchmarked Quarkus and Spring Boot in a setup where both service called a 3rd party service and the connection pool was being a blocker for Quarkus. For our Quarkus version it was 20 and Spring Boot had 500. Adapting Quarkus via config to 500 showed it's real potentional. Anyways I know that Quarkus is using the value both for Quarkus Rest (Reactive, Blocking) and RestEasy Classic. Maybe the value 500 it too high for that usecases but I did not find an straightforward way to distinguish between the 3 variants.