### PR TITLE
Remove Unnecessary Gradle Test Task Dependencies

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -424,7 +424,8 @@ public class QuarkusPlugin implements Plugin<Project> {
                     tasks.register(INTEGRATION_TEST_TASK_NAME, Test.class, intTestTask -> {
                         intTestTask.setGroup("verification");
                         intTestTask.setDescription("Runs Quarkus integration tests");
-                        intTestTask.dependsOn(quarkusBuild, testTask);
+                        intTestTask.dependsOn(quarkusBuild);
+                        intTestTask.shouldRunAfter(testTask);
                         intTestTask.setClasspath(intTestClasspath);
                         intTestTask.setTestClassesDirs(intTestSourceOutputClasses);
                     });
@@ -449,7 +450,8 @@ public class QuarkusPlugin implements Plugin<Project> {
                     tasks.register(TEST_NATIVE_TASK_NAME, Test.class, testNative -> {
                         testNative.setDescription("Runs native image tests");
                         testNative.setGroup("verification");
-                        testNative.dependsOn(quarkusBuild, testTask);
+                        testNative.dependsOn(quarkusBuild);
+                        testNative.shouldRunAfter(testTask);
                         testNative.setClasspath(nativeTestClasspath);
                         testNative.setTestClassesDirs(nativeTestClassesDirs);
                     });


### PR DESCRIPTION
The `quarkusIntTest` and `quarkusNativeTest` tasks do not use the output of the test task, so these tasks should not specify the `test` task as a dependency.

Instead, these tasks now have a `shouldRunAfter` relationship to the test task, because ideally unit tests should run before performing heavier testing.

Fixes #44383 