### PR TITLE
Improve handling of QuarkusBindException

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -1,6 +1,5 @@
 package io.quarkus.runtime;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.locks.Condition;
@@ -9,7 +8,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
-import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.Any;
@@ -170,35 +168,30 @@ public class ApplicationLifecycleManager {
             Throwable rootCause = ExceptionUtil.getRootCause(e);
             if (exitCodeHandler == null) {
                 Logger applicationLogger = Logger.getLogger(Application.class);
-                if (rootCause instanceof QuarkusBindException) {
-                    List<Integer> ports = ((QuarkusBindException) rootCause).getPorts();
-                    if (ports.size() == 1) {
+                if (rootCause instanceof QuarkusBindException qbe) {
+                    String host = qbe.getHost();
+                    int port = qbe.getPort();
+                    if (QuarkusBindException.isKnownHost(host)) {
                         applicationLogger.errorf("Port %d seems to be in use by another process. " +
-                                "Quarkus may already be running or the port is used by another application.", ports.get(0));
-                    } else {
-                        applicationLogger.errorf(
-                                "One or more of the following ports: %s seem to be in use by another process. " +
-                                        "Quarkus may already be running or one of the ports is used by another application.",
-                                ports.stream().map(
-                                        Object::toString).collect(Collectors.joining(",")));
-                    }
-                    if (IS_WINDOWS) {
-                        applicationLogger.warn("Use 'netstat -a -b -n -o' to identify the process occupying the port.");
-                        applicationLogger.warn("You can try to kill it with 'taskkill /PID <pid>' or via the Task Manager.");
-                    } else if (IS_MAC) {
-                        for (Integer port : ports) {
+                                "Quarkus may already be running or the port is used by another application.", port);
+                        if (IS_WINDOWS) {
+                            applicationLogger.warn("Use 'netstat -a -b -n -o' to identify the process occupying the port.");
+                            applicationLogger
+                                    .warn("You can try to kill it with 'taskkill /PID <pid>' or via the Task Manager.");
+                        } else if (IS_MAC) {
                             applicationLogger
                                     .warnf("Use 'netstat -anv | grep %d' to identify the process occupying the port.", port);
-                        }
-                        applicationLogger.warn("You can try to kill it with 'kill -9 <pid>'.");
-                    } else {
-                        for (Integer port : ports) {
+                            applicationLogger.warn("You can try to kill it with 'kill -9 <pid>'.");
+                        } else {
                             applicationLogger
                                     .warnf("Use 'ss -anop | grep %1$d' or 'netstat -anop | grep %1$d' to identify the process occupying the port.",
                                             port);
+                            applicationLogger.warn("You can try to kill it with 'kill -9 <pid>'.");
                         }
-                        applicationLogger.warn("You can try to kill it with 'kill -9 <pid>'.");
+                    } else {
+                        applicationLogger.errorf("Unable to bind to host: %s and port: %d.", host, port);
                     }
+
                 } else if (rootCause instanceof ConfigurationException || rootCause instanceof ConfigValidationException) {
                     System.err.println(rootCause.getMessage());
                 } else if (rootCause instanceof PreventFurtherStepsException

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -380,7 +380,7 @@ public class GrpcServerRecorder {
             VertxServer vertxServer = (VertxServer) server;
             vertxServer.start(ar -> {
                 if (ar.failed()) {
-                    Throwable effectiveCause = getEffectiveThrowable(ar, portToServer);
+                    Throwable effectiveCause = getEffectiveThrowable(ar, configuration.host(), portToServer.getKey());
                     if (effectiveCause instanceof QuarkusBindException) {
                         LOGGER.error("Unable to start the gRPC server");
                     } else {
@@ -467,13 +467,13 @@ public class GrpcServerRecorder {
         return definitions;
     }
 
-    private Throwable getEffectiveThrowable(AsyncResult<Void> ar, Map.Entry<Integer, Server> portToServer) {
+    private Throwable getEffectiveThrowable(AsyncResult<Void> ar, String host, int port) {
         Throwable effectiveCause = ar.cause();
         while (effectiveCause.getCause() != null) {
             effectiveCause = effectiveCause.getCause();
         }
-        if (effectiveCause instanceof BindException) {
-            effectiveCause = new QuarkusBindException(portToServer.getKey());
+        if (effectiveCause instanceof BindException e) {
+            effectiveCause = new QuarkusBindException(host, port, e);
         }
         return effectiveCause;
     }
@@ -716,7 +716,7 @@ public class GrpcServerRecorder {
                 VertxServer server = (VertxServer) grpcServer;
                 server.start(ar -> {
                     if (ar.failed()) {
-                        Throwable effectiveCause = getEffectiveThrowable(ar, portToServer);
+                        Throwable effectiveCause = getEffectiveThrowable(ar, configuration.host(), portToServer.getKey());
                         if (effectiveCause instanceof QuarkusBindException) {
                             LOGGER.error("Unable to start the gRPC server");
                         } else {


### PR DESCRIPTION
In addition to improving the error message to not be misleading, the change also simplifies how `QuarkusBindException` is created and used as the exception now has information about the exact host and port that caused the exception

- Fixes: #47119