### PR TITLE
Use RestResponse in the implementation of REST Data Panache endpoints 

### DIFF
--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -208,17 +208,18 @@ public class PeopleResourceJaxRs { // The actual class name is going to be uniqu
     @GET
     @Path("{id}")
     @Produces("application/json")
-    public Person get(@PathParam("id") Long id){
+    public RestResponse<Person> get(@PathParam("id") Long id){
         Person person = resource.get(id);
         if (person == null) {
-            throw new WebApplicationException(404);
+            return ResponseBuilder.create(404).build();
+        } else {
+            return ResponseBuilder.ok(var3).build();
         }
-        return person;
     }
 
     @GET
     @Produces("application/json")
-    public Response list(@QueryParam("sort") List<String> sortQuery,
+    public RestResponse<Person> list(@QueryParam("sort") List<String> sortQuery,
             @QueryParam("page") @DefaultValue("0") int pageIndex,
             @QueryParam("size") @DefaultValue("20") int pageSize) {
         Page page = Page.of(pageIndex, pageSize);
@@ -229,16 +230,16 @@ public class PeopleResourceJaxRs { // The actual class name is going to be uniqu
 
     @GET
     @Path("/count")
-    public long count() {
-        return resource.count();
+    public RestResponse<Long> count() {
+        return ResponseBuilder.ok(var1.count()).build()
     }
 
     @Transactional
     @POST
     @Consumes("application/json")
     @Produces("application/json")
-    public Response add(Person personToSave) {
-        Person person = resource.add(person);
+    public RestResponse<Person> add(Person personToSave) {
+        Person person = resource.add(personToSave);
         // ... build a new location URL and return 201 response with an entity
     }
 
@@ -247,10 +248,10 @@ public class PeopleResourceJaxRs { // The actual class name is going to be uniqu
     @Path("{id}")
     @Consumes("application/json")
     @Produces("application/json")
-    public Response update(@PathParam("id") Long id, Person personToSave) {
+    public RestResponse<Person> update(@PathParam("id") Long id, Person personToSave) {
         if (resource.get(id) == null) {
             Person person = resource.update(id, personToSave);
-            return Response.status(204).build();
+            return ResponseBuilder.create(204).build();
         }
         Person person = resource.update(id, personToSave);
         // ... build a new location URL and return 201 response with an entity
@@ -259,10 +260,8 @@ public class PeopleResourceJaxRs { // The actual class name is going to be uniqu
     @Transactional
     @DELETE
     @Path("{id}")
-    public void delete(@PathParam("id") Long id) {
-        if (!resource.delete(id)) {
-            throw new WebApplicationException(404);
-        }
+    public RestResponse<Person> delete(@PathParam("id") Long id) {
+        return !var2.delete(id) ? ResponseBuilder.create(404).build() : ResponseBuilder.create(204).build();
     }
 }
 ----

--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -13,7 +13,7 @@ include::_attributes.adoc[]
 A lot of web applications are monotonous CRUD applications with REST APIs that are tedious to write.
 To streamline this task, REST Data with Panache extension can generate the basic CRUD endpoints for your entities and repositories.
 
-Currently, this extension supports Hibernate ORM and MongoDB with Panache and can generate CRUD resources that work with `application/json` and `application/hal+json` content.
+Currently, this extension supports Hibernate ORM and MongoDB with Panache and can generate CRUD resources that work with `application/json` and `application/hal+json` content and generates REST Resources backed by Quarkus REST.
 
 == Setting up REST Data with Panache
 
@@ -22,22 +22,20 @@ Please, check out the next compatibility table to use the right one according to
 
 .Compatibility Table
 |===
-|Extension |Status |Hibernate |RESTEasy
+|Extension |Status |Hibernate
 
 |<<hr-hibernate-orm,quarkus-hibernate-orm-rest-data-panache>>
 |`Stable`
 |`ORM`
-|`Classic and Reactive`
 
 |<<hr-hibernate-reactive,quarkus-hibernate-reactive-rest-data-panache>>
 |`Experimental`
-|`Reactive`
 |`Reactive`
 
 |<<hr-mongodb,quarkus-mongodb-rest-data-panache>>
 |`Experimental`
 |`ORM`
-|`Classic and Reactive`
+
 |===
 
 [[hr-hibernate-orm]]
@@ -46,7 +44,7 @@ Please, check out the next compatibility table to use the right one according to
 * Add the required dependencies to your build file
 ** Hibernate ORM REST Data with Panache extension (`quarkus-hibernate-orm-rest-data-panache`)
 ** A JDBC driver extension (`quarkus-jdbc-postgresql`, `quarkus-jdbc-h2`, `quarkus-jdbc-mariadb`, ...)
-** One of the RESTEasy JSON serialization extensions (the extension supports both Quarkus REST (formerly RESTEasy Reactive) and RESTEasy Classic)
+** One of the REST JSON serialization extensions (such as `quarkus-rest-jackson`)
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
@@ -60,17 +58,9 @@ Please, check out the next compatibility table to use the right one according to
     <artifactId>quarkus-jdbc-postgresql</artifactId>
 </dependency>
 
-<!-- Use this if you are using Quarkus REST -->
 <dependency>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-rest-jackson</artifactId>
-</dependency>
-
-<!-- Use this if you are going to use RESTEasy Classic -->
-<!--
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-jackson</artifactId>
 </dependency>
 -->
 ----
@@ -81,11 +71,7 @@ Please, check out the next compatibility table to use the right one according to
 implementation("io.quarkus:quarkus-hibernate-orm-rest-data-panache")
 implementation("io.quarkus:quarkus-jdbc-postgresql")
 
-// Use this if you are using Quarkus REST
 implementation("io.quarkus:quarkus-rest-jackson")
-
-// Use this if you are going to use RESTEasy Classic
-// implementation("io.quarkus:quarkus-resteasy-jackson")
 ----
 
 * Implement the Panache entities and/or repositories as explained in the xref:hibernate-orm-panache.adoc[Hibernate ORM with Panache] guide.
@@ -143,14 +129,6 @@ To see the Hibernate ORM REST Data with Panache in action, you can check out the
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-rest-jackson</artifactId>
 </dependency>
-
-<!-- Use this if you are going to use RESTEasy Classic -->
-<!--
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-jackson</artifactId>
-</dependency>
--->
 ----
 
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
@@ -160,9 +138,6 @@ implementation("io.quarkus:quarkus-mongodb-rest-data-panache")
 
 // Use this if you are using Quarkus REST
 implementation("io.quarkus:quarkus-rest-jackson")
-
-// Use this if you are going to use RESTEasy Classic
-// implementation("io.quarkus:quarkus-resteasy-jackson")
 ----
 
 * Implement the Panache entities and/or repositories as explained in the xref:mongodb-panache.adoc[MongoDB with Panache] guide.

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/pom.xml
@@ -37,12 +37,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-links-deployment</artifactId>
+            <artifactId>quarkus-rest-links-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/panache/rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/rest-data-panache/deployment/pom.xml
@@ -36,11 +36,6 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-links-deployment</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-links-deployment</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
@@ -9,6 +9,8 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import org.jboss.resteasy.reactive.RestResponse;
+
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
@@ -104,7 +106,8 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
-                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                isNotReactivePanache() ? responseType(resourceMetadata.getEntityType())
+                        : uniType(resourceMetadata.getEntityType()),
                 param("entity", resourceMetadata.getEntityType()), param("uriInfo", UriInfo.class));
 
         // Add method annotations
@@ -115,7 +118,7 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
-        addOpenApiResponseAnnotation(methodCreator, Response.Status.CREATED, resourceMetadata.getEntityType());
+        addOpenApiResponseAnnotation(methodCreator, RestResponse.Status.CREATED, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
         // Add parameter annotations
         if (hasValidatorCapability()) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
@@ -84,11 +84,7 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, Long.class, false);
         addSecurityAnnotations(methodCreator, resourceProperties);
-        if (!isResteasyClassic()) {
-            // We only add the Links annotation in Resteasy Reactive because Resteasy Classic ignores the REL parameter:
-            // it always uses "list" for GET methods, so it interferes with the list implementation.
-            addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
-        }
+        addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
 
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
@@ -4,7 +4,7 @@ import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.responseType;
 import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.uniType;
 
-import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
 
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.ClassCreator;
@@ -75,14 +75,14 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         // Method parameters: sort strings, page index, page size, uri info
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(RESOURCE_METHOD_NAME, classCreator,
-                isNotReactivePanache() ? responseType() : uniType(Long.class));
+                isNotReactivePanache() ? responseType(Long.class) : uniType(Long.class));
 
         // Add method annotations
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), RESOURCE_METHOD_NAME));
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
-        addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, Long.class, false);
+        addOpenApiResponseAnnotation(methodCreator, RestResponse.Status.OK, Long.class, false);
         addSecurityAnnotations(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
@@ -7,6 +7,8 @@ import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreat
 
 import jakarta.ws.rs.core.Response;
 
+import org.jboss.resteasy.reactive.RestResponse;
+
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.ClassCreator;
@@ -84,7 +86,8 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
-                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                isNotReactivePanache() ? responseType(resourceMetadata.getEntityType())
+                        : uniType(resourceMetadata.getEntityType()),
                 param("id", resourceMetadata.getIdType()));
 
         // Add method annotations
@@ -93,7 +96,7 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
-        addOpenApiResponseAnnotation(methodCreator, Response.Status.NO_CONTENT);
+        addOpenApiResponseAnnotation(methodCreator, RestResponse.Status.NO_CONTENT);
         addSecurityAnnotations(methodCreator, resourceProperties);
 
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -7,6 +7,8 @@ import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreat
 
 import jakarta.ws.rs.core.Response;
 
+import org.jboss.resteasy.reactive.RestResponse;
+
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.ClassCreator;
@@ -86,7 +88,8 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
-                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                isNotReactivePanache() ? responseType(resourceMetadata.getEntityType())
+                        : uniType(resourceMetadata.getEntityType()),
                 param("id", resourceMetadata.getIdType()));
 
         // Add method annotations
@@ -94,7 +97,7 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
         addGetAnnotation(methodCreator);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
-        addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType());
+        addOpenApiResponseAnnotation(methodCreator, RestResponse.Status.OK, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
 
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -31,6 +31,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.jboss.jandex.Type;
+import org.jboss.resteasy.reactive.RestResponse;
 
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.AnnotatedElement;
@@ -190,7 +191,8 @@ public class ListMethodImplementor extends StandardMethodImplementor {
                     param.getClazz()));
         }
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(getMethodName(), classCreator,
-                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                isNotReactivePanache() ? responseType(resourceMetadata.getEntityType())
+                        : uniType(resourceMetadata.getEntityType()),
                 parameters.toArray(new SignatureMethodCreator.Parameter[0]));
 
         // Add method annotations
@@ -199,7 +201,7 @@ public class ListMethodImplementor extends StandardMethodImplementor {
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
-        addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType(), true);
+        addOpenApiResponseAnnotation(methodCreator, RestResponse.Status.OK, resourceMetadata.getEntityType(), true);
         addSecurityAnnotations(methodCreator, resourceProperties);
         addSortQueryParamValidatorAnnotation(methodCreator);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
@@ -276,7 +278,8 @@ public class ListMethodImplementor extends StandardMethodImplementor {
                     param.getClazz()));
         }
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(getMethodName(), classCreator,
-                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                isNotReactivePanache() ? responseType(resourceMetadata.getEntityType())
+                        : uniType(resourceMetadata.getEntityType()),
                 parameters.toArray(new SignatureMethodCreator.Parameter[0]));
 
         // Add method annotations
@@ -285,7 +288,7 @@ public class ListMethodImplementor extends StandardMethodImplementor {
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
-        addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType(), true);
+        addOpenApiResponseAnnotation(methodCreator, RestResponse.Status.OK, resourceMetadata.getEntityType(), true);
         addSecurityAnnotations(methodCreator, resourceProperties);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(1), "namedQuery");

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/OverrideUserMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/OverrideUserMethodImplementor.java
@@ -91,8 +91,7 @@ public class OverrideUserMethodImplementor extends StandardMethodImplementor {
             return;
         }
 
-        String linksAnnotationName = isResteasyClassic() ? "org.jboss.resteasy.links.LinkResource"
-                : "io.quarkus.resteasy.reactive.links.RestLink";
+        String linksAnnotationName = "io.quarkus.resteasy.reactive.links.RestLink";
         // Add the links annotation if and only if the user didn't add it.
         if (!methodInfo.hasAnnotation(linksAnnotationName)) {
             super.addLinksAnnotation(element, resourceProperties, entityClassName, rel);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
@@ -13,10 +13,10 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.Response;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestResponse;
 
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -171,25 +171,25 @@ public abstract class StandardMethodImplementor implements MethodImplementor {
         }
     }
 
-    protected void addOpenApiResponseAnnotation(AnnotatedElement element, Response.Status status) {
+    protected void addOpenApiResponseAnnotation(AnnotatedElement element, RestResponse.Status status) {
         if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI)) {
             element.addAnnotation(OPENAPI_RESPONSE_ANNOTATION)
                     .add("responseCode", String.valueOf(status.getStatusCode()));
         }
     }
 
-    protected void addOpenApiResponseAnnotation(AnnotatedElement element, Response.Status status, String entityType) {
+    protected void addOpenApiResponseAnnotation(AnnotatedElement element, RestResponse.Status status, String entityType) {
         addOpenApiResponseAnnotation(element, status, entityType, false);
     }
 
-    protected void addOpenApiResponseAnnotation(AnnotatedElement element, Response.Status status, String entityType,
+    protected void addOpenApiResponseAnnotation(AnnotatedElement element, RestResponse.Status status, String entityType,
             boolean isList) {
         if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI)) {
             addOpenApiResponseAnnotation(element, status, toClass(entityType), isList);
         }
     }
 
-    protected void addOpenApiResponseAnnotation(AnnotatedElement element, Response.Status status, Class<?> clazz,
+    protected void addOpenApiResponseAnnotation(AnnotatedElement element, RestResponse.Status status, Class<?> clazz,
             boolean isList) {
         if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI)) {
             AnnotationCreator schemaAnnotation = AnnotationCreator.of(OPENAPI_SCHEMA_ANNOTATION)

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -12,6 +12,8 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import org.jboss.resteasy.reactive.RestResponse;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
@@ -136,7 +138,8 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
-                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                isNotReactivePanache() ? responseType(resourceMetadata.getEntityType())
+                        : uniType(resourceMetadata.getEntityType()),
                 param("id", resourceMetadata.getIdType()),
                 param("entity", resourceMetadata.getEntityType()),
                 param("uriInfo", UriInfo.class));
@@ -150,7 +153,7 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_UPDATE_METHOD_NAME));
-        addOpenApiResponseAnnotation(methodCreator, Response.Status.CREATED, resourceMetadata.getEntityType());
+        addOpenApiResponseAnnotation(methodCreator, RestResponse.Status.CREATED, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
         // Add parameter annotations
         if (hasValidatorCapability()) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
@@ -22,7 +22,6 @@ import io.quarkus.hal.HalService;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.methods.ListMethodImplementor;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
-import io.quarkus.resteasy.links.runtime.hal.ResteasyHalService;
 import io.quarkus.resteasy.reactive.links.runtime.hal.ResteasyReactiveHalService;
 
 public final class ListHalMethodImplementor extends ListMethodImplementor {
@@ -79,7 +78,7 @@ public final class ListHalMethodImplementor extends ListMethodImplementor {
         ResultHandle instanceHandle = creator.invokeInterfaceMethod(
                 ofMethod(ArcContainer.class, "instance", InstanceHandle.class, Class.class, Annotation[].class),
                 arcContainer,
-                creator.loadClassFromTCCL(isResteasyClassic() ? ResteasyHalService.class : ResteasyReactiveHalService.class),
+                creator.loadClassFromTCCL(ResteasyReactiveHalService.class),
                 creator.newArray(Annotation.class, 0));
         ResultHandle halService = creator.invokeInterfaceMethod(
                 ofMethod(InstanceHandle.class, "get", Object.class), instanceHandle);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
@@ -7,8 +7,8 @@ import java.net.URI;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Link;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.ResponseBuilder;
+
+import org.jboss.resteasy.reactive.RestResponse;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -24,16 +24,17 @@ public final class ResponseImplementor {
 
     public ResultHandle ok(BytecodeCreator creator, ResultHandle entity) {
         ResultHandle builder = creator.invokeStaticMethod(
-                ofMethod(Response.class, "ok", ResponseBuilder.class, Object.class), entity);
-        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
+                ofMethod(RestResponse.ResponseBuilder.class, "ok", RestResponse.ResponseBuilder.class, Object.class), entity);
+        return creator.invokeVirtualMethod(ofMethod(RestResponse.ResponseBuilder.class, "build", RestResponse.class), builder);
     }
 
     public ResultHandle ok(BytecodeCreator creator, ResultHandle entity, ResultHandle links) {
         ResultHandle builder = creator.invokeStaticMethod(
-                ofMethod(Response.class, "ok", ResponseBuilder.class, Object.class), entity);
+                ofMethod(RestResponse.ResponseBuilder.class, "ok", RestResponse.ResponseBuilder.class, Object.class), entity);
         creator.invokeVirtualMethod(
-                ofMethod(ResponseBuilder.class, "links", ResponseBuilder.class, Link[].class), builder, links);
-        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
+                ofMethod(RestResponse.ResponseBuilder.class, "links", RestResponse.ResponseBuilder.class, Link[].class),
+                builder, links);
+        return creator.invokeVirtualMethod(ofMethod(RestResponse.ResponseBuilder.class, "build", RestResponse.class), builder);
     }
 
     public ResultHandle created(BytecodeCreator creator, ResultHandle entity, ResourceProperties resourceProperties) {
@@ -64,38 +65,41 @@ public final class ResponseImplementor {
     }
 
     public ResultHandle noContent(BytecodeCreator creator) {
-        return status(creator, Response.Status.NO_CONTENT.getStatusCode());
+        return status(creator, RestResponse.Status.NO_CONTENT.getStatusCode());
     }
 
     public ResultHandle notFound(BytecodeCreator creator) {
-        return status(creator, Response.Status.NOT_FOUND.getStatusCode());
+        return status(creator, RestResponse.Status.NOT_FOUND.getStatusCode());
     }
 
     public ResultHandle notFoundException(BytecodeCreator creator) {
         return creator.newInstance(MethodDescriptor.ofConstructor(WebApplicationException.class, int.class),
-                creator.load(Response.Status.NOT_FOUND.getStatusCode()));
+                creator.load(RestResponse.Status.NOT_FOUND.getStatusCode()));
     }
 
     private ResultHandle doCreated(BytecodeCreator creator, ResultHandle entity, ResultHandle location) {
-        ResultHandle builder = getResponseBuilder(creator, Response.Status.CREATED.getStatusCode());
+        ResultHandle builder = getResponseBuilder(creator, RestResponse.Status.CREATED.getStatusCode());
         creator.invokeVirtualMethod(
-                ofMethod(ResponseBuilder.class, "entity", ResponseBuilder.class, Object.class), builder, entity);
+                ofMethod(RestResponse.ResponseBuilder.class, "entity", RestResponse.ResponseBuilder.class, Object.class),
+                builder, entity);
         if (location != null) {
             creator.invokeVirtualMethod(
-                    ofMethod(ResponseBuilder.class, "location", ResponseBuilder.class, URI.class), builder, location);
+                    ofMethod(RestResponse.ResponseBuilder.class, "location", RestResponse.ResponseBuilder.class, URI.class),
+                    builder, location);
         }
 
-        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
+        return creator.invokeVirtualMethod(ofMethod(RestResponse.ResponseBuilder.class, "build", RestResponse.class), builder);
     }
 
     private ResultHandle status(BytecodeCreator creator, int status) {
         ResultHandle builder = getResponseBuilder(creator, status);
-        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
+        return creator.invokeVirtualMethod(ofMethod(RestResponse.ResponseBuilder.class, "build", RestResponse.class), builder);
     }
 
     private ResultHandle getResponseBuilder(BytecodeCreator creator, int status) {
         return creator.invokeStaticMethod(
-                ofMethod(Response.class, "status", ResponseBuilder.class, int.class), creator.load(status));
+                ofMethod(RestResponse.ResponseBuilder.class, "create", RestResponse.ResponseBuilder.class, int.class),
+                creator.load(status));
     }
 
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
@@ -13,23 +13,14 @@ import jakarta.ws.rs.core.Response.ResponseBuilder;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
-import io.quarkus.deployment.Capabilities;
-import io.quarkus.deployment.Capability;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.hal.HalService;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
-import io.quarkus.resteasy.links.runtime.hal.ResteasyHalService;
 import io.quarkus.resteasy.reactive.links.runtime.hal.ResteasyReactiveHalService;
 
 public final class ResponseImplementor {
-
-    private final Capabilities capabilities;
-
-    public ResponseImplementor(Capabilities capabilities) {
-        this.capabilities = capabilities;
-    }
 
     public ResultHandle ok(BytecodeCreator creator, ResultHandle entity) {
         ResultHandle builder = creator.invokeStaticMethod(
@@ -60,7 +51,7 @@ public final class ResponseImplementor {
                 MethodDescriptor.ofMethod(ArcContainer.class, "instance", InstanceHandle.class, Class.class,
                         Annotation[].class),
                 arcContainer,
-                creator.loadClassFromTCCL(isResteasyClassic() ? ResteasyHalService.class : ResteasyReactiveHalService.class),
+                creator.loadClassFromTCCL(ResteasyReactiveHalService.class),
                 creator.loadNull());
         ResultHandle halService = creator.invokeInterfaceMethod(
                 MethodDescriptor.ofMethod(InstanceHandle.class, "get", Object.class),
@@ -107,7 +98,4 @@ public final class ResponseImplementor {
                 ofMethod(Response.class, "status", ResponseBuilder.class, int.class), creator.load(status));
     }
 
-    private boolean isResteasyClassic() {
-        return capabilities.isPresent(Capability.RESTEASY);
-    }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/SignatureMethodCreator.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/SignatureMethodCreator.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 import jakarta.ws.rs.core.Response;
 
+import org.jboss.resteasy.reactive.RestResponse;
+
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.SignatureBuilder;
@@ -87,22 +89,23 @@ public final class SignatureMethodCreator {
         private Type type;
     }
 
-    public static ReturnType responseType() {
-        ReturnType returnType = new ReturnType();
-        returnType.classType = Response.class;
-        returnType.type = RESPONSE_TYPE;
-        return returnType;
+    public static ReturnType responseType(Object entityTypeStr) {
+        return getReturnType(RestResponse.class, entityTypeStr);
     }
 
-    public static ReturnType uniType(Object... arguments) {
+    public static ReturnType uniType(Object entityTypeStr) {
+        return getReturnType(Uni.class, entityTypeStr);
+    }
+
+    private static ReturnType getReturnType(Class<?> entityType, Object... arguments) {
         ReturnType returnType = new ReturnType();
         Type[] typeArguments = new Type[arguments.length];
         for (int index = 0; index < arguments.length; index++) {
             typeArguments[index] = toGizmoType(arguments[index]);
         }
 
-        returnType.classType = Uni.class;
-        returnType.type = parameterizedType(classType(Uni.class), typeArguments);
+        returnType.classType = entityType;
+        returnType.type = parameterizedType(classType(entityType), typeArguments);
         return returnType;
     }
 }

--- a/extensions/spring-data-rest/deployment/pom.xml
+++ b/extensions/spring-data-rest/deployment/pom.xml
@@ -38,12 +38,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-links-deployment</artifactId>
+            <artifactId>quarkus-rest-links-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/hibernate-orm-rest-data-panache/pom.xml
+++ b/integration-tests/hibernate-orm-rest-data-panache/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -97,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/HibernateOrmRestDataPanacheTest.java
+++ b/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/HibernateOrmRestDataPanacheTest.java
@@ -237,8 +237,8 @@ class HibernateOrmRestDataPanacheTest {
                 .and().body(book.toString())
                 .when().post("/books")
                 .then().statusCode(400)
-                .and().body("parameterViolations[0].path", equalTo("add.entity.title"))
-                .and().body("parameterViolations[0].message", equalTo("must not be blank"));
+                .and().body("violations[0].field", equalTo("add.entity.title"))
+                .and().body("violations[0].message", equalTo("must not be blank"));
     }
 
     @Test
@@ -307,7 +307,7 @@ class HibernateOrmRestDataPanacheTest {
                 .and().body(book.toString())
                 .when().put("/books/" + CRIME_AND_PUNISHMENT_ID)
                 .then().statusCode(400)
-                .and().body("parameterViolations[0].path", equalTo("update.entity.title"))
-                .and().body("parameterViolations[0].message", equalTo("must not be blank"));
+                .and().body("violations[0].field", equalTo("update.entity.title"))
+                .and().body("violations[0].message", equalTo("must not be blank"));
     }
 }

--- a/integration-tests/spring-data-rest/pom.xml
+++ b/integration-tests/spring-data-rest/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -97,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/SpringDataRestTest.java
+++ b/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/SpringDataRestTest.java
@@ -187,8 +187,8 @@ class SpringDataRestTest {
                 .and().body(book.toString())
                 .when().post("/books")
                 .then().statusCode(400)
-                .and().body("parameterViolations[0].path", equalTo("add.entity.title"))
-                .and().body("parameterViolations[0].message", equalTo("must not be blank"));
+                .and().body("violations[0].field", equalTo("add.entity.title"))
+                .and().body("violations[0].message", equalTo("must not be blank"));
     }
 
     @Test
@@ -257,8 +257,8 @@ class SpringDataRestTest {
                 .and().body(book.toString())
                 .when().put("/books/" + CRIME_AND_PUNISHMENT_ID)
                 .then().statusCode(400)
-                .and().body("parameterViolations[0].path", equalTo("update.entity.title"))
-                .and().body("parameterViolations[0].message", equalTo("must not be blank"));
+                .and().body("violations[0].field", equalTo("update.entity.title"))
+                .and().body("violations[0].message", equalTo("must not be blank"));
     }
 
     @Test


### PR DESCRIPTION
This makes it possible for things like Kotlin Serialization to work
properly.

IMPORTANT: In order to make this possible, this **removes** RESTEasy Classic support for `quarkus-rest-data-panache`

- Fixes: https://github.com/quarkusio/quarkus/issues/46849