### PR TITLE
Do not append email suffix if already present in oidc dev service

### DIFF
--- a/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
+++ b/extensions/devservices/oidc/src/main/java/io/quarkus/devservices/oidc/OidcDevServicesProcessor.java
@@ -714,9 +714,9 @@ public class OidcDevServicesProcessor {
                 .audience(clientId)
                 .subject(user)
                 .upn(user)
-                .claim("name", capitalize(user))
-                .claim(Claims.preferred_username, user + "@example.com")
-                .claim(Claims.email, user + "@example.com")
+                .claim("name", buildNameClaimValue(user))
+                .claim(Claims.preferred_username, buildEmailClaimValue(user))
+                .claim(Claims.email, buildEmailClaimValue(user))
                 .groups(roles)
                 .jws()
                 .keyId(kid)
@@ -731,13 +731,27 @@ public class OidcDevServicesProcessor {
                 .subject(user)
                 .scope(scope)
                 .upn(user)
-                .claim("name", capitalize(user))
-                .claim(Claims.preferred_username, user + "@example.com")
-                .claim(Claims.email, user + "@example.com")
+                .claim("name", buildNameClaimValue(user))
+                .claim(Claims.preferred_username, buildEmailClaimValue(user))
+                .claim(Claims.email, buildEmailClaimValue(user))
                 .groups(roles)
                 .jws()
                 .keyId(kid)
                 .sign(kp.getPrivate());
+    }
+
+    private static String buildNameClaimValue(String user) {
+        if (user.contains("@")) {
+            return capitalize(user.split("@")[0]);
+        }
+        return capitalize(user);
+    }
+
+    private static String buildEmailClaimValue(String user) {
+        if (user.contains("@")) {
+            return user;
+        }
+        return user + "@example.com";
     }
 
     /*
@@ -801,13 +815,13 @@ public class OidcDevServicesProcessor {
                         {
                             "preferred_username": "%1$s",
                             "sub": "%2$s",
-                            "name": "%2$s",
-                            "family_name": "%2$s",
-                            "given_name": "%2$s",
-                            "email": "%3$s"
+                            "name": "%3$s",
+                            "family_name": "%3$s",
+                            "given_name": "%3$s",
+                            "email": "%4$s"
                         }
                         """.formatted(claims.getString(Claims.preferred_username.name()),
-                        claims.getString(Claims.sub.name()), claims.getString(Claims.email.name()));
+                        claims.getString(Claims.sub.name()), claims.getString("name"), claims.getString(Claims.email.name()));
                 rc.response()
                         .putHeader("Content-Type", "application/json")
                         .endAndForget(data);

--- a/integration-tests/oidc-dev-services/src/main/java/io/quarkus/it/oidc/dev/services/SecuredResource.java
+++ b/integration-tests/oidc-dev-services/src/main/java/io/quarkus/it/oidc/dev/services/SecuredResource.java
@@ -44,7 +44,7 @@ public class SecuredResource {
     @GET
     @Path("user-only")
     public String getUserOnly() {
-        return userInfo.getPreferredUserName() + " " + securityIdentity.getRoles();
+        return userInfo.getPreferredUserName() + " " + securityIdentity.getRoles() + " " + userInfo.getName();
     }
 
     @GET

--- a/integration-tests/oidc-dev-services/src/test/java/io/quarkus/it/oidc/dev/services/BearerAuthenticationOidcDevServicesTest.java
+++ b/integration-tests/oidc-dev-services/src/test/java/io/quarkus/it/oidc/dev/services/BearerAuthenticationOidcDevServicesTest.java
@@ -49,7 +49,7 @@ public class BearerAuthenticationOidcDevServicesTest {
                 .get("/secured/user-only")
                 .then()
                 .statusCode(200)
-                .body(Matchers.containsString("alice"))
+                .body(Matchers.startsWith("alice@example.com "))
                 .body(Matchers.containsString("admin"))
                 .body(Matchers.containsString("user"));
     }
@@ -66,8 +66,29 @@ public class BearerAuthenticationOidcDevServicesTest {
                 .get("/secured/user-only")
                 .then()
                 .statusCode(200)
-                .body(Matchers.containsString("bob"))
+                .body(Matchers.startsWith("bob@example.com "))
                 .body(Matchers.containsString("user"));
+    }
+
+    @Test
+    void testEmailAndName() {
+        // test users get an @example.com appended if username is not an email address
+        RestAssured.given()
+                .auth().oauth2(getAccessToken("bob"))
+                .get("/secured/user-only")
+                .then()
+                .statusCode(200)
+                .body(Matchers.startsWith("bob@example.com "))
+                .body(Matchers.containsString(" Bob"));
+
+        // Test no additional @example.com is appended if requested username is likely already an email address
+        RestAssured.given()
+                .auth().oauth2(getAccessToken("bob@example.com"))
+                .get("/secured/user-only")
+                .then()
+                .statusCode(200)
+                .body(Matchers.startsWith("bob@example.com "))
+                .body(Matchers.containsString(" Bob"));
     }
 
     private String getAccessToken(String user) {


### PR DESCRIPTION
This prevents cases in the oidc dev service where user@domain.com resulted in an email claim of user@domain.com@example.com when retrieving a token. Make sure that the name claim contains no email address. use the name claim if present for the userInfo, otherwise the sub claim

closes #47284