### PR TITLE
Allow configuring the chunk size used to consume InputStream in REST Client

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.restclient.config;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -276,9 +277,15 @@ public interface RestClientsConfig {
     boolean http2();
 
     /**
-     * The max HTTP chunk size (8096 bytes by default).
+     * Configures two different things:
+     * <ul>
+     * <li>The max HTTP chunk size</li>
+     * <li>The size of the chunk to be read when an {@link InputStream} is being used as an input</li>
+     * </ul>
      * <p>
      * Can be overwritten by client-specific settings.
+     * <p>
+     * This property is not applicable to the RESTEasy Client.
      */
     @ConfigDocDefault("8k")
     Optional<MemorySize> maxChunkSize();
@@ -607,7 +614,11 @@ public interface RestClientsConfig {
         Optional<Boolean> http2();
 
         /**
-         * The max HTTP chunk size (8096 bytes by default).
+         * Configures two different things:
+         * <ul>
+         * <li>The max HTTP chunk size</li>
+         * <li>The size of the chunk to be read when an {@link InputStream} is being read and sent to the server</li>
+         * </ul>
          * <p>
          * This property is not applicable to the RESTEasy Client.
          */

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -76,10 +76,13 @@ public class ClientSendRequestHandler implements ClientRestHandler {
     private final ClientLogger clientLogger;
     private final Map<Class<?>, MultipartResponseData> multipartResponseDataMap;
     private final int maxChunkSize;
+    private final int inputStreamChunkSize;
 
-    public ClientSendRequestHandler(int maxChunkSize, boolean followRedirects, LoggingScope loggingScope, ClientLogger logger,
+    public ClientSendRequestHandler(int maxChunkSize, int inputStreamChunkSize, boolean followRedirects,
+            LoggingScope loggingScope, ClientLogger logger,
             Map<Class<?>, MultipartResponseData> multipartResponseDataMap) {
         this.maxChunkSize = maxChunkSize;
+        this.inputStreamChunkSize = inputStreamChunkSize;
         this.followRedirects = followRedirects;
         this.loggingScope = loggingScope;
         this.clientLogger = logger;
@@ -177,7 +180,7 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                     Future<HttpClientResponse> sent = httpClientRequest.send(
                             new InputStreamReadStream(
                                     Vertx.currentContext().owner(), (InputStream) requestContext.getEntity().getEntity(),
-                                    httpClientRequest));
+                                    httpClientRequest, inputStreamChunkSize));
                     attachSentHandlers(sent, httpClientRequest, requestContext);
                 } else if (requestContext.isMultiBufferUpload()) {
                     MultivaluedMap<String, String> headerMap = requestContext.getRequestHeadersAsMap();

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
@@ -213,7 +213,9 @@ public class ClientImpl implements Client {
             });
         }
 
-        handlerChain = new HandlerChain(isCaptureStacktrace(configuration), options.getMaxChunkSize(), followRedirects,
+        handlerChain = new HandlerChain(isCaptureStacktrace(configuration), options.getMaxChunkSize(),
+                options.getMaxChunkSize(),
+                followRedirects,
                 loggingScope,
                 clientContext.getMultipartResponsesData(), clientLogger);
     }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/HandlerChain.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/HandlerChain.java
@@ -36,11 +36,13 @@ class HandlerChain {
 
     private ClientRestHandler preClientSendHandler = null;
 
-    public HandlerChain(boolean captureStacktrace, int maxChunkSize, boolean followRedirects, LoggingScope loggingScope,
+    public HandlerChain(boolean captureStacktrace, int maxChunkSize, int inputStreamChunkSize, boolean followRedirects,
+            LoggingScope loggingScope,
             Map<Class<?>, MultipartResponseData> multipartData, ClientLogger clientLogger) {
         this.clientCaptureCurrentContextRestHandler = new ClientCaptureCurrentContextRestHandler(captureStacktrace);
         this.clientSwitchToRequestContextRestHandler = new ClientSwitchToRequestContextRestHandler();
-        this.clientSendHandler = new ClientSendRequestHandler(maxChunkSize, followRedirects, loggingScope, clientLogger,
+        this.clientSendHandler = new ClientSendRequestHandler(maxChunkSize, inputStreamChunkSize, followRedirects, loggingScope,
+                clientLogger,
                 multipartData);
         this.clientSetResponseEntityRestHandler = new ClientSetResponseEntityRestHandler();
         this.clientResponseCompleteRestHandler = new ClientResponseCompleteRestHandler();

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InputStreamReadStream.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InputStreamReadStream.java
@@ -24,22 +24,23 @@ import io.vertx.core.streams.impl.InboundBuffer;
  */
 public class InputStreamReadStream implements ReadStream<Buffer> {
 
-    private static final int CHUNK_SIZE = 2048;
     private static final int MAX_DEPTH = 8;
 
     private final Buffer endSentinel;
     private final Vertx vertx;
     private final InputStream is;
     private final HttpClientRequest request;
+    private final int chunkSize;
     private InboundBuffer<Buffer> inboundBuffer;
     private Handler<Throwable> exceptionHandler;
     private Handler<Void> endHandler;
     private byte[] bytes;
 
-    public InputStreamReadStream(Vertx vertx, InputStream is, HttpClientRequest request) {
+    public InputStreamReadStream(Vertx vertx, InputStream is, HttpClientRequest request, int chunkSize) {
         this.vertx = vertx;
         this.is = is;
         this.request = request;
+        this.chunkSize = chunkSize;
         endSentinel = Buffer.buffer();
     }
 
@@ -109,7 +110,7 @@ public class InputStreamReadStream implements ReadStream<Buffer> {
             @Override
             public void handle(Promise<Buffer> p) {
                 if (bytes == null) {
-                    bytes = new byte[CHUNK_SIZE];
+                    bytes = new byte[chunkSize];
                 }
                 int amount;
                 try {

--- a/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/impl/HandlerChainTest.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/impl/HandlerChainTest.java
@@ -21,7 +21,7 @@ public class HandlerChainTest {
     @Test
     public void preSendHandlerIsAlwaysFirst() throws Exception {
 
-        var initialChain = new HandlerChain(false, 8096, true, LoggingScope.NONE, Collections.emptyMap(),
+        var initialChain = new HandlerChain(false, 8096, 2048, true, LoggingScope.NONE, Collections.emptyMap(),
                 new DefaultClientLogger());
 
         ClientRestHandler preHandler = ctx -> {


### PR DESCRIPTION
This is configured using the existing `max-chunk-size` property. This technically is not the most correct option
(as the property is supposed to control the HTTP chunk size), but intuitively it is where users will look first.

- Relates to: #46677