### PR TITLE
Update Vert.x to 4.5.14 and Netty to 4.1.119

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -110,7 +110,7 @@
         <wildfly-elytron.version>2.6.2.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.2.3.Final</jboss-marshalling.version>
         <jboss-threads.version>3.8.0.Final</jboss-threads.version>
-        <vertx.version>4.5.13</vertx.version>
+        <vertx.version>4.5.14</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -132,7 +132,7 @@
         <infinispan.version>15.0.14.Final</infinispan.version>
         <infinispan.protostream.version>5.0.13.Final</infinispan.protostream.version>
         <caffeine.version>3.2.0</caffeine.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.1.119.Final</netty.version>
         <brotli4j.version>1.16.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
 
         <mutiny.version>2.8.0</mutiny.version>
         <smallrye-common.version>2.11.0</smallrye-common.version>
-        <vertx.version>4.5.13</vertx.version>
+        <vertx.version>4.5.14</vertx.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.18.3</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-        <vertx.version>4.5.13</vertx.version>
+        <vertx.version>4.5.14</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
No API changes in Vert.x, so no need to coordinate with other project releases.

Note: Vert.x includes a fix in the hashCode method for JsonArray and JsonObject, which may impact code relying on their previous (incorrect) behavior.
