### PR TITLE
ArC: add validation of synthetic bean types

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
@@ -120,7 +120,13 @@ public final class BeanConfigurator<T> extends BeanConfiguratorBase<BeanConfigur
                 builder.injections(Collections.singletonList(Injection.forSyntheticBean(injectionPoints)));
             }
 
-            beanConsumer.accept(builder.build());
+            BeanInfo bean = builder.build();
+
+            for (Type type : this.types) {
+                Types.checkLegalBeanType(type, bean);
+            }
+
+            beanConsumer.accept(bean);
         }
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithTypeVariableArrayTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithTypeVariableArrayTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.TypeVariable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticBeanWithTypeVariableArrayTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanRegistrars(new MyBeanRegistrar())
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Type variable is not a legal bean type"));
+    }
+
+    static class MyBean {
+    }
+
+    static class MyBeanCreator implements BeanCreator<MyBean> {
+        @Override
+        public MyBean create(SyntheticCreationalContext<MyBean> context) {
+            return new MyBean();
+        }
+    }
+
+    static class MyBeanRegistrar implements BeanRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(MyBean.class)
+                    .addType(MyBean.class)
+                    .addType(ArrayType.create(TypeVariable.create("T"), 1))
+                    .creator(MyBeanCreator.class)
+                    .done();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithTypeVariableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithTypeVariableTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.jandex.TypeVariable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticBeanWithTypeVariableTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanRegistrars(new MyBeanRegistrar())
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Type variable is not a legal bean type"));
+    }
+
+    static class MyBean {
+    }
+
+    static class MyBeanCreator implements BeanCreator<MyBean> {
+        @Override
+        public MyBean create(SyntheticCreationalContext<MyBean> context) {
+            return new MyBean();
+        }
+    }
+
+    static class MyBeanRegistrar implements BeanRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(MyBean.class)
+                    .addType(MyBean.class)
+                    .addType(TypeVariable.create("T"))
+                    .creator(MyBeanCreator.class)
+                    .done();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithWildcardParameterizedTypeArrayTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithWildcardParameterizedTypeArrayTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.WildcardType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticBeanWithWildcardParameterizedTypeArrayTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanRegistrars(new MyBeanRegistrar())
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Wildcard type is not a legal bean type"));
+    }
+
+    static class MyBean {
+    }
+
+    static class MyBeanCreator implements BeanCreator<MyBean> {
+        @Override
+        public MyBean create(SyntheticCreationalContext<MyBean> context) {
+            return new MyBean();
+        }
+    }
+
+    static class MyBeanRegistrar implements BeanRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(MyBean.class)
+                    .addType(MyBean.class)
+                    .addType(ArrayType.create(
+                            ParameterizedType.builder(List.class).addArgument(WildcardType.UNBOUNDED).build(), 2))
+                    .creator(MyBeanCreator.class)
+                    .done();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithWildcardParameterizedTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithWildcardParameterizedTypeTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.WildcardType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticBeanWithWildcardParameterizedTypeTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanRegistrars(new MyBeanRegistrar())
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Wildcard type is not a legal bean type"));
+    }
+
+    static class MyBean {
+    }
+
+    static class MyBeanCreator implements BeanCreator<MyBean> {
+        @Override
+        public MyBean create(SyntheticCreationalContext<MyBean> context) {
+            return new MyBean();
+        }
+    }
+
+    static class MyBeanRegistrar implements BeanRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(MyBean.class)
+                    .addType(MyBean.class)
+                    .addType(ParameterizedType.builder(List.class).addArgument(WildcardType.UNBOUNDED).build())
+                    .creator(MyBeanCreator.class)
+                    .done();
+        }
+    }
+}


### PR DESCRIPTION
So far, bean types of synthetic beans were not validated, so it was possible to create synthetic beans with illegal bean types. This commit fixes that. If a synthetic bean has an illegal type, definition error occurs.

Fixes #46771