### PR TITLE
Re-authenticate users if the OIDC session cookie can not be read

### DIFF
--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -892,11 +892,13 @@ public class CodeFlowTest {
             sessionCookie = getSessionCookie(webClient, null);
             assertEquals("1|2|3", sessionCookie.getValue());
 
+            webClient.getOptions().setRedirectEnabled(false);
+
             try {
                 webClient.getPage("http://localhost:8081/web-app");
-                fail("401 status error is expected");
+                fail("302 status error is expected");
             } catch (FailingHttpStatusCodeException ex) {
-                assertEquals(401, ex.getStatusCode());
+                assertEquals(302, ex.getStatusCode());
                 assertNull(getSessionCookie(webClient, null));
             }
             webClient.getCookieManager().clearCookies();
@@ -910,9 +912,9 @@ public class CodeFlowTest {
 
             try {
                 webClient.getPage("http://localhost:8081/web-app");
-                fail("401 status error is expected");
+                fail("302 status error is expected");
             } catch (FailingHttpStatusCodeException ex) {
-                assertEquals(401, ex.getStatusCode());
+                assertEquals(302, ex.getStatusCode());
                 assertNull(getSessionCookie(webClient, null));
             }
             webClient.getCookieManager().clearCookies();


### PR DESCRIPTION
Fixes #46765.

The internal session cookie format changed in 3.18, which, given it is not part of the API, should not have caused any issues. However, in advanced OIDC applications, what happens, as explained by @sschellh, is that there could be a large number of currently logged in users  possibly in different regions, which have not had time to logout before the new Quarkus release is deployed. thus keeping the existing session cookies. 

For example, a user logged in the morning, the session is active for 8 hours, new Quarkus is deployed at lunch time, and the user can not access the application after lunch.

In such cases,  if the internal session format changes, currently, Quarkus, after failing to parse the cookie content, stops users in their tracks with `401` which is not a good user experience.

Instead, Quarkus should remove the session cookie it can not parse and request re-authentication - the user may not even notice if the OIDC provider's own session cookies still valid.

This is what this simple PR does - deletes the session cookie (this is already done on main and tested) but instead of terminating the flow with 401, it forces the re-authentication with 302.