### PR TITLE
Make ResponseBuilderImpl more ipv6 aware

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/ResponseBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/ResponseBuilderImpl.java
@@ -29,7 +29,7 @@ public class ResponseBuilderImpl extends AbstractResponseBuilder {
                     String host = req.getRequestHost();
                     int port = -1;
                     int index = host.lastIndexOf(":");
-                    if (index > -1) {
+                    if (index > -1 && (host.charAt(0) != '[' || index > host.lastIndexOf("]"))) {
                         port = Integer.parseInt(host.substring(index + 1));
                         host = host.substring(0, index);
                     }
@@ -70,7 +70,7 @@ public class ResponseBuilderImpl extends AbstractResponseBuilder {
                     String host = req.getRequestHost();
                     int port = -1;
                     int index = host.lastIndexOf(":");
-                    if (index > -1) {
+                    if (index > -1 && (host.charAt(0) != '[' || index > host.lastIndexOf("]"))) {
                         port = Integer.parseInt(host.substring(index + 1));
                         host = host.substring(0, index);
                     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/ResponseBuilderImplTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/jaxrs/ResponseBuilderImplTest.java
@@ -1,0 +1,29 @@
+package org.jboss.resteasy.reactive.server.jaxrs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+
+import jakarta.ws.rs.core.HttpHeaders;
+
+import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ResponseBuilderImplTest {
+
+    @Test
+    public void shouldBuildWithNonAbsoulteLocationAndIPv6Address() {
+        var context = Mockito.mock(ResteasyReactiveRequestContext.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(context.serverRequest().getRequestHost()).thenReturn("[0:0:0:0:0:0:0:1]");
+        Mockito.when(context.getDeployment().getPrefix()).thenReturn("/prefix");
+        CurrentRequestManager.set(context);
+        var response = ResponseBuilderImpl.ok().location(URI.create("/host")).build();
+        assertEquals("//[0:0:0:0:0:0:0:1]/prefix/host", response.getLocation().toString());
+
+        response = ResponseBuilderImpl.ok().contentLocation(URI.create("/host")).build();
+        assertEquals("//[0:0:0:0:0:0:0:1]/host", response.getHeaders().getFirst(HttpHeaders.CONTENT_LOCATION).toString());
+    }
+
+}


### PR DESCRIPTION
Adds a check for ipv6 style host addresses.

The only thing that still looks odd is the content location header value is a URI - should it be a String instead?

closes: #46430