### PR TITLE
Update SmallRye Config to 3.12.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -47,7 +47,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
         <smallrye-common.version>2.10.0</smallrye-common.version>
-        <smallrye-config.version>3.12.2</smallrye-config.version>
+        <smallrye-config.version>3.12.3</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.8</smallrye-open-api.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ plugin-publish = "1.3.1"
 
 # updating Kotlin here makes QuarkusPluginTest > shouldNotFailOnProjectDependenciesWithoutMain(Path) fail
 kotlin = "2.0.21"
-smallrye-config = "3.12.2"
+smallrye-config = "3.12.3"
 
 junit5 = "5.10.5"
 assertj = "3.27.3"

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/MapConverterTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/MapConverterTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.config;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.spi.Converter;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithConverter;
+
+class MapConverterTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("map.value", "key1:value1,key2:value2");
+
+    @Inject
+    MapMapping mapping;
+
+    @Test
+    void mapConverter() {
+        Map<String, String> value = mapping.value();
+        System.out.println(value);
+    }
+
+    @ConfigMapping(prefix = "map")
+    interface MapMapping {
+        @WithConverter(MapConverter.class)
+        Map<String, String> value();
+    }
+
+    public static class MapConverter implements Converter<Map<String, String>> {
+        @Override
+        public Map<String, String> convert(final String value) throws IllegalArgumentException, NullPointerException {
+            return Arrays.stream(value.split(","))
+                    .map(entry -> entry.split(":"))
+                    .collect(Collectors.toMap(entry -> entry[0].trim(), entry -> entry[1].trim()));
+        }
+    }
+}


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.12.3</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1333">#1333</a> Bump version.curator from 5.7.1 to 5.8.0</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1332">#1332</a> Bump jinja2 from 3.1.4 to 3.1.6 in /documentation</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1331">#1331</a> Correctly match Env names when mapping contains empty names</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1327">#1327</a> Do not match prefix Env if exists</li>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1294">#1294</a> Branch-less alphanumeric underscore's replacement</li>
    </ul>
</blockquote>



