### PR TITLE
Fix various issues in refreshed `quarkus update`

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ProjectInfoCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ProjectInfoCommandHandler.java
@@ -3,10 +3,6 @@ package io.quarkus.devtools.commands.handlers;
 import static io.quarkus.devtools.commands.handlers.UpdateProjectCommandHandler.ITEM_FORMAT;
 import static io.quarkus.devtools.commands.handlers.UpdateProjectCommandHandler.printSeparator;
 import static io.quarkus.devtools.commands.handlers.UpdateProjectCommandHandler.updateInfo;
-import static io.quarkus.devtools.messagewriter.MessageFormatter.format;
-import static io.quarkus.devtools.messagewriter.MessageFormatter.Format.BOLD;
-import static io.quarkus.devtools.messagewriter.MessageFormatter.Format.GREEN;
-import static io.quarkus.devtools.messagewriter.MessageFormatter.Format.RED;
 import static io.quarkus.devtools.messagewriter.MessageIcons.UP_TO_DATE_ICON;
 import static io.quarkus.devtools.project.state.ProjectStates.resolveProjectState;
 
@@ -22,6 +18,7 @@ import io.quarkus.devtools.commands.ProjectInfo;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.messagewriter.MessageFormatter;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.state.ExtensionProvider;
 import io.quarkus.devtools.project.state.ModuleState;
@@ -74,9 +71,9 @@ public class ProjectInfoCommandHandler implements QuarkusCommandHandler {
         printSeparator(log);
 
         if (providerInfo.isEmpty()) {
-            log.info(format(RED, "No Quarkus platform BOMs found"));
+            log.info(MessageFormatter.red("No Quarkus platform BOMs found"));
         } else {
-            log.info(format(BOLD, "Quarkus platform BOMs:"));
+            log.info(MessageFormatter.bold("Quarkus platform BOMs:"));
             boolean recommendExtraImports = false;
             for (PlatformInfo platform : providerInfo.values()) {
                 if (!platform.isImported()) {
@@ -87,7 +84,8 @@ public class ProjectInfoCommandHandler implements QuarkusCommandHandler {
                 if (platform.getRecommended() == null) {
                     sb.append(
                             String.format(ITEM_FORMAT, "-",
-                                    "[" + format(RED, platform.getImported().toCompactCoords()) + "] not recommended"));
+                                    "[" + MessageFormatter.red(platform.getImported().toCompactCoords())
+                                            + "] not recommended"));
                     recommendationsAvailable = true;
                 } else if (platform.isVersionUpdateRecommended()) {
                     sb.append(String.format(ITEM_FORMAT, "~",
@@ -103,7 +101,7 @@ public class ProjectInfoCommandHandler implements QuarkusCommandHandler {
                 for (PlatformInfo platform : providerInfo.values()) {
                     if (platform.getImported() == null) {
                         log.info(String.format(ITEM_FORMAT, "+",
-                                "[ " + format(GREEN, platform.getImported().toCompactCoords()) + "]"));
+                                "[ " + MessageFormatter.green(platform.getImported().toCompactCoords()) + "]"));
                     }
                 }
                 recommendationsAvailable = true;
@@ -141,8 +139,9 @@ public class ProjectInfoCommandHandler implements QuarkusCommandHandler {
         }
         if (recommendationsAvailable) {
             log.info(
-                    "Some version alignment recommendation are available and shown by '[" + format(RED, "current") + " -> "
-                            + format(GREEN, "recommended") + "]'.");
+                    "Some version alignment recommendation are available and shown by '[" + MessageFormatter.red("current")
+                            + " -> "
+                            + MessageFormatter.green("recommended") + "]'.");
         }
 
         printSeparator(log);
@@ -154,7 +153,7 @@ public class ProjectInfoCommandHandler implements QuarkusCommandHandler {
         if (provider.getExtensions().isEmpty()) {
             return recommendationsAvailable;
         }
-        log.info(format(BOLD, "Extensions from " + provider.getKey() + ":"));
+        log.info(MessageFormatter.bold("Extensions from " + provider.getKey() + ":"));
         final StringBuilder sb = new StringBuilder();
         for (TopExtensionDependency dep : provider.getExtensions()) {
             sb.setLength(0);
@@ -171,8 +170,9 @@ public class ProjectInfoCommandHandler implements QuarkusCommandHandler {
             if (dep.isNonRecommendedVersion()) {
                 recommendationsAvailable = true;
                 sb.append(String.format(ITEM_FORMAT, "-",
-                        dep.getArtifact().getKey().toGacString() + ":[" + format(RED, dep.getArtifact().getVersion()) + " -> "
-                                + format(GREEN, "managed") + "]"));
+                        dep.getArtifact().getKey().toGacString() + ":[" + MessageFormatter.red(dep.getArtifact().getVersion())
+                                + " -> "
+                                + MessageFormatter.green("managed") + "]"));
             } else {
                 sb.append(
                         String.format(ITEM_FORMAT, UP_TO_DATE_ICON.iconOrMessage(), dep.getArtifact().getKey().toGacString()));

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -196,7 +196,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                 MessageFormatter.bold(
                         "Do you want to apply the generated update recipes with OpenRewrite?")
                 + " ([" + MessageFormatter.green("y") + "]es, [" + MessageFormatter.red("n") + "]o, ["
-                + MessageFormatter.blue("d") + "]ry-run)"
+                + MessageFormatter.blue("d") + "]ry-run + [Enter])"
                 + System.lineSeparator() + System.lineSeparator());
         try (Scanner scanner = new Scanner(new FilterInputStream(System.in) {
             @Override

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -276,18 +276,18 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                                     + "]"));
                 }
             }
-            if (!platformUpdateInfo.getNewImports().isEmpty()) {
-                for (PlatformInfo importInfo : platformUpdateInfo.getNewImports()) {
-                    log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, "+",
-                            "[" + MessageFormatter.green(importInfo.getRecommended().toCompactCoords()) + "] to add"));
-                }
-            }
             if (platformUpdateInfo.isImportsToBeRemoved()) {
                 for (PlatformInfo importInfo : platformUpdateInfo.getPlatformImports().values()) {
                     if (importInfo.getRecommended() == null) {
                         log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, "-",
-                                "[" + MessageFormatter.red(importInfo.getImported().toCompactCoords()) + "] to remove"));
+                                "[" + MessageFormatter.red(importInfo.getImported().toCompactCoords()) + "]"));
                     }
+                }
+            }
+            if (!platformUpdateInfo.getNewImports().isEmpty()) {
+                for (PlatformInfo importInfo : platformUpdateInfo.getNewImports()) {
+                    log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, "+",
+                            "[" + MessageFormatter.green(importInfo.getRecommended().toCompactCoords()) + "]"));
                 }
             }
             log.info("");

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -1,11 +1,5 @@
 package io.quarkus.devtools.commands.handlers;
 
-import static io.quarkus.devtools.messagewriter.MessageFormatter.format;
-import static io.quarkus.devtools.messagewriter.MessageFormatter.Format.BLUE;
-import static io.quarkus.devtools.messagewriter.MessageFormatter.Format.BOLD;
-import static io.quarkus.devtools.messagewriter.MessageFormatter.Format.GREEN;
-import static io.quarkus.devtools.messagewriter.MessageFormatter.Format.RED;
-import static io.quarkus.devtools.messagewriter.MessageFormatter.Format.UNDERLINE;
 import static io.quarkus.devtools.messagewriter.MessageIcons.UP_TO_DATE_ICON;
 import static io.quarkus.devtools.project.state.ProjectStates.resolveProjectState;
 import static io.quarkus.devtools.project.update.ProjectUpdateInfos.resolvePlatformUpdateInfo;
@@ -31,6 +25,7 @@ import io.quarkus.devtools.commands.UpdateProject;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.messagewriter.MessageFormatter;
 import io.quarkus.devtools.messagewriter.MessageIcons;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.BuildTool;
@@ -129,9 +124,8 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                         additionalUpdateRecipes, request);
                 quarkusProject.log().info("");
                 quarkusProject.log()
-                        .info("We have generated a recipe file to update your project (versions updates + specific recipes):");
-                quarkusProject.log().info(format(UNDERLINE,
-                        projectDir.relativize(recipe).toString()));
+                        .info("We have generated a recipe file to update your project (version updates + specific recipes):");
+                quarkusProject.log().info(MessageFormatter.underline(projectDir.relativize(recipe).toString()));
                 quarkusProject.log().info("");
 
                 if (rewriteDryRun) {
@@ -181,8 +175,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                     final Path patchFile = rewriteDir.resolve("rewrite.patch");
                     if (rewriteDryRun && Files.isRegularFile(patchFile)) {
                         quarkusProject.log().info("Patch file available:");
-                        quarkusProject.log().info(format(UNDERLINE,
-                                projectDir.relativize(patchFile).toString()));
+                        quarkusProject.log().info(MessageFormatter.underline(projectDir.relativize(patchFile).toString()));
                         quarkusProject.log().info("");
                     }
 
@@ -200,9 +193,10 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
 
     private static String askUserConfirmationForUpdate(MessageWriter log) {
         System.out.print(System.lineSeparator() +
-                format(BOLD,
-                        "Do you want run the generated update recipe with OpenRewrite ?")
-                + " ([" + format(GREEN, "y") + "]es, [" + format(RED, "n") + "]o, [" + format(BLUE, "d") + "]ry-run)"
+                MessageFormatter.bold(
+                        "Do you want to apply the generated update recipes with OpenRewrite?")
+                + " ([" + MessageFormatter.green("y") + "]es, [" + MessageFormatter.red("n") + "]o, ["
+                + MessageFormatter.blue("d") + "]ry-run)"
                 + System.lineSeparator() + System.lineSeparator());
         try (Scanner scanner = new Scanner(new FilterInputStream(System.in) {
             @Override
@@ -212,7 +206,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
         })) {
             return scanner.nextLine();
         } catch (Exception e) {
-            log.debug("Failed to collect user input for analytics", e);
+            log.debug("Unable to get user confirmation", e);
             return "";
         }
     }
@@ -256,7 +250,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
             MessageWriter log) {
         printSeparator(log);
         if (currentState.getPlatformBoms().isEmpty()) {
-            log.info(format(RED, "The project does not import any Quarkus platform BOM"));
+            log.info(MessageFormatter.red("The project does not import any Quarkus platform BOM"));
             printSeparator(log);
             return false;
         }
@@ -266,43 +260,44 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
             return false;
         }
         if (currentState == recommendedState) {
-            log.info(format(GREEN, "The project is up-to-date)"));
+            log.info(MessageFormatter.green("The project is up-to-date)"));
             printSeparator(log);
             return false;
         }
 
         if (platformUpdateInfo.isPlatformUpdatesAvailable()) {
-            log.info(format(BOLD, "Suggested Quarkus platform BOM updates:"));
+            log.info(MessageFormatter.bold("Suggested Quarkus platform BOM updates:"));
             if (!platformUpdateInfo.getImportVersionUpdates().isEmpty()) {
                 for (PlatformInfo importInfo : platformUpdateInfo.getImportVersionUpdates()) {
                     log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, "~",
                             importInfo.getImported().getKey().toGacString() + ":pom:["
-                                    + format(RED, importInfo.getImported().getVersion()) + " -> "
-                                    + format(GREEN, importInfo.getRecommendedVersion())
+                                    + MessageFormatter.red(importInfo.getImported().getVersion()) + " -> "
+                                    + MessageFormatter.green(importInfo.getRecommendedVersion())
                                     + "]"));
                 }
             }
             if (!platformUpdateInfo.getNewImports().isEmpty()) {
                 for (PlatformInfo importInfo : platformUpdateInfo.getNewImports()) {
                     log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, "+",
-                            "[" + format(GREEN, importInfo.getRecommended().toCompactCoords()) + "] to add"));
+                            "[" + MessageFormatter.green(importInfo.getRecommended().toCompactCoords()) + "] to add"));
                 }
             }
             if (platformUpdateInfo.isImportsToBeRemoved()) {
                 for (PlatformInfo importInfo : platformUpdateInfo.getPlatformImports().values()) {
                     if (importInfo.getRecommended() == null) {
                         log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, "-",
-                                "[" + format(RED, importInfo.getImported().toCompactCoords()) + "] to remove"));
+                                "[" + MessageFormatter.red(importInfo.getImported().toCompactCoords()) + "] to remove"));
                     }
                 }
             }
             log.info("");
         } else if (!extensionsUpdateInfo.shouldUpdateExtensions()) {
-            log.info(format(GREEN, "The project is up-to-date " + MessageIcons.UP_TO_DATE_ICON.iconOrMessage()));
+            log.info(MessageFormatter.green("The project is up-to-date " + MessageIcons.UP_TO_DATE_ICON.iconOrMessage()));
             printSeparator(log);
             return false;
         } else {
-            log.info(format(GREEN, "Quarkus platform BOM(s) are up-to-date " + MessageIcons.UP_TO_DATE_ICON.iconOrMessage()));
+            log.info(MessageFormatter
+                    .green("Quarkus platform BOMs are up-to-date " + MessageIcons.UP_TO_DATE_ICON.iconOrMessage()));
             log.info("");
         }
 
@@ -321,7 +316,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
             if (extensions.isEmpty()) {
                 continue;
             }
-            log.info(format(BOLD,
+            log.info(MessageFormatter.bold(
                     "Suggested extensions updates for '%s':".formatted(platform.getRecommendedProviderKey())));
             for (ExtensionUpdateInfo e : extensions) {
 
@@ -340,13 +335,14 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                         case RECOMMEND_PLATFORM_MANAGED:
                             log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, "-",
                                     e.getCurrentDep().getArtifact().getKey().toGacString()) + ":["
-                                    + format(RED, e.getCurrentDep().getVersion()) + " -> " + format(GREEN, "managed") + "]");
+                                    + MessageFormatter.red(e.getCurrentDep().getVersion()) + " -> "
+                                    + MessageFormatter.green("managed") + "]");
                             break;
                         case ADD_VERSION:
                             log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, versionUpdateType.equals(
                                     ExtensionUpdateInfo.VersionUpdateType.ADD_VERSION) ? "+" : "-",
                                     e.getCurrentDep().getArtifact().getKey().toGacString()) + ":["
-                                    + format(RED, "managed") + " -> " + format(GREEN,
+                                    + MessageFormatter.red("managed") + " -> " + MessageFormatter.green(
                                             e.getRecommendedDependency().getVersion())
                                     + "]");
                             break;
@@ -362,12 +358,12 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
         final List<ExtensionUpdateInfo> simpleVersionUpdates = extensionsUpdateInfo.getSimpleVersionUpdates().stream()
                 .filter(u -> !u.getCurrentDep().isPlatformExtension()).toList();
         if (!simpleVersionUpdates.isEmpty()) {
-            log.info(format(BOLD, "Suggested extensions updates from other origins:"));
+            log.info(MessageFormatter.bold("Suggested extension updates from other origins:"));
             for (ExtensionUpdateInfo u : simpleVersionUpdates) {
                 if (u.getVersionUpdateType() == ExtensionUpdateInfo.VersionUpdateType.PLATFORM_MANAGED) {
                     log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, "-",
                             u.getCurrentDep().getArtifact().getKey().toGacString()) + ":["
-                            + format(RED, u.getCurrentDep().getVersion()) + "]");
+                            + MessageFormatter.red(u.getCurrentDep().getVersion()) + "]");
                 } else {
                     log.info(String.format(UpdateProjectCommandHandler.ITEM_FORMAT, "~",
                             updateInfo(u)));
@@ -390,9 +386,9 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
     }
 
     static String updateInfo(ArtifactCoords current, String newVersion) {
-        return current.getKey().toGacString() + ":[" + format(RED,
+        return current.getKey().toGacString() + ":[" + MessageFormatter.red(
                 current.getVersion()) + " -> "
-                + format(GREEN, newVersion) + "]";
+                + MessageFormatter.green(newVersion) + "]";
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdatesRepository.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdatesRepository.java
@@ -1,7 +1,5 @@
 package io.quarkus.devtools.project.update.rewrite;
 
-import static io.quarkus.devtools.messagewriter.MessageFormatter.Format.GREEN;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -106,14 +104,15 @@ public final class QuarkusUpdatesRepository {
                 }
                 if (log.isDebugEnabled()) {
                     log.debug(String.format(
-                            "=> %d specific recipe(s) found (compatible with OpenRewrite %s plugin version: %s)",
+                            "=> %d specific recipe" + (recipes.size() != 1 ? "s" : "")
+                                    + " found (compatible with OpenRewrite %s plugin version: %s)",
                             recipes.size(),
                             buildTool,
                             propRewritePluginVersion));
                 } else {
                     log.info(String.format(
-                            "=> %s specific recipe(s) found",
-                            MessageFormatter.format(GREEN, String.valueOf(recipes.size()))));
+                            "=> %s specific recipe" + (recipes.size() != 1 ? "s" : "") + " found",
+                            MessageFormatter.green(String.valueOf(recipes.size()))));
                 }
 
             } catch (BootstrapMavenException e) {

--- a/independent-projects/tools/message-writer/src/main/java/io/quarkus/devtools/messagewriter/MessageFormatter.java
+++ b/independent-projects/tools/message-writer/src/main/java/io/quarkus/devtools/messagewriter/MessageFormatter.java
@@ -2,11 +2,11 @@ package io.quarkus.devtools.messagewriter;
 
 public class MessageFormatter {
 
-    public enum Format {
+    enum Format {
         RED("\u001B[91m"),
         GREEN("\u001b[32m"),
         BLUE("\u001b[94m"),
-        RESET("\u001b[39m"),
+        RESET_COLOR("\u001b[39m"),
         UNDERLINE("\u001b[4m"),
         NO_UNDERLINE("\u001b[24m"),
         BOLD("\u001b[1m"),
@@ -24,8 +24,23 @@ public class MessageFormatter {
         }
     }
 
-    public static String format(Format format, String text) {
-        return format + text + Format.RESET;
+    public static String bold(String text) {
+        return Format.BOLD + text + Format.NO_BOLD;
     }
 
+    public static String underline(String text) {
+        return Format.UNDERLINE + text + Format.NO_UNDERLINE;
+    }
+
+    public static String red(String text) {
+        return Format.RED + text + Format.RESET_COLOR;
+    }
+
+    public static String green(String text) {
+        return Format.GREEN + text + Format.RESET_COLOR;
+    }
+
+    public static String blue(String text) {
+        return Format.BLUE + text + Format.RESET_COLOR;
+    }
 }


### PR DESCRIPTION
I started having a look as bold and underline were leaking (it's very visible when running the tests from https://github.com/quarkusio/quarkus-updates) and things led to others.

One important thing is that the `target/rewrite` directory was dropped by the `mvn clean process-sources` so you ended up with no logs being available.

I did a lot of manual testing on my side.

This needs to go in before we push the first final `3.20`.

Fixes #46639 (per Rostislav's comment below)