### PR TITLE
Allow for static JAX-RS resource methods

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -201,6 +201,10 @@ public class Endpoint {
 }
 ----
 
+Quarkus also extends the JAX-RS spec to allow you to use static methods. If the static method is on a class annotated with
+`@Path`, it will be treated the same as a non-static endpoint. If there is no `@Path` annotation on the class then the path
+is assumed to be a root path. This is especially useful for Kotlin as it allows you to define endpoints without creating a class.
+
 === Declaring endpoints: representation / content types
 
 Each endpoint method may consume or produce specific resource representations, which are indicated by

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusInvokerFactory.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusInvokerFactory.java
@@ -54,6 +54,8 @@ public class QuarkusInvokerFactory implements EndpointInvokerFactory {
             ResultHandle res;
             if (Modifier.isInterface(currentClassInfo.flags())) {
                 res = mc.invokeInterfaceMethod(info, mc.getMethodParam(0), args);
+            } else if (Modifier.isStatic(info.flags())) {
+                res = mc.invokeStaticMethod(info, args);
             } else {
                 res = mc.invokeVirtualMethod(info, mc.getMethodParam(0), args);
             }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/FooNoClassPathStaticMethod.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/FooNoClassPathStaticMethod.java
@@ -1,0 +1,13 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+public class FooNoClassPathStaticMethod {
+
+    @Path("noclass")
+    @GET
+    public static String hello() {
+        return "noclass";
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/StaticMethodTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/StaticMethodTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class StaticMethodTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(StaticMethod.class, FooNoClassPathStaticMethod.class);
+                }
+            });
+
+    @Test
+    public void testStaticMethod() {
+        given().when().get("hello")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("hello"));
+        given().when().get("noclass")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("noclass"));
+    }
+
+    @Path("/")
+    public static class StaticMethod {
+
+        @Path("hello")
+        @GET
+        public static String hello() {
+            return "hello";
+        }
+    }
+
+    public static class FooNoClassPathStaticMethod {
+
+        public FooNoClassPathStaticMethod(StaticMethodTest someParam, Objects otherParam) { //CDI can't create this class
+
+        }
+
+        @Path("noclass")
+        @GET
+        public static String hello() {
+            return "noclass";
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/StaticMethodTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/StaticMethodTest.java
@@ -2,7 +2,6 @@ package io.quarkus.resteasy.reactive.server.test;
 
 import static io.restassured.RestAssured.given;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import jakarta.ws.rs.GET;
@@ -47,19 +46,6 @@ public class StaticMethodTest {
         @GET
         public static String hello() {
             return "hello";
-        }
-    }
-
-    public static class FooNoClassPathStaticMethod {
-
-        public FooNoClassPathStaticMethod(StaticMethodTest someParam, Objects otherParam) { //CDI can't create this class
-
-        }
-
-        @Path("noclass")
-        @GET
-        public static String hello() {
-            return "noclass";
         }
     }
 }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -564,11 +564,6 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                     + "' is not public and will therefore be ignored");
             return false;
         }
-        if ((info.flags() & Modifier.STATIC) != 0) {
-            log.warn("Method '" + info.name() + " of Resource class '" + info.declaringClass().name()
-                    + "' is static and will therefore be ignored");
-            return false;
-        }
         return true;
     }
 

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -283,7 +283,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         try {
             String path = scannedResourcePaths.get(classInfo.name());
             ResourceClass clazz = new ResourceClass();
-            if ((classInfo.enclosingClass() != null) && !Modifier.isStatic(classInfo.flags())) {
+            if ((classInfo.enclosingClass() != null) && !Modifier.isStatic(classInfo.flags()) && path != null) {
                 throw new DeploymentException(
                         "Non static nested resources classes are not supported: '" + classInfo.name() + "'");
             }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceMethod.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceMethod.java
@@ -74,13 +74,15 @@ public class ResourceMethod {
 
     private boolean encoded;
 
+    private boolean staticMethod;
+
     public ResourceMethod() {
     }
 
     public ResourceMethod(String httpMethod, String path, String[] produces, String streamElementType, String[] consumes,
             Set<String> nameBindingNames, String name, String returnType, String simpleReturnType, MethodParameter[] parameters,
             boolean blocking, boolean suspended, boolean isSse, boolean isFormParamRequired,
-            List<ResourceMethod> subResourceMethods, boolean encoded) {
+            List<ResourceMethod> subResourceMethods, boolean encoded, boolean staticMethod) {
         this.httpMethod = httpMethod;
         this.path = path;
         this.produces = produces;
@@ -97,6 +99,7 @@ public class ResourceMethod {
         this.isFormParamRequired = isFormParamRequired;
         this.subResourceMethods = subResourceMethods;
         this.encoded = encoded;
+        this.staticMethod = staticMethod;
     }
 
     public boolean isResourceLocator() {
@@ -254,6 +257,14 @@ public class ResourceMethod {
     public ResourceMethod setEncoded(boolean encoded) {
         this.encoded = encoded;
         return this;
+    }
+
+    public boolean isStaticMethod() {
+        return staticMethod;
+    }
+
+    public void setStaticMethod(boolean staticMethod) {
+        this.staticMethod = staticMethod;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -182,6 +182,9 @@ public class ServerEndpointIndexer
     protected ServerResourceMethod createResourceMethod(MethodInfo methodInfo, ClassInfo actualEndpointClass,
             Map<String, Object> methodContext) {
         ServerResourceMethod serverResourceMethod = new ServerResourceMethod();
+        if (Modifier.isStatic(methodInfo.flags())) {
+            serverResourceMethod.setStaticMethod(true);
+        }
         List<HandlerChainCustomizer> methodCustomizers = new ArrayList<>();
         for (MethodScanner i : methodScanners) {
             List<HandlerChainCustomizer> scanned = i.scan(methodInfo, actualEndpointClass, methodContext);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -171,10 +171,10 @@ public class RuntimeDeploymentManager {
         //we use this map to merge them
         Map<MappersKey, Map<String, TreeMap<URITemplate, List<RequestMapper.RequestPath<RuntimeResource>>>>> mappers = new TreeMap<>();
 
-        List<List<ResourceClass>> rcMap = List.of(resourceClasses, locatableResourceClasses);
+        List<List<ResourceClass>> rcMap = List.of(locatableResourceClasses, resourceClasses);
         // We only want to look for static methods on the locatableResourceClasses
         // For resource classes we want to look for all methods
-        var justLookingForStatic = false;
+        var justLookingForStatic = true;
         for (var e : rcMap) {
             for (int i = 0; i < e.size(); i++) {
                 ResourceClass clazz = e.get(i);
@@ -217,7 +217,7 @@ public class RuntimeDeploymentManager {
                 }
 
             }
-            justLookingForStatic = true;
+            justLookingForStatic = false;
         }
 
         classMappers = new ArrayList<>(mappers.size());

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -327,7 +327,7 @@ public class RuntimeResourceDeployment {
         // given that we may inject form params in the endpoint we need to make sure we read the body before
         // we create/inject our endpoint
         ServerRestHandler instanceHandler = null;
-        if (!locatableResource) {
+        if (!locatableResource && !method.isStaticMethod()) {
             if (clazz.isPerRequestResource()) {
                 instanceHandler = new PerRequestInstanceHandler(clazz.getFactory(), info.getClientProxyUnwrapper());
                 score.add(ScoreSystem.Category.Resource, ScoreSystem.Diagnostic.ResourcePerRequest);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
@@ -29,9 +29,9 @@ public class ServerResourceMethod extends ResourceMethod {
             boolean blocking, boolean suspended, boolean sse, boolean formParamRequired,
             List<ResourceMethod> subResourceMethods, Supplier<EndpointInvoker> invoker, Set<String> methodAnnotationNames,
             List<HandlerChainCustomizer> handlerChainCustomizers, ParameterExtractor customerParameterExtractor,
-            boolean encoded) {
+            boolean encoded, boolean staticMethod) {
         super(httpMethod, path, produces, streamElementType, consumes, nameBindingNames, name, returnType, simpleReturnType,
-                parameters, blocking, suspended, sse, formParamRequired, subResourceMethods, encoded);
+                parameters, blocking, suspended, sse, formParamRequired, subResourceMethods, encoded, staticMethod);
         this.invoker = invoker;
         this.methodAnnotationNames = methodAnnotationNames;
         this.handlerChainCustomizers = handlerChainCustomizers;


### PR DESCRIPTION
This is really useful in kotlin as it allows you to define methods that are not inside a class.

e.g. this allows you to write the Kotlin quickstart as:

```kotlin
@GET
@Path("/hello")
@Produces(MediaType.TEXT_PLAIN)
fun hello() = "Hello from Quarkus REST"
```

