### PR TITLE
Dev UI: Added theme: Red and Blue

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.config.Config;
@@ -446,7 +447,7 @@ public class BuildTimeContentProcessor {
 
         BuildTimeConstBuildItem internalBuildTimeData = new BuildTimeConstBuildItem(AbstractDevUIBuildItem.DEV_UI);
 
-        addThemeBuildTimeData(internalBuildTimeData, themeVarsProducer);
+        addThemeBuildTimeData(internalBuildTimeData, devUIConfig, themeVarsProducer);
         addMenuSectionBuildTimeData(internalBuildTimeData, internalPages, extensionsBuildItem);
         addFooterTabBuildTimeData(internalBuildTimeData, extensionsBuildItem, devUIConfig);
         addVersionInfoBuildTimeData(internalBuildTimeData, curateOutcomeBuildItem, nonApplicationRootPathBuildItem);
@@ -466,14 +467,22 @@ public class BuildTimeContentProcessor {
         return "";
     }
 
-    private void addThemeBuildTimeData(BuildTimeConstBuildItem internalBuildTimeData,
+    private void addThemeBuildTimeData(BuildTimeConstBuildItem internalBuildTimeData, DevUIConfig devUIConfig,
             BuildProducer<ThemeVarsBuildItem> themeVarsProducer) {
-        // Theme details TODO: Allow configuration
         Map<String, Map<String, String>> themes = new HashMap<>();
         Map<String, String> dark = new HashMap<>();
         Map<String, String> light = new HashMap<>();
 
-        computeColors(themes, dark, light);
+        switch (devUIConfig.baseTheme()) {
+            case red:
+                computeRedColors(themes, dark, light, devUIConfig.theme());
+                break;
+            case blue:
+                computeBlueColors(themes, dark, light, devUIConfig.theme());
+                break;
+            default:
+                computeDefaultColors(themes, dark, light, devUIConfig.theme());
+        }
 
         internalBuildTimeData.addBuildTimeData("themes", themes);
 
@@ -687,7 +696,7 @@ public class BuildTimeContentProcessor {
             FINEST.getName(),
             ALL.getName());
 
-    private static void computeColors(Map<String, Map<String, String>> themes, Map<String, String> dark,
+    private static void addQuarkusLogoColors(Map<String, String> dark,
             Map<String, String> light) {
         // Quarkus logo colors
         light.put("--quarkus-blue", QUARKUS_BLUE.toString());
@@ -698,105 +707,476 @@ public class BuildTimeContentProcessor {
 
         light.put("--quarkus-center", QUARKUS_DARK.toString());
         dark.put("--quarkus-center", QUARKUS_LIGHT.toString());
+    }
 
-        // Vaadin's Lumo (see https://vaadin.com/docs/latest/styling/lumo/design-tokens/color)
+    /**
+     * To get back to the original, add this
+     * %dev.quarkus.dev-ui.theme.dark.base-color-light=hsla(0, 100%, 100%, 1)
+     * %dev.quarkus.dev-ui.theme.dark.base-color-dark=hsla(210, 10%, 23%, 1)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-5pct-light=hsla(214, 61%, 25%, 0.05)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-5pct-dark=hsla(214, 65%, 85%, 0.06)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-10pct-light=hsla(214, 57%, 24%, 0.1)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-10pct-dark=hsla(214, 60%, 80%, 0.14)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-20pct-light=hsla(214, 53%, 23%, 0.16)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-20pct-dark=hsla(214, 64%, 82%, 0.23)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-30pct-light=hsla(214, 50%, 22%, 0.26)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-30pct-dark=hsla(214, 69%, 84%, 0.32)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-40pct-light=hsla(214, 47%, 21%, 0.38)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-40pct-dark=hsla(214, 73%, 86%, 0.41)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-50pct-light=hsla(214, 45%, 20%, 0.52)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-50pct-dark=hsla(214, 78%, 88%, 0.50)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-60pct-light=hsla(214, 43%, 19%, 0.6)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-60pct-dark=hsla(214, 82%, 90%, 0.6)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-70pct-light=hsla(214, 42%, 18%, 0.69)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-70pct-dark=hsla(214, 87%, 92%, 0.7)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-80pct-light=hsla(214, 41%, 17%, 0.83)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-80pct-dark=hsla(214, 91%, 94%, 0.8)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-90pct-light=hsla(214, 40%, 16%, 0.94)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-90pct-dark=hsla(214, 96%, 96%, 0.9)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-light=hsla(214, 35%, 15%, 1)
+     * %dev.quarkus.dev-ui.theme.dark.contrast-dark=hsla(214, 100%, 98%, 1)
+     * %dev.quarkus.dev-ui.theme.dark.error-color-light=hsla(3, 85%, 48%, 1)
+     * %dev.quarkus.dev-ui.theme.dark.error-color-dark=hsla(3, 90%, 63%, 1)
+     * %dev.quarkus.dev-ui.theme.dark.header-text-color-light=hsla(214, 35%, 15%, 1)
+     * %dev.quarkus.dev-ui.theme.dark.header-text-color-dark=hsla(214, 100%, 98%, 1)
+     */
 
-        // Base
-        light.put("--lumo-base-color", Color.from(0, 100, 100).toString());
-        dark.put("--lumo-base-color", Color.from(210, 10, 23).toString());
+    private static void computeDefaultColors(Map<String, Map<String, String>> themes,
+            Map<String, String> dark,
+            Map<String, String> light,
+            Optional<DevUIConfig.Theme> theme) {
 
-        // Grayscale
-        light.put("--lumo-contrast-5pct", Color.from(214, 61, 25, 0.05).toString());
-        dark.put("--lumo-contrast-5pct", Color.from(214, 65, 85, 0.06).toString());
-        light.put("--lumo-contrast-10pct", Color.from(214, 57, 24, 0.1).toString());
-        dark.put("--lumo-contrast-10pct", Color.from(214, 60, 80, 0.14).toString());
-        light.put("--lumo-contrast-20pct", Color.from(214, 53, 23, 0.16).toString());
-        dark.put("--lumo-contrast-20pct", Color.from(214, 64, 82, 0.23).toString());
-        light.put("--lumo-contrast-30pct", Color.from(214, 50, 22, 0.26).toString());
-        dark.put("--lumo-contrast-30pct", Color.from(214, 69, 84, 0.32).toString());
-        light.put("--lumo-contrast-40pct", Color.from(214, 47, 21, 0.38).toString());
-        dark.put("--lumo-contrast-40pct", Color.from(214, 73, 86, 0.41).toString());
-        light.put("--lumo-contrast-50pct", Color.from(214, 45, 20, 0.52).toString());
-        dark.put("--lumo-contrast-50pct", Color.from(214, 78, 88, 0.50).toString());
-        light.put("--lumo-contrast-60pct", Color.from(214, 43, 19, 0.6).toString());
-        dark.put("--lumo-contrast-60pct", Color.from(214, 82, 90, 0.6).toString());
-        light.put("--lumo-contrast-70pct", Color.from(214, 42, 18, 0.69).toString());
-        dark.put("--lumo-contrast-70pct", Color.from(214, 87, 92, 0.7).toString());
-        light.put("--lumo-contrast-80pct", Color.from(214, 41, 17, 0.83).toString());
-        dark.put("--lumo-contrast-80pct", Color.from(214, 91, 94, 0.8).toString());
-        light.put("--lumo-contrast-90pct", Color.from(214, 40, 16, 0.94).toString());
-        dark.put("--lumo-contrast-90pct", Color.from(214, 96, 96, 0.9).toString());
-        light.put("--lumo-contrast", Color.from(214, 35, 15).toString());
-        dark.put("--lumo-contrast", Color.from(214, 100, 98).toString());
+        addQuarkusLogoColors(dark, light);
 
-        // Primary
-        light.put("--lumo-primary-color-10pct", Color.from(214, 100, 60, 0.13).toString());
-        dark.put("--lumo-primary-color-10pct", Color.from(214, 90, 63, 0.1).toString());
-        light.put("--lumo-primary-color-50pct", Color.from(QUARKUS_BLUE, 0.76).toString());
-        dark.put("--lumo-primary-color-50pct", Color.from(QUARKUS_BLUE, 0.5).toString());
-        light.put("--lumo-primary-color", QUARKUS_BLUE.toString());
-        dark.put("--lumo-primary-color", QUARKUS_BLUE.toString());
-        light.put("--lumo-primary-text-color", QUARKUS_BLUE.toString());
-        dark.put("--lumo-primary-text-color", QUARKUS_BLUE.toString());
-        light.put("--lumo-primary-contrast-color", Color.from(0, 100, 100).toString());
-        dark.put("--lumo-primary-contrast-color", Color.from(0, 100, 100).toString());
+        // Base Colors
+        light.put("--lumo-base-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::baseColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-base-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark, DevUIConfig.ThemeMode::baseColor,
+                Color.from(0, 0, 13).toString()));
 
-        // Error
-        light.put("--lumo-error-color-10pct", Color.from(3, 85, 49, 0.1).toString());
-        dark.put("--lumo-error-color-10pct", Color.from(3, 90, 63, 0.1).toString());
-        light.put("--lumo-error-color-50pct", Color.from(3, 85, 49, 0.5).toString());
-        dark.put("--lumo-error-color-50pct", Color.from(3, 90, 63, 0.5).toString());
-        light.put("--lumo-error-color", Color.from(3, 85, 48).toString());
-        dark.put("--lumo-error-color", Color.from(3, 90, 63).toString());
-        light.put("--lumo-error-text-color", Color.from(3, 89, 42).toString());
-        dark.put("--lumo-error-text-color", Color.from(3, 100, 67).toString());
-        light.put("--lumo-error-contrast-color", Color.from(0, 100, 100).toString());
-        dark.put("--lumo-error-contrast-color", Color.from(0, 100, 100).toString());
+        // Contrast Colors
+        light.put("--lumo-contrast", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light, DevUIConfig.ThemeMode::contrast,
+                Color.from(0, 0, 13).toString()));
+        dark.put("--lumo-contrast", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark, DevUIConfig.ThemeMode::contrast,
+                Color.from(0, 0, 100).toString()));
 
-        // Warning
-        light.put("--lumo-warning-color-10pct", Color.from(30, 100, 50, 0.1).toString());
-        dark.put("--lumo-warning-color-10pct", Color.from(30, 100, 50, 0.1).toString());
-        light.put("--lumo-warning-color-50pct", Color.from(30, 100, 50, 0.5).toString());
-        dark.put("--lumo-warning-color-50pct", Color.from(30, 100, 50, 0.5).toString());
-        light.put("--lumo-warning-color", Color.from(30, 100, 50).toString());
-        dark.put("--lumo-warning-color", Color.from(30, 100, 50).toString());
-        light.put("--lumo-warning-text-color", Color.from(30, 89, 42).toString());
-        dark.put("--lumo-warning-text-color", Color.from(30, 100, 67).toString());
-        light.put("--lumo-warning-contrast-color", Color.from(0, 100, 100).toString());
-        dark.put("--lumo-warning-contrast-color", Color.from(0, 100, 100).toString());
+        // Primary Colors
+        light.put("--lumo-primary-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::primaryColor, QUARKUS_BLUE.toString()));
+        dark.put("--lumo-primary-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::primaryColor, QUARKUS_BLUE.toString()));
 
-        // Success
-        light.put("--lumo-success-color-10pct", Color.from(145, 72, 31, 0.1).toString());
-        dark.put("--lumo-success-color-10pct", Color.from(145, 65, 42, 0.1).toString());
-        light.put("--lumo-success-color-50pct", Color.from(145, 72, 31, 0.5).toString());
-        dark.put("--lumo-success-color-50pct", Color.from(145, 65, 42, 0.5).toString());
-        light.put("--lumo-success-color", Color.from(145, 72, 30).toString());
-        dark.put("--lumo-success-color", Color.from(145, 65, 42).toString());
-        light.put("--lumo-success-text-color", Color.from(145, 85, 25).toString());
-        dark.put("--lumo-success-text-color", Color.from(145, 85, 47).toString());
-        light.put("--lumo-success-contrast-color", Color.from(0, 100, 100).toString());
-        dark.put("--lumo-success-contrast-color", Color.from(0, 100, 100).toString());
+        light.put("--lumo-primary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::primaryTextColor, Color.from(210, 90, 60).toString()));
+        dark.put("--lumo-primary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::primaryTextColor, Color.from(210, 90, 60).toString()));
 
-        // Text
-        light.put("--lumo-header-text-color", Color.from(214, 35, 15).toString());
-        dark.put("--lumo-header-text-color", Color.from(214, 100, 98).toString());
-        light.put("--lumo-body-text-color", Color.from(214, 40, 16, 0.94).toString());
-        dark.put("--lumo-body-text-color", Color.from(214, 96, 96, 0.9).toString());
-        light.put("--lumo-secondary-text-color", Color.from(214, 42, 18, 0.69).toString());
-        dark.put("--lumo-secondary-text-color", Color.from(214, 87, 92, 0.7).toString());
-        light.put("--lumo-tertiary-text-color", Color.from(214, 45, 20, 0.52).toString());
-        dark.put("--lumo-tertiary-text-color", Color.from(214, 78, 88, 0.5).toString());
-        light.put("--lumo-disabled-text-color", Color.from(214, 50, 22, 0.26).toString());
-        dark.put("--lumo-disabled-text-color", Color.from(214, 69, 84, 0.32).toString());
+        light.put("--lumo-primary-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::primaryContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-primary-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::primaryContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Error Colors
+        light.put("--lumo-error-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::errorTextColor, QUARKUS_RED.toString()));
+        dark.put("--lumo-error-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::errorTextColor, QUARKUS_RED.toString()));
+
+        light.put("--lumo-error-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::errorTextColor, Color.from(3, 90, 42).toString()));
+        dark.put("--lumo-error-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::errorTextColor, Color.from(3, 90, 63).toString()));
+
+        light.put("--lumo-error-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::errorContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-error-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::errorContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Warning Colors
+        light.put("--lumo-warning-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::warningColor, Color.from(30, 100, 50).toString()));
+        dark.put("--lumo-warning-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::warningColor, Color.from(30, 100, 50).toString()));
+
+        light.put("--lumo-warning-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::warningTextColor, Color.from(30, 89, 42).toString()));
+        dark.put("--lumo-warning-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::warningTextColor, Color.from(30, 100, 67).toString()));
+
+        light.put("--lumo-warning-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::warningContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-warning-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::warningContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Success Colors
+        light.put("--lumo-success-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successColor, Color.from(145, 72, 30).toString()));
+        dark.put("--lumo-success-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successColor, Color.from(145, 65, 42).toString()));
+
+        light.put("--lumo-success-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successTextColor, Color.from(145, 85, 25).toString()));
+        dark.put("--lumo-success-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successTextColor, Color.from(145, 85, 47).toString()));
+
+        light.put("--lumo-success-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-success-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Text Colors
+        light.put("--lumo-header-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::headerTextColor, Color.from(0, 0, 13).toString()));
+        dark.put("--lumo-header-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::headerTextColor, Color.from(0, 0, 100).toString()));
+
+        light.put("--lumo-body-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::bodyTextColor, Color.from(0, 0, 20, 0.94).toString()));
+        dark.put("--lumo-body-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::bodyTextColor, Color.from(0, 0, 90, 0.9).toString()));
+
+        light.put("--lumo-secondary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::secondaryTextColor, Color.from(0, 0, 40, 0.69).toString()));
+        dark.put("--lumo-secondary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::secondaryTextColor, Color.from(0, 0, 70, 0.7).toString()));
+
+        light.put("--lumo-tertiary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::tertiaryTextColor, Color.from(0, 0, 50, 0.52).toString()));
+        dark.put("--lumo-tertiary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::tertiaryTextColor, Color.from(0, 0, 60, 0.5).toString()));
+
+        light.put("--lumo-disabled-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::disabledTextColor, Color.from(0, 0, 60, 0.26).toString()));
+        dark.put("--lumo-disabled-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::disabledTextColor, Color.from(0, 0, 50, 0.32).toString()));
+
+        // Grayscale Adjustments
+        for (int i = 5; i <= 90; i += 5) {
+            double opacity = i / 100.0;
+            String key = "--lumo-contrast-" + i + "pct";
+
+            // Retrieve from theme if available, otherwise use default computed color
+            String lightContrast = getThemeSettingOrDefault(theme,
+                    DevUIConfig.Theme::light,
+                    getContrastPct(i),
+                    Color.from(0, 0, 13, opacity).toString());
+
+            String darkContrast = getThemeSettingOrDefault(theme,
+                    DevUIConfig.Theme::dark,
+                    getContrastPct(i),
+                    Color.from(0, 0, 100, opacity).toString());
+
+            light.put(key, lightContrast);
+            dark.put(key, darkContrast);
+        }
 
         themes.put("dark", dark);
         themes.put("light", light);
     }
 
-    private static final Color QUARKUS_BLUE = Color.from(211, 63, 54);
-    private static final Color QUARKUS_RED = Color.from(343, 100, 50);
-    private static final Color QUARKUS_DARK = Color.from(180, 36, 5);
-    private static final Color QUARKUS_LIGHT = Color.from(0, 0, 90);
+    private static void computeRedColors(Map<String, Map<String, String>> themes,
+            Map<String, String> dark,
+            Map<String, String> light,
+            Optional<DevUIConfig.Theme> theme) {
+
+        addQuarkusLogoColors(dark, light);
+
+        // Base Colors
+        light.put("--lumo-base-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::baseColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-base-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark, DevUIConfig.ThemeMode::baseColor,
+                Color.from(0, 0, 10).toString()));
+
+        // Contrast Colors
+        light.put("--lumo-contrast", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light, DevUIConfig.ThemeMode::contrast,
+                Color.from(0, 0, 10).toString()));
+        dark.put("--lumo-contrast", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark, DevUIConfig.ThemeMode::contrast,
+                Color.from(0, 0, 100).toString()));
+
+        // Primary Colors
+        light.put("--lumo-primary-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::primaryColor, Color.from(0, 100, 47).toString()));
+        dark.put("--lumo-primary-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::primaryColor, Color.from(0, 100, 47).toString()));
+
+        light.put("--lumo-primary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::primaryTextColor, Color.from(0, 100, 47).toString()));
+        dark.put("--lumo-primary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::primaryTextColor, Color.from(0, 100, 47).toString()));
+
+        light.put("--lumo-primary-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::primaryContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-primary-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::primaryContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Error Colors
+        light.put("--lumo-error-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::errorColor, Color.from(0, 100, 47).toString()));
+        dark.put("--lumo-error-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::errorColor, Color.from(0, 100, 47).toString()));
+
+        light.put("--lumo-error-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::errorTextColor, Color.from(0, 100, 40).toString()));
+        dark.put("--lumo-error-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::errorTextColor, Color.from(0, 100, 55).toString()));
+
+        light.put("--lumo-error-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::errorContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-error-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::errorContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Warning Colors
+        light.put("--lumo-warning-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::warningColor, Color.from(0, 0, 96).toString()));
+        dark.put("--lumo-warning-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::warningColor, Color.from(0, 0, 96).toString()));
+
+        light.put("--lumo-warning-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::warningTextColor, Color.from(0, 0, 80).toString()));
+        dark.put("--lumo-warning-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::warningTextColor, Color.from(0, 0, 85).toString()));
+
+        light.put("--lumo-warning-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::warningContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-warning-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::warningContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Success Colors
+        light.put("--lumo-success-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successColor, Color.from(207, 100, 25).toString()));
+        dark.put("--lumo-success-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successColor, Color.from(207, 100, 25).toString()));
+
+        light.put("--lumo-success-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successTextColor, Color.from(207, 100, 30).toString()));
+        dark.put("--lumo-success-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successTextColor, Color.from(207, 100, 35).toString()));
+
+        light.put("--lumo-success-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-success-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Text Colors
+        light.put("--lumo-header-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 10).toString()));
+        dark.put("--lumo-header-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 100).toString()));
+
+        light.put("--lumo-body-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 20, 0.94).toString()));
+        dark.put("--lumo-body-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 90, 0.9).toString()));
+
+        light.put("--lumo-secondary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 40, 0.69).toString()));
+        dark.put("--lumo-secondary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 70, 0.7).toString()));
+
+        light.put("--lumo-tertiary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 50, 0.52).toString()));
+        dark.put("--lumo-tertiary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 60, 0.5).toString()));
+
+        light.put("--lumo-disabled-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 60, 0.26).toString()));
+        dark.put("--lumo-disabled-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 50, 0.32).toString()));
+
+        // Grayscale Adjustments
+        for (int i = 5; i <= 90; i += 5) {
+            double opacity = i / 100.0;
+            String key = "--lumo-contrast-" + i + "pct";
+
+            // Retrieve from theme if available, otherwise use default computed color
+            String lightContrast = getThemeSettingOrDefault(theme,
+                    DevUIConfig.Theme::light,
+                    getContrastPct(i),
+                    Color.from(0, 0, 10, opacity).toString());
+
+            String darkContrast = getThemeSettingOrDefault(theme,
+                    DevUIConfig.Theme::dark,
+                    getContrastPct(i),
+                    Color.from(0, 0, 100, opacity).toString());
+
+            light.put(key, lightContrast);
+            dark.put(key, darkContrast);
+        }
+
+        themes.put("dark", dark);
+        themes.put("light", light);
+    }
+
+    private static void computeBlueColors(Map<String, Map<String, String>> themes,
+            Map<String, String> dark,
+            Map<String, String> light,
+            Optional<DevUIConfig.Theme> theme) {
+
+        addQuarkusLogoColors(dark, light);
+
+        // Base Colors
+        light.put("--lumo-base-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::baseColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-base-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark, DevUIConfig.ThemeMode::baseColor,
+                Color.from(0, 0, 9).toString()));
+
+        // Contrast Colors
+        light.put("--lumo-contrast", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light, DevUIConfig.ThemeMode::contrast,
+                Color.from(0, 0, 9).toString()));
+        dark.put("--lumo-contrast", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark, DevUIConfig.ThemeMode::contrast,
+                Color.from(0, 0, 100).toString()));
+
+        // Primary Colors
+        light.put("--lumo-primary-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::primaryColor, Color.from(212, 90, 20).toString()));
+        dark.put("--lumo-primary-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::primaryColor, Color.from(212, 90, 20).toString()));
+
+        light.put("--lumo-primary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::primaryTextColor, Color.from(212, 90, 20).toString()));
+        dark.put("--lumo-primary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::primaryTextColor, Color.from(212, 53, 48).toString()));
+
+        light.put("--lumo-primary-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::primaryContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-primary-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::primaryContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Error Colors
+        light.put("--lumo-error-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::errorColor, Color.from(212, 90, 20).toString()));
+        dark.put("--lumo-error-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::errorColor, Color.from(212, 90, 20).toString()));
+
+        light.put("--lumo-error-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::errorTextColor, Color.from(212, 90, 30).toString()));
+        dark.put("--lumo-error-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::errorTextColor, Color.from(212, 90, 40).toString()));
+
+        light.put("--lumo-error-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::errorContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-error-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::errorContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Warning Colors
+        light.put("--lumo-warning-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::warningColor, Color.from(0, 0, 96).toString()));
+        dark.put("--lumo-warning-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::warningColor, Color.from(0, 0, 96).toString()));
+
+        light.put("--lumo-warning-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::warningTextColor, Color.from(0, 0, 80).toString()));
+        dark.put("--lumo-warning-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::warningTextColor, Color.from(0, 0, 85).toString()));
+
+        light.put("--lumo-warning-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::warningContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-warning-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::warningContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Success Colors
+        light.put("--lumo-success-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successColor, Color.from(214, 49, 50).toString()));
+        dark.put("--lumo-success-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successColor, Color.from(214, 49, 50).toString()));
+
+        light.put("--lumo-success-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successTextColor, Color.from(214, 49, 55).toString()));
+        dark.put("--lumo-success-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successTextColor, Color.from(214, 49, 60).toString()));
+
+        light.put("--lumo-success-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 100).toString()));
+        dark.put("--lumo-success-contrast-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 100).toString()));
+
+        // Text colors
+        light.put("--lumo-header-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 9).toString()));
+        dark.put("--lumo-header-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 100).toString()));
+
+        light.put("--lumo-body-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 20, 0.94).toString()));
+        dark.put("--lumo-body-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 90, 0.9).toString()));
+
+        light.put("--lumo-secondary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 40, 0.69).toString()));
+        dark.put("--lumo-secondary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 70, 0.7).toString()));
+
+        light.put("--lumo-tertiary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 50, 0.52).toString()));
+        dark.put("--lumo-tertiary-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 60, 0.5).toString()));
+
+        light.put("--lumo-disabled-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::light,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 60, 0.26).toString()));
+        dark.put("--lumo-disabled-text-color", getThemeSettingOrDefault(theme, DevUIConfig.Theme::dark,
+                DevUIConfig.ThemeMode::successContrastColor, Color.from(0, 0, 50, 0.32).toString()));
+
+        // Grayscale Adjustments
+        for (int i = 5; i <= 90; i += 5) {
+            double opacity = i / 100.0;
+            String key = "--lumo-contrast-" + i + "pct";
+
+            // Retrieve from theme if available, otherwise use default computed color
+            String lightContrast = getThemeSettingOrDefault(theme,
+                    DevUIConfig.Theme::light,
+                    getContrastPct(i),
+                    Color.from(0, 0, 10, opacity).toString());
+
+            String darkContrast = getThemeSettingOrDefault(theme,
+                    DevUIConfig.Theme::dark,
+                    getContrastPct(i),
+                    Color.from(0, 0, 100, opacity).toString());
+
+            light.put(key, lightContrast);
+            dark.put(key, darkContrast);
+        }
+
+        themes.put("dark", dark);
+        themes.put("light", light);
+    }
+
+    private static Function<DevUIConfig.ThemeMode, Optional<String>> getContrastPct(int percentage) {
+        return switch (percentage) {
+            case 5 -> DevUIConfig.ThemeMode::contrast5pct;
+            case 10 -> DevUIConfig.ThemeMode::contrast10pct;
+            case 15 -> DevUIConfig.ThemeMode::contrast15pct;
+            case 20 -> DevUIConfig.ThemeMode::contrast20pct;
+            case 25 -> DevUIConfig.ThemeMode::contrast25pct;
+            case 30 -> DevUIConfig.ThemeMode::contrast30pct;
+            case 35 -> DevUIConfig.ThemeMode::contrast35pct;
+            case 40 -> DevUIConfig.ThemeMode::contrast40pct;
+            case 45 -> DevUIConfig.ThemeMode::contrast45pct;
+            case 50 -> DevUIConfig.ThemeMode::contrast50pct;
+            case 55 -> DevUIConfig.ThemeMode::contrast55pct;
+            case 60 -> DevUIConfig.ThemeMode::contrast60pct;
+            case 65 -> DevUIConfig.ThemeMode::contrast65pct;
+            case 70 -> DevUIConfig.ThemeMode::contrast70pct;
+            case 75 -> DevUIConfig.ThemeMode::contrast75pct;
+            case 80 -> DevUIConfig.ThemeMode::contrast80pct;
+            case 85 -> DevUIConfig.ThemeMode::contrast85pct;
+            case 90 -> DevUIConfig.ThemeMode::contrast90pct;
+            default -> mode -> Optional.empty(); // Just in case, should never happen
+        };
+    }
+
+    private static final Color QUARKUS_BLUE = Color.from(210, 90, 60);
+    private static final Color QUARKUS_RED = Color.from(4, 90, 58);
+    private static final Color QUARKUS_DARK = Color.from(0, 0, 13);
+    private static final Color QUARKUS_LIGHT = Color.from(0, 0, 100);
+
+    private static String getThemeSettingOrDefault(Optional<DevUIConfig.Theme> theme,
+            Function<DevUIConfig.Theme, Optional<DevUIConfig.ThemeMode>> themeModeExtractor,
+            Function<DevUIConfig.ThemeMode, Optional<String>> settingExtractor,
+            String defaultValue) {
+        return theme.flatMap(themeModeExtractor) // Extract dark or light theme mode
+                .flatMap(settingExtractor) // Extract specific setting
+                .orElse(defaultValue); // Return default if not present
+    }
 
     /**
      * This represents a HSLA color

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIConfig.java
@@ -25,6 +25,14 @@ public interface DevUIConfig {
     boolean showJsonRpcLog();
 
     /**
+     * Set the base theme.
+     *
+     * @return Theme
+     */
+    @WithDefault("quarkus")
+    BaseTheme baseTheme();
+
+    /**
      * More hosts allowed for Dev UI
      *
      * Comma separated list of valid URLs, e.g.: www.quarkus.io, myhost.com
@@ -38,6 +46,11 @@ public interface DevUIConfig {
      */
     Cors cors();
 
+    /**
+     * Fine tune the theme
+     */
+    Optional<Theme> theme();
+
     @ConfigGroup
     interface Cors {
 
@@ -46,6 +59,213 @@ public interface DevUIConfig {
          */
         @WithDefault("true")
         boolean enabled();
+    }
+
+    @ConfigGroup
+    interface Theme {
+        /**
+         * Override the dark theme vars
+         */
+        Optional<ThemeMode> dark();
+
+        /**
+         * Override the light theme vars
+         */
+        Optional<ThemeMode> light();
+    }
+
+    @ConfigGroup
+    interface ThemeMode {
+        /**
+         * This will replace the theme base-color
+         */
+        Optional<String> baseColor();
+
+        /**
+         * This will replace the theme contrast
+         */
+        Optional<String> contrast();
+
+        /**
+         * This will replace the theme primary-color
+         */
+        Optional<String> primaryColor();
+
+        /**
+         * This will replace the theme primary-text-color
+         */
+        Optional<String> primaryTextColor();
+
+        /**
+         * This will replace the theme primary-contrast-ccolor
+         */
+        Optional<String> primaryContrastColor();
+
+        /**
+         * This will replace the theme error-color
+         */
+        Optional<String> errorColor();
+
+        /**
+         * This will replace the theme error-text-color
+         */
+        Optional<String> errorTextColor();
+
+        /**
+         * This will replace the theme error-contrast-color
+         */
+        Optional<String> errorContrastColor();
+
+        /**
+         * This will replace the theme warning-color
+         */
+        Optional<String> warningColor();
+
+        /**
+         * This will replace the theme warning-text-color
+         */
+        Optional<String> warningTextColor();
+
+        /**
+         * This will replace the theme warning-contrast-color
+         */
+        Optional<String> warningContrastColor();
+
+        /**
+         * This will replace the theme success-color
+         */
+        Optional<String> successColor();
+
+        /**
+         * This will replace the theme success-text-color
+         */
+        Optional<String> successTextColor();
+
+        /**
+         * This will replace the theme success-contrast-color
+         */
+        Optional<String> successContrastColor();
+
+        /**
+         * This will replace the theme header-text-color
+         */
+        Optional<String> headerTextColor();
+
+        /**
+         * This will replace the theme body-text-color
+         */
+        Optional<String> bodyTextColor();
+
+        /**
+         * This will replace the theme secondary-text-color
+         */
+        Optional<String> secondaryTextColor();
+
+        /**
+         * This will replace the theme tertiary-text-color
+         */
+        Optional<String> tertiaryTextColor();
+
+        /**
+         * This will replace the theme disabled-text-color
+         */
+        Optional<String> disabledTextColor();
+
+        /**
+         * This will replace the theme contrast-5-pct
+         */
+        Optional<String> contrast5pct();
+
+        /**
+         * This will replace the theme contrast-10-pct
+         */
+        Optional<String> contrast10pct();
+
+        /**
+         * This will replace the theme contrast-15-pct
+         */
+        Optional<String> contrast15pct();
+
+        /**
+         * This will replace the theme contrast-20-pct
+         */
+        Optional<String> contrast20pct();
+
+        /**
+         * This will replace the theme contrast-25-pct
+         */
+        Optional<String> contrast25pct();
+
+        /**
+         * This will replace the theme contrast-30-pct
+         */
+        Optional<String> contrast30pct();
+
+        /**
+         * This will replace the theme contrast-35-pct
+         */
+        Optional<String> contrast35pct();
+
+        /**
+         * This will replace the theme contrast-40-pct
+         */
+        Optional<String> contrast40pct();
+
+        /**
+         * This will replace the theme contrast-45-pct
+         */
+        Optional<String> contrast45pct();
+
+        /**
+         * This will replace the theme contrast-50-pct
+         */
+        Optional<String> contrast50pct();
+
+        /**
+         * This will replace the theme contrast-55-pct
+         */
+        Optional<String> contrast55pct();
+
+        /**
+         * This will replace the theme contrast-60-pct
+         */
+        Optional<String> contrast60pct();
+
+        /**
+         * This will replace the theme contrast-65-pct
+         */
+        Optional<String> contrast65pct();
+
+        /**
+         * This will replace the theme contrast-70-pct
+         */
+        Optional<String> contrast70pct();
+
+        /**
+         * This will replace the theme contrast-75-pct
+         */
+        Optional<String> contrast75pct();
+
+        /**
+         * This will replace the theme contrast-80-pct
+         */
+        Optional<String> contrast80pct();
+
+        /**
+         * This will replace the theme contrast-85-pct
+         */
+        Optional<String> contrast85pct();
+
+        /**
+         * This will replace the theme contrast-90-pct
+         */
+        Optional<String> contrast90pct();
+    }
+
+    static enum BaseTheme {
+        quarkus,
+        red,
+        blue
     }
 
 }


### PR DESCRIPTION
This PR adds two new themes (along side the current default) for both dalk and light:

Red:
![red](https://github.com/user-attachments/assets/5e3ad5dd-2c44-41a5-a285-4012cedd519a)

Blue:
![blue](https://github.com/user-attachments/assets/e51951ab-bea5-4f50-a5fc-002092a9be7c)

