### PR TITLE
native-image: Graal's ForeignAPISupport is amd64 only

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.pkg.steps;
 
+import static io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem.Arch.AMD64;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -855,12 +857,15 @@ public class NativeImageBuildStep {
                 addExperimentalVMOption(nativeImageArgs, "-H:+AllowFoldMethods");
 
                 /*
+                 * @formatter:off
                  * Foreign Function and Memory API in Native Image, JDK's JEP 454
                  * This is needed for JDK 24+ internal native calls due to AWT,
                  * e.g. JDK-8337237 et al.
-                 *
+                 * Note GraalVM FFI/FFM support per platform:
+                 * https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/#foreign-functions
+                 * @formatter:on
                  */
-                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_24_2_0) >= 0) {
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_24_2_0) >= 0 && AMD64.active) {
                     addExperimentalVMOption(nativeImageArgs, "-H:+ForeignAPISupport");
                 }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -68,6 +68,7 @@ public final class GraalVM {
 
         public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", "17", Distribution.GRAALVM);
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", "21", Distribution.GRAALVM);
+        public static final Version VERSION_24_2_0 = new Version("GraalVM 24.2.0", "24.2.0", "24", Distribution.GRAALVM);
 
         // Temporarily work around https://github.com/quarkusio/quarkus/issues/36246,
         // till we have a consensus on how to move forward in


### PR DESCRIPTION
Fixes #46235
Fixes #46988

Summary:

* We don't have MacOS support for AWT extension yet. It might be trivial, but it's not coded in yet, so the extension needs to bail out just like on Windows. I am afraid that not having MacOS excluded via `UnsupportedOSBuildItem` is an artifact of moving DarwinFeature to AWT extension. The result is that the **build** might pass, but the Quarkus app **won't start**. If that is the desired design, we should allow the same on Windows and remove its `UnsupportedOSBuildItem`. I think the DarwinFeature previously was in core on purpose, to allow for building apps that effectively won't need to initialize AWT at runtime, i.e. don't need full AWT extension.  @zakkak ? Ideas?

* GraalVM has FFI/FFM implemented for amd64 arch only, so effectively starting Mandrel/GraalVM 24.2, i.e. Mandrel for JDK 24, we are **losing AWT support on Linux aarch64 where it used to work**

* UBI9's microdnf requires `-y`, so container tests hanged on `Is this ok [y/N]:`

* I tested all combinations that made sense to me and where I had access to HW, e.g. I skipped natively amd64 based MacOS. I used either our Mandrel 24.2 / JDK 24 ea builds or GraalVM CE 25 ea dev builds.

* :green_circle:  - run went as expected; spoiler alert: All runs went as expected.

# Tested

## Windows amd64 hosted :green_circle: 
**Expected:** :orange_circle: - SKIPPED, AWT Quarkus unsupported OS
**Actual:** :orange_circle:

```
C:\tmp\quarkus(issue-46235 -> origin)
λ mvnw verify -f integration-tests/pom.xml -pl awt  -Pnative
    -Dquarkus.native.container-build=false -Dquarkus.container-image.build=false -DskipITs=false

[ERROR] Caused by: java.lang.UnsupportedOperationException:
Windows AWT integration is not ready in Quarkus native-image and would result in java.lang.UnsatisfiedLinkError: no awt in java.library.path.
```

## Windows amd64 with Linux amd64 builder image :green_circle: 
**Expected:** :green_circle:
**Actual:**  :green_circle:

```
λ mvnw verify -f integration-tests/pom.xml -pl awt -Pnative 
    -Dquarkus.native.builder-image=quay.io/karmkarm/ubi9-quarkus-mandrel-builder-image:jdk-24-amd64
    -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true 
...

Finished generating 'quarkus-integration-test-awt-999-SNAPSHOT-runner' in 15m 51s.
...
[INFO] [io.quarkus.container.image.docker.common.deployment.CommonProcessor]
Executing the following command to build image: 
'podman build -f C:\tmp\quarkus\integration-tests\awt\src\main\docker\Dockerfile.native -t karm/quarkus-integration-test-awt:999-SNAPSHOT C:\tmp\quarkus\integration-tests\awt'
...
INFO  [io.qua.tes.com.DefaultDockerContainerLauncher] (main) 
Executing "podman run --name quarkus-integration-test-GQcdk -i --rm -p 8081:8081 -p 8444:8444 --net=quarkus-integration-test-UNOtv --env QUARKUS_LOG_CATEGORY__IO_QUARKUS__LEVEL=INFO --env QUARKUS_HTTP_PORT=8081 --env QUARKUS_HTTP_SSL_PORT=8444 --env TEST_URL=http://localhost:8081 --env QUARKUS_PROFILE=prod --env QUARKUS_CONTAINER_IMAGE_BUILD=true --env QUARKUS_NATIVE_CONTAINER_BUILD=true --env QUARKUS_NATIVE_BUILDER_IMAGE=quay.io/karmkarm/ubi9-quarkus-mandrel-builder-image:jdk-24-amd64 karm/quarkus-integration-test-awt:999-SNAPSHOT"
...
[INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0

```

## MacOS aarch64 hosted :green_circle:
**Expected:** :orange_circle: - SKIPPED, AWT Quarkus unsupported OS
**Actual:** :orange_circle:

```
[ERROR] Caused by: java.lang.UnsupportedOperationException:
    MacOS AWT integration is not ready in Quarkus native-image and would result in
    java.lang.UnsatisfiedLinkError: Can't load library: awt | java.library.path = [.].,
    AWT needs JDK's JEP 454 FFI/FFM support and that is not available for AArch64 with GraalVM's native-image,
    see: https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/#foreign-functions
```

## MacOS amd64 (via Rosetta) hosted :green_circle:
**Expected:** :orange_circle: - SKIPPED, AWT Quarkus unsupported OS
**Actual:** :orange_circle:

```
[ERROR] Caused by: java.lang.UnsupportedOperationException:
    MacOS AWT integration is not ready in Quarkus native-image and would result in
    java.lang.UnsatisfiedLinkError: Can't load library: awt | java.library.path = [.].
```

## MacOS amd64 with Linux amd64 builder

N/A - I don't have access to such HW and I don't want to try to
remove Podman machine from my MacOS aarch64 systems and try to run
podman there via Rosetta. It should work just like Windows above :-)


## MacOS aarch64 with Linux aarch64 builder image :green_circle:
**Expected:** :orange_circle: - SKIPPED, ForeignAPISupport is amd64 only
**Actual:** :orange_circle:

```
[ERROR] Caused by: java.lang.UnsupportedOperationException:
    AWT needs JDK's JEP 454 FFI/FFM support and that is not available for AArch64 with GraalVM's native-image,
    see: https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/#foreign-functions
```

## Linux amd64 hosted :green_circle:
**Expected:** :green_circle:
**Actual:** :green_circle:

```
$ ./mvnw verify -f integration-tests/pom.xml -pl awt  -Pnative
    -Dquarkus.native.container-build=false -Dquarkus.container-image.build=false -DskipITs=false 
OK
```

## Linux amd64 with Linux amd64 builder image :green_circle:
**Expected:** :green_circle:
**Actual:** :green_circle:

```
$ ./mvnw verify -f integration-tests/pom.xml -pl awt -Pnative
    -Dquarkus.native.builder-image=quay.io/karmkarm/ubi9-quarkus-mandrel-builder-image:jdk-24-amd64
    -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true
OK
```

## Linux aarch64 hosted :green_circle:
**Expected:** :orange_circle: - SKIPPED, ForeignAPISupport is amd64 only
**Actual:** :orange_circle:

```
$ ./mvnw verify -f integration-tests/pom.xml -pl awt  -Pnative
    -Dquarkus.native.container-build=false -Dquarkus.container-image.build=false -DskipITs=false 

[ERROR] Caused by: java.lang.UnsupportedOperationException:
    AWT needs JDK's JEP 454 FFI/FFM support and that is not available for AArch64 with GraalVM's native-image,
    see: https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/#foreign-functions
```

## Linux aarch64 with Linux aarch64 builder image :green_circle:
**Expected:** :orange_circle: - SKIPPED, ForeignAPISupport is amd64 only
**Actual:** :orange_circle:

```
$ ./mvnw verify -f integration-tests/pom.xml -pl awt -Pnative
    -Dquarkus.native.builder-image=quay.io/karmkarm/ubi9-quarkus-mandrel-builder-image:jdk-24-aarch64
    -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true -DskipITs=false

[ERROR] Caused by: java.lang.UnsupportedOperationException:
    AWT needs JDK's JEP 454 FFI/FFM support and that is not available for AArch64 with GraalVM's native-image,
    see: https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/#foreign-functions
```

Thanks for feedback