### PR TITLE
Map rest client exception to status specific Exception

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jackson/deployment/src/test/java/io/quarkus/rest/client/reactive/jackson/test/InvalidJsonFromServerTest.java
+++ b/extensions/resteasy-reactive/rest-client-jackson/deployment/src/test/java/io/quarkus/rest/client/reactive/jackson/test/InvalidJsonFromServerTest.java
@@ -5,11 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -30,8 +30,9 @@ public class InvalidJsonFromServerTest {
     @Test
     public void test() {
         assertThatThrownBy(() -> client.get())
-                .isInstanceOf(ClientWebApplicationException.class)
+                .isInstanceOf(WebApplicationException.class)
                 .hasMessageContaining("HTTP 200")
+                .cause()
                 .cause()
                 .hasMessageContaining("was expecting double-quote to start field name");
     }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ContextualErrorMessagesConfigTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ContextualErrorMessagesConfigTest.java
@@ -1,8 +1,9 @@
 package io.quarkus.rest.client.reactive;
 
+import jakarta.ws.rs.WebApplicationException;
+
 import org.assertj.core.api.Assertions;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -31,7 +32,7 @@ public class ContextualErrorMessagesConfigTest {
         try {
             client.echo("Bob");
             Assertions.fail("An exception was expected.");
-        } catch (ClientWebApplicationException e) {
+        } catch (WebApplicationException e) {
             Assertions.assertThat(e.getMessage()).doesNotContain("io.quarkus.rest.client.reactive.HelloClient2#echo");
         }
     }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ContextualErrorMessagesTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ContextualErrorMessagesTest.java
@@ -1,8 +1,9 @@
 package io.quarkus.rest.client.reactive;
 
+import jakarta.ws.rs.WebApplicationException;
+
 import org.assertj.core.api.Assertions;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -31,7 +32,7 @@ public class ContextualErrorMessagesTest {
         try {
             client.echo("Bob");
             Assertions.fail("An exception was expected.");
-        } catch (ClientWebApplicationException e) {
+        } catch (WebApplicationException e) {
             Assertions.assertThat(e.getMessage()).contains("io.quarkus.rest.client.reactive.HelloClient2#echo");
         }
     }

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/encoded/ClientWithPathParamAndEncodedTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/encoded/ClientWithPathParamAndEncodedTest.java
@@ -8,12 +8,12 @@ import java.net.URI;
 
 import jakarta.ws.rs.Encoded;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -33,7 +33,7 @@ public class ClientWithPathParamAndEncodedTest {
         ClientWithoutEncoded client = RestClientBuilder.newBuilder()
                 .baseUri(baseUri)
                 .build(ClientWithoutEncoded.class);
-        ClientWebApplicationException ex = assertThrows(ClientWebApplicationException.class, () -> client.call("a/b"));
+        NotFoundException ex = assertThrows(NotFoundException.class, () -> client.call("a/b"));
         assertTrue(ex.getMessage().contains("Not Found"));
     }
 

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartResponseTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartResponseTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeoutException;
 
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -27,7 +28,6 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
-import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.jboss.resteasy.reactive.MultipartForm;
 import org.jboss.resteasy.reactive.PartType;
 import org.jboss.resteasy.reactive.RestForm;
@@ -161,7 +161,7 @@ public class MultipartResponseTest {
     @Test
     void shouldBeSaneOnServerError() {
         Client client = createClient();
-        assertThatThrownBy(client::error).isInstanceOf(ClientWebApplicationException.class);
+        assertThatThrownBy(client::error).isInstanceOf(InternalServerErrorException.class);
     }
 
     @Test

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ExceptionUtil.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ExceptionUtil.java
@@ -1,0 +1,55 @@
+package org.jboss.resteasy.reactive.client.impl;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotAcceptableException;
+import jakarta.ws.rs.NotAllowedException;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.RedirectionException;
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.ServiceUnavailableException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status.Family;
+
+class ExceptionUtil {
+
+    private ExceptionUtil() {
+    }
+
+    static WebApplicationException toException(String message, Response response,
+            Throwable cause) {
+        Response.Status status = response.getStatusInfo().toEnum();
+        if (status == null) {
+            return createExceptionForFamily(message, response, cause);
+        } else {
+            return switch (status) {
+                case BAD_REQUEST -> new BadRequestException(message, response, cause);
+                case UNAUTHORIZED -> new NotAuthorizedException(message, response, cause);
+                case FORBIDDEN -> new ForbiddenException(message, response, cause);
+                case NOT_FOUND -> new NotFoundException(message, response, cause);
+                case METHOD_NOT_ALLOWED -> new NotAllowedException(message, response, cause);
+                case NOT_ACCEPTABLE -> new NotAcceptableException(message, response, cause);
+                case UNSUPPORTED_MEDIA_TYPE -> new NotSupportedException(message, response, cause);
+                case INTERNAL_SERVER_ERROR -> new InternalServerErrorException(message, response, cause);
+                case SERVICE_UNAVAILABLE -> new ServiceUnavailableException(message, response, cause);
+                default -> createExceptionForFamily(message, response, cause);
+            };
+        }
+    }
+
+    private static WebApplicationException createExceptionForFamily(String message,
+            Response response, Throwable cause) {
+        Family statusFamily = response.getStatusInfo().getFamily();
+        return switch (statusFamily) {
+            case REDIRECTION -> new RedirectionException(message, response);
+            case CLIENT_ERROR -> new ClientErrorException(message, response, cause);
+            case SERVER_ERROR -> new ServerErrorException(message, response, cause);
+            default -> new WebApplicationException(message, cause, response);
+        };
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -199,10 +199,14 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
                         + invokedMethod.getDeclaringClass().getName() + "#"
                         + invokedMethod.getName() + "'";
             }
-            return new ClientWebApplicationException(message,
-                    webApplicationException instanceof ClientWebApplicationException ? webApplicationException.getCause()
-                            : webApplicationException,
-                    webApplicationException.getResponse());
+            return ExceptionUtil.toException(message,
+                    webApplicationException.getResponse(),
+                    webApplicationException instanceof ClientWebApplicationException
+                            ? webApplicationException
+                            : new ClientWebApplicationException(
+                                    webApplicationException.getMessage(),
+                                    webApplicationException.getCause(),
+                                    webApplicationException.getResponse()));
         }
         return res;
     }

--- a/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/handlers/ClientResponseCompleteRestHandlerTest.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/handlers/ClientResponseCompleteRestHandlerTest.java
@@ -10,7 +10,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Map;
 
-import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -60,7 +61,7 @@ class ClientResponseCompleteRestHandlerTest {
         try {
             httpClient.target(generateURL("/get-400")).request().get(String.class);
             fail("Should have thrown an exception");
-        } catch (WebApplicationException e) {
+        } catch (BadRequestException e) {
             Response response = e.getResponse();
             checkResponse(response);
             Map<String, Object> parsedResponseContent = readAndParseResponse(response);
@@ -80,7 +81,7 @@ class ClientResponseCompleteRestHandlerTest {
         try {
             httpClient.target(generateURL("/get-500")).request().get(String.class);
             fail("Should have thrown an exception");
-        } catch (WebApplicationException e) {
+        } catch (InternalServerErrorException e) {
             Response response = e.getResponse();
             checkResponse(response);
             Map<String, Object> parsedResponseContent = readAndParseResponse(response);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/RuntimeExceptionMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/RuntimeExceptionMapper.java
@@ -66,7 +66,7 @@ public class RuntimeExceptionMapper {
         //we don't read WebApplicationException's thrown from the client as true 'WebApplicationException'
         //we consider it a security risk to transparently pass on the result to the calling server
         boolean isWebApplicationException = throwable instanceof WebApplicationException
-                && !(throwable instanceof ResteasyReactiveClientProblem);
+                && !(throwable.getCause() instanceof ResteasyReactiveClientProblem);
         Response response = null;
         if (isWebApplicationException) {
             response = ((WebApplicationException) throwable).getResponse();


### PR DESCRIPTION
Closes #24185 

- Instead of mapping the rest-client's `WebApplicationException` to `ClientWebApplicationException` this maps the exceptions to their status code specific `WebApplicationException` subclasses
- To differentiate `WebApplicationException`s thrown by the rest-client in [RuntimeExceptionMapper#mapException](https://github.com/quarkusio/quarkus/blob/e299fed1f4ae2667196a5ca4f1bb1abf5cf2919d/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/RuntimeExceptionMapper.java#L68-L69), my idea was that the `cause` should always be a wrapped in a `ClientWebApplicationException` if its thrown by the rest-client