### PR TITLE
Postpone Stork shutdown

### DIFF
--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/SmallRyeStorkRecorder.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/SmallRyeStorkRecorder.java
@@ -27,7 +27,7 @@ public class SmallRyeStorkRecorder {
             Stork.initialize(infrastructure);
         }
 
-        shutdown.addShutdownTask(new Runnable() {
+        shutdown.addLastShutdownTask(new Runnable() {
             @Override
             public void run() {
                 Stork.shutdown();


### PR DESCRIPTION
Stork can be used during shutdown tasks and should be stopped last.

Fix https://github.com/quarkusio/quarkus/issues/41658
