### PR TITLE
Use actual `@RestLink` annotation in `StandardMethodImplementor`

### DIFF
--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
@@ -32,6 +32,7 @@ import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
 import io.quarkus.rest.data.panache.deployment.utils.ResponseImplementor;
 import io.quarkus.rest.data.panache.runtime.sort.SortQueryParamValidator;
+import io.quarkus.resteasy.reactive.links.RestLink;
 
 /**
  * A standard JAX-RS method implementor.
@@ -108,7 +109,7 @@ public abstract class StandardMethodImplementor implements MethodImplementor {
                 linkResource.addValue("entityClassName", entityClassName);
                 linkResource.addValue("rel", rel);
             } else {
-                AnnotationCreator linkResource = element.addAnnotation("io.quarkus.resteasy.reactive.links.RestLink");
+                AnnotationCreator linkResource = element.addAnnotation(RestLink.class);
                 Class<?> entityClass;
                 try {
                     entityClass = Thread.currentThread().getContextClassLoader().loadClass(entityClassName);


### PR DESCRIPTION
This is done to make it easier to search for all of its usages