### PR TITLE
Update Grafana LGTM to 0.9.0

### DIFF
--- a/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
+++ b/extensions/observability-devservices/common/src/main/java/io/quarkus/observability/common/ContainerConstants.java
@@ -4,7 +4,7 @@ public final class ContainerConstants {
 
     // Images
 
-    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.8.2";
+    public static final String LGTM = "docker.io/grafana/otel-lgtm:0.9.0";
 
     // Ports
 

--- a/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
+++ b/extensions/observability-devservices/testcontainers/src/main/java/io/quarkus/observability/testcontainers/LgtmContainer.java
@@ -131,7 +131,8 @@ public class LgtmContainer extends GrafanaContainer<LgtmContainer, LgtmConfig> {
                 .withStartupTimeout(config.timeout())
                 .withStrategy(super.waitStrategy())
                 .withStrategy(
-                        Wait.forLogMessage(".*The OpenTelemetry collector and the Grafana LGTM stack are up and running.*", 1)
+                        Wait.forLogMessage(".*(The OpenTelemetry collector and the Grafana LGTM stack are up and running|" +
+                                "All components are up and running).*", 1)
                                 .withStartupTimeout(config.timeout()));
     }
 


### PR DESCRIPTION
This includes reduced startup time from https://github.com/grafana/docker-otel-lgtm/pull/332