### PR TITLE
Add podman to gradle task for checking available image builders

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageCheckRequirementsTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageCheckRequirementsTask.java
@@ -51,7 +51,8 @@ public abstract class ImageCheckRequirementsTask extends DefaultTask {
         docker,
         jib,
         buildpack,
-        openshift
+        openshift,
+        podman
     }
 
     Optional<ImageCheckRequirementsTask.Builder> builderFromSystemProperties() {


### PR DESCRIPTION
This must have been missed in the original podman container image implementation.

Fixes #47153