### PR TITLE
Fix true-false typo

### DIFF
--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -295,7 +295,7 @@ A user may choose to disable all the Java options provided by extensions by conf
                 <version>${quarkus.platform.version}</version>
                 <configuration>
                     <extensionJvmOptions>
-                        <disableAll>false</disableAll>
+                        <disableAll>true</disableAll>
                     </extensionJvmOptions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fixes a `true`-`false` typo in the example for how to "disable all the Java options provided by extensions by configuring disableAll parameter". 

This content is referenced by a new feature listed in the 3.20 release notes, and users may required the corrected information in this PR. 

@aloubyansky 

