### PR TITLE
Return locators path parameters in UriInfo

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceUriInfoTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceUriInfoTest.java
@@ -1,0 +1,115 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.test.simple.PortProviderUtil;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class SubResourceUriInfoTest {
+    @RegisterExtension
+    static QuarkusUnitTest testExtension = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    JavaArchive war = ShrinkWrap.create(JavaArchive.class);
+                    war.addClasses(PortProviderUtil.class);
+                    war.addClasses(UsersResource.class);
+                    war.addClasses(UserResource.class);
+                    war.addClasses(ContactResource.class);
+                    war.addClasses(ResponseHolder.class);
+                    return war;
+                }
+            });
+
+    @Test
+    public void basicTest() {
+        RestAssured.given()
+                .get("/users/userId/contacts/contactId")
+                .then()
+                .statusCode(200)
+                .body(equalTo("{id=[userId]}{id=[contactId, userId]}{id=[contactId, userId]}"));
+    }
+
+    @RequestScoped
+    @Path("users")
+    public static class UsersResource {
+
+        @Inject
+        ResponseHolder responseHolder;
+
+        @Inject
+        UriInfo uriInfo;
+
+        @Inject
+        ResourceContext resourceContext;
+
+        @Path("{id}")
+        public UserResource get(@RestPath String id) {
+            responseHolder.setResponse(responseHolder.getResponse() + uriInfo.getPathParameters().toString());
+            return resourceContext.getResource(UserResource.class);
+        }
+    }
+
+    @RequestScoped
+    public static class UserResource {
+
+        @Inject
+        ResponseHolder responseHolder;
+        @Inject
+        UriInfo uriInfo;
+
+        @Inject
+        ResourceContext resourceContext;
+
+        @Path("contacts/{id}")
+        public ContactResource get(@RestPath String id) {
+            responseHolder.setResponse(responseHolder.getResponse() + uriInfo.getPathParameters().toString());
+            return resourceContext.getResource(ContactResource.class);
+        }
+    }
+
+    @RequestScoped
+    public static class ContactResource {
+
+        @Inject
+        ResponseHolder responseHolder;
+
+        @Inject
+        UriInfo uriInfo;
+
+        @GET
+        public String getName(@RestPath String id) {
+            responseHolder.setResponse(responseHolder.getResponse() + uriInfo.getPathParameters().toString());
+            return responseHolder.getResponse();
+        }
+    }
+
+    @RequestScoped
+    public static class ResponseHolder {
+        String response = "";
+
+        public String getResponse() {
+            return response;
+        }
+
+        public void setResponse(String response) {
+            this.response = response;
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/UriInfoImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/UriInfoImpl.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map.Entry;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.PathSegment;
@@ -32,7 +31,11 @@ public class UriInfoImpl implements UriInfo {
 
     private final ResteasyReactiveRequestContext currentRequest;
     private MultivaluedMap<String, String> queryParams;
+
+    // marker for which target the pathParams where created, may be null when getPathParams was never called
+    private RuntimeResource pathParamsTargetMarker;
     private MultivaluedMap<String, String> pathParams;
+
     private URI requestUri;
 
     public UriInfoImpl(ResteasyReactiveRequestContext currentRequest) {
@@ -150,14 +153,12 @@ public class UriInfoImpl implements UriInfo {
     public MultivaluedMap<String, String> getPathParameters(boolean decode) {
         if (!decode)
             throw encodedNotSupported();
-        if (pathParams == null) {
-            pathParams = new QuarkusMultivaluedHashMap<>();
-            RuntimeResource target = currentRequest.getTarget();
-            if (target != null) { // a target can be null if this happens in a filter that runs before the target is set
-                for (Entry<String, Integer> pathParam : target.getPathParameterIndexes().entrySet()) {
-                    pathParams.add(pathParam.getKey(), currentRequest.getPathParam(pathParam.getValue(), false));
-                }
-            }
+        // pathParams have to be recreated when the target changes.
+        // this happens e.g. when the ResteasyReactiveRequestContext#restart is called for sub resources
+        // The sub resource, can have additional path params that are not present on the locator
+        if (pathParams == null && pathParamsTargetMarker == null || pathParamsTargetMarker != currentRequest.getTarget()) {
+            pathParams = currentRequest.getAllPathParameters(false);
+            pathParamsTargetMarker = currentRequest.getTarget();
         }
         return new UnmodifiableMultivaluedMap<>(pathParams);
     }


### PR DESCRIPTION
This enables to return the full set of path parameters that we know of at time of UriInfo.getPathparameters invocation. I.e. when called in a locator, return path parameters of the locator. When called in the sub resource, return path parameters of the sub resource and the locator as well.

- Closes: #23990