### PR TITLE
Clear the Stork configs during initialization

### DIFF
--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfigProvider.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfigProvider.java
@@ -11,6 +11,7 @@ public class StorkConfigProvider implements ConfigProvider {
     private static final List<ServiceConfig> serviceConfigs = new ArrayList<>();
 
     public static void init(List<ServiceConfig> configs) {
+        serviceConfigs.clear();
         serviceConfigs.addAll(configs);
     }
 


### PR DESCRIPTION
This avoids leaking configuration between continuous testing runs.
