### PR TITLE
Fix ClassCastException when ResourceMethod with same method name exist

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/util/HashUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/HashUtil.java
@@ -16,7 +16,7 @@ public final class HashUtil {
 
     private static void toHex(byte[] digest, StringBuilder sb) {
         for (int i = 0; i < digest.length; ++i) {
-            sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100).substring(1, 3));
+            sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100), 1, 3);
         }
     }
 

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusInvokerFactory.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusInvokerFactory.java
@@ -1,12 +1,12 @@
 package io.quarkus.resteasy.reactive.server.deployment;
 
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.function.Supplier;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
-import org.jboss.resteasy.reactive.common.model.MethodParameter;
 import org.jboss.resteasy.reactive.common.model.ResourceMethod;
 import org.jboss.resteasy.reactive.common.processor.HashUtil;
 import org.jboss.resteasy.reactive.server.processor.EndpointInvokerFactory;
@@ -34,14 +34,14 @@ public class QuarkusInvokerFactory implements EndpointInvokerFactory {
     @Override
     public Supplier<EndpointInvoker> create(ResourceMethod method, ClassInfo currentClassInfo, MethodInfo info) {
 
-        StringBuilder sigBuilder = new StringBuilder();
-        sigBuilder.append(method.getName())
-                .append(method.getReturnType());
-        for (MethodParameter t : method.getParameters()) {
-            sigBuilder.append(t);
-        }
+        String endpointIdentifier = info.toString() +
+                method.getHttpMethod() +
+                method.getPath() +
+                Arrays.toString(method.getConsumes()) +
+                Arrays.toString(method.getProduces());
+
         String baseName = currentClassInfo.name() + "$quarkusrestinvoker$" + method.getName() + "_"
-                + HashUtil.sha1(sigBuilder.toString());
+                + HashUtil.sha1(endpointIdentifier);
         try (ClassCreator classCreator = new ClassCreator(
                 new GeneratedClassGizmoAdaptor(generatedClassBuildItemBuildProducer, true), baseName, null,
                 Object.class.getName(), EndpointInvoker.class.getName())) {

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/ResourceMethodSameSignatureTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/ResourceMethodSameSignatureTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+class ResourceMethodSameSignatureTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(GreetingResource.class));
+
+    @Test
+    void basicTest() {
+        RestAssured.get("/greetings/Quarkus")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("Hello Quarkus"));
+
+        RestAssured.get("/greetings/Quarkus/with-question")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("Hello [Quarkus], how are you?"));
+
+        RestAssured.given().contentType("text/plain").post("/greetings/Quarkus")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("Hello Quarkus"));
+
+        RestAssured.given().contentType("application/xml").post("/greetings/Quarkus")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("Hello [Quarkus], how are you?"));
+    }
+
+    @Path("/greetings")
+    @ApplicationScoped
+    public static class GreetingResource {
+
+        @GET
+        @Path("/{name}")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello(@PathParam("name") String name) {
+            return "Hello %s".formatted(name);
+        }
+
+        @GET
+        @Path("/{name}/with-question")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello(@PathParam("name") List<String> name) {
+            return "Hello %s, how are you?".formatted(name);
+        }
+
+        @POST
+        @Path("/{name}")
+        @Consumes(MediaType.TEXT_PLAIN)
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello(@PathParam("name") String name, String ignored) {
+            return "Hello %s".formatted(name);
+        }
+
+        @POST
+        @Path("/{name}")
+        @Consumes(MediaType.APPLICATION_XML)
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello(@PathParam("name") List<String> name, String ignored) {
+            return "Hello %s, how are you?".formatted(name);
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/HashUtil.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/HashUtil.java
@@ -20,7 +20,7 @@ public final class HashUtil {
             byte[] digest = md.digest(value);
             StringBuilder sb = new StringBuilder(40);
             for (int i = 0; i < digest.length; ++i) {
-                sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100).substring(1, 3));
+                sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100), 1, 3);
             }
             return sb.toString();
         } catch (NoSuchAlgorithmException e) {
@@ -38,7 +38,7 @@ public final class HashUtil {
             byte[] digest = md.digest(value);
             StringBuilder sb = new StringBuilder(40);
             for (int i = 0; i < digest.length; ++i) {
-                sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100).substring(1, 3));
+                sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100), 1, 3);
             }
             return sb.toString();
         } catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
In case a resource method was in the same class as another method by the same name, but different method parameters, a ClassCastException was thrown. This was because the identifier for the rest invoker was the same. MethodParameter.toString does not return the List<String> wrapper, only the type for the param container, i.e. String. Also, small cleanup for the HashUtil, no need for the additional substring call.

- Closes: #40831