### PR TITLE
Make ObjectMapper/JsonbProducer unremovable if json mapper is required by ORM

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/PersistenceUnitDescriptorBuildItem.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/PersistenceUnitDescriptorBuildItem.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.builder.item.MultiBuildItem;
-import io.quarkus.deployment.Capabilities;
-import io.quarkus.deployment.Capability;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDefinition;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
 import io.quarkus.hibernate.orm.runtime.boot.xml.RecordableXmlMapping;
@@ -37,16 +35,17 @@ public final class PersistenceUnitDescriptorBuildItem extends MultiBuildItem {
             RecordedConfig config,
             String multiTenancySchemaDataSource,
             List<RecordableXmlMapping> xmlMappings,
-            boolean isReactive, boolean fromPersistenceXml, Capabilities capabilities) {
+            boolean isReactive, boolean fromPersistenceXml,
+            boolean isHibernateValidatorPresent, Optional<FormatMapperKind> jsonMapper, Optional<FormatMapperKind> xmlMapper) {
         this.descriptor = descriptor;
         this.config = config;
         this.multiTenancySchemaDataSource = multiTenancySchemaDataSource;
         this.xmlMappings = xmlMappings;
         this.isReactive = isReactive;
         this.fromPersistenceXml = fromPersistenceXml;
-        this.isHibernateValidatorPresent = capabilities.isPresent(Capability.HIBERNATE_VALIDATOR);
-        this.jsonMapper = json(capabilities);
-        this.xmlMapper = xml(capabilities);
+        this.isHibernateValidatorPresent = isHibernateValidatorPresent;
+        this.jsonMapper = jsonMapper;
+        this.xmlMapper = xmlMapper;
     }
 
     public Collection<String> getManagedClassNames() {
@@ -90,22 +89,5 @@ public final class PersistenceUnitDescriptorBuildItem extends MultiBuildItem {
         return new QuarkusPersistenceUnitDefinition(descriptor, config,
                 xmlMappings, isReactive, fromPersistenceXml, isHibernateValidatorPresent,
                 jsonMapper, xmlMapper, integrationStaticDescriptors);
-    }
-
-    private Optional<FormatMapperKind> json(Capabilities capabilities) {
-        if (capabilities.isPresent(Capability.JACKSON)) {
-            return Optional.of(FormatMapperKind.JACKSON);
-        }
-        if (capabilities.isPresent(Capability.JSONB)) {
-            return Optional.of(FormatMapperKind.JSONB);
-        }
-        return Optional.empty();
-    }
-
-    private Optional<FormatMapperKind> xml(Capabilities capabilities) {
-        if (capabilities.isPresent(Capability.JAXB)) {
-            return Optional.of(FormatMapperKind.JAXB);
-        }
-        return Optional.empty();
     }
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/FormatMapperKind.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/FormatMapperKind.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.orm.runtime.customized;
 
+import java.util.Optional;
+
 import jakarta.json.bind.Jsonb;
 
 import org.hibernate.type.format.FormatMapper;
@@ -20,11 +22,21 @@ public enum FormatMapperKind {
             // as well as an XmlMapper instance instead of an ObjectMapper...
             return new JacksonJsonFormatMapper(Arc.container().instance(ObjectMapper.class).get());
         }
+
+        @Override
+        public Optional<String> requiredBeanType() {
+            return Optional.of("com.fasterxml.jackson.databind.ObjectMapper");
+        }
     },
     JSONB {
         @Override
         public FormatMapper create() {
             return new JsonBJsonFormatMapper(Arc.container().instance(Jsonb.class).get());
+        }
+
+        @Override
+        public Optional<String> requiredBeanType() {
+            return Optional.of("io.quarkus.jsonb.JsonbProducer");
         }
     },
     JAXB {
@@ -32,7 +44,14 @@ public enum FormatMapperKind {
         public FormatMapper create() {
             return new JaxbXmlFormatMapper();
         }
+
+        @Override
+        public Optional<String> requiredBeanType() {
+            return Optional.empty();
+        }
     };
 
     public abstract FormatMapper create();
+
+    public abstract Optional<String> requiredBeanType();
 }

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -36,12 +36,14 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.RecorderBeanInitializedBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -69,6 +71,7 @@ import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRu
 import io.quarkus.hibernate.orm.deployment.spi.DatabaseKindDialectBuildItem;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
+import io.quarkus.hibernate.orm.runtime.customized.FormatMapperKind;
 import io.quarkus.hibernate.orm.runtime.recording.RecordedConfig;
 import io.quarkus.hibernate.reactive.runtime.FastBootHibernateReactivePersistenceProvider;
 import io.quarkus.hibernate.reactive.runtime.HibernateReactive;
@@ -140,6 +143,7 @@ public final class HibernateReactiveProcessor {
             BuildProducer<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptors,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
             List<DatabaseKindDialectBuildItem> dbKindDialectBuildItems) {
 
         final boolean enableHR = hasEntities(jpaModel);
@@ -186,6 +190,13 @@ public final class HibernateReactiveProcessor {
                     launchMode.getLaunchMode(),
                     systemProperties, nativeImageResources, hotDeploymentWatchedFiles, dbKindDialectBuildItems);
 
+            Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities);
+            Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities);
+            jsonMapper.flatMap(FormatMapperKind::requiredBeanType)
+                    .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
+            xmlMapper.flatMap(FormatMapperKind::requiredBeanType)
+                    .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
+
             //Some constant arguments to the following method:
             // - this is Reactive
             // - we don't support starting Hibernate Reactive from a persistence.xml
@@ -199,7 +210,8 @@ public final class HibernateReactiveProcessor {
                             persistenceUnitConfig.unsupportedProperties()),
                     null,
                     jpaModel.getXmlMappings(reactivePU.getName()),
-                    true, false, capabilities));
+                    true, false,
+                    isHibernateValidatorPresent(capabilities), jsonMapper, xmlMapper));
         }
     }
 
@@ -528,4 +540,24 @@ public final class HibernateReactiveProcessor {
         return !jpaModel.getEntityClassNames().isEmpty();
     }
 
+    private static Optional<FormatMapperKind> jsonMapperKind(Capabilities capabilities) {
+        if (capabilities.isPresent(Capability.JACKSON)) {
+            return Optional.of(FormatMapperKind.JACKSON);
+        }
+        if (capabilities.isPresent(Capability.JSONB)) {
+            return Optional.of(FormatMapperKind.JSONB);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<FormatMapperKind> xmlMapperKind(Capabilities capabilities) {
+        if (capabilities.isPresent(Capability.JAXB)) {
+            return Optional.of(FormatMapperKind.JAXB);
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isHibernateValidatorPresent(Capabilities capabilities) {
+        return capabilities.isPresent(Capability.HIBERNATE_VALIDATOR);
+    }
 }


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/43105

not sure how best to test this one ... I did test it against the reproducer project from the issue. But here... didn't think that it was worth creating another integration tests module just for this one test... any suggestion? 🙈 