### PR TITLE
Allow adding Open API specification endpoint to OpenAPI using config

### DIFF
--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -119,6 +119,13 @@ public interface SmallRyeOpenApiConfig {
     boolean autoAddSecurity();
 
     /**
+     * This will automatically add the OpenAPI specification document endpoint to the schema.
+     * It also adds "openapi" to the list of tags and specify an "operationId"
+     */
+    @WithDefault("false")
+    boolean autoAddOpenApiEndpoint();
+
+    /**
      * Required when using `apiKey` security. The location of the API key. Valid values are "query", "header" or "cookie".
      */
     Optional<String> apiKeyParameterIn();

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -94,6 +94,7 @@ import io.quarkus.security.Authenticated;
 import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.smallrye.openapi.OpenApiFilter;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
+import io.quarkus.smallrye.openapi.deployment.filter.AutoAddOpenApiEndpointFilter;
 import io.quarkus.smallrye.openapi.deployment.filter.AutoServerFilter;
 import io.quarkus.smallrye.openapi.deployment.filter.ClassAndMethod;
 import io.quarkus.smallrye.openapi.deployment.filter.DefaultInfoFilter;
@@ -401,6 +402,15 @@ public class SmallRyeOpenApiProcessor {
         };
 
         return new OpenApiFilteredIndexViewBuildItem(indexView);
+    }
+
+    @BuildStep
+    void addAutoOpenApiEndpointFilter(BuildProducer<AddToOpenAPIDefinitionBuildItem> addToOpenAPIDefinitionProducer,
+            SmallRyeOpenApiConfig config) {
+        if (config.autoAddOpenApiEndpoint()) {
+            addToOpenAPIDefinitionProducer
+                    .produce(new AddToOpenAPIDefinitionBuildItem(new AutoAddOpenApiEndpointFilter(config.path())));
+        }
     }
 
     @BuildStep

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoAddOpenApiEndpointFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoAddOpenApiEndpointFilter.java
@@ -1,0 +1,67 @@
+package io.quarkus.smallrye.openapi.deployment.filter;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.media.Content;
+
+public class AutoAddOpenApiEndpointFilter implements OASFilter {
+    private static final String OPENAPI_TAG = "openapi";
+    private static final String ENDPOINT_DESCRIPTION = "OpenAPI specification";
+
+    private final String path;
+
+    private enum MediaTypeForEndpoint {
+        JSON,
+        YAML,
+        BOTH,
+    }
+
+    public AutoAddOpenApiEndpointFilter(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+        Paths paths = openAPI.getPaths();
+        if (paths == null) {
+            paths = OASFactory.createPaths();
+            openAPI.setPaths(paths);
+        }
+        openAPI.addTag(OASFactory.createTag().name(OPENAPI_TAG));
+        createPathItem(paths, "", MediaTypeForEndpoint.BOTH);
+        createPathItem(paths, "Json", MediaTypeForEndpoint.JSON);
+        createPathItem(paths, "Yaml", MediaTypeForEndpoint.YAML);
+        createPathItem(paths, "Yml", MediaTypeForEndpoint.YAML);
+    }
+
+    private void createPathItem(Paths paths, String suffix, MediaTypeForEndpoint mediaTypeForEndpoints) {
+        Content openApiContent = OASFactory.createContent();
+        if (mediaTypeForEndpoints == MediaTypeForEndpoint.JSON || mediaTypeForEndpoints == MediaTypeForEndpoint.BOTH) {
+            openApiContent.addMediaType("application/json", OASFactory.createMediaType());
+        }
+        if (mediaTypeForEndpoints == MediaTypeForEndpoint.YAML || mediaTypeForEndpoints == MediaTypeForEndpoint.BOTH) {
+            openApiContent.addMediaType("application/yaml", OASFactory.createMediaType());
+        }
+        var openApiResponse = OASFactory.createAPIResponses()
+                .addAPIResponse(
+                        "200",
+                        OASFactory.createAPIResponse()
+                                .description(ENDPOINT_DESCRIPTION)
+                                .content(openApiContent));
+        var pathItemPath = this.path;
+        // Strip off dot
+        if (!suffix.isEmpty()) {
+            pathItemPath += "." + suffix.toLowerCase();
+        }
+        var pathItem = OASFactory.createPathItem()
+                .GET(
+                        OASFactory.createOperation()
+                                .description(ENDPOINT_DESCRIPTION)
+                                .addTag(OPENAPI_TAG)
+                                .operationId("getOpenAPISpecification" + suffix)
+                                .responses(openApiResponse));
+        paths.addPathItem(pathItemPath, pathItem);
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
@@ -148,6 +148,11 @@ class SecurityConfigFilterTest {
         }
 
         @Override
+        public boolean autoAddOpenApiEndpoint() {
+            return false;
+        }
+
+        @Override
         public Optional<String> apiKeyParameterIn() {
             return Optional.ofNullable(apiKeyParameterIn);
         }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoAddOpenApiEndpointFilterDisabledTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoAddOpenApiEndpointFilterDisabledTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class AutoAddOpenApiEndpointFilterDisabledTest {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(
+                            new StringAsset("""
+                                    quarkus.smallrye-openapi.auto-add-open-api-endpoint=false
+                                    quarkus.smallrye-openapi.path=%s
+                                    """.formatted(OPEN_API_PATH)),
+
+                            "application.properties"));
+
+    @Test
+    public void testNoAddedFilterDoesNotProducePath() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("paths", Matchers.not(Matchers.hasKey(OPEN_API_PATH)));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoAddOpenApiEndpointFilterNoResourcesTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoAddOpenApiEndpointFilterNoResourcesTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class AutoAddOpenApiEndpointFilterNoResourcesTest {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(
+                            new StringAsset("""
+                                    quarkus.smallrye-openapi.auto-add-open-api-endpoint=true
+                                    quarkus.smallrye-openapi.path=%s
+                                    """.formatted(OPEN_API_PATH)),
+
+                            "application.properties"));
+
+    @Test
+    public void testNoResourcesDoesNotCrashFilter() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("paths", Matchers.hasKey(OPEN_API_PATH));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoAddOpenApiEndpointFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoAddOpenApiEndpointFilterTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class AutoAddOpenApiEndpointFilterTest {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(
+                            new StringAsset("""
+                                    quarkus.smallrye-openapi.auto-add-open-api-endpoint=true
+                                    quarkus.smallrye-openapi.path=%s
+                                    """.formatted(OPEN_API_PATH)),
+
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiFilterResource() {
+        var endpointPath = "paths.'%s'.get".formatted(OPEN_API_PATH);
+        var contentPath = "paths.'%s'.get.responses.200.content".formatted(OPEN_API_PATH);
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("paths", Matchers.hasKey(OPEN_API_PATH))
+                .body(endpointPath + ".tags", Matchers.hasItem("openapi"))
+                .body(endpointPath + ".responses", Matchers.hasKey("200"))
+                .body(endpointPath + ".operationId", Matchers.equalTo("getOpenAPISpecification"))
+                .body(contentPath, Matchers.hasKey("application/json"))
+                .body(contentPath, Matchers.hasKey("application/yaml"))
+                .body(contentPath + ".size()", Matchers.equalTo(2))
+                .body("tags", Matchers.hasItem(Matchers.hasEntry("name", "openapi")));
+    }
+
+    @Test
+    public void testSpecificYamlEndpointFilterResource() {
+        var yamlPath = OPEN_API_PATH + ".yaml";
+        var endpointPath = "paths.'%s'.get".formatted(yamlPath);
+        var contentPath = "paths.'%s'.get.responses.200.content".formatted(yamlPath);
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("paths", Matchers.hasKey(yamlPath))
+                .body(endpointPath + ".operationId", Matchers.equalTo("getOpenAPISpecificationYaml"))
+                .body(contentPath, Matchers.hasKey("application/yaml"))
+                .body(contentPath + ".size()", Matchers.equalTo(1));
+    }
+
+    @Test
+    public void testSpecificYmlEndpointFilterResource() {
+        var ymlPath = OPEN_API_PATH + ".yml";
+        var endpointPath = "paths.'%s'.get".formatted(ymlPath);
+        var contentPath = "paths.'%s'.get.responses.200.content".formatted(ymlPath);
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("paths", Matchers.hasKey(ymlPath))
+                .body(endpointPath + ".operationId", Matchers.equalTo("getOpenAPISpecificationYml"))
+                .body(contentPath, Matchers.hasKey("application/yaml"))
+                .body(contentPath + ".size()", Matchers.equalTo(1));
+    }
+
+    @Test
+    public void testSpecificJsonEndpointFilterResource() {
+        var jsonPath = OPEN_API_PATH + ".json";
+        var endpointPath = "paths.'%s'.get".formatted(jsonPath);
+        var contentPath = "paths.'%s'.get.responses.200.content".formatted(jsonPath);
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("paths", Matchers.hasKey(jsonPath))
+                .body(endpointPath + ".operationId", Matchers.equalTo("getOpenAPISpecificationJson"))
+                .body(contentPath, Matchers.hasKey("application/json"))
+                .body(contentPath + ".size()", Matchers.equalTo(1));
+    }
+}


### PR DESCRIPTION
This mirrors the PR that allow for adding the health endpoint to the OpenAPI config [1] to also do that for the documented Open API endpoint itself.

Since the server dynamically generates this file, it can be requested from the server. Thus, it should also be possible to specify it in the document.

To avoid a recursive problem of needing to specify the full structure of the document itself, inside of the document, we only specify that it is a JSON object.

[1]: https://github.com/quarkusio/quarkus/pull/12044/

# Context

Logius maintains a standard for API Design Rules. This standard [specifies that an Open API document](https://gitdocumentatie.logius.nl/publicatie/api/adr/#/core/publish-openapi) must be published. We do this by [checking with a linter](https://github.com/Logius-standaarden/API-Design-Rules/blob/af99a11dc1f78cfd6b09967b8f890efa00b635f8/linter/spectral.yml#L77-L85) that the path (`/openapi.json`) exists.

We instruct folks to document these in their API's, but since Quarkus does it for our developers, it can also augment the Open API schema with it. Therefore, the filter automates that process and, instead of instructing our developers to implement 50 lines of Java, they now can enable it with 1 line of configuration.