### PR TITLE
Introduce `quarkus-grpc-kotlin` extension

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2321,6 +2321,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-grpc-kotlin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-grpc-kotlin-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-websockets</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -800,6 +800,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-grpc-kotlin</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-hal</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -811,6 +811,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-kotlin-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hal-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/AdditionalOutputHandler.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/AdditionalOutputHandler.java
@@ -1,0 +1,37 @@
+package io.quarkus.grpc.codegen;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.microprofile.config.Config;
+
+/**
+ * Simple SPI that allows code to add additional options to the gRPC code generation invocation
+ */
+public interface AdditionalOutputHandler {
+
+    /**
+     * Whether this handler should be invoked for the given context
+     */
+    boolean supports(SupportsInput input);
+
+    /**
+     * Actually provide the additional options to be passed to the gRPC codegen
+     */
+    HandleOutput handle(HandleInput input);
+
+    interface SupportsInput {
+
+        Config config();
+    }
+
+    interface HandleInput {
+
+        Path outDir();
+    }
+
+    interface HandleOutput {
+
+        List<String> additionalOptions();
+    }
+}

--- a/extensions/grpc/deployment/pom.xml
+++ b/extensions/grpc/deployment/pom.xml
@@ -55,6 +55,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-virtual-threads-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-kotlin-deployment</artifactId>
+            <optional>true</optional> <!-- conditional dependency -->
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/grpc/kotlin/deployment/pom.xml
+++ b/extensions/grpc/kotlin/deployment/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-grpc-kotlin-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-grpc-kotlin-deployment</artifactId>
+    <name>Quarkus - gRPC - Kotlin - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-codegen</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-kotlin</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/grpc/kotlin/deployment/src/main/java/io/quarkus/grpc/kotlin/deployment/KotlinOutputHandler.java
+++ b/extensions/grpc/kotlin/deployment/src/main/java/io/quarkus/grpc/kotlin/deployment/KotlinOutputHandler.java
@@ -1,0 +1,25 @@
+package io.quarkus.grpc.kotlin.deployment;
+
+import java.util.List;
+
+import io.quarkus.grpc.codegen.AdditionalOutputHandler;
+
+public class KotlinOutputHandler implements AdditionalOutputHandler {
+
+    private static final String GENERATE_KOTLIN = "quarkus.generate-code.grpc.kotlin.generate";
+
+    @Override
+    public boolean supports(SupportsInput input) {
+        return input.config().getOptionalValue(GENERATE_KOTLIN, Boolean.class).orElse(true);
+    }
+
+    @Override
+    public HandleOutput handle(HandleInput input) {
+        return new HandleOutput() {
+            @Override
+            public List<String> additionalOptions() {
+                return List.of("--kotlin_out=" + input.outDir());
+            }
+        };
+    }
+}

--- a/extensions/grpc/kotlin/deployment/src/main/resources/META-INF/services/io.quarkus.grpc.codegen.AdditionalOutputHandler
+++ b/extensions/grpc/kotlin/deployment/src/main/resources/META-INF/services/io.quarkus.grpc.codegen.AdditionalOutputHandler
@@ -1,0 +1,1 @@
+io.quarkus.grpc.kotlin.deployment.KotlinOutputHandler

--- a/extensions/grpc/kotlin/pom.xml
+++ b/extensions/grpc/kotlin/pom.xml
@@ -2,28 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>quarkus-extensions-parent</artifactId>
         <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-grpc-parent</artifactId>
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-grpc-parent</artifactId>
-    <name>Quarkus - gRPC parent</name>
+    <artifactId>quarkus-grpc-kotlin-parent</artifactId>
+    <name>Quarkus - gRPC - Kotlin</name>
     <packaging>pom</packaging>
+
     <modules>
-        <module>protoc</module>
-        <module>codegen</module>
-        <module>api</module>
-        <module>stubs</module>
-        <module>reflection</module>
         <module>deployment</module>
         <module>runtime</module>
-        <module>xds</module>
-        <module>inprocess</module>
-        <module>cli</module>
-        <module>kotlin</module>
     </modules>
 </project>

--- a/extensions/grpc/kotlin/runtime/pom.xml
+++ b/extensions/grpc/kotlin/runtime/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-grpc-kotlin-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-grpc-kotlin</artifactId>
+    <name>Quarkus - gRPC - Kotlin - Runtime</name>
+    <description>Provides Kotlin support for Quarkus gRPC</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-kotlin</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <dependencyCondition>
+                        <artifact>io.quarkus:quarkus-kotlin</artifact>
+                    </dependencyCondition>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/grpc/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/grpc/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,5 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "gRPC Kotlin"
+metadata:
+  unlisted: true

--- a/extensions/grpc/runtime/pom.xml
+++ b/extensions/grpc/runtime/pom.xml
@@ -53,6 +53,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-virtual-threads</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-kotlin</artifactId>
+            <optional>true</optional> <!-- conditional dependency -->
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-no-java/application/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-no-java/application/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.quarkus:quarkus-arc")
     implementation("io.quarkus:quarkus-grpc")
-    compileOnly("com.google.protobuf:protobuf-kotlin")
 
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.rest-assured:rest-assured")


### PR DESCRIPTION
This is automatically added by Quarkus during build time if both the `quarkus-grpc` and `quarkus-kotlin` extensions are present.
Currently, all the extension does is plug into the gRPC codegen phase.

- Fixes: #46675