### PR TITLE
Fix ambiguous bean resolution for sub resource interfaces with multiple implementations

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceAmbiguousInjectTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceAmbiguousInjectTest.java
@@ -1,0 +1,128 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.test.simple.PortProviderUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+class SubResourceAmbiguousInjectTest {
+    @RegisterExtension
+    static QuarkusUnitTest testExtension = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    JavaArchive war = ShrinkWrap.create(JavaArchive.class);
+                    war.addClass(PortProviderUtil.class);
+                    war.addClass(EnglishGreeterResource.class);
+                    war.addClass(SpanishGreeterResource.class);
+                    war.addClass(GreeterResource.class);
+                    war.addClass(LanguageResource.class);
+                    war.addClass(LanguageResourceV2.class);
+                    war.addClass(GreeterResourceV2.class);
+                    war.addClass(EnglishGreeterResource.class);
+                    war.addClass(SpanishGreeterResource.class);
+                    return war;
+                }
+            });
+
+    @Test
+    void basicTest() {
+        given().when().get("/languages/en").then().statusCode(200).body(is("hello"));
+        given().when().get("/languages/v2/es").then().statusCode(200).body(is("hola"));
+    }
+
+    @RequestScoped
+    public static class EnglishGreeterResource implements GreeterResource {
+        @Override
+        public String greeting() {
+            return "hello";
+        }
+    }
+
+    @RequestScoped
+    public static class SpanishGreeterResource implements GreeterResource {
+        @Override
+        public String greeting() {
+            return "hola";
+        }
+    }
+
+    public interface GreeterResource {
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        String greeting();
+    }
+
+    @Path("languages")
+    public static class LanguageResource {
+
+        private final Map<String, GreeterResource> languages;
+
+        @Inject
+        public LanguageResource(
+                final EnglishGreeterResource english, final SpanishGreeterResource spanish) {
+            languages = Map.of("en", english, "es", spanish);
+        }
+
+        @Path("{language}")
+        public GreeterResource locateGreeter(@PathParam("language") final String language) {
+            return languages.get(language);
+        }
+    }
+
+    @Path("languages/v2")
+    public static class LanguageResourceV2 {
+
+        private final Map<String, GreeterResourceV2> languages;
+
+        @Inject
+        public LanguageResourceV2(
+                final EnglishGreeterResourceV2 english, final SpanishGreeterResourceV2 spanish) {
+            languages = Map.of("en", english, "es", spanish);
+        }
+
+        @Path("{language}")
+        public GreeterResourceV2 locateGreeter(@PathParam("language") final String language) {
+            return languages.get(language);
+        }
+    }
+
+    public abstract static class GreeterResourceV2 {
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public abstract String greeting();
+    }
+
+    @RequestScoped
+    public static class EnglishGreeterResourceV2 extends GreeterResourceV2 {
+        @Override
+        public String greeting() {
+            return "hello";
+        }
+    }
+
+    @RequestScoped
+    public static class SpanishGreeterResourceV2 extends GreeterResourceV2 {
+        @Override
+        public String greeting() {
+            return "hola";
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -297,7 +297,10 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                 }
                 clazz.setPath(sanitizePath(path));
             }
-            if (factoryCreator != null) {
+            if (factoryCreator != null && !classInfo.isInterface()) {
+                // Most likely an interface for a sub resource. The ResourceLocatorHandler does not use the factory to create new instances, but uses the result of the sub resource locator method instead
+                // Interfaces therefore do not need a factory here
+                // Otherwise, when having multiple implementations of the interface, an Ambiguous Bean Resolution error occurs, since io.quarkus.arc.runtime.BeanContainerImpl.createFactory is run, even if the factory is never invoked
                 clazz.setFactory(factoryCreator.apply(classInfo.name().toString()));
             }
             Map<String, String> classLevelExceptionMappers = this.classLevelExceptionMappers.get(classInfo.name());


### PR DESCRIPTION
Sub resource interfaces need to be scanned because of tests like this https://github.com/quarkusio/quarkus/blob/main/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/resource/ResourceLocatorBaseResource.java#L50

Essentially, no implemting class of the interface exists, only a `Proxy.newProxyInstance`. The spec does not mention that this is allowed. I have personally never seen anyone use this sort of pattern - but this is a test that was copied from resteasy classic. So propably someone does use this.

So instead of removing the test, and not scanning the sub resource interface anymore for the resource methods, no endpoint factory is created anymore for interfaces.
The result of a sub resource locator method, where the interface might have been used in practice, already returns an instance. So there is need for the endpoint factory for interfaces.

The same might be true for abstract classes with multiple implementations. However, https://github.com/quarkusio/quarkus/issues/47003, prevents the ambiguous bean resolution error for them. I added a test case for abstract classes, to make sure they stay working at least.

closes #47107 