### PR TITLE
Make ClientRequestFilter run on the same Vert.x context as other handlers

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/HandlerChain.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/HandlerChain.java
@@ -87,10 +87,10 @@ class HandlerChain {
         if (preClientSendHandler != null) {
             result.add(preClientSendHandler);
         }
+        result.add(clientCaptureCurrentContextRestHandler);
         for (int i = 0; i < requestFilters.size(); i++) {
             result.add(new ClientRequestFilterRestHandler(requestFilters.get(i)));
         }
-        result.add(clientCaptureCurrentContextRestHandler);
         result.add(clientSwitchToRequestContextRestHandler);
         result.add(clientSendHandler);
         result.add(clientSetResponseEntityRestHandler);


### PR DESCRIPTION
Relates to: #46798