### PR TITLE
Refactor jmxserver detection in native executable build

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -967,10 +967,6 @@ public class NativeImageBuildStep {
                 if (nativeConfig.monitoring().isPresent()) {
                     monitoringOptions.addAll(nativeConfig.monitoring().get());
                 }
-
-                nativeImageArgs.add("-J-Dquarkus.native.jmxserver.included="
-                        + monitoringOptions.contains(NativeConfig.MonitoringOption.JMXSERVER));
-
                 if (!monitoringOptions.isEmpty()) {
                     nativeImageArgs.add("--enable-monitoring=" + monitoringOptions.stream()
                             .map(o -> o.name().toLowerCase(Locale.ROOT)).collect(Collectors.joining(",")));

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuil
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
+import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.runtime.ssl.SslContextConfigurationRecorder;
 
@@ -34,7 +35,8 @@ class NativeImageConfigBuildStep {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    void build(SslContextConfigurationRecorder sslContextConfigurationRecorder,
+    void build(NativeConfig nativeConfig,
+            SslContextConfigurationRecorder sslContextConfigurationRecorder,
             List<NativeImageConfigBuildItem> nativeImageConfigBuildItems,
             SslNativeConfigBuildItem sslNativeConfig,
             List<JniBuildItem> jniBuildItems,
@@ -80,6 +82,12 @@ class NativeImageConfigBuildStep {
 
         if (!inlineBeforeAnalysisBuildItems.isEmpty()) {
             nativeImage.produce(new NativeImageSystemPropertyBuildItem("quarkus.native.inline-before-analysis", "true"));
+        }
+
+        if (nativeConfig.monitoring().isPresent()) {
+            nativeImage.produce(new NativeImageSystemPropertyBuildItem("quarkus.native.monitoring",
+                    nativeConfig.monitoring().get().stream().map(x -> x.toString().toLowerCase())
+                            .collect(Collectors.joining(","))));
         }
 
         for (JniBuildItem jniBuildItem : jniBuildItems) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_management_JMX.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_management_JMX.java
@@ -1,5 +1,7 @@
 package io.quarkus.runtime.graal;
 
+import java.util.function.BooleanSupplier;
+
 import javax.management.JMX;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -7,7 +9,7 @@ import javax.management.ObjectName;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(JMX.class)
+@TargetClass(value = JMX.class, onlyWith = Target_javax_management_JMX.JmxServerNotIncluded.class)
 final class Target_javax_management_JMX {
 
     @Substitute
@@ -19,4 +21,15 @@ final class Target_javax_management_JMX {
         throw new IllegalStateException("Not Implemented in native mode");
     }
 
+    static final class JmxServerNotIncluded implements BooleanSupplier {
+
+        @Override
+        public boolean getAsBoolean() {
+            String monitoringProperty = System.getProperty("quarkus.native.monitoring");
+            if (monitoringProperty != null) {
+                return !monitoringProperty.contains("jmxserver");
+            }
+            return true;
+        }
+    }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_management_JMX.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_management_JMX.java
@@ -1,7 +1,5 @@
 package io.quarkus.runtime.graal;
 
-import java.util.function.BooleanSupplier;
-
 import javax.management.JMX;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -9,7 +7,7 @@ import javax.management.ObjectName;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(value = JMX.class, onlyWith = Target_javax_management_JMX.JmxServerNotIncluded.class)
+@TargetClass(JMX.class)
 final class Target_javax_management_JMX {
 
     @Substitute
@@ -21,11 +19,4 @@ final class Target_javax_management_JMX {
         throw new IllegalStateException("Not Implemented in native mode");
     }
 
-    static final class JmxServerNotIncluded implements BooleanSupplier {
-
-        @Override
-        public boolean getAsBoolean() {
-            return !Boolean.getBoolean("quarkus.native.jmxserver.included");
-        }
-    }
 }


### PR DESCRIPTION
Avoids warnings without introducing a new configuration option

Closes https://github.com/quarkusio/quarkus/issues/46692
Reverts/Supersedes https://github.com/quarkusio/quarkus/pull/46592
Fixes https://github.com/quarkusio/quarkus/issues/46506