### PR TITLE
Fix gradle devui NoClassDefFound

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -448,7 +448,6 @@ public abstract class QuarkusDev extends QuarkusTask {
         if (getModules().isPresent() && !getModules().get().isEmpty()) {
             builder.addModules(getModules().get());
         }
-
         for (Map.Entry<String, ?> e : project.getProperties().entrySet()) {
             if (e.getValue() instanceof String) {
                 builder.buildSystemProperty(e.getKey(), e.getValue().toString());
@@ -465,11 +464,14 @@ public abstract class QuarkusDev extends QuarkusTask {
         builder.extensionDevModeConfig(appModel.getExtensionDevModeConfig())
                 .extensionDevModeJvmOptionFilter(extensionJvmOptions);
 
+        builder.jvmArgs("-Dgradle.project.path="
+                + getProject().getLayout().getProjectDirectory().getAsFile().getAbsolutePath());
+
         analyticsService.sendAnalytics(
                 DEV_MODE,
                 appModel,
                 Map.of(GRADLE_VERSION, getProject().getGradle().getGradleVersion()),
-                getProject().getBuildDir().getAbsoluteFile());
+                getProject().getLayout().getBuildDirectory().getAsFile().get());
 
         final Set<ArtifactKey> projectDependencies = new HashSet<>();
         for (ResolvedDependency localDep : DependenciesFilter.getReloadableModules(appModel)) {
@@ -562,6 +564,7 @@ public abstract class QuarkusDev extends QuarkusTask {
                         configuration.setCanBeConsumed(false);
                         configuration.extendsFrom(platformConfig);
                         configuration.getDependencies().add(getQuarkusGradleBootstrapResolver());
+                        configuration.getDependencies().add(getQuarkusMavenBootstrapResolver());
                         configuration.getDependencies().add(getQuarkusCoreDeployment(appModel));
                     });
             devModeDependencyConfiguration = getProject().getConfigurations()
@@ -585,7 +588,15 @@ public abstract class QuarkusDev extends QuarkusTask {
     }
 
     private Dependency getQuarkusGradleBootstrapResolver() {
-        final String pomPropsPath = "META-INF/maven/io.quarkus/quarkus-bootstrap-gradle-resolver/pom.properties";
+        return getQuarkusBootstrapResolver("quarkus-bootstrap-gradle-resolver");
+    }
+
+    private Dependency getQuarkusMavenBootstrapResolver() {
+        return getQuarkusBootstrapResolver("quarkus-bootstrap-maven-resolver");
+    }
+
+    private Dependency getQuarkusBootstrapResolver(String artifactId) {
+        final String pomPropsPath = "META-INF/maven/io.quarkus/" + artifactId + "/pom.properties";
         final InputStream devModePomPropsIs = DevModeMain.class.getClassLoader().getResourceAsStream(pomPropsPath);
         if (devModePomPropsIs == null) {
             throw new GradleException("Failed to locate " + pomPropsPath + " on the classpath");
@@ -608,9 +619,8 @@ public abstract class QuarkusDev extends QuarkusTask {
         if (devModeVersion == null) {
             throw new GradleException("Classpath resource " + pomPropsPath + " is missing version");
         }
-        Dependency gradleResolverDep = getProject().getDependencies()
+        return getProject().getDependencies()
                 .create(String.format("%s:%s:%s", devModeGroupId, devModeArtifactId, devModeVersion));
-        return gradleResolverDep;
     }
 
     private Dependency getQuarkusCoreDeployment(ApplicationModel appModel) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
@@ -63,7 +63,6 @@ public class ExtensionsProcessor {
                 && launchModeBuildItem.getDevModeType().get().equals(DevModeType.LOCAL)) {
 
             BuildTimeActionBuildItem buildTimeActions = new BuildTimeActionBuildItem(NAMESPACE);
-
             getCategories(buildTimeActions);
             getInstallableExtensions(buildTimeActions);
             getInstalledNamespaces(buildTimeActions);
@@ -145,6 +144,8 @@ public class ExtensionsProcessor {
                     }
 
                     return null;
+                } catch (IllegalStateException e) {
+                    return null;
                 } catch (QuarkusCommandException e) {
                     throw new RuntimeException(e);
                 }
@@ -198,7 +199,13 @@ public class ExtensionsProcessor {
     }
 
     private QuarkusProject getQuarkusProject() {
-        Path projectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        Path projectRoot;
+        String gradlePath = System.getProperty("gradle.project.path");
+        if (gradlePath != null) {
+            projectRoot = Path.of(gradlePath);
+        } else {
+            projectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        }
         return QuarkusProjectHelper.getCachedProject(projectRoot);
     }
 

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-continuous-testing.js
@@ -150,7 +150,9 @@ export class QwcContinuousTesting extends QwcHotReloadElement {
 
     _cancelObservers(){
         this._streamStateObserver.cancel();
-        this._streamResultsObserver.cancel();
+        if(this._streamResultsObserver){
+            this._streamResultsObserver.cancel();
+        }
     }
 
     _lastKnownState(){

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -86,7 +86,8 @@ export class QwcExtensions extends observeState(LitElement) {
         _favourites: {state: true},
         _addDialogOpened: {state: true},
         _installedExtensions: {state: true, type: Array},
-        _selectedFilters: {state: true, type: Array}
+        _selectedFilters: {state: true, type: Array},
+        _addExtensionsEnabled: {state: true, type: Boolean},
     }
 
     constructor() {
@@ -96,12 +97,18 @@ export class QwcExtensions extends observeState(LitElement) {
         this._installedExtensions = [];
         this._filteritems = ["Favorites","Active","Inactive"];
         this._selectedFilters = this._getStoredFilters();
+        this._addExtensionsEnabled = false;
     }
 
     connectedCallback() {
         super.connectedCallback();
         this.jsonRpc.getInstalledNamespaces().then(jsonRpcResponse => {
-            this._installedExtensions = jsonRpcResponse.result;
+            if (jsonRpcResponse.result) {
+                this._installedExtensions = jsonRpcResponse.result;
+                this._addExtensionsEnabled = true;
+            }
+        }).catch(e => {
+            notifier.showErrorMessage("Could not list namespaces "+ e?.error?.message);
         });
     }
 
@@ -355,30 +362,32 @@ export class QwcExtensions extends observeState(LitElement) {
     }
 
     _renderAddDialog(){
-        return html`
-            <vaadin-dialog
-              theme="no-padding"
-              resizable
-              draggable
-              header-title="Add extension"
-              .opened="${this._addDialogOpened}"
-              @opened-changed="${(event) => {
-                this._addDialogOpened = event.detail.value;
-              }}"
-              ${dialogHeaderRenderer(
-                  () => html`
-                    <vaadin-button theme="tertiary" @click="${() => (this._addDialogOpened = false)}">
-                        <vaadin-icon icon="font-awesome-solid:xmark"></vaadin-icon>
-                    </vaadin-button>
-                  `,
-                  []
+        if (this._addExtensionsEnabled) {
+            return html`
+                <vaadin-dialog
+                theme="no-padding"
+                resizable
+                draggable
+                header-title="Add extension"
+                .opened="${this._addDialogOpened}"
+                @opened-changed="${(event) => {
+                    this._addDialogOpened = event.detail.value;
+                }}"
+                ${dialogHeaderRenderer(
+                    () => html`
+                        <vaadin-button theme="tertiary" @click="${() => (this._addDialogOpened = false)}">
+                            <vaadin-icon icon="font-awesome-solid:xmark"></vaadin-icon>
+                        </vaadin-button>
+                    `,
+                    []
+                    )}
+                ${dialogRenderer(
+                    () => html`<qwc-extension-add @inprogress="${this._installRequest}"></qwc-extension-add>`
                 )}
-              ${dialogRenderer(
-                () => html`<qwc-extension-add @inprogress="${this._installRequest}"></qwc-extension-add>`
-              )}
-            ></vaadin-dialog>
-            ${this._renderAddExtensionButton()}
-          `;
+                ></vaadin-dialog>
+                ${this._renderAddExtensionButton()}
+            `;
+        }
     }
     
     _renderAddExtensionButton(){


### PR DESCRIPTION
This PR fixes #45112.
It fixes the devui NoClassDefFound errors triggered when using the gradle build tool in dev mode and disables the Add extension button.

When #43840 was merged it allowed to dynamically add new extensions using the dev ui but it doesn't work nicelly with gradle projects:

1. It did'nt correctly identify the path of the project with gradle as the current working dir in gradle retrieved here https://github.com/quarkusio/quarkus/blob/43c95ab7714af941a82299dfb4ff903d61b5b5c0/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java#L201 will be in the `build/classes/java/main` directory and not the project directory and as such will always detect a gradle project as being a maven project
2. In the gradle dev mode task we only explicitly add parentFirstDependencies and as such the maven resolver dependencies are absent from the classpath https://github.com/quarkusio/quarkus/blob/43c95ab7714af941a82299dfb4ff903d61b5b5c0/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java#L498
3. One all the above is resolved, the `io.quarkus.devtools.project.buildfile.GenericGradleBuildFile` extensionManager cannot neither list nor add any new extension as it doesn't work outside of the gradle plugin.
