### PR TITLE
Only set eventLoopGroup on GRPC if native transports not enabled

### DIFF
--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/MutinyStubInjectionTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/MutinyStubInjectionTest.java
@@ -45,7 +45,7 @@ public class MutinyStubInjectionTest {
     @Test
     public void test() {
         String neo = service.invoke("neo-mutiny");
-        assertThat(neo).startsWith("Hello neo-mutiny").doesNotContain("vert.x");
+        assertThat(neo).startsWith("Hello neo-mutiny").contains("vert.x");
 
         neo = service.invokeFromIoThread("neo-io");
         assertThat(neo).startsWith("Hello neo-io").contains("vert.x");

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
@@ -212,7 +212,7 @@ public class Channels {
                 // just use the existing Vertx event loop group, if possible
                 Vertx vertx = container.instance(Vertx.class).get();
                 // only support NIO for now, since Vertx::transport is not exposed in the API
-                if (vertx != null && vertx.isNativeTransportEnabled()) {
+                if (vertx != null && !vertx.isNativeTransportEnabled()) {
                     // see https://github.com/eclipse-vertx/vert.x/pull/5292
                     boolean reuseNettyAllocators = Boolean.getBoolean("vertx.reuseNettyAllocators");
                     if (reuseNettyAllocators) {


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/47021