### PR TITLE
ArC: fix decorated interface defaults methods not overriden by a bean

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -827,6 +827,13 @@ public class BeanInfo implements InjectionTargetInfo {
                 addDecoratedMethods(decoratedMethods, superClassInfo, originalClassInfo, boundDecorators, skipPredicate);
             }
         }
+
+        for (DotName i : classInfo.interfaceNames()) {
+            ClassInfo interfaceInfo = getClassByName(beanDeployment.getBeanArchiveIndex(), i);
+            if (interfaceInfo != null) {
+                addDecoratedMethods(decoratedMethods, interfaceInfo, originalClassInfo, boundDecorators, skipPredicate);
+            }
+        }
     }
 
     private List<DecoratorMethod> findMatchingDecorators(MethodInfo method, List<DecoratorInfo> decorators) {
@@ -856,6 +863,9 @@ public class BeanInfo implements InjectionTargetInfo {
                     boolean matches = true;
                     decoratedMethodParams = Types.getResolvedParameters(decoratedTypeClass, resolvedTypeParameters,
                             decoratedMethod,
+                            beanDeployment.getBeanArchiveIndex());
+                    methodParams = Types.getResolvedParameters(decoratedTypeClass, resolvedTypeParameters,
+                            method,
                             beanDeployment.getBeanArchiveIndex());
                     for (int i = 0; i < methodParams.size(); i++) {
                         BeanResolver resolver = beanDeployment.getDelegateInjectionPointResolver();


### PR DESCRIPTION
- resolves #46721