### PR TITLE
Extract beforeTest action to make task build compatible with configuration cache

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
@@ -1,0 +1,91 @@
+package io.quarkus.gradle.actions;
+
+import static io.quarkus.gradle.extension.QuarkusPluginExtension.getLastFile;
+import static io.quarkus.runtime.LaunchMode.TEST;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.testing.Test;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.gradle.tasks.QuarkusPluginExtensionView;
+import io.quarkus.gradle.tooling.ToolingUtils;
+import io.smallrye.config.SmallRyeConfig;
+
+public class BeforeTestAction implements Action<Task> {
+
+    private final File projectDir;
+    private final FileCollection combinedOutputSourceDirs;
+    private final Provider<RegularFile> applicationModelPath;
+    private final Provider<File> nativeRunnerPath;
+    private final FileCollection mainSourceSetClassesDir;
+    private final QuarkusPluginExtensionView extensionView;
+
+    public BeforeTestAction(File projectDir, FileCollection combinedOutputSourceDirs,
+            Provider<RegularFile> applicationModelPath, Provider<File> nativeRunnerPath,
+            FileCollection mainSourceSetClassesDir,
+            QuarkusPluginExtensionView extensionView) {
+        this.projectDir = projectDir;
+        this.combinedOutputSourceDirs = combinedOutputSourceDirs;
+        this.applicationModelPath = applicationModelPath;
+        this.nativeRunnerPath = nativeRunnerPath;
+        this.mainSourceSetClassesDir = mainSourceSetClassesDir;
+        this.extensionView = extensionView;
+
+    }
+
+    @Override
+    public void execute(Task t) {
+        try {
+            Test task = (Test) t;
+            final Map<String, Object> props = task.getSystemProperties();
+
+            ApplicationModel applicationModel = ToolingUtils
+                    .deserializeAppModel(applicationModelPath.get().getAsFile().toPath());
+
+            SmallRyeConfig config = extensionView.buildEffectiveConfiguration(applicationModel, new HashMap<>()).getConfig();
+            config.getOptionalValue(TEST.getProfileKey(), String.class)
+                    .ifPresent(value -> props.put(TEST.getProfileKey(), value));
+
+            final Path serializedModel = applicationModelPath.get().getAsFile().toPath();
+            props.put(BootstrapConstants.SERIALIZED_TEST_APP_MODEL, serializedModel.toString());
+
+            StringJoiner outputSourcesDir = new StringJoiner(",");
+            for (File outputSourceDir : combinedOutputSourceDirs.getFiles()) {
+                outputSourcesDir.add(outputSourceDir.getAbsolutePath());
+            }
+            props.put(BootstrapConstants.OUTPUT_SOURCES_DIR, outputSourcesDir.toString());
+
+            final File outputDirectoryAsFile = getLastFile(mainSourceSetClassesDir);
+
+            Path projectDirPath = projectDir.toPath();
+
+            // Identify the folder containing the sources associated with this test task
+            String fileList = task.getTestClassesDirs().getFiles().stream()
+                    .filter(File::exists)
+                    .distinct()
+                    .map(testSrcDir -> String.format("%s:%s",
+                            projectDirPath.relativize(testSrcDir.toPath()),
+                            projectDirPath.relativize(outputDirectoryAsFile.toPath())))
+                    .collect(Collectors.joining(","));
+            task.environment(BootstrapConstants.TEST_TO_MAIN_MAPPINGS, fileList);
+            task.getLogger().debug("test dir mapping - {}", fileList);
+
+            String nativeRunner = nativeRunnerPath.get().toPath().toAbsolutePath().toString();
+            props.put("native.image.path", nativeRunner);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to resolve deployment classpath", e);
+        }
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -7,11 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -27,22 +23,17 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradle.api.tasks.testing.Test;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.process.JavaForkOptions;
 
-import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.gradle.AppModelGradleResolver;
-import io.quarkus.gradle.QuarkusPlugin;
 import io.quarkus.gradle.dsl.Manifest;
 import io.quarkus.gradle.tasks.AbstractQuarkusExtension;
-import io.quarkus.gradle.tasks.QuarkusBuild;
 import io.quarkus.gradle.tasks.QuarkusGradleUtils;
 import io.quarkus.gradle.tooling.ToolingUtils;
 import io.quarkus.runtime.LaunchMode;
-import io.smallrye.config.SmallRyeConfig;
 
 public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
     // TODO dynamically load generation provider, or make them write code directly in quarkus-generated-sources
@@ -77,56 +68,6 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
     @SuppressWarnings("unused")
     public void manifest(Action<Manifest> action) {
         action.execute(this.getManifest());
-    }
-
-    public void beforeTest(Test task) {
-        try {
-            Map<String, Object> props = task.getSystemProperties();
-            ApplicationModel appModel = getApplicationModel(TEST);
-
-            SmallRyeConfig config = buildEffectiveConfiguration(appModel)
-                    .getConfig();
-            config.getOptionalValue(TEST.getProfileKey(), String.class)
-                    .ifPresent(value -> props.put(TEST.getProfileKey(), value));
-
-            Path serializedModel = ToolingUtils.serializeAppModel(appModel, task, true);
-            props.put(BootstrapConstants.SERIALIZED_TEST_APP_MODEL, serializedModel.toString());
-
-            StringJoiner outputSourcesDir = new StringJoiner(",");
-            for (File outputSourceDir : combinedOutputSourceDirs()) {
-                outputSourcesDir.add(outputSourceDir.getAbsolutePath());
-            }
-            props.put(BootstrapConstants.OUTPUT_SOURCES_DIR, outputSourcesDir.toString());
-
-            SourceSetContainer sourceSets = getSourceSets();
-            SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
-
-            File outputDirectoryAsFile = getLastFile(mainSourceSet.getOutput().getClassesDirs());
-
-            Path projectDirPath = projectDir.toPath();
-
-            // Identify the folder containing the sources associated with this test task
-            String fileList = sourceSets.stream()
-                    .filter(sourceSet -> Objects.equals(
-                            task.getTestClassesDirs().getAsPath(),
-                            sourceSet.getOutput().getClassesDirs().getAsPath()))
-                    .flatMap(sourceSet -> sourceSet.getOutput().getClassesDirs().getFiles().stream())
-                    .filter(File::exists)
-                    .distinct()
-                    .map(testSrcDir -> String.format("%s:%s",
-                            projectDirPath.relativize(testSrcDir.toPath()),
-                            projectDirPath.relativize(outputDirectoryAsFile.toPath())))
-                    .collect(Collectors.joining(","));
-            task.environment(BootstrapConstants.TEST_TO_MAIN_MAPPINGS, fileList);
-            task.getLogger().debug("test dir mapping - {}", fileList);
-
-            QuarkusBuild quarkusBuild = project.getTasks().named(QuarkusPlugin.QUARKUS_BUILD_TASK_NAME, QuarkusBuild.class)
-                    .get();
-            String nativeRunner = quarkusBuild.getNativeRunner().toPath().toAbsolutePath().toString();
-            props.put("native.image.path", nativeRunner);
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to resolve deployment classpath", e);
-        }
     }
 
     public Property<String> getFinalName() {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
@@ -210,7 +210,7 @@ public abstract class QuarkusPluginExtensionView {
         }
     }
 
-    protected EffectiveConfig buildEffectiveConfiguration(ApplicationModel appModel,
+    public EffectiveConfig buildEffectiveConfiguration(ApplicationModel appModel,
             Map<String, ?> additionalForcedProperties) {
         ResolvedDependency appArtifact = appModel.getAppArtifact();
 

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
@@ -81,8 +81,7 @@ public class CachingTest {
                 "-Dquarkus.randomized.value=" + UUID.randomUUID())
                 .toArray(new String[0]);
 
-        Map<String, String> env = Map.of();
-
+        Map<String, String> env = Map.of("FOO_ENV_VAR", "initial-value");
         assertBuildResult("initial", gradleBuild(rerunTasks(arguments), env), ALL_SUCCESS);
         assertBuildResult("initial rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
 
@@ -97,8 +96,8 @@ public class CachingTest {
         assertBuildResult("change FOO_ENV_VAR rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
 
         // Change an unrelated environment variable, all up-to-date
-        env = Map.of("SOME_UNRELATED", "meep");
-        assertBuildResult("SOME_UNRELATED", gradleBuild(arguments, env), FROM_CACHE);
+        env = Map.of("FOO_ENV_VAR", "some-other-value", "SOME_UNRELATED", "meep");
+        assertBuildResult("SOME_UNRELATED", gradleBuild(arguments, env), ALL_UP_TO_DATE);
     }
 
     @Test
@@ -170,7 +169,7 @@ public class CachingTest {
         Map<String, String> env = simulateCI ? Map.of("CI", "yes") : Map.of();
 
         List<String> args = new ArrayList<>();
-        Collections.addAll(args, "build", "--info", "--stacktrace", "--build-cache", "--configuration-cache");
+        Collections.addAll(args, "build", "--info", "--stacktrace", "--build-cache", "--no-configuration-cache");
         if (packageType.equals("native-sources")) {
             args.add("-Dquarkus.native.enabled=true");
             args.add("-Dquarkus.native.sources-only=true");

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CachingTest.java
@@ -81,7 +81,7 @@ public class CachingTest {
                 "-Dquarkus.randomized.value=" + UUID.randomUUID())
                 .toArray(new String[0]);
 
-        Map<String, String> env = Map.of("FOO_ENV_VAR", "initial-value");
+        Map<String, String> env = Map.of();
         assertBuildResult("initial", gradleBuild(rerunTasks(arguments), env), ALL_SUCCESS);
         assertBuildResult("initial rebuild", gradleBuild(arguments, env), ALL_UP_TO_DATE);
 

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
@@ -37,12 +37,13 @@ public class TasksConfigurationCacheCompatibilityTest {
     private static Stream<String> compatibleTasks() {
         return Stream.of(
                 QUARKUS_GENERATE_CODE_TASK_NAME,
+                QUARKUS_GENERATE_CODE_TESTS_TASK_NAME,
                 QUARKUS_GENERATE_CODE_DEV_TASK_NAME,
                 QUARKUS_BUILD_DEP_TASK_NAME,
                 QUARKUS_BUILD_APP_PARTS_TASK_NAME,
                 QUARKUS_SHOW_EFFECTIVE_CONFIG_TASK_NAME,
                 QUARKUS_BUILD_TASK_NAME,
-                QUARKUS_GENERATE_CODE_TESTS_TASK_NAME);
+                "build");
     }
 
     private static Stream<String> nonCompatibleQuarkusBuildTasks() {
@@ -66,14 +67,12 @@ public class TasksConfigurationCacheCompatibilityTest {
     }
 
     @ParameterizedTest
-    @Order(4)
+    @Order(2)
     @MethodSource("compatibleTasks")
     public void configurationCacheIsReusedTest(String taskName) throws IOException, URISyntaxException {
         URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
         FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
         FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
-
-        buildResult(":help", "--configuration-cache");
 
         BuildResult firstBuild = buildResult(taskName, "--configuration-cache");
         assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"));
@@ -83,7 +82,7 @@ public class TasksConfigurationCacheCompatibilityTest {
     }
 
     @ParameterizedTest
-    @Order(5)
+    @Order(3)
     @MethodSource("compatibleTasks")
     public void configurationCacheIsReusedWhenProjectIsolationIsUsedTest(String taskName)
             throws IOException, URISyntaxException {
@@ -99,7 +98,7 @@ public class TasksConfigurationCacheCompatibilityTest {
     }
 
     @ParameterizedTest
-    @Order(2)
+    @Order(4)
     @MethodSource("nonCompatibleQuarkusBuildTasks")
     public void quarkusBuildTasksNonCompatibleWithConfigurationCacheNotFail(String taskName)
             throws IOException, URISyntaxException {
@@ -114,7 +113,7 @@ public class TasksConfigurationCacheCompatibilityTest {
 
     @ParameterizedTest
     @MethodSource("nonCompatibleQuarkusBuildTasks")
-    @Order(3)
+    @Order(5)
     public void quarkusBuildTasksNonCompatibleWithConfigurationCacheNotFailWhenUsingConfigurationCache(String taskName)
             throws IOException, URISyntaxException {
         URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -322,7 +322,7 @@ public class ApplicationDeploymentClasspathBuilder {
         return platformImports.get(this.platformImportName);
     }
 
-    public PlatformImports getPlatformImportsWithoutResolvingPlatform() {
+    public PlatformImportsImpl getPlatformImportsWithoutResolvingPlatform() {
         return platformImports.get(this.platformImportName);
     }
 


### PR DESCRIPTION
### Context
When executing `./gradlew build` in a project using the Quarkus Gradle Plugin, the build does not take advantage of the configuration cache due to incompatible logic in the beforeTest action configured on the Test task by the plugin.

## Changes
### Extracting and removing beforeTest logic
This PR resolves the issue by extracting the `beforeTest` action into a new file, adapting the logic to be configuration cache–compatible, and removing the original configuration from `QuarkusExtension`.

### Cacheability of `QuarkusApplicationModelTask`
Once `./gradlew build` becomes compatible with the configuration cache, we observed cache misses in the QuarkusGenerateCode task. These were caused by mutations in the WorkSpaceModule. To address this, we introduced proper cacheability handling for this task by incorporating its path and using the PlatformImports implementation.

### Impact on tests
Since all tasks involved in `./gradlew build` are now configuration cache–compatible, the `CachingTest` was affected, as it expected to match the previous configuration cache report outputs. We’ve disabled configuration cache for this specific test and instead included the build task in the dedicated configuration cache compatibility tests.

## Results
`./gradlew build` now successfully hits the configuration cache in a multi-module project:
https://ge.solutions-team.gradle.com/s/4simzr66nv47