### PR TITLE
Configure OTel log level

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -135,6 +135,18 @@ If not set, it will default to `http://localhost:4317`.
 
 To configure the connection using the same properties for all signals, please check the base xref:opentelemetry.adoc#create-the-configuration[configuration section of the OpenTelemetry guide].
 
+==== Setting the log level
+
+By default all log levels are exported.
+
+If the following configuration is created in the the `application.properties` file, only logs with a level of `ERROR` or higher will be exported:
+[source,properties]
+----
+quarkus.otel.logs.level=ERROR
+----
+
+As in other logs in Quarkus, log levels can be set to xref:logging.adoc#use-log-levels[these values].
+
 == Run the application
 
 First we need to start a system to visualise the OpenTelemetry data.

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingFileTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingFileTest.java
@@ -84,7 +84,7 @@ public class OtelLoggingFileTest {
                                 .doesNotContainKey(EXCEPTION_TYPE)
                                 .doesNotContainKey(EXCEPTION_MESSAGE)
                                 .doesNotContainKey(EXCEPTION_STACKTRACE)
-                                // attributed do not duplicate tracing data
+                                // attributes do not duplicate tracing data
                                 .doesNotContainKey("spanId")
                                 .doesNotContainKey("traceId")
                                 .doesNotContainKey("sampled"));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingHandlerLevelTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingHandlerLevelTest.java
@@ -1,0 +1,133 @@
+package io.quarkus.opentelemetry.deployment.logs;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static io.opentelemetry.semconv.incubating.LogIncubatingAttributes.LOG_FILE_PATH;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryLogRecordExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryLogRecordExporterProvider;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporterProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OtelLoggingHandlerLevelTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(JBossLoggingBean.class)
+                            .addClasses(InMemoryLogRecordExporter.class, InMemoryLogRecordExporterProvider.class,
+                                    TestSpanExporter.class, TestSpanExporterProvider.class)
+                            .addAsResource(new StringAsset(InMemoryLogRecordExporterProvider.class.getCanonicalName()),
+                                    "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider")
+                            .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
+                                    "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
+                            .add(new StringAsset(
+                                    "quarkus.otel.logs.enabled=true\n" +
+                                            "quarkus.otel.logs.level=ERROR\n" +
+                                            "quarkus.otel.traces.enabled=true\n"),
+                                    "application.properties"));
+
+    @Inject
+    InMemoryLogRecordExporter logRecordExporter;
+
+    @Inject
+    TestSpanExporter spanExporter;
+
+    @Inject
+    JBossLoggingBean jBossLoggingBean;
+
+    @BeforeEach
+    void setup() {
+        logRecordExporter.reset();
+        spanExporter.reset();
+    }
+
+    @Test
+    public void testINFONoShow() {
+        final String message = "Info message must not be in the logs";
+        RuntimeException craftedException = new RuntimeException("crafted exception");
+
+        assertEquals("hello", jBossLoggingBean.hello(message)); // INFO level suppressed
+        assertEquals(Boolean.TRUE, jBossLoggingBean.logException(craftedException));
+
+        List<LogRecordData> finishedLogRecordItems = logRecordExporter.getFinishedLogRecordItemsAtLeast(1);
+
+        // There should be only one log record, the error log
+        assertThat(finishedLogRecordItems.size())
+                .withFailMessage(() -> finishedLogRecordItems.stream()
+                        .map(LogRecordData::getBodyValue)
+                        .map(line -> line.asString() + "\n")
+                        .collect(toList())
+                        .toString())
+                .isOne();
+
+        LogRecordData last = finishedLogRecordItems.get(finishedLogRecordItems.size() - 1);
+
+        assertThat(last.getSpanContext().getSpanId()).isEqualTo("0000000000000000");
+        assertThat(last.getSpanContext().getTraceId()).isEqualTo("00000000000000000000000000000000");
+        assertThat(last.getSpanContext().getTraceFlags().asHex()).isEqualTo("00");
+        assertThat(last.getTimestampEpochNanos()).isNotNull().isLessThan(System.currentTimeMillis() * 1_000_000);
+        assertThat(last)
+                .hasSeverity(Severity.ERROR)
+                .hasSeverityText("ERROR")
+                .hasAttributesSatisfying(
+                        attributes -> assertThat(attributes)
+                                .containsEntry("log.logger.namespace", "org.jboss.logging.Logger")
+                                .containsEntry(EXCEPTION_TYPE, "java.lang.RuntimeException")
+                                .containsEntry(EXCEPTION_MESSAGE, "crafted exception")
+                                .containsEntry(EXCEPTION_STACKTRACE, extractStackTrace(craftedException))
+                                .doesNotContainKey(LOG_FILE_PATH)
+                                // attributes do not duplicate tracing data
+                                .doesNotContainKey("spanId")
+                                .doesNotContainKey("traceId")
+                                .doesNotContainKey("sampled"));
+    }
+
+    private String extractStackTrace(final Throwable throwable) {
+        try (StringWriter sw = new StringWriter(1024); PrintWriter pw = new PrintWriter(sw)) {
+            throwable.printStackTrace(pw);
+            sw.flush();
+            return sw.toString();
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    @ApplicationScoped
+    public static class JBossLoggingBean {
+        private static final Logger LOG = Logger.getLogger(JBossLoggingBean.class.getName());
+
+        public String hello(final String message) {
+            LOG.info(message);
+            return "hello";
+        }
+
+        public boolean logException(final Throwable throwable) {
+            LOG.error("logging an exception", throwable);
+            return true;
+        }
+    }
+}

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
@@ -142,7 +142,7 @@ public class OtelLoggingTest {
                                 .doesNotContainKey(EXCEPTION_MESSAGE)
                                 .doesNotContainKey(EXCEPTION_STACKTRACE)
                                 .doesNotContainKey(LOG_FILE_PATH)
-                                // attributed do not duplicate tracing data
+                                // attributes do not duplicate tracing data
                                 .doesNotContainKey("spanId")
                                 .doesNotContainKey("traceId")
                                 .doesNotContainKey("sampled"));
@@ -166,7 +166,7 @@ public class OtelLoggingTest {
                                 .containsEntry(EXCEPTION_MESSAGE, "Crafted exception")
                                 .containsEntry(EXCEPTION_STACKTRACE, extractStackTrace(craftedException))
                                 .doesNotContainKey(LOG_FILE_PATH)
-                                // attributed do not duplicate tracing data
+                                // attributes do not duplicate tracing data
                                 .doesNotContainKey("spanId")
                                 .doesNotContainKey("traceId")
                                 .doesNotContainKey("sampled"));
@@ -203,7 +203,7 @@ public class OtelLoggingTest {
                                 .doesNotContainKey(EXCEPTION_MESSAGE)
                                 .doesNotContainKey(EXCEPTION_STACKTRACE)
                                 .doesNotContainKey(LOG_FILE_PATH)
-                                // attributed do not duplicate tracing data
+                                // attributes do not duplicate tracing data
                                 .doesNotContainKey("spanId")
                                 .doesNotContainKey("traceId")
                                 .doesNotContainKey("sampled"));
@@ -240,7 +240,7 @@ public class OtelLoggingTest {
                                 .doesNotContainKey(EXCEPTION_MESSAGE)
                                 .doesNotContainKey(EXCEPTION_STACKTRACE)
                                 .doesNotContainKey(LOG_FILE_PATH)
-                                // attributed do not duplicate tracing data
+                                // attributes do not duplicate tracing data
                                 .doesNotContainKey("spanId")
                                 .doesNotContainKey("traceId")
                                 .doesNotContainKey("sampled"));

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/LogsRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/LogsRuntimeConfig.java
@@ -1,6 +1,10 @@
 package io.quarkus.opentelemetry.runtime.config.runtime;
 
+import java.util.logging.Level;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.logging.LevelConverter;
+import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
@@ -15,4 +19,13 @@ public interface LogsRuntimeConfig {
     @WithDefault("true")
     @WithName("handler.enabled")
     boolean handlerEnabled();
+
+    /**
+     * The log level to use for the OpenTelemetry logging handler.
+     * <p>
+     * This is a Quarkus specific property. The default log level is ALL.
+     */
+    @WithDefault("ALL")
+    @WithConverter(LevelConverter.class)
+    Level level();
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/logs/OpenTelemetryLogRecorder.java
@@ -16,7 +16,9 @@ public class OpenTelemetryLogRecorder {
         if (config.sdkDisabled() || !config.logs().handlerEnabled()) {
             return new RuntimeValue<>(Optional.empty());
         }
-        OpenTelemetry openTelemetry = beanContainer.beanInstance(OpenTelemetry.class);
-        return new RuntimeValue<>(Optional.of(new OpenTelemetryLogHandler(openTelemetry)));
+        final OpenTelemetry openTelemetry = beanContainer.beanInstance(OpenTelemetry.class);
+        final OpenTelemetryLogHandler logHandler = new OpenTelemetryLogHandler(openTelemetry);
+        logHandler.setLevel(config.logs().level());
+        return new RuntimeValue<>(Optional.of(logHandler));
     }
 }


### PR DESCRIPTION
I'm not sure if I should have moved the OTel handler configs next to the other logs at:
https://github.com/quarkusio/quarkus/blob/901675f0488572664e2ced2fa09445c7d69d1d5f/core/runtime/src/main/java/io/quarkus/runtime/logging/LogRuntimeConfig.java#L36 

Because this is setup in a totally different extension, I left it as it is.