### PR TITLE
ArC: fix disposer resolution in case the disposed parameter declares no qualifiers

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DisposerInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DisposerInfo.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.DefinitionException;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -75,8 +76,13 @@ public class DisposerInfo implements InjectionTargetInfo {
 
     Collection<AnnotationInstance> getDisposedParameterQualifiers() {
         Set<AnnotationInstance> resultingQualifiers = new HashSet<>();
-        Annotations.getParameterAnnotations(declaringBean.getDeployment(), disposerMethod, disposedParameter.position())
-                .stream().forEach(a -> resultingQualifiers.addAll(declaringBean.getDeployment().extractQualifiers(a)));
+        for (AnnotationInstance ann : Annotations.getParameterAnnotations(declaringBean.getDeployment(), disposerMethod,
+                disposedParameter.position())) {
+            resultingQualifiers.addAll(declaringBean.getDeployment().extractQualifiers(ann));
+        }
+        if (resultingQualifiers.isEmpty()) {
+            resultingQualifiers.add(AnnotationInstance.builder(Default.class).build());
+        }
         return resultingQualifiers;
     }
 


### PR DESCRIPTION
In case a disposed parameter of a disposer method declares no qualifiers, the disposer method was considered matching even for a producer that does declare qualifiers. This is wrong, because per the typesafe resolution rules, if there's no qualifier, `@Default` is assumed.

This commit fixes that: in case no qualifier is declared, `@Default` is assumed, so that the disposer only matches a producer that also declares no qualifier (or explicitly declares `@Default`).

Related to #46646