### PR TITLE
GraalVM 25 for JDK 25 enabled ForeignAPI on aarch64

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -861,11 +861,12 @@ public class NativeImageBuildStep {
                  * Foreign Function and Memory API in Native Image, JDK's JEP 454
                  * This is needed for JDK 24+ internal native calls due to AWT,
                  * e.g. JDK-8337237 et al.
-                 * Note GraalVM FFI/FFM support per platform:
+                 * Note GraalVM FFI/FFM support per platform prior to JDK 25 and JDK 25+
                  * https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/#foreign-functions
                  * @formatter:on
                  */
-                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_24_2_0) >= 0 && AMD64.active) {
+                if ((graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_24_2_0) >= 0 && AMD64.active) ||
+                        graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_0_0) >= 0) {
                     addExperimentalVMOption(nativeImageArgs, "-H:+ForeignAPISupport");
                 }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -69,6 +69,7 @@ public final class GraalVM {
         public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", "17", Distribution.GRAALVM);
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", "21", Distribution.GRAALVM);
         public static final Version VERSION_24_2_0 = new Version("GraalVM 24.2.0", "24.2.0", "24", Distribution.GRAALVM);
+        public static final Version VERSION_25_0_0 = new Version("GraalVM 25.0.0", "25.0.0", "25", Distribution.GRAALVM);
 
         // Temporarily work around https://github.com/quarkusio/quarkus/issues/36246,
         // till we have a consensus on how to move forward in

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -65,12 +65,15 @@ class AwtProcessor {
         } else {
             v = nativeImageRunnerBuildItem.getBuildRunner().getGraalVMVersion();
         }
-        if (v.compareTo(GraalVM.Version.VERSION_24_2_0) >= 0) {
+
+        if (v.compareTo(io.quarkus.deployment.pkg.steps.GraalVM.Version.VERSION_24_2_0) >= 0
+                && v.compareTo(GraalVM.Version.VERSION_25_0_0) < 0) {
             unsupported.produce(new UnsupportedOSBuildItem(AARCH64,
                     "AWT needs JDK's JEP 454 FFI/FFM support and that is not available for AArch64 with " +
-                            "GraalVM's native-image, see: " +
+                            "GraalVM's native-image prior to JDK 25, see: " +
                             "https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/#foreign-functions"));
         }
+
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)


### PR DESCRIPTION
@zakkak Not sure if it's not premature to merge this, but I can confirm that GraalVM native-image, master branch HEAD b0b873054 for **JDK 25** enables `-H:+ForeignAPISupport` on aarch64. Quarkus AWT tests passes just fine with it on Linux aarch64, while it fails with GraalVM for **JDK 24** as expected:
```
[ERROR] Caused by: java.lang.UnsupportedOperationException: AWT needs JDK's JEP 454 FFI/FFM support and that is not available for AArch64 with GraalVM's native-image prior to JDK 25, see: https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/foreign-interface/#foreign-functions
```