### PR TITLE
Using SocketException in all of the OIDC retry code

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -8,9 +8,9 @@ import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.getPasswo
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.ServerSocket;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
@@ -814,7 +814,7 @@ public class KeycloakDevServicesProcessor {
     }
 
     private static Predicate<? super Throwable> realmEndpointNotAvailable() {
-        return t -> (t instanceof ConnectException
+        return t -> (t instanceof SocketException
                 || (t instanceof RealmEndpointAccessException && ((RealmEndpointAccessException) t).getErrorStatus() == 404));
     }
 

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
@@ -3,7 +3,7 @@ package io.quarkus.oidc.client.registration.runtime;
 import static io.quarkus.jsonp.JsonProviderHolder.jsonProvider;
 
 import java.io.IOException;
-import java.net.ConnectException;
+import java.net.SocketException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -163,7 +163,7 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
         // Retry up to three times with a one-second delay between the retries if the connection is closed
         Buffer buffer = Buffer.buffer(clientRegJson);
         Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, request, filters, buffer).sendBuffer(buffer)
-                .onFailure(ConnectException.class)
+                .onFailure(SocketException.class)
                 .retry()
                 .atMost(oidcConfig.connectionRetryCount())
                 .onFailure().transform(t -> {

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
@@ -3,7 +3,7 @@ package io.quarkus.oidc.client.registration.runtime;
 import static io.quarkus.jsonp.JsonProviderHolder.jsonProvider;
 
 import java.io.IOException;
-import java.net.ConnectException;
+import java.net.SocketException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -162,7 +162,7 @@ public class RegisteredClientImpl implements RegisteredClient {
         }
         // Retry up to three times with a one-second delay between the retries if the connection is closed
         Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, request, buffer).sendBuffer(buffer)
-                .onFailure(ConnectException.class)
+                .onFailure(SocketException.class)
                 .retry()
                 .atMost(oidcConfig.connectionRetryCount())
                 .onFailure().transform(t -> {

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -1,7 +1,7 @@
 package io.quarkus.oidc.client.runtime;
 
 import java.io.IOException;
-import java.net.ConnectException;
+import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Instant;
@@ -244,7 +244,7 @@ public class OidcClientImpl implements OidcClient {
         // Retry up to three times with a one-second delay between the retries if the connection is closed
         Buffer buffer = OidcCommonUtils.encodeForm(body);
         Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, endpointType, request, buffer).sendBuffer(buffer)
-                .onFailure(ConnectException.class)
+                .onFailure(SocketException.class)
                 .retry()
                 .atMost(oidcConfig.connectionRetryCount())
                 .onFailure().transform(t -> {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -3,8 +3,8 @@ package io.quarkus.oidc.common.runtime;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.ConnectException;
 import java.net.InetAddress;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
@@ -514,7 +514,7 @@ public class OidcCommonUtils {
     }
 
     public static Predicate<? super Throwable> oidcEndpointNotAvailable() {
-        return t -> (t instanceof ConnectException
+        return t -> (t instanceof SocketException
                 || (t instanceof OidcEndpointAccessException && ((OidcEndpointAccessException) t).getErrorStatus() == 404));
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -1,7 +1,7 @@
 package io.quarkus.oidc.runtime;
 
 import java.io.Closeable;
-import java.net.ConnectException;
+import java.net.SocketException;
 import java.security.Key;
 import java.util.HashMap;
 import java.util.List;
@@ -346,7 +346,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
 
         OidcEndpoint.Type endpoint = introspect ? OidcEndpoint.Type.INTROSPECTION : OidcEndpoint.Type.TOKEN;
         Uni<HttpResponse<Buffer>> response = filterHttpRequest(requestProps, endpoint, request, buffer).sendBuffer(buffer)
-                .onFailure(ConnectException.class)
+                .onFailure(SocketException.class)
                 .retry()
                 .atMost(oidcConfig.connectionRetryCount()).onFailure().transform(Throwable::getCause);
         return response.onItem();


### PR DESCRIPTION
Fixes #46615.

Right now the retry code in various OIDC extensions checks `ConnectException` but widening it a little bit and checking its superclass `SocketException` should capture more network related issues like a slow network etc.

There was also a proposal at #46615 to retry in case of OIDC failing with the server errors but unfortunately it is out of scope, Quarkus OIDC extensions can not be dealing with the live OIDC server problems.