### PR TITLE
Mongo: restrict the reactive transport configuration to the actual reactive cases

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
@@ -205,14 +205,13 @@ public interface MongoClientConfig {
      */
     Optional<UuidRepresentation> uuidRepresentation();
 
-    enum TransportConfig {
+    enum ReactiveTransportConfig {
         /**
          * Uses a Netty-based transport re-using the existing Netty event loops.
          */
         NETTY,
         /**
-         * With a reactive driver it uses an async transport backed by a driver-managed thread pool,
-         * while with a blocking driver it uses a blocking transport.
+         * With a reactive driver it uses an async transport backed by a driver-managed thread pool.
          */
         MONGO
     }
@@ -221,12 +220,6 @@ public interface MongoClientConfig {
      * Configures the reactive transport.
      */
     @WithDefault("netty")
-    TransportConfig reactiveTransport();
-
-    /**
-     * Configures the blocking transport.
-     */
-    @WithDefault("mongo")
-    TransportConfig blockingTransport();
+    ReactiveTransportConfig reactiveTransport();
 
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
@@ -283,19 +283,18 @@ public class MongoClients {
 
         MongoClientSettings.Builder settings = MongoClientSettings.builder();
 
-        switch (config.reactiveTransport()) {
-            case NETTY:
-                // we supports just NIO for now
-                if (!vertx.isNativeTransportEnabled()) {
-                    configureNettyTransport(settings);
-                }
-                break;
-            case MONGO:
-                // no-op since this is the default behaviour
-                break;
-        }
-
         if (isReactive) {
+            switch (config.reactiveTransport()) {
+                case NETTY:
+                    // we supports just NIO for now
+                    if (!vertx.isNativeTransportEnabled()) {
+                        configureNettyTransport(settings);
+                    }
+                    break;
+                case MONGO:
+                    // no-op since this is the default behaviour
+                    break;
+            }
             reactiveContextProviders.stream().findAny().ifPresent(settings::contextProvider);
         }
 


### PR DESCRIPTION
Ensure the Mongo reactive transport configuration is only applied to the actual reactive cases, not the blocking ones.