### PR TITLE
Docs: Fix spacing issue in metadata of Using S2I to deploy Quarkus applications to OpenShift procedure

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift-S2I-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-S2I-howto.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="deploying-to-openshift-S2I-howto"]
 = Using S2I to deploy {project-name} applications to {openshift}
-
 include::_attributes.adoc[]
 :diataxis-type: howto
 :categories: cloud, native


### PR DESCRIPTION
This PR aims to fix an issue with the rendering of the  _Using S2I to deploy Quarkus applications to OpenShift procedure (see [PR 45954](https://github.com/quarkusio/quarkus/pull/45954)) caused by a spacing typo.