### PR TITLE
Allow setting Clear-Site-Data on OIDC logout

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1141,6 +1141,15 @@ There are two main ways for the authentication information to expire: the tokens
 
 Let's start with explicit logout operations.
 
+[NOTE]
+====
+You can request setting https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data[Clear-Site-Data] directives for all of the logout operations with a `quarkus.oidc.logout.clear-site-data` configuration property. For example:
+
+[source,properties]
+----
+quarkus.oidc.logout.clear-site-data=cache,cookies
+----
+====
 
 [[user-initiated-logout]]
 ==== User-initiated logout

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import io.quarkus.oidc.common.runtime.OidcClientCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcConstants;
@@ -483,6 +484,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         public Map<String, String> extraParams;
 
         /**
+         * Clear-Site-Data header directives
+         */
+        Optional<Set<ClearSiteData>> clearSiteData = Optional.of(Set.of());
+
+        /**
          * Back-Channel Logout configuration
          */
         public Backchannel backchannel = new Backchannel();
@@ -545,6 +551,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             postLogoutPath = mapping.postLogoutPath();
             postLogoutUriParam = mapping.postLogoutUriParam();
             extraParams = mapping.extraParams();
+            clearSiteData = mapping.clearSiteData();
             backchannel.addConfigMappingValues(mapping.backchannel());
             frontchannel.addConfigMappingValues(mapping.frontchannel());
         }
@@ -577,6 +584,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         @Override
         public io.quarkus.oidc.runtime.OidcTenantConfig.Frontchannel frontchannel() {
             return frontchannel;
+        }
+
+        @Override
+        public Optional<Set<ClearSiteData>> clearSiteData() {
+            return clearSiteData;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -1512,11 +1512,13 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             if (isRpInitiatedLogout(context, configContext)) {
                 LOG.debug("Performing an RP initiated logout");
                 fireEvent(SecurityEvent.Type.OIDC_LOGOUT_RP_INITIATED, identity);
+                OidcUtils.setClearSiteData(context, configContext.oidcConfig());
                 return buildLogoutRedirectUriUni(context, configContext, idToken);
             }
             if (isBackChannelLogoutPendingAndValid(configContext, identity)
                     || isFrontChannelLogoutValid(context, configContext,
                             identity)) {
+                OidcUtils.setClearSiteData(context, configContext.oidcConfig());
                 return removeSessionCookie(context, configContext.oidcConfig())
                         .map(new Function<Void, Void>() {
                             @Override
@@ -1528,5 +1530,6 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             }
             return VOID_UNI;
         }
+
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcSessionImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcSessionImpl.java
@@ -39,6 +39,7 @@ public class OidcSessionImpl implements OidcSession {
         return oidcConfigUni.onItem().transformToUni(new Function<OidcTenantConfig, Uni<? extends Void>>() {
             @Override
             public Uni<Void> apply(OidcTenantConfig oidcConfig) {
+                OidcUtils.setClearSiteData(routingContext, oidcConfig);
                 return OidcUtils.removeSessionCookie(routingContext, oidcConfig,
                         resolver.getTokenStateManager());
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import io.quarkus.oidc.JavaScriptRequestChecker;
 import io.quarkus.oidc.TenantConfigResolver;
@@ -291,6 +292,53 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
          * Front-Channel Logout configuration
          */
         Frontchannel frontchannel();
+
+        enum ClearSiteData {
+            /**
+             * Clear cache
+             */
+            CACHE("cache"),
+
+            /**
+             * Clear client hints.
+             */
+            CLIENT_HINTS("clientHints"),
+
+            /**
+             * Clear cookies.
+             */
+            COOKIES("cookies"),
+
+            /**
+             * Clear execution contexts
+             */
+            EXECUTION_CONTEXTS("executionContexts"),
+
+            /**
+             * Clear storage
+             */
+            STORAGE("storage"),
+
+            /**
+             * Clear all types of data
+             */
+            WILDCARD("*");
+
+            private String directive;
+
+            private ClearSiteData(String directive) {
+                this.directive = directive;
+            }
+
+            public String directive() {
+                return "\"" + directive + "\"";
+            }
+        }
+
+        /**
+         * Clear-Site-Data header directives
+         */
+        Optional<Set<ClearSiteData>> clearSiteData();
     }
 
     interface Backchannel {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
@@ -50,6 +51,7 @@ import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.runtime.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Authentication;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Logout.ClearSiteData;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Roles;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Token;
 import io.quarkus.oidc.runtime.providers.KnownOidcProviders;
@@ -104,6 +106,7 @@ public final class OidcUtils {
     public static final String DPOP_PROOF = "dpop_proof";
     public static final String DPOP_PROOF_JWT_HEADERS = "dpop_proof_jwt_headers";
     public static final String DPOP_PROOF_JWT_CLAIMS = "dpop_proof_jwt_claims";
+    public static final String CLEAR_SITE_DATA_HEADER = "Clear-Site-Data";
 
     private static final String APPLICATION_JWT = "application/jwt";
 
@@ -840,5 +843,19 @@ public final class OidcUtils {
         }
         String remainder = ct.substring(APPLICATION_JWT.length()).trim();
         return remainder.indexOf(';') == 0;
+    }
+
+    public static void setClearSiteData(RoutingContext context, OidcTenantConfig oidcConfig) {
+        Set<ClearSiteData> dirs = oidcConfig.logout().clearSiteData().orElse(Set.of());
+        if (!dirs.isEmpty()) {
+            StringBuilder builder = new StringBuilder();
+            for (ClearSiteData dir : dirs) {
+                if (!builder.isEmpty()) {
+                    builder.append(",");
+                }
+                builder.append(dir.directive());
+            }
+            context.response().putHeader(CLEAR_SITE_DATA_HEADER, builder.toString());
+        }
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/LogoutConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/LogoutConfigBuilder.java
@@ -2,12 +2,16 @@ package io.quarkus.oidc.runtime.builders;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import io.quarkus.oidc.OidcTenantConfigBuilder;
 import io.quarkus.oidc.runtime.OidcTenantConfig;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Logout.ClearSiteData;
 
 /**
  * Builder for the {@link OidcTenantConfig.Logout}.
@@ -15,7 +19,8 @@ import io.quarkus.oidc.runtime.OidcTenantConfig;
 public final class LogoutConfigBuilder {
     private record LogoutImpl(Optional<String> path, Optional<String> postLogoutPath, String postLogoutUriParam,
             Map<String, String> extraParams, OidcTenantConfig.Backchannel backchannel,
-            OidcTenantConfig.Frontchannel frontchannel) implements OidcTenantConfig.Logout {
+            OidcTenantConfig.Frontchannel frontchannel,
+            Optional<Set<ClearSiteData>> clearSiteData) implements OidcTenantConfig.Logout {
     }
 
     private record FrontchannelImpl(Optional<String> path) implements OidcTenantConfig.Frontchannel {
@@ -28,6 +33,7 @@ public final class LogoutConfigBuilder {
     private String postLogoutUriParam;
     private OidcTenantConfig.Backchannel backchannel;
     private OidcTenantConfig.Frontchannel frontchannel;
+    private Optional<Set<ClearSiteData>> clearSiteData = Optional.of(new HashSet<>());
 
     public LogoutConfigBuilder() {
         this(new OidcTenantConfigBuilder());
@@ -44,6 +50,7 @@ public final class LogoutConfigBuilder {
         this.postLogoutUriParam = logout.postLogoutUriParam();
         this.backchannel = logout.backchannel();
         this.frontchannel = logout.frontchannel();
+        this.clearSiteData = logout.clearSiteData();
     }
 
     /**
@@ -106,6 +113,26 @@ public final class LogoutConfigBuilder {
     }
 
     /**
+     * Clear all site data
+     *
+     * @return this builder
+     */
+    public LogoutConfigBuilder clearSiteData() {
+        this.clearSiteData(List.of(ClearSiteData.WILDCARD));
+        return this;
+    }
+
+    /**
+     * @param clear site data directives {@link OidcTenantConfig.Logout#clearSiteData()}
+     * @return this builder
+     */
+    public LogoutConfigBuilder clearSiteData(List<ClearSiteData> directives) {
+        Objects.requireNonNull(directives);
+        this.clearSiteData.get().addAll(directives);
+        return this;
+    }
+
+    /**
      * @param backchannel {@link OidcTenantConfig.Logout#backchannel()}
      * @return this builder
      */
@@ -134,7 +161,8 @@ public final class LogoutConfigBuilder {
      * @return built {@link OidcTenantConfig.Logout}
      */
     public OidcTenantConfig.Logout build() {
-        return new LogoutImpl(path, postLogoutPath, postLogoutUriParam, Map.copyOf(extraParams), backchannel, frontchannel);
+        return new LogoutImpl(path, postLogoutPath, postLogoutUriParam, Map.copyOf(extraParams), backchannel, frontchannel,
+                clearSiteData);
     }
 
     /**

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.WithConverter;
@@ -160,15 +161,16 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         LOGOUT_PATH,
         LOGOUT_POST_LOGOUT_PATH,
         LOGOUT_POST_LOGOUT_URI_PARAM,
-        LOGOUT_POST_LOGOUT_EXTRA_PARAMS,
-        LOGOUT_POST_LOGOUT_BACK_CHANNEL,
-        LOGOUT_POST_LOGOUT_FRONT_CHANNEL,
-        LOGOUT_POST_LOGOUT_FRONT_CHANNEL_PATH,
-        LOGOUT_POST_LOGOUT_BACK_CHANNEL_PATH,
-        LOGOUT_POST_LOGOUT_BACK_CHANNEL_TOKEN_CACHE_SIZE,
-        LOGOUT_POST_LOGOUT_BACK_CHANNEL_TOKEN_CACHE_TTL,
-        LOGOUT_POST_LOGOUT_BACK_CHANNEL_CLEAN_UP_TIMER_INTERVAL,
-        LOGOUT_POST_LOGOUT_BACK_CHANNEL_LOGOUT_TOKEN_KEY,
+        LOGOUT_CLEAR_SITE_DATA,
+        LOGOUT_EXTRA_PARAMS,
+        LOGOUT_BACK_CHANNEL,
+        LOGOUT_FRONT_CHANNEL,
+        LOGOUT_FRONT_CHANNEL_PATH,
+        LOGOUT_BACK_CHANNEL_PATH,
+        LOGOUT_BACK_CHANNEL_TOKEN_CACHE_SIZE,
+        LOGOUT_BACK_CHANNEL_TOKEN_CACHE_TTL,
+        LOGOUT_BACK_CHANNEL_CLEAN_UP_TIMER_INTERVAL,
+        LOGOUT_BACK_CHANNEL_LOGOUT_TOKEN_KEY,
         TOKEN_ISSUER,
         TOKEN_AUDIENCE,
         TOKEN_SUBJECT_REQUIRED,
@@ -480,42 +482,48 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
 
             @Override
             public Map<String, String> extraParams() {
-                invocationsRecorder.put(ConfigMappingMethods.LOGOUT_POST_LOGOUT_EXTRA_PARAMS, true);
+                invocationsRecorder.put(ConfigMappingMethods.LOGOUT_EXTRA_PARAMS, true);
                 return Map.of();
             }
 
             @Override
+            public Optional<Set<ClearSiteData>> clearSiteData() {
+                invocationsRecorder.put(ConfigMappingMethods.LOGOUT_CLEAR_SITE_DATA, true);
+                return Optional.of(Set.of());
+            }
+
+            @Override
             public Backchannel backchannel() {
-                invocationsRecorder.put(ConfigMappingMethods.LOGOUT_POST_LOGOUT_BACK_CHANNEL, true);
+                invocationsRecorder.put(ConfigMappingMethods.LOGOUT_BACK_CHANNEL, true);
                 return new Backchannel() {
                     @Override
                     public Optional<String> path() {
-                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_POST_LOGOUT_BACK_CHANNEL_PATH, true);
+                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_BACK_CHANNEL_PATH, true);
                         return Optional.empty();
                     }
 
                     @Override
                     public int tokenCacheSize() {
-                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_POST_LOGOUT_BACK_CHANNEL_TOKEN_CACHE_SIZE, true);
+                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_BACK_CHANNEL_TOKEN_CACHE_SIZE, true);
                         return 0;
                     }
 
                     @Override
                     public Duration tokenCacheTimeToLive() {
-                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_POST_LOGOUT_BACK_CHANNEL_TOKEN_CACHE_TTL, true);
+                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_BACK_CHANNEL_TOKEN_CACHE_TTL, true);
                         return null;
                     }
 
                     @Override
                     public Optional<Duration> cleanUpTimerInterval() {
-                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_POST_LOGOUT_BACK_CHANNEL_CLEAN_UP_TIMER_INTERVAL,
+                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_BACK_CHANNEL_CLEAN_UP_TIMER_INTERVAL,
                                 true);
                         return Optional.empty();
                     }
 
                     @Override
                     public String logoutTokenKey() {
-                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_POST_LOGOUT_BACK_CHANNEL_LOGOUT_TOKEN_KEY, true);
+                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_BACK_CHANNEL_LOGOUT_TOKEN_KEY, true);
                         return "";
                     }
                 };
@@ -523,11 +531,11 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
 
             @Override
             public Frontchannel frontchannel() {
-                invocationsRecorder.put(ConfigMappingMethods.LOGOUT_POST_LOGOUT_FRONT_CHANNEL, true);
+                invocationsRecorder.put(ConfigMappingMethods.LOGOUT_FRONT_CHANNEL, true);
                 return new Frontchannel() {
                     @Override
                     public Optional<String> path() {
-                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_POST_LOGOUT_FRONT_CHANNEL_PATH, true);
+                        invocationsRecorder.put(ConfigMappingMethods.LOGOUT_FRONT_CHANNEL_PATH, true);
                         return Optional.empty();
                     }
                 };

--- a/integration-tests/oidc-wiremock-logout/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock-logout/src/main/resources/application.properties
@@ -14,6 +14,7 @@ quarkus.oidc.code-flow-form-post.revoke-path=${keycloak.url}/realms/quarkus/revo
 # reuse the wiremock JWK endpoint stub for the `quarkus` realm - it is the same for the query and form post response mode
 quarkus.oidc.code-flow-form-post.jwks-path=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 quarkus.oidc.code-flow-form-post.logout.backchannel.path=/back-channel-logout
+quarkus.oidc.code-flow-form-post.logout.clear-site-data=cache,cookies
 quarkus.oidc.code-flow-form-post.token.audience=https://server.example.com,https://id.server.example.com
 
 quarkus.native.additional-build-args=-H:IncludeResources=private.*\\.*,-H:IncludeResources=.*\\.p12

--- a/integration-tests/oidc-wiremock-logout/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock-logout/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -7,6 +7,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.time.Duration;
@@ -94,6 +95,8 @@ public class CodeFlowAuthorizationTest {
             WebResponse webResponse = webClient
                     .loadWebResponse(new WebRequest(URI.create("http://localhost:8081/service/code-flow-form-post").toURL()));
             assertEquals(302, webResponse.getStatusCode());
+            String clearSiteData = webResponse.getResponseHeaderValue("clear-site-data");
+            assertTrue(clearSiteData.equals("\"cache\",\"cookies\"") || clearSiteData.equals("\"cookies\",\"cache\""));
 
             assertNull(getSessionCookie(webClient, "code-flow-form-post"));
 


### PR DESCRIPTION
Fixes #46723.

This simple PR allows OIDC users to choose to send one or more [Clear-Site-Data](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) directives after the logout request. Even though the PR is simple, I added a `release/noteworthy-feature` label to draw some attention to it since `Clear-Site-Data` is a rather new HTTP response header but which can be rather useful. 
Also, this PR is done as part of the threat modelling activity.

I also did some minor, test-level only updates to fix a few logout constant names