### PR TITLE
Properly rest mocks (again)

### DIFF
--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/NestedSpyTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/NestedSpyTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.mockbean;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+
+@QuarkusTest
+public class NestedSpyTest {
+
+    @InjectSpy
+    MessageService messageService;
+
+    @Nested
+    public class ActualTest {
+
+        @InjectSpy
+        SuffixService suffixService;
+
+        @Test
+        @Order(1)
+        public void testGreet() {
+            Mockito.when(messageService.getMessage()).thenReturn("hi");
+            Mockito.when(suffixService.getSuffix()).thenReturn("!");
+
+            given()
+                    .when().get("/greeting")
+                    .then()
+                    .statusCode(200)
+                    .body(is("HI!"));
+        }
+
+        @Test
+        @Order(2)
+        public void testGreetAgain() {
+            Mockito.when(messageService.getMessage()).thenReturn("yolo");
+            Mockito.when(suffixService.getSuffix()).thenReturn("!!!");
+
+            given()
+                    .when().get("/greeting")
+                    .then()
+                    .statusCode(200)
+                    .body(is("YOLO!!!"));
+        }
+
+        @Test
+        @Order(3)
+        public void testNoSpy() {
+            given()
+                    .when().get("/greeting")
+                    .then()
+                    .statusCode(200)
+                    .body(is("HELLO"));
+        }
+    }
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.mockito.Mockito;
+import org.mockito.internal.util.MockUtil;
 
 final class MockitoMocksTracker {
 
@@ -26,7 +26,7 @@ final class MockitoMocksTracker {
 
     static void reset(Object testInstance) {
         for (Mocked m : getMocks(testInstance)) {
-            Mockito.framework().clearInlineMock(m.mock);
+            MockUtil.resetMock(m.mock);
         }
     }
 

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.mockito.Mockito;
 import org.mockito.internal.util.MockUtil;
 
 final class MockitoMocksTracker {
@@ -28,6 +29,13 @@ final class MockitoMocksTracker {
         for (Mocked m : getMocks(testInstance)) {
             MockUtil.resetMock(m.mock);
         }
+    }
+
+    static void clear(Object testInstance) {
+        for (Mocked m : getMocks(testInstance)) {
+            Mockito.framework().clearInlineMock(m.mock);
+        }
+        TEST_TO_USED_MOCKS.remove(testInstance);
     }
 
     static Optional<Object> currentMock(Object testInstance, Object beanInstance) {

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetMockitoMocksAfterAllCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetMockitoMocksAfterAllCallback.java
@@ -3,14 +3,18 @@ package io.quarkus.test.junit.mockito.internal;
 import io.quarkus.test.junit.callback.QuarkusTestAfterAllCallback;
 import io.quarkus.test.junit.callback.QuarkusTestContext;
 
-public class ResetOuterMockitoMocksCallback implements QuarkusTestAfterAllCallback {
+public class ResetMockitoMocksAfterAllCallback implements QuarkusTestAfterAllCallback {
 
     @Override
     public void afterAll(QuarkusTestContext context) {
+        MockitoMocksTracker.clear(context.getTestInstance());
+
         if (context.getOuterInstances() != null) {
             for (Object outerInstance : context.getOuterInstances()) {
                 MockitoMocksTracker.reset(outerInstance);
+                MockitoMocksTracker.clear(outerInstance);
             }
         }
+
     }
 }

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetMockitoMocksAfterEachCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetMockitoMocksAfterEachCallback.java
@@ -3,7 +3,7 @@ package io.quarkus.test.junit.mockito.internal;
 import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
 import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
 
-public class ResetMockitoMocksCallback implements QuarkusTestAfterEachCallback {
+public class ResetMockitoMocksAfterEachCallback implements QuarkusTestAfterEachCallback {
 
     @Override
     public void afterEach(QuarkusTestMethodContext context) {

--- a/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterAllCallback
+++ b/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterAllCallback
@@ -1,2 +1,2 @@
-io.quarkus.test.junit.mockito.internal.ResetOuterMockitoMocksCallback
+io.quarkus.test.junit.mockito.internal.ResetMockitoMocksAfterAllCallback
 io.quarkus.test.junit.mockito.internal.CreateMockitoSpiesCallback

--- a/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
+++ b/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
@@ -1,1 +1,1 @@
-io.quarkus.test.junit.mockito.internal.ResetMockitoMocksCallback
+io.quarkus.test.junit.mockito.internal.ResetMockitoMocksAfterEachCallback


### PR DESCRIPTION
Follows up on: #47181.

This should fix the flaky tests we've been seeing on `PerClassSpyTest`

P.S. If #47181 is backported, then this needs to be as well