### PR TITLE
Do not use cached classpath elements when initializing deployment and runtime classloaders

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
@@ -3,7 +3,7 @@ package io.quarkus.paths;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.Objects;
 
 public class DirectoryPathTree extends OpenContainerPathTree implements Serializable {
 
@@ -28,12 +28,12 @@ public class DirectoryPathTree extends OpenContainerPathTree implements Serializ
 
     public DirectoryPathTree(Path dir, PathFilter pathFilter, boolean manifestEnabled) {
         super(pathFilter, manifestEnabled);
-        this.dir = dir;
+        this.dir = Objects.requireNonNull(dir, "Directory is null");
     }
 
     protected DirectoryPathTree(Path dir, PathFilter pathFilter, PathTreeWithManifest pathTreeWithManifest) {
         super(pathFilter, pathTreeWithManifest);
-        this.dir = dir;
+        this.dir = Objects.requireNonNull(dir, "Directory is null");
     }
 
     @Override
@@ -72,7 +72,7 @@ public class DirectoryPathTree extends OpenContainerPathTree implements Serializ
     }
 
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
-        dir = Paths.get(in.readUTF());
+        dir = Path.of(in.readUTF());
         pathFilter = (PathFilter) in.readObject();
         manifestEnabled = in.readBoolean();
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
@@ -93,7 +93,11 @@ public abstract class OpenContainerPathTree extends PathTreeWithManifest impleme
 
     @Override
     public Collection<Path> getRoots() {
-        return List.of(getRootPath());
+        final Path rootPath = getRootPath();
+        if (rootPath == null) {
+            throw new RuntimeException("rootPath is null for " + getContainerPath());
+        }
+        return List.of(rootPath);
     }
 
     @Override

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
@@ -102,10 +102,14 @@ public interface ClassPathElement extends Closeable {
     }
 
     static ClassPathElement fromDependency(ResolvedDependency dep) {
-        return new PathTreeClassPathElement(dep.getContentTree(), dep.isRuntimeCp(), dep);
+        return fromDependency(dep.getContentTree(), dep);
     }
 
-    static ClassPathElement EMPTY = new ClassPathElement() {
+    static ClassPathElement fromDependency(PathTree contentTree, ResolvedDependency dep) {
+        return new PathTreeClassPathElement(contentTree, dep.isRuntimeCp(), dep);
+    }
+
+    ClassPathElement EMPTY = new ClassPathElement() {
 
         @Override
         public Path getRoot() {


### PR DESCRIPTION
This is a quick fix for an issue that appeared in the Camel Quarkus CI reported in [#dev > Test time ApplicationArchiveImpl.getRootDirectories NPE @ 💬](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Test.20time.20ApplicationArchiveImpl.2EgetRootDirectories.20NPE/near/509877831)