### PR TITLE
Downgrading mockito.version to 5.12.0 as it is compatible with junit.jupiter.version 5.10.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -174,7 +174,7 @@
         <quarkus-spring-data-api.version>3.4</quarkus-spring-data-api.version>
         <quarkus-spring-security-api.version>6.4</quarkus-spring-security-api.version>
         <quarkus-spring-boot-api.version>3.4</quarkus-spring-boot-api.version>
-        <mockito.version>5.16.1</mockito.version>
+        <mockito.version>5.12.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <quarkus-security.version>2.2.1</quarkus-security.version>
         <keycloak-client.version>26.0.4</keycloak-client.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -69,7 +69,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <smallrye-mutiny-vertx-core.version>3.18.1</smallrye-mutiny-vertx-core.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
-        <mockito.version>5.16.1</mockito.version>
+        <mockito.version>5.12.0</mockito.version>
         <wiremock.version>3.12.1</wiremock.version>
         <mutiny-zero.version>1.1.1</mutiny-zero.version>
 

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -54,7 +54,7 @@
         <junit.version>5.10.5</junit.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <mockito.version>5.16.1</mockito.version>
+        <mockito.version>5.12.0</mockito.version>
         <quarkus.version>${project.version}</quarkus.version>
         <maven-model-helper.version>37</maven-model-helper.version>
         <jandex.version>3.2.7</jandex.version>


### PR DESCRIPTION
Newest version of mockito that does not require JUnit 5.11 is: mockito-junit-jupiter:5.12.0 - https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter/5.12.0 

Fixes: https://github.com/quarkusio/quarkus/issues/46858