### PR TITLE
Add a bit more context when we can't read Jandex index

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
@@ -289,17 +289,17 @@ public class IndexingUtil {
                 try {
                     if (reader.getIndexVersion() < REQUIRED_INDEX_VERSION) {
                         log.warnf(
-                                "Re-indexing %s - at least Jandex 2.1 must be used to index an application dependency",
-                                visit.getPath());
+                                "Re-indexing %s:%s - at least Jandex 2.1 must be used to index an application dependency",
+                                visit.getRoot(), visit.getPath());
                         return null;
                     }
                     return reader.read();
                 } catch (UnsupportedVersion e) {
                     throw new UnsupportedVersion(
-                            "Can't read Jandex index from " + visit.getPath() + ": " + e.getMessage());
+                            "Can't read Jandex index from " + visit.getRoot() + ":" + visit.getPath() + ": " + e.getMessage());
                 }
             } catch (IOException e) {
-                throw new UncheckedIOException("Can't read Jandex index from " + visit.getPath(), e);
+                throw new UncheckedIOException("Can't read Jandex index from " + visit.getRoot() + ":" + visit.getPath(), e);
             }
         }
     }


### PR DESCRIPTION
At the moment, we only have the relative path, which is kinda useless to determine where the index is coming from.

This is easy and easily backportable so even if we do more significant changes there, I think it's worth getting this in.