### PR TITLE
Qute: fix nested literal separator in a virtual method parameter

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TypeInfos.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TypeInfos.java
@@ -221,8 +221,13 @@ final class TypeInfos {
         }
 
         @Override
-        public boolean isLiteralSeparator(char candidate) {
-            return candidate == '<' || candidate == '>';
+        public boolean isLiteralSeparatorStart(char candidate) {
+            return candidate == '<';
+        }
+
+        @Override
+        public boolean isLiteralSeparatorEnd(char startSeparator, char candidate) {
+            return candidate == '>';
         }
 
     };

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/StringTemplateExtensionsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/StringTemplateExtensionsTest.java
@@ -93,6 +93,21 @@ public class StringTemplateExtensionsTest {
         assertEquals("Hello fool!",
                 hello.data("name", "fool")
                         .render());
+
+        // https://github.com/quarkusio/quarkus/issues/47092
+        assertEquals("Quteiscool!",
+                engine.parse("{str:builder('Qute').append(\"is\").append(\"cool!\")}")
+                        .render());
+        assertEquals("Qute's cool!",
+                engine.parse("{str:builder('Qute').append(\"'s\").append(\" cool!\")}")
+                        .render());
+        assertEquals("\"Qute\" is cool!",
+                engine.parse("{str:builder('\"Qute\" ').append('is').append(\" cool!\")}")
+                        .render());
+        assertEquals("Hello '!",
+                engine.parse("{str:concat(\"Hello '\",\"!\")}")
+                        .render());
+
     }
 
 }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/StringTemplateExtensionsTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/StringTemplateExtensionsTest.java
@@ -19,9 +19,15 @@ public class StringTemplateExtensionsTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot(root -> root.addAsResource(
-                    new StringAsset("{str:eval('Hello {name}!')}"),
-                    "templates/hello.txt"));
+            .withApplicationRoot(root -> root
+                    .addAsResource(
+                            new StringAsset("{str:eval('Hello {name}!')}"),
+                            "templates/hello.txt")
+                    .addAsResource(
+                            // https://github.com/quarkusio/quarkus/issues/47092
+                            // This will trigger value resolver generation for StringBuilder
+                            new StringAsset("{str:builder.append('Qute').append(\" is\").append(' cool!')}"),
+                            "templates/builder.txt"));
 
     @Inject
     Engine engine;

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
@@ -894,6 +894,8 @@ public class ValueResolverGenerator extends AbstractGenerator {
                 } else {
                     tryCatch.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE, whenRet, invokeRet);
                 }
+                // Always return from the matching block so that other matching methods are not used
+                paramMatchScope.returnVoid();
             }
         }
 


### PR DESCRIPTION
- fix the parser if a virtual method parameter contains a string literal with nested literal separator, such as "Hello '"
- fixes #47092