### PR TITLE
SmallRye Fault Tolerance: add support for OpenTelemetry Metrics

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/OpenTelemetrySdkBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/OpenTelemetrySdkBuildItem.java
@@ -7,10 +7,39 @@ import io.quarkus.runtime.RuntimeValue;
 
 public final class OpenTelemetrySdkBuildItem extends SimpleBuildItem {
 
+    private final boolean tracingBuildTimeEnabled;
+    private final boolean metricsBuildTimeEnabled;
+    private final boolean loggingBuildTimeEnabled;
+
     private final RuntimeValue<Boolean> runtimeEnabled;
 
-    public OpenTelemetrySdkBuildItem(RuntimeValue<Boolean> sdkEnabled) {
-        this.runtimeEnabled = sdkEnabled;
+    public OpenTelemetrySdkBuildItem(boolean tracingBuildTimeEnabled, boolean metricsBuildTimeEnabled,
+            boolean loggingBuildTimeEnabled, RuntimeValue<Boolean> runtimeEnabled) {
+        this.tracingBuildTimeEnabled = tracingBuildTimeEnabled;
+        this.metricsBuildTimeEnabled = metricsBuildTimeEnabled;
+        this.loggingBuildTimeEnabled = loggingBuildTimeEnabled;
+        this.runtimeEnabled = runtimeEnabled;
+    }
+
+    /**
+     * @return {@code true} if OpenTelemetry Tracing is enabled at build time
+     */
+    public boolean isTracingBuildTimeEnabled() {
+        return tracingBuildTimeEnabled;
+    }
+
+    /**
+     * @return {@code true} if OpenTelemetry Metrics is enabled at build time
+     */
+    public boolean isMetricsBuildTimeEnabled() {
+        return metricsBuildTimeEnabled;
+    }
+
+    /**
+     * @return {@code true} if OpenTelemetry Logging is enabled at build time
+     */
+    public boolean isLoggingBuildTimeEnabled() {
+        return loggingBuildTimeEnabled;
     }
 
     /**

--- a/tcks/microprofile-fault-tolerance/pom.xml
+++ b/tcks/microprofile-fault-tolerance/pom.xml
@@ -26,6 +26,7 @@
                         <!-- Disable quarkus optimization -->
                         <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
                         <smallrye.faulttolerance.mp-compatibility>true</smallrye.faulttolerance.mp-compatibility>
+                        <quarkus.otel.metrics.enabled>true</quarkus.otel.metrics.enabled>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->
@@ -35,16 +36,6 @@
                     </dependenciesToScan>
                     <reuseForks>false</reuseForks>
                     <excludes>
-                        <!-- Quarkus doesn't implement OpenTelemetry Metrics yet -->
-                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.AllAnnotationTelemetryTest</exclude>
-                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.BulkheadTelemetryTest</exclude>
-                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.CircuitBreakerTelemetryTest</exclude>
-                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.ClashingNameTelemetryTest</exclude>
-                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.ClassLevelTelemetryTest</exclude>
-                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.FallbackTelemetryTest</exclude>
-                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.FaultToleranceDisabledTelemetryTest</exclude>
-                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.RetryTelemetryTest</exclude>
-                        <exclude>org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.TimeoutTelemetryTest</exclude>
                         <!-- We do not support enablement via beans.xml -->
                         <exclude>org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.FaultToleranceInterceptorEnableByXmlTest</exclude>
                     </excludes>
@@ -64,6 +55,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
@@ -88,6 +83,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
One TCK test remains excluded, because it has a bug [1].

[1] https://github.com/microprofile/microprofile-fault-tolerance/pull/655