### PR TITLE
Update SmallRye Config to 3.12.4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -47,7 +47,7 @@
         <microprofile-lra.version>2.0.1</microprofile-lra.version>
         <microprofile-openapi.version>4.0.2</microprofile-openapi.version>
         <smallrye-common.version>2.10.0</smallrye-common.version>
-        <smallrye-config.version>3.12.3</smallrye-config.version>
+        <smallrye-config.version>3.12.4</smallrye-config.version>
         <smallrye-health.version>4.2.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>4.0.8</smallrye-open-api.version>


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.12.4</h2>
    <ul>
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1336">#1336</a> Do not report as unmapped property names from ConfigMapping instances</li>
    </ul>
</blockquote>
<br>

Quarkus:
- Fixes #47007