### PR TITLE
Detect json features of subresources as well

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -258,8 +258,12 @@ public class ResteasyReactiveJacksonProcessor {
         }
         Collection<ClassInfo> resourceClasses = resourceScanningResultBuildItem.get().getResult().getScannedResources()
                 .values();
+
+        List<ClassInfo> allResourceClasses = new ArrayList<>(resourceClasses);
+        allResourceClasses.addAll(resourceScanningResultBuildItem.get().getResult().getPossibleSubResources().values());
+
         Set<JacksonFeatureBuildItem.Feature> jacksonFeatures = new HashSet<>();
-        for (ClassInfo resourceClass : resourceClasses) {
+        for (ClassInfo resourceClass : allResourceClasses) {
             if (resourceClass.annotationsMap().containsKey(JSON_VIEW)) {
                 jacksonFeatures.add(JacksonFeatureBuildItem.Feature.JSON_VIEW);
                 for (AnnotationInstance instance : resourceClass.annotationsMap().get(JSON_VIEW)) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/CustomSerializationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/CustomSerializationResource.java
@@ -27,9 +27,9 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import io.quarkus.resteasy.reactive.jackson.CustomDeserialization;
 import io.quarkus.resteasy.reactive.jackson.CustomSerialization;
 
-@Path("/custom-serialization")
 @CustomSerialization(CustomSerializationResource.UnquotedFieldsPersonSerialization.class)
 @CustomDeserialization(CustomSerializationResource.UnquotedFieldsPersonDeserialization.class)
+@Path("")
 public class CustomSerializationResource {
 
     @ServerExceptionMapper
@@ -39,7 +39,7 @@ public class CustomSerializationResource {
     }
 
     @GET
-    @Path("/person")
+    @Path("/custom-serialization/person")
     public Person getPerson() {
         Person person = new Person();
         person.setFirst("Bob");
@@ -50,7 +50,7 @@ public class CustomSerializationResource {
     }
 
     @POST
-    @Path("/person")
+    @Path("/custom-serialization/person")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public Person getPerson(Person person) {
@@ -58,7 +58,7 @@ public class CustomSerializationResource {
     }
 
     @POST
-    @Path("/people/list")
+    @Path("/custom-serialization/people/list")
     @Consumes(MediaType.APPLICATION_JSON)
     public List<Person> getPeople(List<Person> people) {
         List<Person> reversed = new ArrayList<>(people.size());
@@ -69,7 +69,7 @@ public class CustomSerializationResource {
     }
 
     @GET
-    @Path("/invalid-use-of-custom-serializer")
+    @Path("/custom-serialization/invalid-use-of-custom-serializer")
     public User invalidUseOfCustomSerializer() {
         return testUser();
     }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonViewSubResourceTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonViewSubResourceTest.java
@@ -1,0 +1,126 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static io.restassured.RestAssured.given;
+import static jakarta.ws.rs.core.Response.Status.CREATED;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JsonViewSubResourceTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(User.class, Views.class, UsersResource.class, PublicUserResource.class,
+                                    PrivateUserResource.class, MixedUserResource.class, SerializeDeserializeUserResource.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        given().accept("application/json").get("users/public")
+                .then()
+                .statusCode(200)
+                .body(not(containsString("1")), containsString("test"));
+
+        given().accept("application/json").get("users/private")
+                .then()
+                .statusCode(200)
+                .body(containsString("1"), containsString("test"));
+
+        given().accept("application/json").get("users/mixed")
+                .then()
+                .statusCode(200)
+                .body(containsString("1"), containsString("test"));
+
+        given().accept("application/json")
+                .contentType("application/json")
+                .body("""
+                        {
+                         "id": 1,
+                         "name": "Foo"
+                        }
+                        """)
+                .post("users/serialize-deserialize")
+                .then()
+                .statusCode(201)
+                .body("id", equalTo(0))
+                .body("name", equalTo("Foo"));
+    }
+
+    @Path("users")
+    public static class UsersResource {
+
+        @Path("public")
+        public PublicUserResource getPublic() {
+            return new PublicUserResource();
+        }
+
+        @Path("private")
+        public PrivateUserResource getPrivate() {
+            return new PrivateUserResource();
+        }
+
+        @Path("mixed")
+        public MixedUserResource getMixed() {
+            return new MixedUserResource();
+        }
+
+        @Path("serialize-deserialize")
+        public SerializeDeserializeUserResource getSerializeDeserialize() {
+            return new SerializeDeserializeUserResource();
+        }
+    }
+
+    @JsonView(Views.Public.class)
+    public static class PublicUserResource {
+        @GET
+        public User get() {
+            return User.testUser();
+        }
+    }
+
+    @JsonView(Views.Private.class)
+    public static class PrivateUserResource {
+        @GET
+        public User get() {
+            return User.testUser();
+        }
+    }
+
+    @JsonView(Views.Public.class)
+    public static class MixedUserResource {
+        @GET
+        @JsonView(Views.Private.class)
+        public User get() {
+            return User.testUser();
+        }
+    }
+
+    public static class SerializeDeserializeUserResource {
+        @POST
+        @JsonView(Views.Private.class)
+        public RestResponse<User> get(@JsonView(Views.Public.class) User user) {
+            return RestResponse.status(CREATED, user);
+        }
+    }
+}


### PR DESCRIPTION
This enables usage of jsonview, customserialization, and customdeserialization on sub resources. These json features need to be scanned for in the resource class, but the sub resources where never inspected.

closes #37145