### PR TITLE
Revert "Execute simple JUnit tests and @QuarkusComponentTest first"

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
@@ -58,11 +58,11 @@ import io.quarkus.test.junit.main.QuarkusMainTest;
  */
 public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
-    protected static final String DEFAULT_ORDER_PREFIX_NON_QUARKUS_TEST = "10_";
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST = "20_";
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_MATCHING_RES = "30_";
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE = "40_";
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES = "45_";
+    protected static final String DEFAULT_ORDER_PREFIX_NON_QUARKUS_TEST = "60_";
 
     static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST = "junit.quarkus.orderer.prefix.quarkus-test";
 

--- a/test-framework/junit5/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
+++ b/test-framework/junit5/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
@@ -98,8 +98,6 @@ class QuarkusTestProfileAwareClassOrdererTest {
         new QuarkusTestProfileAwareClassOrderer().orderClasses(contextMock);
 
         assertThat(input).containsExactly(
-                nonQuarkusTest1Desc,
-                nonQuarkusTest2Desc,
                 quarkusTest1Desc,
                 quarkusTest1aDesc,
                 quarkusTest2Desc,
@@ -114,7 +112,9 @@ class QuarkusTestProfileAwareClassOrdererTest {
                 quarkusTestWithRestrictedResourceDesc,
                 quarkusTestWithRestrictedResourceDesc2,
                 quarkusTestWithMetaResourceDesc,
-                quarkusTestWithMetaResourceDesc2);
+                quarkusTestWithMetaResourceDesc2,
+                nonQuarkusTest1Desc,
+                nonQuarkusTest2Desc);
     }
 
     @Test
@@ -124,9 +124,9 @@ class QuarkusTestProfileAwareClassOrdererTest {
         List<ClassDescriptor> input = Arrays.asList(quarkusTestDesc, nonQuarkusTestDesc);
         doReturn(input).when(contextMock).getClassDescriptors();
 
-        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "45_", "60_", Optional.empty()).orderClasses(contextMock);
+        new QuarkusTestProfileAwareClassOrderer("20_", "30_", "40_", "45_", "01_", Optional.empty()).orderClasses(contextMock);
 
-        assertThat(input).containsExactly(quarkusTestDesc, nonQuarkusTestDesc);
+        assertThat(input).containsExactly(nonQuarkusTestDesc, quarkusTestDesc);
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 3b89af2de24c3d95f36de5a3d2f65684a16fe52a.

It has been causing various issues, probably caused by some isolation problems.
Holly's patch should fix the problem so let's wait for it to be in before reapplying this.

Fixes #46459

/cc @holly-cummins 