### PR TITLE
Use provided scope for jboss-logging-annotations dependency

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4764,6 +4764,7 @@
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-annotations</artifactId>
                 <version>${jboss-logging-annotations.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -64,6 +64,7 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
+            <scope>provided</scope>
          </dependency>
         <dependency>
             <groupId>org.jboss.threads</groupId>


### PR DESCRIPTION
Fixes #45761

This PR adds the provided scope to the dependency `jboss-logging-annotations`

I also added a commit that pass the dependency `jboss-logging-processor` as an argument to `annotationProcessorPaths`.