### PR TITLE
Docs: Adds some non-trivial precisions about database multitenancy

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1265,6 +1265,9 @@ With this approach, all datasources used by the same persistence unit
 are assumed to point to a database of the same vendor (same `db-kind`) and version.
 
 Mismatches will not be detected, and may result in unpredictable behavior.
+
+Tenant **list** is **fixed as build time** event if most values can be modified as runtime.
+In case of dynamic tenant list, you must use <<database-approach,database approach>>.
 ====
 
 [source,properties]
@@ -1366,6 +1369,55 @@ Creating an application-scoped bean that implements this interface
 and annotating it with `@PersistenceUnitExtension` (or `@PersistenceUnitExtension("nameOfYourPU")` for a <<multiple-persistence-units,named persistence unit>>)
 will replace the current Quarkus default implementation `io.quarkus.hibernate.orm.runtime.tenant.DataSourceTenantConnectionResolver`.
 Your custom connection resolver would allow for example to read tenant information from a database and create a connection per tenant at runtime based on it.
+
+Beware the created `ConnectionProvider` should handle connexion pools and transactions.
+Here is an implementation example using standard Quarkus technologies – Agroal for pooling and Narayana for transactions:
+
+[source,java]
+----
+@ApplicationScoped
+@PersistenceUnitExtension
+public class ExampleTenantConnexionResolver implements TenantConnectionResolver {
+
+    private final jakarta.transaction.TransactionManager transactionManager;
+    private final TransactionSynchronizationRegistry transactionSynchronizationRegistry;
+
+    public ExampleTenantConnexionResolver(
+            TransactionManager transactionManager,
+            TransactionSynchronizationRegistry transactionSynchronizationRegistry) {
+        this.transactionManager = transactionManager;
+        this.transactionSynchronizationRegistry = transactionSynchronizationRegistry;
+    }
+
+    @Override
+    public ConnectionProvider resolve(String tenantId) {
+        return new QuarkusConnectionProvider(createDatasource(tenantId));
+    }
+
+    private AgroalDataSource createDatasource(String tenantId) {
+        try {
+            final var txIntegration = new NarayanaTransactionIntegration(
+                    transactionManager, transactionSynchronizationRegistry, null, false, null);
+            final var dataSourceConfig = new AgroalDataSourceConfigurationSupplier()
+                    .connectionPoolConfiguration(pc -> pc.initialSize(2)
+                            .maxSize(10)
+                            .minSize(2)
+                            .maxLifetime(Duration.of(5, ChronoUnit.MINUTES))
+                            .acquisitionTimeout(Duration.of(30, ChronoUnit.SECONDS))
+                            .transactionIntegration(txIntegration)
+                            .connectionFactoryConfiguration(
+                                    // Fetch JDBC URL, username and password from a per-tenant dynamic source
+                                    cf -> cf.jdbcUrl("jdbc:postgresql://postgres:5432/" + tenantId)
+                                            .credential(new NamePrincipal(username))
+                                            .credential(new SimplePassword(password))));
+            return AgroalDataSource.from(dataSourceConfig.get());
+        } catch (SQLException ex) {
+            throw new IllegalStateException(
+                    "Failed to create a new data source based on the existing datasource configuration", ex);
+        }
+    }
+}
+----
 
 [[interceptors]]
 == Interceptors

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1008,6 +1008,7 @@ as it will also clone some enhancement-specific fields that are specific to the 
 This limitation might be removed in the future.
 ====
 
+[[automatic-integration]]
 === Automatic integration
 
 Transaction Manager integration::
@@ -1266,8 +1267,8 @@ are assumed to point to a database of the same vendor (same `db-kind`) and versi
 
 Mismatches will not be detected, and may result in unpredictable behavior.
 
-Tenant **list** is **fixed as build time** event if most values can be modified as runtime.
-In case of dynamic tenant list, you must <<programmatically-resolving-tenants-connections,resolve the tenant connections programmatically>>.
+The list of datasources is defined at build time, so with this approach the **list** of tenants is **fixed at build time**.
+If the list of tenants needs to change at runtime, you must <<programmatically-resolving-tenants-connections,resolve the tenant connections programmatically>>.
 ====
 
 [source,properties]
@@ -1382,12 +1383,12 @@ Here is an implementation example of a `TenantConnectionResolver` implementation
 ----
 @ApplicationScoped
 @PersistenceUnitExtension
-public class ExampleTenantConnexionResolver implements TenantConnectionResolver {
+public class ExampleTenantConnectionResolver implements TenantConnectionResolver {
 
     private final jakarta.transaction.TransactionManager transactionManager;
     private final TransactionSynchronizationRegistry transactionSynchronizationRegistry;
 
-    public ExampleTenantConnexionResolver(
+    public ExampleTenantConnectionResolver(
             TransactionManager transactionManager,
             TransactionSynchronizationRegistry transactionSynchronizationRegistry) {
         this.transactionManager = transactionManager;

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1370,8 +1370,13 @@ and annotating it with `@PersistenceUnitExtension` (or `@PersistenceUnitExtensio
 will replace the current Quarkus default implementation `io.quarkus.hibernate.orm.runtime.tenant.DataSourceTenantConnectionResolver`.
 Your custom connection resolver would allow for example to read tenant information from a database and create a connection per tenant at runtime based on it.
 
-Beware the created `ConnectionProvider` should handle connexion pools and transactions.
-Here is an implementation example using standard Quarkus technologies – Agroal for pooling and Narayana for transactions:
+[CAUTION]
+====
+<<automatic-integration,Automatic integrations>> will **not** work with programmatically-created `ConnectionProvider`.
+This implies all these integrations, including those from other Quarkus modules (e.g. xref:smallrye-health.adoc[SmallRye Health]) must be done manually.
+====
+
+Here is an implementation example of a `TenantConnectionResolver` implementation using standard Quarkus technologies – Agroal for pooling and Narayana for transactions:
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1267,7 +1267,7 @@ are assumed to point to a database of the same vendor (same `db-kind`) and versi
 Mismatches will not be detected, and may result in unpredictable behavior.
 
 Tenant **list** is **fixed as build time** event if most values can be modified as runtime.
-In case of dynamic tenant list, you must use <<database-approach,database approach>>.
+In case of dynamic tenant list, you must <<programmatically-resolving-tenants-connections,resolve the tenant connections programmatically>>.
 ====
 
 [source,properties]
@@ -1398,6 +1398,7 @@ public class ExampleTenantConnexionResolver implements TenantConnectionResolver 
         try {
             final var txIntegration = new NarayanaTransactionIntegration(
                     transactionManager, transactionSynchronizationRegistry, null, false, null);
+            // Fetch JDBC URL, username, password & other values from a per-tenant dynamic source
             final var dataSourceConfig = new AgroalDataSourceConfigurationSupplier()
                     .connectionPoolConfiguration(pc -> pc.initialSize(2)
                             .maxSize(10)
@@ -1406,7 +1407,6 @@ public class ExampleTenantConnexionResolver implements TenantConnectionResolver 
                             .acquisitionTimeout(Duration.of(30, ChronoUnit.SECONDS))
                             .transactionIntegration(txIntegration)
                             .connectionFactoryConfiguration(
-                                    // Fetch JDBC URL, username and password from a per-tenant dynamic source
                                     cf -> cf.jdbcUrl("jdbc:postgresql://postgres:5432/" + tenantId)
                                             .credential(new NamePrincipal(username))
                                             .credential(new SimplePassword(password))));

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1397,7 +1397,8 @@ public class ExampleTenantConnectionResolver implements TenantConnectionResolver
 
     @Override
     public ConnectionProvider resolve(String tenantId) {
-        return new QuarkusConnectionProvider(createDatasource(tenantId));
+        // Use your own ConnectionProvider implementation here
+        return new YourOwnCustomConnectionProviderImpl(createDatasource(tenantId));
     }
 
     private AgroalDataSource createDatasource(String tenantId) {


### PR DESCRIPTION
1. Explicitly document the fact that tenant list is fixed at build time when using database multitenancy
2. Adds a warning about connexion pooling and transactions on custom datasources provider, with an example