### PR TITLE
Quarkus REST: Introduce the Parameter<T> type for tri-state query and form parameters

### DIFF
--- a/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java
+++ b/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java
@@ -143,7 +143,7 @@ public class CsrfRequestResponseReactiveFilter {
 
             ResteasyReactiveRequestContext rrContext = (ResteasyReactiveRequestContext) requestContext
                     .getServerRequestContext();
-            String csrfTokenFormParam = (String) rrContext.getFormParameter(config.formFieldName(), true, false);
+            String csrfTokenFormParam = (String) rrContext.getFormParameter(config.formFieldName(), true, false, false);
             LOG.debugf("CSRF token found in the form parameter");
             verifyCsrfToken(requestContext, routing, config, cookieToken, csrfTokenFormParam);
 

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ImpliedReadBodyRequestFilterTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ImpliedReadBodyRequestFilterTest.java
@@ -105,7 +105,7 @@ public class ImpliedReadBodyRequestFilterTest {
             ResteasyReactiveRequestContext rrContext = (ResteasyReactiveRequestContext) containerRequestContext
                     .getServerRequestContext();
             if (containerRequestContext.getMethod().equals("POST")) {
-                String nameFormParam = (String) rrContext.getFormParameter("name", true, false);
+                String nameFormParam = (String) rrContext.getFormParameter("name", true, false, false);
                 if (nameFormParam != null) {
                     containerRequestContext.getHeaders().putSingle("suffix", "!".repeat(nameFormParam.length()));
                 } else {

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ReadBodyRequestFilterTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ReadBodyRequestFilterTest.java
@@ -105,7 +105,7 @@ public class ReadBodyRequestFilterTest {
             ResteasyReactiveRequestContext rrContext = (ResteasyReactiveRequestContext) containerRequestContext
                     .getServerRequestContext();
             if (containerRequestContext.getMethod().equals("POST")) {
-                String nameFormParam = (String) rrContext.getFormParameter("name", true, false);
+                String nameFormParam = (String) rrContext.getFormParameter("name", true, false, false);
                 if (nameFormParam != null) {
                     containerRequestContext.getHeaders().putSingle("suffix", "!".repeat(nameFormParam.length()));
                 } else {

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/WithFormBodyTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/WithFormBodyTest.java
@@ -58,7 +58,7 @@ public class WithFormBodyTest {
         @Path("empty")
         @POST
         public String helloEmptyPost(ServerRequestContext requestContext) {
-            return "hello " + ((ResteasyReactiveRequestContext) requestContext).getFormParameter("name", true, false);
+            return "hello " + ((ResteasyReactiveRequestContext) requestContext).getFormParameter("name", true, false, false);
         }
     }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
@@ -6,6 +6,7 @@ import static io.quarkus.resteasy.reactive.server.test.simple.OptionalQueryParam
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 
+import java.util.Arrays;
 import java.util.function.Supplier;
 
 import org.apache.http.HttpStatus;
@@ -52,7 +53,8 @@ public class SimpleQuarkusRestTestCase {
                                     ParameterWithFromString.class, BeanParamSubClass.class, FieldInjectedSubClassResource.class,
                                     BeanParamSuperClass.class, IllegalClassExceptionMapper.class,
                                     MyParameterProvider.class, MyParameterConverter.class, MyParameter.class,
-                                    NewParamsRestResource.class, InterfaceResource.class, InterfaceResourceImpl.class);
+                                    NewParamsRestResource.class, InterfaceResource.class, InterfaceResourceImpl.class,
+                                    TriParameterQueryParamResource.class, TriParameterFormParamResource.class);
                 }
             });
 
@@ -479,6 +481,80 @@ public class SimpleQuarkusRestTestCase {
     public void testInterfaceResource() {
         RestAssured.get("/iface")
                 .then().statusCode(200).body(Matchers.equalTo("Hello"));
+    }
+
+    @Test
+    public void testTriParameterQuery() {
+        testTriParameterQuery("/tri-parameter-query/string", "name", "Stef");
+        testTriParameterQuery("/tri-parameter-query/container/string", "string", "Stef");
+        testTriParameterQuery("/tri-parameter-query/integer", "name", "12");
+        testTriParameterQuery("/tri-parameter-query/container/integer", "integer", "12");
+
+        testTriParameterQuery("/tri-parameter-query/string-list", "name", "Stef", "Octave");
+        testTriParameterQuery("/tri-parameter-query/container/string-list", "stringList", "Stef", "Octave");
+        testTriParameterQuery("/tri-parameter-query/integer-list", "name", "1", "2");
+        testTriParameterQuery("/tri-parameter-query/container/integer-list", "integerList", "1", "2");
+
+        testTriParameterQuery("/tri-parameter-query/string-array", "name", "Stef", "Octave");
+        testTriParameterQuery("/tri-parameter-query/container/string-array", "stringArray", "Stef", "Octave");
+        testTriParameterQuery("/tri-parameter-query/integer-array", "name", "1", "2");
+        testTriParameterQuery("/tri-parameter-query/container/integer-array", "integerArray", "1", "2");
+        testTriParameterQuery("/tri-parameter-query/int-array", "name", "1", "2");
+        testTriParameterQuery("/tri-parameter-query/container/int-array", "intArray", "1", "2");
+    }
+
+    private void testTriParameterQuery(String endpoint, String paramName, String... values) {
+        // verify with nothing
+        Assertions.assertEquals("absent: true, cleared: false, set: false, value: null",
+                RestAssured.given()
+                        .get(endpoint)
+                        .asString());
+        // verify with cleared value
+        Assertions.assertEquals("absent: false, cleared: true, set: false, value: null",
+                RestAssured.given().queryParam(paramName, "").get(endpoint).asString());
+        // verify with set value
+        String expectedValues = values.length == 1 ? values[0] : Arrays.toString(values);
+        Assertions.assertEquals("absent: false, cleared: false, set: true, value: " + expectedValues,
+                RestAssured.given().queryParam(paramName, values).get(endpoint)
+                        .asString());
+
+    }
+
+    @Test
+    public void testTriParameterForm() {
+        testTriParameterForm("/tri-parameter-form/string", "name", "Stef");
+        testTriParameterForm("/tri-parameter-form/container/string", "string", "Stef");
+        testTriParameterForm("/tri-parameter-form/integer", "name", "12");
+        testTriParameterForm("/tri-parameter-form/container/integer", "integer", "12");
+
+        testTriParameterForm("/tri-parameter-form/string-list", "name", "Stef", "Octave");
+        testTriParameterForm("/tri-parameter-form/container/string-list", "stringList", "Stef", "Octave");
+        testTriParameterForm("/tri-parameter-form/integer-list", "name", "1", "2");
+        testTriParameterForm("/tri-parameter-form/container/integer-list", "integerList", "1", "2");
+
+        testTriParameterForm("/tri-parameter-form/string-array", "name", "Stef", "Octave");
+        testTriParameterForm("/tri-parameter-form/container/string-array", "stringArray", "Stef", "Octave");
+        testTriParameterForm("/tri-parameter-form/integer-array", "name", "1", "2");
+        testTriParameterForm("/tri-parameter-form/container/integer-array", "integerArray", "1", "2");
+        testTriParameterForm("/tri-parameter-form/int-array", "name", "1", "2");
+        testTriParameterForm("/tri-parameter-form/container/int-array", "intArray", "1", "2");
+    }
+
+    private void testTriParameterForm(String endpoint, String paramName, String... values) {
+        // verify with nothing
+        Assertions.assertEquals("absent: true, cleared: false, set: false, value: null",
+                RestAssured.given()
+                        .post(endpoint)
+                        .asString());
+        // verify with cleared value
+        Assertions.assertEquals("absent: false, cleared: true, set: false, value: null",
+                RestAssured.given().formParam(paramName, "").post(endpoint).asString());
+        // verify with set value
+        String expectedValues = values.length == 1 ? values[0] : Arrays.toString(values);
+        Assertions.assertEquals("absent: false, cleared: false, set: true, value: " + expectedValues,
+                RestAssured.given().formParam(paramName, values).post(endpoint)
+                        .asString());
+
     }
 
     @Test

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/TriParameterFormParamResource.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/TriParameterFormParamResource.java
@@ -1,0 +1,159 @@
+package io.quarkus.resteasy.reactive.server.test.simple;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.Parameter;
+import org.jboss.resteasy.reactive.RestForm;
+
+@Path("/tri-parameter-form")
+public class TriParameterFormParamResource {
+
+    public static class ParameterContainer {
+        @RestForm
+        Parameter<String> string;
+
+        @RestForm
+        Parameter<Integer> integer;
+
+        @RestForm
+        Parameter<List<String>> stringList;
+        @RestForm
+        Parameter<List<Integer>> integerList;
+        @RestForm
+        Parameter<String[]> stringArray;
+        @RestForm
+        Parameter<Integer[]> integerArray;
+        @RestForm
+        Parameter<int[]> intArray;
+    }
+
+    @Path("string")
+    @POST
+    public String string(@RestForm Parameter<String> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + name.getValue();
+    }
+
+    @Path("container/string")
+    @POST
+    public String string(ParameterContainer param) {
+        return "absent: " + param.string.isAbsent()
+                + ", cleared: " + param.string.isCleared()
+                + ", set: " + param.string.isSet()
+                + ", value: " + param.string.getValue();
+    }
+
+    @Path("integer")
+    @POST
+    public String integer(@RestForm Parameter<Integer> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + name.getValue();
+    }
+
+    @Path("container/integer")
+    @POST
+    public String integer(ParameterContainer param) {
+        return "absent: " + param.integer.isAbsent()
+                + ", cleared: " + param.integer.isCleared()
+                + ", set: " + param.integer.isSet()
+                + ", value: " + param.integer.getValue();
+    }
+
+    @Path("string-list")
+    @POST
+    public String stringList(@RestForm Parameter<List<String>> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + name.getValue();
+    }
+
+    @Path("container/string-list")
+    @POST
+    public String stringList(ParameterContainer param) {
+        return "absent: " + param.stringList.isAbsent()
+                + ", cleared: " + param.stringList.isCleared()
+                + ", set: " + param.stringList.isSet()
+                + ", value: " + param.stringList.getValue();
+    }
+
+    @Path("integer-list")
+    @POST
+    public String integerList(@RestForm Parameter<List<Integer>> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + name.getValue();
+    }
+
+    @Path("container/integer-list")
+    @POST
+    public String integerList(ParameterContainer param) {
+        return "absent: " + param.integerList.isAbsent()
+                + ", cleared: " + param.integerList.isCleared()
+                + ", set: " + param.integerList.isSet()
+                + ", value: " + param.integerList.getValue();
+    }
+
+    @Path("string-array")
+    @POST
+    public String stringArray(@RestForm Parameter<String[]> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + Arrays.toString(name.getValue());
+    }
+
+    @Path("container/string-array")
+    @POST
+    public String stringArray(ParameterContainer param) {
+        return "absent: " + param.stringArray.isAbsent()
+                + ", cleared: " + param.stringArray.isCleared()
+                + ", set: " + param.stringArray.isSet()
+                + ", value: " + Arrays.toString(param.stringArray.getValue());
+    }
+
+    @Path("integer-array")
+    @POST
+    public String integerArray(@RestForm Parameter<Integer[]> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + Arrays.toString(name.getValue());
+    }
+
+    @Path("container/integer-array")
+    @POST
+    public String integerArray(ParameterContainer param) {
+        return "absent: " + param.integerArray.isAbsent()
+                + ", cleared: " + param.integerArray.isCleared()
+                + ", set: " + param.integerArray.isSet()
+                + ", value: " + Arrays.toString(param.integerArray.getValue());
+    }
+
+    @Path("int-array")
+    @POST
+    public String intArray(@RestForm Parameter<int[]> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + Arrays.toString(name.getValue());
+    }
+
+    @Path("container/int-array")
+    @POST
+    public String intArray(ParameterContainer param) {
+        return "absent: " + param.intArray.isAbsent()
+                + ", cleared: " + param.intArray.isCleared()
+                + ", set: " + param.intArray.isSet()
+                + ", value: " + Arrays.toString(param.intArray.getValue());
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/TriParameterQueryParamResource.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/TriParameterQueryParamResource.java
@@ -1,0 +1,159 @@
+package io.quarkus.resteasy.reactive.server.test.simple;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.Parameter;
+import org.jboss.resteasy.reactive.RestQuery;
+
+@Path("/tri-parameter-query")
+public class TriParameterQueryParamResource {
+
+    public static class ParameterContainer {
+        @RestQuery
+        Parameter<String> string;
+
+        @RestQuery
+        Parameter<Integer> integer;
+
+        @RestQuery
+        Parameter<List<String>> stringList;
+        @RestQuery
+        Parameter<List<Integer>> integerList;
+        @RestQuery
+        Parameter<String[]> stringArray;
+        @RestQuery
+        Parameter<Integer[]> integerArray;
+        @RestQuery
+        Parameter<int[]> intArray;
+    }
+
+    @Path("string")
+    @GET
+    public String string(@RestQuery Parameter<String> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + name.getValue();
+    }
+
+    @Path("container/string")
+    @GET
+    public String string(ParameterContainer param) {
+        return "absent: " + param.string.isAbsent()
+                + ", cleared: " + param.string.isCleared()
+                + ", set: " + param.string.isSet()
+                + ", value: " + param.string.getValue();
+    }
+
+    @Path("integer")
+    @GET
+    public String integer(@RestQuery Parameter<Integer> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + name.getValue();
+    }
+
+    @Path("container/integer")
+    @GET
+    public String integer(ParameterContainer param) {
+        return "absent: " + param.integer.isAbsent()
+                + ", cleared: " + param.integer.isCleared()
+                + ", set: " + param.integer.isSet()
+                + ", value: " + param.integer.getValue();
+    }
+
+    @Path("string-list")
+    @GET
+    public String stringList(@RestQuery Parameter<List<String>> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + name.getValue();
+    }
+
+    @Path("container/string-list")
+    @GET
+    public String stringList(ParameterContainer param) {
+        return "absent: " + param.stringList.isAbsent()
+                + ", cleared: " + param.stringList.isCleared()
+                + ", set: " + param.stringList.isSet()
+                + ", value: " + param.stringList.getValue();
+    }
+
+    @Path("integer-list")
+    @GET
+    public String integerList(@RestQuery Parameter<List<Integer>> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + name.getValue();
+    }
+
+    @Path("container/integer-list")
+    @GET
+    public String integerList(ParameterContainer param) {
+        return "absent: " + param.integerList.isAbsent()
+                + ", cleared: " + param.integerList.isCleared()
+                + ", set: " + param.integerList.isSet()
+                + ", value: " + param.integerList.getValue();
+    }
+
+    @Path("string-array")
+    @GET
+    public String stringArray(@RestQuery Parameter<String[]> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + Arrays.toString(name.getValue());
+    }
+
+    @Path("container/string-array")
+    @GET
+    public String stringArray(ParameterContainer param) {
+        return "absent: " + param.stringArray.isAbsent()
+                + ", cleared: " + param.stringArray.isCleared()
+                + ", set: " + param.stringArray.isSet()
+                + ", value: " + Arrays.toString(param.stringArray.getValue());
+    }
+
+    @Path("integer-array")
+    @GET
+    public String integerArray(@RestQuery Parameter<Integer[]> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + Arrays.toString(name.getValue());
+    }
+
+    @Path("container/integer-array")
+    @GET
+    public String integerArray(ParameterContainer param) {
+        return "absent: " + param.integerArray.isAbsent()
+                + ", cleared: " + param.integerArray.isCleared()
+                + ", set: " + param.integerArray.isSet()
+                + ", value: " + Arrays.toString(param.integerArray.getValue());
+    }
+
+    @Path("int-array")
+    @GET
+    public String intArray(@RestQuery Parameter<int[]> name) {
+        return "absent: " + name.isAbsent()
+                + ", cleared: " + name.isCleared()
+                + ", set: " + name.isSet()
+                + ", value: " + Arrays.toString(name.getValue());
+    }
+
+    @Path("container/int-array")
+    @GET
+    public String intArray(ParameterContainer param) {
+        return "absent: " + param.intArray.isAbsent()
+                + ", cleared: " + param.intArray.isCleared()
+                + ", set: " + param.intArray.isSet()
+                + ", value: " + Arrays.toString(param.intArray.getValue());
+    }
+}

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
@@ -157,7 +157,7 @@ public class ClientEndpointIndexer
                 elementType, declaredTypes.getDeclaredType(), declaredTypes.getDeclaredUnresolvedType(), signature, type,
                 single,
                 defaultValue, parameterResult.isObtainedAsCollection(), parameterResult.isOptional(), encoded,
-                mimePart, partFileName, null);
+                mimePart, partFileName, null, parameterResult.isTriParameter());
     }
 
     private String getPartFileName(Map<DotName, AnnotationInstance> annotations) {

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -35,7 +35,6 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MULTI;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MULTI_PART_DATA_INPUT;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MULTI_PART_FORM_PARAM;
-import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MULTI_VALUED_MAP;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.NON_BLOCKING;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.OBJECT;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.OFFSET_DATE_TIME;
@@ -78,6 +77,7 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.STRING;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.SUSPENDED;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.TRANSACTIONAL;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.TRI_PARAMETER;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.UNI;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.URI_INFO;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.YEAR;
@@ -1433,6 +1433,26 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                             genericElementType, currentMethodInfo);
                 }
                 builder.setOptional(true);
+            } else if (pt.name().equals(TRI_PARAMETER)) {
+                typeHandled = true;
+                Type triElement = pt.arguments().get(0);
+                elementType = toClassName(triElement, currentClassInfo, actualEndpointInfo, index);
+                String genericElementType = null;
+                if (convertible) {
+                    boolean isArray = false;
+                    if (triElement.kind() == Kind.ARRAY) {
+                        ArrayType at = triElement.asArrayType();
+                        genericElementType = toClassName(at.constituent(), currentClassInfo, actualEndpointInfo, index);
+                        isArray = true;
+                    } else if (triElement.kind() == Kind.PARAMETERIZED_TYPE) {
+                        genericElementType = toClassName(triElement.asParameterizedType().arguments().get(0),
+                                currentClassInfo, actualEndpointInfo, index);
+                    }
+
+                    handleTriParameterParam(existingConverters, anns, errorLocation, hasRuntimeConverters, builder, elementType,
+                            genericElementType, currentMethodInfo, isArray);
+                }
+                builder.setTriParameter(true);
             } else if (convertible) {
                 typeHandled = true;
                 elementType = toClassName(pt, currentClassInfo, actualEndpointInfo, index);
@@ -1573,6 +1593,13 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             String errorLocation,
             boolean hasRuntimeConverters, PARAM builder, String elementType, String genericElementType,
             MethodInfo currentMethodInfo) {
+    }
+
+    protected void handleTriParameterParam(Map<String, String> existingConverters,
+            Map<DotName, AnnotationInstance> parameterAnnotations,
+            String errorLocation,
+            boolean hasRuntimeConverters, PARAM builder, String elementType, String genericElementType,
+            MethodInfo currentMethodInfo, boolean isArray) {
     }
 
     protected void handleSetParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/IndexedParameter.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/IndexedParameter.java
@@ -33,6 +33,7 @@ public class IndexedParameter<T extends IndexedParameter<T>> {
     protected boolean single;
     protected boolean optional;
     protected String separator;
+    protected boolean triParameter;
 
     public boolean isObtainedAsCollection() {
         return !single
@@ -228,6 +229,15 @@ public class IndexedParameter<T extends IndexedParameter<T>> {
 
     public T setSeparator(String separator) {
         this.separator = separator;
+        return (T) this;
+    }
+
+    public boolean isTriParameter() {
+        return triParameter;
+    }
+
+    public T setTriParameter(boolean triParameter) {
+        this.triParameter = triParameter;
         return (T) this;
     }
 }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -4,7 +4,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -86,6 +85,7 @@ import jakarta.ws.rs.sse.SseEventSink;
 import org.jboss.jandex.DotName;
 import org.jboss.resteasy.reactive.DummyElementType;
 import org.jboss.resteasy.reactive.MultipartForm;
+import org.jboss.resteasy.reactive.Parameter;
 import org.jboss.resteasy.reactive.PartFilename;
 import org.jboss.resteasy.reactive.PartType;
 import org.jboss.resteasy.reactive.RestCookie;
@@ -227,6 +227,7 @@ public final class ResteasyReactiveDotNames {
     public static final DotName BIG_INTEGER = DotName.createSimple(BigInteger.class.getName());
     public static final DotName VOID = DotName.createSimple(Void.class.getName());
     public static final DotName OPTIONAL = DotName.createSimple(Optional.class.getName());
+    public static final DotName TRI_PARAMETER = DotName.createSimple(Parameter.class.getName());
 
     public static final DotName PRIMITIVE_INTEGER = DotName.createSimple(int.class.getName());
     public static final DotName PRIMITIVE_LONG = DotName.createSimple(long.class.getName());

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/Parameter.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/Parameter.java
@@ -1,0 +1,55 @@
+package org.jboss.resteasy.reactive;
+
+import java.util.Objects;
+
+public class Parameter<T> {
+    private final T value;
+    private final boolean set;
+
+    private Parameter(T value, boolean set) {
+        if (value != null && !set) {
+            throw new IllegalArgumentException("Cannot be not-set and have a value: " + value);
+        }
+        this.value = value;
+        this.set = set;
+    }
+
+    public static <T> Parameter<T> absent() {
+        return new Parameter<>(null, false);
+    }
+
+    public static <T> Parameter<T> cleared() {
+        return new Parameter<>(null, true);
+    }
+
+    // FIXME: find better name
+    public static <T> Parameter<T> ofNullable(T value) {
+        return new Parameter<>(value, true);
+    }
+
+    public static <T> Parameter<T> set(T value) {
+        Objects.requireNonNull(value, "Parameter value cannot be null");
+        if (value instanceof String string) {
+            if (string.isEmpty()) {
+                throw new IllegalArgumentException("Parameter value cannot be an empty string");
+            }
+        }
+        return new Parameter<>(value, true);
+    }
+
+    public boolean isAbsent() {
+        return set == false;
+    }
+
+    public boolean isCleared() {
+        return set == true && value == null;
+    }
+
+    public boolean isSet() {
+        return set == true && value != null;
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/MethodParameter.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/MethodParameter.java
@@ -26,6 +26,7 @@ public class MethodParameter {
     public String mimeType;
     public String partFileName;
     public String separator;
+    public boolean triParameter;
 
     public MethodParameter() {
     }
@@ -34,7 +35,7 @@ public class MethodParameter {
             ParameterType parameterType,
             boolean single,
             String defaultValue, boolean isObtainedAsCollection, boolean optional, boolean encoded,
-            String mimeType, String partFileName, String separator) {
+            String mimeType, String partFileName, String separator, boolean triParameter) {
         this.name = name;
         this.type = type;
         this.declaredType = declaredType;
@@ -49,6 +50,7 @@ public class MethodParameter {
         this.mimeType = mimeType;
         this.partFileName = partFileName;
         this.separator = separator;
+        this.triParameter = triParameter;
     }
 
     public String getName() {
@@ -114,6 +116,14 @@ public class MethodParameter {
         this.optional = optional;
     }
 
+    public boolean isTriParameter() {
+        return triParameter;
+    }
+
+    public void setTriParameter(boolean triParameter) {
+        this.triParameter = triParameter;
+    }
+
     public MethodParameter setObtainedAsCollection(boolean isObtainedAsCollection) {
         this.isObtainedAsCollection = isObtainedAsCollection;
         return this;
@@ -135,6 +145,7 @@ public class MethodParameter {
             return false;
         MethodParameter that = (MethodParameter) o;
         return encoded == that.encoded && single == that.single && optional == that.optional
+                && triParameter == that.triParameter
                 && isObtainedAsCollection == that.isObtainedAsCollection && Objects.equals(name, that.name)
                 && Objects.equals(type, that.type) && Objects.equals(declaredType, that.declaredType)
                 && Objects.equals(declaredUnresolvedType, that.declaredUnresolvedType)
@@ -147,6 +158,6 @@ public class MethodParameter {
     @Override
     public int hashCode() {
         return Objects.hash(name, type, declaredType, declaredUnresolvedType, signature, parameterType, encoded, single,
-                defaultValue, optional, isObtainedAsCollection, mimeType, partFileName);
+                defaultValue, optional, isObtainedAsCollection, mimeType, partFileName, triParameter);
     }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/types/Types.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/types/Types.java
@@ -119,6 +119,8 @@ public final class Types {
 
         Class<?> superclass = root.getSuperclass();
         Type genericSuper = root.getGenericSuperclass();
+        if (superclass == null)
+            return null;
 
         return recurseSuperclassForInterface(searchedForInterface, typeVarMap, genericSuper, superclass);
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.ext.ParamConverter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
 
+import org.jboss.resteasy.reactive.Parameter;
 import org.jboss.resteasy.reactive.common.ResteasyReactiveConfig;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
 import org.jboss.resteasy.reactive.common.model.ResourceParamConverterProvider;
@@ -164,11 +165,14 @@ public class Deployment {
                 genericType = field.getGenericType();
             } else {
                 genericType = field.getGenericType();
-                if (genericType instanceof ParameterizedType) {
-                    Type[] args = Types.findInterfaceParameterizedTypes(field.getType(), (ParameterizedType) genericType,
+                if (genericType instanceof ParameterizedType parameterizedType) {
+                    Type[] args = Types.findInterfaceParameterizedTypes(field.getType(), parameterizedType,
                             Collection.class);
                     if (args != null && args.length == 1) {
                         genericType = args[0];
+                        klass = Types.getRawType(genericType);
+                    } else if (parameterizedType.getRawType() == Parameter.class) {
+                        genericType = parameterizedType.getActualTypeArguments()[0];
                         klass = Types.getRawType(genericType);
                     } else {
                         throw new RuntimeException("Failed to find Collection supertype of " + field);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/FormParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/FormParamExtractor.java
@@ -7,15 +7,17 @@ public class FormParamExtractor implements ParameterExtractor {
     private final String name;
     private final boolean single;
     private final boolean encoded;
+    private final boolean allowEmpty;
 
-    public FormParamExtractor(String name, boolean single, boolean encoded) {
+    public FormParamExtractor(String name, boolean single, boolean encoded, boolean allowEmpty) {
         this.name = name;
         this.single = single;
         this.encoded = encoded;
+        this.allowEmpty = allowEmpty;
     }
 
     @Override
     public Object extractParameter(ResteasyReactiveRequestContext context) {
-        return context.getFormParameter(name, single, encoded);
+        return context.getFormParameter(name, single, encoded, allowEmpty);
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/MultipartFormParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/MultipartFormParamExtractor.java
@@ -16,6 +16,7 @@ public class MultipartFormParamExtractor implements ParameterExtractor {
     private final Class<Object> typeClass;
     // Note that this is only used for the String type, due to the TCK requiring it
     private final boolean encoded;
+    private final boolean allowEmpty;
 
     public enum Type {
         FileUpload,
@@ -28,7 +29,7 @@ public class MultipartFormParamExtractor implements ParameterExtractor {
     }
 
     public MultipartFormParamExtractor(String name, boolean single, Type type, Class<Object> typeClass,
-            java.lang.reflect.Type genericType, String mimeType, boolean encoded) {
+            java.lang.reflect.Type genericType, String mimeType, boolean encoded, boolean allowEmpty) {
         this.name = name;
         this.single = single;
         this.type = type;
@@ -36,6 +37,7 @@ public class MultipartFormParamExtractor implements ParameterExtractor {
         this.typeClass = typeClass;
         this.genericType = genericType;
         this.encoded = encoded;
+        this.allowEmpty = allowEmpty;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/QueryParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/QueryParamExtractor.java
@@ -9,16 +9,18 @@ public class QueryParamExtractor implements ParameterExtractor {
     private final boolean single;
     private final boolean encoded;
     private final String separator;
+    private final boolean allowEmpty;
 
-    public QueryParamExtractor(String name, boolean single, boolean encoded, String separator) {
+    public QueryParamExtractor(String name, boolean single, boolean encoded, boolean allowEmpty, String separator) {
         this.name = name;
         this.single = single;
         this.encoded = encoded;
         this.separator = separator;
+        this.allowEmpty = allowEmpty;
     }
 
     @Override
     public Object extractParameter(ResteasyReactiveRequestContext context) {
-        return context.getQueryParameter(name, single, encoded, separator);
+        return context.getQueryParameter(name, single, encoded, allowEmpty, separator);
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/converters/TriParameterConverter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/converters/TriParameterConverter.java
@@ -1,0 +1,86 @@
+package org.jboss.resteasy.reactive.server.core.parameters.converters;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collection;
+
+import org.jboss.resteasy.reactive.Parameter;
+import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
+
+public class TriParameterConverter implements ParameterConverter {
+
+    private final ParameterConverter delegate;
+
+    public TriParameterConverter(ParameterConverter delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object convert(Object parameter) {
+        if (parameter == null) {
+            return Parameter.absent();
+        } else if (parameter instanceof String
+                && ((String) parameter).isEmpty()) {
+            return Parameter.cleared();
+        } else if (parameter instanceof Collection list
+                && list.isEmpty()) {
+            return Parameter.absent();
+        } else if (parameter instanceof Collection list
+                && list.size() == 1
+                && list.contains("")) {
+            return Parameter.cleared();
+        } else if (delegate != null) {
+            Object converted = delegate.convert(parameter);
+            if (converted != null
+                    && converted instanceof Collection
+                    // FIXME: this special case is fishy
+                    && ((Collection) converted).isEmpty()) {
+                return Parameter.absent();
+            } else {
+                return Parameter.ofNullable(converted);
+            }
+        } else {
+            return Parameter.set(parameter);
+        }
+    }
+
+    @Override
+    public void init(ParamConverterProviders deployment, Class<?> rawType, Type genericType, Annotation[] annotations) {
+        if (delegate != null) {
+            delegate.init(deployment, rawType, genericType, annotations);
+        }
+    }
+
+    public static class TriParameterSupplier implements DelegatingParameterConverterSupplier {
+        private ParameterConverterSupplier delegate;
+
+        public TriParameterSupplier() {
+        }
+
+        // invoked by reflection for BeanParam in ClassInjectorTransformer
+        public TriParameterSupplier(ParameterConverterSupplier delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ParameterConverter get() {
+            return delegate == null ? new TriParameterConverter(null) : new TriParameterConverter(delegate.get());
+        }
+
+        public ParameterConverterSupplier getDelegate() {
+            return delegate;
+        }
+
+        public TriParameterSupplier setDelegate(ParameterConverterSupplier delegate) {
+            this.delegate = delegate;
+            return this;
+        }
+
+        @Override
+        public String getClassName() {
+            return TriParameterConverter.class.getName();
+        }
+
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -368,7 +368,7 @@ public class RuntimeResourceDeployment {
 
             handlers.add(new ParameterHandler(i, param.getDefaultValue(), extractor,
                     converter, param.parameterType,
-                    param.isObtainedAsCollection(), param.isOptional()));
+                    param.isObtainedAsCollection(), param.isOptional(), param.isTriParameter()));
         }
         addHandlers(handlers, clazz, method, info, HandlerChainCustomizer.Phase.BEFORE_METHOD_INVOKE);
         EndpointInvoker invoker = method.getInvoker().get();
@@ -673,10 +673,10 @@ public class RuntimeResourceDeployment {
                 }
                 if (multiPartType != null) {
                     return new MultipartFormParamExtractor(param.name, param.isSingle(), multiPartType, typeClass, genericType,
-                            param.mimeType, param.encoded);
+                            param.mimeType, param.encoded, param.triParameter);
                 }
                 // regular form
-                return new FormParamExtractor(param.name, param.isSingle(), param.encoded);
+                return new FormParamExtractor(param.name, param.isSingle(), param.encoded, param.triParameter);
             case PATH:
                 Integer index = pathParameterIndexes.get(param.name);
                 if (index == null) {
@@ -694,7 +694,8 @@ public class RuntimeResourceDeployment {
             case ASYNC_RESPONSE:
                 return AsyncResponseExtractor.INSTANCE;
             case QUERY:
-                extractor = new QueryParamExtractor(param.name, param.isSingle(), param.encoded, param.separator);
+                extractor = new QueryParamExtractor(param.name, param.isSingle(), param.encoded, param.triParameter,
+                        param.separator);
                 return extractor;
             case BODY:
                 return BodyParamExtractor.INSTANCE;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ParameterHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ParameterHandler.java
@@ -25,9 +25,10 @@ public class ParameterHandler implements ServerRestHandler {
     private final ParameterType parameterType;
     private final boolean isCollection;
     private final boolean isOptional;
+    private final boolean isTriParameter;
 
     public ParameterHandler(int index, String defaultValue, ParameterExtractor extractor, ParameterConverter converter,
-            ParameterType parameterType, boolean isCollection, boolean isOptional) {
+            ParameterType parameterType, boolean isCollection, boolean isOptional, boolean isTriParameter) {
         this.index = index;
         this.defaultValue = defaultValue;
         this.extractor = extractor;
@@ -35,6 +36,7 @@ public class ParameterHandler implements ServerRestHandler {
         this.parameterType = parameterType;
         this.isCollection = isCollection;
         this.isOptional = isOptional;
+        this.isTriParameter = isTriParameter;
     }
 
     @Override
@@ -75,7 +77,7 @@ public class ParameterHandler implements ServerRestHandler {
             result = defaultValue;
         }
         Throwable toThrow = null;
-        if (converter != null && ((result != null) || isOptional)) {
+        if (converter != null && ((result != null) || isOptional || isTriParameter)) {
             // spec says:
             /*
              * 3.2 Fields and Bean Properties

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionContext.java
@@ -1,9 +1,11 @@
 package org.jboss.resteasy.reactive.server.injection;
 
+// IMPORTANT: these methods are called by bytecode generation in ClassInjectorTransformer: do not modify their signatures
+// without also changing their call-sites there
 public interface ResteasyReactiveInjectionContext {
     Object getHeader(String name, boolean single);
 
-    Object getQueryParameter(String name, boolean single, boolean encoded, String separator);
+    Object getQueryParameter(String name, boolean single, boolean encoded, boolean allowEmpty, String separator);
 
     String getPathParameter(String name, boolean encoded);
 
@@ -11,7 +13,7 @@ public interface ResteasyReactiveInjectionContext {
 
     String getCookieParameter(String name);
 
-    Object getFormParameter(String name, boolean single, boolean encoded);
+    Object getFormParameter(String name, boolean single, boolean encoded, boolean allowEmpty);
 
     <T> T unwrap(Class<T> theType);
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerMethodParameter.java
@@ -21,10 +21,10 @@ public class ServerMethodParameter extends MethodParameter {
             ParameterConverterSupplier converter, String defaultValue, boolean obtainedAsCollection, boolean optional,
             boolean encoded,
             ParameterExtractor customParameterExtractor,
-            String mimeType, String separator) {
+            String mimeType, String separator, boolean triParameter) {
         super(name, type, declaredType, declaredUnresolvedType, signature, parameterType, single, defaultValue,
                 obtainedAsCollection, optional,
-                encoded, mimeType, null /* not useful for server params */, separator);
+                encoded, mimeType, null /* not useful for server params */, separator, triParameter);
         this.converter = converter;
         this.customParameterExtractor = customParameterExtractor;
     }


### PR DESCRIPTION
This is not finished.

Introduces the `Parameter<T>` type for tri-state parameters: absent, cleared and set. Supported for Query and Form parameters (multipart not tested).

Missing:

- Composing methods in `Parameter` (like `Optional`)
- Javadoc
- Guide documentation
- Migration docs

- Closes: #44885
