### PR TITLE
AWS Lambda bump to Java21

### DIFF
--- a/extensions/amazon-lambda-http/deployment/src/main/resources/http/sam.jvm.yaml
+++ b/extensions/amazon-lambda-http/deployment/src/main/resources/http/sam.jvm.yaml
@@ -12,7 +12,7 @@
       Type: AWS::Serverless::Function
       Properties:
         Handler: io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
-        Runtime: java17
+        Runtime: java21
         CodeUri: function.zip
         MemorySize: 512
         Policies: AWSLambdaBasicExecutionRole


### PR DESCRIPTION
Since Quarkus 3.19+ is Java 21 we should bump this lambda config because if you try and deploy it fails right now because of Quarkus set for 21 but the lamdba set for 17