### PR TITLE
Disable OIDC Dev Services tests on Windows

### DIFF
--- a/integration-tests/oidc-dev-services/pom.xml
+++ b/integration-tests/oidc-dev-services/pom.xml
@@ -101,9 +101,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
@@ -117,5 +114,19 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- On GitHub Actions, nested containers are not available on Windows -->
+        <profile>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
On GitHub Actions Windows runners, nested containers are not available so you cannot run Docker containers.

All our tests relying on Docker are disabled on Windows so this one should be disabled too.