### PR TITLE
Use Jdk heap buffer pooling in Reactive SQL Clients

### DIFF
--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
@@ -10,6 +10,7 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemKeyCertO
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.setJdkHeapBufferPooling;
 
 import java.util.List;
 import java.util.Map;
@@ -237,6 +238,8 @@ public class DB2PoolRecorder {
         configurePemKeyCertOptions(connectOptions, dataSourceReactiveRuntimeConfig.keyCertificatePem());
         configureJksKeyCertOptions(connectOptions, dataSourceReactiveRuntimeConfig.keyCertificateJks());
         configurePfxKeyCertOptions(connectOptions, dataSourceReactiveRuntimeConfig.keyCertificatePfx());
+
+        setJdkHeapBufferPooling(connectOptions);
 
         connectOptions.setReconnectAttempts(dataSourceReactiveRuntimeConfig.reconnectAttempts());
 

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
@@ -10,6 +10,7 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemKeyCertO
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.setJdkHeapBufferPooling;
 
 import java.util.List;
 import java.util.Map;
@@ -251,6 +252,8 @@ public class MSSQLPoolRecorder {
         } else {
             mssqlConnectOptions.setHostnameVerificationAlgorithm(algo);
         }
+
+        setJdkHeapBufferPooling(mssqlConnectOptions);
 
         dataSourceReactiveRuntimeConfig.additionalProperties().forEach(mssqlConnectOptions::addProperty);
 

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -10,6 +10,7 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemKeyCertO
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.setJdkHeapBufferPooling;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -259,6 +260,8 @@ public class MySQLPoolRecorder {
             configurePemKeyCertOptions(mysqlConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificatePem());
             configureJksKeyCertOptions(mysqlConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificateJks());
             configurePfxKeyCertOptions(mysqlConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificatePfx());
+
+            setJdkHeapBufferPooling(mysqlConnectOptions);
 
             mysqlConnectOptions.setReconnectAttempts(dataSourceReactiveRuntimeConfig.reconnectAttempts());
 

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -10,6 +10,7 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemKeyCertO
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.setJdkHeapBufferPooling;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -247,6 +248,8 @@ public class PgPoolRecorder {
             configurePemKeyCertOptions(pgConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificatePem());
             configureJksKeyCertOptions(pgConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificateJks());
             configurePfxKeyCertOptions(pgConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificatePfx());
+
+            setJdkHeapBufferPooling(pgConnectOptions);
 
             pgConnectOptions.setReconnectAttempts(dataSourceReactiveRuntimeConfig.reconnectAttempts());
 

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/SSLConfigHelper.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/SSLConfigHelper.java
@@ -4,6 +4,7 @@ import io.quarkus.vertx.core.runtime.config.JksConfiguration;
 import io.quarkus.vertx.core.runtime.config.PemKeyCertConfiguration;
 import io.quarkus.vertx.core.runtime.config.PemTrustCertConfiguration;
 import io.quarkus.vertx.core.runtime.config.PfxConfiguration;
+import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.PemKeyCertOptions;
@@ -111,6 +112,22 @@ public class SSLConfigHelper {
     private static void ensureKeyCertOptionsNotSet(TCPSSLOptions options) {
         if (options.getKeyCertOptions() != null) {
             throw new IllegalArgumentException("Key cert options have already been set");
+        }
+    }
+
+    private static final boolean JDK_SSL_BUFFER_POOLING = Boolean.getBoolean("quarkus.http.server.ssl.jdk.bufferPooling");
+
+    public static void setJdkHeapBufferPooling(TCPSSLOptions tcpSslOptions) {
+        if (!JDK_SSL_BUFFER_POOLING) {
+            return;
+        }
+        var engineOption = tcpSslOptions.getSslEngineOptions();
+        if (engineOption == null) {
+            var jdkEngineOptions = new JdkSSLEngineOptions();
+            jdkEngineOptions.setPooledHeapBuffers(true);
+            tcpSslOptions.setSslEngineOptions(jdkEngineOptions);
+        } else if (engineOption instanceof JdkSSLEngineOptions jdkEngineOptions) {
+            jdkEngineOptions.setPooledHeapBuffers(true);
         }
     }
 


### PR DESCRIPTION
See #42224

To avoid having several sys props for config, reuse the existing one related to http server.