### PR TITLE
Make JsonWebToken available in arbitrarily activated CDI request context in HTTP proxy interceptors

### DIFF
--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -645,6 +645,7 @@ Note that only `@Valid` is supported on the return type.
 The returned class can use any constraint.
 In the case of `Uni`, it checks the item produced asynchronously.
 
+[[using-vertx-web-router]]
 == Using the Vert.x Web Router
 
 You can also register your route directly on the _HTTP routing layer_ by registering routes directly on the `Router` object.

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -741,6 +741,54 @@ Depending on the application, that can be a lot of the `AuthenticationSuccessEve
 For that reason, asynchronous processing can have positive effect on performance.
 <2> Common code for all supported security event types is possible because they all implement the `io.quarkus.security.spi.runtime.SecurityEvent` interface.
 
+== `SecurityIdentity` injection in Vert.x route handlers
+
+When you need to inject `SecurityIdentity` in a Vert.x route handler registered directly on the xref:reactive-routes.adoc#using-vertx-web-router[Vert.x Web Router], then requesting the `SecurityIdentity` propagation is required.
+For example:
+
+[source,java]
+----
+package io.quarkus.it.security;
+
+public class RouterObserver {
+
+    public void route(@Observes Router router, UserInformation userInformation) {
+        router.route("/user-info").handler(event -> event.response().end(userInformation.getPrincipalName()));
+    }
+
+}
+----
+
+The `UserInformation` bean in the example can look like this:
+
+[source,java]
+----
+package io.quarkus.it.security;
+
+@ApplicationScoped
+public class UserInformation {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @ActivateRequestContext
+    String getPrincipalName() {
+        return identity.getPrincipal().getName();
+    }
+
+}
+----
+
+For the `SecurityIdentity` injection in this example to work, you must activate the `SecurityIdentity` propagation:
+
+[source,properties]
+----
+quarkus.http.auth.propagate-security-identity=true <1>
+----
+<1> Propagate the `SecurityIdentity` when a Vert.x route handler is registered programmatically on the Vert.x HTTP router.
+It is required because Quarkus cannot detect that the `SecurityIdentity` injection point is used in the programmatically registered Vert.x route handler.
+For the routes registered declaratively with the `@Route` annotation as well as Jakarta REST endpoints, this configuration is not required.
+
 == References
 
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/AbstractSecurityIdentityAssociation.java
+++ b/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/AbstractSecurityIdentityAssociation.java
@@ -1,0 +1,65 @@
+package io.quarkus.security.spi.runtime;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.runtime.BlockingOperationControl;
+import io.quarkus.runtime.BlockingOperationNotAllowedException;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AnonymousAuthenticationRequest;
+import io.smallrye.mutiny.Uni;
+
+public abstract class AbstractSecurityIdentityAssociation implements CurrentIdentityAssociation {
+
+    private volatile SecurityIdentity identity;
+    private volatile Uni<SecurityIdentity> deferredIdentity;
+
+    @Inject
+    IdentityProviderManager identityProviderManager;
+
+    @Override
+    public void setIdentity(SecurityIdentity identity) {
+        this.identity = identity;
+        this.deferredIdentity = null;
+    }
+
+    @Override
+    public void setIdentity(Uni<SecurityIdentity> identity) {
+        this.identity = null;
+        this.deferredIdentity = identity;
+    }
+
+    public Uni<SecurityIdentity> getDeferredIdentity() {
+        if (deferredIdentity != null) {
+            return deferredIdentity;
+        } else if (identity != null) {
+            return Uni.createFrom().item(identity);
+        } else {
+            return deferredIdentity = identityProviderManager.authenticate(AnonymousAuthenticationRequest.INSTANCE);
+        }
+    }
+
+    @Override
+    public SecurityIdentity getIdentity() {
+        if (identity == null) {
+            if (deferredIdentity != null) {
+                if (BlockingOperationControl.isBlockingAllowed()) {
+                    identity = deferredIdentity.await().indefinitely();
+                } else {
+                    throw new BlockingOperationNotAllowedException(
+                            "Cannot call getIdentity() from the IO thread when lazy authentication " +
+                                    "is in use, as resolving the identity may block the thread. Instead you should inject the "
+                                    +
+                                    "CurrentIdentityAssociation, call CurrentIdentityAssociation#getDeferredIdentity() and " +
+                                    "subscribe to the Uni.");
+                }
+            }
+            if (identity == null) {
+                identity = identityProviderManager.authenticate(AnonymousAuthenticationRequest.INSTANCE).await().indefinitely();
+            }
+        }
+        return identity;
+    }
+
+}

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityCheckRecorder.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityCheckRecorder.java
@@ -29,6 +29,7 @@ import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.StringPermission;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.runtime.interceptor.SecurityCheckStorageBuilder;
 import io.quarkus.security.runtime.interceptor.SecurityConstrainer;
 import io.quarkus.security.runtime.interceptor.check.AuthenticatedCheck;
@@ -392,7 +393,7 @@ public class SecurityCheckRecorder {
                 return new SecurityConstrainer(container.instance(SecurityCheckStorage.class).get(),
                         beanManager, beanManager.getEvent().select(AuthorizationFailureEvent.class),
                         beanManager.getEvent().select(AuthorizationSuccessEvent.class), runtimeConfigReady,
-                        container.select(SecurityIdentityAssociation.class), eventPropsSupplier);
+                        container.select(CurrentIdentityAssociation.class), eventPropsSupplier);
             }
         };
     }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityAssociation.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityAssociation.java
@@ -4,28 +4,18 @@ import java.security.Principal;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
-import jakarta.inject.Inject;
 
-import io.quarkus.runtime.BlockingOperationControl;
-import io.quarkus.runtime.BlockingOperationNotAllowedException;
-import io.quarkus.security.identity.CurrentIdentityAssociation;
-import io.quarkus.security.identity.IdentityProviderManager;
-import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.security.identity.request.AnonymousAuthenticationRequest;
-import io.smallrye.mutiny.Uni;
+import io.quarkus.arc.DefaultBean;
+import io.quarkus.security.spi.runtime.AbstractSecurityIdentityAssociation;
 
+@DefaultBean
 @RequestScoped
-public class SecurityIdentityAssociation implements CurrentIdentityAssociation {
+public class SecurityIdentityAssociation extends AbstractSecurityIdentityAssociation {
 
-    private volatile SecurityIdentity identity;
-    private volatile Uni<SecurityIdentity> deferredIdentity;
-
-    @Inject
-    IdentityProviderManager identityProviderManager;
-
+    @DefaultBean
     @Produces
     @RequestScoped
-    Principal principal() {
+    public Principal principal() {
         //TODO: as this is request scoped we loose the type of the Principal
         //if this is important you can just inject the identity
         return new Principal() {
@@ -36,47 +26,4 @@ public class SecurityIdentityAssociation implements CurrentIdentityAssociation {
         };
     }
 
-    @Override
-    public void setIdentity(SecurityIdentity identity) {
-        this.identity = identity;
-        this.deferredIdentity = null;
-    }
-
-    @Override
-    public void setIdentity(Uni<SecurityIdentity> identity) {
-        this.identity = null;
-        this.deferredIdentity = identity;
-    }
-
-    public Uni<SecurityIdentity> getDeferredIdentity() {
-        if (deferredIdentity != null) {
-            return deferredIdentity;
-        } else if (identity != null) {
-            return Uni.createFrom().item(identity);
-        } else {
-            return deferredIdentity = identityProviderManager.authenticate(AnonymousAuthenticationRequest.INSTANCE);
-        }
-    }
-
-    @Override
-    public SecurityIdentity getIdentity() {
-        if (identity == null) {
-            if (deferredIdentity != null) {
-                if (BlockingOperationControl.isBlockingAllowed()) {
-                    identity = deferredIdentity.await().indefinitely();
-                } else {
-                    throw new BlockingOperationNotAllowedException(
-                            "Cannot call getIdentity() from the IO thread when lazy authentication " +
-                                    "is in use, as resolving the identity may block the thread. Instead you should inject the "
-                                    +
-                                    "CurrentIdentityAssociation, call CurrentIdentityAssociation#getDeferredIdentity() and " +
-                                    "subscribe to the Uni.");
-                }
-            }
-            if (identity == null) {
-                identity = identityProviderManager.authenticate(AnonymousAuthenticationRequest.INSTANCE).await().indefinitely();
-            }
-        }
-        return identity;
-    }
 }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityProxy.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityProxy.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 
 import io.quarkus.security.credential.Credential;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.mutiny.Uni;
 
@@ -17,7 +18,7 @@ import io.smallrye.mutiny.Uni;
 public class SecurityIdentityProxy implements SecurityIdentity {
 
     @Inject
-    SecurityIdentityAssociation association;
+    CurrentIdentityAssociation association;
 
     @Override
     public Principal getPrincipal() {

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/SecurityConstrainer.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/SecurityConstrainer.java
@@ -17,8 +17,8 @@ import jakarta.inject.Singleton;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.runtime.BlockingOperationNotAllowedException;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.security.runtime.SecurityIdentityAssociation;
 import io.quarkus.security.spi.runtime.AuthorizationFailureEvent;
 import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
 import io.quarkus.security.spi.runtime.MethodDescription;
@@ -36,12 +36,12 @@ public class SecurityConstrainer {
     public static final Object CHECK_OK = new Object();
     private final SecurityCheckStorage storage;
     private final SecurityEventHelper<AuthorizationSuccessEvent, AuthorizationFailureEvent> securityEventHelper;
-    private final Instance<SecurityIdentityAssociation> securityIdentityAssociation;
+    private final Instance<CurrentIdentityAssociation> securityIdentityAssociation;
     private final Supplier<Map<String, Object>> additionalEventPropsSupplier;
 
     public SecurityConstrainer(SecurityCheckStorage storage, BeanManager beanManager,
             Event<AuthorizationFailureEvent> authZFailureEvent, Event<AuthorizationSuccessEvent> authZSuccessEvent,
-            boolean runtimeConfigReady, Instance<SecurityIdentityAssociation> securityIdentityAssociation,
+            boolean runtimeConfigReady, Instance<CurrentIdentityAssociation> securityIdentityAssociation,
             Supplier<Map<String, Object>> additionalEventPropsSupplier) {
         this.securityIdentityAssociation = securityIdentityAssociation;
         this.additionalEventPropsSupplier = additionalEventPropsSupplier;

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -69,6 +69,7 @@ import io.quarkus.security.spi.AdditionalSecurityConstrainerEventPropsBuildItem;
 import io.quarkus.security.spi.ClassSecurityAnnotationBuildItem;
 import io.quarkus.security.spi.RegisterClassSecurityCheckBuildItem;
 import io.quarkus.security.spi.runtime.MethodDescription;
+import io.quarkus.vertx.core.deployment.IgnoredContextLocalDataKeysBuildItem;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
@@ -83,6 +84,7 @@ import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.Authenticatio
 import io.quarkus.vertx.http.runtime.security.MtlsAuthenticationMechanism;
 import io.quarkus.vertx.http.runtime.security.PathMatchingHttpSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.VertxBlockingSecurityExecutor;
+import io.quarkus.vertx.http.runtime.security.VertxSecurityIdentityAssociation;
 import io.quarkus.vertx.http.runtime.security.annotation.BasicAuthentication;
 import io.quarkus.vertx.http.runtime.security.annotation.FormAuthentication;
 import io.quarkus.vertx.http.runtime.security.annotation.HttpAuthenticationMechanism;
@@ -255,9 +257,11 @@ public class HttpSecurityProcessor {
             VertxHttpBuildTimeConfig httpBuildTimeConfig,
             BuildProducer<HttpAuthenticationHandlerBuildItem> authenticationHandlerProducer) {
         if (capabilities.isPresent(Capability.SECURITY)) {
+            var authConfig = httpBuildTimeConfig.auth();
             authenticationHandlerProducer.produce(
                     new HttpAuthenticationHandlerBuildItem(
-                            recorder.authenticationMechanismHandler(httpBuildTimeConfig.auth().proactive())));
+                            recorder.authenticationMechanismHandler(authConfig.proactive(),
+                                    authConfig.propagateSecurityIdentity())));
         }
     }
 
@@ -606,6 +610,17 @@ public class HttpSecurityProcessor {
         }
     }
 
+    @BuildStep(onlyIf = AlwaysPropagateSecurityIdentity.class)
+    AdditionalBeanBuildItem createSecurityIdentityAssociation() {
+        return AdditionalBeanBuildItem.unremovableOf(VertxSecurityIdentityAssociation.class);
+    }
+
+    @Record(ExecutionTime.STATIC_INIT)
+    @BuildStep(onlyIf = AlwaysPropagateSecurityIdentity.class)
+    IgnoredContextLocalDataKeysBuildItem dontPropagateSecurityIdentityToDuplicateContext(HttpSecurityRecorder recorder) {
+        return new IgnoredContextLocalDataKeysBuildItem(recorder.getSecurityIdentityContextKeySupplier());
+    }
+
     private static Stream<MethodInfo> getPolicyTargetEndpointCandidates(AnnotationTarget target) {
         if (target.kind() == AnnotationTarget.Kind.METHOD) {
             var method = target.asMethod();
@@ -826,6 +841,20 @@ public class HttpSecurityProcessor {
 
         private HttpAuthenticationHandlerBuildItem(RuntimeValue<AuthenticationHandler> handler) {
             this.handler = handler;
+        }
+    }
+
+    static final class AlwaysPropagateSecurityIdentity implements BooleanSupplier {
+
+        private final boolean alwaysPropagateSecurityIdentity;
+
+        AlwaysPropagateSecurityIdentity(VertxHttpBuildTimeConfig buildTimeConfig) {
+            this.alwaysPropagateSecurityIdentity = buildTimeConfig.auth().propagateSecurityIdentity();
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return alwaysPropagateSecurityIdentity;
         }
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/SecurityIdentityPropagationTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/SecurityIdentityPropagationTest.java
@@ -1,0 +1,120 @@
+package io.quarkus.vertx.http.security;
+
+import java.security.Principal;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.Router;
+
+public class SecurityIdentityPropagationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(RouterObserver.class, UserInfo.class)
+                    .addAsResource(new StringAsset("quarkus.http.auth.propagate-security-identity=true"),
+                            "application.properties"));
+
+    @Test
+    public void testSecurityIdentityAvailable() {
+        // anonymous identity is allowed as no credentials
+        RestAssured.given().get("/admin-user-info").then().statusCode(200).body(Matchers.is(""));
+        // auth not required, but wrong credentials
+        RestAssured.given()
+                .auth().preemptive().basic("user", "user")
+                .get("/admin-user-info").then().statusCode(401);
+
+        // authenticated user with admin role
+        RestAssured.given()
+                .auth().preemptive().basic("admin", "admin")
+                .get("/admin-user-info").then().statusCode(200).body(Matchers.is("admin"));
+        // authenticated user without admin role
+        RestAssured.given()
+                .auth().preemptive().basic("harvey", "harvey")
+                .get("/admin-user-info").then().statusCode(200).body(Matchers.is(""));
+    }
+
+    @Test
+    public void testPrincipalAvailable() {
+        RestAssured.given().get("/user-info-principal").then().statusCode(200).body(Matchers.is(""));
+        RestAssured.given()
+                .auth().preemptive().basic("admin", "admin")
+                .get("/user-info-principal").then().statusCode(200).body(Matchers.is("admin"));
+        RestAssured.given()
+                .auth().preemptive().basic("harvey", "harvey")
+                .get("/user-info-principal").then().statusCode(200).body(Matchers.is("harvey"));
+    }
+
+    public static class RouterObserver {
+
+        public void route(@Observes Router router, UserInfo userInfo) {
+            router.route("/admin-user-info").handler(event -> event.response().end(userInfo.getAdminPrincipalName()));
+            router.route("/user-info-principal").handler(event -> event.response().end(userInfo.getPrincipalName()));
+        }
+    }
+
+    @ApplicationScoped
+    public static class UserInfo {
+
+        @Inject
+        SecurityIdentity identity;
+
+        @Inject
+        Principal principal;
+
+        @ActivateRequestContext
+        String getAdminPrincipalName() {
+            if (identity.hasRole("admin")) {
+                return identity.getPrincipal().getName();
+            }
+            return "";
+        }
+
+        @ActivateRequestContext
+        String getPrincipalName() {
+            return principal.getName();
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class BasicAuthProvider implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+
+        @Override
+        public Class<UsernamePasswordAuthenticationRequest> getRequestType() {
+            return UsernamePasswordAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(UsernamePasswordAuthenticationRequest request,
+                AuthenticationRequestContext authenticationRequestContext) {
+            String username = request.getUsername();
+            boolean isAdmin = "admin".equalsIgnoreCase(username);
+            if (isAdmin || "harvey".equalsIgnoreCase(username)) {
+                var identity = QuarkusSecurityIdentity.builder().setPrincipal(new QuarkusPrincipal(username))
+                        .setAnonymous(false)
+                        .addRole(isAdmin ? "admin" : "harvey")
+                        .build();
+                return Uni.createFrom().item(identity);
+            }
+            return Uni.createFrom().nullItem();
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
@@ -31,4 +31,11 @@ public interface AuthConfig {
      */
     @WithDefault("true")
     boolean proactive();
+
+    /**
+     * Propagate security identity to support its injection in Vert.x route handlers registered directly with the router.
+     */
+    @WithDefault("false")
+    boolean propagateSecurityIdentity();
+
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -11,11 +11,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletionException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -42,12 +38,15 @@ import io.quarkus.security.identity.request.AnonymousAuthenticationRequest;
 import io.quarkus.security.spi.runtime.MethodDescription;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.VertxHttpConfig;
+import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
 import io.smallrye.mutiny.tuples.Functions;
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 
@@ -56,8 +55,9 @@ public class HttpSecurityRecorder {
 
     private static final Logger log = Logger.getLogger(HttpSecurityRecorder.class);
 
-    public RuntimeValue<AuthenticationHandler> authenticationMechanismHandler(boolean proactiveAuthentication) {
-        return new RuntimeValue<>(new AuthenticationHandler(proactiveAuthentication));
+    public RuntimeValue<AuthenticationHandler> authenticationMechanismHandler(boolean proactiveAuthentication,
+            boolean propagateRoutingContext) {
+        return new RuntimeValue<>(new AuthenticationHandler(proactiveAuthentication, propagateRoutingContext));
     }
 
     public Handler<RoutingContext> getHttpAuthenticatorHandler(RuntimeValue<AuthenticationHandler> handlerRuntimeValue) {
@@ -251,11 +251,17 @@ public class HttpSecurityRecorder {
     public static final class AuthenticationHandler implements Handler<RoutingContext> {
         volatile HttpAuthenticator authenticator;
         private final boolean proactiveAuthentication;
+        private final boolean propagateRoutingContext;
         private AbstractPathMatchingHttpSecurityPolicy pathMatchingPolicy;
         private RolesMapping rolesMapping;
 
-        public AuthenticationHandler(boolean proactiveAuthentication) {
+        AuthenticationHandler(boolean proactiveAuthentication, boolean propagateRoutingContext) {
             this.proactiveAuthentication = proactiveAuthentication;
+            this.propagateRoutingContext = propagateRoutingContext;
+        }
+
+        public AuthenticationHandler(boolean proactiveAuthentication) {
+            this(proactiveAuthentication, false);
         }
 
         @Override
@@ -265,6 +271,12 @@ public class HttpSecurityRecorder {
                 // all the build items are finished before this is called (for example Elytron identity providers use
                 // SecurityDomain that is not ready when identity providers are ready; it's racy)
                 authenticator = CDI.current().select(HttpAuthenticator.class).get();
+            }
+            if (propagateRoutingContext) {
+                Context context = Vertx.currentContext();
+                if (context != null && VertxContext.isDuplicatedContext(context)) {
+                    context.putLocal(HttpSecurityUtils.ROUTING_CONTEXT_ATTRIBUTE, event);
+                }
             }
             //we put the authenticator into the routing context so it can be used by other systems
             event.put(HttpAuthenticator.class.getName(), authenticator);
@@ -482,6 +494,10 @@ public class HttpSecurityRecorder {
                 };
             }
         };
+    }
+
+    public RuntimeValue<List<String>> getSecurityIdentityContextKeySupplier() {
+        return new RuntimeValue<>(List.of(HttpSecurityUtils.ROUTING_CONTEXT_ATTRIBUTE));
     }
 
     public Consumer<RoutingContext> createEagerSecurityInterceptor(

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/VertxSecurityIdentityAssociation.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/VertxSecurityIdentityAssociation.java
@@ -1,0 +1,72 @@
+package io.quarkus.vertx.http.runtime.security;
+
+import static io.quarkus.vertx.http.runtime.security.QuarkusHttpUser.DEFERRED_IDENTITY_KEY;
+
+import java.security.Principal;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.spi.runtime.AbstractSecurityIdentityAssociation;
+import io.smallrye.common.vertx.ContextLocals;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@RequestScoped
+public class VertxSecurityIdentityAssociation extends AbstractSecurityIdentityAssociation {
+
+    @Produces
+    @RequestScoped
+    public Principal principal() {
+        return new Principal() {
+            @Override
+            public String getName() {
+                return getIdentity().getPrincipal().getName();
+            }
+        };
+    }
+
+    @Override
+    public Uni<SecurityIdentity> getDeferredIdentity() {
+        RoutingContext routingContext = getRoutingContext();
+        if (routingContext != null) {
+            SecurityIdentity securityIdentity = getSecurityIdentityFromCtx(routingContext);
+            if (securityIdentity != null) {
+                return Uni.createFrom().item(securityIdentity);
+            }
+            Uni<SecurityIdentity> identityUni = routingContext.get(DEFERRED_IDENTITY_KEY);
+            if (identityUni != null) {
+                return identityUni;
+            }
+        }
+        return super.getDeferredIdentity();
+    }
+
+    @Override
+    public SecurityIdentity getIdentity() {
+        RoutingContext routingContext = getRoutingContext();
+        if (routingContext != null) {
+            SecurityIdentity securityIdentity = getSecurityIdentityFromCtx(routingContext);
+            if (securityIdentity != null) {
+                return securityIdentity;
+            }
+            securityIdentity = QuarkusHttpUser.getSecurityIdentityBlocking(routingContext, null);
+            if (securityIdentity != null) {
+                return securityIdentity;
+            }
+        }
+        return super.getIdentity();
+    }
+
+    private static SecurityIdentity getSecurityIdentityFromCtx(RoutingContext routingContext) {
+        if (routingContext.user() instanceof QuarkusHttpUser quarkusHttpUser) {
+            return quarkusHttpUser.getSecurityIdentity();
+        }
+        return null;
+    }
+
+    private static RoutingContext getRoutingContext() {
+        return ContextLocals.get(HttpSecurityUtils.ROUTING_CONTEXT_ATTRIBUTE, null);
+    }
+}

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/IgnoredContextLocalDataKeysBuildItem.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/IgnoredContextLocalDataKeysBuildItem.java
@@ -1,0 +1,26 @@
+package io.quarkus.vertx.core.deployment;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.jboss.threads.ContextHandler;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+
+/**
+ * A build item that allows extensions to declare which keys should not be propagated before a task is executed in
+ * the {@link ContextHandler#runWith(Runnable, Object)} method.
+ */
+public final class IgnoredContextLocalDataKeysBuildItem extends MultiBuildItem {
+
+    private final RuntimeValue<List<String>> ignoredKeysSupplier;
+
+    public IgnoredContextLocalDataKeysBuildItem(RuntimeValue<List<String>> ignoredKeysSupplier) {
+        this.ignoredKeysSupplier = Objects.requireNonNull(ignoredKeysSupplier);
+    }
+
+    RuntimeValue<List<String>> getIgnoredKeysSupplier() {
+        return ignoredKeysSupplier;
+    }
+}


### PR DESCRIPTION
This PR is motivated by user that uses `io.vertx.httpproxy.HttpProxy#reverseProxy(io.vertx.core.http.HttpClient)` and their `io.vertx.httpproxy.ProxyInterceptor` needs to inject `org.eclipse.microprofile.jwt.JsonWebToken` from CDI request context (reproducer is not publicly available, ask @sberyozkin  for details if you require them). There is no `RoutingContext` available, only `io.vertx.httpproxy.ProxyContext` that doesn't expose underlying request's `RoutingContext`.

Why doesn't it work OOTB? Basically what is happening is that injecting `org.eclipse.microprofile.jwt.JsonWebToken` inside a `Handler<RoutingContext>` requires `SecurityIdentity` taken from the CDI request context. But when user activates CDI request context with the `ActivateRequestContext` annotation (or programmatically), where would the request scoped bean take the identity if it cannot access `RoutingContext` with the HTTP user?

Only way how to propagate `RoutingContext` is IMO local data of the Vert.x duplicated context. I know we don't want to do that by default because it relies on the `ConcurrentHashMap` which would be bad when used on the hoth path, but I think it can be justified in this situation when explicitly enabled.

Key part of the original reproducer looked like:

```
final HttpClient httpClient = vertx.createHttpClient(httpClientOptions);
final HttpProxy proxyHandler = HttpProxy.reverseProxy(httpClient);
proxyHandler.origin(uri.getPort(), uri.getHost());
proxyHandler.addInterceptor(myInterceptor);
router.route("my-path").handler(ctx -> {
proxyHandler.handle(ctx.request());
});
```

and `myInterceptor` is `@ApplicationScoped` bean that injects `JsonWebToken`.