### PR TITLE
Include the token with AuthenticaionFailedException

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -5,6 +5,7 @@ import static io.quarkus.oidc.runtime.OidcUtils.extractBearerToken;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -35,8 +36,8 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
         // if a bearer token is provided try to authenticate
         if (token != null) {
             try {
-                setCertificateThumbprint(context, oidcTenantConfig);
-                setDPopProof(context, oidcTenantConfig);
+                setCertificateThumbprint(context, oidcTenantConfig, token);
+                setDPopProof(context, oidcTenantConfig, token);
             } catch (AuthenticationFailedException ex) {
                 return Uni.createFrom().failure(ex);
             }
@@ -46,29 +47,29 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
         return Uni.createFrom().nullItem();
     }
 
-    private static void setCertificateThumbprint(RoutingContext context, OidcTenantConfig oidcTenantConfig) {
+    private static void setCertificateThumbprint(RoutingContext context, OidcTenantConfig oidcTenantConfig, String token) {
         if (oidcTenantConfig.token().binding().certificate()) {
-            Certificate cert = getCertificate(context);
+            Certificate cert = getCertificate(context, token);
             if (!(cert instanceof X509Certificate)) {
                 LOG.warn("Access token must be bound to X509 client certiifcate");
-                throw new AuthenticationFailedException();
+                throw new AuthenticationFailedException(tokenMap(token));
             }
             context.put(OidcConstants.X509_SHA256_THUMBPRINT,
                     TrustStoreUtils.calculateThumprint((X509Certificate) cert));
         }
     }
 
-    private static void setDPopProof(RoutingContext context, OidcTenantConfig oidcTenantConfig) {
+    private static void setDPopProof(RoutingContext context, OidcTenantConfig oidcTenantConfig, String token) {
         if (OidcConstants.DPOP_SCHEME.equals(oidcTenantConfig.token().authorizationScheme())) {
 
             List<String> proofs = context.request().headers().getAll(OidcConstants.DPOP_SCHEME);
             if (proofs == null || proofs.isEmpty()) {
                 LOG.warn("DPOP proof header must be present to verify the DPOP access token binding");
-                throw new AuthenticationFailedException();
+                throw new AuthenticationFailedException(tokenMap(token));
             }
             if (proofs.size() != 1) {
                 LOG.warn("Only a single DPOP proof header is accepted");
-                throw new AuthenticationFailedException();
+                throw new AuthenticationFailedException(tokenMap(token));
             }
             String proof = proofs.get(0);
 
@@ -78,28 +79,28 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
 
             if (!OidcConstants.DPOP_TOKEN_TYPE.equals(proofJwtHeaders.getString(OidcConstants.TOKEN_TYPE_HEADER))) {
                 LOG.warn("Invalid DPOP proof token type ('typ') header");
-                throw new AuthenticationFailedException();
+                throw new AuthenticationFailedException(tokenMap(token));
             }
 
             // Check HTTP method and request URI
             String proofHttpMethod = proofJwtClaims.getString(OidcConstants.DPOP_HTTP_METHOD);
             if (proofHttpMethod == null) {
                 LOG.warn("DPOP proof HTTP method claim is missing");
-                throw new AuthenticationFailedException();
+                throw new AuthenticationFailedException(tokenMap(token));
             }
 
             String httpMethod = context.request().method().name();
             if (!httpMethod.equals(proofHttpMethod)) {
                 LOG.warnf("DPOP proof HTTP method claim %s does not match the request HTTP method %s", proofHttpMethod,
                         httpMethod);
-                throw new AuthenticationFailedException();
+                throw new AuthenticationFailedException(tokenMap(token));
             }
 
             // Check HTTP request URI
             String proofHttpRequestUri = proofJwtClaims.getString(OidcConstants.DPOP_HTTP_REQUEST_URI);
             if (proofHttpRequestUri == null) {
                 LOG.warn("DPOP proof HTTP request uri claim is missing");
-                throw new AuthenticationFailedException();
+                throw new AuthenticationFailedException(tokenMap(token));
             }
 
             String httpRequestUri = context.request().absoluteURI();
@@ -110,7 +111,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             if (!httpRequestUri.equals(proofHttpRequestUri)) {
                 LOG.warnf("DPOP proof HTTP request uri claim %s does not match the request HTTP uri %s", proofHttpRequestUri,
                         httpRequestUri);
-                throw new AuthenticationFailedException();
+                throw new AuthenticationFailedException(tokenMap(token));
             }
 
             context.put(OidcUtils.DPOP_PROOF, proof);
@@ -119,13 +120,17 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
         }
     }
 
-    private static Certificate getCertificate(RoutingContext context) {
+    private static Certificate getCertificate(RoutingContext context, String token) {
         try {
             return context.request().sslSession().getPeerCertificates()[0];
         } catch (SSLPeerUnverifiedException e) {
             LOG.warn("Access token must be certificate bound but no client certificate is available");
-            throw new AuthenticationFailedException();
+            throw new AuthenticationFailedException(tokenMap(token));
         }
+    }
+
+    private static Map<String, Object> tokenMap(String token) {
+        return Map.of(OidcConstants.ACCESS_TOKEN_VALUE, token);
     }
 
     public Uni<ChallengeData> getChallenge(RoutingContext context) {

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/SecurityEventListener.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/SecurityEventListener.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.spi.runtime.AuthenticationFailureEvent;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class SecurityEventListener {
+
+    public void event(@Observes AuthenticationFailureEvent event) {
+        RoutingContext vertxContext = (RoutingContext) event.getEventProperties()
+                .get(RoutingContext.class.getName());
+        AuthenticationFailedException ex = (AuthenticationFailedException) event.getAuthenticationFailure();
+        if ("expired".equals(ex.getAttribute(OidcConstants.ACCESS_TOKEN_VALUE))) {
+            vertxContext.response().setStatusCode(401);
+            vertxContext.response().end("Token: expired");
+        }
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerOpaqueTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerOpaqueTokenAuthorizationTest.java
@@ -72,7 +72,8 @@ public class BearerOpaqueTokenAuthorizationTest {
                 .header("Authorization", "Bearer " + "expired")
                 .get("/opaque/api/users/me/bearer")
                 .then()
-                .statusCode(401);
+                .statusCode(401)
+                .body(Matchers.equalTo("Token: expired"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #45207

This PR is based on the work of @michalvavrik done in the quarkus-security project.

Nearly all `AuthenticationFailedException`s produced from `quarkus-oidc` now include the token which caused the failure.
The main use case as suggested in #45207 is for users revoke it or do some extra logs and checks.

I've decided not to go through all of Quarkus extensions which can handle tokens in this single PR as it will lead to even  larger number of minor changes, so I'd rather deal with smallrye-jwt and elytron-oauth2 at some later stage