### PR TITLE
Update buildpack platform to Snowdrop lib 0.0.14

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -207,7 +207,7 @@
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>10.0.2</strimzi-oauth.nimbus.version>
         <jose4j.version>0.9.6</jose4j.version>
-        <java-buildpack-client.version>0.0.12</java-buildpack-client.version>
+        <java-buildpack-client.version>0.0.14</java-buildpack-client.version>
         <org-crac.version>0.1.3</org-crac.version>
         <sshd-common.version>2.12.1</sshd-common.version>
         <mime4j.version>0.8.12</mime4j.version>

--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackConfig.java
@@ -25,7 +25,28 @@ public interface BuildpackConfig {
     Optional<String> nativeBuilderImage();
 
     /**
-     * Should the builder image be 'trusted' (use creator lifecycle)
+     * The lifecycle image to use when building the project
+     *
+     * This is optional, but can be used to override the lifecycle present within a builder image.
+     */
+    Optional<String> lifecycleImage();
+
+    /**
+     * The platform level to force for the build.
+     *
+     * Normally the platform level is determined from the intersection of the builder image supported
+     * levels, and the platform implementation supported levels. Sometimes it can be beneficial to force
+     * the platform to a particular version to force behavior during the build.
+     */
+    Optional<String> platformLevel();
+
+    /**
+     * Should the builder image be 'trusted' ?
+     *
+     * Trusted builders are allowed to attempt to use the `creator` lifecycle, which runs all the
+     * build phases within a single container. This is only possible for builders that do not use
+     * extensions. Running all phases in one container exposes some phases to information they may
+     * not see normally with a container-per-phase.
      */
     Optional<Boolean> trustBuilderImage();
 
@@ -36,9 +57,28 @@ public interface BuildpackConfig {
     Map<String, String> builderEnv();
 
     /**
+     * Usernames to use with registry hosts
+     */
+    @ConfigDocMapKey("registry-host")
+    Map<String, String> registryUser();
+
+    /**
+     * Passwords to use with registry hosts
+     */
+    @ConfigDocMapKey("registry-host")
+    Map<String, String> registryPassword();
+
+    /**
+     * Tokens to use with registry hosts
+     */
+    @ConfigDocMapKey("registry-host")
+    Map<String, String> registryToken();
+
+    /**
      * The buildpacks run image to use when building the project
      *
      * When not supplied, the run image is determined by the builder image.
+     * If extensions are used by the builder image, they may override the run image.
      */
     Optional<String> runImage();
 
@@ -63,14 +103,34 @@ public interface BuildpackConfig {
     /**
      * DOCKER_HOST value to use.
      *
-     * If not set, the env var DOCKER_HOST is used, if that is not set the platform will look for
-     * 'npipe:///./pipe/docker_engine' for windows, and `unix:///var/run/docker.sock' then
-     * `unix:///var/run/podman.sock` then `unix:///var/run/user/<uid>/podman/podman.sock` for linux
+     * This value is normally auto-determined, and is available for override if needed.
+     *
+     * If not set, the env var DOCKER_HOST is used, if that is not set the platform will
+     * test if `podman` is available on the path, if so, it will use podman to configure the
+     * appropriate values. If `podman` is not on the path, docker is assumed, and per-platform
+     * defaults for docker are used.
      */
     Optional<String> dockerHost();
 
     /**
+     * Path to the Docker socket to use.
+     *
+     * This value is normally auto-determined, and is available for override if needed.
+     *
+     * The path to the socket can vary, especially when the docker/podman daemon is running inside
+     * a VM, if useDaemon mode is true, then this path must refer to the path that can be used to
+     * mount the socket inside a container, so may refer to the path to the socket in the VM rather
+     * than the host.
+     */
+    Optional<String> dockerSocket();
+
+    /**
      * use Daemon mode?
+     *
+     * Should the buildpack build have the docker socket mounted into the build container(s).
+     * If this is false, then the image will be built directly as layers in a remote registry,
+     * this will probably require registry credentials to be passed.
+     *
      * Defaults to 'true'
      */
     @WithDefault("true")
@@ -78,24 +138,27 @@ public interface BuildpackConfig {
 
     /**
      * Use specified docker network during build
+     *
+     * This can be handy when building against a locally hosted docker registry, where you
+     * will require the build containers to be part of the 'host' network to enable them
+     * to access the local registry.
      */
     Optional<String> dockerNetwork();
 
     /**
      * Log level to use.
-     * Defaults to 'info'
+     *
+     * The log level to use when executing the build phases in containers.
+     *
+     * Defaults to 'info', supported values are 'info', 'warn' and 'debug'
      */
     @WithDefault("info")
     String logLevel();
 
     /**
-     * The username to use to authenticate with the registry used to pull the base JVM image
+     * Should the container log information include timestamps?
      */
-    Optional<String> baseRegistryUsername();
-
-    /**
-     * The password to use to authenticate with the registry used to pull the base JVM image
-     */
-    Optional<String> baseRegistryPassword();
+    @WithDefault("true")
+    Boolean getUseTimestamps();
 
 }

--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
@@ -5,23 +5,30 @@ import static io.quarkus.container.image.deployment.util.EnablementUtil.pushCont
 import static io.quarkus.container.util.PathsUtil.findMainSourcesRoot;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 
+import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.async.ResultCallback;
-import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.PushResponseItem;
 
 import dev.snowdrop.buildpack.BuildConfig;
 import dev.snowdrop.buildpack.BuildConfigBuilder;
+import dev.snowdrop.buildpack.BuildConfigFluent.DockerConfigNested;
 import dev.snowdrop.buildpack.config.ImageReference;
+import dev.snowdrop.buildpack.config.RegistryAuthConfig;
+import dev.snowdrop.buildpack.config.RegistryAuthConfigBuilder;
 import dev.snowdrop.buildpack.docker.DockerClientUtils;
+import dev.snowdrop.buildpack.docker.DockerClientUtils.HostAndSocket;
 import io.quarkus.container.image.deployment.ContainerImageConfig;
 import io.quarkus.container.image.deployment.util.NativeBinaryUtil;
 import io.quarkus.container.spi.AvailableContainerImageExtensionBuildItem;
@@ -154,24 +161,6 @@ public class BuildpackProcessor {
         return result;
     }
 
-    private final String getDockerHost(BuildpackConfig buildpackConfig) {
-        String dockerHostVal = null;
-        //use config if present, else try to use env var.
-        //use of null indicates to buildpack lib to default the value itself.
-        if (buildpackConfig.dockerHost().isPresent()) {
-            dockerHostVal = buildpackConfig.dockerHost().get();
-        } else {
-            String dockerHostEnv = System.getenv("DOCKER_HOST");
-            if (dockerHostEnv != null && !dockerHostEnv.isEmpty()) {
-                dockerHostVal = dockerHostEnv;
-            }
-        }
-        if (dockerHostVal != null) {
-            log.info("Using dockerHost of " + dockerHostVal);
-        }
-        return dockerHostVal;
-    }
-
     private String runBuildpackBuild(BuildpackConfig buildpackConfig,
             ContainerImageInfoBuildItem containerImage,
             ContainerImageConfig containerImageConfig,
@@ -191,7 +180,68 @@ public class BuildpackProcessor {
 
         Map<String, String> envMap = new HashMap<>(buildpackConfig.builderEnv());
         if (!envMap.isEmpty()) {
-            log.info("Using builder environment of " + envMap);
+            log.info("Using builder environment with vars " + envMap.keySet());
+        }
+
+        List<RegistryAuthConfig> authConfigs = new ArrayList<>();
+
+        //read in any configured per-registry auth info.
+        Map<String, String> registryUserMap = new HashMap<>(buildpackConfig.registryUser());
+        Map<String, String> registryPasswordMap = new HashMap<>(buildpackConfig.registryPassword());
+        Map<String, String> registryTokenMap = new HashMap<>(buildpackConfig.registryToken());
+
+        Set<String> registries = new HashSet<>();
+        registries.addAll(registryUserMap.keySet());
+        registries.addAll(registryPasswordMap.keySet());
+        registries.addAll(registryTokenMap.keySet());
+
+        //combine per-registry auth arguments into authConfig objects to use during the build.
+        for (String registry : registries) {
+            authConfigs.add(RegistryAuthConfig.builder().accept(RegistryAuthConfigBuilder.class, a -> {
+                a.withRegistryAddress(registry);
+                if (registryUserMap.containsKey(registry)) {
+                    log.debug("adding username to auth credential for " + registry);
+                    a.withUsername(registryUserMap.get(registry));
+                }
+                if (registryPasswordMap.containsKey(registry)) {
+                    log.debug("adding password to auth credential for " + registry);
+                    a.withPassword(registryPasswordMap.get(registry));
+                }
+                if (registryTokenMap.containsKey(registry)) {
+                    log.debug("adding token to auth credential for " + registry);
+                    a.withRegistryToken(registryTokenMap.get(registry));
+                }
+            }).build());
+        }
+
+        //add authConfig for container-image credential properties, if present.
+        if (containerImageConfig.username().isPresent() &&
+                containerImageConfig.password().isPresent()) {
+
+            String registry = null;
+            //user has supplied user&pwd, need to determine registry address.
+            if (!containerImageConfig.registry().isPresent()) {
+                //attempt to retrieve registry from image name
+                registry = containerImage.getRegistry().orElseGet(() -> {
+                    log.info("No container image registry was set, so 'docker.io' will be used");
+                    return "docker.io";
+                });
+            } else {
+                //use supplied registry address
+                registry = containerImageConfig.registry().get();
+            }
+
+            if (registry != null &&
+                    !registries.contains(registry)) {
+                //add registry creds if set via quarkus main properties.
+                //note buildpack specific creds take precedence if duplicated registry is present.
+                log.debug("Adding auth creds from container-image properties");
+                authConfigs.add(RegistryAuthConfig.builder()
+                        .withUsername(containerImageConfig.username().get())
+                        .withPassword(containerImageConfig.password().get())
+                        .withRegistryAddress(registry)
+                        .build());
+            }
         }
 
         // Let's explicitly disable build and push during the build to avoid inception style builds
@@ -209,32 +259,55 @@ public class BuildpackProcessor {
                     .withNewLogConfig()
                     .withLogger(new BuildpackLogger())
                     .withLogLevel(buildpackConfig.logLevel())
+                    .withUseTimestamps(buildpackConfig.getUseTimestamps())
                     .endLogConfig()
                     .withNewDockerConfig()
                     .withPullRetryIncreaseSeconds(buildpackConfig.pullTimeoutIncreaseSeconds())
                     .withPullTimeoutSeconds(buildpackConfig.pullTimeoutSeconds())
                     .withPullRetryCount(buildpackConfig.pullRetryCount())
-                    .withDockerHost(getDockerHost(buildpackConfig))
                     .withDockerNetwork(buildpackConfig.dockerNetwork().orElse(null))
                     .withUseDaemon(buildpackConfig.useDaemon())
+                    .withAuthConfigs(authConfigs)
                     .endDockerConfig()
                     .accept(BuildConfigBuilder.class, b -> {
+
+                        //swap to native image if present and if building native.
                         if (isNativeBuild) {
                             buildpackConfig.nativeBuilderImage().ifPresent(i -> b.withBuilderImage(new ImageReference(i)));
                         } else {
                             b.withBuilderImage(new ImageReference(buildpackConfig.jvmBuilderImage()));
                         }
 
+                        //add run image if present
                         if (buildpackConfig.runImage().isPresent()) {
                             log.info("Using Run image of " + buildpackConfig.runImage().get());
                             b.withRunImage(new ImageReference(buildpackConfig.runImage().get()));
                         }
 
+                        //ask for image to be trusted
                         if (buildpackConfig.trustBuilderImage().isPresent()) {
                             log.info("Setting trusted image to " + buildpackConfig.trustBuilderImage().get());
                             b.editPlatformConfig().withTrustBuilder(buildpackConfig.trustBuilderImage().get())
                                     .endPlatformConfig();
                         }
+
+                        //configure dockerhost/socket if required
+                        DockerConfigNested<BuildConfigBuilder> dc = b.editDockerConfig();
+                        buildpackConfig.dockerHost().ifPresent(dh -> dc.withDockerHost(dh));
+                        buildpackConfig.dockerSocket().ifPresent(ds -> dc.withDockerSocket(ds));
+                        dc.endDockerConfig();
+
+                        //configure lifecycle override image if present
+                        buildpackConfig.lifecycleImage()
+                                .ifPresent(
+                                        li -> b.editPlatformConfig().withLifecycleImage(new ImageReference(li))
+                                                .endPlatformConfig());
+
+                        //force platform level, if present.
+                        buildpackConfig.platformLevel()
+                                .ifPresent(
+                                        pl -> b.editPlatformConfig().withPlatformLevel(pl).endPlatformConfig());
+
                     })
                     .build()
                     .getExitCode();
@@ -246,30 +319,32 @@ public class BuildpackProcessor {
             log.info("Buildpack build complete");
         }
 
-        if (pushContainerImage) {
-            var registry = containerImage.getRegistry()
-                    .orElseGet(() -> {
-                        log.info("No container image registry was set, so 'docker.io' will be used");
-                        return "docker.io";
-                    });
-            AuthConfig authConfig = new AuthConfig();
-            authConfig.withRegistryAddress(registry);
-            containerImageConfig.username().ifPresent(u -> authConfig.withUsername(u));
-            containerImageConfig.password().ifPresent(p -> authConfig.withPassword(p));
-
-            log.info("Pushing image to " + authConfig.getRegistryAddress());
+        //if we built with registry mode, the build happened directly to the remote registry, so there is no need to publish
+        //otherwise, now process the local image & publish to registry.
+        if (pushContainerImage && Boolean.TRUE.equals(buildpackConfig.useDaemon())) {
+            log.info("Pushing image to registry");
             Stream.concat(Stream.of(containerImage.getImage()), containerImage.getAdditionalImageTags().stream()).forEach(i -> {
-                ResultCallback.Adapter<PushResponseItem> callback = DockerClientUtils
-                        .getDockerClient(getDockerHost(buildpackConfig))
-                        .pushImageCmd(i).start();
+
+                HostAndSocket hns = DockerClientUtils.probeContainerRuntime(
+                        new HostAndSocket(buildpackConfig.dockerHost().orElse(""), buildpackConfig.dockerSocket().orElse("")));
+                DockerClient dockerClient = DockerClientUtils.getDockerClient(hns, authConfigs);
+
+                ResultCallback.Adapter<PushResponseItem> callback = new ResultCallback.Adapter<>() {
+                    @Override
+                    public void onNext(PushResponseItem object) {
+                        log.info(object.toString());
+                    }
+                };
+                dockerClient.pushImageCmd(i).exec(callback);
                 try {
                     callback.awaitCompletion();
-                    log.info("Push complete");
                 } catch (Exception e) {
-                    throw new IllegalStateException(e);
+                    log.error(e);
                 }
+
             });
         }
         return targetImageName;
     }
+
 }


### PR DESCRIPTION
Updates quarkus container-image buildpack extension to use the new 0.0.14 snowdrop buildpack platform implementation. 

The new platform impl has better docker/podman detection, and per-registry authentication, and various other smaller fixes. 

Per registry auth is exposed via container-image buildpack config, but the single registry container-image config vars are still honored if set. 