### PR TITLE
Config Reference - Apply styles to all config search inputs

### DIFF
--- a/docs/src/main/asciidoc/stylesheet/config.css
+++ b/docs/src/main/asciidoc/stylesheet/config.css
@@ -105,7 +105,7 @@ table.configuration-reference.tableblock td.tableblock > .content > :last-child 
   margin-bottom: inherit;
 }
 
-input#config-search-0 {
+input[id^="config-search-"] {
   -webkit-appearance: none;
   display: block;
   width: 100%;
@@ -127,8 +127,8 @@ input#config-search-0 {
   letter-spacing: 1.5px;
 }
 
-input#config-search-0:hover,
-input#config-search-0:focus {
+input[id^="config-search-"]:hover,
+input[id^="config-search-"]:focus {
   padding: 12px 2px;
   outline: 0;
   border: 1px solid transparent;


### PR DESCRIPTION
We used to apply the styles only to the first one, which is annoying in the relatively rare case where we have more than one on the same page.

See the second search field here:

![Screenshot from 2025-03-14 15-22-20](https://github.com/user-attachments/assets/59b8df6d-1f1a-4578-8110-09f0351b8588)
