### PR TITLE
Clarify that val properties cannot be used with no-arg compiler plugin

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -861,6 +861,12 @@ data class Person (
 ): PanacheMongoEntity()
 ----
 
+[IMPORTANT]
+====
+Unlike the @BsonCreator approach, `val` cannot be used here. Properties must be defined as `var`, otherwise, the system creates an object with 
+`null` values for every property.
+====
+
 [[reactive]]
 == Reactive Entities and Repositories
 


### PR DESCRIPTION
Should fix: https://github.com/quarkusio/quarkus/issues/45500

I've run into the same issue, because the documentation is a bit unclear here.