### PR TITLE
Dev UI/Swagger: Support expansion of properties in path

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
@@ -11,7 +11,6 @@ import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
-import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.oidc.OidcTenantConfig;
@@ -21,7 +20,6 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.VertxHttpConfig;
-import io.smallrye.config.ConfigValue;
 
 public abstract class AbstractDevUIProcessor {
     protected static final String CONFIG_PREFIX = "quarkus.oidc.";
@@ -41,7 +39,6 @@ public abstract class AbstractDevUIProcessor {
             Duration webClientTimeout,
             Map<String, Map<String, String>> grantOptions,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            ConfigurationBuildItem configurationBuildItem,
             String keycloakAdminUrl,
             Map<String, String> keycloakUsers,
             List<String> keycloakRealms,
@@ -59,11 +56,12 @@ public abstract class AbstractDevUIProcessor {
         // prepare data for provider component
         final boolean swaggerIsAvailable = capabilities.isPresent(Capability.SMALLRYE_OPENAPI);
         final boolean graphqlIsAvailable = capabilities.isPresent(Capability.SMALLRYE_GRAPHQL);
+        final var config = ConfigProvider.getConfig();
 
         final String swaggerUiPath;
         if (swaggerIsAvailable) {
             swaggerUiPath = nonApplicationRootPathBuildItem.resolvePath(
-                    getProperty(configurationBuildItem, "quarkus.swagger-ui.path"));
+                    config.getValue("quarkus.swagger-ui.path", String.class));
         } else {
             swaggerUiPath = null;
         }
@@ -71,7 +69,7 @@ public abstract class AbstractDevUIProcessor {
         final String graphqlUiPath;
         if (graphqlIsAvailable) {
             graphqlUiPath = nonApplicationRootPathBuildItem.resolvePath(
-                    getProperty(configurationBuildItem, "quarkus.smallrye-graphql.ui.root-path"));
+                    config.getValue("quarkus.smallrye-graphql.ui.root-path", String.class));
         } else {
             graphqlUiPath = null;
         }
@@ -88,37 +86,6 @@ public abstract class AbstractDevUIProcessor {
         recorder.createJsonRPCService(beanContainer.getValue(), runtimeProperties, httpConfig);
 
         return cardPage;
-    }
-
-    private static String getProperty(ConfigurationBuildItem configurationBuildItem,
-            String propertyKey) {
-        // strictly speaking we know 'quarkus.swagger-ui.path' is build time property
-        // and 'quarkus.smallrye-graphql.ui.root-path' is build time with runtime fixed,
-        // but I wanted to make this bit more robust till we have DEV UI tests
-        // that will fail when this get changed in the future, then we can optimize this
-
-        ConfigValue configValue = configurationBuildItem
-                .getReadResult()
-                .getAllBuildTimeValues()
-                .get(propertyKey);
-
-        if (configValue == null || configValue.getValue() == null) {
-            configValue = configurationBuildItem
-                    .getReadResult()
-                    .getBuildTimeRunTimeValues()
-                    .get(propertyKey);
-        } else {
-            return configValue.getValue();
-        }
-
-        if (configValue == null || configValue.getValue() == null) {
-            configValue = configurationBuildItem
-                    .getReadResult()
-                    .getRunTimeDefaultValues()
-                    .get(propertyKey);
-        }
-
-        return configValue != null ? configValue.getValue() : null;
     }
 
     protected static String getApplicationType() {

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
@@ -13,7 +13,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.devservices.oidc.OidcDevServicesConfigBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
@@ -53,7 +52,6 @@ public class OidcDevUIProcessor extends AbstractDevUIProcessor {
             BeanContainerBuildItem beanContainer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             BuildProducer<CardPageBuildItem> cardPageProducer,
-            ConfigurationBuildItem configurationBuildItem,
             OidcDevUiRecorder recorder,
             Optional<OidcDevServicesConfigBuildItem> oidcDevServicesConfigBuildItem) {
         if (!isOidcTenantEnabled() || (!isClientIdSet() && oidcDevServicesConfigBuildItem.isEmpty())) {
@@ -88,7 +86,6 @@ public class OidcDevUIProcessor extends AbstractDevUIProcessor {
                     oidcConfig.devui().webClientTimeout(),
                     oidcConfig.devui().grantOptions(),
                     nonApplicationRootPathBuildItem,
-                    configurationBuildItem,
                     keycloakAdminUrl,
                     null,
                     null,

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
@@ -13,7 +13,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.devservices.keycloak.KeycloakAdminPageBuildItem;
 import io.quarkus.devservices.keycloak.KeycloakDevServicesConfigBuildItem;
@@ -42,7 +41,6 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
             OidcDevUiRecorder recorder,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             BeanContainerBuildItem beanContainer,
-            ConfigurationBuildItem configurationBuildItem,
             Capabilities capabilities) {
         final String keycloakAdminUrl = KeycloakDevServicesConfigBuildItem.getKeycloakUrl(configProps);
         if (keycloakAdminUrl != null) {
@@ -67,7 +65,6 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
                     oidcConfig.devui().webClientTimeout(),
                     oidcConfig.devui().grantOptions(),
                     nonApplicationRootPathBuildItem,
-                    configurationBuildItem,
                     keycloakAdminUrl,
                     users,
                     keycloakRealms,


### PR DESCRIPTION
When configuring the swagger UI path as:
```
quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
```

Note that you can use any property other than `quarkus.application.name`.
This fails with:

```
2025-03-06 15:34:26,557 ERROR [io.qua.dep.dev.IsolatedDevModeMain] (main) Failed to start quarkus: java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
        [error]: Build step io.quarkus.devui.deployment.menu.EndpointsProcessor#createEndpointsPage threw an exception: java.lang.IllegalArgumentException: Specified path is an invalid URI. Path was /api/${quarkus.application.name}/internal/swagger-ui
        at io.quarkus.deployment.util.UriNormalizationUtil.toURI(UriNormalizationUtil.java:52)
        at io.quarkus.deployment.util.UriNormalizationUtil.normalizeWithBase(UriNormalizationUtil.java:107)
        at io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem.resolvePath(NonApplicationRootPathBuildItem.java:165)
        at io.quarkus.devui.deployment.menu.EndpointsProcessor.createEndpointsPage(EndpointsProcessor.java:29)
        at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732)
        at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
        at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
        at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
        at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
        at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
        at java.base/java.lang.Thread.run(Thread.java:840)
        at org.jboss.threads.JBossThread.run(JBossThread.java:499)
Caused by: java.net.URISyntaxException: Illegal character in path at index 6: /api/${quarkus.application.name}/internal/swagger-ui
        at java.base/java.net.URI$Parser.fail(URI.java:2976)
```

This issue was introduced as part of the changes in https://github.com/quarkusio/quarkus/pull/43950.

One solution is to use the ConfigProvider API to resolve the property since this already expand all the properties. @radcortez can you confirm if this is ok?

Testing these changes, I can now see that the path is correct:

![Screenshot From 2025-03-07 14-30-07](https://github.com/user-attachments/assets/76122cae-83ea-464b-a4b2-46b93b04ace8)

This is using a Quarkus example named "resteasy".

Fixes https://github.com/quarkusio/quarkus/issues/46662