### PR TITLE
Remove transitivity of deployment dependencies in quarkus-junit, quarkus-junit-mockito and test-frameworks

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -105,6 +105,11 @@
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Minimal test dependencies for consistent build order -->
         <!-- START update-extension-dependencies.sh -->
         <dependency>

--- a/integration-tests/container-image/quarkus-standard-way/pom.xml
+++ b/integration-tests/container-image/quarkus-standard-way/pom.xml
@@ -30,6 +30,18 @@
       <scope>test</scope>
     </dependency>
 
+   <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-development-mode-spi</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-builder</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-internal</artifactId>

--- a/integration-tests/hibernate-reactive-panache-kotlin/pom.xml
+++ b/integration-tests/hibernate-reactive-panache-kotlin/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-builder</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/kubernetes/quarkus-standard-way-kafka/pom.xml
+++ b/integration-tests/kubernetes/quarkus-standard-way-kafka/pom.xml
@@ -41,6 +41,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-builder</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/integration-tests/kubernetes/quarkus-standard-way/pom.xml
+++ b/integration-tests/kubernetes/quarkus-standard-way/pom.xml
@@ -45,6 +45,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-development-mode-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-builder</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/integration-tests/oidc-wiremock/pom.xml
+++ b/integration-tests/oidc-wiremock/pom.xml
@@ -43,6 +43,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-development-mode-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
-import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.oidc.runtime.TrustStoreUtils;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -85,7 +84,7 @@ public class BearerTokenAuthorizationTest {
 
     private String readFile(String filePath) throws Exception {
         try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(filePath)) {
-            byte[] content = FileUtil.readFileContents(is);
+            byte[] content = is.readAllBytes();
             return new String(content, StandardCharsets.UTF_8);
         }
     }

--- a/integration-tests/packaging/pom.xml
+++ b/integration-tests/packaging/pom.xml
@@ -17,6 +17,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bootstrap-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
@@ -32,6 +36,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-builder</artifactId>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>

--- a/test-framework/arquillian/pom.xml
+++ b/test-framework/arquillian/pom.xml
@@ -68,6 +68,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>

--- a/test-framework/common/pom.xml
+++ b/test-framework/common/pom.xml
@@ -17,6 +17,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/test-framework/google-cloud-functions/pom.xml
+++ b/test-framework/google-cloud-functions/pom.xml
@@ -19,7 +19,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-common</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.google.cloud.functions.invoker</groupId>
             <artifactId>java-function-invoker</artifactId>

--- a/test-framework/junit5-config/pom.xml
+++ b/test-framework/junit5-config/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/test-framework/junit5-internal/pom.xml
+++ b/test-framework/junit5-internal/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>quarkus-test-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>

--- a/test-framework/junit5-mockito/pom.xml
+++ b/test-framework/junit5-mockito/pom.xml
@@ -32,6 +32,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/test-framework/junit5/pom.xml
+++ b/test-framework/junit5/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-config</artifactId>
         </dependency>
         <dependency>
@@ -54,11 +59,11 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-		<dependency>
-		    <groupId>org.assertj</groupId>
-		    <artifactId>assertj-core</artifactId>
-		    <scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-framework/oidc-server/pom.xml
+++ b/test-framework/oidc-server/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>wiremock-standalone</artifactId>
         </dependency>
         <dependency>
-            <groupId> jakarta.servlet</groupId>
+            <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
@@ -30,8 +30,12 @@
             <artifactId>quarkus-test-common</artifactId>
         </dependency>
         <dependency>
-          <groupId>io.smallrye.reactive</groupId>
-          <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/test-framework/vertx/pom.xml
+++ b/test-framework/vertx/pom.xml
@@ -20,6 +20,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
_Sorry for the long description but bear with me. And let me know if this makes sense to you or if you have a different point of view on this topic_

Links:
* dependency resolution https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html
* reproducer - https://github.com/ineednousername/quarkus-junit-mock-reproducer/blob/main

Currently quarkus-junit has the dependency 

```

 <groupId>io.quarkus</groupId>
 <artifactId>quarkus-core-deployment</artifactId>

```

which is a regular compile dependency, meaning that it will be propagated transitively.
see also https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html

When creating a new extension as described here https://quarkus.io/guides/building-my-first-extension
and adding quarkus-junit and quarkus-junit-mockito to it you will receive the following error when building the project you will get this error see (reproducer) https://github.com/ineednousername/quarkus-junit-mock-reproducer/blob/main/error.log 

_You might wonder why one wants to do that._
The reasoning is to create a custom extension that is build on top of what quarkus-junit or quarkus-mockito provide.
Simplest case being some commonly reused classes like profiles etc.

**Workaround**
One way of solving the problem above is to exclude the deployment dependencies in the extension build see
https://github.com/ineednousername/quarkus-junit-mock-reproducer/blob/main/runtime/pom.xml#L24

_Why is this workaround bad?_
It forces all people that want to use quarkus and have a similar usecase to be aware of this workaround and figure out why they are getting this error in their runtime project. Which took me some time to figure out in the first place.

_What would be an alternative solution?_
Setting the deployment dependencies in quarkus-junit and quarkus-junit-mockito to provided scope.
(quarkus-core-deployment is coming from the common test project originally)
see https://github.com/quarkusio/quarkus/compare/main...ineednousername:quarkus:test-frameworks-deployment-dependency-scoping?expand=1#diff-64e0b0992fb8f9125ef35c46966d7e1b1b8e70ffed6f693c65ddc95f43c3ec69R20
This way the deployment dependencies are not carried on through the whole dependency chain but need to be declared explicitly in the project that are for some reason using deployment dependencies. 

See also: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html
> A dependency with this scope is added to the classpath used for compilation and test, but not the runtime classpath. It is not transitive.

_What about quarkus-junit-mockito_ 
It is basically the same just with the dependency

```
 <groupId>io.quarkus</groupId>
 <artifactId>quarkus-arc-deployment</artifactId>
```
