### PR TITLE
Guard against class cast exception in QuarkusTestExtension

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -617,7 +617,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         }
         boolean isNewApplication = isNewApplication(state, extensionContext.getRequiredTestClass());
 
-        QuarkusClassLoader cl = (QuarkusClassLoader) extensionContext.getRequiredTestClass().getClassLoader();
+        QuarkusClassLoader cl = getClassLoaderFromTestClass(extensionContext.getRequiredTestClass());
 
         CuratedApplication curatedApplication = runningQuarkusApplication != null
                 ? ((QuarkusClassLoader) runningQuarkusApplication.getClassLoader())


### PR DESCRIPTION
I noticed that I reintroduced the possibility of a class cast exception with my recent fix. The class cast exception Should Not Happen, and would be an internal error if it did, but better to be helpful in that case.