### PR TITLE
Add support for TLS config reload in REST Client

### DIFF
--- a/extensions/keycloak-admin-rest-client/runtime/src/main/java/io/quarkus/keycloak/admin/rest/client/runtime/KeycloakAdminRestClientProvider.java
+++ b/extensions/keycloak-admin-rest-client/runtime/src/main/java/io/quarkus/keycloak/admin/rest/client/runtime/KeycloakAdminRestClientProvider.java
@@ -144,6 +144,11 @@ public class KeycloakAdminRestClientProvider implements ResteasyClientProvider {
             public boolean isTrustAll() {
                 return tlsConfiguration.isTrustAll();
             }
+
+            @Override
+            public Optional<String> getName() {
+                return Optional.ofNullable(tlsConfiguration.getName());
+            }
         };
     }
 }

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
@@ -75,6 +75,11 @@ public class FakeSmtpTestBase {
                             public boolean isTrustAll() {
                                 return trustAll;
                             }
+
+                            @Override
+                            public String getName() {
+                                return "test";
+                            }
                         });
                     }
 

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerTLSRegistryTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MailerTLSRegistryTest.java
@@ -39,6 +39,11 @@ public class MailerTLSRegistryTest extends FakeSmtpTestBase {
                 return jksOptions;
             }
 
+            @Override
+            public String getName() {
+                return "test";
+            }
+
         });
         startServer(new File("target/certs/mailer-certs-keystore.p12").getAbsolutePath());
         mailer.send(getMail()).await().indefinitely();
@@ -52,6 +57,11 @@ public class MailerTLSRegistryTest extends FakeSmtpTestBase {
             @Override
             public boolean isTrustAll() {
                 return true;
+            }
+
+            @Override
+            public String getName() {
+                return "test";
             }
         });
         startServer(SERVER_JKS);
@@ -71,6 +81,11 @@ public class MailerTLSRegistryTest extends FakeSmtpTestBase {
             @Override
             public boolean isTrustAll() {
                 return true;
+            }
+
+            @Override
+            public String getName() {
+                return "test";
             }
         });
         startServer(SERVER_JKS);
@@ -92,7 +107,10 @@ public class MailerTLSRegistryTest extends FakeSmtpTestBase {
         });
         startServer(SERVER_JKS);
         ReactiveMailer mailer = getMailer(mailersConfig, "my-mailer", new BaseTlsConfiguration() {
-
+            @Override
+            public String getName() {
+                return "test";
+            }
         });
 
         Assertions.assertThatThrownBy(() -> mailer.send(getMail()).await().indefinitely())
@@ -116,6 +134,11 @@ public class MailerTLSRegistryTest extends FakeSmtpTestBase {
                 jksOptions.setPath("target/certs/mailer-certs-truststore.p12");
                 jksOptions.setPassword("password");
                 return jksOptions;
+            }
+
+            @Override
+            public String getName() {
+                return "test";
             }
 
         })).hasMessageContaining("missing-mailer-configuration");

--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -88,6 +88,7 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.StaticInitConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
@@ -101,6 +102,7 @@ import io.quarkus.jaxrs.client.reactive.deployment.RestClientDefaultConsumesBuil
 import io.quarkus.jaxrs.client.reactive.deployment.RestClientDefaultProducesBuildItem;
 import io.quarkus.jaxrs.client.reactive.deployment.RestClientDisableRemovalTrailingSlashBuildItem;
 import io.quarkus.jaxrs.client.reactive.deployment.RestClientDisableSmartDefaultProduces;
+import io.quarkus.rest.client.reactive.CertificateUpdateEventListener;
 import io.quarkus.rest.client.reactive.runtime.AnnotationRegisteredProviders;
 import io.quarkus.rest.client.reactive.runtime.HeaderCapturingServerFilter;
 import io.quarkus.rest.client.reactive.runtime.HeaderContainer;
@@ -195,6 +197,7 @@ class RestClientReactiveProcessor {
         restClientRecorder.setRestClientBuilderResolver();
         additionalBeans.produce(new AdditionalBeanBuildItem(RestClient.class));
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(HeaderContainer.class));
+        additionalBeans.produce(new AdditionalBeanBuildItem(CertificateUpdateEventListener.class));
     }
 
     @BuildStep
@@ -479,7 +482,8 @@ class RestClientReactiveProcessor {
             BuildProducer<GeneratedBeanBuildItem> generatedBeans,
             RestClientReactiveConfig clientConfig,
             RestClientsBuildTimeConfig clientsBuildConfig,
-            RestClientRecorder recorder) {
+            RestClientRecorder recorder,
+            ShutdownContextBuildItem shutdown) {
 
         CompositeIndex index = CompositeIndex.create(combinedIndexBuildItem.getIndex());
 
@@ -639,6 +643,8 @@ class RestClientReactiveProcessor {
         if (LaunchMode.current() == LaunchMode.DEVELOPMENT) {
             recorder.setConfigKeys(configKeys);
         }
+
+        recorder.cleanUp(shutdown);
     }
 
     /**

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/SSLTools.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/SSLTools.java
@@ -1,0 +1,83 @@
+package io.quarkus.rest.client.reactive.tls;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+
+import io.vertx.core.buffer.Buffer;
+
+public class SSLTools {
+
+    private SSLTools() {
+    }
+
+    public static KeyStore createKeyStore(String path, String type, String password) {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(type != null ? type : "JKS");
+            if (password != null && !password.isEmpty()) {
+                try (InputStream input = locateStream(path)) {
+                    keyStore.load(input, password.toCharArray());
+                } catch (CertificateException | NoSuchAlgorithmException | IOException e) {
+                    throw new IllegalArgumentException("Failed to initialize key store from classpath resource " + path, e);
+                }
+
+                return keyStore;
+            } else {
+                throw new IllegalArgumentException("No password provided for keystore");
+            }
+        } catch (KeyStoreException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Buffer asBuffer(KeyStore keyStore, char[] password) {
+        if (keyStore != null) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+            try {
+                keyStore.store(out, password);
+                return Buffer.buffer(out.toByteArray());
+            } catch (IOException | NoSuchAlgorithmException | CertificateException | KeyStoreException e) {
+                throw new RuntimeException("Failed to translate keystore to vert.x keystore", e);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private static InputStream locateStream(String path) throws FileNotFoundException {
+        if (path.startsWith("classpath:")) {
+            path = path.replaceFirst("classpath:", "");
+            InputStream resultStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+            if (resultStream == null) {
+                resultStream = SSLTools.class.getResourceAsStream(path);
+            }
+
+            if (resultStream == null) {
+                throw new IllegalArgumentException(
+                        "Classpath resource " + path + " not found for GraphQL Client SSL configuration");
+            } else {
+                return resultStream;
+            }
+        } else {
+            if (path.startsWith("file:")) {
+                path = path.replaceFirst("file:", "");
+            }
+
+            File certificateFile = new File(path);
+            if (!certificateFile.isFile()) {
+                throw new IllegalArgumentException(
+                        "Certificate file: " + path + " not found for GraphQL Client SSL configuration");
+            } else {
+                return new FileInputStream(certificateFile);
+            }
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/TlsConfigReloadKeystoreTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/tls/TlsConfigReloadKeystoreTest.java
@@ -1,0 +1,169 @@
+package io.quarkus.rest.client.reactive.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.KeyStore;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.tls.CertificateUpdatedEvent;
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.ClientAuth;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.PfxOptions;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "wrong-test-reload", password = "password", formats = Format.PKCS12, client = true),
+        @Certificate(name = "test-reload", password = "password", formats = Format.PKCS12, client = true)
+})
+public class TlsConfigReloadKeystoreTest {
+
+    private static final int PORT = 63806;
+    private static final String EXPECTED_RESPONSE = "HelloWorld";
+    private static HttpServer testServer;
+    private static Vertx testVertx;
+
+    private static final File temp = new File("target/test-certificates-" + UUID.randomUUID());
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(Client.class, SSLTools.class))
+            .overrideRuntimeConfigKey("loc", temp.getAbsolutePath())
+            .overrideRuntimeConfigKey("quarkus.rest-client.my-client.tls-configuration-name", "my-tls-client")
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.key-store.p12.path", temp.getAbsolutePath() + "/tls.p12")
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.key-store.p12.password", "password")
+            .overrideRuntimeConfigKey("quarkus.rest-client.my-client.url", "https://127.0.0.1:" + PORT)
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.trust-all", "true")
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    temp.mkdirs();
+                    Files.copy(new File("target/certs/wrong-test-reload-client-keystore.p12").toPath(),
+                            new File(temp, "/tls.p12").toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    @RegisterRestClient(configKey = "my-client")
+    private interface Client {
+        @GET
+        String getResult();
+    }
+
+    @RestClient
+    Client client;
+
+    @Inject
+    TlsConfigurationRegistry registry;
+
+    @ConfigProperty(name = "loc")
+    File certs;
+
+    @Inject
+    Event<CertificateUpdatedEvent> event;
+
+    @BeforeAll
+    static void setupServer() throws Exception {
+        testVertx = Vertx.vertx();
+        testServer = runServer(testVertx, "target/certs/test-reload-keystore.p12",
+                "password", "target/certs/test-reload-server-truststore.p12",
+                "password");
+    }
+
+    @AfterAll
+    static void closeServer() {
+        testServer.close();
+        testVertx.close().toCompletionStage().toCompletableFuture().join();
+    }
+
+    @Test
+    void testReloading() throws IOException {
+        TlsConfiguration tlsClient = registry.get("my-tls-client").orElseThrow();
+        try {
+            client.getResult();
+            Assertions.fail(); // should fail
+        } catch (Exception ex) {
+            assertHasCauseContainingMessage(ex, "Received fatal alert: certificate_unknown");
+        }
+        Files.copy(new File("target/certs/test-reload-client-keystore.p12").toPath(),
+                new File(certs, "/tls.p12").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
+        assertThat(tlsClient.reload()).isTrue();
+        event.fire(new CertificateUpdatedEvent("my-tls-client", tlsClient));
+        Arc.container().requestContext().activate();
+        assertThat(client.getResult()).isEqualTo(EXPECTED_RESPONSE);
+    }
+
+    private void assertHasCauseContainingMessage(Throwable t, String message) {
+        Throwable throwable = t;
+        while (throwable.getCause() != null) {
+            throwable = throwable.getCause();
+            if (throwable.getMessage().contains(message)) {
+                return;
+            }
+        }
+        throw new RuntimeException("Unexpected exception", t);
+    }
+
+    static HttpServer runServer(Vertx vertx, String keystorePath, String keystorePassword,
+            String truststorePath, String truststorePassword)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        HttpServerOptions options = new HttpServerOptions();
+        options.setSsl(true);
+        options.setHost("localhost");
+
+        if (keystorePath != null) {
+            PfxOptions keystoreOptions = new PfxOptions();
+            KeyStore keyStore = SSLTools.createKeyStore(keystorePath, "PKCS12", keystorePassword);
+            keystoreOptions.setValue(SSLTools.asBuffer(keyStore, keystorePassword.toCharArray()));
+            keystoreOptions.setPassword(keystorePassword);
+            options.setKeyCertOptions(keystoreOptions);
+        }
+
+        if (truststorePath != null) {
+            options.setClientAuth(ClientAuth.REQUIRED);
+            PfxOptions truststoreOptions = new PfxOptions();
+            KeyStore trustStore = SSLTools.createKeyStore(truststorePath, "PKCS12", truststorePassword);
+            truststoreOptions.setValue(SSLTools.asBuffer(trustStore, truststorePassword.toCharArray()));
+            truststoreOptions.setPassword(truststorePassword);
+            options.setTrustOptions(truststoreOptions);
+        }
+
+        HttpServer server = vertx.createHttpServer(options);
+        server.requestHandler(request -> {
+            request.response().send("HelloWorld");
+        });
+
+        return server.listen(PORT).toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/CertificateUpdateEventListener.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/CertificateUpdateEventListener.java
@@ -1,0 +1,45 @@
+package io.quarkus.rest.client.reactive;
+
+import java.util.List;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.rest.client.reactive.runtime.RestClientRecorder;
+import io.quarkus.tls.CertificateUpdatedEvent;
+import io.quarkus.tls.TlsConfiguration;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClient;
+
+public class CertificateUpdateEventListener {
+
+    private static final Logger LOG = Logger.getLogger(CertificateUpdateEventListener.class);
+
+    public void onCertificateUpdate(@Observes CertificateUpdatedEvent event) {
+        String updatedTlsConfigurationName = event.name();
+        TlsConfiguration updatedTlsConfiguration = event.tlsConfiguration();
+        List<HttpClient> httpClients = RestClientRecorder.clientsUsingTlsConfig(updatedTlsConfigurationName);
+        if (!httpClients.isEmpty()) {
+            for (HttpClient httpClient : httpClients) {
+                httpClient.updateSSLOptions(updatedTlsConfiguration.getSSLOptions(),
+                        new Handler<>() {
+                            @Override
+                            public void handle(AsyncResult<Boolean> event) {
+                                if (event.succeeded()) {
+                                    LOG.infof(
+                                            "Certificate reloaded for the REST client(s) using the TLS configuration (bucket) name '%s'",
+                                            updatedTlsConfigurationName);
+                                } else {
+                                    LOG.errorf(event.cause(),
+                                            "Certificate reload failed  using the TLS configuration (bucket) name '%s'",
+                                            event.cause(), updatedTlsConfigurationName);
+                                }
+                            }
+                        });
+            }
+
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -159,6 +159,11 @@ public class RestClientBuilderImpl implements RestClientBuilder {
             public boolean isTrustAll() {
                 return tlsConfiguration.isTrustAll();
             }
+
+            @Override
+            public Optional<String> getName() {
+                return Optional.ofNullable(tlsConfiguration.getName());
+            }
         });
         return this;
     }
@@ -577,8 +582,12 @@ public class RestClientBuilderImpl implements RestClientBuilder {
             }
         }
 
-        ClientImpl client = clientBuilder.build();
-        WebTargetImpl target = (WebTargetImpl) client.target(uri);
+        ClientImpl clientImpl = clientBuilder.build();
+        TlsConfig tlsConfig = clientBuilder.getTlsConfig();
+        if (tlsConfig != null && tlsConfig.getName().isPresent()) {
+            RestClientRecorder.registerReloadableHttpClient(tlsConfig.getName().get(), clientImpl.getVertxHttpClient());
+        }
+        WebTargetImpl target = (WebTargetImpl) clientImpl.target(uri);
         target.setParamConverterProviders(paramConverterProviders);
         try {
             return target.proxy(aClass);

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientRecorder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientRecorder.java
@@ -19,8 +19,6 @@ public class RestClientRecorder {
     private static volatile Map<String, String> configKeys;
     private static volatile Set<String> blockingClassNames;
 
-    private static volatile Map<String, String> blockingMethods;
-
     private static final Map<String, List<HttpClient>> tlsConfigNameToVertxHttpClients = new ConcurrentHashMap<>();
 
     public void setConfigKeys(Map<String, String> configKeys) {

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientRecorder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientRecorder.java
@@ -1,11 +1,18 @@
 package io.quarkus.rest.client.reactive.runtime;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
 
+import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.http.HttpClient;
 
 @Recorder
 public class RestClientRecorder {
@@ -13,6 +20,8 @@ public class RestClientRecorder {
     private static volatile Set<String> blockingClassNames;
 
     private static volatile Map<String, String> blockingMethods;
+
+    private static final Map<String, List<HttpClient>> tlsConfigNameToVertxHttpClients = new ConcurrentHashMap<>();
 
     public void setConfigKeys(Map<String, String> configKeys) {
         RestClientRecorder.configKeys = configKeys;
@@ -32,6 +41,28 @@ public class RestClientRecorder {
 
     public void setRestClientBuilderResolver() {
         RestClientBuilderResolver.setInstance(new BuilderResolver());
+    }
+
+    public static void registerReloadableHttpClient(String tlsConfigName, HttpClient httpClient) {
+        tlsConfigNameToVertxHttpClients.computeIfAbsent(tlsConfigName, new Function<>() {
+            @Override
+            public List<HttpClient> apply(String s) {
+                return new ArrayList<>(1);
+            }
+        }).add(httpClient);
+    }
+
+    public static List<HttpClient> clientsUsingTlsConfig(String tlsConfigName) {
+        return tlsConfigNameToVertxHttpClients.getOrDefault(tlsConfigName, Collections.emptyList());
+    }
+
+    public void cleanUp(ShutdownContext shutdown) {
+        shutdown.addShutdownTask(new Runnable() {
+            @Override
+            public void run() {
+                tlsConfigNameToVertxHttpClients.clear();
+            }
+        });
     }
 
 }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientRecorder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientRecorder.java
@@ -12,6 +12,8 @@ public class RestClientRecorder {
     private static volatile Map<String, String> configKeys;
     private static volatile Set<String> blockingClassNames;
 
+    private static volatile Map<String, String> blockingMethods;
+
     public void setConfigKeys(Map<String, String> configKeys) {
         RestClientRecorder.configKeys = configKeys;
     }
@@ -31,4 +33,5 @@ public class RestClientRecorder {
     public void setRestClientBuilderResolver() {
         RestClientBuilderResolver.setInstance(new BuilderResolver());
     }
+
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/BuildTimeRegistrationTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/BuildTimeRegistrationTest.java
@@ -91,6 +91,11 @@ public class BuildTimeRegistrationTest {
                     public boolean isTrustAll() {
                         return false;
                     }
+
+                    @Override
+                    public String getName() {
+                        return "test";
+                    }
                 };
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/RuntimeRegistrationTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/RuntimeRegistrationTest.java
@@ -65,6 +65,11 @@ public class RuntimeRegistrationTest {
             public boolean isTrustAll() {
                 return false;
             }
+
+            @Override
+            public String getName() {
+                return "test";
+            }
         });
 
         TlsConfiguration conf = registry.get("named").orElseThrow();

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -195,6 +195,11 @@ public class VertxCertificateHolder implements TlsConfiguration {
         return true;
     }
 
+    @Override
+    public String getName() {
+        return name;
+    }
+
     public TlsBucketConfig config() {
         return config;
     }

--- a/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/TlsConfiguration.java
+++ b/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/TlsConfiguration.java
@@ -100,4 +100,9 @@ public interface TlsConfiguration {
      */
     boolean reload();
 
+    /**
+     * Returns the name which was associated with this configuration
+     */
+    String getName();
+
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/TlsConfig.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/TlsConfig.java
@@ -77,4 +77,9 @@ public interface TlsConfig {
      * @return {@code true} if the trust store is configured to trust all certificates, {@code false} otherwise.
      */
     boolean isTrustAll();
+
+    /**
+     * Name which was associated with this configuration
+     */
+    Optional<String> getName();
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -211,6 +211,10 @@ public class ClientBuilderImpl extends ClientBuilder {
         return this;
     }
 
+    public TlsConfig getTlsConfig() {
+        return tlsConfig;
+    }
+
     @Override
     public ClientImpl build() {
         HttpClientOptions options = Optional.ofNullable(configuration.getFromContext(HttpClientOptions.class))

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
@@ -220,6 +220,10 @@ public class ClientImpl implements Client {
                 clientContext.getMultipartResponsesData(), clientLogger);
     }
 
+    public HttpClient getVertxHttpClient() {
+        return httpClient;
+    }
+
     private boolean isCaptureStacktrace(ConfigurationImpl configuration) {
         Object captureStacktraceObj = configuration.getProperty(CAPTURE_STACKTRACE);
         if (captureStacktraceObj == null) {


### PR DESCRIPTION
This is done by updating the underlying Vert.x HTTP Client with the updated configuration.
Most of the complexity of the PR is in keeping track of which TLS configuration corresponds 
to which Vert.x HTTP Client