### PR TITLE
Fix the OIDC opaque token check

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -66,6 +66,7 @@ import io.smallrye.jwt.util.ResourceUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.KeyStoreOptions;
 import io.vertx.core.net.ProxyOptions;
@@ -787,9 +788,18 @@ public class OidcCommonUtils {
     }
 
     public static JsonObject decodeAsJsonObject(String encodedContent) {
+        String json = null;
         try {
-            return new JsonObject(base64UrlDecode(encodedContent));
+            json = base64UrlDecode(encodedContent);
         } catch (IllegalArgumentException ex) {
+            LOG.debugf("Invalid Base64URL content: %s", encodedContent);
+            return null;
+        }
+
+        try {
+            return new JsonObject(json);
+        } catch (DecodeException ex) {
+            LOG.debugf("Invalid JSON content: %s", json);
             return null;
         }
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -221,7 +221,7 @@ public final class OidcUtils {
     }
 
     public static boolean isOpaqueToken(String token) {
-        return new StringTokenizer(token, ".").countTokens() != 3;
+        return OidcCommonUtils.decodeJwtContent(token) == null;
     }
 
     public static String decodeJwtContentAsString(String jwt) {
@@ -806,16 +806,17 @@ public final class OidcUtils {
     }
 
     public static boolean isJwtTokenExpired(String token) {
-        if (!isOpaqueToken(token)) {
-            JsonObject claims = OidcCommonUtils.decodeJwtContent(token);
-            Long expiresAt = getJwtExpiresAtClaim(claims);
-            if (expiresAt == null) {
-                return false;
-            }
-            final long nowSecs = System.currentTimeMillis() / 1000;
-            return nowSecs > expiresAt;
+        JsonObject claims = OidcCommonUtils.decodeJwtContent(token);
+        if (claims == null) {
+            // It must be an opaque token
+            return false;
         }
-        return false;
+        Long expiresAt = getJwtExpiresAtClaim(claims);
+        if (expiresAt == null) {
+            return false;
+        }
+        final long nowSecs = System.currentTimeMillis() / 1000;
+        return nowSecs > expiresAt;
     }
 
     static Long getJwtExpiresAtClaim(JsonObject claims) {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -241,7 +241,8 @@ public class OidcUtilsTest {
     public void testTokenIsOpaque() throws Exception {
         assertTrue(OidcUtils.isOpaqueToken("123"));
         assertTrue(OidcUtils.isOpaqueToken("1.23"));
-        assertFalse(OidcUtils.isOpaqueToken("1.2.3"));
+        assertTrue(OidcUtils.isOpaqueToken("1.2.3"));
+        assertFalse(OidcUtils.isOpaqueToken(jwt()));
     }
 
     @Test
@@ -253,15 +254,19 @@ public class OidcUtilsTest {
 
     @Test
     public void testDecodeJwt() throws Exception {
-        final byte[] keyBytes = "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
-                .getBytes(StandardCharsets.UTF_8);
-        SecretKey key = new SecretKeySpec(keyBytes, 0, keyBytes.length, "HMACSHA256");
-        String jwt = Jwt.claims().sign(key);
+        String jwt = jwt();
         assertNull(OidcCommonUtils.decodeJwtContent(jwt + ".4"));
         JsonObject json = OidcCommonUtils.decodeJwtContent(jwt);
         assertTrue(json.containsKey("iat"));
         assertTrue(json.containsKey("exp"));
         assertTrue(json.containsKey("jti"));
+    }
+
+    private static String jwt() {
+        final byte[] keyBytes = "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
+                .getBytes(StandardCharsets.UTF_8);
+        SecretKey key = new SecretKeySpec(keyBytes, 0, keyBytes.length, "HMACSHA256");
+        return Jwt.claims().sign(key);
     }
 
     @Test

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -793,7 +793,7 @@ public class CodeFlowAuthorizationTest {
                                         + "\","
                                         + "  \"access_token\": \"alice\","
                                         + "  \"expires_in\":" + 3 + ","
-                                        + "  \"refresh_token\": \"refresh_expires_in\""
+                                        + "  \"refresh_token\": \"refresh.expires.in\""
                                         + "}")));
 
         wireMockServer
@@ -819,7 +819,7 @@ public class CodeFlowAuthorizationTest {
 
         wireMockServer
                 .stubFor(WireMock.post("/auth/realms/quarkus/access_token_expires_in")
-                        .withRequestBody(containing("refresh_token=refresh_expires_in"))
+                        .withRequestBody(containing("refresh_token=refresh.expires.in"))
                         .willReturn(WireMock.aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +


### PR DESCRIPTION
Fixes #46972.

The current OIDC opaque token check has been proved with #46990 to be incomplete.
Signed JWT tokens have 3 parts separated by 2 dots which is what the current light weight check does, but it can be just a concidence, the binary tokens may have random 2 dots in the sequence as well.
The side-effect highlighted by #46972 is that a binary refresh token with 2 dots is assumed to be JWT, and the parsing exception escapes causing a failure. 
While #46972 can be fixed by only adding another exception catch block as done in this PR, I've also updated the opaque token check which is done in other code branches - it did not cause side-effects so far but might if not fixed