### PR TITLE
Jandex: reindex if the index is too new

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
@@ -44,8 +44,8 @@ public class IndexingUtil {
 
     private static final int JAVA_VERSION;
 
-    // At least Jandex 2.1 is needed
-    private static final int REQUIRED_INDEX_VERSION = 8;
+    // At least Jandex 3.0 is needed
+    private static final int REQUIRED_INDEX_VERSION = 11;
 
     static {
         int version = 8;
@@ -71,7 +71,7 @@ public class IndexingUtil {
 
     public static Index indexTree(OpenPathTree tree, Set<String> removed) throws IOException {
         if (removed == null) {
-            final Index i = tree.apply(JANDEX_INDEX, MetaInfJandexReader.getInstance());
+            final Index i = tree.apply(JANDEX_INDEX, new MetaInfJandexReader(tree.toString()));
             if (i != null) {
                 return i;
             }
@@ -88,17 +88,19 @@ public class IndexingUtil {
             if (existing != null && removed == null) {
                 try (InputStream in = jarFile.getInputStream(existing)) {
                     IndexReader reader = new IndexReader(in);
-                    if (reader.getIndexVersion() < REQUIRED_INDEX_VERSION) {
-                        log.warnf(
-                                "Re-indexing %s - at least Jandex 2.1 must be used to index an application dependency",
-                                file);
-                        return indexJar(jarFile, removed);
-                    } else {
-                        try {
-                            return reader.read();
-                        } catch (UnsupportedVersion e) {
-                            throw new UnsupportedVersion("Can't read Jandex index from " + file + ": " + e.getMessage());
+                    try {
+                        int indexVersion = reader.getIndexVersion();
+                        if (indexVersion < REQUIRED_INDEX_VERSION) {
+                            log.warnf("Reindexing %s, at least Jandex 3.0 must be used"
+                                    + " to index an application dependency (index version is %s)", file, indexVersion);
+                            return indexJar(jarFile, removed);
                         }
+                        return reader.read();
+                    } catch (UnsupportedVersion e) {
+                        log.warnf("Reindexing %s, the index format is too new for the Jandex version"
+                                + " used by your application. Please report it to the author of this JAR (%s)",
+                                file, e.getMessage());
+                        return indexJar(jarFile, removed);
                     }
                 }
             }
@@ -273,10 +275,10 @@ public class IndexingUtil {
     }
 
     private static class MetaInfJandexReader implements Function<PathVisit, Index> {
-        private static MetaInfJandexReader instance;
+        private final String treeDescription;
 
-        private static MetaInfJandexReader getInstance() {
-            return instance == null ? instance = new MetaInfJandexReader() : instance;
+        MetaInfJandexReader(String treeDescription) {
+            this.treeDescription = treeDescription;
         }
 
         @Override
@@ -287,19 +289,22 @@ public class IndexingUtil {
             try (InputStream in = Files.newInputStream(visit.getPath())) {
                 IndexReader reader = new IndexReader(in);
                 try {
-                    if (reader.getIndexVersion() < REQUIRED_INDEX_VERSION) {
-                        log.warnf(
-                                "Re-indexing %s:%s - at least Jandex 2.1 must be used to index an application dependency",
-                                visit.getRoot(), visit.getPath());
+                    int indexVersion = reader.getIndexVersion();
+                    if (indexVersion < REQUIRED_INDEX_VERSION) {
+                        log.warnf("Reindexing %s, at least Jandex 3.0 must be used"
+                                + " to index an application dependency (index version is %s)",
+                                treeDescription, indexVersion);
                         return null;
                     }
                     return reader.read();
                 } catch (UnsupportedVersion e) {
-                    throw new UnsupportedVersion(
-                            "Can't read Jandex index from " + visit.getRoot() + ":" + visit.getPath() + ": " + e.getMessage());
+                    log.warnf("Reindexing %s, the index format is too new for the Jandex version"
+                            + " used by your application. Please report it to the author of this JAR (%s)",
+                            treeDescription, e.getMessage());
+                    return null;
                 }
             } catch (IOException e) {
-                throw new UncheckedIOException("Can't read Jandex index from " + visit.getRoot() + ":" + visit.getPath(), e);
+                throw new UncheckedIOException("Can't read Jandex index from " + treeDescription, e);
             }
         }
     }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/boot/StaticInitFailureTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/boot/StaticInitFailureTest.java
@@ -27,7 +27,9 @@ public class StaticInitFailureTest {
                     .addClass(EntityWithIncorrectMapping.class))
             .withConfigurationResource("application.properties")
             // Expect only one error: the one we triggered
-            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
+                    // Ignore these particular warnings: they are not relevant to this test.
+                    && !record.getMessage().contains("must be used to index an application dependency")) // too old Jandex
             // In particular we don't want a log telling us JPAConfig could not be created
             // because HibernateOrmRuntimeConfig is not initialized yet.
             // JPAConfig should not be created in the first place!

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionExtraSpaceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/dialect/DbVersionExtraSpaceTest.java
@@ -37,7 +37,8 @@ public class DbVersionExtraSpaceTest {
                     // Ignore these particular warnings: they are not relevant to this test.
                     && !record.getMessage().contains("has been blocked for") //sometimes CI has a super slow moment and this triggers the blocked thread detector
                     && !record.getMessage().contains("Agroal")
-                    && !record.getMessage().contains("Netty DefaultChannelId initialization"))
+                    && !record.getMessage().contains("Netty DefaultChannelId initialization")
+                    && !record.getMessage().contains("must be used to index an application dependency")) // too old Jandex
             .assertLogRecords(records -> assertThat(records)
                     .extracting(LogRecord::getMessage) // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
                     .isEmpty());

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/transaction/AbstractTransactionLifecycleTest.java
@@ -49,7 +49,8 @@ public abstract class AbstractTransactionLifecycleTest {
                     && !record.getMessage().contains("has been blocked for") //sometimes CI has a super slow moment and this triggers the blocked thread detector
                     && !record.getMessage().contains("Using Java versions older than 11 to build Quarkus applications")
                     && !record.getMessage().contains("Agroal does not support detecting if a connection is still usable")
-                    && !record.getMessage().contains("Netty DefaultChannelId initialization"))
+                    && !record.getMessage().contains("Netty DefaultChannelId initialization")
+                    && !record.getMessage().contains("must be used to index an application dependency")) // too old Jandex
             .assertLogRecords(records -> assertThat(records)
                     .extracting(LogRecord::getMessage) // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
                     .isEmpty());


### PR DESCRIPTION
We've been bitten by this issue many times in the past: if a dependency upgrades to a newer Jandex than what Quarkus contains, build fails with an `UnsupportedVersion` exception.

This commit is a proper solution: if the exception is thrown, we swallow it and reindex the archive with the Jandex version that Quarkus incorporates.

Further, this commit increments the minimum Jandex version we "trust" from Jandex 2.1 to Jandex 3.0. We rely on new features from Jandex 2.4 and 3.0 on many places, so it makes sense to make 3.0 the new minimum. The changes added in 3.2 and 3.3 are also important, but are not used heavily yet.