### PR TITLE
Add initial HV integration to Panache MongoDB

### DIFF
--- a/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/common/deployment/BasePanacheMongoResourceProcessor.java
+++ b/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/common/deployment/BasePanacheMongoResourceProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.mongodb.panache.common.deployment;
 
+import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.util.JandexUtil.resolveTypeParameters;
 import static org.jboss.jandex.DotName.createSimple;
 
@@ -31,6 +32,8 @@ import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.deployment.staticmethods.InterceptedStaticMethodsTransformersRegisteredBuildItem;
 import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
@@ -40,6 +43,7 @@ import io.quarkus.deployment.bean.JavaBeanUtil;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
@@ -251,6 +255,17 @@ public abstract class BasePanacheMongoResourceProcessor {
             // see MongoOperations#mongoClient
             mongoClientName.produce(new MongoClientNameBuildItem(value, false));
         }
+    }
+
+    @BuildStep
+    @Record(RUNTIME_INIT)
+    public void enableValidation(PanacheMongoRecorder recorder,
+            Capabilities capabilities,
+            ShutdownContextBuildItem shutdownContext) {
+
+        recorder.initializeValidator(
+                capabilities.isPresent(Capability.HIBERNATE_VALIDATOR),
+                shutdownContext);
     }
 
     protected void processEntities(CombinedIndexBuildItem index,

--- a/extensions/panache/mongodb-panache-common/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache-common/runtime/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>quarkus-narayana-jta</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/PanacheMongoRecorder.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/PanacheMongoRecorder.java
@@ -2,12 +2,30 @@ package io.quarkus.mongodb.panache.common;
 
 import java.util.Map;
 
+import jakarta.validation.ValidatorFactory;
+
+import io.quarkus.arc.Arc;
 import io.quarkus.mongodb.panache.common.runtime.MongoPropertyUtil;
+import io.quarkus.mongodb.panache.common.validation.EntityValidator;
+import io.quarkus.mongodb.panache.common.validation.HibernateValidatorEntityValidator;
+import io.quarkus.mongodb.panache.common.validation.NoopEntityValidator;
+import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class PanacheMongoRecorder {
     public void setReplacementCache(Map<String, Map<String, String>> replacementMap) {
         MongoPropertyUtil.setReplacementCache(replacementMap);
+    }
+
+    public void initializeValidator(boolean hasHibernateValidatorCapability, ShutdownContext shutdownContext) {
+        if (hasHibernateValidatorCapability) {
+            final ValidatorFactory validatorFactory = (ValidatorFactory) Arc.container()
+                    .instance("quarkus-hibernate-validator-factory").get();
+            EntityValidator.Holder.INSTANCE = new HibernateValidatorEntityValidator(validatorFactory.getValidator());
+        } else {
+            EntityValidator.Holder.INSTANCE = new NoopEntityValidator<>();
+        }
+        shutdownContext.addShutdownTask(() -> EntityValidator.Holder.INSTANCE = null);
     }
 }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/validation/EntityValidator.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/validation/EntityValidator.java
@@ -1,0 +1,15 @@
+package io.quarkus.mongodb.panache.common.validation;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface EntityValidator<V, E extends RuntimeException> {
+
+    Set<? extends V> validate(Object entity);
+
+    Optional<E> toException(Set<? extends V> violations);
+
+    class Holder {
+        public static EntityValidator<?, ? extends RuntimeException> INSTANCE;
+    }
+}

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/validation/HibernateValidatorEntityValidator.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/validation/HibernateValidatorEntityValidator.java
@@ -1,0 +1,31 @@
+package io.quarkus.mongodb.panache.common.validation;
+
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+
+public class HibernateValidatorEntityValidator
+        implements EntityValidator<ConstraintViolation<?>, ConstraintViolationException> {
+
+    private final Validator validator;
+
+    public HibernateValidatorEntityValidator(Validator validator) {
+        this.validator = validator;
+    }
+
+    @Override
+    public Set<? extends ConstraintViolation<?>> validate(Object entity) {
+        return validator.validate(entity);
+    }
+
+    @Override
+    public Optional<ConstraintViolationException> toException(Set<? extends ConstraintViolation<?>> violations) {
+        if (violations.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new ConstraintViolationException(violations));
+    }
+}

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/validation/NoopEntityValidator.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/validation/NoopEntityValidator.java
@@ -1,0 +1,16 @@
+package io.quarkus.mongodb.panache.common.validation;
+
+import java.util.Optional;
+import java.util.Set;
+
+public class NoopEntityValidator<V, E extends RuntimeException> implements EntityValidator<V, E> {
+    @Override
+    public Set<? extends V> validate(Object entity) {
+        return Set.of();
+    }
+
+    @Override
+    public Optional<E> toException(Set<? extends V> violations) {
+        return Optional.empty();
+    }
+}

--- a/integration-tests/mongodb-panache/pom.xml
+++ b/integration-tests/mongodb-panache/pom.xml
@@ -31,6 +31,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
 
         <!-- Force the scope to compile as we make assertions inside the resources -->
         <dependency>
@@ -118,6 +122,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntity.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntity.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
+
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
@@ -15,6 +17,7 @@ import io.quarkus.mongodb.panache.common.MongoEntity;
 
 @MongoEntity(collection = "TheBookEntity", clientName = "cl2", readPreference = "primary")
 public class BookEntity extends PanacheMongoEntity {
+    @NotNull
     @BsonProperty("bookTitle")
     private String title;
     private String author;

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
@@ -3,8 +3,11 @@ package io.quarkus.it.mongodb.panache.book;
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
@@ -127,4 +130,20 @@ public class BookEntityResource {
         BookEntity.deleteAll();
     }
 
+    @GET
+    @Path("/validation")
+    public Response validation() {
+        BookEntity book = null;
+        try {
+            book = new BookEntity()
+                    .setAuthor("author name")
+                    .setTitle(null) // not setting the title to trigger validation failure
+                    .setCategories(List.of("category1", "category2"));
+            book.persist();
+        } catch (ConstraintViolationException e) {
+            return Response.ok().entity(e.getConstraintViolations().stream()
+                    .map(ConstraintViolation::getMessage).collect(Collectors.joining("; "))).build();
+        }
+        return Response.notAcceptable(null).build();
+    }
 }

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -416,4 +416,8 @@ class MongodbPanacheResourceTest {
         get("/bugs/23813").then().statusCode(200);
     }
 
+    @Test
+    void validation() {
+        get("/books/entity/validation").then().statusCode(200).body(is("must not be null"));
+    }
 }


### PR DESCRIPTION
Hey,
I've put something simple together while between the meetings 🙈 
I'm not sure whether that's the way to insert something in that static `MongoOperations` instance or if there's a better way to do it. 
To make this more complete, I'd say we should add the way to configure the `create`/`update` validation groups.
Opening as a draft to start the discussion.

- Closes: https://github.com/quarkusio/quarkus/issues/46946