### PR TITLE
Allow custom code generators in gradle

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -207,19 +207,22 @@ public class QuarkusPlugin implements Plugin<Project> {
 
         // quarkusGenerateCode
         TaskProvider<QuarkusGenerateCode> quarkusGenerateCode = tasks.register(QUARKUS_GENERATE_CODE_TASK_NAME,
-                QuarkusGenerateCode.class, LaunchMode.NORMAL, SourceSet.MAIN_SOURCE_SET_NAME);
+                QuarkusGenerateCode.class, LaunchMode.NORMAL, SourceSet.MAIN_SOURCE_SET_NAME,
+                quarkusExt.getCodeGenerationInputs().get());
         quarkusGenerateCode.configure(task -> configureGenerateCodeTask(task, quarkusGenerateAppModelTask,
                 QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES));
         // quarkusGenerateCodeDev
         TaskProvider<QuarkusGenerateCode> quarkusGenerateCodeDev = tasks.register(QUARKUS_GENERATE_CODE_DEV_TASK_NAME,
-                QuarkusGenerateCode.class, LaunchMode.DEVELOPMENT, SourceSet.MAIN_SOURCE_SET_NAME);
+                QuarkusGenerateCode.class, LaunchMode.DEVELOPMENT, SourceSet.MAIN_SOURCE_SET_NAME,
+                quarkusExt.getCodeGenerationInputs().get());
         quarkusGenerateCodeDev.configure(task -> {
             task.dependsOn(quarkusGenerateCode);
             configureGenerateCodeTask(task, quarkusGenerateDevAppModelTask, QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES);
         });
         // quarkusGenerateCodeTests
         TaskProvider<QuarkusGenerateCode> quarkusGenerateCodeTests = tasks.register(QUARKUS_GENERATE_CODE_TESTS_TASK_NAME,
-                QuarkusGenerateCode.class, LaunchMode.TEST, SourceSet.TEST_SOURCE_SET_NAME);
+                QuarkusGenerateCode.class, LaunchMode.TEST, SourceSet.TEST_SOURCE_SET_NAME,
+                quarkusExt.getCodeGenerationInputs().get());
         quarkusGenerateCodeTests.configure(task -> {
             task.dependsOn("compileQuarkusTestGeneratedSourcesJava");
             configureGenerateCodeTask(task, quarkusGenerateTestAppModelTask,
@@ -478,13 +481,17 @@ public class QuarkusPlugin implements Plugin<Project> {
                     SourceSet generatedSourceSet = sourceSets.getByName(QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES);
                     SourceSet generatedTestSourceSet = sourceSets.getByName(QuarkusGenerateCode.QUARKUS_TEST_GENERATED_SOURCES);
 
-                    // Register the quarkus-generated-code
-                    for (String provider : QuarkusGenerateCode.CODE_GENERATION_PROVIDER) {
-                        mainSourceSet.getJava().srcDir(
-                                new File(generatedSourceSet.getJava().getClassesDirectory().get().getAsFile(), provider));
-                        testSourceSet.getJava().srcDir(
-                                new File(generatedTestSourceSet.getJava().getClassesDirectory().get().getAsFile(), provider));
-                    }
+                    project.afterEvaluate(project1 -> {
+                        // Register the quarkus-generated-code
+                        for (String provider : quarkusExt.getCodeGenerationProviders().get()) {
+
+                            mainSourceSet.getJava().srcDir(
+                                    new File(generatedSourceSet.getJava().getClassesDirectory().get().getAsFile(), provider));
+                            testSourceSet.getJava().srcDir(
+                                    new File(generatedTestSourceSet.getJava().getClassesDirectory().get().getAsFile(),
+                                            provider));
+                        }
+                    });
                 });
 
         project.getPlugins().withId("org.jetbrains.kotlin.jvm", plugin -> {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -44,10 +45,15 @@ import io.quarkus.runtime.LaunchMode;
 import io.smallrye.config.SmallRyeConfig;
 
 public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
+    // TODO dynamically load generation provider, or make them write code directly in quarkus-generated-sources
+    public static final String[] CODE_GENERATION_PROVIDER = new String[] { "grpc", "avdl", "avpr", "avsc" };
+    public static final String[] CODE_GENERATION_INPUT = new String[] { "proto", "avro" };
     private final SourceSetExtension sourceSetExtension;
 
     private final Property<Boolean> cacheLargeArtifacts;
     private final Property<Boolean> cleanupBuildOutput;
+    private final ListProperty<String> codeGenerationProviders;
+    private final ListProperty<String> codeGenerationInputs;
 
     public QuarkusPluginExtension(Project project) {
         super(project);
@@ -56,6 +62,10 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
                 .convention(true);
         this.cacheLargeArtifacts = project.getObjects().property(Boolean.class)
                 .convention(!System.getenv().containsKey("CI"));
+        this.codeGenerationProviders = project.getObjects().listProperty(String.class)
+                .convention(List.of(CODE_GENERATION_PROVIDER));
+        this.codeGenerationInputs = project.getObjects().listProperty(String.class)
+                .convention(List.of(CODE_GENERATION_INPUT));
 
         this.sourceSetExtension = new SourceSetExtension();
     }
@@ -145,6 +155,30 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
 
     public void setCacheLargeArtifacts(boolean cacheLargeArtifacts) {
         this.cacheLargeArtifacts.set(cacheLargeArtifacts);
+    }
+
+    public void setCodeGenerationInputs(List<String> codeGenerationInputs) {
+        this.codeGenerationInputs.set(codeGenerationInputs);
+    }
+
+    /**
+     * The directories of code generation inputs, only needed if using a customer extension that provides its own code
+     * generator.
+     */
+    public ListProperty<String> getCodeGenerationInputs() {
+        return codeGenerationInputs;
+    }
+
+    public void setCodeGenerationProviders(List<String> codeGenerationProviders) {
+        this.codeGenerationProviders.set(codeGenerationProviders);
+    }
+
+    /**
+     * The identifiers of the code generation providers, only needed if using a customer extension that provides its own code
+     * generator.
+     */
+    public ListProperty<String> getCodeGenerationProviders() {
+        return codeGenerationProviders;
     }
 
     public String finalName() {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -41,9 +42,6 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
 
     public static final String QUARKUS_GENERATED_SOURCES = "quarkus-generated-sources";
     public static final String QUARKUS_TEST_GENERATED_SOURCES = "quarkus-test-generated-sources";
-    // TODO dynamically load generation provider, or make them write code directly in quarkus-generated-sources
-    public static final String[] CODE_GENERATION_PROVIDER = new String[] { "grpc", "avdl", "avpr", "avsc" };
-    public static final String[] CODE_GENERATION_INPUT = new String[] { "proto", "avro" };
 
     private Set<Path> sourcesDirectories;
     private FileCollection compileClasspath;
@@ -52,13 +50,15 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
     private final String inputSourceSetName;
 
     private final QuarkusPluginExtensionView extensionView;
+    private final List<String> codeGenInput;
 
     @Inject
-    public QuarkusGenerateCode(LaunchMode launchMode, String inputSourceSetName) {
+    public QuarkusGenerateCode(LaunchMode launchMode, String inputSourceSetName, List<String> codeGenInput) {
         super("Performs Quarkus pre-build preparations, such as sources generation", true);
         this.launchMode = launchMode;
         this.inputSourceSetName = inputSourceSetName;
         this.extensionView = getProject().getObjects().newInstance(QuarkusPluginExtensionView.class, extension());
+        this.codeGenInput = codeGenInput;
 
     }
 
@@ -98,7 +98,7 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
 
         Path src = projectDir.toPath().resolve("src").resolve(inputSourceSetName);
 
-        for (String input : CODE_GENERATION_INPUT) {
+        for (String input : codeGenInput) {
             Path providerSrcDir = src.resolve(input);
             if (Files.exists(providerSrcDir)) {
                 inputDirectories.add(providerSrcDir.toFile());


### PR DESCRIPTION
At the moment they are hard coded, so this allows for additional generators to be configured.

It would be better if this could be derived automatically, but I am not sure if the lifecycle allows this.