### PR TITLE
Token introspection client read and connection timeout

### DIFF
--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Recorder.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Recorder.java
@@ -50,6 +50,14 @@ public class OAuth2Recorder {
             validatorBuilder.useSslContext(SSLContext.getDefault());
         }
 
+        if (runtimeConfig.connectionTimeout().isPresent()) {
+            validatorBuilder.connectionTimeout((int) runtimeConfig.connectionTimeout().get().toMillis());
+        }
+
+        if (runtimeConfig.readTimeout().isPresent()) {
+            validatorBuilder.readTimeout((int) runtimeConfig.readTimeout().get().toMillis());
+        }
+
         OAuth2IntrospectValidator validator = validatorBuilder.build();
 
         TokenSecurityRealm tokenRealm = TokenSecurityRealm.builder()

--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2RuntimeConfig.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2RuntimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.elytron.security.oauth2.runtime;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -37,4 +38,16 @@ public interface OAuth2RuntimeConfig {
      * <a href="native-and-ssl.html">Using SSL With Native Executables</a>.
      */
     Optional<String> caCertFile();
+
+    /**
+     * Client connection timeout for token introspection.
+     * Infinite if not set.
+     */
+    Optional<Duration> connectionTimeout();
+
+    /**
+     * Client read timeout for token introspection.
+     * Infinite if not set.
+     */
+    Optional<Duration> readTimeout();
 }


### PR DESCRIPTION
Allows to configure the client connection and read timeout for token introspection currently it is not configureable.
Hence the value would be 0 meaning infinite according to the current implementation in `org.wildfly.security.auth.realm.token.validator.OAuth2IntrospectValidator#openConnection`

