### PR TITLE
OpenAPI: disable example merging by default (Swagger UI regression)

### DIFF
--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -110,7 +110,6 @@ public interface SmallRyeOpenApiConfig {
      * Setting it to `true` will automatically add a default server to the schema if none is provided,
      * using the current running server host and port.
      */
-
     Optional<Boolean> autoAddServer();
 
     /**
@@ -122,13 +121,11 @@ public interface SmallRyeOpenApiConfig {
     /**
      * Required when using `apiKey` security. The location of the API key. Valid values are "query", "header" or "cookie".
      */
-
     Optional<String> apiKeyParameterIn();
 
     /**
      * Required when using `apiKey` security. The name of the header, query or cookie parameter to be used.
      */
-
     Optional<String> apiKeyParameterName();
 
     /**
@@ -235,6 +232,15 @@ public interface SmallRyeOpenApiConfig {
      * Set the strategy to automatically create an operation Id
      */
     Optional<OperationIdStrategy> operationIdStrategy();
+
+    /**
+     * Set this boolean value to enable the merging of the deprecated `@Schema`
+     * `example` property into the `examples` array introduced in OAS 3.1.0. If
+     * not set, it will default to `false` and the deprecated `example` will be
+     * kept as a separate annotation on the schema in the OpenAPI model.
+     */
+    @WithDefault("false")
+    boolean mergeSchemaExamples();
 
     public enum SecurityScheme {
         apiKey,

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
@@ -261,5 +261,10 @@ class SecurityConfigFilterTest {
         public Map<String, String> securitySchemeExtensions() {
             return Map.of();
         }
+
+        @Override
+        public boolean mergeSchemaExamples() {
+            return false;
+        }
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MergeSchemaExamplesTestCases.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MergeSchemaExamplesTestCases.java
@@ -1,0 +1,101 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.openapi.api.SmallRyeOASConfig;
+
+abstract class MergeSchemaExamplesTestCases {
+
+    @Schema(name = "Bean")
+    static class Bean {
+        @Schema(example = "Deprecated example", examples = {
+                "New example 1",
+                "New example 2"
+        })
+        private String field;
+
+        public String getField() {
+            return field;
+        }
+    }
+
+    @Path("/resource")
+    static class Resource {
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public Bean get() {
+            return new Bean();
+        }
+    }
+
+    private final String exampleValue;
+    private final String[] examplesValue;
+
+    MergeSchemaExamplesTestCases(String exampleValue, String[] examplesValue) {
+        this.exampleValue = exampleValue;
+        this.examplesValue = examplesValue;
+    }
+
+    @Test
+    void testExamples() {
+        RestAssured.given()
+                .header("Accept", "application/json")
+                .when()
+                .get("/q/openapi")
+                .then()
+                .log().ifValidationFails()
+                .body("components.schemas.Bean.properties.field.example", is(exampleValue))
+                .body("components.schemas.Bean.properties.field.examples", contains(examplesValue));
+    }
+
+    static class MergeSchemaExamplesDefaultTestCase extends MergeSchemaExamplesTestCases {
+        @RegisterExtension
+        static QuarkusUnitTest runner = new QuarkusUnitTest()
+                .withApplicationRoot((jar) -> jar
+                        .addClasses(Resource.class, Bean.class));
+
+        MergeSchemaExamplesDefaultTestCase() {
+            super("Deprecated example", new String[] { "New example 1", "New example 2" });
+        }
+    }
+
+    static class MergeSchemaExamplesQuarkusTrueTestCase extends MergeSchemaExamplesTestCases {
+        @RegisterExtension
+        static QuarkusUnitTest runner = new QuarkusUnitTest()
+                .withApplicationRoot((jar) -> jar
+                        .addClasses(Resource.class, Bean.class)
+                        .addAsResource(new StringAsset("quarkus.smallrye-openapi.merge-schema-examples=true\n"),
+                                "application.properties"));
+
+        MergeSchemaExamplesQuarkusTrueTestCase() {
+            super(null, new String[] { "New example 1", "New example 2", "Deprecated example" });
+        }
+    }
+
+    static class MergeSchemaExamplesSmallRyeTrueTestCase extends MergeSchemaExamplesTestCases {
+        @RegisterExtension
+        static QuarkusUnitTest runner = new QuarkusUnitTest()
+                .withApplicationRoot((jar) -> jar
+                        .addClasses(Resource.class, Bean.class)
+                        .addAsResource(new StringAsset(SmallRyeOASConfig.SMALLRYE_MERGE_SCHEMA_EXAMPLES + "=true\n"),
+                                "application.properties"));
+
+        MergeSchemaExamplesSmallRyeTrueTestCase() {
+            super(null, new String[] { "New example 1", "New example 2", "Deprecated example" });
+        }
+    }
+
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
@@ -54,6 +54,7 @@ public class OpenApiConfigMapping extends RelocateConfigSourceInterceptor {
         mapKey(relocations, SmallRyeOASConfig.INFO_LICENSE_NAME, QUARKUS_INFO_LICENSE_NAME);
         mapKey(relocations, SmallRyeOASConfig.INFO_LICENSE_URL, QUARKUS_INFO_LICENSE_URL);
         mapKey(relocations, SmallRyeOASConfig.OPERATION_ID_STRAGEGY, QUARKUS_OPERATION_ID_STRATEGY);
+        mapKey(relocations, SmallRyeOASConfig.SMALLRYE_MERGE_SCHEMA_EXAMPLES, QUARKUS_MERGE_SCHEMA_EXAMPLES);
         return Collections.unmodifiableMap(relocations);
     }
 
@@ -74,5 +75,6 @@ public class OpenApiConfigMapping extends RelocateConfigSourceInterceptor {
     private static final String QUARKUS_INFO_LICENSE_NAME = "quarkus.smallrye-openapi.info-license-name";
     private static final String QUARKUS_INFO_LICENSE_URL = "quarkus.smallrye-openapi.info-license-url";
     private static final String QUARKUS_OPERATION_ID_STRATEGY = "quarkus.smallrye-openapi.operation-id-strategy";
+    private static final String QUARKUS_MERGE_SCHEMA_EXAMPLES = "quarkus.smallrye-openapi.merge-schema-examples";
 
 }

--- a/tcks/microprofile-openapi/pom.xml
+++ b/tcks/microprofile-openapi/pom.xml
@@ -31,6 +31,7 @@
                         <quarkus.http.non-application-root-path>/</quarkus.http.non-application-root-path>
                         <quarkus.smallrye-openapi.auto-add-tags>false</quarkus.smallrye-openapi.auto-add-tags>
                         <quarkus.smallrye-openapi.auto-add-bad-request-response>false</quarkus.smallrye-openapi.auto-add-bad-request-response>
+                        <quarkus.smallrye-openapi.merge-schema-examples>true</quarkus.smallrye-openapi.merge-schema-examples>
                     </systemPropertyVariables>
                     <!-- This workaround allows us to run a single test using
                         the "test" system property -->


### PR DESCRIPTION
Closes #46628 

Disables by default the automatic merging of OpenAPI schema `example` into the new `examples` array introduced in the OpenAPI specification version 3.1.0. See Swagger UI issue described in #46628 that is affected by the merging of examples.

Users may enable the new configuration property if desired.