### PR TITLE
ArC: @Singleton is no longer treated as bean defining annotation in strict mode

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
@@ -147,7 +147,7 @@ public class BeanArchiveProcessor {
         Set<DotName> beanDefiningAnnotations = BeanDeployment
                 .initBeanDefiningAnnotations(additionalBeanDefiningAnnotations.stream()
                         .map(bda -> new BeanDefiningAnnotation(bda.getName(), bda.getDefaultScope()))
-                        .collect(Collectors.toList()), stereotypes);
+                        .collect(Collectors.toList()), stereotypes, config.strictCompatibility());
         beanDefiningAnnotations.addAll(customScopes.getCustomScopeNames());
         // Also include archives that are not bean archives but contain scopes, qualifiers,
         // interceptor bindings, interceptors or decorators

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -289,8 +289,8 @@ public class BeanDeployment {
     BeanRegistrar.RegistrationContext registerBeans(List<BeanRegistrar> beanRegistrars) {
         List<InjectionPointInfo> injectionPoints = new ArrayList<>();
         BeanDiscoveryResult beanDiscoveryResult = findBeans(
-                initBeanDefiningAnnotations(beanDefiningAnnotations.values(), stereotypes.keySet()), observers,
-                injectionPoints, jtaCapabilities);
+                initBeanDefiningAnnotations(beanDefiningAnnotations.values(), stereotypes.keySet(), strictCompatibility),
+                observers, injectionPoints, jtaCapabilities);
         this.beans.addAll(beanDiscoveryResult.beans);
         this.skippedClasses.addAll(beanDiscoveryResult.skippedClasses);
         // Note that we use unmodifiable views because the underlying collections may change in the next phase
@@ -1485,9 +1485,13 @@ public class BeanDeployment {
 
     // keep it public we need this method in quarkus integration
     public static Set<DotName> initBeanDefiningAnnotations(Collection<BeanDefiningAnnotation> additionalBeanDefiningAnnotations,
-            Set<DotName> stereotypes) {
+            Set<DotName> stereotypes, boolean strictCompatibility) {
         Set<DotName> beanDefiningAnnotations = new HashSet<>();
         for (BuiltinScope scope : BuiltinScope.values()) {
+            if (strictCompatibility && scope == BuiltinScope.SINGLETON) {
+                // `@Singleton` is not a bean defining annotation in CDI, skip it in strict mode
+                continue;
+            }
             beanDefiningAnnotations.add(scope.getInfo().getDotName());
         }
         if (additionalBeanDefiningAnnotations != null) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/injectionpoints/BeanInjectionPointsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/injectionpoints/BeanInjectionPointsTest.java
@@ -29,7 +29,6 @@ import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Inject;
 import jakarta.inject.Qualifier;
-import jakarta.inject.Singleton;
 
 import org.jboss.jandex.ClassType;
 import org.junit.jupiter.api.Test;
@@ -150,7 +149,7 @@ public class BeanInjectionPointsTest {
         assertTrue(found);
     }
 
-    @Singleton
+    @Dependent
     static class MyBean {
         @Inject
         @ExtraAnnotation("a")

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/scope/SingletonInDefaultModeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/scope/SingletonInDefaultModeTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.arc.test.bean.scope;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SingletonInDefaultModeTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(MyBean.class);
+
+    @Test
+    public void test() {
+        InstanceHandle<MyBean> myBean = Arc.container().instance(MyBean.class);
+        assertTrue(myBean.isAvailable());
+        assertNotNull(myBean.get());
+
+        assertDoesNotThrow(() -> {
+            Arc.container().select(MyBean.class).get();
+        });
+    }
+
+    @Singleton
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/scope/SingletonInStrictModeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/scope/SingletonInStrictModeTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.bean.scope;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SingletonInStrictModeTest {
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyBean.class)
+            .strictCompatibility(true)
+            .build();
+
+    @Test
+    public void test() {
+        InstanceHandle<MyBean> myBean = Arc.container().instance(MyBean.class);
+        assertFalse(myBean.isAvailable());
+        assertNull(myBean.get());
+
+        assertThrows(UnsatisfiedResolutionException.class, () -> {
+            Arc.container().select(MyBean.class).get();
+        });
+    }
+
+    @Singleton
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/scope/SingletonStereotypeInDefaultModeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/scope/SingletonStereotypeInDefaultModeTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.arc.test.bean.scope;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SingletonStereotypeInDefaultModeTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(SingletonScoped.class, MyBean.class);
+
+    @Test
+    public void test() {
+        InstanceHandle<MyBean> myBean = Arc.container().instance(MyBean.class);
+        assertNotNull(myBean.get());
+        assertEquals(Singleton.class, myBean.getBean().getScope());
+
+        assertDoesNotThrow(() -> {
+            Arc.container().select(MyBean.class).get();
+        });
+    }
+
+    @Singleton
+    @Stereotype
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SingletonScoped {
+    }
+
+    @SingletonScoped
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/scope/SingletonStereotypeInStrictModeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/scope/SingletonStereotypeInStrictModeTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.arc.test.bean.scope;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SingletonStereotypeInStrictModeTest {
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(SingletonScoped.class, MyBean.class)
+            .strictCompatibility(true)
+            .build();
+
+    @Test
+    public void test() {
+        InstanceHandle<MyBean> myBean = Arc.container().instance(MyBean.class);
+        assertNotNull(myBean.get());
+        assertEquals(Singleton.class, myBean.getBean().getScope());
+
+        assertDoesNotThrow(() -> {
+            Arc.container().select(MyBean.class).get();
+        });
+    }
+
+    @Singleton
+    @Stereotype
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SingletonScoped {
+    }
+
+    @SingletonScoped
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/disabled/DisabledDecoratorInStrictModeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/disabled/DisabledDecoratorInStrictModeTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.decorator.Decorator;
 import jakarta.decorator.Delegate;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -30,7 +30,7 @@ public class DisabledDecoratorInStrictModeTest {
         T convert(T value);
     }
 
-    @Singleton
+    @Dependent
     static class ToUpperCaseConverter implements Converter<String> {
         @Override
         public String convert(String value) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/disabled/DisabledInterceptorInStrictModeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/disabled/DisabledInterceptorInStrictModeTest.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import jakarta.inject.Singleton;
+import jakarta.enterprise.context.Dependent;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InterceptorBinding;
@@ -32,7 +32,7 @@ public class DisabledInterceptorInStrictModeTest {
         assertEquals("pong", bean.ping());
     }
 
-    @Singleton
+    @Dependent
     @MyInterceptorBinding
     static class MyBean {
         String ping() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/NamePrefixCollisionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/NamePrefixCollisionTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.DeploymentException;
 import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -30,7 +29,7 @@ public class NamePrefixCollisionTest {
     }
 
     @Named("x")
-    @Singleton
+    @Dependent
     static class Alpha {
     }
 


### PR DESCRIPTION
This is because `@Singleton` is not a bean defining annotation in CDI, full stop. We want to treat `@Singleton` as bean defining in the default mode, just because it makes sense, but not in strict mode, even though it is not tested in the TCK.

Some tests that run in the strict mode and expect `@Singleton` to be a bean defining annotation are also adjusted in this commit (they use `@Dependent` instead).