### PR TITLE
Correct summary text of spring-boot-properties.adoc

### DIFF
--- a/docs/src/main/asciidoc/spring-boot-properties.adoc
+++ b/docs/src/main/asciidoc/spring-boot-properties.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Accessing application properties with Spring Boot properties API
 include::_attributes.adoc[]
 :categories: compatibility
-:summary: Use Spring Boot's `@ConfigurationProperties` in place of MicroProfile Config annotations
+:summary: Use Spring Boot's @ConfigurationProperties in place of MicroProfile Config annotations
 :topics: spring,configuration,compatibility
 :extensions: io.quarkus:quarkus-spring-boot-properties
 


### PR DESCRIPTION
as backquote cannot be used in summary text. It breaks guides index page.

Please see Spring Boot properties block of https://quarkus.io/guides/