### PR TITLE
Dedicated Dev UI interface to execute HQL (Hibernate ORM) queries

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourcesJdbcBuildTimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourcesJdbcBuildTimeConfig.java
@@ -65,7 +65,8 @@ public interface DataSourcesJdbcBuildTimeConfig {
         public Optional<String> appendToDefaultSelect();
 
         /**
-         * Allowed database host. By default only localhost is allowed. Any provided host here will also be allowed
+         * Allowed database host. By default, only localhost is allowed. Any provided host here will also be allowed.
+         * You can use the special value {@code *} to allow any DB host.
          */
         public Optional<String> allowedDBHost();
     }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -90,6 +90,13 @@ public interface HibernateOrmConfig {
      */
     HibernateOrmConfigMetric metrics();
 
+    /**
+     * Dev UI.
+     */
+    @WithDefaults
+    @WithName("dev-ui")
+    HibernateOrmConfigDevUI devui();
+
     default boolean isAnyNonPersistenceXmlPropertySet() {
         // Do NOT include persistenceXml in here.
         return defaultPersistenceUnit().isAnyPropertySet() ||
@@ -182,4 +189,12 @@ public interface HibernateOrmConfig {
         }
     }
 
+    @ConfigGroup
+    interface HibernateOrmConfigDevUI {
+        /**
+         * Allow hql queries in the Dev UI page
+         */
+        @WithDefault("false")
+        boolean allowHql();
+    }
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevUIProcessor.java
@@ -12,6 +12,7 @@ import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
+import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmEnabled;
 import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
@@ -22,7 +23,7 @@ import io.quarkus.hibernate.orm.runtime.dev.HibernateOrmDevJsonRpcService;
 public class HibernateOrmDevUIProcessor {
 
     @BuildStep
-    public CardPageBuildItem create() {
+    public CardPageBuildItem create(HibernateOrmConfig config) {
         CardPageBuildItem card = new CardPageBuildItem();
         card.addPage(Page.webComponentPageBuilder()
                 .title("Persistence Units")
@@ -39,7 +40,11 @@ public class HibernateOrmDevUIProcessor {
                 .componentLink("hibernate-orm-named-queries.js")
                 .icon("font-awesome-solid:circle-question")
                 .dynamicLabelJsonRPCMethodName("getNumberOfNamedQueries"));
-
+        card.addPage(Page.webComponentPageBuilder()
+                .title("HQL Console")
+                .componentLink("hibernate-orm-hql-console.js")
+                .icon("font-awesome-solid:play")
+                .metadata("allowHql", String.valueOf(config.devui().allowHql())));
         return card;
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-entity-types.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-entity-types.js
@@ -88,6 +88,10 @@ export class HibernateOrmEntityTypesComponent extends QwcHotReloadElement {
         return html`
                 <vaadin-grid .items="${pu.managedEntities}" class="datatable" theme="no-border row-stripes">
                     <vaadin-grid-column auto-width
+                                        header="JPA entity name"
+                                        path="name">
+                    </vaadin-grid-column>
+                    <vaadin-grid-column auto-width
                                         header="Class name"
                                         path="className">
                     </vaadin-grid-column>

--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-hql-console.js
@@ -1,0 +1,479 @@
+import {css, html, QwcHotReloadElement} from 'qwc-hot-reload-element';
+import {RouterController} from 'router-controller';
+import {JsonRpc} from 'jsonrpc';
+import '@vaadin/icon';
+import '@vaadin/button';
+import '@vaadin/combo-box';
+import '@vaadin/grid';
+import '@vaadin/progress-bar';
+import '@vaadin/tabs';
+import '@vaadin/tabsheet';
+import {columnBodyRenderer} from '@vaadin/grid/lit.js';
+import {notifier} from 'notifier';
+
+export class HibernateOrmHqlConsoleComponent extends QwcHotReloadElement {
+    jsonRpc = new JsonRpc(this);
+    configJsonRpc = new JsonRpc("devui-configuration");
+
+    routerController = new RouterController(this);
+
+    static styles = css`
+        .bordered {
+            border: 1px solid var(--lumo-contrast-20pct);
+            border-radius: var(--lumo-border-radius-l);
+            padding: var(--lumo-space-s) var(--lumo-space-m);
+        }
+
+        .dataSources {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            height: 100%;
+            padding-left: 10px;
+        }
+
+        .tablesAndData {
+            display: flex;
+            height: 100%;
+            gap: 20px;
+            padding-right: 20px;
+        }
+
+        .tables {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+
+        .tableData {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+        }
+
+        .tablesCard {
+            min-width: 192px;
+            display: flex;
+        }
+
+        .fill {
+            width: 100%;
+            height: 100%;
+        }
+
+        .small-icon {
+            height: var(--lumo-icon-size-s);
+            width: var(--lumo-icon-size-s);
+        }
+
+        .hqlInput {
+            display: flex;
+            justify-content: space-between;
+            gap: 10px;
+            align-items: center;
+            padding-bottom: 20px;
+            border-bottom-style: dotted;
+            border-bottom-color: var(--lumo-contrast-10pct);
+        }
+
+        #hql {
+            width: 100%;
+        }
+
+        .data {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            width: 100%;
+            height: 100%;
+        }
+
+        .pager {
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .hidden {
+            visibility: hidden;
+        }
+
+        a, a:visited, a:focus, a:active {
+            text-decoration: none;
+            color: var(--lumo-body-text-color);
+        }
+
+        a:hover {
+            text-decoration: none;
+            color: var(--lumo-primary-text-color);
+        }
+
+        .font-large {
+            font-size: var(--lumo-font-size-l);
+        }
+
+        .cursor-text {
+            cursor: text;
+        }
+
+        .no-margin {
+            margin: 0;
+        }
+    `;
+
+
+    static properties = {
+        _persistenceUnits: {state: true, type: Array},
+        _selectedPersistenceUnit: {state: true},
+        _selectedEntity: {state: true},
+        _selectedEntityIndex: {state: true},
+        _currentHQL: {state: true},
+        _currentDataSet: {state: true},
+        _currentMessage: {state: true},
+        _currentPageNumber: {state: true},
+        _currentNumberOfPages: {state: true},
+        _allowHql: {state: true},
+    }
+
+    constructor() {
+        super();
+        this._persistenceUnits = [];
+        this._selectedPersistenceUnit = null;
+        this._selectedEntity = null;
+        this._selectedEntityIndex = 0;
+        this._currentHQL = null;
+        this._currentDataSet = null;
+        this._currentMessage = null;
+        this._currentPageNumber = 1;
+        this._currentNumberOfPages = 1;
+        this._pageSize = 15;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+
+        const page = this.routerController.getCurrentPage();
+        if (page && page.metadata) {
+            this._allowHql = (page.metadata.allowHql === "true");
+        } else {
+            this._allowHql = false;
+        }
+
+        this.hotReload();
+    }
+
+    hotReload() {
+        this.jsonRpc.getInfo().then(response => {
+            this._persistenceUnits = response.result.persistenceUnits;
+            this._selectPersistenceUnit(this._persistenceUnits[0])
+        }).catch(error => {
+            console.error("Failed to fetch persistence units:", error);
+            this._persistenceUnits = [];
+            notifier.showErrorMessage("Failed to fetch persistence units: " + error, "bottom-start", 30);
+        });
+    }
+
+    render() {
+        if (this._persistenceUnits) {
+            return this._renderAllPUs();
+        } else {
+            return this._renderFetchingProgress();
+        }
+    }
+
+    _renderFetchingProgress() {
+        return html`
+            <div style="color: var(--lumo-secondary-text-color);width: 95%;">
+                <div>Fetching persistence units...</div>
+                <vaadin-progress-bar indeterminate></vaadin-progress-bar>
+            </div>`;
+    }
+
+    _renderAllPUs() {
+        return this._persistenceUnits.length === 0
+            ? html`
+                    <p>No persistence units were found.
+                        <vaadin-button @click="${this.hotReload}" theme="small">Check again</vaadin-button>
+                    </p>`
+            : html`
+                    <div class="dataSources">
+                        ${this._renderTablesAndData()}
+                    </div>`;
+    }
+
+    _renderDatasourcesComboBox() {
+        return html`
+            <vaadin-combo-box
+                    label="Persistence Unit"
+                    item-label-path="name"
+                    item-value-path="name"
+                    .items="${this._persistenceUnits}"
+                    .value="${this._persistenceUnits[0]?.name || ''}"
+                    @value-changed="${this._onPersistenceUnitChanged}"
+                    .allowCustomValue="${false}"
+            ></vaadin-combo-box>
+        `;
+    }
+
+    _onPersistenceUnitChanged(event) {
+        const selectedValue = event.detail.value;
+        this._selectPersistenceUnit(this._persistenceUnits.find(unit => unit.name === selectedValue))
+    }
+
+    _selectPersistenceUnit(pu) {
+        this._selectedPersistenceUnit = pu;
+        this._selectedEntityIndex = 0;
+        this._selectedEntity = pu && pu.managedEntities[0] || null;
+    }
+
+    _renderTablesAndData() {
+        return html`
+            <div class="tablesAndData">
+                <div class="tables">
+                    ${this._renderDatasourcesComboBox()}
+                    ${this._renderTables()}
+                </div>
+                <div class="tableData bordered">
+                    ${this._renderDataAndInput()}
+                </div>
+            </div>`;
+    }
+
+    _renderTables() {
+        if (this._selectedPersistenceUnit) {
+            return html`
+                <qui-card class="tablesCard" header="Entities">
+                    <div slot="content">
+                        <vaadin-list-box selected="${this._selectedEntityIndex}"
+                                         @selected-changed="${this._onEntityChanged}">
+                            ${this._selectedPersistenceUnit.managedEntities.map((entity) =>
+                                    html`
+                                        <vaadin-item>${entity.name}</vaadin-item>`
+                            )}
+                        </vaadin-list-box>
+                    </div>
+                </qui-card>`;
+        } else {
+            return this._renderFetchingProgress();
+        }
+    }
+
+    _onEntityChanged(event) {
+        this._selectedEntityIndex = event.detail.value;
+        this._selectedEntity = this._selectedPersistenceUnit.managedEntities[this._selectedEntityIndex];
+        this._clearHqlInput();
+    }
+
+    _clearHqlInput() {
+        if (this._selectedEntity) {
+            this._executeHQL("from " + this._selectedEntity.name);
+        } else {
+            this._currentDataSet = [];
+        }
+    }
+
+    _executeHQL(hql) {
+        this._currentPageNumber = 1;
+        this._currentHQL = hql.trim();
+        this._executeCurrentHQL();
+    }
+
+    _executeClicked() {
+        let newValue = this.shadowRoot.getElementById('hql').getAttribute('value');
+        this._executeHQL(newValue);
+    }
+
+    _executeCurrentHQL() {
+        if (this._currentHQL) {
+            this._currentDataSet = null; // indicates loading
+            this._currentMessage = null;
+
+            this.jsonRpc.executeHQL({
+                persistenceUnit: this._selectedPersistenceUnit.name,
+                hql: this._currentHQL,
+                pageNumber: this._currentPageNumber,
+                pageSize: this._pageSize
+            }).then(jsonRpcResponse => {
+                const error = jsonRpcResponse.error && jsonRpcResponse.error.message || jsonRpcResponse.result.error;
+                if (error) {
+                    this._currentDataSet = [];
+                    notifier.showErrorMessage("Error executing query: " + error, "bottom-start");
+                } else if (jsonRpcResponse.result.message) {
+                    this._currentMessage = jsonRpcResponse.result.message;
+                } else {
+                    this._currentDataSet = jsonRpcResponse.result;
+                    this._currentNumberOfPages = this._getNumberOfPages();
+                }
+            });
+        }
+    }
+
+    // *** data table and HQL input ***
+
+    _renderDataAndInput() {
+        return html`
+            ${this._renderHqlInput()}
+            <div tab="data-tab" style="height:100%;">${this._renderTableData()}</div>`;
+    }
+
+    _renderHqlInput() {
+        if (this._allowHql) {
+            return html`
+                <div class="hqlInput">
+                    <qui-code-block @shiftEnter=${this._shiftEnterPressed} class="font-large cursor-text"
+                                    content="${this._currentHQL}" id="hql"
+                                    mode="sql" theme="dark" value='${this._currentHQL}' editable></qui-code-block>
+                    <vaadin-button class="no-margin" slot="suffix" theme="icon" aria-label="Clear">
+                        <vaadin-tooltip .hoverDelay=${500} slot="tooltip" text="Clear"></vaadin-tooltip>
+                        <vaadin-icon class="small-icon" @click=${this._clearHqlInput}
+                                     icon="font-awesome-solid:trash"></vaadin-icon>
+                    </vaadin-button>
+                    <vaadin-button class="no-margin" slot="suffix" theme="icon" aria-label="Run">
+                        <vaadin-tooltip .hoverDelay=${500} slot="tooltip" text="Run"></vaadin-tooltip>
+                        <vaadin-icon class="small-icon" @click=${this._executeClicked}
+                                     icon="font-awesome-solid:play"></vaadin-icon>
+                    </vaadin-button>
+                </div>`;
+        } else {
+            return html`
+                <vaadin-button theme="small" @click="${this._handleAllowHqlChange}">Allow HQL execution from here
+                </vaadin-button>`;
+        }
+    }
+
+    _handleAllowHqlChange() {
+        this.configJsonRpc.updateProperty({
+            'name': '%dev.quarkus.hibernate-orm.dev-ui.allow-hql',
+            'value': 'true'
+        }).then(e => {
+            this._allowHql = true;
+        });
+    }
+
+    _shiftEnterPressed(event) {
+        this._executeHQL(event.detail.content);
+    }
+
+    _renderTableData() {
+        if (this._selectedEntity) {
+            if (this._currentMessage) {
+                return html`
+                    <div class="data"><span style="padding-top:20px;">${this._currentMessage}</span></div>`;
+            } else if (this._currentDataSet) {
+                return html`
+                    <div class="data">
+                        <vaadin-grid id="data-grid" .items="${this._currentDataSet.data}" theme="row-stripes no-border"
+                                     class="fill" column-reordering-allowed>
+                            ${this._renderTableRows(this._currentDataSet.data)}
+                            <span slot="empty-state">No data.</span>
+                        </vaadin-grid>
+                        ${this._renderPager()}
+                    </div>`;
+            }
+        }
+
+        return html`
+            <div style="color: var(--lumo-secondary-text-color);width: 95%;padding-top:20px;">
+                <div>Fetching data...</div>
+                <vaadin-progress-bar indeterminate></vaadin-progress-bar>
+            </div>`;
+    }
+
+    _renderTableRows(data) {
+        if (!data || data.length === 0) {
+            return html``;
+        }
+
+        const firstResult = data.find(e => !!e); // first non-null element
+        if (typeof firstResult === 'object') {
+            return Object.keys(this._currentDataSet.data[0]).map((col) => {
+                return html`
+                    <vaadin-grid-sort-column path="${col}" header="${col}" auto-width resizable ${columnBodyRenderer(
+                            (item) => this._cellRenderer(item[col]),
+                            []
+                    )}></vaadin-grid-sort-column>`;
+            });
+        } else {
+            return html`
+                <vaadin-grid-sort-column header="0" auto-width resizable ${columnBodyRenderer(
+                        (value) => this._cellRenderer(value),
+                        []
+                )}></vaadin-grid-sort-column>`;
+        }
+    }
+
+    _cellRenderer(value) {
+        if (value) {
+            if (value === 'true') {
+                return html`
+                    <vaadin-icon style="color: var(--lumo-contrast-50pct);" title="${value}"
+                                 icon="font-awesome-regular:square-check"></vaadin-icon>`;
+            } else if (value === 'false') {
+                return html`
+                    <vaadin-icon style="color: var(--lumo-contrast-50pct);" title="${value}"
+                                 icon="font-awesome-regular:square"></vaadin-icon>`;
+            } else if (typeof value === 'string' && (value.startsWith('http://') || value.startsWith('https://'))) {
+                return html`<a href="${value}" target="_blank">${value}</a>`;
+            } else {
+                const s = typeof value === 'object' ? JSON.stringify(value) : value;
+                return html`<span>${s}</span>`;
+            }
+        }
+    }
+
+    // *** pager and page handling ***
+
+    _renderPager() {
+        return html`
+            <div class="pager">
+                ${this._renderPreviousPageButton()}
+                <span>${this._currentPageNumber} of ${this._currentNumberOfPages}</span>
+                ${this._renderNextPageButton()}
+            </div>`;
+    }
+
+    _renderPreviousPageButton() {
+        let klas = "pageButton";
+        if (this._currentPageNumber === 1) {
+            klas = "hidden";
+        }
+        return html`
+            <vaadin-button theme="icon tertiary" aria-label="Previous" @click=${this._previousPage} class="${klas}">
+                <vaadin-icon icon="font-awesome-solid:circle-chevron-left"></vaadin-icon>
+            </vaadin-button>`;
+    }
+
+    _renderNextPageButton() {
+        let klas = "pageButton";
+        if (this._currentPageNumber === this._currentNumberOfPages) {
+            klas = "hidden";
+        }
+        return html`
+            <vaadin-button theme="icon tertiary" aria-label="Next" @click=${this._nextPage} class="${klas}">
+                <vaadin-icon icon="font-awesome-solid:circle-chevron-right"></vaadin-icon>
+            </vaadin-button>`;
+    }
+
+    _previousPage() {
+        if (this._currentPageNumber !== 1) {
+            this._currentPageNumber = this._currentPageNumber - 1;
+            this._executeCurrentHQL();
+        }
+    }
+
+    _nextPage() {
+        this._currentPageNumber = this._currentPageNumber + 1;
+        this._executeCurrentHQL();
+    }
+
+    _getNumberOfPages() {
+        if (this._currentDataSet) {
+            if (this._currentDataSet.totalNumberOfElements > this._pageSize) {
+                return Math.ceil(this._currentDataSet.totalNumberOfElements / this._pageSize);
+            } else {
+                return 1;
+            }
+        }
+    }
+}
+
+customElements.define('hibernate-orm-hql-console', HibernateOrmHqlConsoleComponent);

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusConnectionProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusConnectionProvider.java
@@ -18,6 +18,10 @@ public class QuarkusConnectionProvider implements ConnectionProvider {
         this.dataSource = dataSource;
     }
 
+    public AgroalDataSource getDataSource() {
+        return dataSource;
+    }
+
     @Override
     public Connection getConnection() throws SQLException {
         return dataSource.getConnection();

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevIntegrator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevIntegrator.java
@@ -12,6 +12,7 @@ public class HibernateOrmDevIntegrator implements Integrator {
     public void integrate(Metadata metadata, SessionFactoryImplementor sessionFactoryImplementor,
             SessionFactoryServiceRegistry sessionFactoryServiceRegistry) {
         HibernateOrmDevController.get().pushPersistenceUnit(
+                sessionFactoryImplementor,
                 (String) sessionFactoryImplementor.getProperties()
                         .get(org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME),
                 metadata, sessionFactoryServiceRegistry,

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevJsonRpcService.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevJsonRpcService.java
@@ -1,6 +1,43 @@
 package io.quarkus.hibernate.orm.runtime.dev;
 
+import static org.hibernate.query.sqm.internal.SqmUtil.isMutation;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+import org.hibernate.Transaction;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.Query;
+import org.hibernate.query.spi.SqmQuery;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalDataSourceConfiguration;
+import io.quarkus.devui.runtime.comms.JsonRpcMessage;
+import io.quarkus.devui.runtime.comms.JsonRpcRouter;
+import io.quarkus.devui.runtime.comms.MessageType;
+import io.quarkus.hibernate.orm.runtime.customized.QuarkusConnectionProvider;
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.LaunchMode;
+
 public class HibernateOrmDevJsonRpcService {
+    private boolean isDev;
+    private String allowedHost;
+
+    public HibernateOrmDevJsonRpcService() {
+        this.isDev = LaunchMode.current() == LaunchMode.DEVELOPMENT && !LaunchMode.isRemoteDev();
+        this.allowedHost = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.datasource.dev-ui.allowed-db-host", String.class)
+                .orElse(null);
+    }
 
     public HibernateOrmDevInfo getInfo() {
         return HibernateOrmDevController.get().getInfo();
@@ -18,4 +55,152 @@ public class HibernateOrmDevJsonRpcService {
         return getInfo().getNumberOfNamedQueries();
     }
 
+    private Optional<HibernateOrmDevInfo.PersistenceUnit> findPersistenceUnit(String persistenceUnitName) {
+        return getInfo().getPersistenceUnits().stream().filter(pu -> pu.getName().equals(persistenceUnitName)).findFirst();
+    }
+
+    /**
+     * Execute an arbitrary {@code hql} query in the given {@code persistence unit}. The query might be both a selection or a
+     * mutation statement. For selection queries, the result count is retrieved though a count query and the results, paginated
+     * based on pageNumber and pageSize are returned. For mutation statements, a custom message including the number of affected
+     * records is returned.
+     * <p>
+     * This method handles result serialization (to JSON) internally, and returns a {@link JsonRpcMessage<String>} to avoid
+     * further processing by the {@link JsonRpcRouter}.
+     *
+     * @param persistenceUnit The name of the persistence unit within which the query will be executed
+     * @param hql The Hibernate Query Language (HQL) statement to execute
+     * @param pageNumber The page number, used for selection query results pagination
+     * @param pageSize The page size, used for selection query results pagination
+     * @return a {@link JsonRpcMessage<String>} containing the resulting {@link DataSet} serialized to JSON.
+     */
+    public JsonRpcMessage<Object> executeHQL(String persistenceUnit, String hql, Integer pageNumber, Integer pageSize) {
+        if (!isDev) {
+            return errorDataSet("This method is only allowed in dev mode");
+        }
+
+        if (!hqlIsValid(hql)) {
+            return errorDataSet("The provided HQL was not valid");
+        }
+
+        Optional<HibernateOrmDevInfo.PersistenceUnit> pu = findPersistenceUnit(persistenceUnit);
+        if (pu.isEmpty()) {
+            return errorDataSet("No such persistence unit: " + persistenceUnit);
+        }
+
+        //noinspection resource
+        SessionFactoryImplementor sf = pu.get().sessionFactory();
+
+        // Check the connection for this persistence unit points to an allowed datasource
+        ConnectionProvider connectionProvider = sf.getServiceRegistry().requireService(ConnectionProvider.class);
+        if (connectionProvider instanceof QuarkusConnectionProvider quarkusConnectionProvider) {
+            if (!isAllowedDatabase(quarkusConnectionProvider.getDataSource())) {
+                return errorDataSet("The persistence unit's datasource points to a non-allowed datasource. "
+                        + "By default only local databases are enabled; you can use the 'quarkus.datasource.dev-ui.allowed-db-host'"
+                        + " configuration property to configure allowed hosts ('*' to allow all).");
+            }
+        } else {
+            return errorDataSet("Unsupported Connection Provider type for specified persistence unit.");
+        }
+
+        return sf.fromSession(session -> {
+            try {
+                Query<Object> query = session.createQuery(hql, null);
+                if (isMutation(((SqmQuery) query).getSqmStatement())) {
+                    // DML query, execute update within transaction and return custom message with affected rows
+                    Transaction transaction = session.beginTransaction();
+                    try {
+                        int updateCount = query.executeUpdate();
+                        transaction.commit();
+
+                        String message = "Query executed correctly. Rows affected: " + updateCount;
+                        return new JsonRpcMessage<>(new DataSet(null, -1, message, null), MessageType.Response);
+                    } catch (Exception e) {
+                        // an error happened in executeUpdate() or during commit
+                        transaction.rollback();
+                        throw e;
+                    }
+                } else {
+                    // selection query, execute count query and return paged results
+
+                    // This executes a separate count query
+                    long resultCount = query.getResultCount();
+
+                    try (ScrollableResults<Object> scroll = query.scroll(ScrollMode.SCROLL_INSENSITIVE)) {
+                        boolean hasNext = scroll.scroll((pageNumber - 1) * pageSize + 1);
+                        List<Object> results = new ArrayList<>();
+                        int i = 0;
+                        while (hasNext && i++ < pageSize) {
+                            results.add(scroll.get());
+                            hasNext = scroll.next();
+                        }
+
+                        // manually serialize data within the transaction to ensure lazy-loading can function
+                        String result = writeValueAsString(new DataSet(results, resultCount, null, null));
+                        JsonRpcMessage<Object> message = new JsonRpcMessage<>(result, MessageType.Response);
+                        message.setAlreadySerialized(true);
+                        return message;
+                    }
+                }
+            } catch (Exception ex) {
+                return new JsonRpcMessage<>(new DataSet(null, -1, null, ex.getMessage()), MessageType.Response);
+            }
+        });
+    }
+
+    private static JsonRpcMessage<Object> errorDataSet(String errorMessage) {
+        return new JsonRpcMessage<>(new DataSet(null, -1, null, errorMessage), MessageType.Response);
+    }
+
+    private static String writeValueAsString(DataSet value) {
+        try {
+            JsonRpcRouter jsonRpcRouter = CDI.current().select(JsonRpcRouter.class).get();
+            return jsonRpcRouter.getJsonMapper().toString(value, true);
+        } catch (Exception ex) {
+            throw new RuntimeException(
+                    "Unable to encode results as JSON. Note circular associations are not supported at the moment, use `@JsonIgnore` to break circles.",
+                    ex);
+        }
+    }
+
+    private boolean hqlIsValid(String hql) {
+        return hql != null && !hql.trim().isEmpty();
+    }
+
+    private boolean isAllowedDatabase(AgroalDataSource ads) {
+        final String allowedHost = this.allowedHost == null ? null : this.allowedHost.trim();
+        if (allowedHost != null && allowedHost.equals("*")) {
+            // special value indicating to allow any host
+            return true;
+        }
+
+        AgroalDataSourceConfiguration configuration = ads.getConfiguration();
+        String jdbcUrl = configuration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcUrl();
+
+        try {
+            if (jdbcUrl.startsWith("jdbc:h2:mem:") || jdbcUrl.startsWith("jdbc:h2:file:")
+                    || jdbcUrl.startsWith("jdbc:h2:tcp://localhost")
+                    || (allowedHost != null && !allowedHost.isBlank()
+                            && jdbcUrl.startsWith("jdbc:h2:tcp://" + allowedHost))
+                    || jdbcUrl.startsWith("jdbc:derby:memory:")) {
+                return true;
+            }
+
+            String cleanUrl = jdbcUrl.replace("jdbc:", "");
+            URI uri = new URI(cleanUrl);
+
+            String host = uri.getHost();
+
+            return host != null && ((host.equals("localhost") || host.equals("127.0.0.1") || host.equals("::1")) ||
+                    (allowedHost != null && !allowedHost.isBlank() && host.equalsIgnoreCase(allowedHost)));
+
+        } catch (URISyntaxException e) {
+            Log.warn(e.getMessage());
+        }
+
+        return false;
+    }
+
+    private record DataSet(List<Object> data, long totalNumberOfElements, String message, String error) {
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/comms/JsonRpcMessage.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/comms/JsonRpcMessage.java
@@ -8,6 +8,7 @@ package io.quarkus.devui.runtime.comms;
 public class JsonRpcMessage<T> {
     private T response;
     private MessageType messageType;
+    private boolean alreadySerialized = false;
 
     public JsonRpcMessage() {
     }
@@ -31,5 +32,13 @@ public class JsonRpcMessage<T> {
 
     public void setMessageType(MessageType messageType) {
         this.messageType = messageType;
+    }
+
+    public boolean isAlreadySerialized() {
+        return alreadySerialized;
+    }
+
+    public void setAlreadySerialized(boolean alreadySerialized) {
+        this.alreadySerialized = alreadySerialized;
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcCodec.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcCodec.java
@@ -39,8 +39,11 @@ public final class JsonRpcCodec {
                         "Method [" + jsonRpcMethodName + "] failed: " + exception.getMessage())));
     }
 
-    private void writeResponse(ServerWebSocket socker, JsonRpcResponse response) {
-        socker.writeTextMessage(jsonMapper.toString(response, true));
+    private void writeResponse(ServerWebSocket socket, JsonRpcResponse response) {
+        socket.writeTextMessage(jsonMapper.toString(response, true));
     }
 
+    public JsonMapper getJsonMapper() {
+        return jsonMapper;
+    }
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/AbstractDevUIHibernateOrmTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/AbstractDevUIHibernateOrmTest.java
@@ -1,10 +1,9 @@
 package io.quarkus.test.devui;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Iterator;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,13 +20,15 @@ public abstract class AbstractDevUIHibernateOrmTest extends DevUIJsonRPCTest {
     private final String expectedPersistenceUnitName;
     private final String expectedTableName;
     private final String expectedClassName;
+    private final Integer expectedResults;
 
     public AbstractDevUIHibernateOrmTest(String expectedPersistenceUnitName, String expectedTableName,
-            String expectedClassName) {
+            String expectedClassName, Integer expectedResults) {
         super("io.quarkus.quarkus-hibernate-orm");
         this.expectedPersistenceUnitName = expectedPersistenceUnitName;
         this.expectedTableName = expectedTableName;
         this.expectedClassName = expectedClassName;
+        this.expectedResults = expectedResults;
     }
 
     @Test
@@ -94,5 +95,66 @@ public abstract class AbstractDevUIHibernateOrmTest extends DevUIJsonRPCTest {
         assertNotNull(getNumberOfNamedQueriesResponse);
         assertTrue(getNumberOfNamedQueriesResponse.isInt());
         assertEquals(0, getNumberOfNamedQueriesResponse.asInt());
+    }
+
+    @Test
+    public void testExecuteHQL() throws Exception {
+        String entityName = expectedTableName != null ? expectedTableName : "MyEntity";
+        Map<String, Object> arguments = Map.of(
+                "hql", "select e from " + entityName + " e where e.id = 1",
+                "persistenceUnit", expectedPersistenceUnitName != null ? expectedPersistenceUnitName : "",
+                "pageNumber", 1,
+                "pageSize", 15);
+
+        JsonNode dataSet = super.executeJsonRPCMethod("executeHQL", arguments);
+
+        if (expectedResults != null) {
+            // Expect number of results
+            assertNotNull(dataSet);
+            assertTrue(dataSet.has("totalNumberOfElements"));
+            assertTrue(dataSet.has("data"));
+            assertFalse(dataSet.has("error"));
+
+            JsonNode elements = dataSet.get("totalNumberOfElements");
+            assertTrue(elements.isNumber());
+            assertEquals(expectedResults, elements.intValue());
+
+            JsonNode data = dataSet.get("data");
+            assertTrue(data.isArray());
+            assertEquals(expectedResults, data.size());
+            for (int i = 1; i <= expectedResults; i++) {
+                JsonNode element = data.get(i - 1);
+                assertEquals(i, element.get("id").intValue());
+                assertEquals("entity_" + i, data.get(0).get("field").textValue());
+            }
+        } else if (expectedPersistenceUnitName != null) {
+            // Expecting an empty result set
+            assertNotNull(dataSet);
+            assertTrue(dataSet.has("totalNumberOfElements"));
+            assertTrue(dataSet.has("data"));
+            assertFalse(dataSet.has("error"));
+
+            JsonNode elements = dataSet.get("totalNumberOfElements");
+            assertTrue(elements.isNumber());
+            assertEquals(0, elements.intValue());
+
+            JsonNode data = dataSet.get("data");
+            assertTrue(data.isArray());
+            assertEquals(0, data.size());
+        } else {
+            // Expecting an error
+            assertNotNull(dataSet);
+            assertTrue(dataSet.has("totalNumberOfElements"));
+            assertFalse(dataSet.has("data"));
+            assertTrue(dataSet.has("error"));
+
+            JsonNode elements = dataSet.get("totalNumberOfElements");
+            assertTrue(elements.isNumber());
+            assertEquals(-1, elements.intValue());
+
+            JsonNode error = dataSet.get("error");
+            assertTrue(error.isTextual());
+            assertTrue(error.asText().contains("No such persistence unit"));
+        }
     }
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest.java
@@ -19,6 +19,7 @@ public class DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest extends Abstra
                             + "quarkus.hibernate-orm.active=false\n"
                             + "quarkus.hibernate-orm.datasource=<default>\n"
                             + "quarkus.hibernate-orm.packages=io.quarkus.test.devui\n"
+                            + "quarkus.hibernate-orm.\"namedpu\".database.generation=drop-and-create\n"
                             // ... but it's (implicitly) active for a named PU
                             + "quarkus.hibernate-orm.\"namedpu\".datasource=nameddatasource\n"
                             + "quarkus.hibernate-orm.\"namedpu\".packages=io.quarkus.test.devui.namedpu\n"),
@@ -27,7 +28,7 @@ public class DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest extends Abstra
                     .addClasses(MyNamedPuEntity.class));
 
     public DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest() {
-        super("namedpu", "MyNamedPuEntity", "io.quarkus.test.devui.namedpu.MyNamedPuEntity");
+        super("namedpu", "MyNamedPuEntity", "io.quarkus.test.devui.namedpu.MyNamedPuEntity", null);
     }
 
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmActiveFalseTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmActiveFalseTest.java
@@ -18,7 +18,7 @@ public class DevUIHibernateOrmActiveFalseTest extends AbstractDevUIHibernateOrmT
                     .addClasses(MyEntity.class));
 
     public DevUIHibernateOrmActiveFalseTest() {
-        super(null, null, null);
+        super(null, null, null, null);
     }
 
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmSmokeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateOrmSmokeTest.java
@@ -11,11 +11,13 @@ public class DevUIHibernateOrmSmokeTest extends AbstractDevUIHibernateOrmTest {
     static final QuarkusDevModeTest test = new QuarkusDevModeTest()
             .withApplicationRoot((jar) -> jar.addAsResource(
                     new StringAsset("quarkus.datasource.db-kind=h2\n"
-                            + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"),
+                            + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
+                            + "quarkus.hibernate-orm.database.generation=drop-and-create\n"),
                     "application.properties")
+                    .addAsResource(new StringAsset("INSERT INTO MyEntity(id, field) VALUES(1, 'entity_1');"), "import.sql")
                     .addClasses(MyEntity.class));
 
     public DevUIHibernateOrmSmokeTest() {
-        super("<default>", "MyEntity", "io.quarkus.test.devui.MyEntity");
+        super("<default>", "MyEntity", "io.quarkus.test.devui.MyEntity", 1);
     }
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/MyEntity.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/MyEntity.java
@@ -6,11 +6,25 @@ import jakarta.persistence.Id;
 
 @Entity
 public class MyEntity {
-
     @Id
     Long id;
 
     @Column
     String field;
 
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
 }


### PR DESCRIPTION
Fixes #39584, allowing execution of arbitrary HQL queries in the current Hibernate ORM context.

![HQL_demo](https://github.com/user-attachments/assets/017f7613-b8be-4f7c-b912-f40ecd6bf70c)

The UI is very similar to the [existing Agroal (SQL) database view](https://github.com/quarkusio/quarkus/pull/43618) (many thanks to @phillip-kruger for the inspiration 🙏) but allows selecting Hibernate persistence units and their entities, displaying existing data and executing custom HQL queries. 

Data is rendered using native marshalling _for now_; this is ok for basic result types or simple entities, but it will not do for more complex models (e.g. circular associations, laziness, et.al.). I'm also working on a custom Hibernate tool that allows transforming query results to a textual (JSON) format and account for these complexities - I will update this interface to use that once it's available.