### PR TITLE
Replaced remaining occurrences of deprecated EmptyInterceptor

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1435,9 +1435,9 @@ to your `SessionFactory` by simply defining a CDI bean with the appropriate qual
 [source,java]
 ----
 @PersistenceUnitExtension // <1>
-public static class MyInterceptor extends EmptyInterceptor { // <2>
+public static class MyInterceptor implements Interceptor, Serializable { // <2>
     @Override
-    public boolean onLoad(Object entity, Serializable id, Object[] state, // <3>
+    public boolean onLoad(Object entity, Object id, Object[] state, // <3>
             String[] propertyNames, Type[] types) {
         // ...
         return false;
@@ -1448,8 +1448,7 @@ public static class MyInterceptor extends EmptyInterceptor { // <2>
 to tell Quarkus it should be used in the default persistence unit.
 +
 For <<multiple-persistence-units,named persistence units>>, use `@PersistenceUnitExtension("nameOfYourPU")`
-<2> Either extend `org.hibernate.EmptyInterceptor` or implement `org.hibernate.Interceptor` directly.
-<3> Implement methods as necessary.
+<2> Implement methods of `org.hibernate.Interceptor` as necessary.
 
 [TIP]
 ====

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/interceptor/ApplicationScopedInterceptorTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/interceptor/ApplicationScopedInterceptorTest.java
@@ -2,7 +2,6 @@ package io.quarkus.hibernate.orm.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -14,7 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.transaction.UserTransaction;
 
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.type.Type;
@@ -113,7 +112,7 @@ public class ApplicationScopedInterceptorTest {
     }
 
     @PersistenceUnitExtension // @ApplicationScoped is the default
-    public static class ApplicationScopedInterceptor extends EmptyInterceptor {
+    public static class ApplicationScopedInterceptor implements Interceptor {
         private static final List<ApplicationScopedInterceptor> instances = Collections.synchronizedList(new ArrayList<>());
         private static final List<Object> loadedIds = Collections.synchronizedList(new ArrayList<>());
 
@@ -124,7 +123,7 @@ public class ApplicationScopedInterceptorTest {
         }
 
         @Override
-        public boolean onLoad(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
+        public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames, Type[] types) {
             loadedIds.add(id);
             return false;
         }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/interceptor/DependentInterceptorTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/interceptor/DependentInterceptorTest.java
@@ -2,7 +2,6 @@ package io.quarkus.hibernate.orm.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -15,7 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.transaction.UserTransaction;
 
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.type.Type;
@@ -116,7 +115,7 @@ public class DependentInterceptorTest {
 
     @PersistenceUnitExtension
     @Dependent
-    public static class DependentInterceptor extends EmptyInterceptor {
+    public static class DependentInterceptor implements Interceptor {
         private static final List<DependentInterceptor> instances = Collections.synchronizedList(new ArrayList<>());
         private static final List<Object> loadedIds = Collections.synchronizedList(new ArrayList<>());
 
@@ -127,7 +126,7 @@ public class DependentInterceptorTest {
         }
 
         @Override
-        public boolean onLoad(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
+        public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames, Type[] types) {
             loadedIds.add(id);
             return false;
         }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/interceptor/TransactionScopedInterceptorTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/interceptor/TransactionScopedInterceptorTest.java
@@ -3,7 +3,6 @@ package io.quarkus.hibernate.orm.interceptor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -16,7 +15,7 @@ import jakarta.persistence.Table;
 import jakarta.transaction.TransactionScoped;
 import jakarta.transaction.UserTransaction;
 
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.type.Type;
@@ -118,7 +117,7 @@ public class TransactionScopedInterceptorTest {
 
     @PersistenceUnitExtension
     @TransactionScoped
-    public static class TransactionScopedInterceptor extends EmptyInterceptor {
+    public static class TransactionScopedInterceptor implements Interceptor {
         private static final List<TransactionScopedInterceptor> instances = Collections.synchronizedList(new ArrayList<>());
         private static final List<Object> loadedIds = Collections.synchronizedList(new ArrayList<>());
 
@@ -129,7 +128,7 @@ public class TransactionScopedInterceptorTest {
         }
 
         @Override
-        public boolean onLoad(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
+        public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames, Type[] types) {
             loadedIds.add(id);
             return false;
         }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsInterceptorTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/multiplepersistenceunits/MultiplePersistenceUnitsInterceptorTest.java
@@ -2,7 +2,6 @@ package io.quarkus.hibernate.orm.multiplepersistenceunits;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -10,7 +9,7 @@ import java.util.List;
 import jakarta.inject.Inject;
 import jakarta.transaction.UserTransaction;
 
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.hibernate.Session;
 import org.hibernate.type.Type;
 import org.junit.jupiter.api.BeforeEach;
@@ -105,7 +104,7 @@ public class MultiplePersistenceUnitsInterceptorTest {
     }
 
     @PersistenceUnitExtension
-    public static class MyDefaultPUInterceptor extends EmptyInterceptor {
+    public static class MyDefaultPUInterceptor implements Interceptor {
         private static final List<MyDefaultPUInterceptor> instances = Collections.synchronizedList(new ArrayList<>());
         private static final List<Object> loadedIds = Collections.synchronizedList(new ArrayList<>());
 
@@ -116,14 +115,14 @@ public class MultiplePersistenceUnitsInterceptorTest {
         }
 
         @Override
-        public boolean onLoad(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
+        public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames, Type[] types) {
             loadedIds.add(id);
             return false;
         }
     }
 
     @PersistenceUnitExtension("inventory")
-    public static class MyInventoryPUInterceptor extends EmptyInterceptor {
+    public static class MyInventoryPUInterceptor implements Interceptor {
         private static final List<MyInventoryPUInterceptor> instances = Collections.synchronizedList(new ArrayList<>());
         private static final List<Object> loadedIds = Collections.synchronizedList(new ArrayList<>());
 
@@ -134,7 +133,7 @@ public class MultiplePersistenceUnitsInterceptorTest {
         }
 
         @Override
-        public boolean onLoad(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
+        public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames, Type[] types) {
             loadedIds.add(id);
             return false;
         }


### PR DESCRIPTION
Fix #47184 
- replaced remaining occurrences of deprecated EmptyInterceptor with Interceptor
- changed id param to type Object in because the method signature with Serializable got deprecated