### PR TITLE
Register classes for reflection in amazon lambda and funqy

### DIFF
--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaCommonProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaCommonProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.amazon.lambda.runtime.AmazonLambdaMapperRecorder;
+import io.quarkus.amazon.lambda.runtime.FunctionError;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -14,6 +15,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.SnapStartDefaultValueBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.deployment.pkg.steps.NativeSourcesBuild;
@@ -86,6 +88,12 @@ public final class AmazonLambdaCommonProcessor {
             // only need context readers in native or dev or test mode
             recorder.initContextReaders();
         }
+    }
+
+    @BuildStep(onlyIf = NativeBuild.class)
+    public void registerForSerialization(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(
+                FunctionError.class.getName()).build());
     }
 
 }

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyAmazonLambdaProcessor.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyAmazonLambdaProcessor.java
@@ -14,6 +14,9 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.funqy.lambda.model.cloudevents.CloudEventDataV1;
 import io.quarkus.funqy.lambda.model.cloudevents.CloudEventV1;
+import io.quarkus.funqy.lambda.model.kinesis.PipesKinesisEvent;
+import io.quarkus.funqy.lambda.model.pipes.BatchItemFailures;
+import io.quarkus.funqy.lambda.model.pipes.Response;
 
 public class FunqyAmazonLambdaProcessor {
 
@@ -39,8 +42,12 @@ public class FunqyAmazonLambdaProcessor {
                 Record.class.getName(),
                 StreamsEventResponse.class.getName(),
                 StreamsEventResponse.BatchItemFailure.class.getName(),
+                PipesKinesisEvent.class.getName(),
                 // DynamoDB
                 DynamodbEvent.class.getName(),
-                DynamodbEvent.DynamodbStreamRecord.class.getName()).constructors().methods().fields().build());
+                DynamodbEvent.DynamodbStreamRecord.class.getName(),
+                // Pipes
+                Response.class.getName(),
+                BatchItemFailures.class.getName()).constructors().methods().fields().build());
     }
 }


### PR DESCRIPTION
We forgot to register some classes. So native images sometimes fail unexpectedly:

```java
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class io.quarkus.amazon.lambda.runtime.FunctionError and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS). This appears to be a native image, in which case you may need to configure reflection for the class that is to be serialized
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1328)
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:414)
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.failForEmpty(UnknownSerializer.java:49)
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.serialize(UnknownSerializer.java:30)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:502)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:341)
	at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4811)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:4011)
	at io.quarkus.amazon.lambda.runtime.AbstractLambdaPollLoop.postError(AbstractLambdaPollLoop.java:279)
	at io.quarkus.amazon.lambda.runtime.AbstractLambdaPollLoop$1.run(AbstractLambdaPollLoop.java:154)
	at java.base@21.0.6/java.lang.Thread.runWith(Thread.java:1596)
	at java.base@21.0.6/java.lang.Thread.run(Thread.java:1583)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:896)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:872)
```

and here as well. I registered more missing classes as well:
```java
java.lang.IllegalArgumentException: Could not serialize the provided output.
	at io.quarkus.funqy.lambda.event.AwsEventOutputWriter.writeValue(AwsEventOutputWriter.java:31)
	at io.quarkus.amazon.lambda.runtime.AbstractLambdaPollLoop.postResponse(AbstractLambdaPollLoop.java:255)
	at io.quarkus.amazon.lambda.runtime.AbstractLambdaPollLoop$1.run(AbstractLambdaPollLoop.java:143)
	at java.base@21.0.6/java.lang.Thread.runWith(Thread.java:1596)
	at java.base@21.0.6/java.lang.Thread.run(Thread.java:1583)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:896)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:872)
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class io.quarkus.funqy.lambda.model.pipes.Response and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS). This appears to be a native image, in which case you may need to configure reflection for the class that is to be serialized
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1328)
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:414)
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.failForEmpty(UnknownSerializer.java:49)
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.serialize(UnknownSerializer.java:30)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:502)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:341)
	at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4811)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:4011)
	at io.quarkus.funqy.lambda.event.AwsEventOutputWriter.writeValue(AwsEventOutputWriter.java:27)
```
