### PR TITLE
Prevent config diagnostic warnings from quarkus CLI itself

### DIFF
--- a/devtools/cli/src/main/resources/application.properties
+++ b/devtools/cli/src/main/resources/application.properties
@@ -10,3 +10,4 @@ quarkus.arc.detect-unused-false-positives=false
 quarkus.config.sources.system-only=true
 # Needed to be able to download from the jbang catalog
 quarkus.native.enable-https-url-handler=true
+quarkus.log.category."io.quarkus.config".level=ERROR


### PR DESCRIPTION
This is done to prevent the CLI from logging false warnings
 about extension specific properties (coming from environment variables)
These warnings if correct, would anyway be printed by Quarkus when the application under development is launched

- Closes: #47010