### PR TITLE
Fix a far too broad exec model condition

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsProcessor.java
@@ -94,9 +94,9 @@ public class ExecutionModelAnnotationsProcessor {
                 // gross hack to allow methods declared in Dev UI JSON RPC service classes,
                 // as the proper way (consuming `JsonRPCProvidersBuildItem`) only works in dev mode
                 String clazz = method.declaringClass().name().toString().toLowerCase(Locale.ROOT);
-                return clazz.startsWith("io.quarkus.")
-                        || clazz.startsWith("io.quarkiverse.")
-                        || clazz.endsWith("jsonrpcservice");
+                return (clazz.startsWith("io.quarkus.")
+                        || clazz.startsWith("io.quarkiverse."))
+                        && clazz.endsWith("jsonrpcservice");
             }
         });
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ResourceNotFoundData.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ResourceNotFoundData.java
@@ -27,7 +27,6 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.TemplateHtmlBuilder;
 import io.quarkus.runtime.util.ClassPathUtils;
-import io.smallrye.common.annotation.NonBlocking;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -135,7 +134,6 @@ public class ResourceNotFoundData {
         return builder.toString();
     }
 
-    @NonBlocking
     public JsonObject getJsonContent() {
         List<RouteDescription> combinedRoutes = getCombinedRoutes();
         JsonObject infoMap = new JsonObject();
@@ -200,7 +198,6 @@ public class ResourceNotFoundData {
 
     }
 
-    @NonBlocking
     public String getTextContent() {
         List<RouteDescription> combinedRoutes = getCombinedRoutes();
         try (StringWriter sw = new StringWriter()) {


### PR DESCRIPTION
@phillip-kruger this one is for you. I was puzzled I couldn't reproduce the failure in https://github.com/quarkusio/quarkus/issues/46893 in a test that is in `io.quarkus` and it seems to be the culprit.

That being said, I really think we should actually consume the JsonRPCProvidersBuildItems.
We would produce them in all modes and only take them into account in dev mode, where it matters.

Problem with this condition is that anything out of the Quarkus or Quarkiverse namespace won't work very well.
