### PR TITLE
Correct summary text of config-yaml.adoc

### DIFF
--- a/docs/src/main/asciidoc/config-yaml.adoc
+++ b/docs/src/main/asciidoc/config-yaml.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :diataxis-type: howto
 :categories: core
-:summary: Optionally, use `application.yaml` instead of `application.properties` to configure your application.
+:summary: Optionally, use application.yaml instead of application.properties to configure your application.
 :topics: configuration
 :extensions: io.quarkus:quarkus-config-yaml
 


### PR DESCRIPTION
as backquote cannot be used in summary text. It breaks guide index page.

Please see YAML configuration block of https://quarkus.io/guides/