### PR TITLE
Make TlsConfiguration#getName a default method

### DIFF
--- a/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/TlsConfiguration.java
+++ b/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/TlsConfiguration.java
@@ -102,7 +102,12 @@ public interface TlsConfiguration {
 
     /**
      * Returns the name which was associated with this configuration
+     * <p>
+     * Note: Although this was made default in order to not break deep integrations, it is strongly recommended that the method
+     * be implemented.
      */
-    String getName();
+    default String getName() {
+        return "unset";
+    }
 
 }


### PR DESCRIPTION
This was done in order to unbreak integrations
in 3.20 LTS

Follows up on #46961.

cc @cescoffier @ppalaga 