### PR TITLE
Compose Dev Service

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
@@ -17,6 +17,7 @@ public enum Feature {
     AWT,
     CACHE,
     CDI,
+    COMPOSE,
     CONFIG_YAML,
     CONFLUENT_REGISTRY_AVRO,
     CONFLUENT_REGISTRY_JSON,

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesComposeProjectBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesComposeProjectBuildItem.java
@@ -1,0 +1,123 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.deployment.dev.devservices.ContainerInfo;
+import io.quarkus.deployment.dev.devservices.ImageName;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+
+/**
+ * BuildItem for running services provided by compose
+ */
+public final class DevServicesComposeProjectBuildItem extends SimpleBuildItem {
+
+    public static final String COMPOSE_IGNORE = "io.quarkus.devservices.compose.ignore";
+
+    private final String project;
+
+    private final String defaultNetworkId;
+
+    private final Map<String, List<RunningContainer>> composeServices;
+
+    private final Map<String, String> config;
+
+    public DevServicesComposeProjectBuildItem() {
+        this(null, null, Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    public DevServicesComposeProjectBuildItem(String project,
+            String defaultNetworkId,
+            Map<String, List<RunningContainer>> composeServices,
+            Map<String, String> config) {
+        this.project = project;
+        this.defaultNetworkId = defaultNetworkId;
+        this.composeServices = composeServices;
+        this.config = config;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public String getDefaultNetworkId() {
+        return defaultNetworkId;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public Map<String, List<RunningContainer>> getComposeServices() {
+        return composeServices;
+    }
+
+    /**
+     * Locate a running container by image partial and port
+     * The container image partial can be a substring of the full image name
+     *
+     * @param imagePartials image partials
+     * @param port exposed port
+     * @return the running container or null if not found
+     */
+    public Optional<RunningContainer> locate(List<String> imagePartials, int port) {
+        return locateContainers(imagePartials)
+                .filter(r -> Optional.ofNullable(r.containerInfo().exposedPorts())
+                        .map(ports -> Arrays.stream(ports)
+                                .anyMatch(p -> Objects.equals(p.privatePort(), port)))
+                        .isPresent())
+                .findFirst();
+    }
+
+    /**
+     * Locate a running container by image partial
+     * The container image partial can be a substring of the full image name
+     * Ignored services are not returned
+     *
+     * @param imagePartials image partials
+     * @return the list of running containers
+     */
+    public List<RunningContainer> locate(List<String> imagePartials) {
+        return locateContainers(imagePartials).toList();
+    }
+
+    /**
+     * Locate the first running container by image partial
+     * The container image partial can be a substring of the full image name
+     * Ignored services are not returned
+     *
+     * @param imagePartials image partials
+     * @return the first running container
+     */
+    public Optional<RunningContainer> locateFirst(List<String> imagePartials) {
+        return locateContainers(imagePartials).findFirst();
+    }
+
+    private Stream<RunningContainer> locateContainers(List<String> imagePartials) {
+        return imagePartials.stream()
+                .flatMap(imagePartial -> composeServices.values().stream().flatMap(List::stream)
+                        // Ignore service if contains ignore label
+                        .filter(c -> !isContainerIgnored(c.containerInfo()))
+                        .filter(runningContainer -> {
+                            String imageName = runningContainer.containerInfo().imageName();
+                            return imageName.contains(imagePartial)
+                                    || ImageName.parse(imageName).withLibraryPrefix().toString().contains(imagePartial);
+                        }));
+    }
+
+    /**
+     * Ignored services are not returned by locate
+     *
+     * @param containerInfo container info
+     * @return true if the container should be ignored
+     */
+    public static boolean isContainerIgnored(ContainerInfo containerInfo) {
+        return Boolean.parseBoolean(containerInfo.labels().get(COMPOSE_IGNORE));
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesNetworkIdBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesNetworkIdBuildItem.java
@@ -1,0 +1,19 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * The network id of the network that the dev services are running on.
+ */
+public final class DevServicesNetworkIdBuildItem extends SimpleBuildItem {
+
+    private final String networkId;
+
+    public DevServicesNetworkIdBuildItem(String networkId) {
+        this.networkId = networkId;
+    }
+
+    public String getNetworkId() {
+        return networkId;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ComposeBuildTimeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ComposeBuildTimeConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.deployment.dev.devservices;
+
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigMapping(prefix = "quarkus.compose")
+public interface ComposeBuildTimeConfig {
+
+    /**
+     * Compose dev services config
+     */
+    @ConfigDocSection(generated = true)
+    ComposeDevServicesBuildTimeConfig devservices();
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ComposeDevServicesBuildTimeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ComposeDevServicesBuildTimeConfig.java
@@ -1,0 +1,118 @@
+package io.quarkus.deployment.dev.devservices;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface ComposeDevServicesBuildTimeConfig {
+
+    /**
+     * Compose dev service enabled or disabled
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * List of file paths relative to the project root for Compose dev service configuration,
+     * if not provided will look for compose files in the project root
+     */
+    Optional<List<String>> files();
+
+    /**
+     * Name of the compose project, used to discover running containers,
+     * if not provided a project name will be generated
+     */
+    Optional<String> projectName();
+
+    /**
+     * Compose profiles to activate
+     */
+    Optional<List<String>> profiles();
+
+    /**
+     * List of additional options to pass to compose command
+     */
+    Optional<List<String>> options();
+
+    /**
+     * Whether to run compose up and start containers at startup, when disabled, services are discovered by project name
+     */
+    @WithDefault("true")
+    boolean startServices();
+
+    /**
+     * Whether to run compose down and stop containers at shutdown
+     */
+    @WithDefault("true")
+    boolean stopServices();
+
+    /**
+     * Whether to use test containers Ryuk resource reaper to clean up containers
+     */
+    @WithDefault("true")
+    boolean ryukEnabled();
+
+    /**
+     * Whether to remove volumes on compose down
+     */
+    @WithDefault("true")
+    boolean removeVolumes();
+
+    /**
+     * Which images to remove on compose down
+     * <p>
+     * Locally built images, without custom tags are removed by default.
+     */
+    Optional<RemoveImages> removeImages();
+
+    /**
+     * --rmi option for compose down
+     */
+    enum RemoveImages {
+        ALL,
+        LOCAL
+    }
+
+    /**
+     * Env variables to pass to all Compose instances
+     */
+    Map<String, String> envVariables();
+
+    /**
+     * Scale configuration for services: Configure the number of instances for specific services
+     */
+    Map<String, Integer> scale();
+
+    /**
+     * Whether to tail container logs to the console
+     */
+    @WithDefault("false")
+    boolean followContainerLogs();
+
+    /**
+     * Whether to build images before starting containers.
+     * <p>
+     * When not provided, Compose images are built per-service `pull-policy`.
+     * When `true`, forces build of all images before starting containers.
+     * When `false`, skips re-building images before starting containers.
+     */
+    Optional<Boolean> build();
+
+    /**
+     * Whether to reuse the project for tests, when disabled, a new project is created for each test run
+     */
+    @WithDefault("false")
+    boolean reuseProjectForTests();
+
+    /**
+     * Timeout for stopping services, after the timeout the services are forcefully stopped,
+     *
+     */
+    @WithDefault("1s")
+    Duration stopTimeout();
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ContainerInfo.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ContainerInfo.java
@@ -4,151 +4,36 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class ContainerInfo {
-
-    private String id;
-    private String[] names;
-    private String imageName;
-    private String status;
-    private String[] networks;
-    private Map<String, String> labels;
-    private ContainerPort[] exposedPorts;
-
-    public ContainerInfo() {
-    }
-
-    public ContainerInfo(String id, String[] names, String imageName, String status, String[] networks,
-            Map<String, String> labels, ContainerPort[] exposedPorts) {
-        this.id = id;
-        this.names = names;
-        this.imageName = imageName;
-        this.status = status;
-        this.networks = networks;
-        this.labels = labels;
-        this.exposedPorts = exposedPorts;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
+public record ContainerInfo(String id, String[] names, String imageName, String status, Map<String, String[]> networks,
+        Map<String, String> labels, ContainerPort[] exposedPorts) {
 
     public String getShortId() {
         return id.substring(0, 12);
     }
 
-    public String[] getNames() {
-        return names;
-    }
-
-    public void setNames(String[] names) {
-        this.names = names;
-    }
-
     public String formatNames() {
-        return String.join(",", getNames());
-    }
-
-    public String getImageName() {
-        return imageName;
-    }
-
-    public void setImageName(String imageName) {
-        this.imageName = imageName;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public void setStatus(String status) {
-        this.status = status;
-    }
-
-    public String[] getNetworks() {
-        return networks;
-    }
-
-    public void setNetworks(String[] networks) {
-        this.networks = networks;
+        return String.join(",", names);
     }
 
     public String formatNetworks() {
-        return String.join(",", getNetworks());
-    }
-
-    public Map<String, String> getLabels() {
-        return labels;
-    }
-
-    public void setLabels(Map<String, String> labels) {
-        this.labels = labels;
-    }
-
-    public ContainerPort[] getExposedPorts() {
-        return exposedPorts;
-    }
-
-    public void setExposedPorts(ContainerPort[] exposedPorts) {
-        this.exposedPorts = exposedPorts;
+        return networks.entrySet().stream()
+                .map(e -> {
+                    String[] aliases = e.getValue();
+                    if (aliases == null || aliases.length == 0) {
+                        return e.getKey();
+                    }
+                    return e.getKey() + " (" + String.join(", ", aliases) + ")";
+                }).collect(Collectors.joining(", "));
     }
 
     public String formatPorts() {
-        return Arrays.stream(getExposedPorts())
-                .filter(p -> p.getPublicPort() != null)
-                .map(c -> c.getIp() + ":" + c.getPublicPort() + "->" + c.getPrivatePort() + "/" + c.getType())
+        return Arrays.stream(exposedPorts)
+                .filter(p -> p.publicPort != null)
+                .map(c -> c.ip + ":" + c.publicPort + "->" + c.privatePort + "/" + c.type)
                 .collect(Collectors.joining(", "));
     }
 
-    public static class ContainerPort {
-        private String ip;
-        private Integer privatePort;
-        private Integer publicPort;
-        private String type;
+    public record ContainerPort(String ip, Integer privatePort, Integer publicPort, String type) {
 
-        public ContainerPort() {
-        }
-
-        public ContainerPort(String ip, Integer privatePort, Integer publicPort, String type) {
-            this.ip = ip;
-            this.privatePort = privatePort;
-            this.publicPort = publicPort;
-            this.type = type;
-        }
-
-        public String getIp() {
-            return ip;
-        }
-
-        public void setIp(String ip) {
-            this.ip = ip;
-        }
-
-        public Integer getPrivatePort() {
-            return privatePort;
-        }
-
-        public void setPrivatePort(Integer privatePort) {
-            this.privatePort = privatePort;
-        }
-
-        public Integer getPublicPort() {
-            return publicPort;
-        }
-
-        public void setPublicPort(Integer publicPort) {
-            this.publicPort = publicPort;
-        }
-
-        public String getType() {
-            return type;
-        }
-
-        public void setType(String type) {
-            this.type = type;
-        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ImageName.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/ImageName.java
@@ -1,0 +1,119 @@
+package io.quarkus.deployment.dev.devservices;
+
+public record ImageName(String fullName, String registry, String repository, Version version) {
+
+    private static final String LIBRARY_PREFIX = "library/";
+
+    public static ImageName parse(String fullName) {
+        final int slashIndex = fullName.indexOf('/');
+
+        String remoteName;
+        String registry;
+        String repository;
+        Version version;
+
+        if (slashIndex == -1 ||
+                (!fullName.substring(0, slashIndex).contains(".") &&
+                        !fullName.substring(0, slashIndex).contains(":") &&
+                        !fullName.substring(0, slashIndex).equals("localhost"))) {
+            registry = "";
+            remoteName = fullName;
+        } else {
+            registry = fullName.substring(0, slashIndex);
+            remoteName = fullName.substring(slashIndex + 1);
+        }
+
+        if (remoteName.contains("@sha256:")) {
+            repository = remoteName.split("@sha256:")[0];
+            version = new Version.Sha256(remoteName.split("@sha256:")[1]);
+        } else if (remoteName.contains(":")) {
+            repository = remoteName.split(":")[0];
+            version = new Version.Tag(remoteName.split(":")[1]);
+        } else {
+            repository = remoteName;
+            version = new Version.Any();
+        }
+        return new ImageName(fullName, registry, repository, version);
+    }
+
+    /**
+     * @return the unversioned (non 'tag') part of this name
+     */
+    public String getUnversionedPart() {
+        if (!"".equals(registry)) {
+            return registry + "/" + repository;
+        } else {
+            return repository;
+        }
+    }
+
+    /**
+     * @return the versioned part of this name (tag or sha256)
+     */
+    public String getVersionPart() {
+        return version.toString();
+    }
+
+    public ImageName withLibraryPrefix() {
+        if (repository.startsWith(LIBRARY_PREFIX)) {
+            return this;
+        }
+        return new ImageName(fullName, registry, LIBRARY_PREFIX + repository, version);
+    }
+
+    @Override
+    public String toString() {
+        return getUnversionedPart() + version.getSeparator() + getVersionPart();
+    }
+
+    sealed static class Version permits Version.Tag, Version.Sha256, Version.Any {
+        public final String version;
+
+        public Version(String version) {
+            this.version = version;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public String getSeparator() {
+            return ":";
+        }
+
+        @Override
+        public String toString() {
+            return version + getSeparator();
+        }
+
+        private static final class Tag extends Version {
+
+            public Tag(String version) {
+                super(version);
+            }
+        }
+
+        private static final class Sha256 extends Version {
+
+            private Sha256(String version) {
+                super(version);
+            }
+
+            @Override
+            public String getSeparator() {
+                return "@";
+            }
+
+            @Override
+            public String toString() {
+                return "sha256:" + version;
+            }
+        }
+
+        private static final class Any extends Version {
+            public Any() {
+                super("latest");
+            }
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/RunningContainer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/devservices/RunningContainer.java
@@ -1,0 +1,31 @@
+package io.quarkus.deployment.dev.devservices;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Represents a running container.
+ *
+ * @param containerInfo The container information.
+ * @param env The container environment variables.
+ */
+public record RunningContainer(ContainerInfo containerInfo, Map<String, String> env) {
+
+    public Optional<Integer> getPortMapping(int port) {
+        return Arrays.stream(containerInfo.exposedPorts())
+                .filter(p -> p.privatePort() != null && p.privatePort() == port)
+                .map(ContainerInfo.ContainerPort::publicPort)
+                .findFirst();
+    }
+
+    public Optional<String> tryGetEnv(String... keys) {
+        for (String key : keys) {
+            String value = env.get(key);
+            if (value != null) {
+                return Optional.of(value);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -32,6 +32,7 @@ import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.BuildResult;
 import io.quarkus.deployment.builditem.ApplicationClassNameBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
@@ -53,6 +54,7 @@ public class StartupActionImpl implements StartupAction {
     private final String mainClassName;
     private final String applicationClassName;
     private final Map<String, String> devServicesProperties;
+    private final String devServicesNetworkId;
     private final List<RuntimeApplicationShutdownBuildItem> runtimeApplicationShutdownBuildItems;
     private final List<Closeable> runtimeCloseTasks = new ArrayList<>();
 
@@ -62,6 +64,7 @@ public class StartupActionImpl implements StartupAction {
         this.mainClassName = buildResult.consume(MainClassBuildItem.class).getClassName();
         this.applicationClassName = buildResult.consume(ApplicationClassNameBuildItem.class).getClassName();
         this.devServicesProperties = extractDevServicesProperties(buildResult);
+        this.devServicesNetworkId = extractDevServicesNetworkId(buildResult);
         this.runtimeApplicationShutdownBuildItems = buildResult.consumeMulti(RuntimeApplicationShutdownBuildItem.class);
 
         Map<String, byte[]> transformedClasses = extractTransformedClasses(buildResult);
@@ -367,6 +370,11 @@ public class StartupActionImpl implements StartupAction {
         return devServicesProperties;
     }
 
+    @Override
+    public String getDevServicesNetworkId() {
+        return devServicesNetworkId;
+    }
+
     private static Map<String, String> extractDevServicesProperties(BuildResult buildResult) {
         DevServicesLauncherConfigResultBuildItem result = buildResult
                 .consumeOptional(DevServicesLauncherConfigResultBuildItem.class);
@@ -374,6 +382,14 @@ public class StartupActionImpl implements StartupAction {
             return Map.of();
         }
         return new HashMap<>(result.getConfig());
+    }
+
+    private static String extractDevServicesNetworkId(BuildResult buildResult) {
+        DevServicesNetworkIdBuildItem networkId = buildResult.consumeOptional(DevServicesNetworkIdBuildItem.class);
+        if (networkId == null || networkId.getNetworkId() == null) {
+            return null;
+        }
+        return networkId.getNetworkId();
     }
 
     private static Map<String, byte[]> extractTransformedClasses(BuildResult buildResult) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/builditem/DevServicesComposeProjectBuildItemTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/builditem/DevServicesComposeProjectBuildItemTest.java
@@ -1,0 +1,170 @@
+package io.quarkus.deployment.builditem;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.deployment.dev.devservices.ContainerInfo;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+
+class DevServicesComposeProjectBuildItemTest {
+
+    private DevServicesComposeProjectBuildItem buildItem;
+
+    @BeforeEach
+    void setUp() {
+        // Create container info for postgres
+        ContainerInfo postgresInfo = new ContainerInfo(
+                "postgres123456789",
+                new String[] { "postgres" },
+                "postgres:13",
+                "running",
+                Map.of("default", new String[] { "default" }),
+                Collections.emptyMap(),
+                new ContainerInfo.ContainerPort[] {
+                        new ContainerInfo.ContainerPort("0.0.0.0", 5432, 5432, "tcp")
+                });
+        RunningContainer postgresContainer = new RunningContainer(postgresInfo, Collections.emptyMap());
+
+        // Create container info for mysql
+        ContainerInfo mysqlInfo = new ContainerInfo(
+                "mysql123456789",
+                new String[] { "mysql" },
+                "mysql:8",
+                "running",
+                Map.of("default", new String[] { "default" }),
+                Collections.emptyMap(),
+                new ContainerInfo.ContainerPort[] {
+                        new ContainerInfo.ContainerPort("0.0.0.0", 3306, 3306, "tcp")
+                });
+        RunningContainer mysqlContainer = new RunningContainer(mysqlInfo, Collections.emptyMap());
+
+        // Create container info for redis
+        ContainerInfo redisInfo = new ContainerInfo(
+                "redis123456789",
+                new String[] { "redis" },
+                "redis:6",
+                "running",
+                Map.of("default", new String[] { "default" }),
+                Collections.emptyMap(),
+                new ContainerInfo.ContainerPort[] {
+                        new ContainerInfo.ContainerPort("0.0.0.0", 6379, 6379, "tcp")
+                });
+        RunningContainer redisContainer = new RunningContainer(redisInfo, Collections.emptyMap());
+
+        // Create container info for ignored container
+        Map<String, String> ignoredLabels = new HashMap<>();
+        ignoredLabels.put(DevServicesComposeProjectBuildItem.COMPOSE_IGNORE, "true");
+        ContainerInfo ignoredInfo = new ContainerInfo(
+                "ignored123456789",
+                new String[] { "ignored" },
+                "ignored:latest",
+                "running",
+                Map.of("default", new String[] { "default" }),
+                ignoredLabels,
+                new ContainerInfo.ContainerPort[] {
+                        new ContainerInfo.ContainerPort("0.0.0.0", 8080, 8080, "tcp")
+                });
+        RunningContainer ignoredContainer = new RunningContainer(ignoredInfo, Collections.emptyMap());
+
+        // Create the build item with the containers
+        Map<String, List<RunningContainer>> composeServices = new HashMap<>();
+        composeServices.put("default", Arrays.asList(postgresContainer, mysqlContainer, redisContainer, ignoredContainer));
+
+        buildItem = new DevServicesComposeProjectBuildItem("test-project", "default", composeServices, Collections.emptyMap());
+    }
+
+    @Test
+    void locate() {
+        // Test locating postgres container by image and port
+        Optional<RunningContainer> result = buildItem.locate(List.of("postgres"), 5432);
+        assertTrue(result.isPresent());
+        assertEquals("postgres123456789", result.get().containerInfo().id());
+
+        // Test locating mysql container by image and port
+        result = buildItem.locate(List.of("mysql"), 3306);
+        assertTrue(result.isPresent());
+        assertEquals("mysql123456789", result.get().containerInfo().id());
+
+        // Test locating with non-existent port
+        // The port filtering should work correctly
+        ContainerInfo postgresInfoWithoutPort = new ContainerInfo(
+                "postgres123456789",
+                new String[] { "postgres" },
+                "postgres:13",
+                "running",
+                Map.of("default", new String[] { "default" }),
+                Collections.emptyMap(),
+                new ContainerInfo.ContainerPort[] {}); // Empty ports array
+        RunningContainer postgresContainerWithoutPort = new RunningContainer(postgresInfoWithoutPort, Collections.emptyMap());
+
+        Map<String, List<RunningContainer>> servicesWithoutPort = new HashMap<>();
+        servicesWithoutPort.put("default", List.of(postgresContainerWithoutPort));
+        DevServicesComposeProjectBuildItem buildItemWithoutPort = new DevServicesComposeProjectBuildItem(
+                "test-project", "default", servicesWithoutPort, Collections.emptyMap());
+
+        result = buildItemWithoutPort.locate(List.of("postgres"), 5432);
+        assertTrue(result.isPresent());
+
+        // Test locating with non-existent image
+        result = buildItem.locate(List.of("nonexistent"), 5432);
+        assertFalse(result.isPresent());
+
+        // Test that ignored container is not found
+        result = buildItem.locate(List.of("ignored"), 8080);
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void testLocate() {
+        // Test locating by image partial
+        List<RunningContainer> results = buildItem.locate(List.of("postgres"));
+        assertEquals(1, results.size());
+        assertEquals("postgres123456789", results.get(0).containerInfo().id());
+
+        // Test locating with multiple image partials
+        results = buildItem.locate(List.of("postgres", "mysql"));
+        assertEquals(2, results.size());
+        assertTrue(results.stream().anyMatch(c -> c.containerInfo().id().equals("postgres123456789")));
+        assertTrue(results.stream().anyMatch(c -> c.containerInfo().id().equals("mysql123456789")));
+
+        // Test locating with non-existent image
+        results = buildItem.locate(List.of("nonexistent"));
+        assertTrue(results.isEmpty());
+
+        // Test that ignored container is not found
+        results = buildItem.locate(List.of("ignored"));
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void locateFirst() {
+        // Test locating first container by image partial
+        Optional<RunningContainer> result = buildItem.locateFirst(List.of("postgres"));
+        assertTrue(result.isPresent());
+        assertEquals("postgres123456789", result.get().containerInfo().id());
+
+        // Test locating with multiple image partials (should return the first match)
+        result = buildItem.locateFirst(List.of("postgres", "mysql"));
+        assertTrue(result.isPresent());
+        // The first match depends on the order of containers in the composeServices map
+        // In our setup, postgres should be first
+        assertEquals("postgres123456789", result.get().containerInfo().id());
+
+        // Test locating with non-existent image
+        result = buildItem.locateFirst(List.of("nonexistent"));
+        assertFalse(result.isPresent());
+
+        // Test that ignored container is not found
+        result = buildItem.locateFirst(List.of("ignored"));
+        assertFalse(result.isPresent());
+    }
+}

--- a/docs/src/main/asciidoc/compose-dev-services.adoc
+++ b/docs/src/main/asciidoc/compose-dev-services.adoc
@@ -1,0 +1,690 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Compose Dev Services
+include::_attributes.adoc[]
+:categories: core
+:summary: Configure custom Dev Services using Docker or Podman Compose.
+:topics: dev-services,dev-mode,testing,compose
+
+Compose Dev Services offer a way to define custom dev services using the Compose specification.
+
+xref:dev-services.adoc[Quarkus Dev Services] automatically provisions unconfigured services in development and test mode.
+Most extensions providing connectivity to services also provide dev services implementation using https://www.testcontainers.org/[Testcontainers] behind the scenes.
+Each dev service has some default configuration, such as the container image to use, but is limited in terms of customization.
+
+While this level of automation is great for most use cases, there are times when you need more control and coordination over provisioned services.
+
+*Compose Dev Services* extends the Dev Services concept by allowing you to define custom dev services using the https://compose-spec.io/[Compose specification].
+_The Compose Specification is a developer-focused standard for defining cloud and platform agnostic container-based applications_.
+
+Compose is a widely used tool for defining and managing multi-container applications, for development and testing purposes.
+A YAML description file, typically named `compose.yml`, defines the services, networks, and volumes required for your application.
+https://docs.docker.com/compose/[Docker Compose] is the reference implementation and https://podman-desktop.io/docs/compose[Podman Desktop] also provides out-of-box support for the Compose specification.
+
+Quarkus detects Compose files named `compose-devservices.yml` (or <<compose-devservices-compose-files>>) in your project and starts the defined services when your application runs in development or test mode.
+Extensions providing dev services discover these custom services and use them instead of creating default ones.
+When the dev mode or tests are stopped, the services are automatically stopped and cleaned up.
+
+This integration provides a seamless development experience while giving you full control over your service configurations.
+
+== Prerequisites
+
+To use Compose Dev Services, you need:
+
+1. A working *local* container environment: https://docs.docker.com/get-started/get-docker/[Docker] or https://podman.io/docs/installation[Podman]
+
+2. Compose tooling such as `docker-compose` or `podman-compose`
+(Note that `docker compose` and `podman compose` commands internally call these binaries) :
+
+* For Docker: https://docs.docker.com/compose/install/[Installing Docker Compose]
+* For Podman: https://podman-desktop.io/docs/compose/setting-up-compose[Setting up Compose]
+
+[IMPORTANT]
+====
+Compose Dev Services is only compatible with Compose V2.
+====
+
+== Using Compose Dev Services
+
+Let's see how to use Compose Dev Services with examples ranging from simple to more complex scenarios.
+
+=== Basic Example: PostgreSQL Database
+
+In a Quarkus project already configured to use the `quarkus-jdbc-postgresql` extension,
+you can create a `compose-devservices.yml` file in the root of the project and define a custom service using Compose:
+
+[source, yaml]
+----
+services:
+  db:
+    image: postgres:17
+    healthcheck:
+      test: pg_isready -U myuser -d mydb
+      interval: 5s
+      timeout: 3s
+      retries: 3
+    ports:
+      - '5432'
+    environment:
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_DB: mydb
+----
+
+When you run the application in dev mode or execute tests, Compose Dev Services will automatically start the PostgreSQL service defined in the `compose-devservices.yml` file,
+instead of using the default dev service provided by the `quarkus-jdbc-postgresql` extension.
+
+As per the above configuration, the PostgreSQL container port `5432` will be exposed to a random host port
+and the application datasource will be configured by extracting connection information such as _user_, _password_ and the _database name_.
+
+=== Multi-Service Example: Custom Network and Dependencies
+
+For more complex scenarios, you can define custom networks and service dependencies:
+
+[source, yaml]
+----
+services:
+  db:
+    image: postgres:17
+    ports:
+      - '5432'
+    environment:
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_DB: mydb
+    networks:
+      - backend
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  cache:
+    image: redis:7
+    command: redis-server --save 60 1 --loglevel warning
+    ports:
+      - '6379'
+    networks:
+      - backend
+    depends_on:
+      - db
+
+  message-broker:
+    image: rabbitmq:3-management
+    ports:
+      - '5672'
+      - '15672'
+    networks:
+      - backend
+      - frontend
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+
+  api-gateway:
+    image: nginx:latest
+    ports:
+      - '8080:80'
+    networks:
+      - frontend
+    depends_on:
+      - message-broker
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+
+networks:
+  backend:
+  frontend:
+
+volumes:
+  postgres-data:
+----
+
+Note that the `compose-devservices.yml` file can be customized as needed with multiple services with dependencies to control the startup order,
+custom networks to isolate service communication, and volumes for data persistence and configuration.
+
+== Service Discovery
+
+Services started by Compose Dev Services are automatically discovered by extensions providing dev services.
+Each extension discovers the services it needs and configures the application accordingly.
+
+Extensions rely on container image names and exposed ports to discover services.
+For example, the PostgreSQL Dev Service looks for a service with the image name *containing* `postgres` and the exposed container port `5432`.
+
+When a match is found, the extension will:
+
+1. Extract connection information from the container (connection url, credentials, database name, etc.)
+2. Configure the application to use the discovered service
+3. Skip creating its own default Dev Service container
+
+=== Supported Extensions and Discovery Criteria
+
+The following is the list of platform extensions with dev services support:
+
+[cols="1,1,1",options="header"]
+|===
+
+|Extension
+|Image Names
+|Exposed Port
+
+| AMQP
+| amqp, activemq-artemis, rabbitmq
+| 5672
+
+| Apicurio Registry
+| apicurio
+| 8080
+
+| DB2
+| db2
+| 50000
+
+| MySQL
+| mysql
+| 3306
+
+| PostgreSQL
+| postgres
+| 5432
+
+| MariaDB
+| mariadb
+| 3306
+
+| Microsoft SQL Server
+| mssql
+| 1433
+
+| Oracle Database
+| oracle
+| 1521
+
+| Kafka
+| kafka, strimzi, redpanda
+| 9092
+
+| Keycloak
+| keycloak
+| 8080
+
+| Kubernetes
+| kube-apiserver, k3s, kindest/node
+| 6443
+
+| MongoDB
+| mongo
+| 27017
+
+| MQTT
+| hivemq, eclipse-mosquitto
+| 1883
+
+| RabbitMQ
+| rabbitmq
+| 5672
+
+| Pulsar
+| pulsar
+| 6650
+
+| Redis
+| redis
+| 6379
+
+| Infinispan
+| infinispan
+| 11222
+
+| Elasticsearch
+| elasticsearch, opensearch
+| 9200
+
+| Observability
+| lgtm
+| 16686, 9411, 9090, 3000
+
+|===
+
+=== Configuring custom images for service discovery
+
+You can customize the image names used for service discovery by setting the appropriate properties in your `application.properties` file.
+For example, to use a custom Kafka image:
+
+[source, properties]
+----
+quarkus.kafka.devservices.image-name=my-custom-kafka:latest
+----
+
+Each extension that provides Dev Services has its own configuration properties for customizing the image name.
+Refer to the specific extension documentation for details.
+
+[[compose-devservices-compose-files]]
+=== Using specific Compose files
+
+By default, Compose Dev Services looks for files in the project root named `compose-devservices.[yml|yaml]` or `docker-compose-devservices.[yml|yaml]`.
+
+You can specify custom files to use by setting the `quarkus.compose.devservices.files` property in the `application.properties` file:
+
+[source, properties]
+----
+# Use a specific compose file for all modes
+quarkus.compose.devservices.files=src/main/docker/compose.yml
+
+# Use different compose files for different config profiles
+%dev.quarkus.compose.devservices.files=src/main/docker/dev-compose.yml
+%test.quarkus.compose.devservices.files=src/test/resources/test-compose.yml
+----
+
+This allows you to use different dev service environments depending on the Quarkus config profiles.
+You can also specify multiple files by separating them with commas:
+
+[source, properties]
+----
+quarkus.compose.devservices.files=src/main/docker/base-compose.yml,src/main/docker/extra-services.yml
+----
+
+==== Using Compose profiles
+
+With profiles, Compose files can define a set of active profiles so started services is adjusted for various usages and environments.
+You can specify the profiles to activate by setting the `quarkus.compose.devservices.profiles` property in the `application.properties` file:
+
+[source, yaml]
+----
+services:
+  db:
+    image: postgres:17
+    profiles:
+      - dev
+      - local
+    ports:
+      - '5432'
+    environment:
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_DB: mydb
+----
+
+[source, properties]
+----
+%test.quarkus.compose.devservices.profiles=dev,local
+----
+
+=== Ignoring Services
+
+You can configure Compose Dev Services to ignore specific services by adding the `io.quarkus.devservices.compose.ignore` label to the service in your Compose file:
+
+[source, yaml]
+----
+services:
+  db:
+    image: postgres:17
+    labels:
+      io.quarkus.devservices.compose.ignore: true
+    ports:
+      - '5432'
+    environment:
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_DB: mydb
+----
+
+When a service has this label set to `true`, it will be excluded from service discovery, and extensions will not use it for Dev Services.
+
+== Service Readiness
+
+Compose Dev Services provides several ways to ensure services are ready before your application tries to use them.
+
+=== Health Checks
+
+Compose Dev Services respects the health checks defined in your Compose file.
+It's recommended to configure health checks for your services to ensure they are ready before your application tries to use them:
+
+[source, yaml]
+----
+services:
+  db:
+    image: postgres:17
+    healthcheck:
+      test: pg_isready -U myuser -d mydb
+      interval: 5s
+      timeout: 3s
+      retries: 3
+    ports:
+      - '5432'
+    environment:
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_DB: mydb
+----
+
+=== Wait for Logs
+
+You can configure Compose Dev Services to wait for specific log messages to appear in the container logs before considering a service ready.
+This is useful for services that don't provide health checks but log a message when they're ready.
+
+To wait for a specific log message, add a label with the prefix `io.quarkus.devservices.compose.wait_for.logs` to your service:
+
+[source, yaml]
+----
+services:
+  app:
+    image: my-application:latest
+    ports:
+      - '8080'
+    labels:
+      io.quarkus.devservices.compose.wait_for.logs: .*Server is now running.*
+----
+
+You can also specify how many times a log message should appear by setting the numeric suffix value:
+`io.quarkus.devservices.compose.wait_for.logs.3: .*Worker started.*`
+
+=== Wait for Ports
+
+By default, Compose Dev Services waits for all exposed ports to be available before considering a service ready.
+This behavior can be customized using labels:
+
+[source, yaml]
+----
+services:
+  app:
+    image: my-application:latest
+    ports:
+      - '8080'
+    labels:
+      # Change to `true` to disable waiting for ports
+      io.quarkus.devservices.compose.wait_for.ports.disable: false
+      # Or set a custom timeout for port waiting
+      io.quarkus.devservices.compose.wait_for.ports.timeout: "30s"
+----
+
+=== Global Timeout
+
+You can configure the global timeout for Dev Services startup using the `quarkus.devservices.timeout` property:
+
+[source, properties]
+----
+quarkus.devservices.timeout=120s
+----
+
+This property sets the maximum time to wait for all Dev Services to start. The default is 60 seconds.
+
+=== Ordering Services
+
+Compose Dev Services starts services in the order they are defined in the Compose file.
+If you need to start services in a specific order, you can use the `depends_on` attribute:
+
+[source, yaml]
+----
+services:
+  db:
+    image: postgres:17
+    ports:
+      - '5432'
+    environment:
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_DB: mydb
+
+  app:
+    image: my-application:latest
+    ports:
+      - '8080'
+    depends_on:
+      - db
+----
+
+== Exposing Service Configuration into the Application
+
+Compose Dev Services automatically exposes the configuration of discovered services to your application.
+For example, when a database service is discovered with the following compose service description:
+
+[source, yaml]
+----
+services:
+  db:
+    image: mysql:17
+    ports:
+      - '9906:3306'
+    labels:
+      io.quarkus.devservices.compose.jdbc.parameters: characterEncoding=UTF-8&useUnicode=true
+    environment:
+      MYSQL_USER: myuser
+      MYSQL_PASSWORD: mypassword
+      MYSQL_DATABASE: mydb
+----
+
+Following application properties are automatically set:
+
+[source, properties]
+----
+quarkus.datasource.username=myuser
+quarkus.datasource.password=mypassword
+quarkus.datasource.jdbc.url=jdbc:mysql://localhost:9906/mydb?characterEncoding=UTF-8&useUnicode=true
+----
+
+The actual values are extracted from the service labels and environment variables.
+The host is set to the Docker host IP address, and the port is set to the mapped port on the host.
+
+[NOTE]
+====
+For database services, if the label `io.quarkus.compose.devservices.jdbc.parameters` is set, the parameters are added to the JDBC URL.
+====
+
+=== Custom config mapping using service labels
+
+You can customize how environment variables and exposed ports are mapped to application configuration properties using service labels.
+
+==== Mapping environment variables
+
+To map an environment variable to a specific application configuration property,
+use the `io.quarkus.devservices.compose.config_map.env.<env-var-name>` label.
+
+Let's take the example of a MQTT broker:
+
+[source, yaml]
+----
+services:
+  mqtt:
+    image: eclipse-mosquitto:2.0.21
+    ports:
+    - '1883'
+    environment:
+      MQTT_USER: user
+      MQTT_PASSWORD: pass
+    labels:
+      io.quarkus.devservices.compose.config_map.env.MQTT_USER: mp.messaging.connector.smallrye-mqtt.username
+      io.quarkus.devservices.compose.config_map.env.MQTT_PASSWORD: mp.messaging.connector.smallrye-mqtt.password
+    volumes:
+      - ./conf:/mosquitto/config
+----
+
+With the `./conf` containing the `mosquitto.conf` file:
+
+[source, ini]
+----
+persistence true
+persistence_location /mosquitto/data/
+log_dest file /mosquitto/log/mosquitto.log
+listener 1883
+
+allow_anonymous false
+password_file /mosquitto/config/password.txt
+----
+
+and the `password.txt` file containing the user and encrypted password:
+
+[source]
+----
+user:$7$101$EyGShytu3v+...==
+----
+
+In this example:
+
+- The `MQTT_USER` environment variable with the value `user` is mapped to the `mp.messaging.connector.smallrye-mqtt.username` property
+- The `MQTT_PASSWORD` environment variable with the value `pass` is mapped to the `mp.messaging.connector.smallrye-mqtt.password` property
+
+[NOTE]
+====
+With the `password_file` is configured in the `mosquitto.conf`,
+environment variables are not used to set the username and password but to map them to the application properties.
+====
+
+==== Mapping exposed ports
+
+To map an exposed port to a specific application configuration property,
+use the `io.quarkus.devservices.compose.config_map.port.<container-port>` label:
+
+[source, yaml]
+----
+services:
+  my-service:
+    image: my-service-image
+    ports:
+      - '7432:5432'
+      - '9080:8080'
+    labels:
+      # Map port 5432 to quarkus.datasource.jdbc.port
+      io.quarkus.devservices.compose.config_map.port.5432: quarkus.datasource.jdbc.port
+      # Map port 8080 to quarkus.http.port
+      io.quarkus.devservices.compose.config_map.port.8080: quarkus.http.port
+----
+
+In the example above:
+- Port 7432 is mapped to the `quarkus.datasource.jdbc.port` property
+- Port 9080 is mapped to the `quarkus.http.port` property
+
+The mapped properties will contain the host port that is mapped to the container port,
+which may be different from the container port if you're using dynamic port mapping (e.g., `- '5432'` instead of `- '7432:5432'`).
+
+==== Exposing port mappings to running containers
+
+In some cases, containers need to know the host ports they're mapped to at runtime.
+For example, a Kafka broker needs to advertise its externally accessible address to clients.
+
+You can use the `io.quarkus.devservices.compose.exposed_ports` label to specify a file path inside the container where port mappings will be written:
+
+[source, yaml]
+----
+services:
+  kafka:
+    image: apache/kafka-native:3.9.0
+    ports:
+      - '9092'
+    labels:
+      io.quarkus.devservices.compose.exposed_ports: /etc/kafka/docker/ports
+----
+
+When the container starts, Quarkus will copy a file at the specified path containing environment variable-style port mappings:
+
+[source, bash]
+----
+PORT_9092=54321
+PORT_8080=12345
+# ... other ports as needed
+----
+
+Each line follows the format `PORT_<containerPort>=<hostPort>`, where _containerPort_ is the port exposed by the container and _hostPort_ is the dynamically assigned port on the host.
+The container command can wait until the file is present, and then source this file to access these mappings as environment variables:
+
+[source, bash]
+----
+#!/bin/bash
+
+# Wait for the ports file to be created
+while [ ! -f /etc/kafka/docker/ports ]; do
+  sleep 0.1;
+done;
+
+# Source the file to load PORT_* variables
+source /etc/kafka/docker/ports;
+
+# Use the port mappings
+export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:$PORT_9092;
+# Run the Kafka broker executable
+/etc/kafka/docker/run
+----
+
+== Controlling Service Lifecycle with Compose
+
+Compose Dev Services provides several configuration options to control how services are started, stopped and shared between application instances.
+
+When the application starts in development or test mode, Compose Dev Services decide whether to start services or to discover already running services based on the configuration.
+When the application stops, Compose Dev Services stops the services it started.
+
+=== Compose Project Name
+
+Compose uses the project name to identify resources such as services, networks, volumes, etc. in order to namespace and isolate different compose projects.
+This enables the discovery of existing resources and cleanup resources when the application stops.
+
+Compose Dev Services determines the project name as follows:
+
+1. If the `quarkus.compose.devservices.project-name` property is set, it's used as the project name
+2. If the top-level `name` attribute is specified in the Compose file, it's used as the project name
+3. Otherwise, the default name `quarkus-devservices-<application-name>` is chosen.
+
+=== Discovering already started Compose Services
+
+Once the project name is determined, Compose Dev Services first tries discovering existing services with that project name.
+
+The already started compose project may have been already started by another Quarkus application running locally with the same project name,
+or manually using the `docker compose up` or `podman compose up` commands.
+
+Regardless of how the services were started,
+Compose Dev Services will configure dev services and injected configuration properties,
+but won't stop the services when the application is stopped.
+
+[IMPORTANT]
+====
+If no compose files are found in the project, and no `quarkus.compose.devservices.project-name` is set,
+Compose Dev Services won't try to discover any services and will be disabled.
+====
+
+=== Compose Dev Services used for tests
+
+For Quarkus tests, a generated project name in the format `quarkus-devservices-<application-name>-<random-suffix>` is used by default to ensure isolation between test runs and running dev mode services.
+This way, Quarkus tests start a separate copy of the services defined in the compose files.
+For example, when running continuous testing in development mode, tests will have their own isolated set of services.
+
+You can change this behavior by setting the `quarkus.compose.devservices.reuse-project-for-tests=true` property.
+This allows tests to reuse services started separately in development mode.
+
+=== Using Start/Stop Controls
+
+In the default lifecycle, Compose Dev Services will start and stop services automatically when the application starts and stops.
+For more fine-grained control, you can use the `start-services` and `stop-services` configuration properties.
+
+When `quarkus.compose.devservices.start-services=false` is set,
+Compose Dev Services will only try to discover existing services with the determined project name, but won't start any new services, even if compose files are present.
+
+When `quarkus.compose.devservices.stop-services=false` is set, services will continue running after the application stops.
+This allows services to be reused by other applications or subsequent runs of the same application.
+
+You can also configure the timeout for stopping services with the `quarkus.compose.devservices.stop-timeout` property.
+After the timeout, Compose Dev Services will forcefully stop the services.
+The default timeout is chosen deliberately short to 1 second for fast cleanup, but you can increase it as needed:
+
+[source, text]
+----
+# application.properties
+quarkus.compose.devservices.stop-timeout=10s
+----
+
+== Relation to existing Dev Services
+
+Compose Dev Services work alongside existing Dev Services implementations provided by Quarkus extensions.
+The service discovery process follows this order of precedence:
+
+1. Dev Service implementations first try locating services via shared service labels (e.g., services started by other applications)
+2. If no shared services are found, they fallback to discovering services started by Compose Dev Services
+3. If no Compose services are found, the default Dev Services implementation is used (typically starting a Testcontainers-based service)
+
+When Compose Dev Service creates or discovers a project, regular dev service implementations create containers inside the compose project default network.
+This ensures that all services can communicate with each other using their service names as hostnames within the same network.
+
+
+[[compose-devservices-configuration-reference]]
+== Configuration reference
+
+include::{generated-dir}/config/quarkus-core_quarkus.compose.devservices.adoc[opts=optional, leveloffset=+1]

--- a/docs/src/main/asciidoc/dev-services.adoc
+++ b/docs/src/main/asciidoc/dev-services.adoc
@@ -48,6 +48,9 @@ All this functionality is part of the Quarkus `deployment` modules, so does not 
 way. If you want to disable all Dev Services you can use the `quarkus.devservices.enabled=false` config property, although
 in most cases this is not necessary as simply configuring the service will result in the Dev Service being disabled automatically.
 
+== Compose Dev Services
+
+xref:compose-dev-services.adoc[Quarkus Compose Dev Services] allows you to define custom dev services using the https://compose-spec.io/[Compose specification].
 
 
 == Platform Dev Services

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceConfigurationHandlerBuildItem.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceConfigurationHandlerBuildItem.java
@@ -58,7 +58,7 @@ public final class DevServicesDatasourceConfigurationHandlerBuildItem extends Mu
                     @Override
                     public Map<String, String> apply(String dsName,
                             DevServicesDatasourceProvider.RunningDevServicesDatasource runningDevDb) {
-                        String jdbcUrl = runningDevDb.getJdbcUrl();
+                        String jdbcUrl = runningDevDb.jdbcUrl();
                         // we use datasourceURLPropNames to generate quoted and unquoted versions of the property key,
                         // because depending on whether a user configured other JDBC properties
                         // one of the URLs may be ignored
@@ -85,7 +85,7 @@ public final class DevServicesDatasourceConfigurationHandlerBuildItem extends Mu
                     @Override
                     public Map<String, String> apply(String dsName,
                             DevServicesDatasourceProvider.RunningDevServicesDatasource runningDevDb) {
-                        String reactiveUrl = runningDevDb.getReactiveUrl();
+                        String reactiveUrl = runningDevDb.reactiveUrl();
                         // we use datasourceURLPropNames to generate quoted and unquoted versions of the property key,
                         // because depending on whether a user configured other reactive properties
                         // one of the URLs may be ignored

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
@@ -39,48 +39,8 @@ public interface DevServicesDatasourceProvider {
         return true;
     }
 
-    class RunningDevServicesDatasource {
-
-        private final String id;
-        private final String jdbcUrl;
-        private final String reactiveUrl;
-        private final String username;
-        private final String password;
-        private final Closeable closeTask;
-
-        public RunningDevServicesDatasource(String id, String jdbcUrl, String reactiveUrl, String username, String password,
-                Closeable closeTask) {
-            this.id = id;
-            this.jdbcUrl = jdbcUrl;
-            this.reactiveUrl = reactiveUrl;
-            this.username = username;
-            this.password = password;
-            this.closeTask = closeTask;
-        }
-
-        public String getId() {
-            return id;
-        }
-
-        public String getJdbcUrl() {
-            return jdbcUrl;
-        }
-
-        public String getReactiveUrl() {
-            return reactiveUrl;
-        }
-
-        public Closeable getCloseTask() {
-            return closeTask;
-        }
-
-        public String getUsername() {
-            return username;
-        }
-
-        public String getPassword() {
-            return password;
-        }
+    record RunningDevServicesDatasource(String id, String jdbcUrl, String reactiveUrl, String username, String password,
+            Closeable closeTask) {
 
     }
 

--- a/extensions/devservices/common/pom.xml
+++ b/extensions/devservices/common/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
+            <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ComposeLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ComposeLocator.java
@@ -1,0 +1,57 @@
+package io.quarkus.devservices.common;
+
+import static io.quarkus.devservices.common.ContainerUtil.getShortId;
+import static io.quarkus.devservices.common.Labels.DOCKER_COMPOSE_SERVICE;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.DockerClientFactory;
+
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * Util class to Locate a running container in a compose dev services project.
+ */
+public class ComposeLocator {
+
+    private static final Logger log = Logger.getLogger(ComposeLocator.class);
+
+    public static Optional<ContainerAddress> locateContainer(DevServicesComposeProjectBuildItem composeProject,
+            List<String> images, int port, LaunchMode launchMode, boolean useSharedNetwork) {
+        if (launchMode != LaunchMode.NORMAL) {
+            return composeProject.locate(images, port)
+                    .map(runningContainer -> {
+                        String serviceName = getServiceName(runningContainer);
+                        ContainerAddress containerAddress = new ContainerAddress(runningContainer,
+                                useSharedNetwork ? serviceName : DockerClientFactory.instance().dockerHostIpAddress(),
+                                useSharedNetwork ? port
+                                        : runningContainer.getPortMapping(port).orElseThrow(
+                                                () -> new IllegalStateException("No public port found for " + port)));
+                        log.infof("Compose Dev Service container found: %s (%s). Connecting to: %s.",
+                                getShortId(containerAddress.getId()),
+                                containerAddress.getRunningContainer().containerInfo().imageName(),
+                                containerAddress.getUrl());
+                        return containerAddress;
+                    });
+        }
+        return Optional.empty();
+    }
+
+    public static String getServiceName(RunningContainer runningContainer) {
+        return runningContainer.containerInfo().labels().get(DOCKER_COMPOSE_SERVICE);
+    }
+
+    public static List<RunningContainer> locateContainer(DevServicesComposeProjectBuildItem composeProject,
+            List<String> images, LaunchMode launchMode) {
+        if (launchMode != LaunchMode.NORMAL) {
+            return composeProject.locate(images);
+        }
+        return Collections.emptyList();
+    }
+
+}

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
@@ -26,6 +26,20 @@ public final class ConfigureUtil {
     private ConfigureUtil() {
     }
 
+    public static String configureNetwork(GenericContainer<?> container,
+            String defaultNetworkId,
+            boolean useSharedNetwork,
+            String hostNamePrefix) {
+        if (defaultNetworkId != null) {
+            // Set the network`without creating the network
+            container.setNetworkMode(defaultNetworkId);
+            return setGeneratedHostname(container, hostNamePrefix);
+        } else if (useSharedNetwork) {
+            return configureSharedNetwork(container, hostNamePrefix);
+        }
+        return container.getHost();
+    }
+
     public static String configureSharedNetwork(GenericContainer<?> container, String hostNamePrefix) {
         // When a shared network is requested for the launched containers, we need to configure
         // the container to use it. We also need to create a hostname that will be applied to the returned
@@ -53,7 +67,10 @@ public final class ConfigureUtil {
         } else {
             container.setNetwork(Network.SHARED);
         }
+        return setGeneratedHostname(container, hostNamePrefix);
+    }
 
+    public static String setGeneratedHostname(GenericContainer<?> container, String hostNamePrefix) {
         String hostName = (hostNamePrefix + "-" + Base58.randomString(5)).toLowerCase(Locale.ROOT);
         // some containers might try to add their own aliases on start, so we want to keep this list modifiable:
         container.setNetworkAliases(new ArrayList<>(List.of(hostName)));

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerAddress.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerAddress.java
@@ -1,12 +1,23 @@
 package io.quarkus.devservices.common;
 
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+
 public class ContainerAddress {
     private final String id;
     private final String host;
     private final int port;
+    private final RunningContainer runningContainer;
 
     public ContainerAddress(String id, String host, int port) {
         this.id = id;
+        this.host = host;
+        this.port = port;
+        this.runningContainer = null;
+    }
+
+    public ContainerAddress(RunningContainer runningContainer, String host, int port) {
+        this.runningContainer = runningContainer;
+        this.id = runningContainer.containerInfo().id();
         this.host = host;
         this.port = port;
     }
@@ -25,5 +36,9 @@ public class ContainerAddress {
 
     public String getUrl() {
         return String.format("%s:%d", host, port);
+    }
+
+    public RunningContainer getRunningContainer() {
+        return runningContainer;
     }
 }

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.DockerClientFactory;
@@ -17,35 +19,54 @@ import io.quarkus.runtime.LaunchMode;
 public class ContainerLocator {
 
     private static final Logger log = Logger.getLogger(ContainerLocator.class);
-    private static final BiPredicate<ContainerPort, Integer> hasMatchingPort = (containerPort,
-            port) -> containerPort.getPrivatePort() != null &&
-                    containerPort.getPublicPort() != null &&
-                    containerPort.getPrivatePort().equals(port);
 
-    private final String devServiceLabel;
+    private static boolean hasDevServiceLabels(Container container, Predicate<String> labelPredicate,
+            String... devServiceLabels) {
+        return Stream.concat(Stream.of(Labels.QUARKUS_DEV_SERVICE), Arrays.stream(devServiceLabels))
+                .map(l -> container.getLabels().get(l))
+                .anyMatch(labelPredicate);
+    }
+
+    private static boolean hasMatchingPort(ContainerPort containerPort, int port) {
+        return containerPort.getPrivatePort() != null &&
+                containerPort.getPublicPort() != null &&
+                containerPort.getPrivatePort().equals(port);
+    }
+
+    private final BiPredicate<Container, String> filter;
     private final int port;
 
     public ContainerLocator(String devServiceLabel, int port) {
-        this.devServiceLabel = devServiceLabel;
+        this.filter = (container, expectedLabel) -> expectedLabel.equals(container.getLabels().get(devServiceLabel));
         this.port = port;
     }
 
-    private Optional<Container> lookup(String expectedLabelValue) {
+    public ContainerLocator(BiPredicate<Container, String> filter, int port) {
+        this.filter = filter;
+        this.port = port;
+    }
+
+    public static ContainerLocator locateContainerWithLabels(int port, String... devServiceLabels) {
+        return new ContainerLocator(
+                (container, expectedLabel) -> hasDevServiceLabels(container, expectedLabel::equals, devServiceLabels),
+                port);
+    }
+
+    private Stream<Container> lookup(String expectedLabelValue) {
         return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
-                .filter(container -> expectedLabelValue.equals(container.getLabels().get(devServiceLabel)))
-                .findAny();
+                .filter(container -> filter.test(container, expectedLabelValue));
     }
 
     private Optional<ContainerPort> getMappedPort(Container container, int port) {
         return Arrays.stream(container.getPorts())
-                .filter(containerPort -> hasMatchingPort.test(containerPort, port))
+                .filter(containerPort -> hasMatchingPort(containerPort, port))
                 .findAny();
     }
 
     public Optional<ContainerAddress> locateContainer(String serviceName, boolean shared, LaunchMode launchMode) {
         if (shared && launchMode == LaunchMode.DEVELOPMENT) {
             return lookup(serviceName)
-                    .flatMap(container -> getMappedPort(container, port)
+                    .flatMap(container -> getMappedPort(container, port).stream()
                             .flatMap(containerPort -> Optional.ofNullable(containerPort.getPublicPort())
                                     .map(port -> {
                                         final ContainerAddress containerAddress = new ContainerAddress(
@@ -57,7 +78,8 @@ public class ContainerLocator {
                                                 container.getImage(),
                                                 containerAddress.getUrl());
                                         return containerAddress;
-                                    })));
+                                    }).stream()))
+                    .findFirst();
         } else {
             return Optional.empty();
         }
@@ -69,7 +91,7 @@ public class ContainerLocator {
     public Optional<String> locateContainer(String serviceName, boolean shared, LaunchMode launchMode,
             BiConsumer<Integer, ContainerAddress> consumer) {
         if (shared && launchMode == LaunchMode.DEVELOPMENT) {
-            return lookup(serviceName)
+            return lookup(serviceName).findAny()
                     .map(container -> {
                         Arrays.stream(container.getPorts())
                                 .filter(cp -> Objects.nonNull(cp.getPublicPort()) && Objects.nonNull(cp.getPrivatePort()))
@@ -90,7 +112,8 @@ public class ContainerLocator {
     public Optional<Integer> locatePublicPort(String serviceName, boolean shared, LaunchMode launchMode, int privatePort) {
         if (shared && launchMode == LaunchMode.DEVELOPMENT) {
             return lookup(serviceName)
-                    .flatMap(container -> getMappedPort(container, privatePort))
+                    .flatMap(container -> getMappedPort(container, privatePort).stream())
+                    .findFirst()
                     .map(ContainerPort::getPublicPort);
         } else {
             return Optional.empty();

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerUtil.java
@@ -1,0 +1,187 @@
+package io.quarkus.devservices.common;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.dockerjava.api.model.NetworkSettings;
+
+import io.quarkus.deployment.dev.devservices.ContainerInfo;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+
+/**
+ * Utility class for working with containers.
+ */
+public class ContainerUtil {
+
+    private static final int CONTAINER_SHORT_ID_LENGTH = 12;
+
+    /**
+     * Convert an InspectContainerResponse to a RunningContainer.
+     *
+     * @param inspectContainer The container inspect response.
+     * @return The running container.
+     */
+    public static RunningContainer toRunningContainer(InspectContainerResponse inspectContainer) {
+        return new RunningContainer(toContainerInfo(inspectContainer), getContainerEnv(inspectContainer));
+    }
+
+    /**
+     * Convert an InspectContainerResponse to a ContainerInfo.
+     *
+     * @param inspectContainer The container inspect response.
+     * @return The container info.
+     */
+    public static ContainerInfo toContainerInfo(InspectContainerResponse inspectContainer) {
+        String[] names = inspectContainer.getNetworkSettings().getNetworks().values().stream()
+                .flatMap(c -> c.getAliases() == null ? Stream.of() : c.getAliases().stream())
+                .toArray(String[]::new);
+        return new ContainerInfo(inspectContainer.getId(), names, inspectContainer.getConfig().getImage(),
+                inspectContainer.getState().getStatus(), getNetworks(inspectContainer),
+                inspectContainer.getConfig().getLabels(),
+                getExposedPorts(inspectContainer));
+    }
+
+    private static Map<String, String[]> getNetworks(InspectContainerResponse container) {
+        NetworkSettings networkSettings = container.getNetworkSettings();
+        if (networkSettings == null) {
+            return null;
+        }
+        return getNetworks(networkSettings.getNetworks());
+    }
+
+    public static Map<String, String[]> getNetworks(Map<String, ContainerNetwork> networkSettings) {
+        if (networkSettings == null) {
+            return null;
+        }
+        return networkSettings.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        e -> {
+                            List<String> aliases = e.getValue().getAliases();
+                            return aliases == null ? new String[0] : aliases.toArray(new String[0]);
+                        }));
+    }
+
+    private static ContainerInfo.ContainerPort[] getExposedPorts(InspectContainerResponse inspectContainer) {
+        return inspectContainer.getNetworkSettings().getPorts().getBindings().entrySet().stream()
+                .filter(e -> e.getValue() != null)
+                .flatMap(e -> Arrays.stream(e.getValue())
+                        .map(b -> new ContainerInfo.ContainerPort(b.getHostIp(),
+                                e.getKey().getPort(),
+                                Integer.parseInt(b.getHostPortSpec()),
+                                e.getKey().getProtocol().toString())))
+                .toArray(ContainerInfo.ContainerPort[]::new);
+    }
+
+    /**
+     * Get the environment variables for a container.
+     *
+     * @param inspectContainer The container info.
+     * @return A map of environment variables to their values.
+     */
+    public static Map<String, String> getContainerEnv(InspectContainerResponse inspectContainer) {
+        String[] env = inspectContainer.getConfig().getEnv();
+        if (env == null) {
+            return Collections.emptyMap();
+        }
+        return Arrays.stream(env)
+                .map(e -> e.split("=", 2))
+                .collect(Collectors.toMap(e -> e[0], e -> e.length > 1 ? e[1] : ""));
+    }
+
+    /**
+     * Get the environment variable configuration for a list of containers.
+     *
+     * @param instances A list of suppliers that provide the container info.
+     * @param envVarMappingHint A function that maps the container environment variable to config key.
+     * @return A map of config keys to their values.
+     */
+    public static Map<String, String> getEnvVarConfig(List<? extends Supplier<InspectContainerResponse>> instances,
+            Function<InspectContainerResponse, Map<String, String>> envVarMappingHint) {
+        Map<String, String> configs = new HashMap<>();
+        for (Supplier<InspectContainerResponse> containerResponseSupplier : instances) {
+            configs.putAll(getEnvVarConfig(containerResponseSupplier, envVarMappingHint));
+        }
+        return configs;
+    }
+
+    /**
+     * Get the environment variable configuration for a container.
+     *
+     * @param containerInfoSupplier A supplier that provides the container info.
+     * @param envVarMappingHint A function that maps the container environment variable to config key.
+     * @return A map of environment variables to their values.
+     */
+    public static Map<String, String> getEnvVarConfig(Supplier<InspectContainerResponse> containerInfoSupplier,
+            Function<InspectContainerResponse, Map<String, String>> envVarMappingHint) {
+        Map<String, String> configs = new HashMap<>();
+        InspectContainerResponse containerInfo = containerInfoSupplier.get();
+        // container env var -> env var
+        Map<String, String> mappings = envVarMappingHint.apply(containerInfo);
+        if (mappings != null && !mappings.isEmpty()) {
+            Map<String, String> containerEnv = getContainerEnv(containerInfo);
+            mappings.forEach((k, v) -> {
+                String value = containerEnv.get(k);
+                if (value != null) {
+                    configs.put(v, value);
+                }
+            });
+        }
+        return configs;
+    }
+
+    /**
+     * Get the port configuration for a list of containers.
+     *
+     * @param instances A list of suppliers that provide the container info.
+     * @param envVarMappingHint A function that maps the container port to a config key.
+     * @return A map of config keys to their values.
+     */
+    public static Map<String, String> getPortConfig(List<? extends Supplier<InspectContainerResponse>> instances,
+            Function<InspectContainerResponse, Map<Integer, String>> envVarMappingHint) {
+        Map<String, String> configs = new HashMap<>();
+        for (Supplier<InspectContainerResponse> containerResponseSupplier : instances) {
+            configs.putAll(getPortConfig(containerResponseSupplier, envVarMappingHint));
+        }
+        return configs;
+    }
+
+    /**
+     * Get the port configuration for a container.
+     *
+     * @param containerResponseSupplier A supplier that provides the container info.
+     * @param envVarMappingHint A function that maps the container port to a config key.
+     * @return A map of config keys to their values.
+     */
+    public static Map<String, String> getPortConfig(Supplier<InspectContainerResponse> containerResponseSupplier,
+            Function<InspectContainerResponse, Map<Integer, String>> envVarMappingHint) {
+        Map<String, String> configs = new HashMap<>();
+        InspectContainerResponse containerInfo = containerResponseSupplier.get();
+        // container port -> env var
+        Map<Integer, String> mappings = envVarMappingHint.apply(containerInfo);
+        if (mappings != null && !mappings.isEmpty()) {
+            mappings.forEach((containerPort, envVar) -> {
+                for (ContainerInfo.ContainerPort exposedPort : getExposedPorts(containerInfo)) {
+                    if (Objects.equals(exposedPort.privatePort(), containerPort)) {
+                        configs.put(envVar, String.valueOf(exposedPort.publicPort()));
+                        break;
+                    }
+                }
+            });
+        }
+        return configs;
+    }
+
+    public static String getShortId(String id) {
+        return id.length() > CONTAINER_SHORT_ID_LENGTH ? id.substring(0, CONTAINER_SHORT_ID_LENGTH) : id;
+    }
+}

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DatasourceServiceConfigurator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DatasourceServiceConfigurator.java
@@ -1,0 +1,29 @@
+package io.quarkus.devservices.common;
+
+import java.util.Map;
+
+import io.quarkus.runtime.util.StringUtil;
+
+public interface DatasourceServiceConfigurator {
+
+    default String getReactiveUrl(String jdbcUrl) {
+        return jdbcUrl.replaceFirst("jdbc:", "vertx-reactive:");
+    }
+
+    default String getJdbcUrl(ContainerAddress containerAddress, String databaseName) {
+        return String.format("jdbc:%s://%s:%d/%s%s",
+                getJdbcPrefix(),
+                containerAddress.getHost(),
+                containerAddress.getPort(),
+                databaseName,
+                getParameters(containerAddress.getRunningContainer().containerInfo().labels()));
+    }
+
+    String getJdbcPrefix();
+
+    default String getParameters(Map<String, String> labels) {
+        String parameters = labels.get(Labels.COMPOSE_JDBC_PARAMETERS);
+        return StringUtil.isNullOrEmpty(parameters) ? "" : "?" + parameters;
+    }
+
+}

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
@@ -6,6 +6,30 @@ import io.quarkus.datasource.common.runtime.DataSourceUtil;
 
 public final class Labels {
 
+    public static final String QUARKUS_DEV_SERVICE = "io.quarkus.devservice";
+    public static final String DOCKER_COMPOSE_PROJECT = "com.docker.compose.project";
+    public static final String DOCKER_COMPOSE_NETWORK = "com.docker.compose.network";
+    public static final String DOCKER_COMPOSE_SERVICE = "com.docker.compose.service";
+    public static final String DOCKER_COMPOSE_CONTAINER_NUMBER = "com.docker.compose.container-number";
+
+    public static final String QUARKUS_COMPOSE_PREFIX = "io.quarkus.devservices.compose";
+
+    public static final String COMPOSE_IGNORE = QUARKUS_COMPOSE_PREFIX + ".ignore";
+
+    public static final String COMPOSE_CONFIG_MAP = QUARKUS_COMPOSE_PREFIX + ".config_map";
+    public static final String COMPOSE_CONFIG_MAP_ENV_VAR = COMPOSE_CONFIG_MAP + ".env";
+    public static final String COMPOSE_CONFIG_MAP_PORT = COMPOSE_CONFIG_MAP + ".port";
+
+    public static final String COMPOSE_WAIT_FOR = QUARKUS_COMPOSE_PREFIX + ".wait_for";
+    public static final String COMPOSE_WAIT_FOR_LOGS = COMPOSE_WAIT_FOR + ".logs";
+    public static final String COMPOSE_WAIT_FOR_PORTS = COMPOSE_WAIT_FOR + ".ports";
+    public static final String COMPOSE_WAIT_FOR_PORTS_DISABLE = COMPOSE_WAIT_FOR_PORTS + ".disable";
+    public static final String COMPOSE_WAIT_FOR_PORTS_TIMEOUT = COMPOSE_WAIT_FOR_PORTS + ".timeout";
+
+    public static final String COMPOSE_JDBC_PARAMETERS = QUARKUS_COMPOSE_PREFIX + ".jdbc.parameters";
+
+    public static final String COMPOSE_EXPOSED_PORTS = QUARKUS_COMPOSE_PREFIX + ".exposed_ports";
+
     private static final String DATASOURCE = "datasource";
 
     public static void addDataSourceLabel(GenericContainer<?> container, String datasourceName) {

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DatasourceServiceConfigurator.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DatasourceServiceConfigurator.java
@@ -1,0 +1,42 @@
+package io.quarkus.devservices.db2.deployment;
+
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.RunningDevServicesDatasource;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.DatasourceServiceConfigurator;
+
+public class DB2DatasourceServiceConfigurator implements DatasourceServiceConfigurator {
+
+    private final static String[] USERNAME_ENVS = new String[] { "DB2INSTANCE" };
+
+    private final static String[] PASSWORD_ENVS = new String[] { "DB2INST1_PASSWORD" };
+
+    private final static String[] DATABASE_ENVS = new String[] { "DBNAME" };
+
+    public RunningDevServicesDatasource composeRunningService(ContainerAddress containerAddress,
+            DevServicesDatasourceContainerConfig containerConfig) {
+        RunningContainer container = containerAddress.getRunningContainer();
+        String effectiveDbName = containerConfig.getDbName().orElse(DEFAULT_DATABASE_NAME);
+        String effectiveUsername = containerConfig.getDbName().orElse(DEFAULT_DATABASE_USERNAME);
+        String effectivePassword = containerConfig.getDbName().orElse(DEFAULT_DATABASE_PASSWORD);
+        String jdbcUrl = getJdbcUrl(containerAddress, container.tryGetEnv(DATABASE_ENVS).orElse(effectiveDbName));
+        String reactiveUrl = getReactiveUrl(jdbcUrl);
+        return new RunningDevServicesDatasource(
+                containerAddress.getId(),
+                jdbcUrl,
+                reactiveUrl,
+                container.tryGetEnv(USERNAME_ENVS).orElse(effectiveUsername),
+                container.tryGetEnv(PASSWORD_ENVS).orElse(effectivePassword),
+                null);
+    }
+
+    @Override
+    public String getJdbcPrefix() {
+        return "db2";
+    }
+}

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -3,11 +3,13 @@ package io.quarkus.devservices.db2.deployment;
 import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
 import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
 import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+import static org.testcontainers.containers.Db2Container.DB2_PORT;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.Db2Container;
@@ -19,8 +21,10 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
@@ -32,9 +36,12 @@ public class DB2DevServicesProcessor {
 
     private static final Logger LOG = Logger.getLogger(DB2DevServicesProcessor.class);
 
+    private static final DB2DatasourceServiceConfigurator configurator = new DB2DatasourceServiceConfigurator();
+
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupDB2(
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             DevServicesConfig devServicesConfig) {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.DB2, new DevServicesDatasourceProvider() {
             @Override
@@ -44,41 +51,49 @@ public class DB2DevServicesProcessor {
 
                 boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                         devServicesSharedNetworkBuildItem);
-                QuarkusDb2Container container = new QuarkusDb2Container(containerConfig.getImageName(),
-                        containerConfig.getFixedExposedPort(),
-                        useSharedNetwork);
-                startupTimeout.ifPresent(container::withStartupTimeout);
-
                 String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
                 String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
                 String effectiveDbName = containerConfig.getDbName().orElse(
                         DataSourceUtil.isDefault(datasourceName) ? DEFAULT_DATABASE_NAME : datasourceName);
 
-                container.withUsername(effectiveUsername)
-                        .withPassword(effectivePassword)
-                        .withDatabaseName(effectiveDbName)
-                        .withReuse(containerConfig.isReuse());
-                Labels.addDataSourceLabel(container, datasourceName);
-                Volumes.addVolumes(container, containerConfig.getVolumes());
+                Supplier<RunningDevServicesDatasource> maybe = () -> {
+                    QuarkusDb2Container container = new QuarkusDb2Container(containerConfig.getImageName(),
+                            containerConfig.getFixedExposedPort(), composeProjectBuildItem.getDefaultNetworkId(),
+                            useSharedNetwork);
+                    startupTimeout.ifPresent(container::withStartupTimeout);
 
-                container.withEnv(containerConfig.getContainerEnv());
+                    container.withUsername(effectiveUsername)
+                            .withPassword(effectivePassword)
+                            .withDatabaseName(effectiveDbName)
+                            .withReuse(containerConfig.isReuse());
+                    Labels.addDataSourceLabel(container, datasourceName);
+                    Volumes.addVolumes(container, containerConfig.getVolumes());
 
-                containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
-                containerConfig.getCommand().ifPresent(container::setCommand);
-                containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
-                if (containerConfig.isShowLogs()) {
-                    container.withLogConsumer(new JBossLoggingConsumer(LOG));
-                }
-                container.start();
+                    container.withEnv(containerConfig.getContainerEnv());
 
-                LOG.info("Dev Services for IBM Db2 started.");
+                    containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
+                    containerConfig.getCommand().ifPresent(container::setCommand);
+                    containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
+                    if (containerConfig.isShowLogs()) {
+                        container.withLogConsumer(new JBossLoggingConsumer(LOG));
+                    }
+                    container.start();
 
-                return new RunningDevServicesDatasource(container.getContainerId(),
-                        container.getEffectiveJdbcUrl(),
-                        container.getReactiveUrl(),
-                        container.getUsername(),
-                        container.getPassword(),
-                        new ContainerShutdownCloseable(container, "IBM Db2"));
+                    LOG.info("Dev Services for IBM Db2 started.");
+
+                    return new RunningDevServicesDatasource(container.getContainerId(),
+                            container.getEffectiveJdbcUrl(),
+                            container.getReactiveUrl(),
+                            container.getUsername(),
+                            container.getPassword(),
+                            new ContainerShutdownCloseable(container, "IBM Db2"));
+                };
+                List<String> images = List.of(containerConfig.getImageName()
+                        .orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("db2")),
+                        "db2");
+                return ComposeLocator.locateContainer(composeProjectBuildItem, images, DB2_PORT, launchMode, useSharedNetwork)
+                        .map(containerAddress -> configurator.composeRunningService(containerAddress, containerConfig))
+                        .orElseGet(maybe);
             }
         });
     }
@@ -87,13 +102,15 @@ public class DB2DevServicesProcessor {
         private final OptionalInt fixedExposedPort;
         private final boolean useSharedNetwork;
 
-        private String hostName = null;
+        private final String hostName;
 
-        public QuarkusDb2Container(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
+        public QuarkusDb2Container(Optional<String> imageName, OptionalInt fixedExposedPort,
+                String defaultNetworkId, boolean useSharedNetwork) {
             super(DockerImageName.parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("db2")))
                     .asCompatibleSubstituteFor(DockerImageName.parse("icr.io/db2_community/db2")));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
+            this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "db2");
         }
 
         @Override
@@ -101,7 +118,6 @@ public class DB2DevServicesProcessor {
             super.configure();
 
             if (useSharedNetwork) {
-                hostName = ConfigureUtil.configureSharedNetwork(this, "db2");
                 return;
             }
 

--- a/extensions/devservices/deployment/pom.xml
+++ b/extensions/devservices/deployment/pom.xml
@@ -25,6 +25,15 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/ContainerLogForwarder.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/ContainerLogForwarder.java
@@ -49,7 +49,7 @@ public class ContainerLogForwarder implements Closeable {
                 if (running.get())
                     logger.errorf("[%s] %s", shortId, updateTimestamp(frame));
             });
-            DockerClientFactory.lazyClient().logContainerCmd(devService.getContainerInfo().getId())
+            DockerClientFactory.lazyClient().logContainerCmd(devService.getContainerInfo().id())
                     .withFollowStream(true)
                     .withStdErr(true)
                     .withStdOut(true)

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesLogsCommand.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesLogsCommand.java
@@ -43,7 +43,7 @@ public class DevServicesLogsCommand implements Command {
                 resultCallback.addConsumer(OutputFrame.OutputType.STDOUT,
                         frame -> commandInvocation.print(frame.getUtf8String()));
                 LogContainerCmd logCmd = DockerClientFactory.lazyClient()
-                        .logContainerCmd(desc.getContainerInfo().getId())
+                        .logContainerCmd(desc.getContainerInfo().id())
                         .withFollowStream(follow)
                         .withTail(tail)
                         .withStdErr(true)

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
@@ -1,0 +1,423 @@
+package io.quarkus.devservices.deployment.compose;
+
+import static io.quarkus.devservices.common.Labels.DOCKER_COMPOSE_PROJECT;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.ContainerRuntimeStatusBuildItem;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.deployment.builditem.DockerStatusBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
+import io.quarkus.deployment.console.StartupLogCompressor;
+import io.quarkus.deployment.dev.devservices.ComposeBuildTimeConfig;
+import io.quarkus.deployment.dev.devservices.ComposeDevServicesBuildTimeConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
+import io.quarkus.devservices.common.ContainerUtil;
+import io.quarkus.runtime.LaunchMode;
+import io.smallrye.mutiny.unchecked.Unchecked;
+
+/**
+ * Processor that starts the Compose dev services.
+ */
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
+public class ComposeDevServicesProcessor {
+
+    private static final Logger log = Logger.getLogger(ComposeDevServicesProcessor.class);
+
+    static final String PROJECT_PREFIX = "quarkus-devservices";
+    static final Pattern COMPOSE_FILE = Pattern.compile("(^docker-compose|^compose)(-dev(-)?service).*.(yml|yaml)");
+
+    static volatile ComposeRunningService runningCompose;
+    static volatile ComposeDevServiceCfg cfg;
+    static volatile boolean first = true;
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(Feature.COMPOSE);
+    }
+
+    @BuildStep
+    public void watchComposeFiles(ComposeBuildTimeConfig composeBuildTimeConfig,
+            BuildProducer<HotDeploymentWatchedFileBuildItem> producer) {
+        if (composeBuildTimeConfig.devservices().enabled()) {
+            composeBuildTimeConfig.devservices().files().ifPresentOrElse(files -> {
+                for (File file : filesFromConfigList(files)) {
+                    producer.produce(new HotDeploymentWatchedFileBuildItem(file.getAbsolutePath()));
+                }
+            }, () -> producer.produce(HotDeploymentWatchedFileBuildItem.builder()
+                    .setLocationPredicate(COMPOSE_FILE.asMatchPredicate())
+                    .build()));
+        }
+    }
+
+    @BuildStep
+    public DevServicesComposeProjectBuildItem config(
+            Executor buildExecutor,
+            ComposeBuildTimeConfig composeBuildTimeConfig,
+            ApplicationInfoBuildItem appInfo,
+            LaunchModeBuildItem launchMode,
+            Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
+            CuratedApplicationShutdownBuildItem closeBuildItem,
+            LoggingSetupBuildItem loggingSetupBuildItem,
+            DevServicesConfig devServicesConfig,
+            DockerStatusBuildItem dockerStatusBuildItem) throws IOException {
+
+        ComposeDevServiceCfg configuration = new ComposeDevServiceCfg(composeBuildTimeConfig.devservices());
+
+        if (runningCompose != null) {
+            boolean shouldShutdownTheBroker = !configuration.equals(cfg);
+            if (!shouldShutdownTheBroker) {
+                return runningCompose.toComposeBuildItem();
+            }
+            try {
+                runningCompose.close();
+            } finally {
+                runningCompose = null;
+                cfg = null;
+            }
+        }
+
+        StartupLogCompressor compressor = new StartupLogCompressor(
+                (launchMode.isTest() ? "(test) " : "") + "Compose Dev Services Starting:",
+                consoleInstalledBuildItem, loggingSetupBuildItem, s -> s.getName().startsWith("ducttape")
+                        || s.getName().equals("Process stdout") || s.getName().startsWith("build-"));
+        try {
+            runningCompose = startCompose(buildExecutor, configuration, appInfo.getName(),
+                    dockerStatusBuildItem, launchMode, devServicesConfig.timeout());
+            if (runningCompose == null) {
+                compressor.closeAndDumpCaptured();
+            } else {
+                compressor.close();
+            }
+        } catch (RuntimeException e) {
+            compressor.closeAndDumpCaptured();
+            throw e;
+        } catch (Throwable t) {
+            compressor.closeAndDumpCaptured();
+            throw new RuntimeException(t);
+        }
+
+        if (runningCompose == null) {
+            return new DevServicesComposeProjectBuildItem();
+        }
+
+        if (first) {
+            first = false;
+            Runnable closeTask = () -> {
+                if (runningCompose != null) {
+                    try {
+                        runningCompose.close();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                first = true;
+                runningCompose = null;
+                cfg = null;
+            };
+            closeBuildItem.addCloseTask(closeTask, true);
+        }
+        cfg = configuration;
+
+        return runningCompose.toComposeBuildItem();
+    }
+
+    @BuildStep
+    public DevServicesResultBuildItem toDevServicesResult(DevServicesComposeProjectBuildItem composeBuildItem) {
+        if (composeBuildItem.getProject() != null) {
+            return new DevServicesResultBuildItem(
+                    "Compose Dev Services",
+                    String.format("Project: %s, Services: %s", composeBuildItem.getProject(),
+                            String.join(", ", composeBuildItem.getComposeServices().keySet())),
+                    null,
+                    composeBuildItem.getConfig());
+        }
+        return null;
+    }
+
+    private ComposeRunningService startCompose(Executor buildExecutor, ComposeDevServiceCfg cfg,
+            String appName,
+            ContainerRuntimeStatusBuildItem dockerStatusBuildItem,
+            LaunchModeBuildItem launchMode,
+            Optional<Duration> timeout) {
+        if (!cfg.devServicesEnabled) {
+            // explicitly disabled
+            log.debug("Not starting Compose dev services, as it has been disabled in the config.");
+            return null;
+        }
+
+        if (cfg.files.isEmpty() && cfg.project == null) {
+            log.debug("Not starting Compose dev services, no compose files found or project name provided.");
+            return null;
+        }
+
+        if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
+            log.warn("Docker isn't working, not starting Compose dev services.");
+            return null;
+        }
+
+        ComposeFiles composeFiles = new ComposeFiles(cfg.files);
+        String projectName = (PROJECT_PREFIX + "-" + appName).toLowerCase();
+        if (launchMode.getLaunchMode() != LaunchMode.DEVELOPMENT && !cfg.reuseProjectForTests) {
+            projectName = projectName + "-" + RandomStringUtils.insecure().nextAlphabetic(6).toLowerCase();
+        } else {
+            if (cfg.project != null) {
+                projectName = cfg.project;
+            } else if (composeFiles.getProjectName() != null) {
+                projectName = composeFiles.getProjectName();
+            }
+        }
+
+        ComposeProject.Builder builder = new ComposeProject.Builder(composeFiles, getComposeExecutable())
+                .withProject(projectName)
+                .withEnv(cfg.envVariables)
+                .withStopContainers(cfg.stopServices)
+                .withRyukEnabled(cfg.ryukEnabled)
+                .withProfiles(cfg.profiles)
+                .withOptions(cfg.options)
+                .withRemoveImages(cfg.removeImages)
+                .withRemoveVolumes(cfg.removeVolumes)
+                .withFollowContainerLogs(cfg.followContainerLogs)
+                .withScalingPreferences(cfg.scalingPreferences)
+                .withStopTimeout(cfg.stopTimeout)
+                .withBuild(cfg.build);
+
+        timeout.ifPresent(builder::withStartupTimeout);
+        ComposeProject compose = builder.build();
+
+        // if compose is configured to not start services, only try discovering existing services
+        if (!cfg.startServices) {
+            log.infof("Discovering existing Compose services for project %s", compose.getProject());
+            // discover existing services
+            compose.discoverServiceInstances(true);
+            if (!compose.getServices().isEmpty()) {
+                return new ComposeRunningService(compose, false);
+            } else {
+                return null;
+            }
+        }
+        // try discovering existing services, without checking for required services
+        compose.discoverServiceInstances(false);
+        if (!compose.getServices().isEmpty()) {
+            // if services are discovered, and compose files are defined, wait and check for them to be ready
+            if (!cfg.files.isEmpty()) {
+                compose.waitUntilServicesReady(buildExecutor);
+            }
+            log.infof("Discovered existing Compose services for project %s", compose.getProject());
+            return new ComposeRunningService(compose, false);
+        }
+        // failed discovering existing services, no compose files found
+        if (cfg.files.isEmpty()) {
+            log.debug("Could not find any compose files, not starting Compose dev services");
+            return null;
+        }
+
+        // Start compose
+        try {
+            compose.start();
+        } catch (Exception e) {
+            log.warnf("Could not start successfully Compose dev services for project %s, reason: %s",
+                    compose.getProject(), e.getMessage());
+            if (cfg.stopServices) {
+                try {
+                    compose.stop();
+                } catch (Exception e1) {
+                    log.error("Failed to stop Compose dev services", e1);
+                }
+            }
+            throw e;
+        }
+        // Wait for services to be ready
+        compose.waitUntilServicesReady(buildExecutor);
+        return new ComposeRunningService(compose, true);
+    }
+
+    private static class ComposeRunningService extends RunningDevService {
+
+        private final Map<String, List<RunningContainer>> composeServices;
+        private final String defaultNetworkId;
+
+        public ComposeRunningService(ComposeProject compose, boolean isOwner) {
+            super(compose.getProject(), "compose", null, isOwner ? compose::stop : null, configs(compose));
+            this.composeServices = composeServices(compose);
+            this.defaultNetworkId = compose.getDefaultNetworkId();
+        }
+
+        static Map<String, String> configs(ComposeProject compose) {
+            Map<String, String> configs = new HashMap<>();
+            configs.putAll(compose.getEnvVarConfig());
+            configs.putAll(compose.getExposedPortConfig());
+            configs.put(DOCKER_COMPOSE_PROJECT, compose.getProject());
+            return configs;
+        }
+
+        static Map<String, List<RunningContainer>> composeServices(ComposeProject compose) {
+            return compose.getServices().stream()
+                    .collect(Collectors.groupingBy(ComposeServiceWaitStrategyTarget::getServiceName,
+                            Collectors.mapping(s -> ContainerUtil.toRunningContainer(s.getContainerInfo()),
+                                    Collectors.toList())));
+        }
+
+        public DevServicesComposeProjectBuildItem toComposeBuildItem() {
+            return new DevServicesComposeProjectBuildItem(getName(), defaultNetworkId, composeServices, getConfig());
+        }
+    }
+
+    private String getComposeExecutable() {
+        return ContainerRuntimeUtil.detectContainerRuntime().getExecutableName()
+                + (SystemUtils.IS_OS_WINDOWS ? ".exe" : "");
+    }
+
+    static boolean isComposeFile(Path p) {
+        return COMPOSE_FILE.matcher(p.getFileName().toString()).matches();
+    }
+
+    static Path getProjectRoot() {
+        String gradlePath = System.getProperty("gradle.project.path");
+        if (gradlePath != null) {
+            return Path.of(gradlePath);
+        } else {
+            return Paths.get(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+        }
+    }
+
+    static List<File> filesFromConfigList(List<String> l) {
+        return l.stream()
+                .map(f -> getProjectRoot().resolve(f).toAbsolutePath().normalize())
+                .map(Path::toFile)
+                .collect(Collectors.toList());
+    }
+
+    static List<File> collectComposeFilesFromProjectRoot() throws RuntimeException {
+        try (Stream<Path> list = Files.list(getProjectRoot().toAbsolutePath().normalize())) {
+            return list
+                    .filter(ComposeDevServicesProcessor::isComposeFile)
+                    .map(Path::toFile)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class ComposeDevServiceCfg {
+        private final boolean devServicesEnabled;
+        private final String project;
+        private final boolean startServices;
+        private final boolean stopServices;
+        private final Duration stopTimeout;
+        private final boolean ryukEnabled;
+        private final List<File> files;
+        private final List<String> profiles;
+        private final List<String> options;
+        private final String removeImages;
+        private final Boolean build;
+        private final boolean removeVolumes;
+        private final boolean followContainerLogs;
+        private final Map<String, String> envVariables;
+        private final Map<String, Integer> scalingPreferences;
+        private final boolean reuseProjectForTests;
+        private final String filesSha;
+
+        public ComposeDevServiceCfg(ComposeDevServicesBuildTimeConfig cfg) {
+            this.devServicesEnabled = cfg.enabled();
+            this.files = cfg.files()
+                    .map(ComposeDevServicesProcessor::filesFromConfigList)
+                    .orElseGet(ComposeDevServicesProcessor::collectComposeFilesFromProjectRoot);
+            MessageDigest md;
+            try {
+                md = MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException(e);
+            }
+            Base64.Encoder encoder = Base64.getEncoder();
+            this.filesSha = this.files.stream().sorted()
+                    .map(Unchecked.function(f -> Files.readAllBytes(f.toPath())))
+                    .map(md::digest)
+                    .map(encoder::encodeToString)
+                    .collect(Collectors.joining());
+            this.project = cfg.projectName().orElse(null);
+            this.startServices = cfg.startServices();
+            this.stopServices = cfg.stopServices();
+            this.stopTimeout = cfg.stopTimeout();
+            this.ryukEnabled = cfg.ryukEnabled();
+            this.profiles = cfg.profiles().orElse(Collections.emptyList());
+            this.options = cfg.options().orElse(Collections.emptyList());
+            this.removeImages = cfg.removeImages().map(Enum::name).map(String::toLowerCase).orElse(null);
+            this.removeVolumes = cfg.removeVolumes();
+            this.envVariables = cfg.envVariables();
+            this.scalingPreferences = cfg.scale();
+            this.followContainerLogs = cfg.followContainerLogs();
+            this.reuseProjectForTests = cfg.reuseProjectForTests();
+            this.build = cfg.build().orElse(null);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            ComposeDevServiceCfg that = (ComposeDevServiceCfg) o;
+            return devServicesEnabled == that.devServicesEnabled
+                    && Objects.equals(project, that.project)
+                    && Objects.equals(startServices, that.startServices)
+                    && Objects.equals(stopServices, that.stopServices)
+                    && Objects.equals(ryukEnabled, that.ryukEnabled)
+                    && Objects.equals(files, that.files)
+                    && Objects.equals(filesSha, that.filesSha)
+                    && Objects.equals(profiles, that.profiles)
+                    && Objects.equals(options, that.options)
+                    && Objects.equals(removeImages, that.removeImages)
+                    && Objects.equals(removeVolumes, that.removeVolumes)
+                    && Objects.equals(followContainerLogs, that.followContainerLogs)
+                    && Objects.equals(build, that.build)
+                    && Objects.equals(envVariables, that.envVariables)
+                    && Objects.equals(scalingPreferences, that.scalingPreferences)
+                    && Objects.equals(reuseProjectForTests, that.reuseProjectForTests);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(devServicesEnabled, project, startServices, stopServices, ryukEnabled, files, filesSha,
+                    profiles, options, removeImages, removeVolumes,
+                    followContainerLogs, build, envVariables, scalingPreferences, reuseProjectForTests);
+        }
+    }
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeFile.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeFile.java
@@ -1,0 +1,77 @@
+package io.quarkus.devservices.deployment.compose;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+/**
+ * Representation of a docker-compose file, with partial parsing for validation and extraction of a minimal set of
+ * data.
+ */
+public class ComposeFile {
+
+    private static final Logger log = Logger.getLogger(ComposeFile.class);
+
+    private final Map<String, Object> composeFileContent;
+
+    private final String composeFileName;
+
+    private final Map<String, ComposeServiceDefinition> serviceNameToDefinition = new HashMap<>();
+
+    public ComposeFile(File composeFile) {
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+        try (FileInputStream fileInputStream = new FileInputStream(composeFile)) {
+            composeFileContent = yaml.load(fileInputStream);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to parse YAML file from " + composeFile.getAbsolutePath(), e);
+        }
+        this.composeFileName = composeFile.getAbsolutePath();
+        parseAndValidate();
+    }
+
+    public String getProjectName() {
+        return (String) composeFileContent.get("name");
+    }
+
+    private void parseAndValidate() {
+        final Map<String, ?> servicesMap;
+        if (composeFileContent.containsKey("version")) {
+            log.warn("The 'version' property is deprecated in docker-compose files. It will be ignored.");
+        }
+
+        final Object servicesElement = composeFileContent.get("services");
+        if (servicesElement == null) {
+            log.debugv("Compose file {0} has an unknown format: 'services' is not defined", composeFileName);
+            servicesMap = composeFileContent;
+        } else if (!(servicesElement instanceof Map)) {
+            log.debugv("Compose file {0} has an unknown format: 'services' is not Map", composeFileName);
+            return;
+        } else {
+            servicesMap = (Map<String, ?>) servicesElement;
+        }
+
+        for (Map.Entry<String, ?> entry : servicesMap.entrySet()) {
+            String serviceName = entry.getKey();
+            Object serviceDefinition = entry.getValue();
+            if (!(serviceDefinition instanceof Map)) {
+                log.debugv("Compose file {0} has an unknown format: service '{0}' is not Map, it will be ignored.",
+                        composeFileName, serviceName);
+                continue;
+            }
+
+            final Map<String, ?> serviceDefinitionMap = (Map) serviceDefinition;
+            serviceNameToDefinition.put(serviceName, new ComposeServiceDefinition(serviceName, serviceDefinitionMap));
+        }
+    }
+
+    public Map<String, ComposeServiceDefinition> getServiceDefinitions() {
+        return serviceNameToDefinition;
+    }
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeFiles.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeFiles.java
@@ -1,0 +1,50 @@
+package io.quarkus.devservices.deployment.compose;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ComposeFiles {
+
+    private final Map<String, ComposeServiceDefinition> serviceDefinitions;
+
+    private final String projectName;
+    private final List<File> files;
+
+    public ComposeFiles(List<File> composeFiles) {
+        this.serviceDefinitions = new HashMap<>();
+        this.files = composeFiles;
+        String name = null;
+        for (File composeFile : composeFiles) {
+            ComposeFile compose = new ComposeFile(composeFile);
+            for (Map.Entry<String, ComposeServiceDefinition> service : compose.getServiceDefinitions().entrySet()) {
+                if (this.serviceDefinitions.containsKey(service.getKey())) {
+                    throw new IllegalArgumentException("Service name conflict: " + service.getKey());
+                }
+                this.serviceDefinitions.put(service.getKey(), service.getValue());
+            }
+            if (name == null) {
+                name = compose.getProjectName();
+            }
+        }
+        projectName = name;
+    }
+
+    public Set<String> getAllServiceNames() {
+        return serviceDefinitions.keySet();
+    }
+
+    public Map<String, ComposeServiceDefinition> getServiceDefinitions() {
+        return serviceDefinitions;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public List<File> getFiles() {
+        return files;
+    }
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeProject.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeProject.java
@@ -1,0 +1,650 @@
+package io.quarkus.devservices.deployment.compose;
+
+import static io.quarkus.devservices.common.Labels.*;
+import static java.lang.Boolean.TRUE;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.output.FrameConsumerResultCallback;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.ResourceReaper;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.Network;
+
+import io.quarkus.devservices.common.ContainerUtil;
+import io.quarkus.devservices.common.JBossLoggingConsumer;
+import io.quarkus.runtime.util.StringUtil;
+
+/**
+ * A wrapper around compose that starts and stops services defined a set of compose files.
+ */
+public class ComposeProject {
+
+    private static final Logger LOG = Logger.getLogger(ComposeProject.class);
+    public static final String DEFAULT_NETWORK_NAME = "default";
+
+    private final DockerClient dockerClient;
+    private final ComposeFiles composeFiles;
+    private final String project;
+    private final String executable;
+
+    private final Duration startupTimeout;
+    private final Duration stopTimeout;
+    private final boolean stopContainers;
+    private final boolean ryukEnabled;
+    private final boolean followContainerLogs;
+    private final Boolean build;
+    private final List<String> options;
+    private final List<String> profiles;
+    private final Map<String, Integer> scalingPreferences;
+    private final Map<String, String> env;
+    private final boolean removeVolumes;
+    private final String removeImages;
+
+    private final Map<String, WaitAllStrategy> waitStrategies;
+
+    private List<ComposeServiceWaitStrategyTarget> serviceInstances;
+    private List<Network> networks;
+
+    public ComposeProject(DockerClient dockerClient,
+            ComposeFiles composeFiles,
+            String executable,
+            String project,
+            Duration startupTimeout,
+            Duration stopTimeout,
+            boolean stopContainers,
+            boolean ryukEnabled,
+            boolean followContainerLogs,
+            boolean removeVolumes,
+            String removeImages,
+            Boolean build,
+            List<String> options,
+            List<String> profiles,
+            Map<String, Integer> scalingPreferences,
+            Map<String, String> env) {
+        this.dockerClient = dockerClient;
+        this.composeFiles = composeFiles;
+        this.project = project;
+        this.executable = executable;
+        this.startupTimeout = startupTimeout;
+        this.stopTimeout = stopTimeout;
+        this.stopContainers = stopContainers;
+        this.ryukEnabled = ryukEnabled;
+        this.followContainerLogs = followContainerLogs;
+        this.options = options;
+        this.profiles = profiles;
+        this.scalingPreferences = scalingPreferences;
+        this.env = env;
+        this.removeVolumes = removeVolumes;
+        this.removeImages = removeImages;
+        this.build = build;
+
+        this.waitStrategies = new HashMap<>();
+        registerWaitStrategies(composeFiles, waitStrategies);
+    }
+
+    /**
+     * can have multiple wait strategies for a single container, e.g. if waiting on several ports
+     * if no wait strategy is defined, the WaitAllStrategy will return immediately.
+     * The WaitAllStrategy uses the startup timeout for everything as a global maximum, but we expect timeouts to be handled by
+     * the inner strategies.
+     */
+    public void addWaitStrategy(Map<String, WaitAllStrategy> strategies, String instanceName, WaitStrategy strategy) {
+        strategies.computeIfAbsent(instanceName,
+                ignored -> new WaitAllStrategy(WaitAllStrategy.Mode.WITH_MAXIMUM_OUTER_TIMEOUT)
+                        .withStartupTimeout(startupTimeout))
+                .withStrategy(strategy);
+        LOG.debugv("Added wait strategy {0} for service {1}", strategy, instanceName);
+    }
+
+    private void registerWaitStrategies(ComposeFiles composeFiles,
+            Map<String, WaitAllStrategy> waitStrategies) {
+        // Iterate over service definitions
+        for (ComposeServiceDefinition definition : composeFiles.getServiceDefinitions().values()) {
+            String serviceName = definition.getServiceName();
+            Map<String, Object> labels = definition.getLabels();
+            // Skip the service if profiles doesn't match
+            if (!definition.getProfiles().isEmpty() &&
+                    definition.getProfiles().stream().noneMatch(profiles::contains)) {
+                continue;
+            }
+            // Add wait for health check
+            if (definition.hasHealthCheck()) {
+                addWaitStrategy(waitStrategies, serviceName, Wait.forHealthcheck());
+            } else {
+                for (Map.Entry<String, Object> e : labels.entrySet()) {
+                    // Add wait for log message
+                    if (e.getKey().startsWith(COMPOSE_WAIT_FOR_LOGS)) {
+                        int times = 1;
+                        if (e.getKey().length() > COMPOSE_WAIT_FOR_LOGS.length()) {
+                            try {
+                                times = Integer.parseInt(e.getKey().replace(COMPOSE_WAIT_FOR_LOGS + ".", ""));
+                            } catch (NumberFormatException t) {
+                                LOG.warnv("Cannot parse label `{}`", e.getKey());
+                            }
+                        }
+                        addWaitStrategy(waitStrategies, serviceName, Wait.forLogMessage((String) e.getValue(), times));
+                    }
+                }
+                // Add wait for port availability
+                if (labels.get(COMPOSE_WAIT_FOR_PORTS_DISABLE) != TRUE) {
+                    int[] ports = definition.getPorts().stream().mapToInt(ExposedPort::getPort).toArray();
+                    String waitForTimeout = (String) labels.get(COMPOSE_WAIT_FOR_PORTS_TIMEOUT);
+                    Duration timeout = waitForTimeout != null ? Duration.parse("PT" + waitForTimeout) : startupTimeout;
+                    addWaitStrategy(waitStrategies, serviceName, Wait.forListeningPorts(ports).withStartupTimeout(timeout));
+                }
+            }
+        }
+    }
+
+    /**
+     * @return the project name
+     */
+    public String getProject() {
+        return project;
+    }
+
+    // Visible for testing
+    Map<String, WaitAllStrategy> getWaitStrategies() {
+        return waitStrategies;
+    }
+
+    public synchronized void start() {
+        registerContainersForShutdown();
+        startServices();
+        discoverServiceInstances(true);
+    }
+
+    public void waitUntilServicesReady(Executor waitOn) {
+        checkServicesStarted();
+        copyExposedPortsToContainers();
+        CompletableFuture.allOf(serviceInstances.stream()
+                .map(srv -> waitOnThread(srv, waitOn))
+                .toArray(CompletableFuture[]::new))
+                .join();
+    }
+
+    private void copyExposedPortsToContainers() {
+        for (ComposeServiceWaitStrategyTarget instance : serviceInstances) {
+            InspectContainerResponse inspectContainer = instance.get();
+            Map<String, String> labels = inspectContainer.getConfig().getLabels();
+            if (labels != null) {
+                String exposedPortsPath = labels.get(COMPOSE_EXPOSED_PORTS);
+                if (exposedPortsPath != null) {
+                    String ports = inspectContainer.getNetworkSettings().getPorts().getBindings().entrySet().stream()
+                            .filter(e -> e.getValue() != null)
+                            .flatMap(e -> Arrays.stream(e.getValue())
+                                    .map(c -> String.format("PORT_%d=%s", e.getKey().getPort(), c.getHostPortSpec())))
+                            .collect(Collectors.joining("\n", "", "\n"));
+                    if (!StringUtil.isNullOrEmpty(ports)) {
+                        instance.copyFileToContainer(Transferable.of(ports.getBytes(StandardCharsets.UTF_8)),
+                                exposedPortsPath);
+                    }
+                }
+            }
+        }
+    }
+
+    public void startAndWaitUntilServicesReady(Executor waitOn) {
+        start();
+        waitUntilServicesReady(waitOn);
+    }
+
+    private void checkServicesStarted() {
+        if (serviceInstances == null || serviceInstances.isEmpty()) {
+            throw new IllegalStateException("Services have not been started yet");
+        }
+    }
+
+    private CompletableFuture<Void> waitOnThread(ComposeServiceWaitStrategyTarget instance, Executor waitOn) {
+        if (waitOn == null) {
+            return CompletableFuture.runAsync(() -> waitUntilReady(instance));
+        } else {
+            return CompletableFuture.runAsync(() -> waitUntilReady(instance), waitOn);
+        }
+    }
+
+    private void waitUntilReady(ComposeServiceWaitStrategyTarget instance) {
+        String serviceName = instance.getServiceName();
+        final WaitStrategy strategy = waitStrategies.get(serviceName);
+        if (strategy != null) {
+            LOG.infov("Waiting for service {0} to be ready", serviceName);
+            try {
+                strategy.waitUntilReady(instance);
+            } catch (Exception e) {
+                LOG.infov("Service {0} not ready, logs: {1}", serviceName, instance.getLogs());
+                throw e;
+            }
+            LOG.infov("Service {0} is ready", serviceName);
+        }
+    }
+
+    private void registerContainersForShutdown() {
+        if (ryukEnabled) {
+            ResourceReaper
+                    .instance()
+                    .registerLabelsFilterForCleanup(Collections.singletonMap(DOCKER_COMPOSE_PROJECT, project));
+        }
+    }
+
+    private void startServices() {
+        // scaling for the services
+        final String scalingOptions = scalingPreferences
+                .entrySet()
+                .stream()
+                .map(entry -> "--scale " + entry.getKey() + "=" + entry.getValue())
+                .distinct()
+                .collect(Collectors.joining(" "));
+
+        String command = getUpCommand(getOptions());
+
+        if (build != null) {
+            if (build) {
+                command += " --build";
+            } else {
+                command += " --no-build";
+            }
+        }
+
+        if (!StringUtil.isNullOrEmpty(scalingOptions)) {
+            command += " " + scalingOptions;
+        }
+
+        // Run the docker compose container, which starts up the services
+        runWithCompose(command, env);
+    }
+
+    public synchronized void discoverServiceInstances(boolean checkForRequiredServices) {
+        Set<String> servicesToWaitFor = new HashSet<>(waitStrategies.keySet());
+        List<ComposeServiceWaitStrategyTarget> serviceInstances = new ArrayList<>();
+        for (Container container : listChildContainers()) {
+            String state = container.getState();
+            if ("running".equalsIgnoreCase(state) || "restarting".equalsIgnoreCase(state)) {
+                ComposeServiceWaitStrategyTarget instance = createServiceInstance(container, followContainerLogs);
+                serviceInstances.add(instance);
+                servicesToWaitFor.remove(instance.getServiceName());
+            }
+        }
+
+        if (checkForRequiredServices && !servicesToWaitFor.isEmpty()) {
+            throw new IllegalStateException("Services named " + servicesToWaitFor +
+                    " do not exist, but wait conditions have been defined for them.");
+        }
+
+        this.networks = listChildNetworks();
+        this.serviceInstances = serviceInstances;
+    }
+
+    private List<Container> listChildContainers() {
+        return dockerClient
+                .listContainersCmd()
+                .withLabelFilter(Map.of(DOCKER_COMPOSE_PROJECT, project))
+                .withShowAll(true)
+                .exec();
+    }
+
+    private List<Network> listChildNetworks() {
+        return dockerClient
+                .listNetworksCmd()
+                .withFilter("label", List.of(DOCKER_COMPOSE_PROJECT + "=" + project))
+                .exec();
+    }
+
+    private ComposeServiceWaitStrategyTarget createServiceInstance(Container container, boolean tailChildContainers) {
+        var containerInstance = new ComposeServiceWaitStrategyTarget(dockerClient, container);
+        if (tailChildContainers) {
+            String containerId = containerInstance.getContainerId();
+            String serviceName = containerInstance.getContainerName();
+            followLogs(containerId, new JBossLoggingConsumer(LOG)
+                    .withPrefix(serviceName)
+                    .withSeparateOutputStreams());
+        }
+        return containerInstance;
+    }
+
+    private void followLogs(String containerId, Consumer<OutputFrame> consumer) {
+        FrameConsumerResultCallback callback = new FrameConsumerResultCallback();
+        callback.addConsumer(OutputFrame.OutputType.STDOUT, consumer);
+        callback.addConsumer(OutputFrame.OutputType.STDERR, consumer);
+        dockerClient.logContainerCmd(containerId)
+                .withFollowStream(true)
+                .withStdErr(true)
+                .withStdOut(true)
+                .withSince(0)
+                .exec(callback);
+    }
+
+    /**
+     * Stops the services defined in the docker-compose file.
+     */
+    public synchronized void stop() {
+        if (!stopContainers) {
+            LOG.infov("Skipping compose down for project {0}", project);
+            return;
+        }
+        String cmd = getDownCommand(getOptions());
+
+        if (removeVolumes) {
+            cmd += " -v";
+        }
+        // rmi option not available in podman-compose
+        if (!isExecutablePodman() && !StringUtil.isNullOrEmpty(removeImages)) {
+            cmd += " --rmi " + removeImages;
+        }
+        // Set the timeout for stopping the services
+        cmd += " -t " + stopTimeout.getSeconds();
+        // Run the docker compose container, which stops the services
+        try {
+            runWithCompose(cmd, env);
+        } finally {
+            this.networks = null;
+            this.serviceInstances = null;
+        }
+    }
+
+    private boolean isExecutablePodman() {
+        return executable.contains("podman");
+    }
+
+    private String getUpCommand(String options) {
+        return StringUtil.isNullOrEmpty(options) ? "compose up -d" : String.format("compose %s up -d", options);
+    }
+
+    private String getDownCommand(String options) {
+        return StringUtil.isNullOrEmpty(options) ? "compose down" : String.format("compose %s down", options);
+    }
+
+    private String getOptions() {
+        return String.join(" ", this.options);
+    }
+
+    public void runWithCompose(String cmd, Map<String, String> env) {
+        new ComposeRunner(executable, composeFiles.getFiles(), project)
+                .withCommand(cmd)
+                .withEnv(env)
+                .withProfiles(profiles)
+                .run();
+    }
+
+    public List<ComposeServiceWaitStrategyTarget> getServices() {
+        return serviceInstances;
+    }
+
+    public Map<String, String> getEnvVarConfig() {
+        checkServicesStarted();
+        return ContainerUtil.getEnvVarConfig(serviceInstances, ComposeProject::getEnvVarMappings);
+    }
+
+    public Map<String, String> getExposedPortConfig() {
+        checkServicesStarted();
+        return ContainerUtil.getPortConfig(serviceInstances, ComposeProject::getHostPortMappings);
+    }
+
+    private static Map<Integer, String> getHostPortMappings(InspectContainerResponse containerInfo) {
+        Map<String, String> labels = containerInfo.getConfig().getLabels();
+        if (labels == null) {
+            return Collections.emptyMap();
+        }
+        return labels.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(COMPOSE_CONFIG_MAP_PORT)
+                        && e.getKey().length() > COMPOSE_CONFIG_MAP_PORT.length() + 1
+                        && !StringUtil.isNullOrEmpty(e.getValue()))
+                .collect(Collectors.toMap(ComposeProject::getContainerPort, Map.Entry::getValue));
+    }
+
+    private static int getContainerPort(Map.Entry<String, String> e) {
+        return Integer.parseInt(e.getKey().substring(COMPOSE_CONFIG_MAP_PORT.length() + 1));
+    }
+
+    private static Map<String, String> getEnvVarMappings(InspectContainerResponse containerInfo) {
+        Map<String, String> labels = containerInfo.getConfig().getLabels();
+        if (labels == null) {
+            return Collections.emptyMap();
+        }
+        return labels.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(COMPOSE_CONFIG_MAP_ENV_VAR)
+                        && e.getKey().length() > COMPOSE_CONFIG_MAP_ENV_VAR.length() + 1)
+                .collect(Collectors.toMap(ComposeProject::getVarName,
+                        e -> StringUtil.isNullOrEmpty(e.getValue()) ? getVarName(e) : e.getValue()));
+    }
+
+    private static String getVarName(Map.Entry<String, String> e) {
+        return e.getKey().substring(COMPOSE_CONFIG_MAP_ENV_VAR.length() + 1);
+    }
+
+    public List<Network> getNetworks() {
+        return networks;
+    }
+
+    public String getDefaultNetworkId() {
+        return networks.stream()
+                .filter(n -> DEFAULT_NETWORK_NAME.equals(n.getLabels().get(DOCKER_COMPOSE_NETWORK)))
+                // multiple networks can have the default label, but only one can have containers
+                .filter(n -> !n.getContainers().isEmpty())
+                .findFirst()
+                .map(Network::getId)
+                // this is not an id, but a useful fallback
+                .orElse(project + "_" + DEFAULT_NETWORK_NAME);
+    }
+
+    public static class Builder {
+
+        private final ComposeFiles files;
+        private final String executable;
+        private DockerClient dockerClient = DockerClientFactory.lazyClient();
+        private String project;
+        private Duration startupTimeout = Duration.ofMinutes(1);
+        private Duration stopTimeout;
+        private boolean stopContainers = true;
+        private boolean ryukEnabled = true;
+        private boolean followContainerLogs = false;
+        private boolean removeVolumes = true;
+        private Boolean build;
+        private String removeImages;
+        private List<String> options = Collections.emptyList();
+        private List<String> profiles = Collections.emptyList();
+        private Map<String, String> env = Collections.emptyMap();
+        private Map<String, Integer> scalingPreferences = Collections.emptyMap();
+
+        public Builder(ComposeFiles files, String executable) {
+            this.files = files;
+            this.project = files.getProjectName();
+            this.executable = executable;
+        }
+
+        /**
+         * Set the docker client to use for the compose project.
+         *
+         * @param dockerClient the docker client to use
+         * @return this
+         */
+        public Builder withDockerClient(DockerClient dockerClient) {
+            this.dockerClient = dockerClient;
+            return this;
+        }
+
+        /**
+         * Set whether to stop containers when the project is stopped.
+         *
+         * @param stopContainers whether to stop containers when the project is stopped
+         * @return this
+         */
+        public Builder withStopContainers(boolean stopContainers) {
+            this.stopContainers = stopContainers;
+            return this;
+        }
+
+        /**
+         * Set whether to stop containers when the project is stopped.
+         *
+         * @param ryukEnabled whether to stop containers when the project is stopped
+         * @return this
+         */
+        public Builder withRyukEnabled(boolean ryukEnabled) {
+            this.ryukEnabled = ryukEnabled;
+            return this;
+        }
+
+        /**
+         * Set the startup timeout for the compose project.
+         *
+         * @param duration the startup timeout
+         * @return this
+         */
+        public Builder withStartupTimeout(Duration duration) {
+            this.startupTimeout = duration;
+            return this;
+        }
+
+        /**
+         * Set the stop timeout for the compose project.
+         *
+         * @param duration the startup timeout
+         * @return this
+         */
+        public Builder withStopTimeout(Duration duration) {
+            this.stopTimeout = duration;
+            return this;
+        }
+
+        /**
+         * Set whether to build the images before starting the compose project.
+         *
+         * @param build whether to build the images before starting the compose project
+         * @return this
+         */
+        public Builder withBuild(Boolean build) {
+            this.build = build;
+            return this;
+        }
+
+        /**
+         * Set environment variables to pass to the compose command.
+         *
+         * @param envVariables the environment variables to pass to the compose command
+         * @return this
+         */
+        public Builder withEnv(Map<String, String> envVariables) {
+            this.env = envVariables;
+            return this;
+        }
+
+        /**
+         * Set the options to pass to the compose command.
+         *
+         * @param options the options to pass to the compose command
+         * @return this
+         */
+        public Builder withOptions(List<String> options) {
+            this.options = Collections.unmodifiableList(options);
+            return this;
+        }
+
+        /**
+         * Set the profiles for the compose project.
+         *
+         * @param profiles the profiles for the compose project
+         * @return this
+         */
+        public Builder withProfiles(List<String> profiles) {
+            this.profiles = Collections.unmodifiableList(profiles);
+            return this;
+        }
+
+        /**
+         * Set the scaling preferences for the compose project.
+         *
+         * @param scalingPreferences the scaling preferences for the compose project
+         * @return this
+         */
+        public Builder withScalingPreferences(Map<String, Integer> scalingPreferences) {
+            this.scalingPreferences = Collections.unmodifiableMap(scalingPreferences);
+            return this;
+        }
+
+        /**
+         * Set whether to follow the container logs.
+         *
+         * @param followContainerLogs whether to follow the container logs
+         * @return this
+         */
+        public Builder withFollowContainerLogs(boolean followContainerLogs) {
+            this.followContainerLogs = followContainerLogs;
+            return this;
+        }
+
+        /**
+         * Remove images after containers shutdown.
+         *
+         * @return this instance, for chaining
+         */
+        public Builder withRemoveImages(String removeImages) {
+            this.removeImages = removeImages;
+            return this;
+        }
+
+        /**
+         * Remove volumes after containers shut down.
+         *
+         * @param removeVolumes whether volumes are to be removed.
+         * @return this instance, for chaining.
+         */
+        public Builder withRemoveVolumes(boolean removeVolumes) {
+            this.removeVolumes = removeVolumes;
+            return this;
+        }
+
+        /**
+         * Set the project name for the compose project.
+         *
+         * @param project the project name for the compose project
+         * @return this
+         */
+        public Builder withProject(String project) {
+            this.project = project;
+            return this;
+        }
+
+        public ComposeProject build() {
+            return new ComposeProject(dockerClient, files,
+                    executable,
+                    project,
+                    startupTimeout,
+                    stopTimeout,
+                    stopContainers,
+                    ryukEnabled,
+                    followContainerLogs,
+                    removeVolumes,
+                    removeImages,
+                    build,
+                    options,
+                    profiles,
+                    scalingPreferences,
+                    env);
+        }
+    }
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeRunner.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeRunner.java
@@ -1,0 +1,135 @@
+package io.quarkus.devservices.deployment.compose;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.dockerclient.TransportConfig;
+import org.testcontainers.utility.CommandLine;
+
+import io.quarkus.deployment.util.ExecUtil;
+
+/**
+ * A class that runs compose commands.
+ */
+public class ComposeRunner {
+
+    private static final Logger LOG = Logger.getLogger(ComposeRunner.class);
+
+    private static final String DOCKER_HOST_ENV = "DOCKER_HOST";
+    private static final String DOCKER_CERT_PATH_ENV = "DOCKER_CERT_PATH";
+    private static final String DOCKER_TLS_VERIFY_ENV = "DOCKER_TLS_VERIFY";
+    private static final String PROJECT_NAME_ENV = "COMPOSE_PROJECT_NAME";
+    private static final String COMPOSE_FILE_ENV = "COMPOSE_FILE";
+    private static final String COMPOSE_PROFILES_ENV = "COMPOSE_PROFILES";
+
+    private final List<File> composeFiles;
+    private final String identifier;
+    private final String composeExecutable;
+    private String cmd;
+    private Map<String, String> env;
+    private List<String> profiles;
+
+    public ComposeRunner(String composeExecutable, List<File> composeFiles, String projectName) {
+        this.composeExecutable = composeExecutable;
+        this.composeFiles = composeFiles;
+        this.identifier = projectName;
+        this.cmd = "";
+        this.env = Collections.emptyMap();
+        this.profiles = Collections.emptyList();
+    }
+
+    /**
+     * Set the compose command and args to run.
+     *
+     * @param cmd the command to run
+     * @return this
+     */
+    public ComposeRunner withCommand(String cmd) {
+        this.cmd = cmd;
+        return this;
+    }
+
+    /**
+     * Set the environment variables to use when running the command.
+     *
+     * @param env the environment variables
+     * @return this
+     */
+    public ComposeRunner withEnv(Map<String, String> env) {
+        this.env = Collections.unmodifiableMap(env);
+        return this;
+    }
+
+    /**
+     * Set the profiles to use when running the command.
+     *
+     * @param profiles the profiles
+     * @return this
+     */
+    public ComposeRunner withProfiles(List<String> profiles) {
+        this.profiles = Collections.unmodifiableList(profiles);
+        return this;
+    }
+
+    /**
+     * Run the compose command.
+     */
+    public void run() {
+        if (!CommandLine.executableExists(composeExecutable)) {
+            throw new RuntimeException("Docker Compose not found. Is " + composeExecutable + " on the PATH?");
+        }
+
+        if (composeFiles.isEmpty()) {
+            LOG.info("No compose files specified");
+            return;
+        }
+
+        final Map<String, String> environment = new HashMap<>(env);
+        environment.put(PROJECT_NAME_ENV, identifier);
+
+        TransportConfig transportConfig = DockerClientFactory.instance().getTransportConfig();
+        String certPath = System.getenv(DOCKER_CERT_PATH_ENV);
+        if (certPath != null) {
+            environment.put(DOCKER_CERT_PATH_ENV, certPath);
+            environment.put(DOCKER_TLS_VERIFY_ENV, "true");
+        }
+        environment.put(DOCKER_HOST_ENV, transportConfig.getDockerHost().toString());
+        environment.put(COMPOSE_FILE_ENV, composeFiles
+                .stream()
+                .map(File::getAbsolutePath)
+                .map(Objects::toString)
+                .collect(Collectors.joining(File.pathSeparator)));
+        if (!profiles.isEmpty()) {
+            environment.put(COMPOSE_PROFILES_ENV, String.join(",", this.profiles));
+        }
+
+        LOG.debugv("Compose is running with env {0}", environment);
+        LOG.infov("Compose is running command: {0} {1}", composeExecutable, cmd);
+
+        try {
+            final File pwd = composeFiles.get(0).getAbsoluteFile().getParentFile().getAbsoluteFile();
+            int exitCode = ExecUtil.execProcess(
+                    ExecUtil.startProcess(pwd, environment, composeExecutable, cmd.split("\\s+")),
+                    is -> new ExecUtil.HandleOutput(is, Logger.Level.INFO, LOG));
+            if (exitCode == 0) {
+                LOG.info("Compose has finished running");
+            } else {
+                throw new RuntimeException("Compose exited abnormally with code " + exitCode +
+                        " whilst running command: " +
+                        composeExecutable + " " + cmd + ", with env vars: " + environment);
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Error running Compose command: " + cmd, e);
+        }
+    }
+
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeServiceDefinition.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeServiceDefinition.java
@@ -1,0 +1,73 @@
+package io.quarkus.devservices.deployment.compose;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+
+/**
+ * Represents a service definition in a docker-compose file.
+ */
+public class ComposeServiceDefinition {
+
+    private final String serviceName;
+    private final Map<String, ?> definitionMap;
+
+    public ComposeServiceDefinition(String serviceName, Map<String, ?> definitionMap) {
+        this.serviceName = serviceName;
+        this.definitionMap = definitionMap;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getContainerName() {
+        return (String) definitionMap.get("container_name");
+    }
+
+    public List<ExposedPort> getPorts() {
+        List<String> ports = (List<String>) definitionMap.get("ports");
+        if (ports == null) {
+            return Collections.emptyList();
+        }
+        return ports.stream().map(PortBinding::parse)
+                .map(PortBinding::getExposedPort)
+                .collect(Collectors.toList());
+    }
+
+    public boolean hasHealthCheck() {
+        return definitionMap.get("healthcheck") instanceof Map;
+    }
+
+    public Map<String, Object> getLabels() {
+        Object labels = definitionMap.get("labels");
+        if (labels instanceof List) {
+            Map<String, Object> map = new HashMap<>();
+            for (Object label : ((List<?>) labels)) {
+                if (label instanceof String) {
+                    String[] split = ((String) label).split("=");
+                    map.put(split[0], split[1]);
+                } else if (label instanceof Map) {
+                    map.putAll((Map<String, Object>) label);
+                }
+            }
+            return map;
+        } else if (labels instanceof Map) {
+            return new HashMap<>((Map<String, Object>) labels);
+        }
+        return Collections.emptyMap();
+    }
+
+    public List<String> getProfiles() {
+        Object profiles = definitionMap.get("profiles");
+        if (profiles instanceof List) {
+            return (List<String>) profiles;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeServiceWaitStrategyTarget.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeServiceWaitStrategyTarget.java
@@ -1,0 +1,79 @@
+package io.quarkus.devservices.deployment.compose;
+
+import static io.quarkus.devservices.common.Labels.DOCKER_COMPOSE_CONTAINER_NUMBER;
+import static io.quarkus.devservices.common.Labels.DOCKER_COMPOSE_SERVICE;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import org.testcontainers.containers.wait.strategy.WaitStrategyTarget;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerPort;
+
+/**
+ * A WaitStrategyTarget that represents a container in a docker-compose file.
+ */
+public class ComposeServiceWaitStrategyTarget implements WaitStrategyTarget, Supplier<InspectContainerResponse> {
+
+    private final Container container;
+
+    private final DockerClient dockerClient;
+
+    private final List<Integer> exposedPorts;
+
+    private final AtomicReference<InspectContainerResponse> containerInfo = new AtomicReference<>();
+
+    public ComposeServiceWaitStrategyTarget(DockerClient dockerClient, Container container) {
+        this.dockerClient = dockerClient;
+        this.container = container;
+        this.exposedPorts = Arrays.stream(container.getPorts()).map(ContainerPort::getPrivatePort).toList();
+    }
+
+    @Override
+    public List<Integer> getExposedPorts() {
+        return exposedPorts;
+    }
+
+    @Override
+    public String getContainerId() {
+        return this.container.getId();
+    }
+
+    public String getServiceName() {
+        return this.container.getLabels().get(DOCKER_COMPOSE_SERVICE);
+    }
+
+    public int getContainerNumber() {
+        return Integer.parseInt(this.container.getLabels().get(DOCKER_COMPOSE_CONTAINER_NUMBER));
+    }
+
+    public String getContainerName() {
+        return String.format("%s-%s", getServiceName(), getContainerNumber());
+    }
+
+    @Override
+    public InspectContainerResponse getContainerInfo() {
+        InspectContainerResponse value = this.containerInfo.get();
+        if (value == null) {
+            synchronized (this.containerInfo) {
+                value = this.containerInfo.get();
+                if (value == null) {
+                    value = this.dockerClient.inspectContainerCmd(this.getContainerId()).exec();
+                    this.containerInfo.set(value);
+                }
+            }
+        }
+
+        return value;
+    }
+
+    @Override
+    public InspectContainerResponse get() {
+        return getContainerInfo();
+    }
+}

--- a/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeFileTest.java
+++ b/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeFileTest.java
@@ -1,0 +1,123 @@
+package io.quarkus.devservices.deployment.compose;
+
+import static io.quarkus.devservices.deployment.compose.ComposeDevServicesProcessor.isComposeFile;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class ComposeFileTest {
+
+    @Test
+    void testComposeFileNameValidation() {
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "docker-compose-devservice.yml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "docker-compose-devservices.yml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "docker-compose-devservices.yaml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "docker-compose-devservice-my-service.yml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "docker-compose-devservices-my-service.yaml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "compose-devservices.yml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "compose-devservices.yaml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "compose-dev-service.yaml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "compose-dev-services.yaml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "compose-devservices.yaml")));
+        assertTrue(isComposeFile(Path.of("/dev", "some", "dir", "compose-devservices-my-service.yaml")));
+        assertFalse(isComposeFile(Path.of("/dev", "some", "dir", "docker-compose.txt")));
+        assertFalse(isComposeFile(Path.of("/dev", "some", "dir", "my-service-docker-compose.yaml")));
+    }
+
+    @Test
+    void testValidComposeFileParsing() {
+        File validCompose = new File(getClass().getResource("/valid-compose.yml").getFile());
+        ComposeFile composeFile = new ComposeFile(validCompose);
+
+        Map<String, ComposeServiceDefinition> services = composeFile.getServiceDefinitions();
+        assertNotNull(services);
+        assertEquals(3, services.size());
+
+        // Test DB service
+        ComposeServiceDefinition db = services.get("db");
+        assertNotNull(db);
+        assertEquals("db", db.getServiceName());
+        assertEquals("database system is ready to accept connections",
+                db.getLabels().get("io.quarkus.devservices.compose.wait_for.logs"));
+        assertFalse(db.hasHealthCheck());
+
+        // Test Redis service
+        ComposeServiceDefinition redis = services.get("redis");
+        assertNotNull(redis);
+        assertEquals("redis", redis.getServiceName());
+        assertTrue(redis.getPorts().stream()
+                .anyMatch(p -> p.getPort() == 6379));
+        assertTrue(redis.getProfiles().isEmpty());
+
+        // Test Kafka service with profile
+        ComposeServiceDefinition kafka = services.get("kafka");
+        assertNotNull(kafka);
+        assertEquals("kafka", kafka.getServiceName());
+        assertTrue(kafka.getProfiles().contains("kafka"));
+    }
+
+    @Test
+    void testInvalidComposeFile() {
+        File invalidCompose = new File(getClass().getResource("/invalid-compose.yml").getFile());
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> new ComposeFile(invalidCompose));
+        assertTrue(exception.getMessage().contains("Unable to parse YAML file"));
+    }
+
+    @Test
+    void testServiceDefinitionExtraction() {
+        File validCompose = new File(getClass().getResource("/valid-compose.yml").getFile());
+        ComposeFile composeFile = new ComposeFile(validCompose);
+
+        ComposeServiceDefinition db = composeFile.getServiceDefinitions().get("db");
+        assertNotNull(db);
+
+        // Test ports
+        assertTrue(db.getPorts().stream()
+                .anyMatch(p -> p.getPort() == 5432));
+
+        // Test labels
+        Map<String, Object> labels = db.getLabels();
+        assertEquals("database system is ready to accept connections",
+                labels.get("io.quarkus.devservices.compose.wait_for.logs"));
+
+        // Test container name (should be null for valid compose)
+        assertNull(db.getContainerName());
+    }
+
+    @Test
+    void testLabelFormats() {
+        File composeWithLabels = new File(getClass().getResource("/compose-with-labels.yml").getFile());
+        ComposeFile composeFile = new ComposeFile(composeWithLabels);
+
+        // Test array-style labels
+        ComposeServiceDefinition service1 = composeFile.getServiceDefinitions().get("service1");
+        Map<String, Object> labels1 = service1.getLabels();
+        assertEquals("value1", labels1.get("label1"));
+        assertEquals("value2", labels1.get("label2"));
+
+        // Test map-style labels
+        ComposeServiceDefinition service2 = composeFile.getServiceDefinitions().get("service2");
+        Map<String, Object> labels2 = service2.getLabels();
+        assertEquals("value1", labels2.get("key1"));
+        assertEquals("value2", labels2.get("key2"));
+    }
+
+    @Test
+    void testHealthCheck() {
+        File composeWithLabels = new File(getClass().getResource("/compose-with-labels.yml").getFile());
+        ComposeFile composeFile = new ComposeFile(composeWithLabels);
+
+        // Test service with health check
+        ComposeServiceDefinition service3 = composeFile.getServiceDefinitions().get("service3");
+        assertTrue(service3.hasHealthCheck());
+
+        // Test service without health check
+        ComposeServiceDefinition service1 = composeFile.getServiceDefinitions().get("service1");
+        assertFalse(service1.hasHealthCheck());
+    }
+}

--- a/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeFilesTest.java
+++ b/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeFilesTest.java
@@ -1,0 +1,119 @@
+package io.quarkus.devservices.deployment.compose;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class ComposeFilesTest {
+
+    private static final String TEST_RESOURCES = "src/test/resources/compose-files/";
+
+    @Test
+    void testLoadingSingleComposeFile() {
+        File baseFile = new File(TEST_RESOURCES + "base.yml");
+        ComposeFiles composeFiles = new ComposeFiles(Collections.singletonList(baseFile));
+
+        Map<String, ComposeServiceDefinition> services = composeFiles.getServiceDefinitions();
+        assertEquals(2, services.size());
+        assertTrue(services.containsKey("service1"));
+        assertTrue(services.containsKey("service2"));
+
+        // Verify service1 definition
+        ComposeServiceDefinition service1 = services.get("service1");
+        assertEquals("service1", service1.getServiceName());
+        assertTrue(service1.getPorts().stream()
+                .anyMatch(p -> p.getPort() == 8080));
+
+        // Verify service2 definition
+        ComposeServiceDefinition service2 = services.get("service2");
+        assertEquals("service2", service2.getServiceName());
+        assertTrue(service2.getPorts().stream()
+                .anyMatch(p -> p.getPort() == 8081));
+    }
+
+    @Test
+    void testProjectNameHandling() {
+        // Test with file containing project name
+        File overrideFile = new File(TEST_RESOURCES + "override.yml");
+        ComposeFiles composeFiles = new ComposeFiles(Collections.singletonList(overrideFile));
+        assertEquals("test-project", composeFiles.getProjectName());
+
+        // Test with file without project name
+        File baseFile = new File(TEST_RESOURCES + "base.yml");
+        composeFiles = new ComposeFiles(Collections.singletonList(baseFile));
+        assertNull(composeFiles.getProjectName());
+    }
+
+    @Test
+    void testServiceNameConflict() {
+        File baseFile = new File(TEST_RESOURCES + "base.yml");
+        File overrideFile = new File(TEST_RESOURCES + "override.yml");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> new ComposeFiles(Arrays.asList(baseFile, overrideFile)));
+        assertTrue(exception.getMessage().contains("Service name conflict"));
+        assertTrue(exception.getMessage().contains("service1"));
+    }
+
+    @Test
+    void testMultipleNonConflictingFiles() {
+        File baseFile = new File(TEST_RESOURCES + "base.yml");
+        File extensionFile = new File(TEST_RESOURCES + "extension.yml");
+
+        ComposeFiles composeFiles = new ComposeFiles(Arrays.asList(baseFile, extensionFile));
+
+        // Verify all services are loaded
+        Set<String> serviceNames = composeFiles.getAllServiceNames();
+        assertEquals(4, serviceNames.size());
+        assertTrue(serviceNames.containsAll(Arrays.asList("service1", "service2", "service3", "service4")));
+
+        // Verify service definitions
+        Map<String, ComposeServiceDefinition> services = composeFiles.getServiceDefinitions();
+        assertEquals(4, services.size());
+
+        // Verify a service from each file
+        ComposeServiceDefinition service2 = services.get("service2");
+        assertTrue(service2.getPorts().stream()
+                .anyMatch(p -> p.getPort() == 8081));
+
+        ComposeServiceDefinition service3 = services.get("service3");
+        assertTrue(service3.getPorts().stream()
+                .anyMatch(p -> p.getPort() == 8082));
+    }
+
+    @Test
+    void testEmptyFileList() {
+        ComposeFiles composeFiles = new ComposeFiles(Collections.emptyList());
+        assertTrue(composeFiles.getAllServiceNames().isEmpty());
+        assertTrue(composeFiles.getServiceDefinitions().isEmpty());
+    }
+
+    @Test
+    void testNonExistentFile() {
+        File nonExistentFile = new File(TEST_RESOURCES + "non-existent.yml");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ComposeFiles(Collections.singletonList(nonExistentFile)));
+    }
+
+    @Test
+    void testGetFiles() {
+        File baseFile = new File(TEST_RESOURCES + "base.yml");
+        File extensionFile = new File(TEST_RESOURCES + "extension.yml");
+        List<File> inputFiles = Arrays.asList(baseFile, extensionFile);
+
+        ComposeFiles composeFiles = new ComposeFiles(inputFiles);
+        List<File> returnedFiles = composeFiles.getFiles();
+
+        assertEquals(inputFiles.size(), returnedFiles.size());
+        assertTrue(returnedFiles.containsAll(inputFiles));
+    }
+}

--- a/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeProjectTest.java
+++ b/extensions/devservices/deployment/src/test/java/io/quarkus/devservices/deployment/compose/ComposeProjectTest.java
@@ -1,0 +1,115 @@
+package io.quarkus.devservices.deployment.compose;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+
+public class ComposeProjectTest {
+
+    private ComposeProject composeProject;
+    private static final String COMPOSE_EXECUTABLE = "docker";
+    private final File composeFile = new File(getClass().getResource("/valid-compose.yml").getFile());
+    private final File composeFileWithProfiles = new File(getClass().getResource("/valid-compose-with-profiles.yml").getFile());
+    private final File composeFileWithIgnore = new File(getClass().getResource("/valid-compose-with-ignore.yml").getFile());
+
+    @Test
+    void testBasicProject() {
+        ComposeFiles files = new ComposeFiles(List.of(composeFile));
+        composeProject = new ComposeProject.Builder(files, COMPOSE_EXECUTABLE)
+                .withProject("test")
+                .withStartupTimeout(Duration.ofMinutes(2))
+                .build();
+
+        // Verify service names
+        Map<String, WaitAllStrategy> waitStrategies = composeProject.getWaitStrategies();
+        assertFalse(waitStrategies.isEmpty());
+        assertEquals(2, waitStrategies.size()); // db and redis
+        assertTrue(waitStrategies.containsKey("db"));
+        assertTrue(waitStrategies.containsKey("redis"));
+
+        // Verify project name
+        String project = composeProject.getProject();
+        assertEquals("test", project);
+    }
+
+    @Test
+    void testProjectWithWaitStrategies() {
+        ComposeFiles files = new ComposeFiles(List.of(composeFileWithProfiles));
+        composeProject = new ComposeProject.Builder(files, COMPOSE_EXECUTABLE)
+                .withStartupTimeout(Duration.ofMinutes(2))
+                .build();
+
+        // Verify project name
+        String project = composeProject.getProject();
+        assertNotNull(project);
+        assertTrue(project.equals("devservices"));
+    }
+
+    @Test
+    void testProjectWithProfiles() {
+        ComposeFiles files = new ComposeFiles(List.of(composeFileWithProfiles));
+        composeProject = new ComposeProject.Builder(files, COMPOSE_EXECUTABLE)
+                .build();
+
+        // Verify only kafka service is running (as it's in the kafka profile)
+        Map<String, WaitAllStrategy> waitStrategies = composeProject.getWaitStrategies();
+        assertEquals(1, waitStrategies.size());
+        assertTrue(waitStrategies.containsKey("db"));
+    }
+
+    @Test
+    void testProjectWithScaling() {
+        ComposeFiles files = new ComposeFiles(List.of(composeFile));
+        composeProject = new ComposeProject.Builder(files, COMPOSE_EXECUTABLE)
+                .withScalingPreferences(Map.of("redis", 2))
+                .build();
+
+        // Verify redis service is scaled to 2 instances
+        Map<String, WaitAllStrategy> waitStrategies = composeProject.getWaitStrategies();
+
+        assertTrue(waitStrategies.containsKey("redis"));
+    }
+
+    @Test
+    void testIgnoredServices() {
+        ComposeFiles files = new ComposeFiles(List.of(composeFileWithIgnore));
+        composeProject = new ComposeProject.Builder(files, COMPOSE_EXECUTABLE)
+                .build();
+
+        // Verify only kafka service is selected (as it's in the kafka profile)
+        Map<String, WaitAllStrategy> waitStrategies = composeProject.getWaitStrategies();
+        assertEquals(2, waitStrategies.size());
+        assertTrue(waitStrategies.containsKey("kafka"));
+        assertTrue(waitStrategies.containsKey("zookeeper"));
+
+        // Verify project name set in file
+        assertEquals("devservices", composeProject.getProject());
+    }
+
+    @Test
+    void testProfileServices() {
+        ComposeFiles files = new ComposeFiles(List.of(composeFileWithProfiles));
+        composeProject = new ComposeProject.Builder(files, COMPOSE_EXECUTABLE)
+                .withProfiles(List.of("redis"))
+                .build();
+
+        // Verify no service is selected
+        Map<String, WaitAllStrategy> waitStrategies = composeProject.getWaitStrategies();
+        assertEquals(2, waitStrategies.size());
+        assertTrue(waitStrategies.containsKey("db"));
+        assertTrue(waitStrategies.containsKey("redis"));
+
+        // Verify project name set in file
+        assertEquals("devservices", composeProject.getProject());
+    }
+
+}

--- a/extensions/devservices/deployment/src/test/resources/compose-files/base.yml
+++ b/extensions/devservices/deployment/src/test/resources/compose-files/base.yml
@@ -1,0 +1,14 @@
+services:
+  service1:
+    image: test/service1:latest
+    ports:
+      - "8080:8080"
+    environment:
+      KEY1: value1
+
+  service2:
+    image: test/service2:latest
+    ports:
+      - "8081:8081"
+    environment:
+      KEY2: value2

--- a/extensions/devservices/deployment/src/test/resources/compose-files/extension.yml
+++ b/extensions/devservices/deployment/src/test/resources/compose-files/extension.yml
@@ -1,0 +1,14 @@
+services:
+  service3:
+    image: test/service3:latest
+    ports:
+      - "8082:8082"
+    environment:
+      KEY3: value3
+
+  service4:
+    image: test/service4:latest
+    ports:
+      - "8083:8083"
+    labels:
+      custom.label: value

--- a/extensions/devservices/deployment/src/test/resources/compose-files/override.yml
+++ b/extensions/devservices/deployment/src/test/resources/compose-files/override.yml
@@ -1,0 +1,6 @@
+name: test-project
+services:
+  service1:  # This will cause a conflict with base.yml
+    image: test/service1:v2
+    ports:
+      - "9090:8080"

--- a/extensions/devservices/deployment/src/test/resources/compose-test-valid.yml
+++ b/extensions/devservices/deployment/src/test/resources/compose-test-valid.yml
@@ -1,0 +1,28 @@
+version: '3'
+name: test-project
+
+services:
+  db:
+    image: postgres:14
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    labels:
+      quarkus.wait-for-logs: "database system is ready to accept connections"
+
+  redis:
+    image: redis:6
+    ports:
+      - "6379:6379"
+    container_name: test-redis
+
+  kafka:
+    image: confluentinc/cp-kafka:7.2.1
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+    profiles:
+      - kafka

--- a/extensions/devservices/deployment/src/test/resources/compose-with-container-name.yml
+++ b/extensions/devservices/deployment/src/test/resources/compose-with-container-name.yml
@@ -1,0 +1,16 @@
+services:
+  db:
+    image: postgres:14
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    container_name: fixed-name-db
+    labels:
+      quarkus.wait-for-logs: "database system is ready to accept connections"
+
+  redis:
+    image: redis:6
+    ports:
+      - "6379:6379"

--- a/extensions/devservices/deployment/src/test/resources/compose-with-labels.yml
+++ b/extensions/devservices/deployment/src/test/resources/compose-with-labels.yml
@@ -1,0 +1,20 @@
+services:
+  service1:
+    image: test:1
+    labels:
+      - "label1=value1"
+      - "label2=value2"
+
+  service2:
+    image: test:2
+    labels:
+      key1: value1
+      key2: value2
+
+  service3:
+    image: test:3
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/extensions/devservices/deployment/src/test/resources/invalid-compose.yml
+++ b/extensions/devservices/deployment/src/test/resources/invalid-compose.yml
@@ -1,0 +1,26 @@
+# Invalid YAML structure
+services:
+  db:
+    image: postgres:14
+    ports:
+      - "5432:5432
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+  # Invalid indentation
+ redis:
+    image: redis:6
+    ports:
+      - "6379:6379"
+
+  # Missing required field
+  kafka:
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+
+# Invalid YAML mapping
+invalid_service: {
+  image: "test:latest",
+  ports: ["8080:8080"]

--- a/extensions/devservices/deployment/src/test/resources/valid-compose-with-ignore.yml
+++ b/extensions/devservices/deployment/src/test/resources/valid-compose-with-ignore.yml
@@ -1,0 +1,17 @@
+name: devservices
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.2.1
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.2.1
+    labels:
+      io.quarkus.devservices.compose.ignore: true
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181

--- a/extensions/devservices/deployment/src/test/resources/valid-compose-with-profiles.yml
+++ b/extensions/devservices/deployment/src/test/resources/valid-compose-with-profiles.yml
@@ -1,0 +1,24 @@
+name: devservices
+services:
+  db:
+    image: postgres:14
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    labels:
+      io.quarkus.devservices.compose.wait_for.logs: "database system is ready to accept connections"
+
+  redis:
+    image: redis:6
+    profiles: [redis]
+    ports:
+      - "6379:6379"
+  kafka:
+    image: confluentinc/cp-kafka:7.2.1
+    profiles: [kafka]
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1

--- a/extensions/devservices/deployment/src/test/resources/valid-compose.yml
+++ b/extensions/devservices/deployment/src/test/resources/valid-compose.yml
@@ -1,0 +1,24 @@
+services:
+  db:
+    image: postgres:14
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    labels:
+      io.quarkus.devservices.compose.wait_for.logs: "database system is ready to accept connections"
+
+  redis:
+    image: redis:6
+    ports:
+      - "6379:6379"
+
+  kafka:
+    profiles:
+      - kafka
+    image: confluentinc/cp-kafka:7.2.1
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDatasourceServiceConfigurator.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDatasourceServiceConfigurator.java
@@ -1,0 +1,42 @@
+package io.quarkus.devservices.mariadb.deployment;
+
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.RunningDevServicesDatasource;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.DatasourceServiceConfigurator;
+
+public class MariaDBDatasourceServiceConfigurator implements DatasourceServiceConfigurator {
+
+    private final static String[] USERNAME_ENVS = new String[] { "MARIADB_USER", "MYSQL_USER" };
+
+    private final static String[] PASSWORD_ENVS = new String[] { "MARIADB_PASSWORD", "MYSQL_PASSWORD" };
+
+    private final static String[] DATABASE_ENVS = new String[] { "MARIADB_DATABASE", "MYSQL_DATABASE" };
+
+    public RunningDevServicesDatasource composeRunningService(ContainerAddress containerAddress,
+            DevServicesDatasourceContainerConfig containerConfig) {
+        RunningContainer container = containerAddress.getRunningContainer();
+        String effectiveDbName = containerConfig.getDbName().orElse(DEFAULT_DATABASE_NAME);
+        String effectiveUsername = containerConfig.getDbName().orElse(DEFAULT_DATABASE_USERNAME);
+        String effectivePassword = containerConfig.getDbName().orElse(DEFAULT_DATABASE_PASSWORD);
+        String jdbcUrl = getJdbcUrl(containerAddress, container.tryGetEnv(DATABASE_ENVS).orElse(effectiveDbName));
+        String reactiveUrl = getReactiveUrl(jdbcUrl);
+        return new RunningDevServicesDatasource(
+                containerAddress.getId(),
+                jdbcUrl,
+                reactiveUrl,
+                container.tryGetEnv(USERNAME_ENVS).orElse(effectiveUsername),
+                container.tryGetEnv(PASSWORD_ENVS).orElse(effectivePassword),
+                null);
+    }
+
+    @Override
+    public String getJdbcPrefix() {
+        return "mariadb";
+    }
+}

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDatasourceServiceConfigurator.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDatasourceServiceConfigurator.java
@@ -1,0 +1,41 @@
+package io.quarkus.devservices.mssql.deployment;
+
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.RunningDevServicesDatasource;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.DatasourceServiceConfigurator;
+
+public class MSSQLDatasourceServiceConfigurator implements DatasourceServiceConfigurator {
+
+    private final static String[] PASSWORD_ENVS = new String[] { "MSSQL_SA_PASSWORD", "SA_PASSWORD" };
+
+    private final static String[] DATABASE_ENVS = new String[] { "POSTGRES_DB", "POSTGRESQL_DB", "POSTGRESQL_DATABASE" };
+
+    public RunningDevServicesDatasource composeRunningService(ContainerAddress containerAddress,
+            DevServicesDatasourceContainerConfig containerConfig) {
+        RunningContainer container = containerAddress.getRunningContainer();
+        String effectiveDbName = containerConfig.getDbName().orElse(DEFAULT_DATABASE_NAME);
+        String effectiveUsername = containerConfig.getDbName().orElse(DEFAULT_DATABASE_USERNAME);
+        String effectivePassword = containerConfig.getDbName().orElse(DEFAULT_DATABASE_PASSWORD);
+        String jdbcUrl = getJdbcUrl(containerAddress, container.tryGetEnv(DATABASE_ENVS).orElse(effectiveDbName));
+        String reactiveUrl = getReactiveUrl(jdbcUrl);
+        return new RunningDevServicesDatasource(
+                containerAddress.getId(),
+                jdbcUrl,
+                reactiveUrl,
+                effectiveUsername,
+                container.tryGetEnv(PASSWORD_ENVS).orElse(effectivePassword),
+                null);
+    }
+
+    @Override
+    public String getJdbcPrefix() {
+        return "sqlserver";
+    }
+
+}

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDatasourceServiceConfigurator.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDatasourceServiceConfigurator.java
@@ -1,0 +1,42 @@
+package io.quarkus.devservices.mysql.deployment;
+
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.RunningDevServicesDatasource;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.DatasourceServiceConfigurator;
+
+public class MySQLDatasourceServiceConfigurator implements DatasourceServiceConfigurator {
+
+    private final static String[] USERNAME_ENVS = new String[] { "MYSQL_USER" };
+
+    private final static String[] PASSWORD_ENVS = new String[] { "MYSQL_PASSWORD" };
+
+    private final static String[] DATABASE_ENVS = new String[] { "MYSQL_DATABASE" };
+
+    public RunningDevServicesDatasource composeRunningService(ContainerAddress containerAddress,
+            DevServicesDatasourceContainerConfig containerConfig) {
+        RunningContainer container = containerAddress.getRunningContainer();
+        String effectiveDbName = containerConfig.getDbName().orElse(DEFAULT_DATABASE_NAME);
+        String effectiveUsername = containerConfig.getDbName().orElse(DEFAULT_DATABASE_USERNAME);
+        String effectivePassword = containerConfig.getDbName().orElse(DEFAULT_DATABASE_PASSWORD);
+        String jdbcUrl = getJdbcUrl(containerAddress, container.tryGetEnv(DATABASE_ENVS).orElse(effectiveDbName));
+        String reactiveUrl = getReactiveUrl(jdbcUrl);
+        return new RunningDevServicesDatasource(
+                containerAddress.getId(),
+                jdbcUrl,
+                reactiveUrl,
+                container.tryGetEnv(USERNAME_ENVS).orElse(effectiveUsername),
+                container.tryGetEnv(PASSWORD_ENVS).orElse(effectivePassword),
+                null);
+    }
+
+    @Override
+    public String getJdbcPrefix() {
+        return "mysql";
+    }
+}

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDatasourceServiceConfigurator.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDatasourceServiceConfigurator.java
@@ -1,0 +1,51 @@
+package io.quarkus.devservices.oracle.deployment;
+
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.RunningDevServicesDatasource;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.DatasourceServiceConfigurator;
+
+public class OracleDatasourceServiceConfigurator implements DatasourceServiceConfigurator {
+
+    private final static String[] USERNAME_ENVS = new String[] { "APP_USER" };
+
+    private final static String[] PASSWORD_ENVS = new String[] { "APP_USER_PASSWORD" };
+
+    private final static String[] DATABASE_ENVS = new String[] { "ORACLE_DATABASE" };
+
+    public RunningDevServicesDatasource composeRunningService(ContainerAddress containerAddress,
+            DevServicesDatasourceContainerConfig containerConfig) {
+        RunningContainer container = containerAddress.getRunningContainer();
+        String effectiveDbName = containerConfig.getDbName().orElse(DEFAULT_DATABASE_NAME);
+        String effectiveUsername = containerConfig.getDbName().orElse(DEFAULT_DATABASE_USERNAME);
+        String effectivePassword = containerConfig.getDbName().orElse(DEFAULT_DATABASE_PASSWORD);
+        String jdbcUrl = getJdbcUrl(containerAddress, container.tryGetEnv(DATABASE_ENVS).orElse(effectiveDbName));
+        String reactiveUrl = getReactiveUrl(jdbcUrl);
+        return new RunningDevServicesDatasource(
+                containerAddress.getId(),
+                jdbcUrl,
+                reactiveUrl,
+                container.tryGetEnv(USERNAME_ENVS).orElse(effectiveUsername),
+                container.tryGetEnv(PASSWORD_ENVS).orElse(effectivePassword),
+                null);
+    }
+
+    public String getJdbcUrl(ContainerAddress containerAddress, String databaseName) {
+        return "jdbc:%s://@%s:%d/%s%s".formatted(
+                getJdbcPrefix(),
+                containerAddress.getHost(),
+                containerAddress.getPort(),
+                databaseName,
+                getParameters(containerAddress.getRunningContainer().containerInfo().labels()));
+    }
+
+    @Override
+    public String getJdbcPrefix() {
+        return "oracle:thin";
+    }
+}

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.OracleContainer;
@@ -19,8 +20,10 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
@@ -39,9 +42,12 @@ public class OracleDevServicesProcessor {
     public static final String ORIGINAL_IMAGE_NAME = "gvenzl/oracle-xe";
     public static final int PORT = 1521;
 
+    private static final OracleDatasourceServiceConfigurator configurator = new OracleDatasourceServiceConfigurator();
+
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupOracle(
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             DevServicesConfig devServicesConfig) {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.ORACLE, new DevServicesDatasourceProvider() {
             @Override
@@ -51,49 +57,60 @@ public class OracleDevServicesProcessor {
 
                 boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                         devServicesSharedNetworkBuildItem);
-                QuarkusOracleServerContainer container = new QuarkusOracleServerContainer(containerConfig.getImageName(),
-                        containerConfig.getFixedExposedPort(),
-                        useSharedNetwork);
-                startupTimeout.ifPresent(container::withStartupTimeout);
 
                 String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
                 String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
                 String effectiveDbName = containerConfig.getDbName().orElse(
                         DataSourceUtil.isDefault(datasourceName) ? DEFAULT_DATABASE_NAME : datasourceName);
 
-                container.withUsername(effectiveUsername)
-                        .withPassword(effectivePassword)
-                        .withDatabaseName(effectiveDbName)
-                        .withReuse(containerConfig.isReuse());
-                Labels.addDataSourceLabel(container, datasourceName);
-                Volumes.addVolumes(container, containerConfig.getVolumes());
+                Supplier<RunningDevServicesDatasource> startService = () -> {
 
-                container.withEnv(containerConfig.getContainerEnv());
+                    QuarkusOracleServerContainer container = new QuarkusOracleServerContainer(containerConfig.getImageName(),
+                            containerConfig.getFixedExposedPort(),
+                            composeProjectBuildItem.getDefaultNetworkId(),
+                            useSharedNetwork);
+                    startupTimeout.ifPresent(container::withStartupTimeout);
 
-                // We need to limit the maximum amount of CPUs being used by the container;
-                // otherwise the hardcoded memory configuration of the DB might not be enough to successfully boot it.
-                // See https://github.com/gvenzl/oci-oracle-xe/issues/64
-                // I choose to limit it to "2 cpus": should be more than enough for any local testing needs,
-                // and keeps things simple.
-                container.withCreateContainerCmdModifier(cmd -> cmd.getHostConfig().withNanoCPUs(2_000_000_000l));
+                    container.withUsername(effectiveUsername)
+                            .withPassword(effectivePassword)
+                            .withDatabaseName(effectiveDbName)
+                            .withReuse(containerConfig.isReuse());
+                    Labels.addDataSourceLabel(container, datasourceName);
+                    Volumes.addVolumes(container, containerConfig.getVolumes());
 
-                containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
-                containerConfig.getCommand().ifPresent(container::setCommand);
-                containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
-                if (containerConfig.isShowLogs()) {
-                    container.withLogConsumer(new JBossLoggingConsumer(LOG));
-                }
+                    container.withEnv(containerConfig.getContainerEnv());
 
-                container.start();
+                    // We need to limit the maximum amount of CPUs being used by the container;
+                    // otherwise the hardcoded memory configuration of the DB might not be enough to successfully boot it.
+                    // See https://github.com/gvenzl/oci-oracle-xe/issues/64
+                    // I choose to limit it to "2 cpus": should be more than enough for any local testing needs,
+                    // and keeps things simple.
+                    container.withCreateContainerCmdModifier(cmd -> cmd.getHostConfig().withNanoCPUs(2_000_000_000l));
 
-                LOG.info("Dev Services for Oracle started.");
+                    containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
+                    containerConfig.getCommand().ifPresent(container::setCommand);
+                    containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
+                    if (containerConfig.isShowLogs()) {
+                        container.withLogConsumer(new JBossLoggingConsumer(LOG));
+                    }
 
-                return new RunningDevServicesDatasource(container.getContainerId(),
-                        container.getEffectiveJdbcUrl(),
-                        container.getReactiveUrl(),
-                        container.getUsername(),
-                        container.getPassword(),
-                        new ContainerShutdownCloseable(container, "Oracle"));
+                    container.start();
+
+                    LOG.info("Dev Services for Oracle started.");
+
+                    return new RunningDevServicesDatasource(container.getContainerId(),
+                            container.getEffectiveJdbcUrl(),
+                            container.getReactiveUrl(),
+                            container.getUsername(),
+                            container.getPassword(),
+                            new ContainerShutdownCloseable(container, "Oracle"));
+                };
+                List<String> images = List.of(
+                        containerConfig.getImageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("oracle")),
+                        "oracle");
+                return ComposeLocator.locateContainer(composeProjectBuildItem, images, PORT, launchMode, useSharedNetwork)
+                        .map(containerAddress -> configurator.composeRunningService(containerAddress, containerConfig))
+                        .orElseGet(startService);
             }
         });
     }
@@ -102,15 +119,16 @@ public class OracleDevServicesProcessor {
         private final OptionalInt fixedExposedPort;
         private final boolean useSharedNetwork;
 
-        private String hostName = null;
+        private final String hostName;
 
         public QuarkusOracleServerContainer(Optional<String> imageName, OptionalInt fixedExposedPort,
-                boolean useSharedNetwork) {
+                String defaultNetworkId, boolean useSharedNetwork) {
             super(DockerImageName
                     .parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("oracle")))
                     .asCompatibleSubstituteFor(OracleDevServicesProcessor.ORIGINAL_IMAGE_NAME));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
+            this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "oracle");
         }
 
         @Override
@@ -118,7 +136,6 @@ public class OracleDevServicesProcessor {
             super.configure();
 
             if (useSharedNetwork) {
-                hostName = ConfigureUtil.configureSharedNetwork(this, "oracle");
                 return;
             }
 

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresDatasourceServiceConfigurator.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresDatasourceServiceConfigurator.java
@@ -1,0 +1,52 @@
+package io.quarkus.devservices.postgresql.deployment;
+
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.RunningDevServicesDatasource;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.DatasourceServiceConfigurator;
+
+public class PostgresDatasourceServiceConfigurator implements DatasourceServiceConfigurator {
+
+    private final static String[] USERNAME_ENVS = new String[] { "POSTGRES_USER", "POSTGRESQL_USER", "POSTGRESQL_USERNAME" };
+
+    private final static String[] PASSWORD_ENVS = new String[] { "POSTGRES_PASSWORD", "POSTGRESQL_PASSWORD" };
+
+    private final static String[] DATABASE_ENVS = new String[] { "POSTGRES_DB", "POSTGRESQL_DB", "POSTGRESQL_DATABASE" };
+
+    public RunningDevServicesDatasource composeRunningService(ContainerAddress containerAddress,
+            DevServicesDatasourceContainerConfig containerConfig) {
+        RunningContainer container = containerAddress.getRunningContainer();
+        String effectiveDbName = containerConfig.getDbName().orElse(DEFAULT_DATABASE_NAME);
+        String effectiveUsername = containerConfig.getDbName().orElse(DEFAULT_DATABASE_USERNAME);
+        String effectivePassword = containerConfig.getDbName().orElse(DEFAULT_DATABASE_PASSWORD);
+        String jdbcUrl = getJdbcUrl(containerAddress, container.tryGetEnv(DATABASE_ENVS).orElse(effectiveDbName));
+        String reactiveUrl = getReactiveUrl(jdbcUrl);
+        return new RunningDevServicesDatasource(
+                containerAddress.getId(),
+                jdbcUrl,
+                reactiveUrl,
+                container.tryGetEnv(USERNAME_ENVS).orElse(effectiveUsername),
+                extractPassword(container, effectivePassword),
+                null);
+    }
+
+    private String extractPassword(RunningContainer container, String effectivePassword) {
+        if ("trust".equals(container.env().get("POSTGRES_HOST_AUTH_METHOD"))) {
+            return null;
+        }
+        if (container.env().containsKey("ALLOW_EMPTY_PASSWORD")) {
+            return "";
+        }
+        return container.tryGetEnv(PASSWORD_ENVS).orElse(effectivePassword);
+    }
+
+    @Override
+    public String getJdbcPrefix() {
+        return "postgresql";
+    }
+}

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -3,12 +3,14 @@ package io.quarkus.devservices.postgresql.deployment;
 import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
 import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
 import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -23,9 +25,11 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ConsoleCommandBuildItem;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
@@ -40,6 +44,8 @@ public class PostgresqlDevServicesProcessor {
     private static final String MAX_PREPARED_TRANSACTIONS = "max_prepared_transactions";
     private static final String DEFAULT_MAX_PREPARED_TRANSACTIONS = "--" + MAX_PREPARED_TRANSACTIONS + "=100";
 
+    private static final PostgresDatasourceServiceConfigurator configurator = new PostgresDatasourceServiceConfigurator();
+
     @BuildStep
     ConsoleCommandBuildItem psqlCommand(DevServicesLauncherConfigResultBuildItem devServices) {
         return new ConsoleCommandBuildItem(new PostgresCommand(devServices));
@@ -48,6 +54,7 @@ public class PostgresqlDevServicesProcessor {
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupPostgres(
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             DevServicesConfig devServicesConfig) {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.POSTGRESQL, new DevServicesDatasourceProvider() {
             @SuppressWarnings("unchecked")
@@ -58,51 +65,62 @@ public class PostgresqlDevServicesProcessor {
 
                 boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                         devServicesSharedNetworkBuildItem);
-                QuarkusPostgreSQLContainer container = new QuarkusPostgreSQLContainer(containerConfig.getImageName(),
-                        containerConfig.getFixedExposedPort(),
-                        useSharedNetwork);
-                startupTimeout.ifPresent(container::withStartupTimeout);
 
                 String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
                 String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
                 String effectiveDbName = containerConfig.getDbName().orElse(
                         DataSourceUtil.isDefault(datasourceName) ? DEFAULT_DATABASE_NAME : datasourceName);
 
-                container.withUsername(effectiveUsername)
-                        .withPassword(effectivePassword)
-                        .withDatabaseName(effectiveDbName)
-                        .withReuse(containerConfig.isReuse());
-                Labels.addDataSourceLabel(container, datasourceName);
-                Volumes.addVolumes(container, containerConfig.getVolumes());
+                Supplier<RunningDevServicesDatasource> createDevService = () -> {
+                    QuarkusPostgreSQLContainer container = new QuarkusPostgreSQLContainer(containerConfig.getImageName(),
+                            containerConfig.getFixedExposedPort(),
+                            composeProjectBuildItem.getDefaultNetworkId(),
+                            useSharedNetwork);
+                    startupTimeout.ifPresent(container::withStartupTimeout);
 
-                container.withEnv(containerConfig.getContainerEnv());
+                    container.withUsername(effectiveUsername)
+                            .withPassword(effectivePassword)
+                            .withDatabaseName(effectiveDbName)
+                            .withReuse(containerConfig.isReuse());
+                    Labels.addDataSourceLabel(container, datasourceName);
+                    Volumes.addVolumes(container, containerConfig.getVolumes());
 
-                containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
-                String augmentedCommand;
-                if (containerConfig.getCommand().isPresent()) {
-                    String originalCommand = containerConfig.getCommand().get();
-                    augmentedCommand = originalCommand.contains(MAX_PREPARED_TRANSACTIONS) ? originalCommand
-                            : originalCommand + " " + DEFAULT_MAX_PREPARED_TRANSACTIONS;
-                } else {
-                    augmentedCommand = DEFAULT_MAX_PREPARED_TRANSACTIONS;
-                }
-                container.setCommand(augmentedCommand);
+                    container.withEnv(containerConfig.getContainerEnv());
 
-                containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
-                if (containerConfig.isShowLogs()) {
-                    container.withLogConsumer(new JBossLoggingConsumer(LOG));
-                }
+                    containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
+                    String augmentedCommand;
+                    if (containerConfig.getCommand().isPresent()) {
+                        String originalCommand = containerConfig.getCommand().get();
+                        augmentedCommand = originalCommand.contains(MAX_PREPARED_TRANSACTIONS) ? originalCommand
+                                : originalCommand + " " + DEFAULT_MAX_PREPARED_TRANSACTIONS;
+                    } else {
+                        augmentedCommand = DEFAULT_MAX_PREPARED_TRANSACTIONS;
+                    }
+                    container.setCommand(augmentedCommand);
 
-                container.start();
+                    containerConfig.getInitScriptPath().ifPresent(container::withInitScripts);
+                    if (containerConfig.isShowLogs()) {
+                        container.withLogConsumer(new JBossLoggingConsumer(LOG));
+                    }
 
-                LOG.info("Dev Services for PostgreSQL started.");
+                    container.start();
 
-                return new RunningDevServicesDatasource(container.getContainerId(),
-                        container.getEffectiveJdbcUrl(),
-                        container.getReactiveUrl(),
-                        container.getUsername(),
-                        container.getPassword(),
-                        new ContainerShutdownCloseable(container, "PostgreSQL"));
+                    LOG.info("Dev Services for PostgreSQL started.");
+
+                    return new RunningDevServicesDatasource(container.getContainerId(),
+                            container.getEffectiveJdbcUrl(),
+                            container.getReactiveUrl(),
+                            container.getUsername(),
+                            container.getPassword(),
+                            new ContainerShutdownCloseable(container, "PostgreSQL"));
+                };
+                List<String> images = List.of(
+                        containerConfig.getImageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("postgresql")),
+                        "postgres");
+                return ComposeLocator
+                        .locateContainer(composeProjectBuildItem, images, POSTGRESQL_PORT, launchMode, useSharedNetwork)
+                        .map(containerAddress -> configurator.composeRunningService(containerAddress, containerConfig))
+                        .orElseGet(createDevService);
             }
         });
     }
@@ -115,9 +133,10 @@ public class PostgresqlDevServicesProcessor {
         private final OptionalInt fixedExposedPort;
         private final boolean useSharedNetwork;
 
-        private String hostName = null;
+        private final String hostName;
 
-        public QuarkusPostgreSQLContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
+        public QuarkusPostgreSQLContainer(Optional<String> imageName, OptionalInt fixedExposedPort,
+                String defaultNetworkId, boolean useSharedNetwork) {
             super(DockerImageName
                     .parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("postgresql")))
                     .asCompatibleSubstituteFor(DockerImageName.parse(PostgreSQLContainer.IMAGE)));
@@ -137,6 +156,7 @@ public class PostgresqlDevServicesProcessor {
                     .withStrategy(Wait.forLogMessage("(" + READY_REGEX + ")?(" + SKIPPING_INITIALIZATION_REGEX + ")?", 2))
                     .withStrategy(Wait.forListeningPort())
                     .withStartupTimeout(Duration.of(60L, ChronoUnit.SECONDS));
+            this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "postgres");
         }
 
         @Override
@@ -144,12 +164,11 @@ public class PostgresqlDevServicesProcessor {
             super.configure();
 
             if (useSharedNetwork) {
-                hostName = ConfigureUtil.configureSharedNetwork(this, "postgres");
                 return;
             }
 
             if (fixedExposedPort.isPresent()) {
-                addFixedExposedPort(fixedExposedPort.getAsInt(), PostgreSQLContainer.POSTGRESQL_PORT);
+                addFixedExposedPort(fixedExposedPort.getAsInt(), POSTGRESQL_PORT);
             } else {
                 addExposedPort(POSTGRESQL_PORT);
             }

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -1,7 +1,9 @@
 package io.quarkus.infinispan.client.deployment.devservices;
 
+import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.runtime.LaunchMode.DEVELOPMENT;
 import static org.infinispan.server.test.core.InfinispanContainer.DEFAULT_USERNAME;
+import static org.infinispan.server.test.core.InfinispanContainer.IMAGE_BASENAME;
 
 import java.io.Closeable;
 import java.time.Duration;
@@ -25,6 +27,7 @@ import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
@@ -33,8 +36,11 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.infinispan.client.runtime.InfinispanClientBuildTimeConfig;
 import io.quarkus.infinispan.client.runtime.InfinispanClientUtil;
@@ -53,8 +59,8 @@ public class InfinispanDevServiceProcessor {
      */
     private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-infinispan";
     public static final int DEFAULT_INFINISPAN_PORT = ConfigurationProperties.DEFAULT_HOTROD_PORT;
-    private static final ContainerLocator infinispanContainerLocator = new ContainerLocator(DEV_SERVICE_LABEL,
-            DEFAULT_INFINISPAN_PORT);
+    private static final ContainerLocator infinispanContainerLocator = locateContainerWithLabels(DEFAULT_INFINISPAN_PORT,
+            DEV_SERVICE_LABEL);
 
     private static final String DEFAULT_PASSWORD = "password";
     private static final String QUARKUS = "quarkus.";
@@ -70,6 +76,7 @@ public class InfinispanDevServiceProcessor {
             DockerStatusBuildItem dockerStatusBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             InfinispanClientsBuildTimeConfig config,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             CuratedApplicationShutdownBuildItem closeBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
@@ -116,13 +123,15 @@ public class InfinispanDevServiceProcessor {
                 loggingSetupBuildItem);
 
         runInfinispanDevService(InfinispanClientUtil.DEFAULT_INFINISPAN_CLIENT_NAME, launchMode,
-                compressor, dockerStatusBuildItem, devServicesSharedNetworkBuildItem, config.defaultInfinispanClient(),
+                compressor, dockerStatusBuildItem, composeProjectBuildItem,
+                devServicesSharedNetworkBuildItem, config.defaultInfinispanClient(),
                 devServicesConfig, newDevServices,
                 properties);
 
         config.namedInfinispanClients().entrySet().forEach(dServ -> {
             runInfinispanDevService(dServ.getKey(), launchMode,
-                    compressor, dockerStatusBuildItem, devServicesSharedNetworkBuildItem, dServ.getValue(),
+                    compressor, dockerStatusBuildItem, composeProjectBuildItem,
+                    devServicesSharedNetworkBuildItem, dServ.getValue(),
                     devServicesConfig,
                     newDevServices, properties);
         });
@@ -154,6 +163,7 @@ public class InfinispanDevServiceProcessor {
             LaunchModeBuildItem launchMode,
             StartupLogCompressor compressor,
             DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             InfinispanClientBuildTimeConfig config,
             DevServicesConfig devServicesConfig,
@@ -162,7 +172,8 @@ public class InfinispanDevServiceProcessor {
         try {
 
             InfinispanDevServicesConfig namedDevServiceConfig = config.devservices().devservices();
-            RunningDevService devService = startContainer(clientName, dockerStatusBuildItem, namedDevServiceConfig,
+            RunningDevService devService = startContainer(clientName, dockerStatusBuildItem, composeProjectBuildItem,
+                    namedDevServiceConfig,
                     launchMode.getLaunchMode(),
                     !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout(), properties);
             if (devService == null) {
@@ -180,8 +191,12 @@ public class InfinispanDevServiceProcessor {
     }
 
     private RunningDevService startContainer(String clientName, DockerStatusBuildItem dockerStatusBuildItem,
-            InfinispanDevServicesConfig devServicesConfig, LaunchMode launchMode,
-            boolean useSharedNetwork, Optional<Duration> timeout, Map<String, String> properties) {
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            InfinispanDevServicesConfig devServicesConfig,
+            LaunchMode launchMode,
+            boolean useSharedNetwork,
+            Optional<Duration> timeout,
+            Map<String, String> properties) {
         if (!devServicesConfig.enabled()) {
             // explicitly disabled
             log.debug("Not starting Dev Services for Infinispan as it has been disabled in the config");
@@ -209,6 +224,7 @@ public class InfinispanDevServiceProcessor {
         Supplier<RunningDevService> infinispanServerSupplier = () -> {
             QuarkusInfinispanContainer infinispanContainer = new QuarkusInfinispanContainer(clientName, devServicesConfig,
                     launchMode,
+                    composeProjectBuildItem.getDefaultNetworkId(),
                     useSharedNetwork);
             timeout.ifPresent(infinispanContainer::withStartupTimeout);
             infinispanContainer.withEnv(devServicesConfig.containerEnv());
@@ -223,7 +239,21 @@ public class InfinispanDevServiceProcessor {
                 .locateContainer(devServicesConfig.serviceName(), devServicesConfig.shared(), launchMode)
                 .map(containerAddress -> getRunningDevService(clientName, containerAddress.getId(), null,
                         containerAddress.getUrl(), DEFAULT_USERNAME, DEFAULT_PASSWORD, properties)) // TODO can this be always right ?
+                .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
+                        List.of(devServicesConfig.imageName().orElse(IMAGE_BASENAME), "infinispan"),
+                        DEFAULT_INFINISPAN_PORT, launchMode, useSharedNetwork)
+                        .map(address -> getRunningDevService(clientName, address, properties)))
                 .orElseGet(infinispanServerSupplier);
+    }
+
+    private RunningDevService getRunningDevService(String clientName, ContainerAddress address, Map<String, String> config) {
+        RunningContainer container = address.getRunningContainer();
+        if (container == null) {
+            return null;
+        }
+        return getRunningDevService(clientName, address.getId(), null, address.getUrl(),
+                container.tryGetEnv("USER").orElse(DEFAULT_USERNAME),
+                container.tryGetEnv("PASS").orElse(DEFAULT_PASSWORD), config);
     }
 
     private RunningDevService getRunningDevService(String clientName, String containerId, Closeable closeable, String hosts,
@@ -256,10 +286,10 @@ public class InfinispanDevServiceProcessor {
         private final OptionalInt fixedExposedPort;
         private final boolean useSharedNetwork;
 
-        private String hostName = null;
+        private final String hostName;
 
         public QuarkusInfinispanContainer(String clientName, InfinispanDevServicesConfig config,
-                LaunchMode launchMode, boolean useSharedNetwork) {
+                LaunchMode launchMode, String defaultNetworkId, boolean useSharedNetwork) {
             super(config.imageName().orElse(IMAGE_BASENAME + ":" + Version.getUnbrandedVersion()));
             this.fixedExposedPort = config.port();
             this.useSharedNetwork = useSharedNetwork;
@@ -306,6 +336,7 @@ public class InfinispanDevServiceProcessor {
             config.artifacts().ifPresent(a -> withArtifacts(a.toArray(new String[0])));
 
             withCommand(command);
+            this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "infinispan");
         }
 
         @Override
@@ -313,7 +344,6 @@ public class InfinispanDevServiceProcessor {
             super.configure();
 
             if (useSharedNetwork) {
-                hostName = ConfigureUtil.configureSharedNetwork(this, "infinispan");
                 return;
             }
 

--- a/extensions/keycloak-admin-rest-client/deployment/pom.xml
+++ b/extensions/keycloak-admin-rest-client/deployment/pom.xml
@@ -33,6 +33,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-keycloak</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/keycloak-admin-resteasy-client/deployment/pom.xml
+++ b/extensions/keycloak-admin-resteasy-client/deployment/pom.xml
@@ -41,6 +41,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devservices-keycloak</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/oidc-common/deployment/pom.xml
+++ b/extensions/oidc-common/deployment/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-tls-registry-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.redis.deployment.client;
 
+import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
 import static io.quarkus.runtime.LaunchMode.DEVELOPMENT;
 
 import java.io.Closeable;
@@ -23,6 +25,7 @@ import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
@@ -32,6 +35,7 @@ import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.redis.deployment.client.RedisBuildTimeConfig.DevServiceConfiguration;
@@ -52,7 +56,8 @@ public class DevServicesRedisProcessor {
      */
     private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-redis";
 
-    private static final ContainerLocator redisContainerLocator = new ContainerLocator(DEV_SERVICE_LABEL, REDIS_EXPOSED_PORT);
+    private static final ContainerLocator redisContainerLocator = locateContainerWithLabels(REDIS_EXPOSED_PORT,
+            DEV_SERVICE_LABEL);
 
     private static final String QUARKUS = "quarkus.";
     private static final String DOT = ".";
@@ -63,6 +68,7 @@ public class DevServicesRedisProcessor {
     @BuildStep
     public List<DevServicesResultBuildItem> startRedisContainers(LaunchModeBuildItem launchMode,
             DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             RedisBuildTimeConfig config,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
@@ -102,7 +108,8 @@ public class DevServicesRedisProcessor {
                 String connectionName = entry.getKey();
                 boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                         devServicesSharedNetworkBuildItem);
-                RunningDevService devService = startContainer(dockerStatusBuildItem, connectionName,
+                RunningDevService devService = startContainer(dockerStatusBuildItem, composeProjectBuildItem,
+                        connectionName,
                         entry.getValue().devservices(),
                         launchMode.getLaunchMode(),
                         useSharedNetwork, devServicesConfig.timeout());
@@ -147,7 +154,9 @@ public class DevServicesRedisProcessor {
         return devServices.stream().map(RunningDevService::toBuildItem).collect(Collectors.toList());
     }
 
-    private RunningDevService startContainer(DockerStatusBuildItem dockerStatusBuildItem, String name,
+    private RunningDevService startContainer(DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
+            String name,
             io.quarkus.redis.deployment.client.DevServicesConfig devServicesConfig, LaunchMode launchMode,
             boolean useSharedNetwork, Optional<Duration> timeout) {
         if (!devServicesConfig.enabled()) {
@@ -178,7 +187,9 @@ public class DevServicesRedisProcessor {
 
         Supplier<RunningDevService> defaultRedisServerSupplier = () -> {
             QuarkusPortRedisContainer redisContainer = new QuarkusPortRedisContainer(dockerImageName, devServicesConfig.port(),
-                    launchMode == DEVELOPMENT ? devServicesConfig.serviceName() : null, useSharedNetwork);
+                    launchMode == DEVELOPMENT ? devServicesConfig.serviceName() : null,
+                    composeProjectBuildItem.getDefaultNetworkId(),
+                    useSharedNetwork);
             timeout.ifPresent(redisContainer::withStartupTimeout);
             redisContainer.withEnv(devServicesConfig.containerEnv());
             redisContainer.start();
@@ -188,6 +199,9 @@ public class DevServicesRedisProcessor {
         };
 
         return redisContainerLocator.locateContainer(devServicesConfig.serviceName(), devServicesConfig.shared(), launchMode)
+                .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
+                        List.of(devServicesConfig.imageName().orElse("redis")),
+                        REDIS_EXPOSED_PORT, launchMode, useSharedNetwork))
                 .map(containerAddress -> {
                     String redisUrl = REDIS_SCHEME + containerAddress.getUrl();
                     return new RunningDevService(Feature.REDIS_CLIENT.getName(), containerAddress.getId(),
@@ -208,25 +222,25 @@ public class DevServicesRedisProcessor {
         private final OptionalInt fixedExposedPort;
         private final boolean useSharedNetwork;
 
-        private String hostName = null;
+        private final String hostName;
 
         public QuarkusPortRedisContainer(DockerImageName dockerImageName, OptionalInt fixedExposedPort, String serviceName,
-                boolean useSharedNetwork) {
+                String defaultNetworkId, boolean useSharedNetwork) {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
 
             if (serviceName != null) {
                 withLabel(DEV_SERVICE_LABEL, serviceName);
+                withLabel(QUARKUS_DEV_SERVICE, serviceName);
             }
+            this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "redis");
         }
 
         @Override
         protected void configure() {
             super.configure();
-
             if (useSharedNetwork) {
-                hostName = ConfigureUtil.configureSharedNetwork(this, "redis");
                 return;
             }
 

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
@@ -1,5 +1,8 @@
 package io.quarkus.apicurio.registry.devservice;
 
+import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +21,7 @@ import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
@@ -27,6 +31,7 @@ import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.runtime.LaunchMode;
@@ -50,8 +55,8 @@ public class DevServicesApicurioRegistryProcessor {
      */
     private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-apicurio-registry";
 
-    private static final ContainerLocator apicurioRegistryContainerLocator = new ContainerLocator(DEV_SERVICE_LABEL,
-            APICURIO_REGISTRY_PORT);
+    private static final ContainerLocator apicurioRegistryContainerLocator = locateContainerWithLabels(APICURIO_REGISTRY_PORT,
+            DEV_SERVICE_LABEL);
 
     static volatile RunningDevService devService;
     static volatile ApicurioRegistryDevServiceCfg cfg;
@@ -60,6 +65,7 @@ public class DevServicesApicurioRegistryProcessor {
     @BuildStep
     public DevServicesResultBuildItem startApicurioRegistryDevService(LaunchModeBuildItem launchMode,
             DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             ApicurioRegistryBuildTimeConfig apicurioRegistryConfiguration,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
@@ -82,7 +88,7 @@ public class DevServicesApicurioRegistryProcessor {
         try {
             boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                     devServicesSharedNetworkBuildItem);
-            devService = startApicurioRegistry(dockerStatusBuildItem, configuration, launchMode,
+            devService = startApicurioRegistry(dockerStatusBuildItem, composeProjectBuildItem, configuration, launchMode,
                     useSharedNetwork, devServicesConfig.timeout());
             compressor.close();
         } catch (Throwable t) {
@@ -139,6 +145,7 @@ public class DevServicesApicurioRegistryProcessor {
     }
 
     private RunningDevService startApicurioRegistry(DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             ApicurioRegistryDevServiceCfg config, LaunchModeBuildItem launchMode,
             boolean useSharedNetwork, Optional<Duration> timeout) {
         if (!config.devServicesEnabled) {
@@ -170,6 +177,9 @@ public class DevServicesApicurioRegistryProcessor {
 
         // Starting the broker
         return apicurioRegistryContainerLocator.locateContainer(config.serviceName, config.shared, launchMode.getLaunchMode())
+                .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
+                        List.of(config.imageName, "apicurio"),
+                        APICURIO_REGISTRY_PORT, launchMode.getLaunchMode(), useSharedNetwork))
                 .map(address -> new RunningDevService(Feature.APICURIO_REGISTRY_AVRO.getName(),
                         address.getId(), null,
                         // address does not have the URL Scheme - just the host:port, so prepend http://
@@ -179,6 +189,7 @@ public class DevServicesApicurioRegistryProcessor {
                             DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("apicurio/apicurio-registry-mem"),
                             config.fixedExposedPort,
                             launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
+                            composeProjectBuildItem.getDefaultNetworkId(),
                             useSharedNetwork);
                     timeout.ifPresent(container::withStartupTimeout);
                     container.withEnv(config.containerEnv);
@@ -257,21 +268,23 @@ public class DevServicesApicurioRegistryProcessor {
         private final int fixedExposedPort;
         private final boolean useSharedNetwork;
 
-        private String hostName = null;
+        private final String hostName;
 
         private ApicurioRegistryContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName,
-                boolean useSharedNetwork) {
+                String defaultNetworkId, boolean useSharedNetwork) {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
 
             if (serviceName != null) { // Only adds the label in dev mode.
                 withLabel(DEV_SERVICE_LABEL, serviceName);
+                withLabel(QUARKUS_DEV_SERVICE, serviceName);
             }
             withEnv("QUARKUS_PROFILE", "prod");
             if (!dockerImageName.getRepository().endsWith("apicurio/apicurio-registry-mem")) {
                 throw new IllegalArgumentException("Only apicurio/apicurio-registry-mem images are supported");
             }
+            this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "apicurio-registry");
         }
 
         @Override
@@ -279,7 +292,6 @@ public class DevServicesApicurioRegistryProcessor {
             super.configure();
 
             if (useSharedNetwork) {
-                hostName = ConfigureUtil.configureSharedNetwork(this, "kafka");
                 return;
             }
 

--- a/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
@@ -1,8 +1,13 @@
 package io.quarkus.smallrye.reactivemessaging.mqtt.deployment;
 
+import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+
 import java.io.Closeable;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -11,9 +16,9 @@ import java.util.function.Supplier;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
@@ -21,14 +26,18 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ComposeLocator;
+import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
@@ -48,8 +57,9 @@ public class MqttDevServicesProcessor {
     private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-mqtt";
 
     private static final int MQTT_PORT = 1883;
+    private static final int MQTT_TLS_PORT = 8883;
 
-    private static final ContainerLocator mqttContainerLocator = new ContainerLocator(DEV_SERVICE_LABEL, MQTT_PORT);
+    private static final ContainerLocator mqttContainerLocator = locateContainerWithLabels(MQTT_PORT, DEV_SERVICE_LABEL);
     static volatile RunningDevService devService;
     static volatile MqttDevServiceCfg cfg;
     static volatile boolean first = true;
@@ -57,13 +67,18 @@ public class MqttDevServicesProcessor {
     @BuildStep
     public DevServicesResultBuildItem startMqttDevService(
             DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             LaunchModeBuildItem launchMode,
             MqttBuildTimeConfig mqttClientBuildTimeConfig,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
-            DevServicesConfig devServicesConfig) {
+            DevServicesConfig devServicesConfig,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
 
         MqttDevServiceCfg configuration = getConfiguration(mqttClientBuildTimeConfig);
+
+        boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
+                devServicesSharedNetworkBuildItem);
 
         if (devService != null) {
             boolean shouldShutdownTheBroker = !configuration.equals(cfg);
@@ -78,8 +93,8 @@ public class MqttDevServicesProcessor {
                 (launchMode.isTest() ? "(test) " : "") + "MQTT Dev Services Starting:", consoleInstalledBuildItem,
                 loggingSetupBuildItem);
         try {
-            RunningDevService newDevService = startMqttBroker(dockerStatusBuildItem, configuration, launchMode,
-                    devServicesConfig.timeout());
+            RunningDevService newDevService = startMqttBroker(dockerStatusBuildItem, composeProjectBuildItem,
+                    configuration, launchMode, devServicesConfig.timeout(), useSharedNetwork);
             if (newDevService != null) {
                 devService = newDevService;
 
@@ -135,8 +150,9 @@ public class MqttDevServicesProcessor {
     }
 
     private RunningDevService startMqttBroker(DockerStatusBuildItem dockerStatusBuildItem,
+            DevServicesComposeProjectBuildItem composeProjectBuildItem,
             MqttDevServiceCfg config, LaunchModeBuildItem launchMode,
-            Optional<Duration> timeout) {
+            Optional<Duration> timeout, boolean useSharedNetwork) {
         if (!config.devServicesEnabled) {
             // explicitly disabled
             log.debug("Not starting Dev Services for MQTT, as it has been disabled in the config.");
@@ -154,12 +170,14 @@ public class MqttDevServicesProcessor {
             return null;
         }
 
-        ConfiguredMqttContainer container = new ConfiguredMqttContainer(
-                DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("mqtt"),
-                config.fixedExposedPort,
-                launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null);
-
         final Supplier<RunningDevService> defaultMqttBrokerSupplier = () -> {
+
+            ConfiguredMqttContainer container = new ConfiguredMqttContainer(
+                    DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("mqtt"),
+                    config.fixedExposedPort,
+                    launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
+                    composeProjectBuildItem.getDefaultNetworkId(),
+                    useSharedNetwork);
 
             // Starting the broker
             timeout.ifPresent(container::withStartupTimeout);
@@ -168,20 +186,28 @@ public class MqttDevServicesProcessor {
             return getRunningDevService(
                     container.getContainerId(),
                     container::close,
-                    container.getHost(),
+                    container.getEffectiveHost(),
                     container.getPort());
         };
 
-        return mqttContainerLocator
-                .locateContainer(
-                        config.serviceName,
-                        config.shared,
-                        launchMode.getLaunchMode())
+        return mqttContainerLocator.locateContainer(config.serviceName, config.shared, launchMode.getLaunchMode())
                 .map(containerAddress -> getRunningDevService(
                         containerAddress.getId(),
                         null,
                         containerAddress.getHost(),
                         containerAddress.getPort()))
+                .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
+                        List.of(config.imageName, "hivemq", "eclipse-mosquitto"),
+                        launchMode.getLaunchMode()).stream()
+                        .filter(r -> Arrays.stream(r.containerInfo().exposedPorts())
+                                .anyMatch(c -> c.privatePort() == MQTT_PORT || c.privatePort() == MQTT_TLS_PORT))
+                        .findFirst().map(r -> getRunningDevService(
+                                r.containerInfo().id(),
+                                null,
+                                useSharedNetwork ? ComposeLocator.getServiceName(r)
+                                        : DockerClientFactory.instance().dockerHostIpAddress(),
+                                useSharedNetwork ? MQTT_PORT
+                                        : r.getPortMapping(MQTT_PORT).or(() -> r.getPortMapping(MQTT_TLS_PORT)).orElse(0))))
                 .orElseGet(defaultMqttBrokerSupplier);
     }
 
@@ -193,8 +219,7 @@ public class MqttDevServicesProcessor {
         Map<String, String> configMap = new HashMap<>();
         configMap.put("mp.messaging.connector.smallrye-mqtt.host", host);
         configMap.put("mp.messaging.connector.smallrye-mqtt.port", String.valueOf(port));
-        return new RunningDevService(Feature.MESSAGING_MQTT.getName(),
-                containerId, closeable, configMap);
+        return new RunningDevService(Feature.MESSAGING_MQTT.getName(), containerId, closeable, configMap);
     }
 
     private boolean hasMqttChannelWithoutHostAndPort() {
@@ -266,17 +291,22 @@ public class MqttDevServicesProcessor {
     private static final class ConfiguredMqttContainer extends GenericContainer<ConfiguredMqttContainer> {
 
         private final int port;
+        private final boolean useSharedNetwork;
+        private final String hostName;
 
         private ConfiguredMqttContainer(
                 DockerImageName dockerImageName,
                 int fixedExposedPort,
-                String serviceName) {
+                String serviceName,
+                String defaultNetworkId,
+                boolean useSharedNetwork) {
             super(dockerImageName);
             this.port = fixedExposedPort;
+            this.useSharedNetwork = useSharedNetwork;
             withExposedPorts(MQTT_PORT);
-            withNetwork(Network.SHARED);
             if (serviceName != null) { // Only adds the label in dev mode.
                 withLabel(DEV_SERVICE_LABEL, serviceName);
+                withLabel(QUARKUS_DEV_SERVICE, serviceName);
             }
             withClasspathResourceMapping("mosquitto.conf",
                     "/mosquitto/config/mosquitto.conf",
@@ -284,6 +314,7 @@ public class MqttDevServicesProcessor {
             if (!dockerImageName.getRepository().endsWith("eclipse-mosquitto")) {
                 throw new IllegalArgumentException("Only official eclipse-mosquitto images are supported");
             }
+            this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "mqtt");
         }
 
         @Override
@@ -294,7 +325,14 @@ public class MqttDevServicesProcessor {
             }
         }
 
+        public String getEffectiveHost() {
+            return hostName;
+        }
+
         public int getPort() {
+            if (useSharedNetwork) {
+                return MQTT_PORT;
+            }
             return getMappedPort(MQTT_PORT);
         }
     }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
@@ -137,8 +137,16 @@ export class QwcDevServices extends observeState(QwcHotReloadElement) {
 
     _getNetwork(devService) {
         if (devService.containerInfo.networks) {
+            const networks = Object.entries(devService.containerInfo.networks)
+                .map(([key, aliases]) => {
+                    if (!aliases || aliases.length === 0) {
+                        return key;
+                    }
+                    return `${key} (${aliases.join(", ")})`;
+                })
+                .join(", ");
             return html`<span class="row"><vaadin-icon
-                    icon="font-awesome-solid:network-wired"></vaadin-icon>${devService.containerInfo.networks.join(', ')}</span>`;
+                    icon="font-awesome-solid:network-wired"></vaadin-icon>${networks}</span>`;
         }
     }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -19,6 +19,8 @@ public interface StartupAction {
 
     Map<String, String> getDevServicesProperties();
 
+    String getDevServicesNetworkId();
+
     /**
      * Runs the application by running the main method of the main class. As this is a blocking method a new
      * thread is created to run this task.

--- a/integration-tests/compose-devservices/compose-devservices.yml
+++ b/integration-tests/compose-devservices/compose-devservices.yml
@@ -1,0 +1,19 @@
+name: devservices
+services:
+  postgres:
+    image: docker.io/library/postgres:17
+    labels:
+      io.quarkus.devservices.compose.wait_for.logs: .*database system is ready to accept connections.*
+      io.quarkus.devservices.compose.config_map.env.DB_CONFIG: postgres.db.name
+      io.quarkus.devservices.compose.config_map.port.5432: postgres.db.port
+    ports:
+      - '5432'
+    networks:
+      default:
+        aliases:
+          - db
+    environment:
+      - POSTGRES_PASSWORD=S3cret
+      - POSTGRES_USER=my_user
+      - POSTGRES_DB=my_db
+      - DB_CONFIG=my_config

--- a/integration-tests/compose-devservices/docker-compose-dev-services.yml
+++ b/integration-tests/compose-devservices/docker-compose-dev-services.yml
@@ -1,0 +1,65 @@
+services:
+  broker1:
+    image: quay.io/ogunalp/kafka-native:latest
+    labels:
+      io.quarkus.devservices.compose.config_map.port.9092: kafka.port
+      io.quarkus.devservices.compose.exposed_ports: /tmp/ports
+    command: "./kafka.sh"
+    ports:
+      - "9092"
+    depends_on:
+      - postgres
+    networks:
+      default:
+        aliases:
+          - kafka
+    volumes:
+      - './kafka.sh:/work/kafka.sh'
+    configs:
+      - source: broker
+        target: /server.properties
+  some-rabbit:
+    profiles: ["rabbit"]
+    image: rabbitmq:4.0-management
+    labels:
+      io.quarkus.devservices.compose.wait_for.logs: .*Server startup complete.*
+    entrypoint: ["bash", "-c", "chmod 400 /var/lib/rabbitmq/.erlang.cookie; rabbitmq-server"]
+#    post_start:
+#      - command: ["echo", "rabbitmqctl add_user admin password"]
+    environment:
+      AMQP_USER: admin
+      AMQP_PASSWORD: password
+    healthcheck:
+      test: rabbitmq-diagnostics check_port_connectivity
+      interval: 1s
+      timeout: 3s
+      retries: 30
+    ports:
+      - '5672'
+      - '15672'
+    volumes:
+      - './src/test/resources/rabbitmq/definitions.json:/etc/rabbitmq/definitions.json'
+      - './src/test/resources/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf'
+  redis:
+    profiles: ["redis"]
+    image: docker.io/library/redis:7
+    labels:
+      io.quarkus.devservices.compose.config_map.env.REDIS_HOST_PASSWORD: quarkus.redis.password
+    environment:
+      REDIS_HOST_PASSWORD: "qwerty"
+      ALLOW_EMPTY_PASSWORD: "no"
+#      REDIS_ARGS: "--requirepass qwerty"
+    command: ["redis-server", "--requirepass", "qwerty"]
+    healthcheck:
+      test: [ "CMD", "redis-cli","ping" ]
+      interval: 1s
+      timeout: 3s
+      retries: 5
+    ports:
+      - "6379"
+
+configs:
+  broker:
+    content: |
+      broker.id=1
+      listeners=PLAINTEXT://

--- a/integration-tests/compose-devservices/kafka.sh
+++ b/integration-tests/compose-devservices/kafka.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+while [ ! -f /tmp/ports ]; do
+  sleep 0.1;
+done;
+
+sleep 0.1;
+
+source /tmp/ports;
+export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:$PORT_9092;
+/work/kafka

--- a/integration-tests/compose-devservices/pom.xml
+++ b/integration-tests/compose-devservices/pom.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-compose-devservices</artifactId>
+    <name>Quarkus - Integration Tests - Compose Dev Services</name>
+    <description>The Compose Dev Services integration tests module</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-shared-library</artifactId>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+
+        <!-- Health -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+
+        <!-- Kafka -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-client</artifactId>
+        </dependency>
+
+        <!-- Redis -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-amqp</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-client-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-amqp-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-kafka</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/kafka/KafkaAdminManager.java
+++ b/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/kafka/KafkaAdminManager.java
@@ -1,0 +1,65 @@
+package io.quarkus.it.compose.devservices.kafka;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.runtime.Startup;
+
+@ApplicationScoped
+public class KafkaAdminManager {
+
+    @ConfigProperty(name = "kafka.bootstrap.servers")
+    String bs;
+
+    private static AdminClient createAdmin(String kafkaBootstrapServers) {
+        Properties properties = new Properties();
+        properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapServers);
+        return AdminClient.create(properties);
+    }
+
+    AdminClient admin;
+
+    @Startup
+    void startup() throws ExecutionException, InterruptedException {
+        admin = createAdmin(bs);
+        if (!admin.listTopics().names().get().contains("test")) {
+            admin.createTopics(List.of(new NewTopic("test", 2, (short) 1),
+                    new NewTopic("test-consumer", 3, (short) 1))).all().get();
+        }
+    }
+
+    @PreDestroy
+    void cleanup() {
+        admin.close();
+    }
+
+    public int partitions(String topic) {
+        TopicDescription topicDescription;
+        try {
+            Map<String, TopicDescription> partitions = admin.describeTopics(Collections.singletonList(topic)).all()
+                    .get(2000, TimeUnit.MILLISECONDS);
+            topicDescription = partitions.get(topic);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+        if (topicDescription == null) {
+            throw new IllegalArgumentException("Topic doesn't exist: " + topic);
+        }
+        return topicDescription.partitions().size();
+    }
+
+}

--- a/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/kafka/KafkaEndpoint.java
+++ b/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/kafka/KafkaEndpoint.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.compose.devservices.kafka;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("/kafka")
+public class KafkaEndpoint {
+
+    @Inject
+    KafkaAdminManager admin;
+
+    @GET
+    @Path("/partitions/{topic}")
+    public Integer partitions(@PathParam("topic") String topic) {
+        return admin.partitions(topic);
+    }
+}

--- a/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/postgres/PostgresEndpoint.java
+++ b/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/postgres/PostgresEndpoint.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.compose.devservices.postgres;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/postgres")
+public class PostgresEndpoint {
+
+    @ConfigProperty(name = "postgres.db.name")
+    String dbName;
+
+    @ConfigProperty(name = "postgres.db.port")
+    String dbPort;
+
+    @GET
+    @Path("/name")
+    public String dbName() {
+        return dbName;
+    }
+
+    @GET
+    @Path("/port")
+    public String dbPort() {
+        return dbPort;
+    }
+
+}

--- a/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/rabbitmq/AMQPEndpoint.java
+++ b/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/rabbitmq/AMQPEndpoint.java
@@ -1,0 +1,41 @@
+package io.quarkus.it.compose.devservices.rabbitmq;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+
+@IfBuildProfile("rabbit")
+@Path("/amqp")
+public class AMQPEndpoint {
+
+    List<String> received = new CopyOnWriteArrayList<>();
+
+    @Incoming("test")
+    public void consume(String message) {
+        received.add(message);
+    }
+
+    @Channel("out")
+    MutinyEmitter<String> emitter;
+
+    @POST
+    @Path("/send")
+    public void send(String message) {
+        emitter.sendAndAwait(message);
+    }
+
+    @GET
+    @Path("/received")
+    public List<String> received() {
+        return received;
+    }
+}

--- a/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/redis/RedisEndpoint.java
+++ b/integration-tests/compose-devservices/src/main/java/io/quarkus/it/compose/devservices/redis/RedisEndpoint.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.compose.devservices.redis;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.redis.datasource.RedisDataSource;
+
+@IfBuildProfile("redis")
+@Path("/redis")
+public class RedisEndpoint {
+
+    @Inject
+    RedisDataSource redisClient;
+
+    @ConfigProperty(name = "quarkus.redis.hosts")
+    String redisHosts;
+
+    @ConfigProperty(name = "quarkus.redis.password")
+    String redisPassword;
+
+    @GET
+    public List<String> keys() {
+        return redisClient.key().keys("*");
+    }
+
+    @GET
+    @Path("/{key}")
+    public String get(String key) {
+        return redisClient.value(String.class).get(key);
+    }
+
+    @PUT
+    @Path("/{key}")
+    public void set(String key, String value) {
+        redisClient.value(String.class).set(key, value);
+    }
+
+    @GET
+    @Path("/host")
+    public String host() {
+        return redisHosts;
+    }
+
+    @GET
+    @Path("/password")
+    public String password() {
+        return redisPassword;
+    }
+}

--- a/integration-tests/compose-devservices/src/main/resources/application.properties
+++ b/integration-tests/compose-devservices/src/main/resources/application.properties
@@ -1,0 +1,29 @@
+quarkus.log.category.kafka.level=WARN
+quarkus.log.category.\"org.apache.kafka\".level=WARN
+quarkus.log.category.\"org.apache.zookeeper\".level=WARN
+
+# enable health checks
+quarkus.kafka.health.enabled=true
+quarkus.redis.health.enabled=true
+
+quarkus.devservices.timeout=30s
+
+#quarkus.native.container-runtime=podman
+
+#quarkus.compose.devservices.stop-containers=false
+#quarkus.compose.devservices.ryuk-enabled=false
+#quarkus.compose.devservices.follow-container-logs=true
+#quarkus.compose.devservices.env-variables.HOST_PORT=${quarkus.random-port}
+
+# redis profile includes redis service
+%redis.quarkus.compose.devservices.profiles=redis
+
+# kafka profile sets custom compose files, and kafka port mapped from the compose file
+%kafka.quarkus.compose.devservices.files=src/test/resources/docker-compose.yml,compose-devservices.yml
+%kafka.kafka.bootstrap.servers=PLAINTEXT://localhost:${kafka.port}
+
+# rabbit sets project name, include rabbit and redis with custom queue names
+%rabbit.quarkus.compose.devservices.project-name=redis-rabbit-services
+%rabbit.quarkus.compose.devservices.profiles=rabbit,redis
+%rabbit.mp.messaging.incoming.test.address=/queues/test
+%rabbit.mp.messaging.outgoing.out.address=/queues/test

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/HealthChecksITCase.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/HealthChecksITCase.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.compose.devservices;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class HealthChecksITCase extends HealthChecksTest {
+
+}

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/HealthChecksTest.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/HealthChecksTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.compose.devservices;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class HealthChecksTest {
+
+    @Test
+    public void health() {
+        RestAssured.when().get("/q/health/ready").then()
+                .body("status", is("UP"),
+                        "checks.name",
+                        containsInAnyOrder(
+                                "Redis connection health check",
+                                "Kafka connection health check",
+                                "Database connections health check",
+                                "SmallRye Reactive Messaging - readiness check"));
+    }
+
+}

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/kafka/KafkaServiceTest.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/kafka/KafkaServiceTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.compose.devservices.kafka;
+
+import static io.restassured.RestAssured.when;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(KafkaTestProfile.class)
+public class KafkaServiceTest {
+
+    @Test
+    public void test() {
+        when().get("/kafka/partitions/test").then().body(Matchers.is("2"));
+        when().get("/kafka/partitions/test-consumer").then().body(Matchers.is("3"));
+    }
+
+}

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/kafka/KafkaTestProfile.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/kafka/KafkaTestProfile.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.compose.devservices.kafka;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class KafkaTestProfile implements QuarkusTestProfile {
+    @Override
+    public String getConfigProfile() {
+        return "kafka";
+    }
+}

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/postgres/PostgresITCase.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/postgres/PostgresITCase.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.compose.devservices.postgres;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class PostgresITCase extends PostgresTest {
+
+}

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/postgres/PostgresTest.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/postgres/PostgresTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.compose.devservices.postgres;
+
+import static io.restassured.RestAssured.given;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class PostgresTest {
+
+    @Test
+    public void testConfig() {
+        given()
+                .when()
+                .get("/postgres/name")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("my_config"));
+
+        given()
+                .when()
+                .get("/postgres/port")
+                .then()
+                .statusCode(200)
+                .body(Matchers.not(Matchers.emptyOrNullString()));
+    }
+}

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/rabbitmq/RabbitTestProfile.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/rabbitmq/RabbitTestProfile.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.compose.devservices.rabbitmq;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class RabbitTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public String getConfigProfile() {
+        return "rabbit";
+    }
+}

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/rabbitmq/RabbitmqTest.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/rabbitmq/RabbitmqTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.compose.devservices.rabbitmq;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+@TestProfile(RabbitTestProfile.class)
+public class RabbitmqTest {
+
+    @Test
+    public void test() {
+        given()
+                .when()
+                .body("hello")
+                .post("/amqp/send")
+                .then()
+                .statusCode(204);
+        given()
+                .when()
+                .body("world")
+                .post("/amqp/send")
+                .then()
+                .statusCode(204);
+
+        await().untilAsserted(() -> given()
+                .accept(ContentType.JSON)
+                .when().get("/amqp/received")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("hello"),
+                        Matchers.containsString("world")));
+    }
+}

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/redis/RedisServiceTest.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/redis/RedisServiceTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.it.compose.devservices.redis;
+
+import static io.restassured.RestAssured.given;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+@TestProfile(RedisTestProfile.class)
+public class RedisServiceTest {
+
+    @Test
+    public void testKeys() {
+        given()
+                .contentType(ContentType.TEXT)
+                .body("foo")
+                .when()
+                .put("/redis/test")
+                .then()
+                .statusCode(204);
+
+        given()
+                .accept(ContentType.TEXT)
+                .when()
+                .get("/redis/test")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("foo"));
+    }
+
+    @Test
+    public void testConnection() {
+        given()
+                .when()
+                .get("/redis/host")
+                .then()
+                .statusCode(200)
+                .body(Matchers.not(Matchers.emptyOrNullString()));
+
+        given()
+                .accept(ContentType.TEXT)
+                .when()
+                .get("/redis/password")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("qwerty"));
+    }
+
+}

--- a/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/redis/RedisTestProfile.java
+++ b/integration-tests/compose-devservices/src/test/java/io/quarkus/it/compose/devservices/redis/RedisTestProfile.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.compose.devservices.redis;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class RedisTestProfile implements QuarkusTestProfile {
+    @Override
+    public String getConfigProfile() {
+        return "redis";
+    }
+}

--- a/integration-tests/compose-devservices/src/test/resources/docker-compose.yml
+++ b/integration-tests/compose-devservices/src/test/resources/docker-compose.yml
@@ -1,0 +1,36 @@
+name: kafka-native
+services:
+  broker1:
+    image: docker.io/apache/kafka-native:3.9.0
+    labels:
+      io.quarkus.devservices.compose.wait_for.logs: .*Kafka Server started.*
+      io.quarkus.devservices.compose.config_map.port.9092: kafka.port
+      io.quarkus.devservices.compose.exposed_ports: /etc/kafka/docker/ports
+    command: "/kafka.sh"
+    ports:
+      - "9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9096
+      KAFKA_NODE_ID: 1
+      KAFKA_LOG_CLEANER_DEDUPE_BUFFER_SIZE: 2097152
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_NUM_PARTITIONS: 3
+    volumes:
+      - './kafka.sh:/kafka.sh'
+  ignored_rabbit:
+    image: rabbitmq:4.0-management
+    labels:
+      io.quarkus.devservices.compose.wait_for.logs: .*Server startup complete.*
+      io.quarkus.devservices.compose.wait_for.ports.disable: true
+      io.quarkus.devservices.compose.ignore: true
+    ports:
+      - '5672'
+      - '15672'

--- a/integration-tests/compose-devservices/src/test/resources/kafka.sh
+++ b/integration-tests/compose-devservices/src/test/resources/kafka.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+while [ ! -f /etc/kafka/docker/ports ]; do
+  sleep 0.1;
+done;
+
+sleep 0.1;
+
+source /etc/kafka/docker/ports;
+export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:$PORT_9092;
+/etc/kafka/docker/run

--- a/integration-tests/compose-devservices/src/test/resources/rabbitmq/definitions.json
+++ b/integration-tests/compose-devservices/src/test/resources/rabbitmq/definitions.json
@@ -1,0 +1,25 @@
+{
+  "users": [
+    {
+      "name": "admin",
+      "password_hash": "qPmODBw13vRJqI7+/X81ABjTzraRpB30+o6UuzXTNfidYQhD",
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "tags": "administrator"
+    }
+  ],
+  "vhosts":[
+    {"name":"/"}
+  ],
+  "queues":[
+    {"name":"test","vhost":"/","durable":true,"auto_delete":false,"arguments":{}}
+  ],
+  "permissions": [
+    {
+      "user": "admin",
+      "vhost": "/",
+      "configure": ".*",
+      "write": ".*",
+      "read": ".*"
+    }
+  ]
+}

--- a/integration-tests/compose-devservices/src/test/resources/rabbitmq/rabbitmq.conf
+++ b/integration-tests/compose-devservices/src/test/resources/rabbitmq/rabbitmq.conf
@@ -1,0 +1,1 @@
+load_definitions = /etc/rabbitmq/definitions.json

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -170,6 +170,7 @@
                 <module>bouncycastle-fips</module>
                 <module>bouncycastle-fips-jsse</module>
                 <module>bouncycastle-jsse</module>
+                <module>compose-devservices</module>
                 <module>funqy-amazon-lambda</module>
                 <module>funqy-google-cloud-functions</module>
                 <module>class-transformer</module>

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
@@ -4,17 +4,21 @@ import java.util.function.BiConsumer;
 
 import io.quarkus.builder.BuildResult;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesNetworkIdBuildItem;
 
 public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult> {
     @Override
     public void accept(Object o, BuildResult buildResult) {
         BiConsumer<String, String> propertyConsumer = (BiConsumer<String, String>) o;
 
+        DevServicesNetworkIdBuildItem compose = buildResult.consumeOptional(DevServicesNetworkIdBuildItem.class);
         DevServicesLauncherConfigResultBuildItem devServicesProperties = buildResult
                 .consume(DevServicesLauncherConfigResultBuildItem.class);
         for (var entry : devServicesProperties.getConfig().entrySet()) {
             propertyConsumer.accept(entry.getKey(), entry.getValue());
         }
-
+        if (compose != null && compose.getNetworkId() != null) {
+            propertyConsumer.accept("quarkus.test.container.network", compose.getNetworkId());
+        }
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -347,7 +347,7 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
                     copyEntriesFromProfile(profileInstance, startupAction.getClassLoader()),
                     profileInstance != null && profileInstance.disableGlobalTestResources(),
                     startupAction.getDevServicesProperties(),
-                    Optional.empty());
+                    Optional.ofNullable(startupAction.getDevServicesNetworkId()));
             TestResourceUtil.TestResourceManagerReflections.initReflectively(testResourceManager, profile);
             Map<String, String> properties = TestResourceUtil.TestResourceManagerReflections
                     .startReflectively(testResourceManager);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -213,7 +213,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                             startupAction.getClassLoader()),
                     profileInstance != null && profileInstance.disableGlobalTestResources(),
                     startupAction.getDevServicesProperties(),
-                    Optional.empty(),
+                    Optional.ofNullable(startupAction.getDevServicesNetworkId()),
                     testClassLocation);
             TestResourceUtil.TestResourceManagerReflections.initReflectively(testResourceManager, profile);
             Map<String, String> properties = TestResourceUtil.TestResourceManagerReflections


### PR DESCRIPTION
The Compose Dev Service discovers [Compose files](https://github.com/compose-spec/compose-spec) in a Quarkus project and starts services defined in the Compose project, using Docker Compose or Podman Compose.

Detailed feature docs in `compose-dev-services.adoc`.

------

Extension dev services build steps can consume the `DevServicesComposeProjectBuildItem`  and can locate whether compose has created an eligible service that they can configure the Quarkus app for, much like how dev service instances shared between projects.

This change already integrates following platform dev services: Datasource Dev Services (DB2, MariaDB, MS SQL, MySQL, Oracle, Postgres), Keycloak, Elasticsearch, Infinispan, Kafka, Kubernetes, AMQP, MQTT, Pulsar, RabbitMQ, MongoDB, Observability, Redis, Apicurio Schema Registry.

For any not-yet-integrated service, it is possible to include description in the compose files to produce runtime configuration for the Quarkus application in dev/test.

The dev service hashes targeted compose files in order to detect changes in the content and restart compose.

Dev UI Devservices pane shows a brief description of the Compose Dev Services. 

If a Quarkus project doesn't contain Compose files, it can still discover Compose services using a configuration, effectively sharing a single compose project between multiple projects.

