### PR TITLE
Do not close curated application if it is shared between different tests (with different test resources)

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -340,11 +340,15 @@ public class StartupActionImpl implements StartupAction {
                                 log.error("Failed to run close task", t);
                             }
                         }
-                        if (curatedApplication.getQuarkusBootstrap().getMode() == QuarkusBootstrap.Mode.TEST &&
-                                !curatedApplication.getQuarkusBootstrap().isAuxiliaryApplication()) {
-                            //for tests, we just always shut down the curated application, as it is only used once
-                            //dev mode might be about to restart, so we leave it
-                            curatedApplication.close();
+                        // This will read the state of the curated application at the time of closing;
+                        // If the caller of close knows that the 'next' application shares a curated application, it can set eligible for reuse to true
+                        if (!curatedApplication.isEligibleForReuse()) {
+                            if (curatedApplication.getQuarkusBootstrap().getMode() == QuarkusBootstrap.Mode.TEST
+                                    && !curatedApplication.getQuarkusBootstrap().isAuxiliaryApplication()) {
+                                //for tests, we just always shut down the curated application, as it is only used once
+                                //dev mode might be about to restart, so we leave it
+                                curatedApplication.close();
+                            }
                         }
                     }
                 }

--- a/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
+++ b/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
@@ -84,19 +84,12 @@ public class H2DevServicesProcessor {
                                         } catch (SQLException t) {
                                             t.printStackTrace();
                                         }
-                                        // TODO Yes, this is a port leak
-                                        // The good news is that because it's an in-memory database, it will get shut down
-                                        // when the JVM stops. Nonetheless, this clearly is not ok, and needs
-                                        // a fix so that we do not start databases in the augmentation phase
-                                        // TODO remove this when #45786 and #45785 are done
-                                        final boolean hackPendingDeferredDevServiceStart = true;
-                                        if (!hackPendingDeferredDevServiceStart) {
-                                            tcpServer.stop();
-                                            LOG.info("Dev Services for H2 shut down; server status: " + tcpServer.getStatus());
-
-                                        }
-                                        // End of #45786 and #45785 workaround
-
+                                        tcpServer.stop();
+                                        LOG.info("Dev Services for H2 shut down; server status: " + tcpServer.getStatus());
+                                    } else {
+                                        LOG.info(
+                                                "Dev Services for H2 was NOT shut down as it appears it was down already; server status: "
+                                                        + tcpServer.getStatus());
                                     }
                                 }
                             });

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -68,6 +68,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
     final ApplicationModel appModel;
 
     final AtomicInteger runtimeClassLoaderCount = new AtomicInteger();
+    private boolean eligibleForReuse = false;
 
     CuratedApplication(QuarkusBootstrap quarkusBootstrap, CurationResult curationResult,
             ConfiguredClassLoading configuredClassLoading) {
@@ -75,6 +76,10 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         this.curationResult = curationResult;
         this.appModel = curationResult.getApplicationModel();
         this.configuredClassLoading = configuredClassLoading;
+    }
+
+    public void setEligibleForReuse(boolean eligible) {
+        this.eligibleForReuse = eligible;
     }
 
     public boolean isFlatClassPath() {
@@ -457,6 +462,10 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             baseRuntimeClassLoader = null;
         }
         augmentationElements.clear();
+    }
+
+    public boolean isEligibleForReuse() {
+        return eligibleForReuse;
     }
 
     /**

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -616,6 +616,16 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             currentJUnitTestClass = extensionContext.getRequiredTestClass();
         }
         boolean isNewApplication = isNewApplication(state, extensionContext.getRequiredTestClass());
+
+        QuarkusClassLoader cl = (QuarkusClassLoader) extensionContext.getRequiredTestClass().getClassLoader();
+
+        CuratedApplication curatedApplication = runningQuarkusApplication != null
+                ? ((QuarkusClassLoader) runningQuarkusApplication.getClassLoader())
+                        .getCuratedApplication()
+                : null;
+        boolean isSameCuratedApplication = cl.getCuratedApplication() == curatedApplication;
+        cl.getCuratedApplication().setEligibleForReuse(isSameCuratedApplication);
+
         // TODO if classes are misordered, say because someone overrode the ordering, and there are profiles or resources,
         // we could try to start and application which has already been started, and fail with a mysterious error about
         // null shutdown contexts; we should try and detect that case, and give a friendlier error message


### PR DESCRIPTION
I spotted this investigating https://github.com/quarkusio/quarkus/issues/23612. I noticed that even in the case when a curated application is shared, we always shut it down. This seems clearly wrong and trivially avoidable, by doing a check for new-ness first. 

With that check, the original failure in superheroes is fixed, but the build still fails, because https://github.com/quarkusio/quarkus/issues/47178 turns up in normal testing as well as continuous testing. We have so many undetected problems with continuous testing (for example, #47177), that making normal testing and continuous testing behave in a more similar way is a good thing ... but in the short term, it causes pain. 

So I'm slightly unsure if this fix should be merged, at least before #47178 is fixed.