### PR TITLE
Allow more Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: daily
       time: "23:00"
       timezone: Europe/Paris
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     labels:
       - area/dependencies
     allow:


### PR DESCRIPTION
Now that we have RunsOn, we can test more Dependabot pull requests in parallel.