### PR TITLE
Correctly handle trust managers when no trust manager matching the SNI name can be found

### DIFF
--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/keystores/ExpiryTrustOptions.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/keystores/ExpiryTrustOptions.java
@@ -84,6 +84,11 @@ public class ExpiryTrustOptions implements TrustOptions {
     }
 
     private TrustManager[] getWrappedTrustManagers(TrustManager[] tms) {
+        // If we do not find any trust managers (for example in the SNI case, where we do not have a trust manager for
+        // a given name), return `null` and not an empty array.
+        if (tms == null) {
+            return null;
+        }
         var wrapped = new TrustManager[tms.length];
         for (int i = 0; i < tms.length; i++) {
             var manager = tms[i];
@@ -160,5 +165,11 @@ public class ExpiryTrustOptions implements TrustOptions {
                     Objects.equals(policy, that.policy);
         }
         return false;
+    }
+
+    public String toString() {
+        return "ExpiryTrustOptions[" +
+                "delegate=" + delegate + ", " +
+                "policy=" + policy + ']';
     }
 }


### PR DESCRIPTION
This is particularly important when using RabbitMQ with the AMQP 1.0 connector, as the vhost is used as the SNI name.


Fix https://github.com/quarkusio/quarkus/issues/46652.