### PR TITLE
Bump Keycloak version to 26.1.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -177,7 +177,7 @@
         <mockito.version>5.16.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <quarkus-security.version>2.2.0</quarkus-security.version>
-        <keycloak-client.version>26.0.3</keycloak-client.version>
+        <keycloak-client.version>26.0.4</keycloak-client.version>
         <logstash-gelf.version>1.15.1</logstash-gelf.version>
         <checker-qual.version>3.49.1</checker-qual.version>
         <error-prone-annotations.version>2.36.0</error-prone-annotations.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -95,7 +95,7 @@
         <junit4.version>4.13.2</junit4.version>
 
         <!-- The image to use for tests that run Keycloak -->
-        <keycloak.server.version>26.0.7</keycloak.server.version>
+        <keycloak.server.version>26.1.3</keycloak.server.version>
         <keycloak.wildfly.version>19.0.3</keycloak.wildfly.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.server.version}</keycloak.docker.image>
         <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.wildfly.version}-legacy</keycloak.docker.legacy.image>

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -319,7 +319,7 @@ docker run --name keycloak \
   quay.io/keycloak/keycloak:{keycloak.version} \ <1>
   start --hostname-strict=false --https-key-store-file=/etc/keycloak-keystore.jks <2>
 ----
-<1> For `keycloak.version`, ensure the version is `26.0.7` or later.
+<1> For `keycloak.version`, ensure the version is `26.1.3` or later.
 <2> For Keycloak keystore, use the `keycloak-keystore.jks` file located at https://github.com/quarkusio/quarkus-quickstarts/blob/main/security-keycloak-authorization-quickstart/config/keycloak-keystore.jks[quarkus-quickstarts/security-keycloak-authorization-quickstart/config].
 
 .Accessing the Keycloak server

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -217,7 +217,7 @@ For more information, see the <<bearer-token-tutorial-keycloak-dev-mode>> sectio
 docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 ====
-* Where the `keycloak.version` is set to version `26.0.7` or later.
+* Where the `keycloak.version` is set to version `26.1.3` or later.
 . You can access your Keycloak server at http://localhost:8180[localhost:8180].
 . To access the Keycloak Administration console, log in as the `admin` user by using the following login credentials:
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -201,7 +201,7 @@ To start a Keycloak server, use Docker and run the following command:
 docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
-where `keycloak.version` is set to `26.0.7` or later.
+where `keycloak.version` is set to `26.1.3` or later.
 
 You can access your Keycloak Server at http://localhost:8180[localhost:8180].
 

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -505,7 +505,7 @@ To start a Keycloak Server, you can use Docker and just run the following comman
 docker run --name keycloak -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
-Set `{keycloak.version}` to `26.0.7` or later.
+Set `{keycloak.version}` to `26.1.3` or later.
 
 You can access your Keycloak Server at http://localhost:8180[localhost:8180].
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -242,7 +242,7 @@ For more information, see xref:security-oidc-bearer-token-authentication.adoc#be
 [[keycloak-initialization]]
 === Keycloak initialization
 
-The `quay.io/keycloak/keycloak:26.0.7` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
+The `quay.io/keycloak/keycloak:26.1.3` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
 `quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name.
 For example, set it to `quay.io/keycloak/keycloak:19.0.3-legacy` to use a Keycloak distribution powered by WildFly.
 Be aware that a Quarkus-based Keycloak distribution is only available starting from Keycloak `20.0.0`.

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
@@ -40,7 +40,7 @@ public interface KeycloakDevServicesConfig {
      * ends with `-legacy`.
      * Override with `quarkus.keycloak.devservices.keycloak-x-image`.
      */
-    @WithDefault("quay.io/keycloak/keycloak:26.0.7")
+    @WithDefault("quay.io/keycloak/keycloak:26.1.3")
     String imageName();
 
     /**

--- a/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientAuthWithSignedJwtCreator.java
+++ b/integration-tests/oidc-client-registration/src/main/java/io/quarkus/it/keycloak/ClientAuthWithSignedJwtCreator.java
@@ -84,7 +84,7 @@ public class ClientAuthWithSignedJwtCreator {
                 {
                   "redirect_uris" : [ "http://localhost:8081/protected/jwt-bearer-token-file" ],
                   "token_endpoint_auth_method" : "private_key_jwt",
-                  "grant_types" : [ "client_credentials" ],
+                  "grant_types" : [ "client_credentials", "authorization_code" ],
                   "client_name" : "signed-jwt-test",
                   "client_uri" : "%1$s/auth/realms/quarkus/app",
                   "jwks" : {


### PR DESCRIPTION
This PR required only a minor tightening of one of the OIDC Client registration tests, with KC 26.1.3 refusing otherwise to support the code flow for the registered client which requested one specific grant only.

Keycloak client library was also updated to the latest version which was released just before 26.1.3: https://www.keycloak.org/blog