### PR TITLE
Add more on missing producers - which step failed

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
@@ -180,7 +180,8 @@ public final class BuildChainBuilder {
                 final ItemId id = entry.getKey();
                 if (!consume.flags().contains(ConsumeFlag.OPTIONAL) && !id.isMulti()) {
                     if (!initialIds.contains(id) && !allProduces.containsKey(id)) {
-                        throw new ChainBuildException("No producers for required item " + id);
+                        throw new ChainBuildException(
+                                "No producers for required item " + id + ", step builder used: " + stepBuilder);
                     }
                 }
                 // add every producer


### PR DESCRIPTION
BuildStepBuilder info is very useful to have when experimenting with build processors.