### PR TITLE
Move JGit dependency to `quarkus-build-parent`

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -203,7 +203,6 @@
         <aesh.version>2.8.2</aesh.version>
         <aesh-readline.version>2.6</aesh-readline.version>
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with aesh-readline and dekorate -->
-        <jgit.version>7.2.0.202503040940-r</jgit.version>
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>10.0.2</strimzi-oauth.nimbus.version>
@@ -6436,12 +6435,6 @@
                 <groupId>org.hdrhistogram</groupId>
                 <artifactId>HdrHistogram</artifactId>
                 <version>${hdrhistogram.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.jgit</groupId>
-                <artifactId>org.eclipse.jgit</artifactId>
-                <version>${jgit.version}</version>
             </dependency>
 
             <!-- Quarkus build related dependencies -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -41,6 +41,7 @@
         <!-- Dev tools -->
         <freemarker.version>2.3.34</freemarker.version>
         <commonmark.version>0.24.0</commonmark.version>
+        <jgit.version>7.2.0.202503040940-r</jgit.version>
 
         <!-- Arquillian BOM -->
         <arquillian.version>1.7.0.Final</arquillian.version>
@@ -189,6 +190,11 @@
                 <groupId>org.commonmark</groupId>
                 <artifactId>commonmark</artifactId>
                 <version>${commonmark.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jgit</groupId>
+                <artifactId>org.eclipse.jgit</artifactId>
+                <version>${jgit.version}</version>
             </dependency>
 
             <!-- Extension processor -->


### PR DESCRIPTION
This removes JGit from the `quarkus-bom` as it conflicts with the version provided from the `quarkus-jgit` extension
