### PR TITLE
Reduce byte[] allocations while sending Vertx buffers

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -401,6 +401,11 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
         return response.headWritten();
     }
 
+    public ServerHttpResponse end(Buffer data) {
+        response.end(data, null);
+        return this;
+    }
+
     @Override
     public ServerHttpResponse end(byte[] data) {
         var buffer = VertxByteBufAllocator.POOLED_ALLOCATOR.directBuffer(data.length);

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/serializers/ServerVertxBufferMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/serializers/ServerVertxBufferMessageBodyWriter.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.ext.Provider;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+import org.jboss.resteasy.reactive.server.vertx.VertxResteasyReactiveRequestContext;
 
 import io.vertx.core.buffer.Buffer;
 
@@ -35,6 +36,11 @@ public class ServerVertxBufferMessageBodyWriter implements ServerMessageBodyWrit
 
     @Override
     public void writeResponse(Buffer buffer, Type genericType, ServerRequestContext context) throws WebApplicationException {
-        context.serverResponse().end(buffer.getBytes());
+        var serverHttpResponse = context.serverResponse();
+        if (serverHttpResponse instanceof final VertxResteasyReactiveRequestContext resteasyContext) {
+            resteasyContext.end(buffer);
+        } else {
+            context.serverResponse().end(buffer.getBytes());
+        }
     }
 }


### PR DESCRIPTION
This improvement is coming from how Vertx's `Buffer`s work under the hood.
Currently this call stack at 
![image](https://github.com/user-attachments/assets/c5573d4e-780f-444f-a8cf-d20d253870d8)

Is performing few useless copies:
- `org/jboss/resteasy/reactive/server/vertx/serializers/ServerVertxBufferMessageBodyWriter.writeResponse` allocating a `new byte[]` via `io/vertx/core/buffer/impl/BufferImpl.getBytes` (below)
![image](https://github.com/user-attachments/assets/57e02c50-8c59-4b41-b5c2-0c6e366f247d)
- `org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.end` allocating a fresh new `Buffer` via `io/vertx/core/buffer/Buffer.buffer` which allocate a another `new byte[]` and perform a copy of the previous one (which will be thrown away, immediately) 
![image](https://github.com/user-attachments/assets/3f4403f6-7b24-4bc3-9155-17b847e183d6)

The same problem affects, similarly `ServerMutinyBufferMessageBodyWriter` which is wrapping the Vertx `Buffer` but since it is not exposing it, we cannot do much here (wdyt @jponge ?).

This PR is reducing the copies to 0 - reusing the original `Buffer` - getting rid of the  2 mentioned additional copies