### PR TITLE
Upgrade Stork to 2.7.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -59,7 +59,7 @@
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.18.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.27.0</smallrye-reactive-messaging.version>
-        <smallrye-stork.version>2.7.0</smallrye-stork.version>
+        <smallrye-stork.version>2.7.2</smallrye-stork.version>
         <jakarta.activation.version>2.1.3</jakarta.activation.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <jakarta.authentication-api>3.0.0</jakarta.authentication-api>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -62,7 +62,7 @@
         <rest-assured.version>5.5.1</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.18.3</jackson-bom.version>
-        <smallrye-stork.version>2.7.0</smallrye-stork.version>
+        <smallrye-stork.version>2.7.2</smallrye-stork.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <yasson.version>3.0.4</yasson.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>


### PR DESCRIPTION
Stork 2.7.2 has been released and this is the PR to update Quarkus.

- Fixes: #47077

cc @geoand 