### PR TITLE
Support distinct jsonviews for serialization and deserialization

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -688,7 +688,7 @@ public class ResteasyReactiveJacksonProcessor {
         } else if (target.kind() == AnnotationTarget.Kind.METHOD) {
             return getMethodId(target.asMethod());
         } else if (target.kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {
-            return getMethodId(target.asMethodParameter().method());
+            return "request-body;" + getMethodId(target.asMethodParameter().method());
         }
 
         throw new UnsupportedOperationException(String.format("The `%s` annotation can only "

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonViewDeserializeSerializeTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonViewDeserializeSerializeTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static io.restassured.RestAssured.given;
+import static jakarta.ws.rs.core.Response.Status.CREATED;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JsonViewDeserializeSerializeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(User.class, Views.class, Resource.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        given().accept("application/json")
+                .contentType("application/json")
+                .body("""
+                        {
+                         "id": 1,
+                         "name": "Foo"
+                        }
+                        """)
+                .post("test")
+                .then()
+                .statusCode(201)
+                .body("id", equalTo(0))
+                .body("name", equalTo("Foo"));
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        @JsonView(Views.Private.class)
+        @POST
+        @Produces(MediaType.APPLICATION_JSON)
+        @Consumes(MediaType.APPLICATION_JSON)
+        public RestResponse<User> create(@JsonView(Views.Public.class) User user) {
+            return RestResponse.status(CREATED, user);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyReader.java
@@ -179,16 +179,10 @@ public class FullyFeaturedServerJacksonMessageBodyReader extends AbstractServerJ
                     effectiveReader = readerFromAnnotation;
                 }
 
-                Class<?> jsonViewValue = ResteasyReactiveServerJacksonRecorder.jsonViewForMethod(resourceInfo.getMethodId());
+                Class<?> jsonViewValue = ResteasyReactiveServerJacksonRecorder
+                        .jsonViewForMethod("request-body;" + resourceInfo.getMethodId());
                 if (jsonViewValue != null) {
                     return effectiveReader.withView(jsonViewValue);
-                } else {
-                    jsonViewValue = ResteasyReactiveServerJacksonRecorder
-                            .jsonViewForClass(resourceInfo.getResourceClass());
-                    if (jsonViewValue != null) {
-                        return effectiveReader.withView(jsonViewValue);
-                    }
-
                 }
             }
         }


### PR DESCRIPTION
Before, the jsonview for the request body could leak affect the serialization side, and cause the response entity to be written with the wrong jsonview. Now, the method and class level jsonview affect the serialization side, while a method parameter jsonview affect only the deserialization side.

However, technically speaking, this is also a minor breaking change for undocumented behaviour. Should be worth it though, since this implementation is less surprising, and follows what is currently documented at https://quarkus.io/version/main/guides/rest#jsonview-support.

Therefore, a note for the migration guide:

closes #46751

---
Quarkus Rest - JsonView Deserialization changes

With this version, the deserialization support for jsonviews gets documented and slightly changed.

For example:
```
(1)

@POST
@Produces(MediaType.APPLICATION_JSON)
@Consumes(MediaType.APPLICATION_JSON)
@JsonView(Views.Private.class)
public RestResponse<User> create(User user) {
    return RestResponse.status(CREATED, user);
}

(2)
@POST
@Produces(MediaType.APPLICATION_JSON)
@Consumes(MediaType.APPLICATION_JSON)
@JsonView(Views.Private.class)
public RestResponse<User> create(@JsonView(Views.Public.class) User user) {
    return RestResponse.status(CREATED, user);
}
```

(1) The method parameter `user` was also deserialized using the `Views.Private` view.
(2) The method parameter `user` was most likely to correctly use the expected `Views.Public` view for deserialization. For Serialization however, the `Views.Public` was also used, although the method is annoted with the `Views.Private` view.
 

The behaviour changed, so that now the deserialization is only influenced by the method parameter jsonview. The serialization is now always only influenced by the method (or class level) jsonview.
For (1), the `user` parameter does not use any JsonView anymore.
For (2), this means that the `user` parameter correctly uses Views.Public for deserialization, and for serialization Views.Private gets used