### PR TITLE
Fix text on gradle tooling doc

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -666,7 +666,7 @@ The entries are relative to the root of the generated Uber-Jar. You can specify 
 By default, Quarkus will not discover CDI beans inside another module.
 
 The best way to enable CDI bean discovery for a module in a multi-module project would be to include a `META-INF/beans.xml` file,
-unless it is the main application module already configured with the quarkus-maven-plugin, in which case it will be indexed automatically.
+unless it is the main application module already configured with the `io.quarkus` Gradle plugin, in which case it will be indexed automatically.
 
 Alternatively, there is some unofficial link:https://plugins.gradle.org/search?term=jandex[Gradle Jandex plugins] that can be used instead of the `META-INF/beans.xml` file.
 


### PR DESCRIPTION
Fix mention of `gradle-plugin`.

The application module is indexed automatically by the gradle plugin and not maven plugin (when using gradle tooling).