### PR TITLE
Fix constructor search for Qute template records

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -892,8 +892,10 @@ public class QuteProcessor {
                     String paramName = e.getKey();
                     MethodInfo methodOrConstructor = null;
                     if (validation.checkedTemplate.isRecord()) {
-                        Type[] componentTypes = validation.checkedTemplate.recordClass.recordComponents().stream()
-                                .map(RecordComponentInfo::type).toArray(Type[]::new);
+                        Type[] componentTypes = validation.checkedTemplate.recordClass.recordComponentsInDeclarationOrder()
+                                .stream()
+                                .map(RecordComponentInfo::type)
+                                .toArray(Type[]::new);
                         methodOrConstructor = validation.checkedTemplate.recordClass
                                 .method(MethodDescriptor.INIT, componentTypes);
                     } else {


### PR DESCRIPTION
Addresses an issue in which the build fails with a null pointer exception due to not being able to find the record constructor because the order of the types are not in the order specified in the constructor.