### PR TITLE
Do not use endsWith on Path object for string comparison

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -178,9 +178,10 @@ public final class PathTestHelper {
      * @return directory or JAR containing the application being tested by a test from the given location
      */
     public static Path getAppClassLocationForTestLocation(Path testClassLocationPath) {
-        if (testClassLocationPath.endsWith(".jar")) {
-            if (testClassLocationPath.endsWith("-tests.jar")) {
-                String testClassLocation = testClassLocationPath.toString();
+        String testClassLocation = testClassLocationPath.toString();
+
+        if (testClassLocation.endsWith(".jar")) {
+            if (testClassLocation.endsWith("-tests.jar")) {
                 return Paths.get(new StringBuilder()
                         .append(testClassLocation, 0, testClassLocation.length() - "-tests.jar".length())
                         .append(".jar")
@@ -188,7 +189,6 @@ public final class PathTestHelper {
             }
             return testClassLocationPath;
         }
-        String testClassLocation = testClassLocationPath.toString();
         Optional<Path> mainClassesDir = TEST_TO_MAIN_DIR_FRAGMENTS.entrySet().stream()
                 .filter(e -> testClassLocation.contains(e.getKey()))
                 .map(e -> {
@@ -211,7 +211,7 @@ public final class PathTestHelper {
         }
         // could be a custom test classes dir under the 'target' dir with the main
         // classes still under 'target/classes'
-        p = Path.of(testClassLocation).getParent();
+        p = testClassLocationPath.getParent();
         if (p != null && p.getFileName().toString().equals(TARGET)) {
             p = p.resolve("classes");
             if (Files.exists(p)) {


### PR DESCRIPTION
Resolves #46704.

I misunderstood how `endsWith` on a `Path` works; it [only looks at whole path elements](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#endsWith-java.lang.String-). As a result, a little 'optimisation' in https://github.com/quarkusio/quarkus/pull/46625 broke tests in jars by causing the 'is this a jar?' branch to be bypassed. 

We probably should have a test for this which catches the issue without needing to go to the JBeret ecosystem CI, but I'll add that separately, so that we can get this fix in ASAP.

