### PR TITLE
Execution Model Validation: properly discover Dev UI JSON RPC classes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsProcessor.java
@@ -86,6 +86,11 @@ public class ExecutionModelAnnotationsProcessor {
         }
     }
 
+    /**
+     * @deprecated this method will be removed in Quarkus 3.24, which gives extensions 2 releases
+     *             to start producing {@code JsonRPCProvidersBuildItem} always, not just in dev mode
+     */
+    @Deprecated(since = "3.22", forRemoval = true)
     @BuildStep
     ExecutionModelAnnotationsAllowedBuildItem devuiJsonRpcServices() {
         return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {

--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -876,14 +876,13 @@ You must register the `JsonPRCService` in your processor in the deployment modul
 
 [source,java]
 ----
-@BuildStep(onlyIf = IsDevelopment.class)// <1>
-JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {// <2>
-    return new JsonRPCProvidersBuildItem(CacheJsonRPCService.class);// <3>
+@BuildStep
+JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {// <1>
+    return new JsonRPCProvidersBuildItem(CacheJsonRPCService.class);// <2>
 }
 ----
-<1> Always only do this in Dev Mode
-<2> Produce or return a `JsonRPCProvidersBuildItem`
-<3> Define the class in your runtime module that will contain methods that make data available in the UI
+<1> Produce or return a `JsonRPCProvidersBuildItem`
+<2> Define the class in your runtime module that will contain methods that make data available in the UI
 
 https://github.com/quarkusio/quarkus/blob/main/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devui/CacheDevUiProcessor.java[Example code]
 

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/devui/AgroalDevUIProcessor.java
@@ -18,7 +18,6 @@ class AgroalDevUIProcessor {
     @BuildStep
     void devUI(DataSourcesJdbcBuildTimeConfig config,
             BuildProducer<CardPageBuildItem> cardPageProducer,
-            BuildProducer<JsonRPCProvidersBuildItem> jsonRPCProviderProducer,
             LaunchModeBuildItem launchMode) {
 
         if (launchMode.getDevModeType().isPresent() && launchMode.getDevModeType().get().equals(DevModeType.LOCAL)) {
@@ -34,8 +33,12 @@ class AgroalDevUIProcessor {
                         .metadata("allowedHost", config.devui().allowedDBHost().orElse(null)));
 
                 cardPageProducer.produce(cardPageBuildItem);
-                jsonRPCProviderProducer.produce(new JsonRPCProvidersBuildItem(DatabaseInspector.class));
             }
         }
+    }
+
+    @BuildStep
+    JsonRPCProvidersBuildItem createJsonRPCService() {
+        return new JsonRPCProvidersBuildItem(DatabaseInspector.class);
     }
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevUIProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/ArcDevUIProcessor.java
@@ -102,7 +102,7 @@ public class ArcDevUIProcessor {
         return pageBuildItem;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(ArcJsonRPCService.class);
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/JsonRpcMethodsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devui/JsonRpcMethodsProcessor.java
@@ -1,0 +1,31 @@
+package io.quarkus.arc.deployment.devui;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
+
+// this class is present in the `arc/deployment` module, because it has to be present always
+// and cannot be in the `core/deployment` module, as it depends on `quarkus-vertx-http-dev-ui-spi`
+public class JsonRpcMethodsProcessor {
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem jsonRpcMethods(List<JsonRPCProvidersBuildItem> rpcProviders) {
+        Set<String> classes = new HashSet<>();
+        for (JsonRPCProvidersBuildItem rpcProvider : rpcProviders) {
+            classes.add(rpcProvider.getJsonRPCMethodProviderClass().getName());
+        }
+
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                return classes.contains(method.declaringClass().name().toString());
+            }
+        });
+    }
+}

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devui/CacheDevUiProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devui/CacheDevUiProcessor.java
@@ -21,7 +21,7 @@ public class CacheDevUiProcessor {
         return pageBuildItem;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(CacheJsonRPCService.class);
     }

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/devui/ContainerImageDevUiProcessor.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/devui/ContainerImageDevUiProcessor.java
@@ -37,7 +37,7 @@ public class ContainerImageDevUiProcessor {
         return card;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCServiceForContainerBuild() {
         DevConsoleManager.register("container-image-build-action", build());
         return new JsonRPCProvidersBuildItem(ContainerBuilderJsonRpcService.class);

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devui/DevUIDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devui/DevUIDatasourceProcessor.java
@@ -30,7 +30,7 @@ public class DevUIDatasourceProcessor {
         return card;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(DatasourceJsonRpcService.class);
     }

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/devui/FlywayDevUIProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/deployment/devui/FlywayDevUIProcessor.java
@@ -45,7 +45,7 @@ public class FlywayDevUIProcessor {
         return card;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(FlywayJsonRpcService.class);
     }

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcMethodsProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcMethodsProcessor.java
@@ -2,18 +2,35 @@ package io.quarkus.grpc.deployment;
 
 import java.util.function.Predicate;
 
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
 
 public class GrpcMethodsProcessor {
     @BuildStep
-    ExecutionModelAnnotationsAllowedBuildItem grpcMethods() {
+    ExecutionModelAnnotationsAllowedBuildItem grpcMethods(CombinedIndexBuildItem combinedIndex) {
+        IndexView index = combinedIndex.getIndex();
+
         return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
             @Override
             public boolean test(MethodInfo method) {
-                return method.declaringClass().hasDeclaredAnnotation(GrpcDotNames.GRPC_SERVICE);
+                // either the method is on a `@GrpcService` class
+                if (method.declaringClass().hasDeclaredAnnotation(GrpcDotNames.GRPC_SERVICE)) {
+                    return true;
+                }
+
+                // or the method is inherited by a `@GrpcService` class
+                for (ClassInfo subclass : index.getAllKnownSubclasses(method.declaringClass().name())) {
+                    if (subclass.hasDeclaredAnnotation(GrpcDotNames.GRPC_SERVICE)) {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         });
     }

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devui/GrpcDevUIProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devui/GrpcDevUIProcessor.java
@@ -226,7 +226,7 @@ public class GrpcDevUIProcessor {
         return null;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(GrpcJsonRPCService.class);
     }

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devui/InfinispanDevUIProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devui/InfinispanDevUIProcessor.java
@@ -43,7 +43,7 @@ public class InfinispanDevUIProcessor {
         return cardPageBuildItem;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     public JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(InfinispanJsonRPCService.class, BuiltinScope.SINGLETON.getName());
     }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/devui/KafkaDevUIProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/devui/KafkaDevUIProcessor.java
@@ -48,7 +48,7 @@ public class KafkaDevUIProcessor {
         return cardPageBuildItem;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(KafkaJsonRPCService.class);
     }

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/devui/KafkaStreamsDevUIProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/devui/KafkaStreamsDevUIProcessor.java
@@ -23,7 +23,7 @@ public class KafkaStreamsDevUIProcessor {
         cardPageProducer.produce(cardPageBuildItem);
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     public void createJsonRPCService(BuildProducer<JsonRPCProvidersBuildItem> jsonRPCServiceProducer) {
         jsonRPCServiceProducer.produce(new JsonRPCProvidersBuildItem(KafkaStreamsJsonRPCService.class));
     }

--- a/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/devui/LiquibaseDevUIProcessor.java
+++ b/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/devui/LiquibaseDevUIProcessor.java
@@ -40,7 +40,7 @@ public class LiquibaseDevUIProcessor {
         cardPageBuildItemBuildProducer.produce(card);
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(LiquibaseJsonRpcService.class);
     }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevUIProcessor.java
@@ -95,7 +95,7 @@ public class OidcDevUIProcessor extends AbstractDevUIProcessor {
         }
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem produceOidcDevJsonRpcService() {
         return new JsonRPCProvidersBuildItem(OidcDevJsonRpcService.class);
     }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
@@ -76,7 +76,7 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
         }
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem produceOidcDevJsonRpcService() {
         return new JsonRPCProvidersBuildItem(OidcDevJsonRpcService.class);
     }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/devconsole/RestClientReactiveDevUIProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/devconsole/RestClientReactiveDevUIProcessor.java
@@ -27,7 +27,7 @@ public class RestClientReactiveDevUIProcessor {
         return pageBuildItem;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(RestClientsJsonRPCService.class);
     }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/ReactiveClientHeadersFromBuilderTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/ReactiveClientHeadersFromBuilderTest.java
@@ -30,7 +30,6 @@ import io.quarkus.rest.client.reactive.ReactiveClientHeadersFactory;
 import io.quarkus.rest.client.reactive.TestJacksonBasicMessageBodyReader;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
-import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 
@@ -97,7 +96,6 @@ public class ReactiveClientHeadersFromBuilderTest {
 
     @ApplicationScoped
     public static class Service {
-        @Blocking
         public String getValue() {
             return HEADER_VALUE;
         }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/ReactiveClientHeadersFromProviderTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/ReactiveClientHeadersFromProviderTest.java
@@ -30,7 +30,6 @@ import io.quarkus.rest.client.reactive.ReactiveClientHeadersFactory;
 import io.quarkus.rest.client.reactive.TestJacksonBasicMessageBodyReader;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
-import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 
@@ -95,7 +94,6 @@ public class ReactiveClientHeadersFromProviderTest {
 
     @ApplicationScoped
     public static class Service {
-        @Blocking
         public String getValue() {
             return HEADER_VALUE;
         }

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
@@ -46,7 +46,7 @@ public class ResteasyReactiveDevUIProcessor {
         cardPageProducer.produce(cardPageBuildItem);
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     public void createJsonRPCService(BuildProducer<JsonRPCProvidersBuildItem> jsonRPCServiceProducer) {
         jsonRPCServiceProducer.produce(new JsonRPCProvidersBuildItem(ResteasyReactiveJsonRPCService.class));
     }

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/devui/SchedulerDevUIProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/devui/SchedulerDevUIProcessor.java
@@ -35,7 +35,7 @@ public class SchedulerDevUIProcessor {
         footerPages.produce(new FooterPageBuildItem(logPageBuilder));
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem rpcProvider() {
         return new JsonRPCProvidersBuildItem(SchedulerJsonRPCService.class);
     }

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/devui/FaultToleranceDevUIProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/devui/FaultToleranceDevUIProcessor.java
@@ -22,7 +22,7 @@ public class FaultToleranceDevUIProcessor {
         return pageBuildItem;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem jsonRPCService() {
         return new JsonRPCProvidersBuildItem(FaultToleranceJsonRpcService.class);
     }

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/GraphqlMethodsProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/GraphqlMethodsProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.graphql.deployment;
 import java.util.function.Predicate;
 
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
@@ -15,6 +16,7 @@ import io.smallrye.graphql.api.federation.Resolver;
 public class GraphqlMethodsProcessor {
     private static final DotName QUERY = DotName.createSimple(Query.class);
     private static final DotName MUTATION = DotName.createSimple(Mutation.class);
+    private static final DotName NAME = DotName.createSimple(Name.class);
     private static final DotName SUBSCRIPTION = DotName.createSimple(Subscription.class);
     private static final DotName RESOLVER = DotName.createSimple(Resolver.class);
 
@@ -26,6 +28,7 @@ public class GraphqlMethodsProcessor {
                 // maybe just look for `@GraphQLApi` on the declaring class?
                 return method.hasDeclaredAnnotation(QUERY)
                         || method.hasDeclaredAnnotation(MUTATION)
+                        || method.hasDeclaredAnnotation(NAME)
                         || method.hasDeclaredAnnotation(SUBSCRIPTION)
                         || method.hasDeclaredAnnotation(RESOLVER);
             }

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/devui/RabbitDevUIProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/devui/RabbitDevUIProcessor.java
@@ -23,7 +23,7 @@ public class RabbitDevUIProcessor {
         cardPageBuildItemBuildProducer.produce(card);
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem registerJsonRpcBackend() {
         return new JsonRPCProvidersBuildItem(RabbitMqJsonRpcService.class);
     }

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/devui/ReactiveMessagingDevUIProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/devui/ReactiveMessagingDevUIProcessor.java
@@ -64,7 +64,7 @@ public class ReactiveMessagingDevUIProcessor {
         return card;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(ReactiveMessagingJsonRpcService.class);
     }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
@@ -53,8 +53,7 @@ public class LogStreamProcessor {
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    void createJsonRPCService(BuildProducer<JsonRPCProvidersBuildItem> jsonRPCProvidersProducer,
-            BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer,
+    void registerBuildTimeActions(BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer,
             LaunchModeBuildItem launchModeBuildItem) {
 
         Optional<TestSupport> ts = TestSupport.instance();
@@ -136,7 +135,11 @@ public class LogStreamProcessor {
         });
 
         buildTimeActionProducer.produce(keyStrokeActions);
-        jsonRPCProvidersProducer.produce(new JsonRPCProvidersBuildItem(namespace, LogStreamJsonRPCService.class));
+    }
+
+    @BuildStep
+    JsonRPCProvidersBuildItem createJsonRPCService() {
+        return new JsonRPCProvidersBuildItem(namespace, LogStreamJsonRPCService.class);
     }
 
     private boolean testsDisabled(LaunchModeBuildItem launchModeBuildItem, Optional<TestSupport> ts) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
@@ -96,8 +96,7 @@ public class ConfigurationProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     @Record(ExecutionTime.RUNTIME_INIT)
-    void registerJsonRpcService(
-            BuildProducer<JsonRPCProvidersBuildItem> jsonRPCProvidersProducer,
+    void registerBuildTimeActions(
             BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanProducer,
             ConfigDevUIRecorder recorder,
@@ -144,8 +143,11 @@ public class ConfigurationProcessor {
                 CurrentConfig.CURRENT = Collections.emptyList();
             }
         }, true);
+    }
 
-        jsonRPCProvidersProducer.produce(new JsonRPCProvidersBuildItem(NAMESPACE, ConfigJsonRPCService.class));
+    @BuildStep
+    JsonRPCProvidersBuildItem registerJsonRpcService() {
+        return new JsonRPCProvidersBuildItem(NAMESPACE, ConfigJsonRPCService.class);
     }
 
     private static final Pattern codePattern = Pattern.compile("(\\{@code )([^}]+)(\\})");

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -65,8 +65,7 @@ public class ContinuousTestingProcessor {
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    void createJsonRPCService(LaunchModeBuildItem launchModeBuildItem,
-            BuildProducer<JsonRPCProvidersBuildItem> jsonRPCProvidersProducer,
+    void registerBuildTimeActions(LaunchModeBuildItem launchModeBuildItem,
             BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer) {
 
         BuildTimeActionBuildItem actions = new BuildTimeActionBuildItem(NAMESPACE);
@@ -80,8 +79,11 @@ public class ContinuousTestingProcessor {
         registerGetResultsMethod(launchModeBuildItem, actions);
         registerGetStatusMethod(launchModeBuildItem, actions);
         buildTimeActionProducer.produce(actions);
+    }
 
-        jsonRPCProvidersProducer.produce(new JsonRPCProvidersBuildItem(NAMESPACE, ContinuousTestingJsonRPCService.class));
+    @BuildStep
+    JsonRPCProvidersBuildItem createJsonRPCService() {
+        return new JsonRPCProvidersBuildItem(NAMESPACE, ContinuousTestingJsonRPCService.class);
     }
 
     private boolean testsDisabled(LaunchModeBuildItem launchModeBuildItem, Optional<TestSupport> ts) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/EndpointsProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/EndpointsProcessor.java
@@ -55,7 +55,7 @@ public class EndpointsProcessor {
         return endpointsPage;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(NAMESPACE, ResourceNotFoundData.class);
     }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ReadmeProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ReadmeProcessor.java
@@ -42,7 +42,7 @@ public class ReadmeProcessor {
         }
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCServiceForCache() {
         return new JsonRPCProvidersBuildItem(NS, ReadmeJsonRPCService.class);
     }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ReportIssuesProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ReportIssuesProcessor.java
@@ -8,7 +8,7 @@ import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.Page;
 
 public class ReportIssuesProcessor {
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem registerJsonRpcService() {
         return new JsonRPCProvidersBuildItem("report-issues", ReportIssuesJsonRPCService.class);
     }

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/JsonRPCProvidersBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/JsonRPCProvidersBuildItem.java
@@ -3,7 +3,12 @@ package io.quarkus.devui.spi;
 import org.jboss.jandex.DotName;
 
 /**
- * This allows you to register a class that will provide data during runtime for JsonRPC Requests
+ * This allows you to register a class that will provide data during runtime for JsonRPC Requests.
+ * <p>
+ * Note that this build item should <em>not</em> be produced only in dev mode (e.g. using
+ * {@code @BuildStep(onlyIf = IsDevelopment.class)}), because it is also used to discover
+ * valid usages of execution model affecting annotations (see
+ * {@link io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem}).
  */
 public final class JsonRPCProvidersBuildItem extends AbstractDevUIBuildItem {
 

--- a/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/devui/WebSocketServerDevUIProcessor.java
+++ b/extensions/websockets-next/deployment/src/main/java/io/quarkus/websockets/next/deployment/devui/WebSocketServerDevUIProcessor.java
@@ -45,7 +45,7 @@ public class WebSocketServerDevUIProcessor {
         cardPages.produce(pageBuildItem);
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem rpcProvider() {
         return new JsonRPCProvidersBuildItem(WebSocketNextJsonRPCService.class);
     }


### PR DESCRIPTION
The `JsonRPCProvidersBuildItem` often used to be produced only in dev mode (but note that some extensions produce it always already). This disallowed using this build item to discover Dev UI JSON RPC classes properly, so we used to ship a gross hack in the execution model annotation validation.

It is time to fix that. The `JsonRPCProvidersBuildItem` is always produced, so we can rely on it for discovering all the Dev UI JSON RPC classes.